### PR TITLE
Fix networked character physics hit volumes

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkCharacterComponent.cpp
@@ -220,20 +220,23 @@ namespace Multiplayer
             Multiplayer::GetNetworkTime()->SyncEntitiesToRewindState(entitySweptBounds);
         }
 
-        if ((GetParent().m_physicsCharacter == nullptr) || (velocity.GetLengthSq() <= 0.0f))
+        if (GetParent().m_physicsCharacter != nullptr)
         {
-            return GetEntity()->GetTransform()->GetWorldTranslation();
+            GetParent().m_physicsCharacter->SetRotation(GetEntity()->GetTransform()->GetWorldRotationQuaternion());
+
+            if (velocity.GetLengthSq() > 0.0f)
+            {
+                GetParent().m_physicsCharacter->Move(velocity * deltaTime, deltaTime);
+                GetEntity()->GetTransform()->SetWorldTM(GetParent().m_physicsCharacter->GetTransform());
+                AZLOG(
+                    NET_Movement,
+                    "Moved to position %f x %f x %f",
+                    GetParent().m_physicsCharacter->GetBasePosition().GetX(),
+                    GetParent().m_physicsCharacter->GetBasePosition().GetY(),
+                    GetParent().m_physicsCharacter->GetBasePosition().GetZ());
+            }
         }
-        GetParent().m_physicsCharacter->Move(velocity * deltaTime, deltaTime);
-        GetEntity()->GetTransform()->SetWorldTranslation(GetParent().m_physicsCharacter->GetBasePosition());
-        AZLOG
-        (
-            NET_Movement,
-            "Moved to position %f x %f x %f",
-            GetParent().m_physicsCharacter->GetBasePosition().GetX(),
-            GetParent().m_physicsCharacter->GetBasePosition().GetY(),
-            GetParent().m_physicsCharacter->GetBasePosition().GetZ()
-        );
+
         return GetEntity()->GetTransform()->GetWorldTranslation();
     }
 }

--- a/Gems/Multiplayer/Code/Source/Components/NetworkHitVolumesComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkHitVolumesComponent.cpp
@@ -140,6 +140,7 @@ namespace Multiplayer
 
     void NetworkHitVolumesComponent::OnCharacterDeactivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
+        DestroyHitVolumes();
         m_physicsCharacter = nullptr;
     }
 
@@ -240,6 +241,7 @@ namespace Multiplayer
 
     void NetworkHitVolumesComponent::OnActorInstanceDestroyed([[maybe_unused]] EMotionFX::ActorInstance* actorInstance)
     {
+        DestroyHitVolumes();
         m_actorComponent = nullptr;
     }
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1567,6 +1567,7 @@ namespace Multiplayer
                         NetBindComponent* netBindComponent = m_networkEntityManager.GetNetworkEntityTracker()->GetNetBindComponent(entity);
                         if (netBindComponent != nullptr)
                         {
+                            AZ_Assert(netBindComponent->GetEntity() != nullptr, "Null entity for this component");
                             gatheredEntities.push_back(netBindComponent);
                         }
                     }

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -229,6 +229,8 @@ namespace PhysX
             m_callbackManager->SetControllerFilter(CollisionLayerBasedControllerFilter);
             m_callbackManager->SetObjectPreFilter(CollisionLayerBasedObjectPreFilter);
         }
+
+        m_orientation = AZ::Quaternion::CreateIdentity();
     }
 
     void CharacterController::SetFilterDataAndShape(const Physics::CharacterConfiguration& characterConfig)
@@ -423,7 +425,7 @@ namespace PhysX
         m_pxController->setFootPosition(PxMathConvertExtended(position));
         if (m_shadowBody)
         {
-            m_shadowBody->SetTransform(AZ::Transform::CreateTranslation(GetBasePosition()));
+            m_shadowBody->SetTransform(GetTransform());
         }
     }
 
@@ -639,7 +641,7 @@ namespace PhysX
                 m_pxController->move(PxMathConvert(requestedMovement), m_minimumMovementDistance, deltaTime, m_pxControllerFilters);
                 if (m_shadowBody)
                 {
-                    m_shadowBody->SetKinematicTarget(AZ::Transform::CreateTranslation(GetBasePosition()));
+                    m_shadowBody->SetKinematicTarget(GetTransform());
                 }
             }
             const AZ::Vector3 newPosition = GetBasePosition();
@@ -662,7 +664,8 @@ namespace PhysX
     {
         if (m_shadowBody)
         {
-            AZ::Transform transform = AZ::Transform::CreateFromQuaternionAndTranslation(rotation, GetBasePosition());
+            m_orientation = rotation;
+            AZ::Transform transform = GetTransform();
             m_shadowBody->SetKinematicTarget(transform);
         }
     }
@@ -687,11 +690,12 @@ namespace PhysX
 
     AZ::Transform CharacterController::GetTransform() const
     {
-        return AZ::Transform::CreateTranslation(GetPosition());
+        return AZ::Transform::CreateFromQuaternionAndTranslation(m_orientation, GetPosition());
     }
 
     void CharacterController::SetTransform(const AZ::Transform& transform)
     {
+        m_orientation = transform.GetRotation();
         SetBasePosition(transform.GetTranslation());
     }
 

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -260,6 +260,7 @@ namespace PhysX
         float m_maximumSpeed = 100.0f; ///< If the accumulated requested velocity for a tick exceeds this magnitude, it will be clamped.
         AZStd::unique_ptr<CharacterControllerCallbackManager>
             m_callbackManager; ///< Manages callbacks for collision filtering, collision notifications, and handling riding on objects.
+        AZ::Quaternion m_orientation; ///< The orientation of the character.
     };
 
     //! Example implementation of controller-controller filtering callback.

--- a/Gems/PhysX/Code/Tests/CharacterControllerTests.cpp
+++ b/Gems/PhysX/Code/Tests/CharacterControllerTests.cpp
@@ -140,6 +140,27 @@ namespace PhysX
 
     Physics::ShapeType controllerShapeTypes[] = { Physics::ShapeType::Capsule, Physics::ShapeType::Box };
 
+    TEST_F(PhysXDefaultWorldTest, CharacterControllerWhenRotationSetReturnsCorrectRotation)
+    {
+        ControllerTestBasis basis(m_testSceneHandle);
+        basis.Update(AZ::Vector3::CreateZero());
+
+        // Set an arbitrary character rotation and base position through separate calls.
+        // We deliberately set the rotation first and the base position second so that we can also verify
+        // that setting the position *after* the rotation hasn't reintroduced a regression where setting the position
+        // would clear the rotation.
+        const AZ::Vector3 arbitraryPosition = AZ::Vector3(300.0f, 200.0f, 100.0f);
+        const AZ::Quaternion arbitraryRotation = AZ::Quaternion::CreateFromEulerDegreesXYZ(AZ::Vector3(10.0f, 20.0f, 30.0f));
+        basis.m_controller->SetRotation(arbitraryRotation);
+        basis.m_controller->SetBasePosition(arbitraryPosition);
+
+        auto characterTransform = basis.m_controller->GetTransform();
+
+        // Verify that both the position and rotation are the same as what we set.
+        EXPECT_EQ(characterTransform.GetTranslation(), arbitraryPosition);
+        EXPECT_EQ(characterTransform.GetRotation(), arbitraryRotation);
+    }
+
     TEST_F(PhysXDefaultWorldTest, CharacterController_UnimpededController_MovesAtDesiredVelocity)
     {
         ControllerTestBasis basis(m_testSceneHandle);


### PR DESCRIPTION
## What does this PR do?

This fixes the hit volumes on networked characters. Previously, the character physics didn't support rotation of the character controller, so the attached hit volumes always stayed unrotated, regardless of the visual character's rotation. With this fix, the hit volumes rotate with the networked characters.

Changes:
* Changed the NetworkCharacterComponent to set the rotation on the physics character.
* Changed the CharacterController to store a copy of the rotation and correctly apply it to the shadow body, and added a unit test to trivially validate that this works.
* Changed the NetworkHitVolumes to destroy themselves when the physics character is destroyed, so that they'll recreate correctly when a new physics character is created. (This fixes a teleportation bug with the hit volumes where they weren't associated correctly after the physics character was disabled / enabled)
* Added an assert to MultiplayerSystemComponent. There's an occasional crash related to corrupt net binding components ending up in the gathered entities list; this assert will hopefully catch the problem a little bit sooner than the crash to help with debugging if/when it happens again.

## How was this PR tested?

Ran the unit test before and after the changes to verify that it failed before and succeeded after.
Ran MPS before and after the changes and verified that the hit volumes now rotate correctly.

Before:
https://user-images.githubusercontent.com/82224783/228595750-6dc48ead-b1c5-40c5-95a0-a784397b979b.mp4


After:
https://user-images.githubusercontent.com/82224783/228595620-c32efc14-f14d-4f3b-9668-d4eb7dd9b3c1.mp4

