### PR TITLE
Setting registry support for r_streamingImageMipBias

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageSystemDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageSystemDescriptor.h
@@ -24,6 +24,9 @@ namespace AZ
             //! The maximum size of the image pool used for streaming images.
             //! Check ImageSystemInterface::GetSystemStreamingPool() for detail of this image pool
             uint64_t m_systemStreamingImagePoolSize = 0;
+            
+            //! The mipmap bias applied to streamable images created from the system streaming image pool
+            int16_t m_systemStreamingImagePoolMipBias = 0;
 
             //! The maximum size of the image pool used for system attachments images.
             //! Check ImageSystemInterface::GetSystemAttachmentPool() for detail of this image pool

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -392,11 +392,15 @@ namespace AZ
             // Sync values from ImageSystemDescriptor back to the cvars
             // Note 1: we need the sync here because one instance of the cvars might be initialized early than setting registry,
             // so it can't be initialized properly. See cvar_r_streamingImagePoolBudgetMb_Init and cvar_r_streamingImageMipBias_Init
-            // Note 2: we need to use PerformCommand instead of assign value directly because of this issue https://github.com/o3de/o3de/issues/5537
-            AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %" PRIu64, desc.m_systemStreamingImagePoolSize);
-            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
-            commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %" PRIu16, desc.m_systemStreamingImagePoolMipBias);
-            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
+            // Note 2: we need to use PerformCommand instead of assign value directly because of this issue https://github.com/o3de/o3de/issues/5537            
+            AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
+            if (console)
+            {
+                AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %" PRIu64, desc.m_systemStreamingImagePoolSize);
+                console->PerformCommand(commandString.c_str());
+                commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %" PRId16, desc.m_systemStreamingImagePoolMipBias);
+                console->PerformCommand(commandString.c_str());
+            }
 
             const SystemImagePoolDescriptor systemStreamingPoolDescriptor{ desc.m_systemStreamingImagePoolSize, "ImageSystem::SystemStreamingImagePool" };
             const SystemImagePoolDescriptor systemAttachmentPoolDescriptor{desc.m_systemAttachmentImagePoolSize, "ImageSystem::AttachmentImagePool" };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -29,6 +29,7 @@
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Math/Color.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 AZ_DECLARE_BUDGET(RPI);
 
@@ -37,6 +38,31 @@ namespace AZ
 
     namespace
     {
+        const char* MemoryBudgetSettingPath = "/O3DE/Atom/RPI/Initialization/ImageSystemDescriptor/SystemStreamingImagePoolSize";
+        const char* MipBiasSettingPath = "/O3DE/Atom/RPI/Initialization/ImageSystemDescriptor/SystemStreamingImagePoolMipBias";
+        
+        size_t cvar_r_streamingImagePoolBudgetMb_Init()
+        {
+            size_t value = 0;
+            auto settingsRegistry = AZ::SettingsRegistry::Get();
+            if (settingsRegistry)
+            {
+                settingsRegistry->Get(value, MemoryBudgetSettingPath);
+            }
+            return value;
+        }
+
+        int16_t cvar_r_streamingImageMipBias_Init()
+        {
+            s64 value = 0;
+            auto settingsRegistry = AZ::SettingsRegistry::Get();
+            if (settingsRegistry)
+            {
+                settingsRegistry->Get(value, MipBiasSettingPath);
+            }
+            return aznumeric_cast<int16_t>(value);
+        }
+
         void cvar_r_streamingImagePoolBudgetMb_Changed(const size_t& value)
         {
             if (auto* imageSystem = RPI::ImageSystemInterface::Get())
@@ -45,6 +71,14 @@ namespace AZ
                 size_t newBudget = value * 1024 * 1024;
                 [[maybe_unused]] bool success = pool->SetMemoryBudget(newBudget);
                 AZ_Warning("StreamingImagePool", success, "Can't update StreamingImagePool's memory budget to %uM", value);
+            }
+            else
+            {
+                // Update setting registry value which is used for image system initialization
+                if (auto settingsRegistry = AZ::SettingsRegistry::Get())
+                {
+                    settingsRegistry->Set(MemoryBudgetSettingPath, value);
+                }
             }
         }
 
@@ -55,12 +89,20 @@ namespace AZ
                 Data::Instance<RPI::StreamingImagePool> pool = imageSystem->GetSystemStreamingPool();
                 pool->SetMipBias(value);
             }
+            else
+            {
+                // Update setting registry value which is used for image system initialization
+                if (auto settingsRegistry = AZ::SettingsRegistry::Get())
+                {
+                    settingsRegistry->Set(MipBiasSettingPath, aznumeric_cast<s64>(value));
+                }
+            }
         }
     }
 
     // cvars for changing streaming image pool budget and setup mip bias of streaming controller
-    AZ_CVAR(size_t, r_streamingImagePoolBudgetMb, 0, cvar_r_streamingImagePoolBudgetMb_Changed, ConsoleFunctorFlags::Null, "Change gpu memory budget for the RPI system streaming image pool");
-    AZ_CVAR(int16_t, r_streamingImageMipBias, 0, cvar_r_streamingImageMipBias_Changed, ConsoleFunctorFlags::Null, "Set a mipmap bias for all streamable images created from the system streaming image pool");
+    AZ_CVAR(size_t, r_streamingImagePoolBudgetMb, cvar_r_streamingImagePoolBudgetMb_Init(), cvar_r_streamingImagePoolBudgetMb_Changed, ConsoleFunctorFlags::Null, "Change gpu memory budget for the RPI system streaming image pool");
+    AZ_CVAR(int16_t, r_streamingImageMipBias, cvar_r_streamingImageMipBias_Init(), cvar_r_streamingImageMipBias_Changed, ConsoleFunctorFlags::Null, "Set a mipmap bias for all streamable images created from the system streaming image pool");
 
     namespace RPI
     {
@@ -347,6 +389,12 @@ namespace AZ
                 Data::AssetId m_assetId;
             };
 
+            // sync values from desc back to the cvars
+            AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %d", desc.m_systemStreamingImagePoolSize);
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
+            commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %d", desc.m_systemStreamingImagePoolMipBias);
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
+
             const SystemImagePoolDescriptor systemStreamingPoolDescriptor{ desc.m_systemStreamingImagePoolSize, "ImageSystem::SystemStreamingImagePool" };
             const SystemImagePoolDescriptor systemAttachmentPoolDescriptor{desc.m_systemAttachmentImagePoolSize, "ImageSystem::AttachmentImagePool" };
 
@@ -365,6 +413,7 @@ namespace AZ
                 AZ_Assert(created, "Failed to build streaming image pool");
 
                 m_systemStreamingPool = StreamingImagePool::FindOrCreate(poolAsset);
+                m_systemStreamingPool->SetMipBias(desc.m_systemStreamingImagePoolMipBias);
             }
 
             // Create the system attachment pool.
@@ -415,4 +464,3 @@ namespace AZ
         }
     } // namespace RPI
 }// namespace AZ
-

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -394,7 +394,7 @@ namespace AZ
             // due to this issue: https://github.com/o3de/o3de/issues/5537
             AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %" PRIu64, desc.m_systemStreamingImagePoolSize);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
-            commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %d", desc.m_systemStreamingImagePoolMipBias);
+            commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %" PRIu16, desc.m_systemStreamingImagePoolMipBias);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
 
             const SystemImagePoolDescriptor systemStreamingPoolDescriptor{ desc.m_systemStreamingImagePoolSize, "ImageSystem::SystemStreamingImagePool" };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -392,7 +392,7 @@ namespace AZ
             // Sync values from desc back to the cvars
             // Note: we need this code because one of the instance of the cvar might be initialized early than setting registry
             // due to this issue: https://github.com/o3de/o3de/issues/5537
-            AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %d", desc.m_systemStreamingImagePoolSize);
+            AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %" PRIu64, desc.m_systemStreamingImagePoolSize);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
             commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %d", desc.m_systemStreamingImagePoolMipBias);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -43,13 +43,13 @@ namespace AZ
         
         size_t cvar_r_streamingImagePoolBudgetMb_Init()
         {
-            size_t value = 0;
+            u64 value = 0;
             auto settingsRegistry = AZ::SettingsRegistry::Get();
             if (settingsRegistry)
             {
                 settingsRegistry->Get(value, MemoryBudgetSettingPath);
             }
-            return value;
+            return aznumeric_cast<size_t>(value);
         }
 
         int16_t cvar_r_streamingImageMipBias_Init()
@@ -389,9 +389,10 @@ namespace AZ
                 Data::AssetId m_assetId;
             };
 
-            // Sync values from desc back to the cvars
-            // Note: we need this code because one of the instance of the cvar might be initialized early than setting registry
-            // due to this issue: https://github.com/o3de/o3de/issues/5537
+            // Sync values from ImageSystemDescriptor back to the cvars
+            // Note 1: we need the sync here because one instance of the cvars might be initialized early than setting registry,
+            // so it can't be initialized properly. See cvar_r_streamingImagePoolBudgetMb_Init and cvar_r_streamingImageMipBias_Init
+            // Note 2: we need to use PerformCommand instead of assign value directly because of this issue https://github.com/o3de/o3de/issues/5537
             AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %" PRIu64, desc.m_systemStreamingImagePoolSize);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
             commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %" PRIu16, desc.m_systemStreamingImagePoolMipBias);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -389,7 +389,9 @@ namespace AZ
                 Data::AssetId m_assetId;
             };
 
-            // sync values from desc back to the cvars
+            // Sync values from desc back to the cvars
+            // Note: we need this code because one of the instance of the cvar might be initialized early than setting registry
+            // due to this issue: https://github.com/o3de/o3de/issues/5537
             AZ::CVarFixedString commandString = AZ::CVarFixedString::format("r_streamingImagePoolBudgetMb %d", desc.m_systemStreamingImagePoolSize);
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
             commandString = AZ::CVarFixedString::format("r_streamingImageMipBias %d", desc.m_systemStreamingImagePoolMipBias);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -77,7 +77,7 @@ namespace AZ
                 // Update setting registry value which is used for image system initialization
                 if (auto settingsRegistry = AZ::SettingsRegistry::Get())
                 {
-                    settingsRegistry->Set(MemoryBudgetSettingPath, value);
+                    settingsRegistry->Set(MemoryBudgetSettingPath, aznumeric_cast<u64>(value));
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageSystemDescriptor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageSystemDescriptor.cpp
@@ -22,6 +22,7 @@ namespace AZ
                 serializeContext->Class<ImageSystemDescriptor>()
                     ->Version(0)
                     ->Field("SystemStreamingImagePoolSize", &ImageSystemDescriptor::m_systemStreamingImagePoolSize)
+                    ->Field("SystemStreamingImagePoolMipBias", &ImageSystemDescriptor::m_systemStreamingImagePoolMipBias)
                     ->Field("SystemAttachmentImagePoolSize", &ImageSystemDescriptor::m_systemAttachmentImagePoolSize)
                     ;
             }

--- a/Gems/Atom/RPI/Registry/atom_rpi.setreg
+++ b/Gems/Atom/RPI/Registry/atom_rpi.setreg
@@ -6,7 +6,7 @@
                     "CommonSrgsShaderAssetPath": "shaders/sceneandviewsrgs.azshader",
                     "ImageSystemDescriptor": {
                         "SystemStreamingImagePoolSize": 0,
-                        "SystemStreamingImagePoolMipBias": 1,
+                        "SystemStreamingImagePoolMipBias": 0,
                         "SystemAttachmentImagePoolSize": 0
                     },
                     "GpuQuerySystemDescriptor": {

--- a/Gems/Atom/RPI/Registry/atom_rpi.setreg
+++ b/Gems/Atom/RPI/Registry/atom_rpi.setreg
@@ -6,7 +6,8 @@
                     "CommonSrgsShaderAssetPath": "shaders/sceneandviewsrgs.azshader",
                     "ImageSystemDescriptor": {
                         "SystemStreamingImagePoolSize": 0,
-                        "SystemAttachmentImagePoolSize": 0 
+                        "SystemStreamingImagePoolMipBias": 1,
+                        "SystemAttachmentImagePoolSize": 0
                     },
                     "GpuQuerySystemDescriptor": {
                         "OcclusionQueryCount": 128,


### PR DESCRIPTION
## What does this PR do?

Add streaming image mip bias setting to setting registry: "/O3DE/Atom/RPI/Initialization/ImageSystemDescriptor/SystemStreamingImagePoolMipBias"
Also add value syncing for image streaming cvars and settings. 

Now user can use following way to setup texture mip bias when start app:
1. setting registry  "/O3DE/Atom/RPI/Initialization/ImageSystemDescriptor/SystemStreamingImagePoolMipBias" 
2. use --r_streamingImageMipBias=x in application's command line
3. add the cvar to <project-root>/Cache/<platform>/user.cfg

## How was this PR tested?

Editor
