### PR TITLE
Multiplayer: Don't Attempt Player Spawn on Level Load if Not in Multiplayer Mode 

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1694,6 +1694,12 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::OnRootSpawnableReady([[maybe_unused]] AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable, [[maybe_unused]] uint32_t generation)
     {
+        // Ignore level loads if not in multiplayer mode
+        if (m_agentType == MultiplayerAgentType::Uninitialized)
+        {
+            return;
+        }
+
         // Spawn players waiting to be spawned. This can happen when a player connects before a level is loaded, so there isn't any player spawner components registered
         IMultiplayerSpawner* spawner = AZ::Interface<IMultiplayerSpawner>::Get();
         if (!spawner)


### PR DESCRIPTION
Multiplayer System can ignore doing special stuff on level loads if not in multiplayer mode.
Stops a wrong/confusing error log from occurring.
```"Attempting to spawn players on level load failed."```

Alternative solution is to only connect to RootSpawnableNotificationBus::Handler when we need to but OnRootSpawnableReady is rarely called and this logic seems easier to read instead of placing BusConnects and BusDisconnects outside of De/Activate().

Fixes #13431

## How was this PR tested?
Using Multiplayer game, before hosting or connecting attempt to load level in a launcher and make sure log error doesn't occur.
```"Attempting to spawn players on level load failed."```

Using Multiplayer game press CTRL+G in editor (with editorsv_enabled false) and ensure log error doesn't occur.
```"Attempting to spawn players on level load failed."```

