### PR TITLE
Fixed a crash when processing assets in a case with mixed failures

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -4978,7 +4978,7 @@ namespace AssetProcessor
                     }
                     else
                     {
-                        AZ_Error("AssetProcessor", false, "%s", outcome.GetError().c_str());
+                        AZ_Error(AssetProcessor::ConsoleChannel, false, "%s", outcome.GetError().c_str());
                         return {};
                     }
                 }

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.cpp
@@ -292,14 +292,13 @@ namespace AssetProcessor
             }
         }
 
-        AZ_TracePrintf(
-            AssetProcessor::DebugChannel,
-            "JobTrace jobIndex == -1!!! (%i %s,%s,%s)\n",
-            rcJob,
+        AZ_Error(
+            AssetProcessor::ConsoleChannel,
+            false,
+            "Programmer Error: Could not mark job for file %s as completed, job was not tracked in the m_jobs container. It was either already finished, or never queued. (platform:%s, job key:%s)\n",
             rcJob->GetJobEntry().GetAbsoluteSourcePath().toUtf8().constData(),
             rcJob->GetPlatformInfo().m_identifier.c_str(),
             rcJob->GetJobKey().toUtf8().constData());
-        AZ_Assert(false, "Job not found!!!");
     }
 
     void RCJobListModel::markAsCataloged(const AssetProcessor::QueueElementID& check)


### PR DESCRIPTION
## What does this PR do?
Fixed a crash when processing assets in a case with mixed failures.
FinishJob was called twice in some cases, causing this crash.
Cleaned up the assert **message.**

## How was this PR tested?

Tested with Multiplayer Sample project. Processing assets on an empty cache crashes without this fix, and does not crash with this fix.