### PR TITLE
Contains crash fixes + fixes related to Renderdoc capture

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -40,8 +40,11 @@ namespace AZ
         //! Returns true if the command line option is set
         bool QueryCommandLineOption(const AZStd::string& commandLineOption);
 
-        //! Returns if the current bakcend is null 
+        //! Returns true if the current backend is null 
         bool IsNullRHI();
+
+        //! Returns true if the current backend is vulkan 
+        bool IsVulkanRHI();
 
         //! Returns true if the Atom/GraphicsDevMode settings registry key is set
         bool IsGraphicsDevModeEnabled();

--- a/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
@@ -110,6 +110,11 @@ namespace AZ
             return RHI::Factory::Get().GetAPIUniqueIndex() == static_cast<uint32_t>(APIIndex::Null);
         }
 
+        bool IsVulkanRHI()
+        {
+            return RHI::Factory::Get().GetAPIUniqueIndex() == static_cast<uint32_t>(APIIndex::Vulkan);
+        }
+
         AZStd::string GetCommandLineValue(const AZStd::string& commandLineOption)
         {
             const AzFramework::CommandLine* commandLine = nullptr;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -124,7 +124,11 @@ namespace AZ
             m_instanceCreateInfo.ppEnabledLayerNames = m_descriptor.m_requiredLayers.data();
             m_instanceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(m_descriptor.m_requiredExtensions.size());
             m_instanceCreateInfo.ppEnabledExtensionNames = m_descriptor.m_requiredExtensions.data();
-            if (m_context.CreateInstance(&m_instanceCreateInfo, VkSystemAllocator::Get(), &m_instance) != VK_SUCCESS)
+
+            //For instance creation/destruction use nullptr for VkAllocationCallbacks* as using VkSystemAllocator::Get() crashes RenderDoc when used with openxr
+            //enabled projects. We think its because RenderDoc maybe injecting something when doing allocations. Using nullptr when USE_RENDERDOC or enableRenderDoc
+            //is enabled is another option but it will not work for Android easily and will require further work, not to mention manually enabling this for Android renderdoc. 
+            if (m_context.CreateInstance(&m_instanceCreateInfo, nullptr, &m_instance) != VK_SUCCESS)
             {
                 AZ_Warning("Vulkan", false, "Failed to create Vulkan instance");
                 return false;
@@ -167,7 +171,8 @@ namespace AZ
                 }
                 m_supportedDevices.clear();
 
-                m_context.DestroyInstance(m_instance, VkSystemAllocator::Get());
+                //Using use nullptr for VkAllocationCallbacks*. Please see comments above related to Instance creation
+                m_context.DestroyInstance(m_instance, nullptr);
                 m_instance = VK_NULL_HANDLE;
             }
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -95,7 +95,7 @@ namespace AZ
 
         void SwapChain::SetNameInternal(const AZStd::string_view& name)
         {
-            if (IsInitialized() && !name.empty())
+            if ((m_nativeSwapChain != VK_NULL_HANDLE) && IsInitialized() && !name.empty())
             {
                 Debug::SetNameToObject(reinterpret_cast<uint64_t>(m_nativeSwapChain), name.data(), VK_OBJECT_TYPE_SWAPCHAIN_KHR, static_cast<Device&>(GetDevice()));
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -30,6 +30,7 @@
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI.Reflect/PlatformLimitsDescriptor.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/XRRenderingInterface.h>
 
 #include <AzCore/Interface/Interface.h>
@@ -83,12 +84,17 @@ namespace AZ
             if (m_xrSystem)
             {
                 AZ::RHI::ResultCode resultCode = m_xrSystem->InitInstance();
-                // Fail result code can happen if no compatible device is attached. UnRegister xr system if that happens
-                if (resultCode == AZ::RHI::ResultCode::Fail)
+                // Check if the result code is a Success. Failure can happen if no compatible device is attached.
+                // Check if the active rhi backend is not vulkan
+                // UnRegister xr system if any of the criteria is not met
+                if (resultCode == AZ::RHI::ResultCode::Fail || !AZ::RHI::IsVulkanRHI())
                 {
                     UnregisterXRSystem();
+                    AZ_Error(
+                        "RPISystem",
+                        resultCode == AZ::RHI::ResultCode::Success,
+                        "Unable to initialize XR System. Possible reasons could be no xr compatible device found or Link mode not enabled or a non vulkan rhi in use.");
                 }
-                AZ_Error("RPISystem", resultCode == AZ::RHI::ResultCode::Success, "Unable to initialize XR System. Possible reasons could be no xr compatible device found or Link mode not enabled");
             }
 
             //Init RHI device


### PR DESCRIPTION

## What does this PR do?

- Fixes app crash when launched from Renderdoc with openxr enabled
- Fix a crash when calling VK::SetNameInternal with null object
- Add support to unregister XR if rhi is not vulkan essentially preventing a crash. 

## How was this PR tested?

Tested on openxr and Automated testing on PC and quest2
