### PR TITLE
Fixed issue with shortcuts not working in a dock widget depending on focus

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -38,9 +38,13 @@ namespace AzToolsFramework
 
         bool eventFilter(QObject* watched, QEvent* event) override;
 
+        bool TriggerActiveActionsForWidget(const QWidget* watchedWidget, const QKeyEvent* keyEvent);
+
     private:
         static bool TriggerActiveActionsWithShortcut(
             const QList<QAction*>& contextActions, const QList<QAction*>& widgetActions, const QKeySequence& shortcutKeySequence);
+        static bool TriggerActiveActionsWithShortcut(
+            const QList<QAction*>& contextActions, const QList<QAction*>& widgetActions, const QKeyEvent* shortcutKeyEvent);
 
         ApplicationWatcher* m_applicationWatcher = nullptr;
         EditorActionContext* m_editorActionContext = nullptr;
@@ -55,6 +59,8 @@ namespace AzToolsFramework
     public:
         ActionManager();
         ~ActionManager();
+
+        static constexpr AZStd::string_view ActionContextWidgetIdentifier = "ActionContextWidgetIdentifier";
 
     private:
         // ActionManagerInterface overrides ...

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyManager.cpp
@@ -46,6 +46,9 @@ namespace AzToolsFramework
                 contextIdentifier.c_str()));
         }
 
+        // Set the context identifier as a property on the widget so that the watcher can be queried easily later
+        widget->setProperty(ActionManager::ActionContextWidgetIdentifier.data(), contextIdentifier.c_str());
+
         widget->installEventFilter(widgetWatcher);
         return AZ::Success();
     }
@@ -61,6 +64,7 @@ namespace AzToolsFramework
                 contextIdentifier.c_str()));
         }
 
+        widget->setProperty(ActionManager::ActionContextWidgetIdentifier.data(), QVariant());
         widget->removeEventFilter(widgetWatcher);
         return AZ::Success();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -711,9 +711,11 @@ namespace ScriptCanvasEditor
         // File menu
         connect(ui->action_New_Script, &QAction::triggered, this, &MainWindow::OnFileNew);
         ui->action_New_Script->setShortcut(QKeySequence(QKeySequence::New));
+        addAction(ui->action_New_Script);
 
         connect(ui->action_Open, &QAction::triggered, this, &MainWindow::OnFileOpen);
         ui->action_Open->setShortcut(QKeySequence(QKeySequence::Open));
+        addAction(ui->action_Open);
 
         connect(ui->action_UpgradeTool, &QAction::triggered, this, &MainWindow::RunUpgradeTool);
         ui->action_UpgradeTool->setVisible(true);


### PR DESCRIPTION
## What does this PR do?

This PR addresses an issue where sometimes shortcuts weren't working properly in dock widgets depending on which widget the user had attempted to focus. The particular use-case that exposed this issue was when the user had first opened the Script Canvas tool, the `Ctrl+N` hot-key would trigger the Editor's main "New Level" dialog instead of creating a new graph in Script Canvas. This is because if the user had just opened Script Canvas (or had clicked somewhere in its drop area, menu bar or dock widget resize handles), the Script Canvas main widget wouldn't actually get focus because those areas don't accept focus, so instead the focus widget would become the `DockWidget` that owns the Script Canvas widget. So because the action context watcher was only listening for shortcut events on the Script Canvas widget itself, it never gets the shortcut event, so it propagates further up to the main Editor itself.

With this change, there is additional logic for if a `DockWidget` instance receives a shortcut event, it will check it's child widget to see if it has an action context watcher installed on it, and if so, will let it try and handle the shortcut event if possible.

Here is a quick gif of it working with the Script Canvas tool. In this gif, I'm first clicking inside the Script Canvas tool and then pressing the `Ctrl+N` hotkey, and then clicking back in the main Editor and repeating the shortcut. Before this change, the "New  Level" dialog would always be triggered instead of the new graph in Script Canvas when it is focused:

![DockWidgetShortcutsWorking](https://user-images.githubusercontent.com/7519264/229605647-e0584e35-24f9-4fef-bb17-a2a8dfec05ae.gif)

## How was this PR tested?

Tested the shortcuts as indicated in the reproduction steps with Script Canvas floating and also docked inside the main Editor.