### PR TITLE
Material Canvas: Save and restore graph element selection on load, undo, and redo

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphView.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphView.cpp
@@ -672,7 +672,7 @@ namespace AtomToolsFramework
                     {
                         GraphCanvas::SceneRequestBus::Event(m_activeGraphId, &GraphCanvas::SceneRequests::ClearSelection);
                         GraphCanvas::VisualRequestBus::Event(nodeId, &GraphCanvas::VisualRequests::SetVisible, true);
-
+                        GraphCanvas::SceneMemberUIRequestBus::Event(nodeId, &GraphCanvas::SceneMemberUIRequests::SetSelected, true);
                         GraphCanvas::SceneNotificationBus::Event(m_activeGraphId, &GraphCanvas::SceneNotifications::PostCreationEvent);
                     }
                 }

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
@@ -58,7 +58,7 @@ namespace GraphModelIntegration
         EntitySaveDataContainerPtr m_sceneMetadata;
 
         //! Graph Canvas metadata that pertains to each node in our data model. For example,
-        //! the selected of each node.
+        //! the position of each node.
         NodeMetadataMap m_nodeMetadata;
     };
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphCanvasMetadata.h
@@ -12,6 +12,9 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/containers/map.h>
 
+// Graph Canvas
+#include <GraphCanvas/Types/EntitySaveData.h>
+
 // Graph Model
 #include <GraphModel/Model/Common.h>
 
@@ -36,26 +39,40 @@ namespace GraphModelIntegration
     {
     public:
         AZ_RTTI(GraphCanvasMetadata, "{BD95C3EB-CD09-4F82-9724-032BD1827B95}");
+        AZ_CLASS_ALLOCATOR(GraphCanvasMetadata, AZ::SystemAllocator);
+        static void Reflect(AZ::ReflectContext* context);
 
+        GraphCanvasMetadata() = default;
         virtual ~GraphCanvasMetadata() = default;
-
-        static void Reflect(AZ::ReflectContext* reflectContext);
 
     private:
         friend class GraphController;
 
         // I tried using a unique_ptr but SerializeContext didn't like it
-        typedef AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer> EntitySaveDataContainerPtr;
+        using EntitySaveDataContainerPtr = AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer>;
 
         // Using a map instead of unordered_map for simpler xml diffs
-        typedef AZStd::map<GraphModel::NodeId, EntitySaveDataContainerPtr> NodeMetadataMap;
-        typedef AZStd::map<AZ::EntityId, EntitySaveDataContainerPtr> OtherMetadataMap;
+        using NodeMetadataMap = AZStd::map<GraphModel::NodeId, EntitySaveDataContainerPtr>;
 
         //! Graph Canvas metadata that pertains to the entire scene
         EntitySaveDataContainerPtr m_sceneMetadata;
 
         //! Graph Canvas metadata that pertains to each node in our data model. For example,
-        //! the position of each node.
+        //! the selected of each node.
         NodeMetadataMap m_nodeMetadata;
     };
-}
+
+    //! Structure used to serialize the selection state for nodes and constructs so that it can be restored when loading and undoing operations
+    class GraphCanvasSelectionData : public GraphCanvas::ComponentSaveData
+    {
+    public:
+        AZ_RTTI(GraphCanvasSelectionData, "{FC18625B-1E97-415D-9832-B222DE054680}", GraphCanvas::ComponentSaveData);
+        AZ_CLASS_ALLOCATOR(GraphCanvasSelectionData, AZ::SystemAllocator);
+        static void Reflect(AZ::ReflectContext* context);
+
+        GraphCanvasSelectionData() = default;
+        virtual ~GraphCanvasSelectionData() = default;
+        bool m_selected = {};
+    };
+
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -15,9 +15,10 @@
 #include <QPixmap>
 
 // Graph Canvas
-#include <GraphCanvas/Editor/GraphModelBus.h>
-#include <GraphCanvas/Components/Slots/SlotBus.h>
+#include <GraphCanvas/Components/EntitySaveDataBus.h>
 #include <GraphCanvas/Components/SceneBus.h>
+#include <GraphCanvas/Components/Slots/SlotBus.h>
+#include <GraphCanvas/Editor/GraphModelBus.h>
 
 // Graph Model
 #include <GraphModel/GraphModelBus.h>
@@ -35,6 +36,7 @@ namespace GraphModelIntegration
     class GraphController
         : private GraphCanvas::GraphModelRequestBus::Handler
         , private GraphCanvas::SceneNotificationBus::Handler
+        , public GraphCanvas::EntitySaveDataRequestBus::Router
         , public GraphControllerRequestBus::Handler
     {
     public:
@@ -126,11 +128,8 @@ namespace GraphModelIntegration
         AZ::Entity* CreateSlotUi(GraphModel::SlotPtr slot, AZ::EntityId nodeUiId);
 
         //! Creates the GraphCanvas node UI represeting a given Node
-        //! \param scenePosition  Pass in a lambda function that provides the node's position given it's GraphCanvas node EntityId.
-        AZ::EntityId CreateNodeUi(GraphModel::NodeId nodeId, GraphModel::NodePtr node, AZStd::function<AZ::Vector2(AZ::EntityId/*nodeUiId*/)> getScenePosition);
-
-        //! Utility function for adding a Graph Canvas node to a Graph Canvas scene
-        void AddNodeUiToScene(AZ::EntityId graphCanvasNodeId, const AZ::Vector2& scenePosition);
+        //! \param scenePosition The node's position
+        AZ::EntityId CreateNodeUi(GraphModel::NodeId nodeId, GraphModel::NodePtr node, const AZ::Vector2& scenePosition);
 
         //! Creates the GraphCanvas UI represeting a given Connection
         void CreateConnectionUi(GraphModel::ConnectionPtr connection);
@@ -154,18 +153,21 @@ namespace GraphModelIntegration
         void OnEntitiesDeserialized(const GraphCanvas::GraphSerialization& serializationSource) override;
         void OnEntitiesDeserializationComplete(const GraphCanvas::GraphSerialization& serializationSource) override;
         void OnNodeIsBeingEdited(bool isBeingEditeed) override;
+        void OnSelectionChanged() override;
+
+        ////////////////////////////////////////////////////////////////////////////////////
+        // GraphCanvas::EntitySaveDataRequestBus::Router
+        void WriteSaveData(GraphCanvas::EntitySaveDataContainer& saveDataContainer) const override;
+        void ReadSaveData(const GraphCanvas::EntitySaveDataContainer& saveDataContainer) override;
 
         ////////////////////////////////////////////////////////////////////////////////////
         // GraphCanvas::GraphModelRequestBus, connections
-
         void DisconnectConnection([[maybe_unused]] const AZ::EntityId& connectionUiId) override {}
         bool CreateConnection(const AZ::EntityId& connectionUiId, const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) override;
-
         bool IsValidConnection(const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) const override;
 
         ////////////////////////////////////////////////////////////////////////////////////
         // GraphCanvas::GraphModelRequestBus, undo
-
         void RequestUndoPoint() override;
         void RequestPushPreventUndoStateUpdate() override;
         void RequestPopPreventUndoStateUpdate() override;
@@ -174,7 +176,6 @@ namespace GraphModelIntegration
 
         ////////////////////////////////////////////////////////////////////////////////////
         // GraphCanvas::GraphModelRequestBus, other
-
         void EnableNodes(const AZStd::unordered_set<GraphCanvas::NodeId>& nodeIds) override;
         void DisableNodes(const AZStd::unordered_set<GraphCanvas::NodeId>& nodeIds) override;
 

--- a/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
+++ b/Gems/GraphModel/Code/Source/GraphModelSystemComponent.cpp
@@ -50,6 +50,7 @@ namespace GraphModel
 
         // Reflect data types for integrating graph model with graph canvas
         GraphModelIntegration::GraphCanvasMetadata::Reflect(context);
+        GraphModelIntegration::GraphCanvasSelectionData::Reflect(context);
 
         // Reflect MIME events for graph canvas nodes
         GraphModelIntegration::CreateGraphCanvasNodeMimeEvent::Reflect(context);

--- a/Gems/GraphModel/Code/Source/Integration/GraphCanvasMetadata.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphCanvasMetadata.cpp
@@ -17,10 +17,9 @@
 
 namespace GraphModelIntegration
 {
-    void GraphCanvasMetadata::Reflect(AZ::ReflectContext* reflectContext)
+    void GraphCanvasMetadata::Reflect(AZ::ReflectContext* context)
     {
-        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext);
-        if (serializeContext)
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<GraphCanvasMetadata>()
                 ->Version(0)
@@ -29,4 +28,14 @@ namespace GraphModelIntegration
                 ;
         }
     }
-} // namespace ShaderCanvas
+
+    void GraphCanvasSelectionData::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<GraphCanvasSelectionData, GraphCanvas::ComponentSaveData>()
+                ->Version(0)
+                ->Field("selected", &GraphCanvasSelectionData::m_selected);
+        }
+    }
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -302,34 +302,25 @@ namespace GraphModelIntegration
 
         GraphCanvasMetadata* graphCanvasMetadata = GetGraphMetadata();
 
+        // Connect the EntitySaveDataRequestBus using a router. This will allow the graph controller to inject custom selection save
+        // data for all graph canvas objects. This should only be connected while serializing save data for the current graph.
+        GraphCanvas::EntitySaveDataRequestBus::Router::BusRouterConnect();
+
         // Create UI for all the Nodes
         for (const auto& pair : m_graph->GetNodes())
         {
             const NodeId nodeId = pair.first;
             NodePtr node = pair.second;
 
-            // Search the metadata to find the saved position of the Node
-            auto getScenePosition = [this, nodeId, graphCanvasMetadata](AZ::EntityId nodeUiId)
+            AZStd::shared_ptr<GraphCanvas::EntitySaveDataContainer> container;
+            auto metadataIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
+            if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end() && metadataIter->second)
             {
-                AZ::Vector2 position(0, 0);
+                container = metadataIter->second;
+            }
 
-                const auto metadataIter = graphCanvasMetadata->m_nodeMetadata.find(nodeId);
-                if (metadataIter != graphCanvasMetadata->m_nodeMetadata.end() && metadataIter->second)
-                {
-                    GraphCanvas::EntitySaveDataRequestBus::Event(
-                        nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *metadataIter->second);
-                }
-                else
-                {
-                    AZ_UNUSED(this); // Prevent unused warning in release builds
-                    AZ_Error(m_graph->GetSystemName(), false, "Failed to load position information for node [%d]", nodeId);
-                }
-
-                GraphCanvas::GeometryRequestBus::EventResult(position, nodeUiId, &GraphCanvas::GeometryRequests::GetPosition);
-                return position;
-            };
-
-            CreateNodeUi(nodeId, node, getScenePosition);
+            AZ::EntityId nodeUiId = CreateNodeUi(nodeId, node, AZ::Vector2::CreateZero());
+            GraphCanvas::EntitySaveDataRequestBus::Event(nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *container);
         }
 
         // Wrap any nodes stored in the node wrappings
@@ -347,14 +338,17 @@ namespace GraphModelIntegration
             CreateConnectionUi(connection);
         }
 
-        // Load graph canvas metadata for the scene
+        // Load graph canvas metadata for the scene. This will recreate all of the utility types like comments, bookmarks, groups, etc. 
         if (graphCanvasMetadata->m_sceneMetadata)
         {
             GraphCanvas::EntitySaveDataRequestBus::Event(
                 GetGraphCanvasSceneId(), &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *graphCanvasMetadata->m_sceneMetadata);
         }
 
-        // After the graph has been reconstructed, this signal will Inform the scene, node groups, and other types to update their state
+        // Disconnect the EntitySaveDataRequestBus after save data serialization as completed
+        GraphCanvas::EntitySaveDataRequestBus::Router::BusRouterDisconnect();
+
+        // After the graph has been reconstructed, this signal will inform the scene, node groups, and other types to update their state
         // after all of the graph elements are in place. This is necessary for node groups to reclaim nodes that were contained within them
         // when the graph was saved.
         GraphCanvas::SceneRequestBus::Event(GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::SignalLoadEnd);
@@ -415,9 +409,7 @@ namespace GraphModelIntegration
     }
 
     AZ::EntityId GraphController::CreateNodeUi(
-        [[maybe_unused]] GraphModel::NodeId nodeId,
-        GraphModel::NodePtr node,
-        AZStd::function<AZ::Vector2(AZ::EntityId /*nodeUiId*/)> getScenePosition)
+        [[maybe_unused]] GraphModel::NodeId nodeId, GraphModel::NodePtr node, const AZ::Vector2& scenePosition)
     {
         using namespace GraphModel;
 
@@ -515,24 +507,8 @@ namespace GraphModelIntegration
             }
         }
 
-        // Add the node to the scene at a specific position...
-        //     We have to use a callback function (getScenePosition) to do this because:
-        //     At some point, we need to get the node's position from GraphCanvasMetadataMap. It would be nice if we could do this either
-        //     before or after CreateNodeUi(). But we can't because of two ordering issues: 1) We have to use the GraphCanvas node EntityId
-        //     to get the position data from GraphCanvasMetadataMap. This EntityId isn't available until the
-        //        GraphCanvas node is created (a couple lines up).
-        //     2) We have to call AddNodeUiToScene() before creating all the GraphCavnas slots (below), because there's a bug where creating
-        //     the slots
-        //        first will cause the node to be stretched way too wide.
-        AddNodeUiToScene(nodeUiId, getScenePosition(nodeUiId));
-
-        return nodeUiId;
-    }
-
-    void GraphController::AddNodeUiToScene(AZ::EntityId nodeUiId, const AZ::Vector2& scenePosition)
-    {
         GraphCanvas::SceneRequestBus::Event(GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::AddNode, nodeUiId, scenePosition, false);
-        GraphCanvas::SceneMemberUIRequestBus::Event(nodeUiId, &GraphCanvas::SceneMemberUIRequests::SetSelected, true);
+        return nodeUiId;
     }
 
     void GraphController::CreateConnectionUi(GraphModel::ConnectionPtr connection)
@@ -564,19 +540,17 @@ namespace GraphModelIntegration
 
         const GraphModel::NodeId nodeId = m_graph->AddNode(node);
 
-        AZ::EntityId graphCanvasNodeId = CreateNodeUi(
-            nodeId,
-            node,
-            [sceneDropPosition](AZ::EntityId)
-            {
-                return sceneDropPosition;
-            });
+        AZ::EntityId graphCanvasNodeId = CreateNodeUi(nodeId, node, sceneDropPosition);
+
+        GraphCanvas::SceneMemberUIRequestBus::Event(graphCanvasNodeId, &GraphCanvas::SceneMemberUIRequests::SetSelected, true);
+
+        SaveMetadata(graphCanvasNodeId);
 
         // Offset the sceneDropPosition so if multiple nodes are dragged into the scene at the same time, the don't stack exactly on top of
         // each other
         AZ::EntityId gridId;
         GraphCanvas::SceneRequestBus::EventResult(gridId, GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::GetGrid);
-        AZ::Vector2 offset;
+        AZ::Vector2 offset = AZ::Vector2::CreateZero();
         GraphCanvas::GridRequestBus::EventResult(offset, gridId, &GraphCanvas::GridRequests::GetMinorPitch);
         sceneDropPosition += offset;
 
@@ -844,6 +818,7 @@ namespace GraphModelIntegration
             if (nodeId.IsValid())
             {
                 GraphCanvas::SceneMemberUIRequestBus::Event(nodeId, &GraphCanvas::SceneMemberUIRequests::SetSelected, selected);
+                SaveMetadata(nodeId);
             }
         }
     }
@@ -1111,6 +1086,65 @@ namespace GraphModelIntegration
             GraphCanvas::GraphModelRequestBus::Event(
                 m_graphCanvasSceneId, &GraphCanvas::GraphModelRequests::RequestPopPreventUndoStateUpdate);
             GraphCanvas::GraphModelRequestBus::Event(m_graphCanvasSceneId, &GraphCanvas::GraphModelRequests::RequestUndoPoint);
+        }
+    }
+
+    void GraphController::OnSelectionChanged()
+    {
+        bool loading = false;
+        GraphCanvas::SceneRequestBus::EventResult(loading, GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::IsLoading);
+        bool pasting = false;
+        GraphCanvas::SceneRequestBus::EventResult(pasting, GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::IsPasting);
+        if (loading || pasting)
+        {
+            return;
+        }
+
+        // Save selection save data and other metadata every time the selection changes unless this is during a reload or a face operation
+        SaveMetadata(GetGraphCanvasSceneId());
+        GraphCanvas::SceneRequestBus::Event(
+            GetGraphCanvasSceneId(),
+            [&](GraphCanvas::SceneRequests* scene)
+            {
+                for (const auto& element : scene->GetNodes())
+                {
+                    SaveMetadata(element);
+                }
+                for (const auto& element : scene->GetConnections())
+                {
+                    SaveMetadata(element);
+                }
+            });
+    }
+
+    void GraphController::WriteSaveData(GraphCanvas::EntitySaveDataContainer& saveDataContainer) const
+    {
+        // Store selection save data for the current graph element
+        const AZ::EntityId nodeUiId = *GraphCanvas::EntitySaveDataRequestBus::GetCurrentBusId();
+
+        // Save data will only be stored for selected items to minimize file size
+        bool selected = false;
+        GraphCanvas::SceneMemberUIRequestBus::EventResult(selected, nodeUiId, &GraphCanvas::SceneMemberUIRequests::IsSelected);
+        if (selected)
+        {
+            auto data = saveDataContainer.FindCreateSaveData<GraphCanvasSelectionData>();
+            data->m_selected = selected;
+        }
+    }
+
+    void GraphController::ReadSaveData(const GraphCanvas::EntitySaveDataContainer& saveDataContainer)
+    {
+        // Restore selection and position data for the current graph element
+        const AZ::EntityId nodeUiId = *GraphCanvas::EntitySaveDataRequestBus::GetCurrentBusId();
+
+        if (auto data = saveDataContainer.FindSaveData<GraphCanvasSelectionData>())
+        {
+            GraphCanvas::SceneMemberUIRequestBus::Event(nodeUiId, &GraphCanvas::SceneMemberUIRequests::SetSelected, data->m_selected);
+        }
+
+        if (auto data = saveDataContainer.FindSaveData<GraphCanvas::GeometrySaveData>())
+        {
+            GraphCanvas::GeometryRequestBus::Event(nodeUiId, &GraphCanvas::GeometryRequests::SetPosition, data->m_position);
         }
     }
 
@@ -1549,9 +1583,21 @@ namespace GraphModelIntegration
 
     void GraphController::SaveMetadata(const AZ::EntityId& graphCanvasElement)
     {
-        using namespace GraphModel;
+        bool loading = false;
+        GraphCanvas::SceneRequestBus::EventResult(loading, GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::IsLoading);
+        bool pasting = false;
+        GraphCanvas::SceneRequestBus::EventResult(pasting, GetGraphCanvasSceneId(), &GraphCanvas::SceneRequests::IsPasting);
+        if (loading || pasting)
+        {
+            return;
+        }
 
+        using namespace GraphModel;
         GraphCanvasMetadata* graphCanvasMetadata = GetGraphMetadata();
+
+        // Connect the EntitySaveDataRequestBus using a router. This will allow the graph controller to inject custom selection save
+        // data for all graph canvas objects. This should only be connected while serializing save data for the current graph.
+        GraphCanvas::EntitySaveDataRequestBus::Router::BusRouterConnect();
 
         // Save into m_nodeMetadata
         if (const auto node = m_elementMap.Find<Node>(graphCanvasElement))
@@ -1575,6 +1621,9 @@ namespace GraphModelIntegration
 
             GraphControllerNotificationBus::Event(m_graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, nullptr);
         }
+
+        // Disconnect the EntitySaveDataRequestBus after save data serialization as completed
+        GraphCanvas::EntitySaveDataRequestBus::Router::BusRouterDisconnect();
     }
 
     QGraphicsLinearLayout* GraphController::GetLayoutFromNode(GraphModel::NodePtr node)

--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -320,7 +320,11 @@ namespace GraphModelIntegration
             }
 
             AZ::EntityId nodeUiId = CreateNodeUi(nodeId, node, AZ::Vector2::CreateZero());
-            GraphCanvas::EntitySaveDataRequestBus::Event(nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *container);
+
+            if (container)
+            {
+                GraphCanvas::EntitySaveDataRequestBus::Event(nodeUiId, &GraphCanvas::EntitySaveDataRequests::ReadSaveData, *container);
+            }
         }
 
         // Wrap any nodes stored in the node wrappings


### PR DESCRIPTION
## What does this PR do?

This change implements graph model selection state serialization so that it can be saved and restored when graphs are loaded and after undo and redo operations. Prior to these changes, loading, undue, and reduce selected all nodes in the graph.

In order to accomplish this, rather than creating new components and injecting them into all of the graph canvas native types, graph controller creates a router for entity state save data to inject and retrieve selection and position data with the rest of the metadata.

Additionally, this change adds batching for drag and drop operations so that tracking multiple nodes from the node palette can be undone and redone as an atomic operation.

Resolves https://github.com/o3de/o3de/issues/13919

## How was this PR tested?

Tested by creating multiple combinations of nodes, dragging from the docked node palette as well as using the context menu node palette. Performed undo, redo, save, and open operations to validate that selection state and position are restored consistently in material canvas.

Doing additional testing in landscape canvas.
