### PR TITLE
Fixed Shader hot reload for FullscreenTrianglePass

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/FullscreenTrianglePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/FullscreenTrianglePass.h
@@ -59,6 +59,11 @@ namespace AZ
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 
+            // ShaderReloadNotificationBus overrides...
+            void OnShaderReinitialized(const Shader& shader) override;
+            void OnShaderAssetReinitialized(const Data::Asset<ShaderAsset>& shaderAsset) override;
+            void OnShaderVariantReinitialized(const ShaderVariant& shaderVariant) override;
+
             RHI::Viewport m_viewportState;
             RHI::Scissor m_scissorState;
 
@@ -77,13 +82,6 @@ namespace AZ
             Data::Instance<ShaderResourceGroup> m_drawShaderResourceGroup;
 
         private:
-
-            ///////////////////////////////////////////////////////////////////
-            // ShaderReloadNotificationBus overrides...
-            void OnShaderReinitialized(const Shader& shader) override;
-            void OnShaderAssetReinitialized(const Data::Asset<ShaderAsset>& shaderAsset) override;
-            ///////////////////////////////////////////////////////////////////
-
             void LoadShader();
             void UpdateSrgs();
             void BuildDrawItem();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -53,12 +53,17 @@ namespace AZ
 
         void FullscreenTrianglePass::OnShaderReinitialized(const Shader&)
         {
-            UpdateSrgs();
+            LoadShader();
         }
 
         void FullscreenTrianglePass::OnShaderAssetReinitialized(const Data::Asset<ShaderAsset>&)
         {
-            UpdateSrgs();
+            LoadShader();
+        }
+
+        void FullscreenTrianglePass::OnShaderVariantReinitialized(const ShaderVariant&)
+        {
+            LoadShader();
         }
 
         void FullscreenTrianglePass::LoadShader()


### PR DESCRIPTION
## What does this PR do?

Shader hot reload did not work for the `FullscreenTrianglePass`. The `ShaderReloadNotificationBus` overrides did not actually reload the shader, but only called `UpdateSrg` for the old shader. The new code actually reloads the shader.

I also made the `ShaderReloadNotificationBus` overrides protected (formerly they were private), so derived passes can react to reloaded shaders.

## How was this PR tested?

Windows and Vulkan. Tested hot reload on a custom compute pass.
