### PR TITLE
Closes #15427

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -231,8 +231,10 @@ namespace AZ
 
         bool MaterialTypeAsset::PostLoadInit()
         {
-            [[maybe_unused]] bool success = InitializeNonSerializedData();
-            AZ_Assert(success, "Failed to InitializeNonSerializedData");
+            // Attempt to initialize non-serialized data. The referenced shader assets in the ShaderCollection
+            // may not be ready right now, but in the future the system will retry when said assets
+            // are ready.
+            InitializeNonSerializedData();
 
             for (const auto& shaderItem : m_generalShaderCollection)
             {


### PR DESCRIPTION
## What does this PR do?

Removed unnecessary assert when loading non-serialized data in MaterialTypeAsset::PostLoadInit().

## How was this PR tested?
Did the same steps as described in this bug: https://github.com/o3de/o3de/issues/15488, and the Editor doesn't crash anymore.

Also did the other related bug described by @amzn-tommy in the same GHI and the bug doesn't occur anymore (Using an MC generated material, saving the level, closing the Editor, reopening the Editor and the level).
