### PR TITLE
Simplify and improve prefab undo utility functions

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
@@ -57,16 +57,17 @@ namespace AzToolsFramework
             //! @return The path to the entity with the given id.
             virtual AZ::Dom::Path GenerateEntityPathFromFocusedPrefab(AZ::EntityId entityId) = 0;
 
-            //! Generates an entity alias from given entity id and prefix and then add it as path into the provided patch.
-            //! @param providedPatch The patch to add entity alias path to.
-            //! @param entityId The entity id to use for generating alias path.
-            //! @param prefix The prefix that will be added in front of the generated entity alias from entityId. 
-            virtual void AppendEntityAliasToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId, const AZStd::string& prefix = "") = 0;
+            //! Prepends an entity alias path to paths in the provided patch array.
+            //! @param patches The patches that contains paths to prepend the given path to.
+            //! @param entityId The entity id to use for generating entity alias path.
+            //! @param pathPrefix The prefix that will be added in front of the generated entity alias path from entity id.
+            virtual void PrependEntityAliasPathToPatchPaths(
+                PrefabDom& patches, AZ::EntityId entityId, const AZStd::string& pathPrefix = "") = 0;
 
-            //! Add given entity alias path into the provided patch.
-            //! @param providedPatch The patch to add entity alias path to.
-            //! @param entityAliasPath The entity alias path to be added as path into the patch.
-            virtual void AppendEntityAliasPathToPatchPaths(PrefabDom& providedPatch, const AZStd::string& entityAliasPath) = 0;
+            //! Prepends a path to the paths in the provided patch array.
+            //! @param patches The patches that contains paths to prepend the given path to.
+            //! @param pathToPrepend The given path to prepend.
+            virtual void PrependPathToPatchPaths(PrefabDom& patches, const AZStd::string& pathToPrepend) = 0;
 
             //! Updates the template links (updating instances) for the given template and triggers propagation on its instances.
             //! @param providedPatch The patch to apply to the template.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
@@ -113,7 +113,7 @@ namespace AzToolsFramework
 
             //get template id associated with instance
             TemplateId templateId = instanceOptionalReference->get().GetTemplateId();
-            AppendEntityAliasToPatchPaths(providedPatch, entityId);
+            PrependEntityAliasPathToPatchPaths(providedPatch, entityId);
             return PatchTemplate(providedPatch, templateId);
         }
 
@@ -176,26 +176,26 @@ namespace AzToolsFramework
             return AZStd::move(fullPathBetweenInstances);
         }
 
-        void InstanceToTemplatePropagator::AppendEntityAliasToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId, const AZStd::string& prefix)
+        void InstanceToTemplatePropagator::PrependEntityAliasPathToPatchPaths(
+            PrefabDom& patches, AZ::EntityId entityId, const AZStd::string& pathPrefix)
         {
-            AppendEntityAliasPathToPatchPaths(providedPatch, prefix + GenerateEntityAliasPath(entityId));
+            PrependPathToPatchPaths(patches, pathPrefix + GenerateEntityAliasPath(entityId));
         }
 
-        void InstanceToTemplatePropagator::AppendEntityAliasPathToPatchPaths(PrefabDom& providedPatch, const AZStd::string& entityAliasPath)
+        void InstanceToTemplatePropagator::PrependPathToPatchPaths(PrefabDom& patches, const AZStd::string& pathToPrepend)
         {
-            if (!providedPatch.IsArray())
+            if (!patches.IsArray())
             {
                 AZ_Error("Prefab", false, "Patch is not an array of updates.  Update failed.");
                 return;
             }
 
-            if (entityAliasPath.empty())
+            if (pathToPrepend.empty())
             {
                 return;
             }
 
-            //update all entities or just the single container
-            for (auto& patchValue : providedPatch.GetArray())
+            for (auto& patchValue : patches.GetArray())
             {
                 auto pathIter = patchValue.FindMember("path");
 
@@ -206,9 +206,8 @@ namespace AzToolsFramework
                     continue;
                 }
 
-                AZStd::string path = entityAliasPath + pathIter->value.GetString();
-
-                pathIter->value.SetString(path.c_str(), static_cast<rapidjson::SizeType>(path.length()), providedPatch.GetAllocator());
+                AZStd::string newPath = pathToPrepend + pathIter->value.GetString();
+                pathIter->value.SetString(newPath.c_str(), static_cast<rapidjson::SizeType>(newPath.length()), patches.GetAllocator());
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
@@ -184,11 +184,7 @@ namespace AzToolsFramework
 
         void InstanceToTemplatePropagator::PrependPathToPatchPaths(PrefabDom& patches, const AZStd::string& pathToPrepend)
         {
-            if (!patches.IsArray())
-            {
-                AZ_Error("Prefab", false, "Patch is not an array of updates.  Update failed.");
-                return;
-            }
+            AZ_Assert(patches.IsArray(), "PrependPathToPatchPaths - Provided patches should be an array object DOM value.");
 
             if (pathToPrepend.empty())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
@@ -39,8 +39,10 @@ namespace AzToolsFramework
 
             AZ::Dom::Path GenerateEntityPathFromFocusedPrefab(AZ::EntityId entityId) override;
 
-            void AppendEntityAliasToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId, const AZStd::string& prefix = "") override;
-            void AppendEntityAliasPathToPatchPaths(PrefabDom& providedPatch, const AZStd::string& entityAliasPath) override;
+            void PrependEntityAliasPathToPatchPaths(
+                PrefabDom& patches, AZ::EntityId entityId, const AZStd::string& pathPrefix = "") override;
+
+            void PrependPathToPatchPaths(PrefabDom& patches, const AZStd::string& pathToPrepend) override;
 
             InstanceOptionalReference GetTopMostInstanceInHierarchy(AZ::EntityId entityId) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -413,11 +413,11 @@ namespace AzToolsFramework::Prefab
         return climbUpResult;
     }
 
-    LinkId PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId) const
+    LinkId PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths(PrefabDom& patches, AZ::EntityId entityId) const
     {
-        if (!providedPatch.IsArray())
+        if (!patches.IsArray())
         {
-            AZ_Error("Prefab", false, "PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths - "
+            AZ_Error("Prefab", false, "PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths - "
                 "The given patch is not an array of updates. Returns an invalid link id.");
             return InvalidLinkId;
         }
@@ -426,7 +426,7 @@ namespace AzToolsFramework::Prefab
         InstanceClimbUpResult climbUpResult = ClimbUpToFocusedOrRootInstanceFromEntity(entityId);
         if (!climbUpResult.m_isTargetInstanceReached)
         {
-            AZ_Error("Prefab", false, "PrefabFocusHandler::AppendPathFromFocusedInstanceToPatchPaths - "
+            AZ_Error("Prefab", false, "PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths - "
                 "Entity id is not owned by a descendant of the focused prefab instance.");
             return InvalidLinkId;
         }
@@ -439,12 +439,12 @@ namespace AzToolsFramework::Prefab
             AZStd::string prefix = PrefabInstanceUtils::GetRelativePathFromClimbedInstances(
                 climbUpResult.m_climbedInstances, true);
 
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(providedPatch, entityId, AZStd::move(prefix));
+            m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patches, entityId, AZStd::move(prefix));
             return climbUpResult.m_climbedInstances.back()->GetLinkId();
         }
         else
         {
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(providedPatch, entityId);
+            m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patches, entityId);
             return InvalidLinkId;
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -415,12 +415,8 @@ namespace AzToolsFramework::Prefab
 
     LinkId PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths(PrefabDom& patches, AZ::EntityId entityId) const
     {
-        if (!patches.IsArray())
-        {
-            AZ_Error("Prefab", false, "PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths - "
-                "The given patch is not an array of updates. Returns an invalid link id.");
-            return InvalidLinkId;
-        }
+        AZ_Assert(false, "PrefabFocusHandler::PrependPathFromFocusedInstanceToPatchPaths - "
+            "The provided patches should an array of patches to update.");
 
         // Climb up the instance hierarchy from the owning instance until it hits the focused prefab instance.
         InstanceClimbUpResult climbUpResult = ClimbUpToFocusedOrRootInstanceFromEntity(entityId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -57,7 +57,7 @@ namespace AzToolsFramework::Prefab
         TemplateId GetFocusedPrefabTemplateId(AzFramework::EntityContextId entityContextId) const override;
         InstanceOptionalReference GetFocusedPrefabInstance(AzFramework::EntityContextId entityContextId) const override;
         bool IsFocusedPrefabInstanceReadOnly(AzFramework::EntityContextId entityContextId) const override;
-        LinkId AppendPathFromFocusedInstanceToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId) const override;
+        LinkId PrependPathFromFocusedInstanceToPatchPaths(PrefabDom& patches, AZ::EntityId entityId) const override;
 
         // PrefabFocusPublicInterface and PrefabFocusPublicRequestBus overrides ...
         PrefabFocusOperationResult FocusOnOwningPrefab(AZ::EntityId entityId) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusInterface.h
@@ -55,9 +55,9 @@ namespace AzToolsFramework::Prefab
         //! @return True if the currently focused prefab instance is read-only, false otherwise.
         virtual bool IsFocusedPrefabInstanceReadOnly(AzFramework::EntityContextId entityContextId) const = 0;
 
-        //! Appends the path from the focused instance to entity id into the provided patch array.
-        //! @param providedPatch The provided path array to be appended to.
+        //! Prepends the path from the focused instance to entity id into the provided patch array.
+        //! @param patches The provided patch array to prepend path to.
         //! @return LinkId stored in the instance closest to the focused instance in hierarchy.
-        virtual LinkId AppendPathFromFocusedInstanceToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId) const = 0;
+        virtual LinkId PrependPathFromFocusedInstanceToPatchPaths(PrefabDom& patches, AZ::EntityId entityId) const = 0;
     };
 } // namespace AzToolsFramework::Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -307,7 +307,7 @@ namespace AzToolsFramework
                         PrefabDom reparentPatch;
                         m_instanceToTemplateInterface->GeneratePatch(
                             reparentPatch, nestedContainerEntityDomBefore, nestedContainerEntityDomAfter);
-                        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(reparentPatch, topLevelEntityId);
+                        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(reparentPatch, topLevelEntityId);
 
                         // We won't parent this undo node to the undo batch so that the newly created template and link will remain
                         // unaffected by undo actions. This is needed so that any future instantiations of the template will work.
@@ -354,7 +354,7 @@ namespace AzToolsFramework
                 PrefabDom childSortOrderUpdatePatches;
                 m_instanceToTemplateInterface->GeneratePatch(childSortOrderUpdatePatches,
                     newContainerEntityDomInitialStateWithTransform, newContainerEntityDomWithTransformAndChildSortOrder);
-                m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(childSortOrderUpdatePatches, newContainerEntityId);
+                m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(childSortOrderUpdatePatches, newContainerEntityId);
                 m_instanceToTemplateInterface->PatchTemplate(childSortOrderUpdatePatches, newInstanceTemplateId);
 
                 // Create a link between the new prefab template and its parent template with undo/redo support.
@@ -450,7 +450,7 @@ namespace AzToolsFramework
 
             PrefabDom patch;
             m_instanceToTemplateInterface->GeneratePatch(patch, containerEntityDomBefore, containerEntityDomAfter);
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, containerEntityId);
+            m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, containerEntityId);
 
             return AZStd::move(patch);
         }
@@ -562,7 +562,7 @@ namespace AzToolsFramework
                 // Generate patch to be stored in the link
                 PrefabDom patch;
                 m_instanceToTemplateInterface->GeneratePatch(patch, containerEntityDomBefore, containerEntityDomAfter);
-                m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, containerEntityId);
+                m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, containerEntityId);
 
                 CreateLink(instanceToCreate->get(), instanceToParentUnder->get().GetTemplateId(), undoBatch.GetUndoBatch(), AZStd::move(patch));
 
@@ -851,7 +851,7 @@ namespace AzToolsFramework
 
             PrefabDom patch;
             m_instanceToTemplateInterface->GeneratePatch(patch, beforeState, afterState);
-            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, entityId);
+            m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, entityId);
 
             if (patch.IsArray() && !patch.Empty())
             {
@@ -927,7 +927,7 @@ namespace AzToolsFramework
 
                         PrefabDom newPatch;
                         m_instanceToTemplateInterface->GeneratePatch(newPatch, afterState, afterStateafterReparenting);
-                        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(newPatch, entityId);
+                        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(newPatch, entityId);
 
                         InstanceOptionalReference owningInstanceAfterReparenting =
                             m_instanceEntityMapperInterface->FindOwningInstance(entityId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -122,7 +122,7 @@ namespace AzToolsFramework
                 PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, endState, entityAliasPath);
+                    PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, endState, entityAliasPath);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -45,9 +45,6 @@ namespace AzToolsFramework
         {
             m_templateId = templateId;
 
-            m_redoPatch.SetArray();
-            m_undoPatch.SetArray();
-
             for (const AZ::Entity* entity : entityList)
             {
                 if (entity)
@@ -56,7 +53,7 @@ namespace AzToolsFramework
                     m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDom, *entity);
 
                     const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entity->GetId());
-                    PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, entityDom, entityAliasPath);
+                    PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, entityDom, entityAliasPath, PatchType::Add);
                     PrefabUndoUtils::AppendRemovePatch(m_undoPatch, entityAliasPath);
                 }
             }
@@ -74,9 +71,6 @@ namespace AzToolsFramework
         {
             m_templateId = templateId;
 
-            m_redoPatch.SetArray();
-            m_undoPatch.SetArray();
-
             for (const auto& entityDomAndPath : entityDomAndPathList)
             {
                 const PrefabDomValue* entityDomValue = entityDomAndPath.first;
@@ -84,7 +78,7 @@ namespace AzToolsFramework
                 {
                     const AZStd::string& entityAliasPath = entityDomAndPath.second;
                     PrefabUndoUtils::AppendRemovePatch(m_redoPatch, entityAliasPath);
-                    PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomValue, entityAliasPath);
+                    PrefabUndoUtils::AppendUpdateValuePatch(m_undoPatch, *entityDomValue, entityAliasPath, PatchType::Add);
                 }
             }
         }
@@ -119,8 +113,8 @@ namespace AzToolsFramework
 
             //generate undo/redo patches
             const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
-            PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, initialState, endState, entityAliasPath);
-            PrefabUndoUtils::GenerateUpdateEntityPatch(m_undoPatch, endState, initialState, entityAliasPath);
+            PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch, initialState, endState, entityAliasPath);
+            PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_undoPatch, endState, initialState, entityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
             if (updateCache)
@@ -128,7 +122,7 @@ namespace AzToolsFramework
                 PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom, endState, entityAliasPath);
+                    PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, endState, entityAliasPath);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -53,7 +53,7 @@ namespace AzToolsFramework
                     m_instanceToTemplateInterface->GenerateEntityDomBySerializing(entityDom, *entity);
 
                     const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entity->GetId());
-                    PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, entityDom, entityAliasPath, PatchType::Add);
+                    PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, entityDom, entityAliasPath);
                     PrefabUndoUtils::AppendRemovePatch(m_undoPatch, entityAliasPath);
                 }
             }
@@ -78,7 +78,7 @@ namespace AzToolsFramework
                 {
                     const AZStd::string& entityAliasPath = entityDomAndPath.second;
                     PrefabUndoUtils::AppendRemovePatch(m_redoPatch, entityAliasPath);
-                    PrefabUndoUtils::AppendUpdateValuePatch(m_undoPatch, *entityDomValue, entityAliasPath, PatchType::Add);
+                    PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomValue, entityAliasPath);
                 }
             }
         }
@@ -122,7 +122,7 @@ namespace AzToolsFramework
                 PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, endState, entityAliasPath);
+                    PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, endState, entityAliasPath);
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndo.cpp
@@ -113,8 +113,8 @@ namespace AzToolsFramework
 
             //generate undo/redo patches
             const AZStd::string& entityAliasPath = m_instanceToTemplateInterface->GenerateEntityAliasPath(entityId);
-            PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch, initialState, endState, entityAliasPath);
-            PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_undoPatch, endState, initialState, entityAliasPath);
+            PrefabUndoUtils::GenerateAndAppendPatch(m_redoPatch, initialState, endState, entityAliasPath);
+            PrefabUndoUtils::GenerateAndAppendPatch(m_undoPatch, endState, initialState, entityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
             if (updateCache)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -102,10 +102,8 @@ namespace AzToolsFramework
             PrefabDomReference cachedOwningInstanceDom = focusedInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
-                    parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
-                    newEntityDom, newEntityAliasPath);
+                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -63,9 +63,9 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    PrefabUndoUtils::GenerateUpdateEntityPatch(
+                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                         m_redoPatch, parentEntityDomBeforeAddingEntity, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                    PrefabUndoUtils::GenerateUpdateEntityPatch(
+                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                         m_undoPatch, parentEntityDomAfterAddingEntity, parentEntityDomBeforeAddingEntity, parentEntityAliasPath);
                 }
             }
@@ -85,9 +85,9 @@ namespace AzToolsFramework
                     }
                     else
                     {
-                        PrefabUndoUtils::GenerateUpdateEntityPatch(
+                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                             m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                        PrefabUndoUtils::GenerateUpdateEntityPatch(
+                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                             m_undoPatch, parentEntityDomAfterAddingEntity, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
                     }
                 }
@@ -95,16 +95,16 @@ namespace AzToolsFramework
 
             PrefabDom newEntityDom;
             m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
-            PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPath);
+            PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, newEntityDom, newEntityAliasPath, PatchType::Add);
             PrefabUndoUtils::AppendRemovePatch(m_undoPatch, newEntityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
             PrefabDomReference cachedOwningInstanceDom = focusedInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom,
+                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
                     parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom,
+                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
                     newEntityDom, newEntityAliasPath);
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -63,9 +63,9 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                    PrefabUndoUtils::GenerateAndAppendPatch(
                         m_redoPatch, parentEntityDomBeforeAddingEntity, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                    PrefabUndoUtils::GenerateAndAppendPatch(
                         m_undoPatch, parentEntityDomAfterAddingEntity, parentEntityDomBeforeAddingEntity, parentEntityAliasPath);
                 }
             }
@@ -85,9 +85,9 @@ namespace AzToolsFramework
                     }
                     else
                     {
-                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                        PrefabUndoUtils::GenerateAndAppendPatch(
                             m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                        PrefabUndoUtils::GenerateAndAppendPatch(
                             m_undoPatch, parentEntityDomAfterAddingEntity, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntity.cpp
@@ -95,15 +95,15 @@ namespace AzToolsFramework
 
             PrefabDom newEntityDom;
             m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
-            PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, newEntityDom, newEntityAliasPath, PatchType::Add);
+            PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPath);
             PrefabUndoUtils::AppendRemovePatch(m_undoPatch, newEntityAliasPath);
 
             // Preemptively updates the cached DOM to prevent reloading instance DOM.
             PrefabDomReference cachedOwningInstanceDom = focusedInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
+                PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
@@ -74,7 +74,7 @@ namespace AzToolsFramework
                     "Could not load parent entity's DOM from the focused template's DOM. "
                     "Focused template id: '%llu'.", static_cast<AZ::u64>(focusedTemplateId));
 
-                PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch,
+                PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch,
                     *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPathForPatch);
             }
 
@@ -83,7 +83,7 @@ namespace AzToolsFramework
 
             PrefabDom newEntityDom;
             m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
-            PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPathForPatch);
+            PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, newEntityDom, newEntityAliasPathForPatch, PatchType::Add);
 
             const LinkId linkId = climbUpResult.m_climbedInstances.back()->GetLinkId();
             PrefabUndoUpdateLink::Capture(m_redoPatch, linkId);
@@ -92,9 +92,9 @@ namespace AzToolsFramework
             PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom,
+                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
                     parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom,
+                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
                     newEntityDom, newEntityAliasPath);
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
@@ -74,8 +74,8 @@ namespace AzToolsFramework
                     "Could not load parent entity's DOM from the focused template's DOM. "
                     "Focused template id: '%llu'.", static_cast<AZ::u64>(focusedTemplateId));
 
-                PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch,
-                    *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPathForPatch);
+                PrefabUndoUtils::GenerateAndAppendPatch(
+                    m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterAddingEntity, parentEntityAliasPathForPatch);
             }
 
             const AZStd::string newEntityAliasPathForPatch =

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
@@ -92,10 +92,8 @@ namespace AzToolsFramework
             PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
-                    parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom,
-                    newEntityDom, newEntityAliasPath);
+                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoAddEntityAsOverride.cpp
@@ -83,7 +83,7 @@ namespace AzToolsFramework
 
             PrefabDom newEntityDom;
             m_instanceToTemplateInterface->GenerateEntityDomBySerializing(newEntityDom, newEntity);
-            PrefabUndoUtils::AppendUpdateValuePatch(m_redoPatch, newEntityDom, newEntityAliasPathForPatch, PatchType::Add);
+            PrefabUndoUtils::AppendAddEntityPatch(m_redoPatch, newEntityDom, newEntityAliasPathForPatch);
 
             const LinkId linkId = climbUpResult.m_climbedInstances.back()->GetLinkId();
             PrefabUndoUpdateLink::Capture(m_redoPatch, linkId);
@@ -92,8 +92,8 @@ namespace AzToolsFramework
             PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
-                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
+                PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, parentEntityDomAfterAddingEntity, parentEntityAliasPath);
+                PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, newEntityDom, newEntityAliasPath);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.cpp
@@ -20,6 +20,8 @@ namespace AzToolsFramework
             : UndoSystem::URSequencePoint(undoOperationName)
             , m_changed(true)
             , m_templateId(InvalidTemplateId)
+            , m_redoPatch(rapidjson::kArrayType)
+            , m_undoPatch(rapidjson::kArrayType)
         {
             m_instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
             AZ_Assert(m_instanceToTemplateInterface, "Failed to grab instance to template interface");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.cpp
@@ -18,10 +18,10 @@ namespace AzToolsFramework
     {
         PrefabUndoBase::PrefabUndoBase(const AZStd::string& undoOperationName)
             : UndoSystem::URSequencePoint(undoOperationName)
-            , m_changed(true)
-            , m_templateId(InvalidTemplateId)
             , m_redoPatch(rapidjson::kArrayType)
             , m_undoPatch(rapidjson::kArrayType)
+            , m_templateId(InvalidTemplateId)
+            , m_changed(true)
         {
             m_instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
             AZ_Assert(m_instanceToTemplateInterface, "Failed to grab instance to template interface");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.h
@@ -36,15 +36,16 @@ namespace AzToolsFramework
             void virtual Redo(InstanceOptionalConstReference instanceToExclude);
 
         protected:
-            bool m_changed;
-            TemplateId m_templateId;
-
             PrefabDom m_redoPatch;
             PrefabDom m_undoPatch;
+
+            TemplateId m_templateId;
 
             InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;
             InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
+
+            bool m_changed;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoBase.h
@@ -36,6 +36,7 @@ namespace AzToolsFramework
             void virtual Redo(InstanceOptionalConstReference instanceToExclude);
 
         protected:
+            bool m_changed;
             TemplateId m_templateId;
 
             PrefabDom m_redoPatch;
@@ -44,8 +45,6 @@ namespace AzToolsFramework
             InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;
             InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
-
-            bool m_changed;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
@@ -35,8 +35,8 @@ namespace AzToolsFramework::Prefab
         m_templateId = instance.GetTemplateId();
 
         // generate undo/redo patches
-        PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch, initialState, endState, pathToComponentProperty);
-        PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_undoPatch, endState, initialState, pathToComponentProperty);
+        PrefabUndoUtils::GenerateAndAppendPatch(m_redoPatch, initialState, endState, pathToComponentProperty);
+        PrefabUndoUtils::GenerateAndAppendPatch(m_undoPatch, endState, initialState, pathToComponentProperty);
 
         // Preemptively updates the cached DOM to prevent reloading instance DOM.
         if (updateCache)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
@@ -44,7 +44,7 @@ namespace AzToolsFramework::Prefab
             PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, endState, pathToComponentProperty);
+                PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, endState, pathToComponentProperty);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.cpp
@@ -34,10 +34,9 @@ namespace AzToolsFramework::Prefab
         Instance& instance = instanceReference->get();
         m_templateId = instance.GetTemplateId();
 
-
         // generate undo/redo patches
-        PrefabUndoUtils::GenerateUpdateEntityPatch(m_redoPatch, initialState, endState, pathToComponentProperty);
-        PrefabUndoUtils::GenerateUpdateEntityPatch(m_undoPatch, endState, initialState, pathToComponentProperty);
+        PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_redoPatch, initialState, endState, pathToComponentProperty);
+        PrefabUndoUtils::AppendUpdateValuePatchByComparison(m_undoPatch, endState, initialState, pathToComponentProperty);
 
         // Preemptively updates the cached DOM to prevent reloading instance DOM.
         if (updateCache)
@@ -45,7 +44,7 @@ namespace AzToolsFramework::Prefab
             PrefabDomReference cachedOwningInstanceDom = instance.GetCachedInstanceDom();
             if (cachedOwningInstanceDom.has_value())
             {
-                PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom, endState, pathToComponentProperty);
+                PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, endState, pathToComponentProperty);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
@@ -137,7 +137,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance DOM.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateEntityInInstanceDom(
+                    PrefabUndoUtils::UpdateValueInInstanceDom(
                         cachedOwningInstanceDom, afterStateOfComponentProperty, pathToPropertyFromFocusedPrefab.ToString());
                 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
@@ -137,7 +137,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance DOM.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInInstanceDom(
+                    PrefabUndoUtils::UpdateValueInPrefabDom(
                         cachedOwningInstanceDom, afterStateOfComponentProperty, pathToPropertyFromFocusedPrefab.ToString());
                 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -30,8 +30,6 @@ namespace AzToolsFramework
             Instance& focusedInstance)
         {
             m_templateId = focusedInstance.GetTemplateId();
-            m_redoPatch.SetArray();
-            m_undoPatch.SetArray();
 
             PrefabDom& focusedTempalteDom = m_prefabSystemComponentInterface->FindTemplateDom(m_templateId);
 
@@ -50,7 +48,7 @@ namespace AzToolsFramework
 
                 PrefabDomPath entityDomPathInFocusedTemplate(entityAliasPath.c_str());
                 const PrefabDomValue* entityDomInFocusedTemplate = entityDomPathInFocusedTemplate.Get(focusedTempalteDom);
-                PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomInFocusedTemplate, entityAliasPath);
+                PrefabUndoUtils::AppendUpdateValuePatch(m_undoPatch, *entityDomInFocusedTemplate, entityAliasPath, PatchType::Add);
 
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
@@ -91,9 +89,9 @@ namespace AzToolsFramework
                         continue;
                     }
 
-                    PrefabUndoUtils::AppendUpdateEntityPatch(
+                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                         m_redoPatch, parentEntityDomBeforeRemoving, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
-                    PrefabUndoUtils::AppendUpdateEntityPatch(
+                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                         m_undoPatch, parentEntityDomAfterRemovingChildren, parentEntityDomBeforeRemoving, parentEntityAliasPath);
                 }
                 else
@@ -113,9 +111,9 @@ namespace AzToolsFramework
                             continue;
                         }
 
-                        PrefabUndoUtils::AppendUpdateEntityPatch(
+                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                             m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
-                        PrefabUndoUtils::AppendUpdateEntityPatch(
+                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                             m_undoPatch, parentEntityDomAfterRemovingChildren, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
                     }
                 }
@@ -123,7 +121,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateEntityInInstanceDom(
+                    PrefabUndoUtils::UpdateValueInInstanceDom(
                         cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -89,9 +89,9 @@ namespace AzToolsFramework
                         continue;
                     }
 
-                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                    PrefabUndoUtils::GenerateAndAppendPatch(
                         m_redoPatch, parentEntityDomBeforeRemoving, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
-                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                    PrefabUndoUtils::GenerateAndAppendPatch(
                         m_undoPatch, parentEntityDomAfterRemovingChildren, parentEntityDomBeforeRemoving, parentEntityAliasPath);
                 }
                 else
@@ -111,9 +111,9 @@ namespace AzToolsFramework
                             continue;
                         }
 
-                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                        PrefabUndoUtils::GenerateAndAppendPatch(
                             m_redoPatch, *parentEntityDomInFocusedTemplate, parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
-                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                        PrefabUndoUtils::GenerateAndAppendPatch(
                             m_undoPatch, parentEntityDomAfterRemovingChildren, *parentEntityDomInFocusedTemplate, parentEntityAliasPath);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -48,7 +48,7 @@ namespace AzToolsFramework
 
                 PrefabDomPath entityDomPathInFocusedTemplate(entityAliasPath.c_str());
                 const PrefabDomValue* entityDomInFocusedTemplate = entityDomPathInFocusedTemplate.Get(focusedTempalteDom);
-                PrefabUndoUtils::AppendUpdateValuePatch(m_undoPatch, *entityDomInFocusedTemplate, entityAliasPath, PatchType::Add);
+                PrefabUndoUtils::AppendAddEntityPatch(m_undoPatch, *entityDomInFocusedTemplate, entityAliasPath);
 
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
@@ -121,7 +121,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInPrefabDom(
+                    PrefabUndoUtils::UpdateEntityInPrefabDom(
                         cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDelete.cpp
@@ -53,7 +53,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::RemoveValueInInstanceDom(cachedOwningInstanceDom, entityAliasPath);
+                    PrefabUndoUtils::RemoveValueInPrefabDom(cachedOwningInstanceDom, entityAliasPath);
                 }
             }
 
@@ -121,7 +121,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInInstanceDom(
+                    PrefabUndoUtils::UpdateValueInPrefabDom(
                         cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -116,7 +116,7 @@ namespace AzToolsFramework
                     PrefabDom parentEntityDomAfterRemovingChildren;
                     m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterRemovingChildren, *parentEntity);
 
-                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                    PrefabUndoUtils::GenerateAndAppendPatch(
                         m_redoPatch,
                         *parentEntityDomInFocusedTemplate,
                         parentEntityDomAfterRemovingChildren,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -35,8 +35,6 @@ namespace AzToolsFramework
                 "PrefabUndoDeleteAsOverride::Capture - Owning instance should not be the focused instance for override edit node.");
 
             m_templateId = focusedInstance.GetTemplateId();
-            m_redoPatch.SetArray();
-            m_undoPatch.SetArray();
 
             PrefabDom& focusedTempalteDom = m_prefabSystemComponentInterface->FindTemplateDom(m_templateId);
 
@@ -118,7 +116,7 @@ namespace AzToolsFramework
                     PrefabDom parentEntityDomAfterRemovingChildren;
                     m_instanceToTemplateInterface->GenerateEntityDomBySerializing(parentEntityDomAfterRemovingChildren, *parentEntity);
 
-                    PrefabUndoUtils::AppendUpdateEntityPatch(
+                    PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                         m_redoPatch,
                         *parentEntityDomInFocusedTemplate,
                         parentEntityDomAfterRemovingChildren,
@@ -127,7 +125,7 @@ namespace AzToolsFramework
                     // Preemptively updates the cached DOM to prevent reloading instance.
                     if (cachedOwningInstanceDom.has_value())
                     {
-                        PrefabUndoUtils::UpdateEntityInInstanceDom(
+                        PrefabUndoUtils::UpdateValueInInstanceDom(
                             cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -125,7 +125,7 @@ namespace AzToolsFramework
                     // Preemptively updates the cached DOM to prevent reloading instance.
                     if (cachedOwningInstanceDom.has_value())
                     {
-                        PrefabUndoUtils::UpdateValueInPrefabDom(
+                        PrefabUndoUtils::UpdateEntityInPrefabDom(
                             cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoDeleteAsOverride.cpp
@@ -69,7 +69,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::RemoveValueInInstanceDom(cachedOwningInstanceDom->get(), entityAliasPath);
+                    PrefabUndoUtils::RemoveValueInPrefabDom(cachedOwningInstanceDom->get(), entityAliasPath);
                 }
             }
 
@@ -81,7 +81,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::RemoveValueInInstanceDom(cachedOwningInstanceDom->get(), instanceAliasPath);
+                    PrefabUndoUtils::RemoveValueInPrefabDom(cachedOwningInstanceDom->get(), instanceAliasPath);
                 }
             }
 
@@ -125,7 +125,7 @@ namespace AzToolsFramework
                     // Preemptively updates the cached DOM to prevent reloading instance.
                     if (cachedOwningInstanceDom.has_value())
                     {
-                        PrefabUndoUtils::UpdateValueInInstanceDom(
+                        PrefabUndoUtils::UpdateValueInPrefabDom(
                             cachedOwningInstanceDom->get(), parentEntityDomAfterRemovingChildren, parentEntityAliasPath);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -94,7 +94,7 @@ namespace AzToolsFramework
 
                     if (entityDomInTopTemplate)
                     {
-                        PrefabUndoUtils::AppendUpdateEntityPatch(
+                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
                             overridePatches, *entityDomInTopTemplate, entityDomAfterUpdate, entityPathFromTopInstance);
                     }
                     else if (auto overrideType = m_prefabOverridePublicInterface->GetEntityOverrideType(entity->GetId());
@@ -102,7 +102,8 @@ namespace AzToolsFramework
                     {
                         // Override patches on the entity would be merged into the entity DOM value stored in the
                         // add-entity override patch.
-                        PrefabUndoUtils::AppendAddEntityPatch(overridePatches, entityDomAfterUpdate, entityPathFromTopInstance);
+                        PrefabUndoUtils::AppendUpdateValuePatch(
+                            overridePatches, entityDomAfterUpdate, entityPathFromTopInstance, PatchType::Add);
                     }
                     else
                     {
@@ -122,7 +123,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance DOM.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateEntityInInstanceDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
+                    PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -123,7 +123,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance DOM.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInInstanceDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
+                    PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -94,7 +94,7 @@ namespace AzToolsFramework
 
                     if (entityDomInTopTemplate)
                     {
-                        PrefabUndoUtils::AppendUpdateValuePatchByComparison(
+                        PrefabUndoUtils::GenerateAndAppendPatch(
                             overridePatches, *entityDomInTopTemplate, entityDomAfterUpdate, entityPathFromTopInstance);
                     }
                     else if (auto overrideType = m_prefabOverridePublicInterface->GetEntityOverrideType(entity->GetId());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -102,8 +102,7 @@ namespace AzToolsFramework
                     {
                         // Override patches on the entity would be merged into the entity DOM value stored in the
                         // add-entity override patch.
-                        PrefabUndoUtils::AppendUpdateValuePatch(
-                            overridePatches, entityDomAfterUpdate, entityPathFromTopInstance, PatchType::Add);
+                        PrefabUndoUtils::AppendAddEntityPatch(overridePatches, entityDomAfterUpdate, entityPathFromTopInstance);
                     }
                     else
                     {
@@ -123,7 +122,7 @@ namespace AzToolsFramework
                 // Preemptively updates the cached DOM to prevent reloading instance DOM.
                 if (cachedOwningInstanceDom.has_value())
                 {
-                    PrefabUndoUtils::UpdateValueInPrefabDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
+                    PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
@@ -16,6 +16,16 @@ namespace AzToolsFramework
     {
         namespace PrefabUndoUtils
         {
+            void AppendAddEntityPatch(
+                PrefabDom& patches,
+                const PrefabDomValue& newEntityDom,
+                const AZStd::string& newEntityAliasPath)
+            {
+                AZ_Assert(patches.IsArray(), "AppendAddEntityPatch - Provided patches should be an array object DOM value.");
+
+                AppendUpdateValuePatch(patches, newEntityDom, newEntityAliasPath, PatchType::Add);
+            }
+
             void AppendUpdateValuePatch(
                 PrefabDom& patches,
                 const PrefabDomValue& domValue,
@@ -79,6 +89,12 @@ namespace AzToolsFramework
                 {
                     patches.PushBack(newPatch.Move(), patches.GetAllocator());
                 }
+            }
+
+            void UpdateEntityInPrefabDom(
+                PrefabDomReference prefabDom, const PrefabDomValue& entityDom, const AZStd::string& entityAliasPath)
+            {
+                UpdateValueInPrefabDom(prefabDom, entityDom, entityAliasPath);
             }
 
             void UpdateValueInPrefabDom(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
@@ -81,24 +81,24 @@ namespace AzToolsFramework
                 }
             }
 
-            void UpdateValueInInstanceDom(
-                PrefabDomReference instanceDom, const PrefabDomValue& domValue, const AZStd::string& pathToValue)
+            void UpdateValueInPrefabDom(
+                PrefabDomReference prefabDom, const PrefabDomValue& domValue, const AZStd::string& pathToValue)
             {
                 if (!pathToValue.empty())
                 {
-                    PrefabDomValue endStateCopy(domValue, instanceDom->get().GetAllocator());
+                    PrefabDomValue endStateCopy(domValue, prefabDom->get().GetAllocator());
 
                     PrefabDomPath domPathToValue(pathToValue.c_str());
-                    domPathToValue.Set(instanceDom->get(), endStateCopy.Move());
+                    domPathToValue.Set(prefabDom->get(), endStateCopy.Move());
                 }
             }
 
-            void RemoveValueInInstanceDom(PrefabDomReference instanceDom, const AZStd::string& pathToRemove)
+            void RemoveValueInPrefabDom(PrefabDomReference prefabDom, const AZStd::string& pathToRemove)
             {
                 if (!pathToRemove.empty())
                 {
                     PrefabDomPath domPathToRemove(pathToRemove.c_str());
-                    domPathToRemove.Erase(instanceDom->get());
+                    domPathToRemove.Erase(prefabDom->get());
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
@@ -60,16 +60,16 @@ namespace AzToolsFramework
                 patches.PushBack(removeTargetEntityPatch.Move(), patches.GetAllocator());
             }
 
-            void AppendUpdateValuePatchByComparison(
+            void GenerateAndAppendPatch(
                 PrefabDom& patches,
                 const PrefabDomValue& domValueBeforeUpdate,
                 const PrefabDomValue& domValueAfterUpdate,
                 const AZStd::string& pathToValue)
             {
-                AZ_Assert(patches.IsArray(), "AppendUpdateValuePatchByComparison - Provided patches should be an array object DOM value.");
+                AZ_Assert(patches.IsArray(), "GenerateAndAppendPatch - Provided patches should be an array object DOM value.");
 
                 auto instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
-                AZ_Assert(instanceToTemplateInterface, "AppendUpdateValuePatchByComparison - Could not get InstanceToTemplateInterface.");
+                AZ_Assert(instanceToTemplateInterface, "GenerateAndAppendPatch - Could not get InstanceToTemplateInterface.");
 
                 PrefabDom newPatches(&(patches.GetAllocator()));
                 instanceToTemplateInterface->GeneratePatch(newPatches, domValueBeforeUpdate, domValueAfterUpdate);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.cpp
@@ -73,7 +73,7 @@ namespace AzToolsFramework
 
                 PrefabDom newPatches(&(patches.GetAllocator()));
                 instanceToTemplateInterface->GeneratePatch(newPatches, domValueBeforeUpdate, domValueAfterUpdate);
-                instanceToTemplateInterface->AppendEntityAliasPathToPatchPaths(newPatches, pathToValue);
+                instanceToTemplateInterface->PrependPathToPatchPaths(newPatches, pathToValue);
 
                 for (auto& newPatch : newPatches.GetArray())
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
@@ -17,21 +17,12 @@ namespace AzToolsFramework
     namespace Prefab
     {
         namespace PrefabUndoUtils
-        {
-            //! Create an add-entity patch for new entity with alias path, and append it to patch array.
-            //! @param patches An array object of DOM values which stores undo or redo patches.
-            //! @param newEntityDom The entity DOM generated from the new entity.
-            //! @param newEntityAliasPath The given alias path for the new entity.
-            void AppendAddEntityPatch(
-                PrefabDom& patches,
-                const PrefabDomValue& newEntityDom,
-                const AZStd::string& newEntityAliasPath);
-            
+        {            
             //! Create an 'add' or 'replace' patch for updating value in DOM.
             //! To remove value, use AppendRemovePatch.
             //! @param patches An array object of DOM values which stores undo or redo patches.
             //! @param domValue The DOM value to add or replace.
-            //! @param pathToUpdate The given path for the new value.
+            //! @param pathToUpdate The given path to the value.
             //! @param patchType The patch type for the patch (supported value: Add and Edit).
             void AppendUpdateValuePatch(
                 PrefabDom& patches,
@@ -46,37 +37,25 @@ namespace AzToolsFramework
                 PrefabDom& patches,
                 const AZStd::string& pathToRemove);
 
-            //! Create edit-entity patch(es), and append them to patch array.
+            //! Create patches by comparing DOM states before and after update, and append them to patch array.
             //! @param patches An array object of DOM values which stores undo or redo patches.
-            //! @param entityDomBeforeUpdate The DOM presenting state of an entity before update.
-            //! @param entityDomAfterUpdate The DOM presenting state of an entity after update.
-            //! @param entityAliasPath The given alias path for the entity to be updated.
-            void AppendUpdateEntityPatch(
+            //! @param domValueBeforeUpdate The DOM presenting state of the value before update.
+            //! @param domValueAfterUpdate The DOM presenting state of the value after update.
+            //! @param pathToValue The given path to the value.
+            void AppendUpdateValuePatchByComparison(
                 PrefabDom& patches,
-                const PrefabDomValue& entityDomBeforeUpdate,
-                const PrefabDomValue& entityDomAfterUpdate,
-                const AZStd::string& entityAliasPath);
+                const PrefabDomValue& domValueBeforeUpdate,
+                const PrefabDomValue& domValueAfterUpdate,
+                const AZStd::string& pathToValue);
 
-            //! Create edit-entity patch(es), and output them to patch array.
-            //! Note: It will overwrite the given patch array with new patches.
-            //! @param patches An array object of DOM values which stores undo or redo patches.
-            //! @param entityDomBeforeUpdate The DOM presenting state of an entity before update.
-            //! @param entityDomAfterUpdate The DOM presenting state of an entity after update.
-            //! @param entityAliasPath The given alias path for the entity to be updated.
-            void GenerateUpdateEntityPatch(
-                PrefabDom& patches,
-                const PrefabDomValue& entityDomBeforeUpdate,
-                const PrefabDomValue& entityDomAfterUpdate,
-                const AZStd::string& entityAliasPath);
-
-            //! Update the entity in instance DOM with the provided entity DOM.
+            //! Update the value in instance DOM with the provided DOM value.
             //! @param instanceDom The given instance DOM.
-            //! @param entityDom The entity DOM that will be put in the instance DOM.
-            //! @param entityAliasPath The given alias path to the entity.
-            void UpdateEntityInInstanceDom(
+            //! @param domValue The DOM value that will be put in the instance DOM.
+            //! @param pathToValue The given path to the value.
+            void UpdateValueInInstanceDom(
                 PrefabDomReference instanceDom,
-                const PrefabDomValue& entityDom,
-                const AZStd::string& entityAliasPath);
+                const PrefabDomValue& domValue,
+                const AZStd::string& pathToValue);
 
             //! Remove DOM value in instance DOM.
             //! @param instanceDom The given instance DOM.
@@ -84,6 +63,7 @@ namespace AzToolsFramework
             void RemoveValueInInstanceDom(
                 PrefabDomReference instanceDom,
                 const AZStd::string& pathToRemove);
+
         } // namespace PrefabUndoUtils
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
@@ -17,7 +17,16 @@ namespace AzToolsFramework
     namespace Prefab
     {
         namespace PrefabUndoUtils
-        {            
+        {
+            //! Create an add-entity patch for new entity with alias path, and append it to patch array.
+            //! @param patches An array object of DOM values which stores undo or redo patches.
+            //! @param newEntityDom The entity DOM generated from the new entity.
+            //! @param newEntityAliasPath The given alias path for the new entity.
+            void AppendAddEntityPatch(
+                PrefabDom& patches,
+                const PrefabDomValue& newEntityDom,
+                const AZStd::string& newEntityAliasPath);
+
             //! Create an 'add' or 'replace' patch for updating value in DOM.
             //! To remove value, use AppendRemovePatch.
             //! @param patches An array object of DOM values which stores undo or redo patches.
@@ -47,6 +56,15 @@ namespace AzToolsFramework
                 const PrefabDomValue& domValueBeforeUpdate,
                 const PrefabDomValue& domValueAfterUpdate,
                 const AZStd::string& pathToValue);
+
+            //! Update the entity in prefab DOM with the provided entity DOM.
+            //! @param prefabDom The given prefab DOM.
+            //! @param entityDom The entity DOM that will be put in the prefab DOM.
+            //! @param entityAliasPath The given alias path to the entity.
+            void UpdateEntityInPrefabDom(
+                PrefabDomReference prefabDom,
+                const PrefabDomValue& entityDom,
+                const AZStd::string& entityAliasPath);
 
             //! Update the value in prefab DOM with the provided DOM value.
             //! @param prefabDom The given prefab DOM.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
@@ -42,7 +42,7 @@ namespace AzToolsFramework
             //! @param domValueBeforeUpdate The DOM presenting state of the value before update.
             //! @param domValueAfterUpdate The DOM presenting state of the value after update.
             //! @param pathToValue The given path to the value.
-            void AppendUpdateValuePatchByComparison(
+            void GenerateAndAppendPatch(
                 PrefabDom& patches,
                 const PrefabDomValue& domValueBeforeUpdate,
                 const PrefabDomValue& domValueAfterUpdate,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoUtils.h
@@ -48,20 +48,20 @@ namespace AzToolsFramework
                 const PrefabDomValue& domValueAfterUpdate,
                 const AZStd::string& pathToValue);
 
-            //! Update the value in instance DOM with the provided DOM value.
-            //! @param instanceDom The given instance DOM.
-            //! @param domValue The DOM value that will be put in the instance DOM.
+            //! Update the value in prefab DOM with the provided DOM value.
+            //! @param prefabDom The given prefab DOM.
+            //! @param domValue The DOM value that will be put in the prefab DOM.
             //! @param pathToValue The given path to the value.
-            void UpdateValueInInstanceDom(
-                PrefabDomReference instanceDom,
+            void UpdateValueInPrefabDom(
+                PrefabDomReference prefabDom,
                 const PrefabDomValue& domValue,
                 const AZStd::string& pathToValue);
 
-            //! Remove DOM value in instance DOM.
-            //! @param instanceDom The given instance DOM.
+            //! Remove DOM value in prefab DOM.
+            //! @param prefabDom The given prefab DOM.
             //! @param pathToRemove The path to where the value will be removed.
-            void RemoveValueInInstanceDom(
-                PrefabDomReference instanceDom,
+            void RemoveValueInPrefabDom(
+                PrefabDomReference prefabDom,
                 const AZStd::string& pathToRemove);
 
         } // namespace PrefabUndoUtils

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Link/SingleInstanceMultiplePatchesBenchmarks.cpp
@@ -64,7 +64,7 @@ namespace Benchmark
 
                         PrefabDom patch;
                         instanceToTemplateInterface->GeneratePatch(patch, entityDomBefore, entityDomAfter);
-                        instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, entity->GetId());
+                        instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, entity->GetId());
                         for (auto& entry : patch.GetArray())
                         {
                             PrefabDomValue patchEntryCopy;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoLinkTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoLinkTests.cpp
@@ -92,7 +92,7 @@ namespace UnitTest
 
         PrefabDom patch;
         m_instanceToTemplateInterface->GeneratePatch(patch, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, nestedContainerEntityId);
 
         //apply the patch
         PrefabDom& templateDomReference = m_prefabSystemComponent->FindTemplateDom(nestedTemplateId);
@@ -111,7 +111,7 @@ namespace UnitTest
         nestedTestComponent->m_entityIdProperty = rootContainerEntityId;
         m_instanceToTemplateInterface->GenerateEntityDomBySerializing(modifiedEntityDom, *nestedContainerEntity);
         m_instanceToTemplateInterface->GeneratePatch(patch, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, nestedContainerEntityId);
 
         //create an undo node to apply the patch and prep for undo
         PrefabUndoInstanceLink undoInstanceLinkNode("Undo Link Patch");
@@ -163,7 +163,7 @@ namespace UnitTest
         //create patch
         PrefabDom patch;
         m_instanceToTemplateInterface->GeneratePatch(patch, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, nestedContainerEntityId);
         m_instanceToTemplateInterface->PatchTemplate(patch, nestedTemplateId);
         m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
 
@@ -190,7 +190,7 @@ namespace UnitTest
         //create patch
         PrefabDom linkPatch;
         m_instanceToTemplateInterface->GeneratePatch(linkPatch, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(linkPatch, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(linkPatch, nestedContainerEntityId);
 
         AZStd::vector<InstanceAlias> aliases = rootInstance->GetNestedInstanceAliases(nestedTemplateId);
 
@@ -229,7 +229,7 @@ namespace UnitTest
         //create patch
         PrefabDom updatePatch;
         m_instanceToTemplateInterface->GeneratePatch(updatePatch, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(updatePatch, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(updatePatch, nestedContainerEntityId);
 
         //create the update link undo/redo node
         PrefabUndoUpdateLink undoLinkUpdateNode("Undo Link Update");
@@ -306,7 +306,7 @@ namespace UnitTest
         //create patch
         PrefabDom updatePatchIntField;
         m_instanceToTemplateInterface->GeneratePatch(updatePatchIntField, initialEntityDom, modifiedEntityDom);
-        m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(updatePatchIntField, nestedContainerEntityId);
+        m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(updatePatchIntField, nestedContainerEntityId);
 
         //create the update link undo/redo node
         PrefabUndoUpdateLink undoIntFieldNode("Undo Link Update");


### PR DESCRIPTION
## What does this PR do?

This PR simplifies and improves utility functions in 'PrefabUndoUtils'. They are used to encapsulate repeated code to generate undo/redo patches and update value in cached instance DOM.

The purpose of this PR is to remove duplicate code and avoid confusion in usage.

**Change List:**
- Keep functions for entity-level or property-level updates. Entity-level would call property-level version.
- Replaced `GenerateUpdateEntityPatch` by `GenerateAndAppendPatch`.
- Changed to initialize undo/redo patch arrays in member initialization list, rather than calling `SetArray` before usage.
- For path helper function, use 'Append' to 'Prepend' in naming, and use assertions to check if the provided patches is array type.

## How was this PR tested?

Does not alter workflow logic. Passed existing unit tests.
