### PR TITLE
Material Canvas: Fixed multiple issues with node resizing

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
@@ -175,7 +175,10 @@ namespace GraphCanvas
             QObject::connect(m_lineEdit, &QLineEdit::textChanged, [this]() { ResizeToContents(); });
             QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusIn, [this]() { EditStart(); });
             QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusOut, [this]() { EditFinished(); });
-            QObject::connect(m_lineEdit, &QLineEdit::editingFinished, [this]() { SubmitValue(); UpdateDisplay(); });
+            QObject::connect(m_lineEdit, &QLineEdit::editingFinished, [this]() {
+                SubmitValue();
+                UpdateDisplay();
+            });
 
             m_proxyWidget->setWidget(m_lineEdit);
             UpdateDisplay();

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/StringNodePropertyDisplay.cpp
@@ -84,11 +84,6 @@ namespace GraphCanvas
         }
 
         ResizeToContents();
-        
-        if (m_proxyWidget)
-        {
-            m_proxyWidget->update();
-        }
     }
 
     QGraphicsLayoutItem* StringNodePropertyDisplay::GetDisabledGraphicsLayoutItem()
@@ -180,7 +175,7 @@ namespace GraphCanvas
             QObject::connect(m_lineEdit, &QLineEdit::textChanged, [this]() { ResizeToContents(); });
             QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusIn, [this]() { EditStart(); });
             QObject::connect(m_lineEdit, &Internal::FocusableLineEdit::OnFocusOut, [this]() { EditFinished(); });
-            QObject::connect(m_lineEdit, &QLineEdit::editingFinished, [this]() { SubmitValue(); });
+            QObject::connect(m_lineEdit, &QLineEdit::editingFinished, [this]() { SubmitValue(); UpdateDisplay(); });
 
             m_proxyWidget->setWidget(m_lineEdit);
             UpdateDisplay();
@@ -231,6 +226,11 @@ namespace GraphCanvas
                     SceneRequestBus::Event(GetSceneId(), &SceneRequests::StartNudging, fixedNodes);
                 }
             }
+        }
+        
+        if (m_proxyWidget)
+        {
+            m_proxyWidget->update();
         }
     }
 

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
@@ -56,48 +56,45 @@ namespace GraphCanvas
     //////////////////////////
     // ReadOnlyVectorControl
     //////////////////////////
-    
+
     ReadOnlyVectorControl::ReadOnlyVectorControl(int index, const VectorDataInterface& dataInterface)
         : m_index(index)
         , m_dataInterface(dataInterface)
     {
+        m_textLabel = aznew GraphCanvasLabel();
+        m_textLabel->SetRoundedCornersMode(GraphCanvasLabel::RoundedCornersMode::LeftCorners);
+        m_textLabel->SetLabel(dataInterface.GetLabel(index));
+
+        m_valueLabel = aznew GraphCanvasLabel();
+        m_valueLabel->SetRoundedCornersMode(GraphCanvasLabel::RoundedCornersMode::RightCorners);
+
         m_layout = new QGraphicsLinearLayout(Qt::Orientation::Horizontal);
         m_layout->setSpacing(0);
         m_layout->setContentsMargins(0, 0, 0, 0);
-        
-        m_textLabel = aznew GraphCanvasLabel();
-        m_textLabel->SetRoundedCornersMode(GraphCanvasLabel::RoundedCornersMode::LeftCorners);
-        m_valueLabel = aznew GraphCanvasLabel();
-        m_valueLabel->SetRoundedCornersMode(GraphCanvasLabel::RoundedCornersMode::RightCorners);
-        
         m_layout->addItem(m_textLabel);
         m_layout->addItem(m_valueLabel);
-
-        m_textLabel->SetLabel(dataInterface.GetLabel(index));
-        
-        setContentsMargins(0, 0, 0, 0);
-    
         setLayout(m_layout);
+        setContentsMargins(0, 0, 0, 0);
     }
-    
+
     ReadOnlyVectorControl::~ReadOnlyVectorControl()
     {
     }
-    
+
     void ReadOnlyVectorControl::RefreshStyle(const AZ::EntityId& sceneId)
     {
-        AZStd::string styleName = m_dataInterface.GetElementStyle(m_index);
+        const AZStd::string styleName = m_dataInterface.GetElementStyle(m_index);
         m_textLabel->SetSceneStyle(sceneId, NodePropertyDisplay::CreateDisplayLabelStyle(styleName + "_text").c_str());
         m_valueLabel->SetSceneStyle(sceneId, NodePropertyDisplay::CreateDisplayLabelStyle(styleName + "_value").c_str());
     }
-    
+
     void ReadOnlyVectorControl::UpdateDisplay()
     {
-        double value = m_dataInterface.GetValue(m_index);
-
-        AZStd::string displayValue = AZStd::string::format("%.*g%s", m_dataInterface.GetDisplayDecimalPlaces(m_index), value, m_dataInterface.GetSuffix(m_index));
-
-        m_valueLabel->SetLabel(displayValue);
+        m_valueLabel->SetLabel(AZStd::string::format(
+            "%.*g%s",
+            m_dataInterface.GetDisplayDecimalPlaces(m_index),
+            m_dataInterface.GetValue(m_index),
+            m_dataInterface.GetSuffix(m_index)));
     }
 
     int ReadOnlyVectorControl::GetIndex() const
@@ -129,11 +126,14 @@ namespace GraphCanvas
         : QGraphicsWidget(parent)
         , m_pixmap(new QGraphicsPixmapItem(this))
     {
+        m_pixmap->setVisible(false);
         setGraphicsItem(m_pixmap);
+        setContentsMargins(0, 0, 0, 0);
     }
 
     void IconLayoutItem::setIcon(const QPixmap& pixmap)
     {
+        m_pixmap->setVisible(!pixmap.isNull());
         m_pixmap->setPixmap(pixmap);
     }
 
@@ -162,23 +162,23 @@ namespace GraphCanvas
         displayLayout->setSpacing(5);
         displayLayout->setContentsMargins(0, 0, 0, 0);
         displayLayout->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-        
+
         m_iconDisplay = new IconLayoutItem();
         m_iconDisplay->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
         displayLayout->addItem(m_iconDisplay);
         displayLayout->setAlignment(m_iconDisplay, Qt::AlignBottom);
- 
-        int elementCount = dataInterface->GetElementCount();
+
+        const int elementCount = dataInterface->GetElementCount();
         m_vectorDisplays.reserve(elementCount);
-        for (int i=0; i < elementCount; ++i)
+        for (int i = 0; i < elementCount; ++i)
         {
             m_vectorDisplays.push_back(aznew ReadOnlyVectorControl(i, (*dataInterface)));
             displayLayout->addItem(m_vectorDisplays.back());
         }
 
         m_displayWidget->setLayout(displayLayout);
-        
+
         m_disabledLabel = aznew GraphCanvasLabel();
     }
 
@@ -194,23 +194,21 @@ namespace GraphCanvas
     
     void VectorNodePropertyDisplay::RefreshStyle()
     {
-        AZ::EntityId sceneId = GetSceneId();
+        const AZ::EntityId sceneId = GetSceneId();
 
-        AZStd::string elementStyle = m_dataInterface->GetStyle();
+        const AZStd::string elementStyle = m_dataInterface->GetStyle();
 
         m_styleHelper.SetScene(sceneId);
         m_styleHelper.SetStyle(NodePropertyDisplay::CreateDisplayLabelStyle(elementStyle).c_str());
         m_disabledLabel->SetSceneStyle(GetSceneId(), NodePropertyDisplay::CreateDisabledLabelStyle(elementStyle).c_str());
 
-        QColor backgroundColor = m_styleHelper.GetAttribute(GraphCanvas::Styling::Attribute::BackgroundColor, QColor(0, 0, 0, 0));
-
-        m_displayWidget->setAutoFillBackground(true);
-
         QPalette palette = m_displayWidget->palette();
+        const QColor backgroundColor = m_styleHelper.GetAttribute(GraphCanvas::Styling::Attribute::BackgroundColor, QColor(0, 0, 0, 0));
         palette.setColor(QPalette::ColorRole::Window, backgroundColor);
         m_displayWidget->setPalette(palette);
+        m_displayWidget->setAutoFillBackground(true);
 
-        qreal spacing = static_cast<QGraphicsLinearLayout*>(m_displayWidget->layout())->spacing();
+        const qreal spacing = static_cast<QGraphicsLinearLayout*>(m_displayWidget->layout())->spacing();
 
         // Start off with - spacing to make the iteration logic cleaner.
         qreal elementWidth = -spacing;
@@ -222,7 +220,7 @@ namespace GraphCanvas
         {
             control->RefreshStyle(sceneId);
 
-            QSizeF maximumSize = control->maximumSize();
+            const QSizeF maximumSize = control->maximumSize();
 
             // Maximum size might be stupidly large, which will cause an error
             // from Qt as it tries to overly allocate space for something.
@@ -230,21 +228,28 @@ namespace GraphCanvas
             // As such we want to put an upper limit on this that is large but not unreasonable.
             // Can't really do this at the element level since it messes with the styling
             // when I set it. So instead we'll do it here.
-            elementWidth += AZ::GetMin(maximumSize.width(), k_sizingConstraint) + spacing;
-            elementHeight = AZStd::GetMax(elementHeight, AZ::GetMin(k_sizingConstraint, maximumSize.height()));
+            elementWidth += AZ::GetMin(k_sizingConstraint, maximumSize.width()) + spacing;
+            elementHeight = AZ::GetMax(elementHeight, AZ::GetMin(k_sizingConstraint, maximumSize.height()));
         }
-        elementWidth += m_iconDisplay->preferredWidth();
+
+        if (m_iconDisplay && m_iconDisplay->isVisible())
+        {
+            elementWidth += m_iconDisplay->preferredWidth();
+        }
 
         m_displayWidget->setMinimumSize(elementWidth, elementHeight);
         m_displayWidget->setPreferredSize(elementWidth, elementHeight);
         m_displayWidget->setMaximumSize(elementWidth, elementHeight);
         m_displayWidget->adjustSize();
 
-        if (m_propertyVectorCtrl)
+        if (m_widgetContainer)
         {
-            m_propertyVectorCtrl->setMinimumSize(aznumeric_cast<int>(elementWidth), aznumeric_cast<int>(elementHeight));
-            m_propertyVectorCtrl->setMaximumSize(aznumeric_cast<int>(elementWidth), aznumeric_cast<int>(elementHeight));
-            m_propertyVectorCtrl->adjustSize();
+            const QSizeF minimumSize = m_displayWidget->minimumSize();
+            const QSizeF maximumSize = m_displayWidget->maximumSize();
+
+            m_widgetContainer->setMinimumSize(aznumeric_cast<int>(minimumSize.width()), aznumeric_cast<int>(minimumSize.height()));
+            m_widgetContainer->setMaximumSize(aznumeric_cast<int>(maximumSize.width()), aznumeric_cast<int>(maximumSize.height()));
+            m_widgetContainer->adjustSize();
         }
     }
 
@@ -258,23 +263,17 @@ namespace GraphCanvas
         const auto buttonIcon = m_dataInterface->GetIcon();
         if (m_iconDisplay)
         {
-            if (!buttonIcon.isNull())
-            {
-                m_iconDisplay->setPreferredSize(buttonIcon.size());
-                m_iconDisplay->setIcon(buttonIcon);
-            }
+            m_iconDisplay->setIcon(buttonIcon);
+            m_iconDisplay->setPreferredSize(buttonIcon.size());
             m_iconDisplay->setVisible(!buttonIcon.isNull());
         }
 
         if (m_button)
         {
-            if (!buttonIcon.isNull())
-            {
-                QIcon newIcon(buttonIcon);
-                m_button->setFixedSize(buttonIcon.size());
-                m_button->setIconSize(buttonIcon.size());
-                m_button->setIcon(newIcon);
-            }
+            const QIcon newIcon(buttonIcon);
+            m_button->setIcon(newIcon);
+            m_button->setFixedSize(buttonIcon.size());
+            m_button->setIconSize(buttonIcon.size());
             m_button->setVisible(!buttonIcon.isNull());
         }
 
@@ -353,13 +352,15 @@ namespace GraphCanvas
     {
         if (!m_propertyVectorCtrl)
         {
-            m_proxyWidget = new QGraphicsProxyWidget();
-
             m_widgetContainer = new QWidget();
-            QHBoxLayout* layout = new QHBoxLayout(m_widgetContainer);
-            m_widgetContainer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+            m_widgetContainer->setContentsMargins(0, 0, 0, 0);
+            m_widgetContainer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            m_widgetContainer->setProperty("HasNoWindowDecorations", true);
 
+            QHBoxLayout* layout = new QHBoxLayout(m_widgetContainer);
             layout->setAlignment(Qt::AlignLeft);
+            layout->setMargin(0);
+            layout->setSpacing(0);
             layout->setContentsMargins(0, 0, 0, 0);
 
             m_button = new QToolButton(m_widgetContainer);
@@ -373,12 +374,10 @@ namespace GraphCanvas
             });
             layout->addWidget(m_button);
 
-            m_proxyWidget->setFlag(QGraphicsItem::ItemIsFocusable, true);
-            m_proxyWidget->setFocusPolicy(Qt::StrongFocus);
-            m_proxyWidget->setAcceptDrops(false);
-
             const int elementCount = m_dataInterface->GetElementCount();
             m_propertyVectorCtrl = new AzQtComponents::VectorInput(m_widgetContainer, elementCount);
+            m_propertyVectorCtrl->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            QObject::connect(m_propertyVectorCtrl, &AzQtComponents::VectorInput::editingFinished, [this]() { SubmitValue(); });
 
             for (int i = 0; i < elementCount; ++i)
             {
@@ -390,11 +389,12 @@ namespace GraphCanvas
                 m_propertyVectorCtrl->setSuffix(m_dataInterface->GetSuffix(i));
             }
 
-            m_propertyVectorCtrl->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-            QObject::connect(m_propertyVectorCtrl, &AzQtComponents::VectorInput::editingFinished, [this]() { SubmitValue(); });
-
             layout->addWidget(m_propertyVectorCtrl);
-            m_widgetContainer->setProperty("HasNoWindowDecorations", true);
+
+            m_proxyWidget = new QGraphicsProxyWidget();
+            m_proxyWidget->setFlag(QGraphicsItem::ItemIsFocusable, true);
+            m_proxyWidget->setFocusPolicy(Qt::StrongFocus);
+            m_proxyWidget->setAcceptDrops(false);
             m_proxyWidget->setWidget(m_widgetContainer);
             
             UpdateDisplay();
@@ -411,10 +411,10 @@ namespace GraphCanvas
             delete m_widgetContainer; // NB: this implicitly deletes m_proxy widget
             m_widgetContainer = nullptr;
             m_propertyVectorCtrl = nullptr;
-            m_button= nullptr;
+            m_button = nullptr;
             m_proxyWidget = nullptr;
         }
     }
 
 #include <Source/Components/NodePropertyDisplays/moc_VectorNodePropertyDisplay.cpp>
-}
+} // namespace GraphCanvas

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/GraphController.h
@@ -148,6 +148,7 @@ namespace GraphModelIntegration
         // GraphCanvas::SceneNotificationBus, connections
         void OnNodeAdded(const AZ::EntityId& nodeUiId, bool isPaste) override;
         void OnNodeRemoved(const AZ::EntityId& nodeUiId) override;
+        void OnConnectionAdded(const AZ::EntityId& connectionUiId) override;
         void OnConnectionRemoved(const AZ::EntityId& connectionUiId) override;
         void OnEntitiesSerialized(GraphCanvas::GraphSerialization& serializationTarget) override;
         void OnEntitiesDeserialized(const GraphCanvas::GraphSerialization& serializationSource) override;


### PR DESCRIPTION
## What does this PR do?

- Changing the value of a string property display will now cause the node to grow with the length of the string and shrink to reclaim wasted space.
- Vector property displays now correctly set the container and proxy widget sizes together correctly. Both now also consider visibility of the optional button or icon. This eliminates the popping and displacement whenever hovering over a node containing a vector.
- The graph model graph controller now automatically adjusts the size of any affected nodes whenever connections are added or removed. This ensures that nodes always take up the minimum amount of space whenever all of their slots with properties have connections.

Resolves https://github.com/o3de/o3de/issues/13918
Resolves https://github.com/o3de/o3de/issues/13916

## How was this PR tested?

- Tested creating, hovering over, clicking, dragging, connecting, and entering values into different material canvas and script canvas nodes with vectors and strings.
- Confirmed that nodes grow when entering larger string values and shrink when deleting characters or when white space is truncated from the end of the string.
- Confirmed that connecting and disconnecting nodes containing vectors and other types automatically resize in script canvas and landscape canvas.
- Confirmed that hovering over nodes containing vectors does not cause the node size to pop or grow with a bunch of empty space.