### PR TITLE
Re-adding removed asset and re-enabling skipped test

### DIFF
--- a/AutomatedTesting/Assets/Objects/PxMesh/test.fbx
+++ b/AutomatedTesting/Assets/Objects/PxMesh/test.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee4799379bfcfa99e95afd6494da51fbeda95f21ea71d267ae7102f048edec85
+size 63872

--- a/AutomatedTesting/Assets/Objects/PxMesh/test.fbx.assetinfo
+++ b/AutomatedTesting/Assets/Objects/PxMesh/test.fbx.assetinfo
@@ -1,0 +1,49 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{5C756CD0-D832-5259-99F0-A1C8F6EFDC84}",
+            "name": "test",
+            "NodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode",
+                    "RootNode.group2",
+                    "RootNode.group2.pSphere1",
+                    "RootNode.group2.pCube1",
+                    "RootNode.group2.pCube2",
+                    "RootNode.group2.pCube3"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "test",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.group2",
+                    "RootNode.group2.pSphere1",
+                    "RootNode.group2.pCube1",
+                    "RootNode.group2.pCube2",
+                    "RootNode.group2.pCube3"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{75C73BDA-1256-53D6-B4ED-B4C9D53440EE}"
+        }
+    ]
+}

--- a/AutomatedTesting/Assets/Objects/PxMesh/test.mtl
+++ b/AutomatedTesting/Assets/Objects/PxMesh/test.mtl
@@ -1,0 +1,24 @@
+<Material MtlFlags="524544" DccMaterialHash="1950359039">
+ <SubMaterials>
+  <Material Name="walls" MtlFlags="524416" Shader="Illum" GenMask="80000001" Diffuse="0.123040,0.697600,0.109360" Specular="0.000000,0.000000,0.000000" Emittance="0.000000,0.000000,0.000000" Opacity="1.000000" Shininess="10.000000" DccMaterialHash="1738538488">
+   <Textures>
+    <Texture Map="Diffuse" File="EngineAssets/Textures/white.dds"/>
+   </Textures>
+  </Material>
+  <Material Name="windows_glass" MtlFlags="524416" Shader="Illum" GenMask="80000001" Diffuse="0.800000,0.800000,0.800000" Specular="0.133942,0.133942,0.133942" Emittance="0.000000,0.000000,0.000000" Opacity="1.000000" Shininess="2.152480" DccMaterialHash="568682549">
+   <Textures>
+    <Texture Map="Diffuse" File="c:/users/bozhko/desktop/auto_error.png"/>
+   </Textures>
+  </Material>
+  <Material Name="door" MtlFlags="524416" Shader="Illum" GenMask="80000001" Diffuse="0.697600,0.109360,0.193440" Specular="0.000000,0.000000,0.000000" Emittance="0.000000,0.000000,0.000000" Opacity="1.000000" Shininess="10.000000" DccMaterialHash="4199249980">
+   <Textures>
+    <Texture Map="Diffuse" File="EngineAssets/Textures/white.dds"/>
+   </Textures>
+  </Material>
+  <Material Name="porch_concrete" MtlFlags="524416" Shader="Illum" GenMask="80000001" Diffuse="0.109360,0.256400,0.697600" Specular="0.000000,0.000000,0.000000" Emittance="0.000000,0.000000,0.000000" Opacity="1.000000" Shininess="10.000000" DccMaterialHash="3366379657">
+   <Textures>
+    <Texture Map="Diffuse" File="EngineAssets/Textures/white.dds"/>
+   </Textures>
+  </Material>
+ </SubMaterials>
+</Material>

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/PhysXColliderSurfaceTagEmitter_E2E_Editor.py
@@ -171,8 +171,8 @@ def PhysXColliderSurfaceTagEmitter_E2E_Editor():
 
     # Setup collider entity with a PhysX Mesh
     test_physx_mesh_asset_id = asset.AssetCatalogRequestBus(
-        bus.Broadcast, "GetAssetIdByPath", os.path.join("levels", "physics",
-                                                        "Material_PerFaceMaterialGetsCorrectMaterial",
+        bus.Broadcast, "GetAssetIdByPath", os.path.join("assets", "objects",
+                                                        "pxmesh",
                                                         "test.pxmesh"), math.Uuid(), False)
     collider_entity.remove_component(PHYSX_PRIMITIVE_COLLIDER)
     collider_entity.add_component(PHYSX_MESH_COLLIDER)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
@@ -89,6 +89,7 @@ class TestAutomation(EditorTestSuite):
     class test_MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully(EditorBatchedTest):
         from .EditorScripts import MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully as test_module
 
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/15456")
     class test_PhysXColliderSurfaceTagEmitter_E2E_Editor(EditorBatchedTest):
         from .EditorScripts import PhysXColliderSurfaceTagEmitter_E2E_Editor as test_module
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
@@ -89,7 +89,6 @@ class TestAutomation(EditorTestSuite):
     class test_MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully(EditorBatchedTest):
         from .EditorScripts import MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully as test_module
 
-    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/15456")
     class test_PhysXColliderSurfaceTagEmitter_E2E_Editor(EditorBatchedTest):
         from .EditorScripts import PhysXColliderSurfaceTagEmitter_E2E_Editor as test_module
 


### PR DESCRIPTION
## What does this PR do?

- Re-adds an asset that was removed causing test_PhysXColliderSurfaceTagEmitter_E2E_Editor to fail
- Re-enables the skipped test
- Fixes https://github.com/o3de/o3de/issues/15456

## How was this PR tested?

- Ran updated Dynamic Vegetation suite