### PR TITLE
Fix open in other asset browser

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
@@ -190,6 +190,11 @@ namespace AzToolsFramework
             m_rootIndex = index;
         }
 
+        const QModelIndex AssetBrowserThumbnailViewProxyModel::GetRootIndex() const
+        {
+            return m_rootIndex;
+        }
+
         bool AssetBrowserThumbnailViewProxyModel::GetShowSearchResultsMode() const
         {
             return m_searchResultsMode;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
@@ -28,6 +28,7 @@ namespace AzToolsFramework
             // Used to keep track of the root index on the view consuming this model, so that the model
             // can generate extra data such as whether an entry is on the top level.
             void SetRootIndex(const QModelIndex& index);
+            const QModelIndex GetRootIndex() const;
 
             bool GetShowSearchResultsMode() const;
             void SetShowSearchResultsMode(bool searchMode);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -288,6 +288,7 @@ namespace AzToolsFramework
             }
 
             m_assetTreeView = treeView;
+            m_assetTreeView->SetAttachedThumbnailView(this);
 
             if (!m_assetTreeView)
             {
@@ -418,6 +419,28 @@ namespace AzToolsFramework
             filterCopy->SetFilterPropagation(AssetBrowserEntryFilter::Down);
 
             m_assetFilterModel->SetFilter(FilterConstType(filterCopy));
+        }
+
+        void AssetBrowserThumbnailView::SelectEntry(QString assetName)
+        {
+            QModelIndex rootIndex = m_thumbnailViewProxyModel->GetRootIndex();
+
+            auto model = GetThumbnailViewWidget()->model();
+
+            for (int rowIndex = 0; rowIndex < model->rowCount(rootIndex); rowIndex++)
+            {
+                auto index = model->index(rowIndex, 0, rootIndex);
+                if (!index.isValid())
+                {
+                    continue;
+                }
+
+                auto str = index.data().toString();
+                if (assetName == str)
+                {
+                    GetThumbnailViewWidget()->selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
+                }
+            }
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -62,6 +62,7 @@ namespace AzToolsFramework
             void setSelectionMode(QAbstractItemView::SelectionMode mode);
             QAbstractItemView::SelectionMode selectionMode() const;
 
+            void SelectEntry(QString assetName);
         signals:
             void entryClicked(const AssetBrowserEntry* entry);
             void entryDoubleClicked(const AssetBrowserEntry* entry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -23,6 +23,7 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeViewDialog.h>
 #include <AzToolsFramework/AssetBrowser/Views/EntryDelegate.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
@@ -259,6 +260,13 @@ namespace AzToolsFramework
             // Entries are in reverse order, so fix this
             AZStd::reverse(entries.begin(), entries.end());
 
+            // If we're in the thumbnail view, the actual asset will not appear in this treeview.
+            if (m_attachedThumbnailView)
+            {
+                m_attachedThumbnailView->SelectEntry(entries.back().data());
+                entries.pop_back();
+            }
+
             SelectEntry(QModelIndex(), entries);
         }
 
@@ -368,6 +376,7 @@ namespace AzToolsFramework
             }
             else if (m_indexToSelectAfterUpdate.isValid())
             {
+                AZ_Printf("sjr", "AssetBrowserTreeView::UpdateAfterFilter selecting required\n");
                 selectionModel()->select(m_indexToSelectAfterUpdate, QItemSelectionModel::ClearAndSelect);
                 m_indexToSelectAfterUpdate = QModelIndex();
             }
@@ -648,7 +657,20 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::SetShowIndexAfterUpdate(QModelIndex index)
         {
+            AZ_Printf("sjr", "AssetBrowserTreeView::SetShowIndexAfterUpdate %d, %d, %ld\n", index.row(), index.column(), index.internalPointer());
+            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
             m_indexToSelectAfterUpdate = index;
+            m_assetBrowserSortFilterProxyModel->FilterUpdatedSlotImmediate();
+        }
+
+        void AssetBrowserTreeView::SetAttachedThumbnailView(AssetBrowserThumbnailView* thumbnailView)
+        {
+            m_attachedThumbnailView = thumbnailView;
+        }
+
+        AssetBrowserThumbnailView* AssetBrowserTreeView::GetAttachedThumbnailView() const
+        {
+            return m_attachedThumbnailView;
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -32,6 +32,7 @@ namespace AzToolsFramework
         class AssetBrowserEntry;
         class AssetBrowserModel;
         class AssetBrowserFilterModel;
+        class AssetBrowserThumbnailView;
         class EntryDelegate;
 
         class AssetBrowserTreeView
@@ -103,6 +104,9 @@ namespace AzToolsFramework
 
             void SetShowIndexAfterUpdate(QModelIndex index);
 
+            void SetAttachedThumbnailView(AssetBrowserThumbnailView* thumbnailView);
+            AssetBrowserThumbnailView* GetAttachedThumbnailView() const;
+
         Q_SIGNALS:
             void selectionChangedSignal(const QItemSelection& selected, const QItemSelection& deselected);
             void ClearStringFilter();
@@ -128,6 +132,8 @@ namespace AzToolsFramework
 
             QTimer* m_scTimer = nullptr;
             const int m_scUpdateInterval = 100;
+
+            AssetBrowserThumbnailView* m_attachedThumbnailView = nullptr;
 
             QString m_name;
 


### PR DESCRIPTION
## What does this PR do?

This PR resolves #14841. It now selects the correct folder in the treeview and asset in the thumbnail view.

## How was this PR tested?

Tested manually in the new thumbnail browser and verified the old browser still works.
