### PR TITLE
When an asset in a seed file is no longer available, an error icon and error message is now displayed instead of a blank line.

### DIFF
--- a/Code/Tools/AssetBundler/source/models/SeedListTableModel.h
+++ b/Code/Tools/AssetBundler/source/models/SeedListTableModel.h
@@ -13,6 +13,7 @@
 #include <AzToolsFramework/Asset/AssetSeedManager.h>
 #include <AzFramework/Platform/PlatformDefaults.h>
 
+#include <QIcon>
 #include <QSharedPointer>
 
 namespace AssetBundler
@@ -23,6 +24,7 @@ namespace AssetBundler
 
         QString m_relativePath;
         QString m_platformList;
+        QString m_errorMessage; // If the asset isn't available, this will contain an error message to display instead.
     };
 
     using AdditionalSeedInfoPtr = AZStd::shared_ptr<AdditionalSeedInfo>;
@@ -77,6 +79,8 @@ namespace AssetBundler
 
         AZStd::shared_ptr<AzToolsFramework::AssetSeedManager> m_seedListManager;
         AdditionalSeedInfoMap m_additionalSeedInfoMap;
+
+        QIcon m_errorImage;
 
         bool m_hasUnsavedChanges = false;
         bool m_isFileOnDisk = true;


### PR DESCRIPTION
## What does this PR do?

Without this change: When you view a seed list with a missing asset in the Asset Bundler GUI, it displays a blank line. There is an error message in the log output at the bottom of the screen, but it's still confusing having a blank line.

With this change: Instead a blank line, the asset hint and ID are displayed (if available), and an error icon is displayed to call attention to this row.

This change addresses this issue: https://github.com/o3de/o3de/issues/15271

This is what this change looks like:

![image](https://user-images.githubusercontent.com/4838196/229610781-c89e1163-10cb-4ff2-ac39-0f7ee1ac5203.png)


## How was this PR tested?

Manual testing - we don't have automation for asset bundler GUI available yet.
