### PR TITLE
Standardized path resolution for wildcard product dependencies.

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
@@ -511,11 +511,15 @@ namespace AssetProcessor
 
             bool isExcludedDependency = dependencyPathSearch.starts_with(ExcludedDependenciesSymbol);
             dependencyPathSearch = isExcludedDependency ? dependencyPathSearch.substr(1) : dependencyPathSearch;
+            // The database uses % for wildcards, both path based searching uses *, so keep a copy of the path with the * wildcard for later
+            // use.
+            AZStd::string pathWildcardSearchPath(dependencyPathSearch);
             bool isExactDependency = !AzFramework::StringFunc::Replace(dependencyPathSearch, '*', '%');
 
             if (cleanedupDependency.m_dependencyType == AssetBuilderSDK::ProductPathDependencyType::ProductFile)
             {
                 SanitizeForDatabase(dependencyPathSearch);
+                SanitizeForDatabase(pathWildcardSearchPath);
                 AzToolsFramework::AssetDatabase::ProductDatabaseEntryContainer productInfoContainer;
                 QString productNameWithPlatform = QString("%1%2%3").arg(platform.c_str(), AZ_CORRECT_DATABASE_SEPARATOR_STRING, dependencyPathSearch.c_str());
 
@@ -550,6 +554,24 @@ namespace AssetProcessor
                     {
                         if (m_stateData->GetSourceByJobID(productDatabaseEntry.m_jobPK, sourceDatabaseEntry))
                         {
+                            // The SQL wildcard search is greedy and doesn't match the path based, glob style wildcard search that is
+                            // expected in this case. This also matches the behavior of resolving unmet dependencies later. There are two
+                            // cases that wildcard dependencies resolve:
+                            //  1. When the product with the wildcard dependency is first created, it resolves those dependencies against
+                            //  what's already in the database. That's this case.
+                            //  2. When another product is created, all existing wildcard dependencies are compared against that product to
+                            //  see if it matches them.
+                            // This check here makes sure that the filter for 1 matches 2.
+                            if (!isExactDependency)
+                            {
+                                AZ::IO::PathView searchPath(productDatabaseEntry.m_productName);
+
+                                if (!searchPath.Match(pathWildcardSearchPath))
+                                {
+                                    continue;
+                                }
+                            }
+
                             AZStd::vector<AssetBuilderSDK::ProductDependency>& productDependencyList = isExcludedDependency ? excludedDeps : resolvedDeps;
                             productDependencyList.emplace_back(AZ::Data::AssetId(sourceDatabaseEntry.m_sourceGuid, productDatabaseEntry.m_subID), productDependencyFlags);
                         }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -2244,7 +2244,10 @@ bool SearchDependencies(AzToolsFramework::AssetDatabase::ProductDependencyDataba
     return false;
 }
 
-void VerifyDependencies(AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer dependencyContainer, AZStd::initializer_list<AZ::Data::AssetId> assetIds, AZStd::initializer_list<const char*> unresolvedPaths = {})
+void VerifyDependencies(
+    AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer dependencyContainer,
+    AZStd::vector<AZ::Data::AssetId> assetIds, 
+    AZStd::initializer_list<const char*> unresolvedPaths = {})
 {
     EXPECT_EQ(dependencyContainer.size(), assetIds.size() + unresolvedPaths.size());
 
@@ -2281,6 +2284,88 @@ void VerifyDependencies(AzToolsFramework::AssetDatabase::ProductDependencyDataba
 
         ASSERT_TRUE(found) << "Unresolved path " << unresolvedPath << " was not found";
     }
+}
+
+void VerifyDependencies(
+    AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer dependencyContainer,
+    AZStd::initializer_list<AZ::Data::AssetId> assetIds,
+    AZStd::initializer_list<const char*> unresolvedPaths = {})
+{
+    VerifyDependencies(dependencyContainer, AZStd::vector<AZ::Data::AssetId>(assetIds), unresolvedPaths);
+}
+
+void PathDependencyTest::RunWildcardDependencyTestOnPaths(
+    const AZStd::string& wildcardDependency,
+    const AZStd::vector<AZStd::string>& expectedMatchingPaths,
+    const AZStd::vector<AZStd::string>& expectedNotMatchingPaths)
+{
+    using namespace AssetProcessor;
+    using namespace AssetBuilderSDK;
+
+    AZStd::vector<AZ::Data::AssetId> expectedMatchingProducts;
+
+    for (const auto& assetName : expectedMatchingPaths)
+    {
+        TestAsset testAsset(assetName.c_str());
+
+        bool result = ProcessAsset(testAsset, { { ".txt" }, {} });
+        ASSERT_TRUE(result) << "Failed to Process Assets";
+
+        expectedMatchingProducts.push_back(testAsset.m_products[0]);
+    }
+
+    for (const auto& assetName : expectedNotMatchingPaths)
+    {
+        TestAsset testAsset(assetName.c_str());
+
+        bool result = ProcessAsset(testAsset, { { ".txt" }, {} });
+        ASSERT_TRUE(result) << "Failed to Process Assets";
+    }
+
+    TestAsset primaryFile("test_text");
+    bool result =
+        ProcessAsset(primaryFile, { { ".asset" }, {} }, { { wildcardDependency.c_str(), ProductPathDependencyType::ProductFile } });
+    ASSERT_TRUE(result) << "Failed to Process main test asset";
+
+    AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer dependencyContainer;
+    result = m_sharedConnection->GetProductDependencies(dependencyContainer);
+    ASSERT_TRUE(result) << "Failed to Get Product Dependencies";
+
+    VerifyDependencies(dependencyContainer, expectedMatchingProducts, { wildcardDependency.c_str() });
+}
+
+// Wildcard matching does not extend past directory markers.
+// So a dependency on "Root/Path/*.txt" will only match text files in Root/Path, and not subfolders.
+// For example, "Root/Path/Subfolder/file.txt" would not be matched.
+TEST_F(PathDependencyTest, WildcardDependencies_WildcardWithPath_ResolveCorrectly)
+{
+    RunWildcardDependencyTestOnPaths(
+        "root/path/*.txt",
+        // Should match - this file is in the matching subfolder
+        /*expectedMatchingPaths*/ { "root/path/file1.txt" },
+        /*expectedNotMatchingPaths*/
+        { // Should not match - This is in a subfolder, and wildcards don't cross directory markers.
+          "root/path/subfolder/file3.txt",
+          // Should not match - This is in the root folder, and wildcards don't cross directory markers.
+          "root/file4.txt" });
+}
+
+TEST_F(PathDependencyTest, WildcardDependencies_WildcardWithSecondExtension_MatchesFile)
+{
+    RunWildcardDependencyTestOnPaths(
+        "root/path/*.txt",
+        // Should match - the matching rules with wildcard here will match if there are multiple extensions and one matches.
+        /*expectedMatchingPaths*/ { "root/path/file1.txt.ext2" },
+        /*expectedNotMatchingPaths*/ {});
+}
+
+TEST_F(PathDependencyTest, WildcardDependencies_WildcardOnFilenameNoDirectories_MatchesAll)
+{
+    RunWildcardDependencyTestOnPaths(
+        "*.txt",
+        // Should match - If a directory is not included in the search, it matches all files regardless of directory.
+        /*expectedMatchingPaths*/ { "root/path/to/file1.txt", "another/folder/path/file2.txt", "file3.txt" },
+        /*expectedNotMatchingPaths*/ {});
 }
 
 TEST_F(DuplicateProcessTest, SameAssetProcessedTwice_DependenciesResolveWithoutError)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
@@ -281,6 +281,12 @@ struct PathDependencyTest
     bool ProcessAsset(TestAsset& asset, const OutputAssetSet& outputAssets, const AssetBuilderSDK::ProductPathDependencySet& dependencies = {}, const AZStd::string& folderPath = "subfolder1/", const AZStd::string& extension = ".txt");
 
     void RunWildcardTest(bool useCorrectDatabaseSeparator, AssetBuilderSDK::ProductPathDependencyType pathDependencyType, bool buildDependenciesFirst);
+
+    void RunWildcardDependencyTestOnPaths(
+        const AZStd::string& wildcardDependency,
+        const AZStd::vector<AZStd::string>& expectedMatchingPaths,
+        const AZStd::vector<AZStd::string>& expectedNotMatchingPaths);
+
     AssetProcessor::AssetDatabaseConnection* m_sharedConnection{};
 };
 


### PR DESCRIPTION
## What does this PR do?

There are two code paths when resolving product path dependencies with wildcards.

1. The product with a dependency checks all existing files already resolved in the database.
2. Later jobs finish, and the existing previously emitted wildcard path dependencies are checked against the newly completed files.

Without this change, there was a difference in those code paths:

1. This did a database search with database style wildcard. This meant a wildcard matched against the whole string, and didn't stop at directory markers.
2. This did a path search with path style wildcards. This meant a wildcard stopped matching at directory change markers.

This meant that, if you re-processed a file with a wildcard dependency after the asset processor went idle, you could get new dependencies, due to the difference in how it was resolved.

This change standardizes the behavior to 2, which matches how other systems have worked with paths and wildcards.

## How was this PR tested?

Tested locally with multiplayer sample.

Some of the new automated tests fail without the fix, so they verify that the fix works. These tests all pass locally.
