### PR TITLE
Material Canvas: Fix checkbox and node property displays refreshing

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -562,9 +562,21 @@ namespace AtomToolsFramework
                         // Set up the change call back to apply the value of the property from the inspector to the slot. This could
                         // also send a document modified notifications and queue regeneration of shader and material assets but the
                         // compilation process and going through the ap is not responsive enough for this to matter.
-                        propertyConfig.m_dataChangeCallback = [currentSlot](const AZStd::any& value)
+                        propertyConfig.m_dataChangeCallback = [currentSlot, graphId = m_graphId](const AZStd::any& value)
                         {
                             currentSlot->SetValue(value);
+
+                            // Retrieve and refresh the node property displays with the updated slot value.
+                            GraphCanvas::SlotId slotId{};
+                            GraphModelIntegration::GraphControllerRequestBus::EventResult(
+                                slotId, graphId, &GraphModelIntegration::GraphControllerRequests::GetSlotIdBySlot, currentSlot);
+
+                            GraphCanvas::NodePropertyRequestBus::Event(slotId, [](GraphCanvas::NodePropertyRequests* nodePropertyRequests) {
+                                if (auto display = nodePropertyRequests->GetNodePropertyDisplay())
+                                {
+                                    display->UpdateDisplay();
+                                }
+                            });
                             return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
                         };
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/BooleanDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/BooleanDataInterface.h
@@ -17,19 +17,18 @@
 namespace GraphModelIntegration
 {
     //! Satisfies GraphCanvas API requirements for showing bool property widgets in nodes.
-    class BooleanDataInterface
-        : public GraphCanvas::BooleanDataInterface
+    class BooleanDataInterface : public GraphCanvas::BooleanDataInterface
     {
     public:
         AZ_CLASS_ALLOCATOR(BooleanDataInterface, AZ::SystemAllocator);
 
         BooleanDataInterface(GraphModel::SlotPtr slot);
         ~BooleanDataInterface() = default;
-        
+
         bool GetBool() const override;
         void SetBool(bool enabled) override;
 
     private:
         AZStd::weak_ptr<GraphModel::Slot> m_slot;
     };
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/FloatDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/FloatDataInterface.h
@@ -17,15 +17,14 @@
 namespace GraphModelIntegration
 {
     //! Satisfies GraphCanvas API requirements for showing float property widgets in nodes.
-    class FloatDataInterface
-        : public GraphCanvas::NumericDataInterface
+    class FloatDataInterface : public GraphCanvas::NumericDataInterface
     {
     public:
         AZ_CLASS_ALLOCATOR(FloatDataInterface, AZ::SystemAllocator);
 
         FloatDataInterface(GraphModel::SlotPtr slot);
         ~FloatDataInterface() = default;
-        
+
         double GetNumber() const override;
         void SetNumber(double value) override;
 
@@ -34,6 +33,5 @@ namespace GraphModelIntegration
 
     private:
         AZStd::weak_ptr<GraphModel::Slot> m_slot;
-    };  
-}
-
+    };
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/IntegerDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/IntegerDataInterface.h
@@ -40,19 +40,15 @@ namespace GraphModelIntegration
 
         void SetNumber(double value)
         {
-            if (GraphModel::SlotPtr slot = m_slot.lock())
+            GraphModel::SlotPtr slot = m_slot.lock();
+            if (slot && slot->GetValue<T>() != static_cast<T>(value))
             {
-                if (static_cast<T>(value) != slot->GetValue<T>())
-                {
-                    const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
-                    GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
+                GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                    slot->SetValue(static_cast<T>(value));
-                    GraphControllerNotificationBus::Event(
-                        graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
-                    GraphControllerNotificationBus::Event(
-                        graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
-                }
+                slot->SetValue(static_cast<T>(value));
+                GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
 

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/ReadOnlyDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/ReadOnlyDataInterface.h
@@ -17,8 +17,7 @@
 namespace GraphModelIntegration
 {
     //! Satisfies GraphCanvas API requirements for showing read only property widgets in nodes.
-    class ReadOnlyDataInterface
-        : public GraphCanvas::ReadOnlyDataInterface
+    class ReadOnlyDataInterface : public GraphCanvas::ReadOnlyDataInterface
     {
     public:
         AZ_CLASS_ALLOCATOR(ReadOnlyDataInterface, AZ::SystemAllocator);
@@ -32,4 +31,4 @@ namespace GraphModelIntegration
     private:
         AZStd::weak_ptr<GraphModel::Slot> m_slot;
     };
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/StringDataInterface.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/StringDataInterface.h
@@ -17,8 +17,7 @@
 namespace GraphModelIntegration
 {
     //! Satisfies GraphCanvas API requirements for showing string property widgets in nodes.
-    class StringDataInterface
-        : public GraphCanvas::StringDataInterface
+    class StringDataInterface : public GraphCanvas::StringDataInterface
     {
     public:
         AZ_CLASS_ALLOCATOR(StringDataInterface, AZ::SystemAllocator);
@@ -32,4 +31,4 @@ namespace GraphModelIntegration
     private:
         AZStd::weak_ptr<GraphModel::Slot> m_slot;
     };
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/VectorDataInterface.inl
@@ -28,6 +28,7 @@ namespace GraphModelIntegration
             : m_slot(slot)
         {
         }
+
         ~VectorDataInterface() = default;
 
         const char* GetLabel(int index) const override
@@ -45,14 +46,17 @@ namespace GraphModelIntegration
             }
             return "???";
         }
+
         AZStd::string GetStyle() const override
         {
             return "vectorized";
         }
+
         AZStd::string GetElementStyle(int index) const override
         {
             return AZStd::string::format("vector_%i", index);
         }
+
         int GetElementCount() const override
         {
             return ElementCount;
@@ -60,34 +64,26 @@ namespace GraphModelIntegration
 
         double GetValue(int index) const override
         {
-            if (GraphModel::SlotPtr slot = m_slot.lock())
-            {
-                if (index < ElementCount)
-                {
-                    return slot->GetValue<Type>().GetElement(index);
-                }
-            }
-            return 0.0;
+            GraphModel::SlotPtr slot = m_slot.lock();
+            return slot && index < ElementCount ? slot->GetValue<Type>().GetElement(index) : 0.0;
         }
+
         void SetValue(int index, double value) override
         {
-            if (GraphModel::SlotPtr slot = m_slot.lock())
+            GraphModel::SlotPtr slot = m_slot.lock();
+            if (slot && index < ElementCount)
             {
-                if (index < ElementCount)
+                Type vector = slot->GetValue<Type>();
+                if (vector.GetElement(index) != value)
                 {
-                    Type vector = slot->GetValue<Type>();
-                    if (value != vector.GetElement(index))
-                    {
-                        const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
-                        GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+                    const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
+                    GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                        vector.SetElement(index, aznumeric_cast<float>(value));
-                        slot->SetValue(vector);
-                        GraphControllerNotificationBus::Event(
-                            graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
-                        GraphControllerNotificationBus::Event(
-                            graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
-                    }
+                    vector.SetElement(index, aznumeric_cast<float>(value));
+                    slot->SetValue(vector);
+
+                    GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                    GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
                 }
             }
         }

--- a/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/BooleanDataInterface.cpp
@@ -19,31 +19,22 @@ namespace GraphModelIntegration
 
     bool BooleanDataInterface::GetBool() const
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
-        {
-            return slot->GetValue<bool>();
-        }
-        else
-        {
-            return false;
-        }
+        GraphModel::SlotPtr slot = m_slot.lock();
+        return slot ? slot->GetValue<bool>() : false;
     }
 
     void BooleanDataInterface::SetBool(bool enabled)
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
+        GraphModel::SlotPtr slot = m_slot.lock();
+        if (slot && slot->GetValue<bool>() != enabled)
         {
-            if (enabled != slot->GetValue<bool>())
-            {
-                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
-                GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+            const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
+            GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                slot->SetValue(enabled);
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
-            }
+            slot->SetValue(enabled);
+            GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+            GraphControllerNotificationBus::Event(
+                graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
         }
     }
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/FloatDataInterface.cpp
@@ -19,30 +19,22 @@ namespace GraphModelIntegration
 
     double FloatDataInterface::GetNumber() const
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
-        {
-            return slot->GetValue<float>();
-        }
-        else
-        {
-            return 0.0;
-        }
+        GraphModel::SlotPtr slot = m_slot.lock();
+        return slot ? slot->GetValue<float>() : 0.0;
     }
+
     void FloatDataInterface::SetNumber(double value)
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
+        GraphModel::SlotPtr slot = m_slot.lock();
+        if (slot && slot->GetValue<float>() != static_cast<float>(value))
         {
-            if (static_cast<float>(value) != slot->GetValue<float>())
-            {
-                const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
-                GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
+            const GraphCanvas::GraphId graphCanvasSceneId = GetDisplay()->GetSceneId();
+            GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
-                slot->SetValue(static_cast<float>(value));
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
-            }
+            slot->SetValue(static_cast<float>(value));
+            GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+            GraphControllerNotificationBus::Event(
+                graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
         }
     }
 
@@ -55,4 +47,4 @@ namespace GraphModelIntegration
     {
         return std::numeric_limits<float>::max();
     }
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Source/Integration/ReadOnlyDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/ReadOnlyDataInterface.cpp
@@ -19,10 +19,7 @@ namespace GraphModelIntegration
 
     AZStd::string ReadOnlyDataInterface::GetString() const
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
-        {
-            return slot->GetValue<AZStd::string>();
-        }
-        return "";
+        GraphModel::SlotPtr slot = m_slot.lock();
+        return slot ? slot->GetValue<AZStd::string>() : AZStd::string();
     }
-}
+} // namespace GraphModelIntegration

--- a/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/StringDataInterface.cpp
@@ -23,15 +23,10 @@ namespace GraphModelIntegration
 
     AZStd::string StringDataInterface::GetString() const
     {
-        if (GraphModel::SlotPtr slot = m_slot.lock())
-        {
-            return slot->GetValue<AZStd::string>();
-        }
-        else
-        {
-            return "";
-        }
+        GraphModel::SlotPtr slot = m_slot.lock();
+        return slot ? slot->GetValue<AZStd::string>() : AZStd::string();
     }
+
     void StringDataInterface::SetString(const AZStd::string& value)
     {
         if (GraphModel::SlotPtr slot = m_slot.lock())
@@ -45,11 +40,9 @@ namespace GraphModelIntegration
                 GraphCanvas::ScopedGraphUndoBatch undoBatch(graphCanvasSceneId);
 
                 slot->SetValue(trimValue);
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
-                GraphControllerNotificationBus::Event(
-                    graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
+                GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelSlotModified, slot);
+                GraphControllerNotificationBus::Event(graphCanvasSceneId, &GraphControllerNotifications::OnGraphModelGraphModified, slot->GetParentNode());
             }
         }
     }
-}
+} // namespace GraphModelIntegration


### PR DESCRIPTION
## What does this PR do?

Refresh the node property displays in the graph view whenever properties are edited using the inspector.

Resolves https://github.com/o3de/o3de/issues/13875

## How was this PR tested?

Tested setting checkbox and other properties in the inspector to see them update in the graph view.