### PR TITLE
Fix accidental opt-in of all test targets to sharding.

### DIFF
--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
@@ -132,7 +132,7 @@ namespace TestImpact
             const size_t numTestRunsCompleted,
             const size_t totalNumTestRuns)
         {
-            if (m_consoleOutputMode == ConsoleOutputMode::Buffered)
+            if (m_consoleOutputMode == ConsoleOutputMode::Buffered && testRun.GetResult() != Client::TestRunResult::AllTestsPass)
             {
                 if (!testRun.GetStdOutput().empty())
                 {

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
@@ -33,6 +33,12 @@ namespace TestImpact
         return m_launchMeta.m_launchMethod;
     }
 
+    bool NativeTestTarget::CanShard() const
+    {
+        // Target must be able to enumerate as well as being opted in to test sharding in order to shard
+        return CanEnumerate() && GetSuiteLabelSet().contains(TiafShardingLabel);
+    }
+
     bool NativeTestTarget::CanEnumerate() const
     {
         return GetSuiteLabelSet().contains(SupportedTestFrameworks::GTest);

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
@@ -28,6 +28,9 @@ namespace TestImpact
         //! Returns the test target launch method.
         LaunchMethod GetLaunchMethod() const;
 
+        //! Returns `true` if the target can shard, otherwise `false`.
+        bool CanShard() const;
+
         // TestTarget overrides ...
         bool CanEnumerate() const override;
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
@@ -196,8 +196,12 @@ namespace TestImpact
     ShardedTestJobInfo<TestJobRunner> NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateJobInfo(
         const TestTargetAndEnumeration& testTargetAndEnumeration, typename TestJobRunner::JobInfo::Id startingId)
     {
+        // If the target can shard and has more than one test, and the max concurrency is greater than 1, we will shard
         if (const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
-            m_maxConcurrency > 1 && testEnumeration.has_value() && testEnumeration->GetNumEnabledTests() > 1)
+            testTarget->CanShard()
+            && m_maxConcurrency > 1
+            && testEnumeration.has_value()
+            && testEnumeration->GetNumEnabledTests() > 1)
         {
             return GenerateJobInfoImpl(testTargetAndEnumeration, startingId);
         }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -106,7 +106,7 @@
       "CONFIGURATION": "profile",
       "SCRIPT_PATH": "scripts/build/TestImpactAnalysis/tiaf_driver.py",
       "SCRIPT_PARAMETERS": 
-      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suites smoke main --label-excludes REQUIRES_gpu --test-failure-policy=continue --runtime-type=native"
+      "--config=\"%OUTPUT_DIRECTORY%/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=%BRANCH_NAME% --dst-branch=%CHANGE_TARGET% --commit=%CHANGE_ID% --s3-bucket=%TEST_IMPACT_S3_BUCKET% --mars-index-prefix=o3de-tiaf --s3-top-level-dir=%REPOSITORY_NAME% --build-number=%BUILD_NUMBER% --suites smoke main --label-excludes REQUIRES_gpu --test-failure-policy=continue --runtime-type=native --target-output=stdout"
     }
   },
   "test_impact_analysis_profile_python": {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the accidental opting in of all test targets to the test sharding optimization.

This PR also adds test target stdout to the native TIAF runtime, but only outputs the stdout for test targets that fail in any way.

## How was this PR tested?

This PR will be tested in AR.
