### PR TITLE
Disable warning and error message box UI in material editor and material canvas tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_tools_utils.py
@@ -277,9 +277,19 @@ def exit() -> None:
     azlmbr.atomtools.general.exit()
 
 
-def disable_material_canvas_file_writes() -> None:
+def disable_document_message_box_settings() -> None:
     """
-    Modifies some registry settings to disable MaterialCanvas graph compilation on open/edit/save.
+    Modifies some registry settings to disable warning and error message boxes that block test progression.
+
+    :return: None
+    """
+    azlmbr.atomtools.util.SetSettingsValue_bool("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayErrorMessageDialogs", False)
+    azlmbr.atomtools.util.SetSettingsValue_bool("/O3DE/AtomToolsFramework/AtomToolsDocumentSystem/DisplayWarningMessageDialogs", False)
+
+
+def disable_graph_compiler_settings() -> None:
+    """
+    Modifies some registry settings to disable automatic graph compilation on open/edit/save.
     This is because some tests (i.e. main suite) need to avoid file writing/saving during the test run.
 
     :return: None

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialCanvas_Atom_BasicTests.py
@@ -79,8 +79,11 @@ def MaterialCanvas_BasicFunctionalityChecks_AllChecksPass():
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
 
     with Tracer() as error_tracer:
+        # Disable registry settings to prevent message boxes from blocking test progression.
+        atom_tools_utils.disable_document_message_box_settings()
+
         # Disable automatic material and shader generation when opening graphs (to avoid any file writing/saving).
-        atom_tools_utils.disable_material_canvas_file_writes()
+        atom_tools_utils.disable_graph_compiler_settings()
 
         # Set constants before starting test steps.
         test_1_material_graph = os.path.join(atom_tools_utils.MATERIALCANVAS_GRAPH_PATH, "test1.materialgraph")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_BasicTests.py
@@ -116,6 +116,8 @@ def MaterialEditor_BasicFunctionalityChecks_AllChecksPass():
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
 
     with Tracer() as error_tracer:
+        # Disable registry settings to prevent message boxes from blocking test progression.
+        atom_tools_utils.disable_document_message_box_settings()
 
         # Set constants before starting test steps.
         standard_pbr_material_type = os.path.join(atom_tools_utils.MATERIAL_TYPES_PATH, "StandardPBR.materialtype")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/MaterialEditor_Atom_PeriodicTests.py
@@ -192,6 +192,9 @@ def MaterialEditor_FileSaveChecks_AllChecksPass():
         second_material_document_copy = os.path.join(
             atom_tools_utils.TEST_DATA_MATERIALS_PATH, "second_material_document.material")
 
+        # Disable registry settings to prevent message boxes from blocking test progression.
+        atom_tools_utils.disable_document_message_box_settings()
+
         # 1. Open an existing material document referred to as "original_material_document".
         original_material_document_id = atom_tools_utils.open_document(original_material_document)
         Report.result(


### PR DESCRIPTION
## What does this PR do?

Changes atom tools document system registry settings from Python test scripts to disable warning and error message boxes that can potentially block test progression. All of the messages that would be displayed in the user facing message boxes will still be logged.

## How was this PR tested?

Tests continue to run successfully locally without error.