### PR TITLE
Skinmesh motion vector fix

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -528,6 +528,7 @@ namespace AZ
             meshDataHandle->m_originalModelAsset = descriptor.m_modelAsset;
             meshDataHandle->m_meshLoader = AZStd::make_unique<ModelDataInstance::MeshLoader>(descriptor.m_modelAsset, &*meshDataHandle);
             meshDataHandle->m_flags.m_isAlwaysDynamic = descriptor.m_isAlwaysDynamic;
+            meshDataHandle->m_flags.m_isDrawMotion = descriptor.m_isAlwaysDynamic;
 
             if (descriptor.m_excludeFromReflectionCubeMaps)
             {
@@ -1289,7 +1290,6 @@ namespace AZ
         {
             m_model = model;
             m_flags.m_needsInit = true;
-            m_flags.m_isDrawMotion = m_flags.m_isAlwaysDynamic;
             m_aabb = m_model->GetModelAsset()->GetAabb();
         }
 


### PR DESCRIPTION
## What does this PR do?
Fixed an edge case that the m_isDrawMotion wasn't set correctly if the mesh asset was already loaded when creating the MeshHandle

## How was this PR tested?

ASV SkinemeshMotionVector test
