### PR TITLE
Fixed issue with shortcuts not working after entering/exiting game mode

### DIFF
--- a/Code/Editor/KeyboardCustomizationSettings.cpp
+++ b/Code/Editor/KeyboardCustomizationSettings.cpp
@@ -9,6 +9,8 @@
 
 #include "KeyboardCustomizationSettings.h"
 
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
+
 // Qt
 #include <QMenu>
 #include <QMenuBar>
@@ -349,6 +351,12 @@ void KeyboardCustomizationSettings::ClearShortcutsAndAccelerators()
 /** static */
 void KeyboardCustomizationSettings::EnableShortcutsGlobally(bool enable)
 {
+    // This is part of the legacy shortcut manager, so bypass it if the new action manager is enabled.
+    if (AzToolsFramework::IsNewActionManagerEnabled())
+    {
+        return;
+    }
+
     for (auto it : m_instances)
     {
         it->EnableShortcuts(enable);


### PR DESCRIPTION
## What does this PR do?

Fixes #15463

Discovered the root cause was `KeyboardCustomizationSettings` (part of the legacy shortcut manager) calling `KeyboardCustomizationSettings::EnableShortcutsGlobally` which removes all shortcuts from any actions found in the main `QMenuBar` on entering game mode. It would then attempt to re-load shortcuts from a previous snapshot, but this logic doesn't work with the new action manager enabled, so circumvented the logic that was removing the shortcuts.

Ideally we could disable `KeyboardCustomizationSettings` entirely when the new action manager is enabled, but it has some ties to the toolbox macro tool and EMFX, so leaving it in place for now.

## How was this PR tested?

Tested entering/exiting game mode and verified that any main menu shortcuts still work afterwards (e.g. duplicate).