### PR TITLE
Material Canvas: Move check for invalid render pipeline asset ID so that it's handled on all code paths

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportScene.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportScene.cpp
@@ -108,25 +108,26 @@ namespace AtomToolsFramework
         {
             return m_renderPipelines.emplace(pipelineAssetId, renderPipeline).first;
         }
-        else
-        {
-            return m_renderPipelines.end();
-        }
+
+        return m_renderPipelines.end();
     }
 
     bool EntityPreviewViewportScene::ActivateRenderPipeline(const AZ::Data::AssetId& pipelineAssetId)
     {
-        auto iter = m_renderPipelines.find(pipelineAssetId);
+        if (!pipelineAssetId.IsValid())
+        {
+            return false;
+        }
 
+        auto iter = m_renderPipelines.find(pipelineAssetId);
         if (iter == m_renderPipelines.end())
         {
             iter = AddRenderPipeline(pipelineAssetId);
-        }
-
-        if (iter == m_renderPipelines.end())
-        {
-            // The pipeline was not found and could not be loaded
-            return false;
+            if (iter == m_renderPipelines.end())
+            {
+                // The pipeline was not found and could not be loaded
+                return false;
+            }
         }
 
         if (iter->first != m_activeRenderPipelineId)
@@ -155,14 +156,7 @@ namespace AtomToolsFramework
     {
         using namespace AZ::RPI;
         AZ::Data::AssetId assetId = AssetUtils::GetAssetIdForProductPath(pipelineAssetPath.c_str(), AssetUtils::TraceLevel::Error);
-        if (assetId.IsValid())
-        {
-            return ActivateRenderPipeline(assetId);
-        }
-        else
-        {
-            return false;
-        }
+        return ActivateRenderPipeline(assetId);
     }
 
     AZ::RPI::ScenePtr EntityPreviewViewportScene::GetScene() const


### PR DESCRIPTION
## What does this PR do?

Move check for invalid render pipeline asset ID so that it's handled on all code paths

## How was this PR tested?

I have been running with these changes locally for some time. 
Confirmed that code still compiles and render pipelines are updated when changed from the viewport drop down.