### PR TITLE
Material Canvas: Resetting graph compiler data between state transitions

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphCompiler.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphCompiler.cpp
@@ -65,21 +65,29 @@ namespace AtomToolsFramework
         {
         case State::Idle:
             ReportStatus(AZStd::string::format("%s (Idle)", GetGraphPath().c_str()));
+            m_graph.reset();
+            m_graphName.clear();
+            m_graphPath.clear();
+            m_generatedFiles.clear();
             break;
         case State::Compiling:
-            m_generatedFiles.clear();
             ReportStatus(AZStd::string::format("%s (Compiling)", GetGraphPath().c_str()));
+            m_generatedFiles.clear();
             break;
         case State::Processing:
+            ReportStatus(AZStd::string::format("%s (Processing)", GetGraphPath().c_str()));
             break;
         case State::Complete:
             ReportStatus(AZStd::string::format("%s (Complete)", GetGraphPath().c_str()));
+            m_graph.reset();
             break;
         case State::Failed:
             ReportStatus(AZStd::string::format("%s (Failed)", GetGraphPath().c_str()));
+            m_graph.reset();
             break;
         case State::Canceled:
             ReportStatus(AZStd::string::format("%s (Cancelled)", GetGraphPath().c_str()));
+            m_graph.reset();
             break;
         }
 
@@ -170,7 +178,7 @@ namespace AtomToolsFramework
                     }
 
                     ReportStatus(AZStd::string::format(
-                        "Processing %s (%s)", generatedFile.c_str(), AzToolsFramework::AssetSystem::JobStatusString(job.m_status)));
+                        "%s (Processing: %s)", generatedFile.c_str(), AzToolsFramework::AssetSystem::JobStatusString(job.m_status)));
 
                     switch (job.m_status)
                     {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -383,6 +383,8 @@ namespace AtomToolsFramework
             });
 
             graphCompiler->CompileGraph(graph, graphName, graphPath);
+            graphCompiler->SetStateChangeHandler({});
+            graph.reset();
         };
 
         auto job = AZ::CreateJobFunction(compileJobFn, true);


### PR DESCRIPTION
## What does this PR do?

Resetting graph compiler data between state transitions and updating status messages

## How was this PR tested?

Confirmed that code still compiles.
Confirmed that state changes display the correct messages.
Confirmed that assets and data captured with the graph compiler and job are released with job completion, cancellation, and before exit.