### PR TITLE
Fixed material canvas crash when switching pipelines plus fixes mesh rendering

### DIFF
--- a/AutomatedTesting/Registry/material_pipelines.setreg
+++ b/AutomatedTesting/Registry/material_pipelines.setreg
@@ -4,7 +4,8 @@
             "RPI": {
                 "MaterialPipelineFiles": [
                     "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline",
-                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipeline.materialpipeline"
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipeline.materialpipeline",
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/MultiView/MultiViewPipeline.materialpipeline"
                 ]
             }
         }

--- a/Gems/Atom/Feature/Common/Assets/Textures/VRSTexture.attimage
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VRSTexture.attimage
@@ -12,7 +12,7 @@
                 "Width": 64,
                 "Height": 64
             },
-            "Format": 24
+            "Format": "R8_UINT"
         },
         "Name": "$VrsTexture",
         "IsUniqueName": true

--- a/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
@@ -26,7 +26,7 @@ namespace AZ
 
         ValidationMode ReadValidationMode()
         {
-#if 1 //JJS defined(AZ_RELEASE_BUILD)
+#if defined(AZ_RELEASE_BUILD)
             // Always disabled in Release configuration.
             return ValidationMode::Disabled;
 #else


### PR DESCRIPTION
## What does this PR do?

- Enables MultiView pipeline for Automated Testing
- Enables Vk validation
- Setting VRS image to R8_Uint as by default dx12 only works with this format. For Vulkan if openxr is enabled we pick the correct format based on device requirement. For quest 2 it automatically switches to R8G8.


## How was this PR tested?

Tested Material canvas and openxrtest
