### PR TITLE
Emissive and AO presets now generate mips by default.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AmbientOcclusion.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AmbientOcclusion.preset
@@ -8,7 +8,10 @@
             "Name": "AmbientOcclusion",
             "SourceColor": "Linear",
             "DestColor": "Linear",
-            "PixelFormat": "BC4"
+            "PixelFormat": "BC4",
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
         },
         "PlatformsPresets": {
             "android": {
@@ -17,7 +20,10 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "MaxTextureSize": 2048,
-                "PixelFormat": "ASTC_4x4"
+                "PixelFormat": "ASTC_4x4",
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+                }
             },
             "ios": {
                 "UUID": "{02ED0ECE-B198-49D9-85BC-CEBA6C28546C}",
@@ -25,21 +31,30 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "MaxTextureSize": 2048,
-                "PixelFormat": "ASTC_4x4"
+                "PixelFormat": "ASTC_4x4",
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
             },
             "mac": {
                 "UUID": "{02ED0ECE-B198-49D9-85BC-CEBA6C28546C}",
                 "Name": "AmbientOcclusion",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "BC4"
+                "PixelFormat": "BC4",
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
             },
             "provo": {
                 "UUID": "{02ED0ECE-B198-49D9-85BC-CEBA6C28546C}",
                 "Name": "AmbientOcclusion",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "BC4"
+                "PixelFormat": "BC4",
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+                }
             }
         }
     }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Emissive.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Emissive.preset
@@ -8,7 +8,10 @@
             "Name": "Emissive",
             "RGB_Weight": "CIEXYZ",
             "PixelFormat": "BC7",
-            "DiscardAlpha": true
+            "DiscardAlpha": true,
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
         },
         "PlatformsPresets": {
             "android": {
@@ -17,7 +20,10 @@
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "ASTC_4x4",
                 "MaxTextureSize": 2048,
-                "DiscardAlpha": true
+                "DiscardAlpha": true,
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+                }
             },
             "ios": {
                 "UUID": "{07041D83-E0C3-4726-8735-CA0FE550C9A0}",
@@ -25,21 +31,30 @@
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "ASTC_6x6",
                 "MaxTextureSize": 2048,
-                "DiscardAlpha": true
+                "DiscardAlpha": true,
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+                }
             },
             "mac": {
                 "UUID": "{07041D83-E0C3-4726-8735-CA0FE550C9A0}",
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "BC7",
-                "DiscardAlpha": true
+                "DiscardAlpha": true,
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+                }
             },
             "provo": {
                 "UUID": "{07041D83-E0C3-4726-8735-CA0FE550C9A0}",
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "BC7",
-                "DiscardAlpha": true
+                "DiscardAlpha": true,
+                "MipMapSetting": {
+                  "MipGenType": "Box"
+              }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

This changes the presets for Emissive and Ambient Occlusion textures to generate mipmaps by default. Previously, they weren't generating mipmaps. Mipmap generation allows these textures to work better with mip streaming and pool budgets.

## How was this PR tested?

Ran AP on MPS and verified that the emissive and AO textures were now generating mipmaps.
