### PR TITLE
Automatically expand file tree in "Open Level" dialog

### DIFF
--- a/Code/Editor/LevelFileDialog.cpp
+++ b/Code/Editor/LevelFileDialog.cpp
@@ -66,6 +66,7 @@ CLevelFileDialog::CLevelFileDialog(bool openDialog, QWidget* parent)
     if (m_bOpenDialog)
     {
         setWindowTitle(tr("Open Level"));
+        ui->treeView->expandToDepth(1);
         ui->newFolderButton->setVisible(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Open"));
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #13445

Automatically expands the file tree for the "Open Level" dialog.

## How was this PR tested?

Manual testing.

Before:
![image](https://user-images.githubusercontent.com/82231674/229492060-4c8b8216-df56-4754-99fc-3b6b9bb0a691.png)

After:
![image](https://user-images.githubusercontent.com/82231674/229492105-da412750-4471-46c2-a181-5f986f384f24.png)

