### PR TITLE
Fixes an issue on network transform where an entity out of view could…

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkTransformComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkTransformComponent.h
@@ -31,10 +31,14 @@ namespace Multiplayer
     private:
         void OnPreRender(float deltaTime);
         void OnCorrection();
+        void OnTransformChanged();
         void OnParentChanged(NetEntityId parentId);
         
         EntityPreRenderEvent::Handler m_entityPreRenderEventHandler;
         EntityCorrectionEvent::Handler m_entityCorrectionEventHandler;
+        AZ::Event<AZ::Quaternion>::Handler m_rotationChangedEventHandler;
+        AZ::Event<AZ::Vector3>::Handler m_translationChangedEventHandler;
+        AZ::Event<float>::Handler m_scaleChangedEventHandler;
         AZ::Event<NetEntityId>::Handler m_parentChangedEventHandler;
         AZ::Event<uint8_t>::Handler m_resetCountChangedEventHandler;
 

--- a/Gems/Multiplayer/Code/Source/AutoGen/NetworkTransformComponent.AutoComponent.xml
+++ b/Gems/Multiplayer/Code/Source/AutoGen/NetworkTransformComponent.AutoComponent.xml
@@ -12,9 +12,9 @@
 
     <Include File="Multiplayer/MultiplayerTypes.h"/>
 
-    <NetworkProperty Type="AZ::Quaternion" Name="rotation" Init="AZ::Quaternion::CreateIdentity()" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="false" />
+    <NetworkProperty Type="AZ::Quaternion" Name="rotation" Init="AZ::Quaternion::CreateIdentity()" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" />
     <NetworkProperty Type="AZ::Vector3" Name="translation" Init="AZ::Vector3::CreateZero()" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" />
-    <NetworkProperty Type="float" Name="scale" Init="1.0f" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="false" />
+    <NetworkProperty Type="float" Name="scale" Init="1.0f" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" />
     <NetworkProperty Type="uint8_t"     Name="resetCount" Init="0" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="false" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="true" GenerateEventBindings="true" />
     <NetworkProperty Type="NetEntityId" Name="parentEntityId" Init="InvalidNetEntityId" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" />
     <NetworkProperty Type="int32_t"     Name="parentAttachmentBoneId" Init="-1" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" />

--- a/Gems/Multiplayer/Code/Source/Components/NetworkTransformComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkTransformComponent.cpp
@@ -65,8 +65,11 @@ namespace Multiplayer
     NetworkTransformComponent::NetworkTransformComponent()
         : m_entityPreRenderEventHandler([this](float deltaTime) { OnPreRender(deltaTime); })
         , m_entityCorrectionEventHandler([this]() { OnCorrection(); })
+        , m_rotationChangedEventHandler([this](AZ::Quaternion) { OnTransformChanged(); })
+        , m_translationChangedEventHandler([this](AZ::Vector3) { OnTransformChanged(); })
+        , m_scaleChangedEventHandler([this](float) { OnTransformChanged(); })
         , m_parentChangedEventHandler([this](NetEntityId parentId) { OnParentChanged(parentId); })
-        , m_resetCountChangedEventHandler([this]([[maybe_unused]] uint8_t resetCount) { m_syncTransformImmediate = true; })
+        , m_resetCountChangedEventHandler([this]([[maybe_unused]] uint8_t resetCount) { OnTransformChanged(); })
     {
         ;
     }
@@ -80,6 +83,9 @@ namespace Multiplayer
     {
         GetNetBindComponent()->AddEntityPreRenderEventHandler(m_entityPreRenderEventHandler);
         GetNetBindComponent()->AddEntityCorrectionEventHandler(m_entityCorrectionEventHandler);
+        RotationAddEvent(m_rotationChangedEventHandler);
+        TranslationAddEvent(m_translationChangedEventHandler);
+        ScaleAddEvent(m_scaleChangedEventHandler);
         ParentEntityIdAddEvent(m_parentChangedEventHandler);
         ResetCountAddEvent(m_resetCountChangedEventHandler);
 
@@ -167,6 +173,12 @@ namespace Multiplayer
                 transformComponent->SetLocalTM(targetTransform);
             }
         }
+    }
+
+    void NetworkTransformComponent::OnTransformChanged()
+    {
+        m_syncTransformImmediate = true;
+        OnPreRender(0.0f);
     }
 
     void NetworkTransformComponent::OnParentChanged(NetEntityId parentId)

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -59,6 +59,11 @@ namespace PhysX
         if (numShapes > 0)
         {
             auto* scene = Utils::GetDefaultScene();
+            if (scene == nullptr)
+            {
+                return;
+            }
+
             auto* pxScene = static_cast<physx::PxScene*>(scene->GetNativePointer());
             PHYSX_SCENE_READ_LOCK(pxScene);
 


### PR DESCRIPTION
Fixes an issue on network transform where an entity out of view could receive a transform update from the server, but due to being out of view never push that updated transform into the entities transform component, thereby remaining frozen out of view on the client. Also fixes a nullptr crash seen in physics colliders during level teardown.