### PR TITLE
Updated the ShaderVariantAssetBuilder.

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -108,8 +108,9 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 33; // // material pipeline MATERIAL_TYPE_AZSLI_FILE_PATH trick
-                shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+                shaderVariantAssetBuilderDescriptor.m_version = 34; // Listens for *.hashedvariantlist and *.hashedvariantinfo files.
+                shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+                shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();
                 shaderVariantAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::CreateJobs, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
                 shaderVariantAssetBuilderDescriptor.m_processJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::ProcessJob, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -121,7 +122,7 @@ namespace AZ
                 AssetBuilderSDK::AssetBuilderDesc shaderVariantListBuilderDescriptor;
                 shaderVariantListBuilderDescriptor.m_name = "Shader Variant List Builder";
                 shaderVariantListBuilderDescriptor.m_version = 1; // First version of ShaderVariantListBuilder
-                shaderVariantListBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", ShaderVariantListBuilder::Extension/*RPI::ShaderVariantListSourceData::Extension*/), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+                shaderVariantListBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantListBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantListBuilder>();
                 shaderVariantListBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderVariantListBuilder::CreateJobs, &m_shaderVariantListBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
                 shaderVariantListBuilderDescriptor.m_processJobFunction = AZStd::bind(&ShaderVariantListBuilder::ProcessJob, &m_shaderVariantListBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/HashedVariantListSourceData.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/HashedVariantListSourceData.h
@@ -42,6 +42,11 @@ namespace AZ
 
             static constexpr const char* Extension = "hashedvariantinfo";
 
+            // Original, and absolute, path of the corresponsing *.shader file.
+            // This needs to be stored to preserve the casing. Without this, Linux
+            // won't work.
+            AZStd::string m_shaderPath;
+
             AZ::RPI::ShaderVariantListSourceData::VariantInfo m_variantInfo;
             size_t m_hash = 0; // Hash of all the data in @m_variantInfo
 
@@ -73,6 +78,11 @@ namespace AZ
             static constexpr uint32_t SubId = 0;
 
             static void Reflect(ReflectContext* context);
+
+            // Original, and absolute, path of the corresponsing *.shader file.
+            // This needs to be stored to preserve the casing. Without this Linux
+            // won't work.
+            AZStd::string m_shaderPath;
 
             AZStd::vector<HashedVariantInfoSourceData> m_hashedVariants;
         };

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -272,6 +272,14 @@ namespace AZ
                 //jobDescriptor.m_jobDependencyList.emplace_back(variantTreeJobDependency);
                 // ***************************************************************************
 
+                // If the *.shader file changes, all the variants need to be rebuilt.
+                AssetBuilderSDK::JobDependency shaderAssetJobDependency;
+                shaderAssetJobDependency.m_jobKey = ShaderAssetBuilder::ShaderAssetBuilderJobKey;
+                shaderAssetJobDependency.m_platformIdentifier = info.m_identifier;
+                shaderAssetJobDependency.m_sourceFile.m_sourceFileDependencyPath = shaderSourceFileFullPath;
+                shaderAssetJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+                jobDescriptor.m_jobDependencyList.emplace_back(shaderAssetJobDependency);
+                
                 // Store the shader source file full path in the job, so we don't have to recalculate it again
                 // in ProcessJob().
                 jobDescriptor.m_jobParameters.emplace(ShaderSourceFilePathJobParam, shaderSourceFileFullPath);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h>
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
 
-#include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
 #include <Atom/RPI.Edit/Shader/ShaderVariantAssetCreator.h>
 #include <Atom/RPI.Edit/Shader/ShaderVariantTreeAssetCreator.h>
 #include <Atom/RPI.Edit/Common/JsonUtils.h>
@@ -51,6 +50,7 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
+#include "HashedVariantListSourceData.h"
 #include "ShaderAssetBuilder.h"
 #include "ShaderBuilderUtility.h"
 #include "SrgLayoutUtility.h"
@@ -60,362 +60,232 @@
 #include <ShaderPlatformInterfaceRequest.h>
 #include "ShaderBuildArgumentsManager.h"
 
+
 namespace AZ
 {
     namespace ShaderBuilder
     {
         static constexpr char ShaderVariantAssetBuilderName[] = "ShaderVariantAssetBuilder";
 
-        //! Adds source file dependencies for every place a referenced file may appear, and detects if one of
-        //! those possible paths resolves to the expected file.
-        //! @param currentFilePath - the full path to the file being processed
-        //! @param referencedParentPath - the path to a reference file, which may be relative to the @currentFilePath, or may be a full asset path.
-        //! @param sourceFileDependencies - new source file dependencies will be added to this list
-        //! @param foundSourceFile - if one of the source file dependencies is found, the highest priority one will be indicated here, otherwise this will be empty.
-        //! @return true if the referenced file was found and @foundSourceFile was set
-        bool LocateReferencedSourceFile(
-            AZStd::string_view currentFilePath, AZStd::string_view referencedParentPath,
-            AZStd::vector<AssetBuilderSDK::SourceFileDependency>& sourceFileDependencies,
-            AZStd::string& foundSourceFile)
+
+        AZStd::string ShaderVariantAssetBuilder::GetShaderVariantTreeAssetJobKey()
         {
-            foundSourceFile.clear();
-
-            bool found = false;
-
-            AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDependencyPaths(currentFilePath, referencedParentPath);
-            for (auto& file : possibleDependencies)
-            {
-                AssetBuilderSDK::SourceFileDependency sourceFileDependency;
-                sourceFileDependency.m_sourceFileDependencyPath = file;
-                sourceFileDependencies.push_back(sourceFileDependency);
-
-                if (!found)
-                {
-                    AZ::Data::AssetInfo sourceInfo;
-                    AZStd::string watchFolder;
-                    AzToolsFramework::AssetSystemRequestBus::BroadcastResult(found, &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath, file.c_str(), sourceInfo, watchFolder);
-
-                    if (found)
-                    {
-                        foundSourceFile = file;
-                    }
-                }
-            }
-
-            return found;
+            return AZStd::string::format("%s_varianttree", ShaderVariantAssetBuilderJobKeyPrefix);
         }
 
-        //! Validates if a given .shadervariantlist file is located at the correct path for a given .shader full path.
-        //! There are two valid paths:
-        //! 1- Lower Precedence: The same folder where the .shader file is located.
-        //! 2- Higher Precedence: <project-path>/ShaderVariants/<Same Scan Folder Subpath as the .shader file>.
-        //! The "Higher Precedence" path gives the option to game projects to override what variants to generate. If this
-        //!     file exists then the "Lower Precedence" path is disregarded.
-        //! A .shader full path is located under an AP scan folder.
-        //! Example: "@gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR_ForwardPass.shader"
-        //!     - In this example the Scan Folder is "<atom-gem-path>/Feature/Common/Assets", while the subfolder is "Materials/Types".
-        //! The "Higher Precedence" expected valid location for the .shadervariantlist would be:
-        //!     - <GameProject>/ShaderVariants/Materials/Types/StandardPBR_ForwardPass.shadervariantlist.
-        //! The "Lower Precedence" valid location would be:
-        //!     - @gemroot:Atom_Feature_Common@/Assets/Materials/Types/StandardPBR_ForwardPass.shadervariantlist.
-        //! @shouldExitEarlyFromProcessJob [out] Set to true if ProcessJob should do no work but return successfully.
-        //!     Set to false if ProcessJob should do work and create assets.
-        //!     When @shaderVariantListFileFullPath is provided by a Gem/Feature instead of the Game Project
-        //!     We check if the game project already defined the shader variant list, and if it did it means
-        //!     ProcessJob should do no work, but return successfully nonetheless.
-        static bool ValidateShaderVariantListLocation(const AZStd::string& shaderVariantListFileFullPath,
-            const AZStd::string& shaderFileFullPath, bool& shouldExitEarlyFromProcessJob)
+
+        AZStd::string ShaderVariantAssetBuilder::GetShaderVariantAssetJobKey()
         {
-            AZStd::string scanFolderFullPath;
-            AZStd::string shaderProductFileRelativePath;
-            bool success = false;
-            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(success
-                , &AzToolsFramework::AssetSystem::AssetSystemRequest::GenerateRelativeSourcePath
-                , shaderFileFullPath, shaderProductFileRelativePath, scanFolderFullPath);
-            if (!success)
+            return AZStd::string::format("%s_variant", ShaderVariantAssetBuilderJobKeyPrefix);
+        }
+
+
+        // @param intermediateAssetRelativePath: Can be a <shaderName>.hashedvariantlist, or <shaderName>_<StableId>.hashedvariantinfo
+        // returns the absolute path of the corresponding <shaderName>.shader
+        static bool GetShaderSourceFullPath(const AZStd::string& intermediateAssetRelativePath,
+                                          AZStd::string& shaderSourceFileFullPath)
+        {
+            AZStd::string shaderRelativePath;
+
+            // Get the extension.
+            AZStd::string fileExtension;
+            AzFramework::StringFunc::Path::GetExtension(intermediateAssetRelativePath.c_str(), fileExtension, false /*includeDot*/);
+            if (fileExtension == HashedVariantListSourceData::Extension)
             {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "Couldn't get the scan folder for shader [%s]", shaderFileFullPath.c_str());
-                return false;
+                shaderRelativePath = intermediateAssetRelativePath;
+                AZ::StringFunc::Path::ReplaceExtension(shaderRelativePath, RPI::ShaderSourceData::Extension);
             }
-            AZ_TracePrintf(ShaderVariantAssetBuilderName, "For shader [%s], Scan folder full path [%s], relative file path [%s]", shaderFileFullPath.c_str(), scanFolderFullPath.c_str(), shaderProductFileRelativePath.c_str());
-
-            AZStd::string shaderVariantListFileRelativePath = shaderProductFileRelativePath;
-            AZ::StringFunc::Path::ReplaceExtension(shaderVariantListFileRelativePath, RPI::ShaderVariantListSourceData::Extension);
-
-            AZ::IO::FixedMaxPath gameProjectPath = AZ::Utils::GetProjectPath();
-
-            auto expectedHigherPrecedenceFileFullPath = (gameProjectPath
-                / RPI::ShaderVariantTreeAsset::CommonSubFolder / shaderProductFileRelativePath).LexicallyNormal();
-            expectedHigherPrecedenceFileFullPath.ReplaceExtension(AZ::RPI::ShaderVariantListSourceData::Extension);
-
-            auto normalizedShaderVariantListFileFullPath = AZ::IO::FixedMaxPath(shaderVariantListFileFullPath).LexicallyNormal();
-
-            if (expectedHigherPrecedenceFileFullPath == normalizedShaderVariantListFileFullPath)
+            else if (fileExtension == HashedVariantInfoSourceData::Extension)
             {
-                // Whenever the Game Project declares a *.shadervariantlist file we always do work.
-                shouldExitEarlyFromProcessJob = false;
-                return true;
+                size_t charPos = AZ::StringFunc::Find(intermediateAssetRelativePath, "_", 0, true /* reverse*/);
+                AZ_Assert(charPos != AZStd::string::npos, "Was expecting a file name with the pattern: <shaderName>_<StableId>.hashedvariantinfo");
+                AZStd::string pathBefore_ = intermediateAssetRelativePath.substr(0, charPos);
+                shaderRelativePath = AZStd::string::format("%s.%s", pathBefore_.c_str(), RPI::ShaderSourceData::Extension);
             }
 
-            AZ::Data::AssetInfo assetInfo;
+            // When the game project customizes a shadervariantlist for a particular shader,
+            // the path starts with ShaderVariants/ or shadervariants/, in that case the real relative path of the shader
+            // starts AFTER ShaderVariants/ or shadervariants/.
+            if (AZ::StringFunc::StartsWith(intermediateAssetRelativePath, RPI::ShaderVariantTreeAsset::CommonSubFolder, false /*case sensitive*/))
+            {
+                const auto startPos = sizeof(RPI::ShaderVariantTreeAsset::CommonSubFolder);
+                shaderRelativePath = shaderRelativePath.substr(startPos);
+            }
+
+            bool shaderSourceFound = false;
+            AZ::Data::AssetInfo sourceInfo;
             AZStd::string watchFolder;
-            bool foundHigherPrecedenceAsset = false;
-            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(foundHigherPrecedenceAsset
-                , &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath
-                , expectedHigherPrecedenceFileFullPath.c_str(), assetInfo, watchFolder);
-            if (foundHigherPrecedenceAsset)
+
+            // Try to find the source file starting at the originatingSourceFilePath, and return the full path
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                shaderSourceFound,
+                &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+                shaderRelativePath.c_str(),
+                sourceInfo,
+                watchFolder);
+            if (!shaderSourceFound)
             {
-                AZ_TracePrintf(ShaderVariantAssetBuilderName, "The shadervariantlist [%s] has been overriden by the game project with [%s]",
-                    normalizedShaderVariantListFileFullPath.c_str(), expectedHigherPrecedenceFileFullPath.c_str());
-                shouldExitEarlyFromProcessJob = true;
-                return true;
-            }
-
-            // Check the "Lower Precedence" case, .shader path == .shadervariantlist path.
-            AZ::IO::Path normalizedShaderFileFullPath = AZ::IO::Path(shaderFileFullPath).LexicallyNormal();
-
-            auto normalizedShaderFileFullPathWithoutExtension = normalizedShaderFileFullPath;
-            normalizedShaderFileFullPathWithoutExtension.ReplaceExtension("");
-
-            auto normalizedShaderVariantListFileFullPathWithoutExtension = normalizedShaderVariantListFileFullPath;
-            normalizedShaderVariantListFileFullPathWithoutExtension.ReplaceExtension("");
-
-            if (normalizedShaderFileFullPathWithoutExtension != normalizedShaderVariantListFileFullPathWithoutExtension)
-            {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "For shader file at path [%s], the shader variant list [%s] is expected to be located at [%s.%s] or [%s]"
-                    , normalizedShaderFileFullPath.c_str(), normalizedShaderVariantListFileFullPath.c_str(),
-                    normalizedShaderFileFullPathWithoutExtension.c_str(), RPI::ShaderVariantListSourceData::Extension,
-                    expectedHigherPrecedenceFileFullPath.c_str());
+                AZ_Error(ShaderVariantAssetBuilderName, false, "Failed to find shader source from relative path=[%s]", shaderRelativePath.c_str());
                 return false;
             }
-
-            shouldExitEarlyFromProcessJob = false;
-            return true;
+            return AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), shaderRelativePath.c_str(), shaderSourceFileFullPath, true);
         }
 
-        // We treat some issues as warnings and return "Success" from CreateJobs allows us to report the dependency.
-        // If/when a valid dependency file appears, that will trigger the ShaderVariantAssetBuilder to run again.
-        // Since CreateJobs will pass, we forward this message to ProcessJob which will report it as an error.
-        struct LoadResult
-        {
-            enum class Code
-            {
-                Error,
-                DeferredError,
-                Success
-            };
-
-            Code m_code;
-            AZStd::string m_deferredMessage; // Only used when m_code == DeferredError
-        };
-
-        static LoadResult LoadShaderVariantList(const AZStd::string& variantListFullPath, RPI::ShaderVariantListSourceData& shaderVariantList, AZStd::string& shaderSourceFileFullPath,
-            bool& shouldExitEarlyFromProcessJob)
-        {
-            // Need to get the name of the shader file from the template so that we can preprocess the shader data and setup
-            // source file dependencies.
-            if (!RPI::JsonUtils::LoadObjectFromFile(variantListFullPath, shaderVariantList, AZStd::numeric_limits<size_t>::max()))
-            {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "Failed to parse Shader Variant List Descriptor JSON from [%s]", variantListFullPath.c_str());
-                return LoadResult{LoadResult::Code::Error};
-            }
-
-            const AZStd::string resolvedShaderPath = AZ::RPI::AssetUtils::ResolvePathReference(variantListFullPath, shaderVariantList.m_shaderFilePath);
-            if (!AZ::IO::LocalFileIO::GetInstance()->Exists(resolvedShaderPath.c_str()))
-            {
-                return LoadResult{LoadResult::Code::DeferredError, AZStd::string::format("The shader path [%s] was not found.", resolvedShaderPath.c_str())};
-            }
-
-            shaderSourceFileFullPath = resolvedShaderPath;
-
-            if (!ValidateShaderVariantListLocation(variantListFullPath, shaderSourceFileFullPath, shouldExitEarlyFromProcessJob))
-            {
-                return LoadResult{LoadResult::Code::Error};
-            }
-
-            if (shouldExitEarlyFromProcessJob)
-            {
-                return LoadResult{LoadResult::Code::Success};
-            }
-
-            auto resultOutcome = RPI::ShaderVariantTreeAssetCreator::ValidateStableIdsAreUnique(shaderVariantList.m_shaderVariants);
-            if (!resultOutcome.IsSuccess())
-            {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "Variant info validation error: %s", resultOutcome.GetError().c_str());
-                return LoadResult{LoadResult::Code::Error};
-            }
-
-            if (!IO::FileIOBase::GetInstance()->Exists(shaderSourceFileFullPath.c_str()))
-            {
-                return LoadResult{LoadResult::Code::DeferredError, AZStd::string::format("ShaderSourceData file does not exist: %s.", shaderSourceFileFullPath.c_str())};
-            }
-
-            return LoadResult{LoadResult::Code::Success};
-        } // LoadShaderVariantListAndAzslSource
 
         void ShaderVariantAssetBuilder::CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response) const
         {
-            AZStd::string variantListFullPath;
-            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), variantListFullPath, true);
+            // Please see comments in the header file for the core principles of this builder.
 
-            AZ_TracePrintf(ShaderVariantAssetBuilderName, "CreateJobs for Shader Variant List \"%s\"\n", variantListFullPath.data());
+            // Is this a *.hashedvariantlist? if so We need to create the ShaderVariantTreeAsset
+            AZStd::string fileExtension;
+            AzFramework::StringFunc::Path::GetExtension(request.m_sourceFile.c_str(), fileExtension, false /*includeDot*/);
+            if (fileExtension == HashedVariantListSourceData::Extension)
+            {
+                CreateShaderVariantTreeJobs(request, response);
+                return;
+            }
+            else if (fileExtension == HashedVariantInfoSourceData::Extension)
+            {
+                CreateShaderVariantJobs(request, response);
+                return;
+            }
 
-            RPI::ShaderVariantListSourceData shaderVariantList;
+            AZ_Error(ShaderVariantAssetBuilderName, false, "Unsupported file extension: %s", fileExtension.c_str());
+            response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
+        }  // CreateJobs
+
+
+        void ShaderVariantAssetBuilder::CreateShaderVariantTreeJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response) const
+        {
+            //AZStd::string variantListWatchFolderPath(request.m_watchFolder.data());
+            AZStd::string variantListRelativePath(request.m_sourceFile.data());
+            AZStd::string hashedVariantListFullPath;
+            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), hashedVariantListFullPath, true);
+
+            AZ_TracePrintf(ShaderVariantAssetBuilderName, "CreateShaderVariantTreeJob for Hashed Shader Variant List \"%s\"\n", hashedVariantListFullPath.data());
+
             AZStd::string shaderSourceFileFullPath;
-            bool shouldExitEarlyFromProcessJob = false;
-            const LoadResult loadResult = LoadShaderVariantList(variantListFullPath, shaderVariantList, shaderSourceFileFullPath, shouldExitEarlyFromProcessJob);
-
-            if (loadResult.m_code == LoadResult::Code::Error)
+            if (!GetShaderSourceFullPath(variantListRelativePath, shaderSourceFileFullPath))
             {
                 response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
                 return;
             }
 
-            // Even if the shader file doesn't exist yet, when calling LocateReferencedSourceFile() the source
-            // asset dependency list will be populated. This will cause to re-run this builder
-            // when the source *.shader file comes into existence.
-            AZStd::string foundShaderFile;
-            LocateReferencedSourceFile(variantListFullPath, shaderVariantList.m_shaderFilePath, response.m_sourceFileDependencyList, foundShaderFile);
-
-            if (loadResult.m_code == LoadResult::Code::DeferredError || shouldExitEarlyFromProcessJob)
-            {
-                for (const AssetBuilderSDK::PlatformInfo& info : request.m_enabledPlatforms)
-                {
-                    // Let's create fake jobs that will fail ProcessJob, but are useful to establish dependency on the shader file.
-                    AssetBuilderSDK::JobDescriptor jobDescriptor;
-
-                    jobDescriptor.m_priority = -5000;
-                    jobDescriptor.m_critical = false;
-                    // We are going to create a fake job that we know will fail.
-                    // We need to use a job key of a real product (In this case we are using the job key for the ShaderVariantTreeAsset).
-                    // Using a real product job key will guarantee to clear old errors in the future, because a successful product build will
-                    // replace the lingering error thanks to matching job keys.
-                    jobDescriptor.m_jobKey = GetShaderVariantTreeAssetJobKey();
-                    jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
-                    
-                    if (!foundShaderFile.empty())
-                    {
-                        AssetBuilderSDK::JobDependency jobDependency;
-                        jobDependency.m_jobKey = ShaderAssetBuilder::ShaderAssetBuilderJobKey;
-                        jobDependency.m_platformIdentifier = info.m_identifier;
-                        jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                        jobDependency.m_sourceFile.m_sourceFileDependencyPath = foundShaderFile;
-                        jobDescriptor.m_jobDependencyList.push_back(jobDependency);
-                    }
-
-                    if (loadResult.m_code == LoadResult::Code::DeferredError)
-                    {
-                        jobDescriptor.m_jobParameters.emplace(ShaderVariantLoadErrorParam, loadResult.m_deferredMessage);
-                    }
-
-                    if (shouldExitEarlyFromProcessJob)
-                    {
-                        // The value doesn't matter, what matters is the presence of the key which will
-                        // signal that no assets should be produced on behalf of this shadervariantlist because
-                        // the game project overrode it.
-                        jobDescriptor.m_jobParameters.emplace(ShouldExitEarlyFromProcessJobParam, variantListFullPath);
-                    }
-
-                    response.m_createJobOutputs.push_back(jobDescriptor);
-                }
-                response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
-                return;
-            }
-            
             for (const AssetBuilderSDK::PlatformInfo& info : request.m_enabledPlatforms)
             {
                 AZ_TraceContext("For platform", info.m_identifier.data());
 
-                // First job is for the ShaderVariantTreeAsset.
-                {
-                    AssetBuilderSDK::JobDescriptor jobDescriptor;
-                
-                    // The ShaderVariantTreeAsset is high priority, but must be generated after the ShaderAsset 
-                    jobDescriptor.m_priority = 1;
-                    jobDescriptor.m_critical = false;
-                
-                    jobDescriptor.m_jobKey = GetShaderVariantTreeAssetJobKey();
-                    jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
+                AssetBuilderSDK::JobDescriptor jobDescriptor;
 
-                    if (!foundShaderFile.empty())
-                    {
-                        AssetBuilderSDK::JobDependency jobDependency;
-                        jobDependency.m_jobKey = ShaderAssetBuilder::ShaderAssetBuilderJobKey;
-                        jobDependency.m_platformIdentifier = info.m_identifier;
-                        jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                        jobDependency.m_sourceFile.m_sourceFileDependencyPath = foundShaderFile;
-                        jobDescriptor.m_jobDependencyList.push_back(jobDependency);
-                    }
-                
-                    jobDescriptor.m_jobParameters.emplace(ShaderSourceFilePathJobParam, shaderSourceFileFullPath);
-                
-                    response.m_createJobOutputs.push_back(jobDescriptor);
-                }
+                // The ShaderVariantTreeAsset is high priority, but must be generated after the ShaderAsset 
+                jobDescriptor.m_priority = 1;
+                jobDescriptor.m_critical = false;
 
-                // One job for each variant. Each job will produce one ".azshadervariant" per RHI per supervariant.
-                for (const AZ::RPI::ShaderVariantListSourceData::VariantInfo& variantInfo : shaderVariantList.m_shaderVariants)
-                {
-                    AZStd::string variantInfoAsJsonString;
-                    [[maybe_unused]] const bool convertSuccess = AZ::RPI::JsonUtils::SaveObjectToJsonString(variantInfo, variantInfoAsJsonString);
-                    AZ_Assert(convertSuccess, "Failed to convert VariantInfo to json string");
+                jobDescriptor.m_jobKey = GetShaderVariantTreeAssetJobKey();
+                jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
 
-                    AssetBuilderSDK::JobDescriptor jobDescriptor;
+                // Declare job dependency on the .azshader, this way the ShaderAsset must be built before
+                // the ShaderVariantTreeAsset.
+                AssetBuilderSDK::JobDependency jobDependency;
+                jobDependency.m_jobKey = ShaderAssetBuilder::ShaderAssetBuilderJobKey;
+                jobDependency.m_platformIdentifier = info.m_identifier;
+                jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+                jobDependency.m_sourceFile.m_sourceFileDependencyPath = shaderSourceFileFullPath;
+                jobDescriptor.m_jobDependencyList.push_back(jobDependency);
 
-                    // There can be tens/hundreds of thousands of shader variants. By default each shader will get
-                    // a root variant that can be used at runtime. In order to prevent the AssetProcessor from
-                    // being overtaken by shader variant compilation We mark all non-root shader variant generation
-                    // as non critical and very low priority.
-                    jobDescriptor.m_priority = -5000;
-                    jobDescriptor.m_critical = false;
+                // Store the shader source file full path in the job, so we don't have to recalculate it again
+                // in ProcessJob().
+                jobDescriptor.m_jobParameters.emplace(ShaderSourceFilePathJobParam, shaderSourceFileFullPath);
 
-                    jobDescriptor.m_jobKey = GetShaderVariantAssetJobKey(RPI::ShaderVariantStableId{variantInfo.m_stableId});
-                    jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
-
-                    // The ShaderVariantAssets are job dependent on the ShaderVariantTreeAsset.
-                    AssetBuilderSDK::SourceFileDependency fileDependency;
-                    fileDependency.m_sourceFileDependencyPath = variantListFullPath;
-                    AssetBuilderSDK::JobDependency variantTreeJobDependency;
-                    variantTreeJobDependency.m_jobKey = GetShaderVariantTreeAssetJobKey();
-                    variantTreeJobDependency.m_platformIdentifier = info.m_identifier;
-                    variantTreeJobDependency.m_sourceFile = fileDependency;
-                    variantTreeJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                    jobDescriptor.m_jobDependencyList.emplace_back(variantTreeJobDependency);
-
-                    jobDescriptor.m_jobParameters.emplace(ShaderVariantJobVariantParam, variantInfoAsJsonString);
-                    jobDescriptor.m_jobParameters.emplace(ShaderSourceFilePathJobParam, shaderSourceFileFullPath);
-
-                    response.m_createJobOutputs.push_back(jobDescriptor);
-                }
+                response.m_createJobOutputs.push_back(jobDescriptor);
 
             }
             response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
-        }  // CreateJobs
+        }
+
+
+        // For a file with the following name: <shaderName>_<StableId>.hashedvariantinfo
+        // returns the absolute path that looks like: <shaderName>.hashedvariantlist
+        static AZStd::string GetHashedVariantListPathFromVariantInfoPath(const AZStd::string& hashedVariantInfoParentPath, const AZStd::string& hashedVariantInfoRelativePath)
+        {
+            size_t charPos = AZ::StringFunc::Find(hashedVariantInfoRelativePath, "_", 0, true /* reverse*/);
+            AZStd::string pathBefore_ = hashedVariantInfoRelativePath.substr(0, charPos);
+            return AZStd::string::format("%s%s%s.%s", hashedVariantInfoParentPath.c_str(), AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING, pathBefore_.c_str(), HashedVariantListSourceData::Extension);
+        }
+
+
+        void ShaderVariantAssetBuilder::CreateShaderVariantJobs([[maybe_unused]] const AssetBuilderSDK::CreateJobsRequest& request,
+                                                               [[maybe_unused]] AssetBuilderSDK::CreateJobsResponse& response) const
+        {
+
+            AZStd::string hashedVariantInfoRelativePath(request.m_sourceFile.data());
+            AZStd::string hashedVariantInfoFullPath;
+            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), hashedVariantInfoFullPath, true);
+            
+            AZ_TracePrintf(ShaderVariantAssetBuilderName, "CreateShaderVariantJobs for Hashed Variant Info [%s]\n", hashedVariantInfoFullPath.data());
+            
+            AZStd::string shaderSourceFileFullPath;
+            if (!GetShaderSourceFullPath(hashedVariantInfoRelativePath, shaderSourceFileFullPath))
+            {
+                response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
+                return;
+            }
+
+            AZStd::string hashedVariantInfoParentPath(request.m_watchFolder.data());
+            AZStd::string hashedVariantListFullPath = GetHashedVariantListPathFromVariantInfoPath(hashedVariantInfoParentPath, hashedVariantInfoRelativePath);
+            
+            for (const AssetBuilderSDK::PlatformInfo& info : request.m_enabledPlatforms)
+            {
+                AZ_TraceContext("For platform", info.m_identifier.data());
+            
+                AssetBuilderSDK::JobDescriptor jobDescriptor;
+            
+                // There can be tens/hundreds of thousands of shader variants. By default each shader will get
+                // a root variant that can be used at runtime. In order to prevent the AssetProcessor from
+                // being overwhelmed by shader variant compilation We mark all non-root shader variant generation
+                // as non critical and very low priority.
+                jobDescriptor.m_priority = -5000;
+                jobDescriptor.m_critical = false;
+            
+                jobDescriptor.m_jobKey = GetShaderVariantAssetJobKey();
+                jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
+            
+                // The ShaderVariantAssets should be built AFTER the ShaderVariantTreeAsset.
+                // But unfortunately we can not declare job dependency because it will cause
+                // recompilation of all ShaderVariantAssets whenever the ShaderVariantTreeAsset
+                // changes.
+                // Ideally, what we need is a mode for job dependencies which says:
+                // "make sure X completes before Y runs, but don't re-run Y just because X ran".
+                //
+                // Temporary workaround: We set the job priority to -5000 (very low) for ShaderVariantAssets
+                // and job priority 1 (very high) for ShaderVariantTreeAssets.
+                //
+                // TODO: Add "OrderOnly" job dependency type to the Asset System so we can:
+                //  "make sure X completes before Y runs, but don't re-run Y just because X ran".
+                // 
+                // **************************************************************************
+                //AssetBuilderSDK::JobDependency variantTreeJobDependency;
+                //variantTreeJobDependency.m_jobKey = GetShaderVariantTreeAssetJobKey();
+                //variantTreeJobDependency.m_platformIdentifier = info.m_identifier;
+                //variantTreeJobDependency.m_sourceFile.m_sourceFileDependencyPath = hashedVariantListFullPath;
+                //variantTreeJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+                //jobDescriptor.m_jobDependencyList.emplace_back(variantTreeJobDependency);
+                // ***************************************************************************
+
+                // Store the shader source file full path in the job, so we don't have to recalculate it again
+                // in ProcessJob().
+                jobDescriptor.m_jobParameters.emplace(ShaderSourceFilePathJobParam, shaderSourceFileFullPath);
+            
+                response.m_createJobOutputs.push_back(jobDescriptor);
+            
+            }
+            response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
+
+        }
+
 
         void ShaderVariantAssetBuilder::ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const
         {
-            const auto& jobParameters = request.m_jobDescription.m_jobParameters;
-
-            if (jobParameters.contains(ShaderVariantLoadErrorParam))
-            {
-                AZ_Error(ShaderVariantAssetBuilderName, false, "Error during CreateJobs: %s", jobParameters.at(ShaderVariantLoadErrorParam).c_str());
-                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
-                return;
-            }
-            
-            if (jobParameters.contains(ShouldExitEarlyFromProcessJobParam))
-            {
-                AZ_TracePrintf(ShaderVariantAssetBuilderName, "Doing nothing on behalf of [%s] because it's been overridden by game project.", jobParameters.at(ShouldExitEarlyFromProcessJobParam).c_str());
-                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
-                return;
-            }
-
-            AssetBuilderSDK::JobCancelListener jobCancelListener(request.m_jobId);
-            if (jobCancelListener.IsCancelled())
-            {
-                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Cancelled;
-                return;
-            }
-
             if (request.m_jobDescription.m_jobKey == GetShaderVariantTreeAssetJobKey())
             {
                 ProcessShaderVariantTreeJob(request, response);
@@ -490,7 +360,8 @@ namespace AZ
                 return;
             }
         }
-    
+
+
         static bool LoadSrgLayoutListFromShaderAssetBuilder(
             const RHI::ShaderPlatformInterface* shaderPlatformInterface,
             const AssetBuilderSDK::PlatformInfo& platformInfo,
@@ -548,7 +419,8 @@ namespace AZ
             
             return true;
         }
-    
+
+
         static bool LoadBindingDependenciesFromShaderAssetBuilder(
             const RHI::ShaderPlatformInterface* shaderPlatformInterface,
             const AssetBuilderSDK::PlatformInfo& platformInfo,
@@ -608,27 +480,41 @@ namespace AZ
             return hlslSourceOutcome.TakeValue();
         }
 
+
         void ShaderVariantAssetBuilder::ProcessShaderVariantTreeJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const
         {
-            AZStd::string variantListFullPath;
-            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), variantListFullPath, true);
-
-            RPI::ShaderVariantListSourceData shaderVariantListDescriptor;
-            if (!RPI::JsonUtils::LoadObjectFromFile(variantListFullPath, shaderVariantListDescriptor, AZStd::numeric_limits<size_t>::max()))
+            AssetBuilderSDK::JobCancelListener jobCancelListener(request.m_jobId);
+            if (jobCancelListener.IsCancelled())
             {
-                AZ_Assert(false, "Failed to parse Shader Variant List Descriptor JSON [%s]", variantListFullPath.c_str());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Cancelled;
+                return;
+            }
+
+            AZStd::string hashedVariantListFullPath;
+            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), hashedVariantListFullPath, true);
+
+            HashedVariantListSourceData hashedVariantListDescriptor;
+            if (!RPI::JsonUtils::LoadObjectFromFile(hashedVariantListFullPath, hashedVariantListDescriptor, AZStd::numeric_limits<size_t>::max()))
+            {
+                AZ_Assert(false, "Failed to parse Hashed Variant List Descriptor JSON [%s]", hashedVariantListFullPath.c_str());
                 response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
                 return;
             }
 
-            const AZStd::string& shaderSourceFileFullPath = request.m_jobDescription.m_jobParameters.at(ShaderSourceFilePathJobParam);
+            const auto& jobParameters = request.m_jobDescription.m_jobParameters;
+            const AZStd::string& shaderSourceFileFullPath = jobParameters.at(ShaderSourceFilePathJobParam);
 
-            //For debugging purposes will create a dummy azshadervarianttree file.
             AZStd::string shaderName;
             AZ::StringFunc::Path::GetFileName(shaderSourceFileFullPath.c_str(), shaderName);
 
-            // No error checking because the same calls were already executed during CreateJobs()
             auto descriptorParseOutcome = ShaderBuilderUtility::LoadShaderDataJson(shaderSourceFileFullPath);
+            if (!descriptorParseOutcome.IsSuccess())
+            {
+                AZ_Assert(false, "Failed to parse shader file [%s]", shaderSourceFileFullPath.c_str());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+                return;
+            }
+
             RPI::ShaderSourceData shaderSourceDescriptor = descriptorParseOutcome.TakeValue();
             RPI::Ptr<RPI::ShaderOptionGroupLayout> shaderOptionGroupLayout;
 
@@ -673,10 +559,17 @@ namespace AZ
                 previousLoopApiName = thisLoopApiName;
             }
 
+            AZStd::vector<RPI::ShaderVariantListSourceData::VariantInfo> variantInfos;
+            variantInfos.reserve(hashedVariantListDescriptor.m_hashedVariants.size());
+            for (const auto& hashedVariantInfo : hashedVariantListDescriptor.m_hashedVariants)
+            {
+                variantInfos.push_back(hashedVariantInfo.m_variantInfo);
+            }
+            
             RPI::ShaderVariantTreeAssetCreator shaderVariantTreeAssetCreator;
             shaderVariantTreeAssetCreator.Begin(Uuid::CreateRandom());
             shaderVariantTreeAssetCreator.SetShaderOptionGroupLayout(*shaderOptionGroupLayout);
-            shaderVariantTreeAssetCreator.SetVariantInfos(shaderVariantListDescriptor.m_shaderVariants);
+            shaderVariantTreeAssetCreator.SetVariantInfos(variantInfos);
             Data::Asset<RPI::ShaderVariantTreeAsset> shaderVariantTreeAsset;
             if (!shaderVariantTreeAssetCreator.End(shaderVariantTreeAsset))
             {
@@ -708,24 +601,28 @@ namespace AZ
  
         }
 
+
         void ShaderVariantAssetBuilder::ProcessShaderVariantJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const
         {
             AssetBuilderSDK::JobCancelListener jobCancelListener(request.m_jobId);
 
-            AZStd::string fullPath;
-            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), fullPath, true);
+            AZStd::string hashedVariantInfoFullPath;
+            AZ::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), hashedVariantInfoFullPath, true);
+
+            HashedVariantInfoSourceData hashedVariantInfoDescriptor;
+            if (!RPI::JsonUtils::LoadObjectFromFile(hashedVariantInfoFullPath, hashedVariantInfoDescriptor, AZStd::numeric_limits<size_t>::max()))
+            {
+                AZ_Assert(false, "Failed to parse Hashed Variant Info Descriptor JSON [%s]", hashedVariantInfoFullPath.c_str());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+                return;
+            }
+
+            const RPI::ShaderVariantListSourceData::VariantInfo& variantInfo = hashedVariantInfoDescriptor.m_variantInfo;
 
             const auto& jobParameters = request.m_jobDescription.m_jobParameters;
             const AZStd::string& shaderSourceFileFullPath = jobParameters.at(ShaderSourceFilePathJobParam);
-            auto descriptorParseOutcome = ShaderBuilderUtility::LoadShaderDataJson(shaderSourceFileFullPath);
-            RPI::ShaderSourceData shaderSourceData = descriptorParseOutcome.TakeValue();
             AZStd::string shaderFileName;
             AZ::StringFunc::Path::GetFileName(shaderSourceFileFullPath.c_str(), shaderFileName);
-
-            const AZStd::string& variantJsonString = jobParameters.at(ShaderVariantJobVariantParam);
-            RPI::ShaderVariantListSourceData::VariantInfo variantInfo;
-            [[maybe_unused]] const bool fromJsonStringSuccess = AZ::RPI::JsonUtils::LoadObjectFromJsonString(variantJsonString, variantInfo);
-            AZ_Assert(fromJsonStringSuccess, "Failed to convert json string to VariantInfo");
 
             RPI::ShaderSourceData shaderSourceDescriptor;
             AZStd::shared_ptr<ShaderFiles> sources = ShaderBuilderUtility::PrepareSourceInput(ShaderVariantAssetBuilderName, shaderSourceFileFullPath, shaderSourceDescriptor);
@@ -768,7 +665,7 @@ namespace AZ
                 AZ_TraceContext("Platform API", apiName);
 
                 buildArgsManager.PushArgumentScope(apiName);
-                buildArgsManager.PushArgumentScope(shaderSourceData.m_removeBuildArguments, shaderSourceData.m_addBuildArguments, shaderSourceData.m_definitions);
+                buildArgsManager.PushArgumentScope(shaderSourceDescriptor.m_removeBuildArguments, shaderSourceDescriptor.m_addBuildArguments, shaderSourceDescriptor.m_definitions);
 
                 // Loop through all the Supervariants.
                 uint32_t supervariantIndexCounter = 0;
@@ -789,7 +686,7 @@ namespace AZ
                     AZStd::string shaderStemNamePrefix = shaderFileName;
                     if (supervariantIndex.GetIndex() > 0)
                     {
-                        shaderStemNamePrefix += supervariantInfo.m_name.GetStringView();
+                        shaderStemNamePrefix += AZStd::string::format("-%s", supervariantInfo.m_name.GetCStr());
                     }
 
                     // We need these additional pieces of information To build a shader variant asset:
@@ -895,7 +792,7 @@ namespace AZ
                     // Preserve the Temp folder when shaders are compiled with debug symbols
                     // or because the ShaderSourceData has m_keepTempFolder set to true.
                     response.m_keepTempFolder |= shaderVariantCreationContext.m_shaderBuildArguments.m_generateDebugInfo
-                        || shaderSourceData.m_keepTempFolder || RHI::IsGraphicsDevModeEnabled();
+                        || shaderSourceDescriptor.m_keepTempFolder || RHI::IsGraphicsDevModeEnabled();
 
                     AZStd::optional<RHI::ShaderPlatformInterface::ByProducts> outputByproducts;
                     auto shaderVariantAssetOutcome = CreateShaderVariantAsset(variantInfo, shaderVariantCreationContext, outputByproducts);
@@ -947,6 +844,7 @@ namespace AZ
 
             response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
         }
+
 
         bool ShaderVariantAssetBuilder::SerializeOutShaderVariantAsset(
             const Data::Asset<RPI::ShaderVariantAsset> shaderVariantAsset, const AZStd::string& shaderStemNamePrefix,
@@ -1181,6 +1079,7 @@ namespace AZ
             variantCreator.End(shaderVariantAsset);
             return AZ::Success(AZStd::move(shaderVariantAsset));
         }
+
 
         bool ShaderVariantAssetBuilder::LaunchRadeonGPUAnalyzer(AZStd::vector<AZStd::string> command, const AZStd::string& workingDirectory, AZStd::string& failMessage)
         {

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.h
@@ -48,13 +48,24 @@ namespace AZ
             const AZStd::string& m_hlslSourceContent;
         };
 
+
+        // This builder listens for two file extensions:
+        // *.hashedvariantlist -> This file contains the whole list of variants that is used
+        //     to create the ShaderVariantTreeAsset (*.azshadervarianttree) per Supervariant listed in the
+        //     source *.shader file. This job will declare job dependency on the ShaderAsset + root
+        //     ShaderVariantAsset that are produced by the ShaderAssetBuilder.
+        // *.hashedvariantinfo -> This file contains the description of a single shader variant. One job
+        //     will be issued for each one of these files. This job will declare job dependency on
+        //     the ShaderVarianTreeAsset mentioned above. In turn, each one of these jobs will produce one
+        //     ShaderVariantAsset (*.azshadervariant) per RHI, AND per Supervariant listed in the source
+        //     *.shader
         class ShaderVariantAssetBuilder
             : public AssetBuilderSDK::AssetBuilderCommandBus::Handler
         {
         public:
             AZ_TYPE_INFO(ShaderVariantAssetBuilder, "{C959AEC2-2083-4488-AD88-F61B1144535B}");
 
-            static constexpr char ShaderVariantAssetBuilderJobKey[] = "Shader Variant Asset";
+            static constexpr char ShaderVariantAssetBuilderJobKeyPrefix[] = "Shader Variant Asset";
 
             ShaderVariantAssetBuilder() = default;
             ~ShaderVariantAssetBuilder() = default;
@@ -82,10 +93,13 @@ namespace AZ
         private:
             AZ_DISABLE_COPY_MOVE(ShaderVariantAssetBuilder);
 
-            static constexpr uint32_t ShaderVariantLoadErrorParam = 0;
-            static constexpr uint32_t ShaderSourceFilePathJobParam = 2;
-            static constexpr uint32_t ShaderVariantJobVariantParam = 3;
-            static constexpr uint32_t ShouldExitEarlyFromProcessJobParam = 4;
+            static constexpr uint32_t ShaderSourceFilePathJobParam = 1;
+
+            void CreateShaderVariantTreeJobs(const AssetBuilderSDK::CreateJobsRequest& request
+                , AssetBuilderSDK::CreateJobsResponse& response) const;
+
+            void CreateShaderVariantJobs(const AssetBuilderSDK::CreateJobsRequest& request
+                , AssetBuilderSDK::CreateJobsResponse& response) const;
 
             //! Called from ProcessJob when the job is supposed to create a ShaderVariantTreeAsset.
             void ProcessShaderVariantTreeJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const;
@@ -97,8 +111,8 @@ namespace AZ
             // Launch rga.exe with ProcessLauncher
             static bool LaunchRadeonGPUAnalyzer(AZStd::vector<AZStd::string> command, const AZStd::string& workingDirectory, AZStd::string& failMessage);
 
-            static AZStd::string GetShaderVariantTreeAssetJobKey() { return AZStd::string::format("%s_varianttree", ShaderVariantAssetBuilderJobKey); }
-            static AZStd::string GetShaderVariantAssetJobKey(RPI::ShaderVariantStableId variantStableId) { return AZStd::string::format("%s_variant_%u", ShaderVariantAssetBuilderJobKey, variantStableId.GetIndex()); }
+            static AZStd::string GetShaderVariantTreeAssetJobKey();
+            static AZStd::string GetShaderVariantAssetJobKey();
 
         };
 

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
@@ -146,13 +146,13 @@ namespace AZ
             AZ_Trace(ShaderVariantListBuilderName, "For shader [%s], Scan folder full path [%s], relative file path [%s]", shaderAbsolutePath.c_str(), scanFolderFullPath.c_str(), shaderProductFileRelativePath.c_str());
 
             AZStd::string shaderVariantListFileRelativePath = shaderProductFileRelativePath;
-            AZ::StringFunc::Path::ReplaceExtension(shaderVariantListFileRelativePath, ShaderVariantListBuilder::Extension);// Will be RPI::ShaderVariantListSourceData::Extension);
+            AZ::StringFunc::Path::ReplaceExtension(shaderVariantListFileRelativePath, RPI::ShaderVariantListSourceData::Extension);
 
             AZ::IO::FixedMaxPath gameProjectPath = AZ::Utils::GetProjectPath();
 
             auto expectedHigherPrecedenceFileFullPath = (gameProjectPath
                 / RPI::ShaderVariantTreeAsset::CommonSubFolder / shaderProductFileRelativePath).LexicallyNormal();
-            expectedHigherPrecedenceFileFullPath.ReplaceExtension(ShaderVariantListBuilder::Extension);// Will be AZ::RPI::ShaderVariantListSourceData::Extension);
+            expectedHigherPrecedenceFileFullPath.ReplaceExtension(RPI::ShaderVariantListSourceData::Extension);
 
             auto normalizedShaderVariantListFileFullPath = AZ::IO::FixedMaxPath(shaderVariantListAbsolutePath).LexicallyNormal();
 
@@ -190,7 +190,7 @@ namespace AZ
             {
                 AZ_Error(ShaderVariantListBuilderName, false, "For shader file at path [%s], the shader variant list [%s] is expected to be located at [%s.%s] or [%s]"
                     , normalizedShaderFileFullPath.c_str(), normalizedShaderVariantListFileFullPath.c_str(),
-                    normalizedShaderFileFullPathWithoutExtension.c_str(), ShaderVariantListBuilder::Extension, // Will be RPI::ShaderVariantListSourceData::Extension,
+                    normalizedShaderFileFullPathWithoutExtension.c_str(), RPI::ShaderVariantListSourceData::Extension,
                     expectedHigherPrecedenceFileFullPath.c_str());
                 return false;
             }

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
@@ -76,6 +76,13 @@ namespace AZ
 
         static constexpr char ShaderVariantListBuilderName[] = "ShaderVariantListBuilder";
 
+        //! Searches recursively inside @parentFolder, for @relativePath and discovers the correct casing
+        //! For each component of @relativePath
+        static AZStd::string GetRelativePathWithCorrectCasing(const AZStd::string& parentFolder, const AZStd::string& relativePath)
+        {
+            if (relativePath.)
+        }
+
         //! Adds source file dependencies for every place a referenced file may appear, and detects if one of
         //! those possible paths resolves to the expected file.
         //! @param variantListFullpath - The full path to the shader variant list file being processed.

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
@@ -36,12 +36,14 @@ namespace AZ
             {
                 serializeContext->Class<HashedVariantInfoSourceData>()
                     ->Version(1)
+                    ->Field("ShaderPath", &HashedVariantInfoSourceData::m_shaderPath)
                     ->Field("VariantInfo", &HashedVariantInfoSourceData::m_variantInfo)
                     ->Field("Hash", &HashedVariantInfoSourceData::m_hash)
                     ;
 
                 serializeContext->Class<HashedVariantListSourceData>()
                     ->Version(1)
+                    ->Field("ShaderPath", &HashedVariantListSourceData::m_shaderPath)
                     ->Field("HashedVariants", &HashedVariantListSourceData::m_hashedVariants)
                     ;
             }
@@ -75,13 +77,6 @@ namespace AZ
         }
 
         static constexpr char ShaderVariantListBuilderName[] = "ShaderVariantListBuilder";
-
-        //! Searches recursively inside @parentFolder, for @relativePath and discovers the correct casing
-        //! For each component of @relativePath
-        static AZStd::string GetRelativePathWithCorrectCasing(const AZStd::string& parentFolder, const AZStd::string& relativePath)
-        {
-            if (relativePath.)
-        }
 
         //! Adds source file dependencies for every place a referenced file may appear, and detects if one of
         //! those possible paths resolves to the expected file.
@@ -151,9 +146,6 @@ namespace AZ
                 return false;
             }
             AZ_Trace(ShaderVariantListBuilderName, "For shader [%s], Scan folder full path [%s], relative file path [%s]", shaderAbsolutePath.c_str(), scanFolderFullPath.c_str(), shaderProductFileRelativePath.c_str());
-
-            AZStd::string shaderVariantListFileRelativePath = shaderProductFileRelativePath;
-            AZ::StringFunc::Path::ReplaceExtension(shaderVariantListFileRelativePath, RPI::ShaderVariantListSourceData::Extension);
 
             AZ::IO::FixedMaxPath gameProjectPath = AZ::Utils::GetProjectPath();
 
@@ -426,6 +418,16 @@ namespace AZ
             }
             variantListFullPath = jobParameters.at(ShaderVariantListAbsolutePathJobParam);
 
+            //ShaderAbsolutePathJobParam
+            AZStd::string shaderFullPath;
+            if (!jobParameters.contains(ShaderAbsolutePathJobParam))
+            {
+                AZ_Error(ShaderVariantListBuilderName, false, "Missing job Parameter: ShaderAbsolutePathJobParam");
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+                return;
+            }
+            shaderFullPath = jobParameters.at(ShaderAbsolutePathJobParam);
+
             AssetBuilderSDK::JobCancelListener jobCancelListener(request.m_jobId);
             if (jobCancelListener.IsCancelled())
             {
@@ -454,6 +456,7 @@ namespace AZ
             // content but have different StableIds. If two variants with different StableId has the same content this will be an error.
             AZStd::unordered_map<size_t, uint32_t> hashToStableIdMap;
             HashedVariantListSourceData hashedVariantList;
+            hashedVariantList.m_shaderPath = shaderFullPath;
             for (const auto& variantInfo : shaderVariantList.m_shaderVariants)
             {
                 size_t optionValuesHash = HashedVariantInfoSourceData::HashCombineShaderOptionValues(0, variantInfo.m_options);
@@ -467,6 +470,7 @@ namespace AZ
                 hashToStableIdMap.emplace(optionValuesHash, variantInfo.m_stableId);
             
                 HashedVariantInfoSourceData hashedVariantInfo;
+                hashedVariantInfo.m_shaderPath = shaderFullPath;
                 hashedVariantInfo.m_variantInfo = variantInfo;
                 hashedVariantInfo.CalculateHash(optionValuesHash);
                 hashedVariantList.m_hashedVariants.emplace_back(AZStd::move(hashedVariantInfo));

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.h
@@ -38,11 +38,6 @@ namespace AZ
         public:
             AZ_TYPE_INFO_WITH_NAME_DECL(ShaderVariantListBuilder);
 
-            // TODO. Because we are merging this code in phases, we start with the "shadervariantlist2"
-            // extension which is the same "shadervariantlist" file format the we all know and love.
-            // Later we'll do another PR that actually referenced the "shadervariantlist" extension.
-            static constexpr char Extension[] = "shadervariantlist2";
-
             static constexpr char JobKey[] = "HashedShaderVariantList";
 
             ShaderVariantListBuilder() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderVariantAsyncLoader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderVariantAsyncLoader.h
@@ -59,7 +59,7 @@ namespace AZ
             // IShaderVariantFinder overrides
             bool QueueLoadShaderVariantAssetByVariantId(Data::Asset<ShaderAsset> shaderAsset, const ShaderVariantId& shaderVariantId, SupervariantIndex supervariantIndex) override;
             bool QueueLoadShaderVariantTreeAsset(const Data::AssetId& shaderAssetId) override;
-            bool QueueLoadShaderVariantAsset(const Data::AssetId& shaderVariantTreeAssetId, ShaderVariantStableId variantStableId, SupervariantIndex supervariantIndex) override;
+            bool QueueLoadShaderVariantAsset(const Data::AssetId& shaderVariantTreeAssetId, ShaderVariantStableId variantStableId, const AZ::Name& supervariantName) override;
 
             Data::Asset<ShaderVariantAsset> GetShaderVariantAssetByVariantId(
                 Data::Asset<ShaderAsset> shaderAsset, const ShaderVariantId& shaderVariantId, SupervariantIndex supervariantIndex) override;
@@ -99,7 +99,7 @@ namespace AZ
             //! in the asset database AND a request to load such asset is properly queued.
             bool TryToLoadShaderVariantTreeAsset(const Data::AssetId& shaderAssetId);
 
-            bool TryToLoadShaderVariantAsset(const Data::AssetId& shaderVariantAssetId);
+            bool TryToLoadShaderVariantAsset(const Data::AssetId& shaderVariantAssetId, const Data::AssetId& shaderVariantTreeAssetId);
 
 
             //! A thread that runs forever servicing shader variant and trees load requests.
@@ -114,17 +114,25 @@ namespace AZ
             //! This is a list of AssetId of ShaderAsset (Do not confuse with the AssetId ShaderVariantTreeAsset).
             AZStd::vector<Data::AssetId> m_shaderVariantTreePendingRequests;
 
-            //! This is a list of AssetId of ShaderVariantAsset.
-            AZStd::vector<Data::AssetId> m_shaderVariantPendingRequests;
+            //! This is a list of ShaderVariantAsset::AssetId + ShaderVariantTreeAsset::AssetId
+            AZStd::vector<AZStd::pair<Data::AssetId, Data::AssetId>> m_shaderVariantPendingRequests;
+
+            // Even though a ShaderVariantAsset comes from a unique source asset (the *.hashedvariantinfo),
+            // all SubIds are unique across all ShaderVariantAssets that are related with a ShaderAsset (Regardless
+            // of Supervariant and StableId, because the Supervariant and the StableId, along with the RHI are encoded
+            // in the product SubId).
+            // We can safely use the product subId as the key in a map.
+            using ShaderVariantProductSubId = RHI::Handle<uint32_t, ShaderVariantAsyncLoader>;
 
             struct ShaderVariantCollection
             {
                 Data::AssetId m_shaderAssetId;
                 Data::Asset<ShaderVariantTreeAsset> m_shaderVariantTree;
-                //! The key is the AssetId of the ShaderVariantAsset
+
                 //! We need to preserve a reference to shaderVariantAsset, otherwise the asset load will be canceled
                 //! or the asset could be removed from the asset database before it is passed back to the shader system.
-                AZStd::unordered_map<Data::AssetId, Data::Asset<ShaderVariantAsset>> m_shaderVariantsMap;
+                //! The key is the product SubId of the ShaderVariantAsset.
+                AZStd::unordered_map<ShaderVariantProductSubId, Data::Asset<ShaderVariantAsset>> m_shaderVariantsMap;
             };
 
             //! The key is the shader variant tree asset id.
@@ -133,6 +141,11 @@ namespace AZ
             //! Key: AssetId of a ShaderAsset; Value: AssetId of a ShaderVariantTreeAsset.
             //! REMARK: To go the other way, you can use m_shaderVariantData.
             AZStd::unordered_map<Data::AssetId, Data::AssetId> m_shaderAssetIdToShaderVariantTreeAssetId;
+
+            //! Key: AssetId of a ShaderVariantAsset; Value: AssetId of a ShaderVariantTreeAsset.
+            //! This is necessary so we can quickly find the ShaderVariantTreeAsset when the asset system
+            //! calls OnAssetReady(), OnAssetReloaded(), etc.
+            AZStd::unordered_map<Data::AssetId, Data::AssetId> m_shaderVariantAssetIdToShaderVariantTreeAssetId;
 
         };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
@@ -61,7 +61,7 @@ namespace AZ
             //! Returns true if the request was queued successfully.
             virtual bool QueueLoadShaderVariantAsset(
                 const Data::AssetId& shaderVariantTreeAssetId, ShaderVariantStableId variantStableId,
-                SupervariantIndex supervariantIndex) = 0;
+                const AZ::Name& supervariantName) = 0;
 
             //! This is a quick blocking call that will return a valid asset only if it's been fully loaded already,
             //! Otherwise it returns an invalid asset and the caller is supposed to call QueueLoadShaderVariantAssetByVariantId().

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
@@ -110,6 +110,9 @@ namespace AZ
             //! Note that this will append the system supervariant name from RPI::ShaderSystem when searching.
             SupervariantIndex GetSupervariantIndex(const AZ::Name& supervariantName) const;
 
+            //! If a Supervariant with such index doesn't exist, returns the default supervariant name "".
+            const AZ::Name& GetSupervariantName(SupervariantIndex supervariantIndex) const;
+
             //! This function should be your one stop shop to get a ShaderVariantAsset.
             //! Finds and returns the best matching ShaderVariantAsset given a ShaderVariantId.
             //! If the ShaderVariantAsset is not fully loaded and ready at the moment, this function

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h
@@ -52,8 +52,8 @@ namespace AZ
             static constexpr AZ::u32 ProductSubID = 0; //Reserved for ShaderVariantTreeAssets.
 
             //! See comments in ValidateShaderVariantListLocation() inside ShaderVariantAssetBuilder.cpp
-            static constexpr const char* CommonSubFolder = "ShaderVariants";
-            static constexpr const char* CommonSubFolderLowerCase = "shadervariants";
+            static constexpr char CommonSubFolder[] = "ShaderVariants";
+            static constexpr char CommonSubFolderLowerCase[] = "shadervariants";
 
             ShaderVariantTreeAsset() = default;
             ~ShaderVariantTreeAsset() = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
@@ -19,6 +19,48 @@ namespace AZ
         AZ_CVAR(uint32_t, r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms, 0, nullptr, ConsoleFunctorFlags::Null,
             "Override the delay between iterations of checking for shader variant assets. 0 means use the default value (1000ms).");
 
+        static Data::AssetId GetShaderVariantAssetUuidFromShaderVariantTreeId(const Data::AssetId& shaderVariantTreeAssetId, const AZ::Name& supervariantName, ShaderVariantStableId stableId)
+        {
+            AZStd::string variantTreeRelativePath;
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(variantTreeRelativePath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, shaderVariantTreeAssetId);
+            if (variantTreeRelativePath.empty())
+            {
+                return {};
+            }
+
+            AZStd::string shaderName; // Just the file name, no extension, no parent directory.
+            if (!AZ::StringFunc::Path::GetFileName(variantTreeRelativePath.c_str(), shaderName))
+            {
+                return {};
+            }
+
+            AZStd::string folderPath;
+            if (!AZ::StringFunc::Path::GetFolderPath(variantTreeRelativePath.c_str(), folderPath))
+            {
+                return {};
+            }
+
+            AZStd::string shaderVariantProductPath;
+
+            if (supervariantName.IsEmpty())
+            {
+                shaderVariantProductPath = AZStd::string::format("%s%s%s_%s_%u.%s",
+                    folderPath.c_str(), AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING, shaderName.c_str(),
+                    RHI::Factory::Get().GetName().GetCStr(), stableId.GetIndex(), ShaderVariantAsset::Extension);
+            }
+            else
+            {
+                shaderVariantProductPath = AZStd::string::format("%s%s%s-%s_%s_%u.%s",
+                    folderPath.c_str(), AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING, shaderName.c_str(), supervariantName.GetCStr(),
+                    RHI::Factory::Get().GetName().GetCStr(), stableId.GetIndex(), ShaderVariantAsset::Extension);
+            }
+
+            Data::AssetId variantAssetId;
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(variantAssetId, &AZ::Data::AssetCatalogRequests::GetAssetIdByPath, shaderVariantProductPath.c_str(), AZ::Uuid(), false);
+
+            return variantAssetId;
+        }
+
         void ShaderVariantAsyncLoader::Init()
         {
             m_isServiceShutdown.store(false);
@@ -38,7 +80,11 @@ namespace AZ
         {
             AZStd::unordered_set<ShaderVariantAsyncLoader::TupleShaderAssetAndShaderVariantId> newShaderVariantPendingRequests;
             AZStd::unordered_set<Data::AssetId> shaderVariantTreePendingRequests;
-            AZStd::unordered_set<Data::AssetId> shaderVariantPendingRequests;
+
+            // first: AssetId of a ShaderVariantAsset
+            // second: AssetId of its corresponding ShaderVariantTreeAsset 
+            AZStd::vector<AZStd::pair<Data::AssetId, Data::AssetId>> shaderVariantPendingRequests;
+
             while (true)
             {
                 //We'll wait here until there's work to do or this service has been shutdown.
@@ -80,19 +126,20 @@ namespace AZ
                         });
                     m_shaderVariantTreePendingRequests.clear();
 
-                    AZStd::for_each(m_shaderVariantPendingRequests.begin(), m_shaderVariantPendingRequests.end(),
-                        [&](const Data::AssetId& assetId)
-                        {
-                            shaderVariantPendingRequests.insert(assetId);
-                        });
-                    m_shaderVariantPendingRequests.clear();
+                    {
+                        shaderVariantPendingRequests.reserve(shaderVariantPendingRequests.size() + m_shaderVariantPendingRequests.size());
+                        AZStd::move(m_shaderVariantPendingRequests.begin(), m_shaderVariantPendingRequests.end(), AZStd::back_inserter(shaderVariantPendingRequests));
+                        m_shaderVariantPendingRequests.clear();
+                    }
+
                 }
 
                 // Time to work hard.
                 auto tupleItor = newShaderVariantPendingRequests.begin();
                 while (tupleItor != newShaderVariantPendingRequests.end())
                 {
-                    auto shaderVariantTreeAsset = GetShaderVariantTreeAsset(tupleItor->m_shaderAsset.GetId());
+                    const auto& shaderAsset = tupleItor->m_shaderAsset;
+                    auto shaderVariantTreeAsset = GetShaderVariantTreeAsset(shaderAsset.GetId());
                     if (shaderVariantTreeAsset)
                     {
                         AZ_Assert(shaderVariantTreeAsset.IsReady(), "shaderVariantTreeAsset is not ready!");
@@ -105,11 +152,14 @@ namespace AZ
                             continue;
                         }
 
-                        uint32_t shaderVariantProductSubId = ShaderVariantAsset::MakeAssetProductSubId(
-                            RHI::Factory::Get().GetAPIUniqueIndex(), tupleItor->m_supervariantIndex.GetIndex(), searchResult.GetStableId());
-                        Data::AssetId shaderVariantAssetId(shaderVariantTreeAsset.GetId().m_guid, shaderVariantProductSubId);
-                        shaderVariantPendingRequests.insert(shaderVariantAssetId);
-                        tupleItor = newShaderVariantPendingRequests.erase(tupleItor);
+                        const auto& superVariantName = shaderAsset->GetSupervariantName(tupleItor->m_supervariantIndex);
+                        Data::AssetId shaderVariantAssetId = GetShaderVariantAssetUuidFromShaderVariantTreeId(shaderVariantTreeAsset.GetId(), superVariantName, searchResult.GetStableId());
+                        if (shaderVariantAssetId.IsValid())
+                        {
+                            AZStd::pair<Data::AssetId, Data::AssetId> pair(shaderVariantAssetId, shaderVariantTreeAsset.GetId());
+                            shaderVariantPendingRequests.emplace_back(AZStd::move(pair));
+                            tupleItor = newShaderVariantPendingRequests.erase(tupleItor);
+                        }
                         continue;
                     }
                     // If we are here the shaderVariantTreeAsset is not ready, but maybe it is already queued for loading,
@@ -132,16 +182,16 @@ namespace AZ
                     }
                 }
 
-                auto variantItor = shaderVariantPendingRequests.begin();
-                while (variantItor != shaderVariantPendingRequests.end())
+                auto assetIdTupleItor = shaderVariantPendingRequests.begin();
+                while (assetIdTupleItor != shaderVariantPendingRequests.end())
                 {
-                    if (TryToLoadShaderVariantAsset(*variantItor))
+                    if (TryToLoadShaderVariantAsset(assetIdTupleItor->first, assetIdTupleItor->second))
                     {
-                        variantItor = shaderVariantPendingRequests.erase(variantItor);
+                        assetIdTupleItor = shaderVariantPendingRequests.erase(assetIdTupleItor);
                     }
                     else
                     {
-                        variantItor++;
+                        assetIdTupleItor++;
                     }
                 }
 
@@ -175,6 +225,7 @@ namespace AZ
             m_shaderVariantPendingRequests.clear();
             m_shaderVariantData.clear();
             m_shaderAssetIdToShaderVariantTreeAssetId.clear();
+            m_shaderVariantAssetIdToShaderVariantTreeAssetId.clear();
         }
 
 
@@ -198,7 +249,7 @@ namespace AZ
         }
 
         bool ShaderVariantAsyncLoader::QueueLoadShaderVariantAsset(
-            const Data::AssetId& shaderVariantTreeAssetId, ShaderVariantStableId variantStableId, SupervariantIndex supervariantIndex)
+            const Data::AssetId& shaderVariantTreeAssetId, ShaderVariantStableId variantStableId, const AZ::Name& supervariantName)
         {
             if (m_isServiceShutdown.load())
             {
@@ -207,12 +258,11 @@ namespace AZ
 
             AZ_Assert(variantStableId != RootShaderVariantStableId, "Root Variants Are Found inside ShaderAssets");
 
-            uint32_t shaderVariantProductSubId =
-                ShaderVariantAsset::MakeAssetProductSubId(RHI::Factory::Get().GetAPIUniqueIndex(), supervariantIndex.GetIndex(), variantStableId);
-            Data::AssetId shaderVariantAssetId(shaderVariantTreeAssetId.m_guid, shaderVariantProductSubId);
+            Data::AssetId shaderVariantAssetId = GetShaderVariantAssetUuidFromShaderVariantTreeId(shaderVariantTreeAssetId, supervariantName, variantStableId);
             {
+                AZStd::pair<Data::AssetId, Data::AssetId> pair(shaderVariantAssetId, shaderVariantTreeAssetId);
                 AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
-                m_shaderVariantPendingRequests.push_back(shaderVariantAssetId);
+                m_shaderVariantPendingRequests.emplace_back(AZStd::move(pair));
             }
             m_workCondition.notify_one();
             return true;
@@ -294,9 +344,8 @@ namespace AZ
         {
             AZ_Assert(variantStableId != RootShaderVariantStableId, "Root Variants Are Found inside ShaderAssets");
 
-            uint32_t shaderVariantProductSubId =
-                ShaderVariantAsset::MakeAssetProductSubId(RHI::Factory::Get().GetAPIUniqueIndex(), supervariantIndex.GetIndex(), variantStableId);
-            Data::AssetId shaderVariantAssetId(shaderVariantTreeAssetId.m_guid, shaderVariantProductSubId);
+            uint32_t subId = ShaderVariantAsset::MakeAssetProductSubId(RHI::Factory::Get().GetAPIUniqueIndex(), supervariantIndex.GetIndex(), variantStableId);
+            ShaderVariantProductSubId shaderVariantProductSubId(subId);
 
             AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
             auto findIt = m_shaderVariantData.find(shaderVariantTreeAssetId);
@@ -306,7 +355,7 @@ namespace AZ
             }
             ShaderVariantCollection& shaderVariantCollection = findIt->second;
             auto& shaderVariantsMap = shaderVariantCollection.m_shaderVariantsMap;
-            auto variantFindIt = shaderVariantsMap.find(shaderVariantAssetId);
+            auto variantFindIt = shaderVariantsMap.find(shaderVariantProductSubId);
             if (variantFindIt == shaderVariantsMap.end())
             {
                 return {};
@@ -315,7 +364,7 @@ namespace AZ
             if (shaderVariantAsset.IsReady())
             {
                 Data::Asset<ShaderVariantAsset> registeredShaderVariantAsset =
-                    AZ::Data::AssetManager::Instance().FindAsset<ShaderVariantAsset>(shaderVariantAssetId, AZ::Data::AssetLoadBehavior::NoLoad);
+                    AZ::Data::AssetManager::Instance().FindAsset<ShaderVariantAsset>(shaderVariantAsset.GetId(), AZ::Data::AssetLoadBehavior::NoLoad);
                 if (!registeredShaderVariantAsset.GetId().IsValid())
                 {
                     // The shader variant was removed from the asset database, this would normally happen when the source .shadervariantlist file
@@ -425,14 +474,28 @@ namespace AZ
 
             {
                 AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
-                Data::AssetId shaderVariantTreeAssetId(shaderVariantAsset.GetId().m_guid, 0);
+
+                Data::AssetId shaderVariantTreeAssetId;
+                auto findTreeItor = m_shaderVariantAssetIdToShaderVariantTreeAssetId.find(shaderVariantAsset.GetId());
+                if (findTreeItor != m_shaderVariantAssetIdToShaderVariantTreeAssetId.end())
+                {
+                    shaderVariantTreeAssetId = findTreeItor->second;
+                }
+                else
+                {
+                    AZ_Assert(false, "Was expecting to have a ShaderVariantTreeAsset Id for shader variant asset with id=%s and hint=%s",
+                        shaderVariantAsset.GetId().ToString<AZStd::string>().c_str(), shaderVariantAsset.GetHint().c_str());
+                    return;
+                }
+
                 auto findIt = m_shaderVariantData.find(shaderVariantTreeAssetId);
                 if (findIt != m_shaderVariantData.end())
                 {
                     ShaderVariantCollection& shaderVariantCollection = findIt->second;
                     shaderAssetId = shaderVariantCollection.m_shaderAssetId;
                     auto& shaderVariantMap = shaderVariantCollection.m_shaderVariantsMap;
-                    shaderVariantMap.emplace(shaderVariantAsset.GetId(), shaderVariantAsset);
+                    ShaderVariantProductSubId subId(shaderVariantAsset.GetId().m_subId);
+                    shaderVariantMap.emplace(subId, shaderVariantAsset);
                 }
                 else
                 {
@@ -487,14 +550,28 @@ namespace AZ
 
             {
                 AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
-                Data::AssetId shaderVariantTreeAssetId(shaderVariantAsset.GetId().m_guid, 0);
+                Data::AssetId shaderVariantTreeAssetId;
+                auto findTreeItor = m_shaderVariantAssetIdToShaderVariantTreeAssetId.find(shaderVariantAsset.GetId());
+                if (findTreeItor != m_shaderVariantAssetIdToShaderVariantTreeAssetId.end())
+                {
+                    shaderVariantTreeAssetId = findTreeItor->second;
+                }
+                else
+                {
+                    AZ_Assert(false, "Was expecting to have a ShaderVariantTreeAsset Id for shader variant asset with id=%s and hint=%s",
+                        shaderVariantAsset.GetId().ToString<AZStd::string>().c_str(), shaderVariantAsset.GetHint().c_str());
+                    return;
+                }
+
+                m_shaderVariantAssetIdToShaderVariantTreeAssetId.erase(findTreeItor);
                 auto findIt = m_shaderVariantData.find(shaderVariantTreeAssetId);
                 if (findIt != m_shaderVariantData.end())
                 {
                     ShaderVariantCollection& shaderVariantCollection = findIt->second;
                     shaderAssetId = shaderVariantCollection.m_shaderAssetId;
                     auto& shaderVariantMap = shaderVariantCollection.m_shaderVariantsMap;
-                    auto shaderVariantFindIt = shaderVariantMap.find(shaderVariantAsset.GetId());
+                    ShaderVariantProductSubId subId(shaderVariantAsset.GetId().m_subId);
+                    auto shaderVariantFindIt = shaderVariantMap.find(subId);
                     if (shaderVariantFindIt != shaderVariantMap.end())
                     {
                         shaderVariantMap.erase(shaderVariantFindIt);
@@ -606,14 +683,13 @@ namespace AZ
             return true;
         }
 
-        bool ShaderVariantAsyncLoader::TryToLoadShaderVariantAsset(const Data::AssetId& shaderVariantAssetId)
+        bool ShaderVariantAsyncLoader::TryToLoadShaderVariantAsset(const Data::AssetId& shaderVariantAssetId, const Data::AssetId& shaderVariantTreeAssetId)
         {
             // Will be used to address the notification bus.
             Data::AssetId shaderAssetId;
 
             //If we already loaded such asset let's simply dispatch the notification on the next tick.
             Data::Asset<ShaderVariantAsset> shaderVariantAsset;
-            Data::AssetId shaderVariantTreeAssetId(shaderVariantAssetId.m_guid, 0);
             {
                 AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
                 auto findIt = m_shaderVariantData.find(shaderVariantTreeAssetId);
@@ -622,7 +698,8 @@ namespace AZ
                     ShaderVariantCollection& shaderVariantCollection = findIt->second;
                     shaderAssetId = shaderVariantCollection.m_shaderAssetId;
                     auto& shaderVariantMap = shaderVariantCollection.m_shaderVariantsMap;
-                    auto variantFindIt = shaderVariantMap.find(shaderVariantAssetId);
+                    ShaderVariantProductSubId subId(shaderVariantAssetId.m_subId);
+                    auto variantFindIt = shaderVariantMap.find(subId);
                     if (variantFindIt != shaderVariantMap.end())
                     {
                         shaderVariantAsset = variantFindIt->second;
@@ -667,12 +744,18 @@ namespace AZ
             // We need to preserve a reference to shaderVariantAsset, otherwise the asset load will be cancelled.
             {
                 AZStd::unique_lock<decltype(m_mutex)> lock(m_mutex);
+
+                // Keep a record. This will make it easy to find the ShaderVariantTreeAssset when OnAssetReady(), OnAssetReloaded(), etc
+                // are called on behalf the ShaderVariantAsset,
+                m_shaderVariantAssetIdToShaderVariantTreeAssetId.emplace(shaderVariantAssetId, shaderVariantTreeAssetId);
+
                 auto findIt = m_shaderVariantData.find(shaderVariantTreeAssetId);
                 if (findIt != m_shaderVariantData.end())
                 {
                     ShaderVariantCollection& shaderVariantCollection = findIt->second;
                     auto& shaderVariantMap = shaderVariantCollection.m_shaderVariantsMap;
-                    shaderVariantMap.emplace(shaderVariantAssetId, shaderVariantAsset);
+                    ShaderVariantProductSubId subId(shaderVariantAssetId.m_subId);
+                    shaderVariantMap.emplace(subId, shaderVariantAsset);
                 }
                 else
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -180,6 +180,16 @@ namespace AZ
             return supervariantIndex;
         }
 
+        const AZ::Name& ShaderAsset::GetSupervariantName(SupervariantIndex supervariantIndex) const
+        {
+            const auto& supervariants = GetCurrentShaderApiData().m_supervariants;
+            if (supervariantIndex.GetIndex() >= supervariants.size())
+            {
+                return supervariants[0].m_name;
+            }
+            return supervariants[supervariantIndex.GetIndex()].m_name;
+        }
+
         Data::Asset<ShaderVariantAsset> ShaderAsset::GetVariantAsset(
             const ShaderVariantId& shaderVariantId, SupervariantIndex supervariantIndex)
         {
@@ -262,7 +272,7 @@ namespace AZ
                 }
                 if (variantTreeAssetId.IsValid())
                 {
-                    variantFinder->QueueLoadShaderVariantAsset(variantTreeAssetId, shaderVariantStableId, supervariantIndex);
+                    variantFinder->QueueLoadShaderVariantAsset(variantTreeAssetId, shaderVariantStableId, GetSupervariantName(supervariantIndex));
                 }
                 return GetRootVariantAsset(supervariantIndex);
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -185,6 +185,7 @@ namespace AZ
             const auto& supervariants = GetCurrentShaderApiData().m_supervariants;
             if (supervariantIndex.GetIndex() >= supervariants.size())
             {
+                // Index 0 always exists, because the default supervariant always exists.
                 return supervariants[0].m_name;
             }
             return supervariants[supervariantIndex.GetIndex()].m_name;


### PR DESCRIPTION
## What does this PR do?
This new version doesn't consume *.shadervariantlist files. Instead it consumes *.hashedvariantlist and *.hashedvariantinfo files.

As a reminder, the ShaderVariantListBuilder consumes *.shadervariantlist and produces Intermediate Assets: One *.hashedvarianlist + Several *.hashedvariantinfo

In turn, this new ShaderVariantAssetBuilder has two inputs:
- First Input: *.hashedvariantlist. Output: ShaderVariantTreeAsset (*.azshadervarianttree)
- Second Input: *.hashedvariantinfo. Ouputs: ShaderVariantAsset (*.azshadervariant) one for each combination of RHI+Supervariant+StableId.

**What's the benefit**:
The main benefit is that whenever the original *.shadervariantlist file changes, let's say because the user added a new variant, or because the user modified an existing variant, only the new/updated variant will be rebuilt. This will have a huge impact in the future where there can be, let's say 1000 variants listed in the *.shadervariantlist file. If you add +1 variant, for a new total of 1001 variants, then only the new ShaderVariantAsset will be compiled, instead of recompiling all 1001 ShaderVariantAssets.

## How was this PR tested?

Validated that when adding a new variant to a *.shadervariantlist file, and when modifying an exisiting one, only that new ShaderVariantAsset was created/rebuilt instead of the whole list of variants.
