### PR TITLE
Fixed a Vulkan validation warning with Raytracing Acceleration structures

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
@@ -372,7 +372,7 @@ namespace AZ
                         // acceleration structure descriptor is added as the pNext in the VkWriteDescriptorSet
                         VkWriteDescriptorSetAccelerationStructureKHR writeAccelerationStructure = {};
                         writeAccelerationStructure.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
-                        writeAccelerationStructure.accelerationStructureCount = 1;
+                        writeAccelerationStructure.accelerationStructureCount = interval.m_max - interval.m_min;
                         writeAccelerationStructure.pAccelerationStructures = updateData.m_accelerationStructures.data() + interval.m_min;
                         writeAccelerationStructureDescs.push_back(AZStd::move(writeAccelerationStructure));
 
@@ -416,6 +416,7 @@ namespace AZ
                     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                     case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                     case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                         unboundedArraySize = aznumeric_cast<uint32_t>(updateData.m_bufferViewsInfo.size());
                         break;
                     case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.cpp
@@ -380,6 +380,9 @@ namespace AZ
                     case RHI::ShaderInputBufferType::Typed:
                         vbinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
                         break;
+                    case RHI::ShaderInputBufferType::AccelerationStructure:
+                        vbinding.descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+                        break;
                     default:
                         vbinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
                         break;


### PR DESCRIPTION
## What does this PR do?

Removes a Vulkan validation error when Raytracing acceleration structures are in the unbound array of an SRG.
Raytracing acceleration structures were wrongly bound as storage buffers, which led to the following validation error:

```
<09:32:53> [Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-00331 ] Object 0: handle = 0xe76bbd0000001fba, name = ..., type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0xde8c9ed7 | vkUpdateDescriptorSets() pDescriptorWrites[7] failed write update validation for VkDescriptorSet 0xe76bbd0000001fba[...] with error: Write update to VkDescriptorSet 0xe76bbd0000001fba[...] allocated with VkDescriptorSetLayout 0xc20bd20000000656[] binding #8 failed with error message: Attempted write update to buffer descriptor failed due to: Buffer (VkBuffer 0xfd51ae00000015ca[TLAS]) with usage mask 0x1a0002 being used for a descriptor update of type VK_DESCRIPTOR_TYPE_STORAGE_BUFFER does not have VK_BUFFER_USAGE_STORAGE_BUFFER_BIT set.. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_STORAGE_BUFFER or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, the buffer member of each element of pBufferInfo must have been created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT set (https://vulkan.lunarg.com/doc/view/1.3.239.0/windows/1.3-extensions/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-00331)
```

## How was this PR tested?

Windows & Vulkan. Tested with a custom Raytracing pass with acceleration structures in an unbounded array.