### PR TITLE
Fixed the intermittent timeouts when connecting to editor server

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
@@ -53,7 +53,7 @@ namespace Multiplayer
         virtual void OnEditorConnectionAttemptsFailed([[maybe_unused]]uint16_t failedAttempts) {}
 
         //! Notification when the Editor starts sending the current level data (spawnable) to the server.
-        virtual void OnEditorSendingLevelData() {}
+        virtual void OnEditorSendingLevelData([[maybe_unused]] uint32_t bytesSent, [[maybe_unused]] uint32_t bytesTotal) {}
 
         //! Notification when the Editor has sent all the level data successful and is now fully connected to the multiplayer simulation.
         virtual void OnConnectToSimulationSuccess() {}

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -375,10 +375,11 @@ namespace Multiplayer
         m_centerViewportDebugText = OnServerLaunchFailMessage;
     }
 
-    void MultiplayerConnectionViewportMessageSystemComponent::OnEditorSendingLevelData()
+    void MultiplayerConnectionViewportMessageSystemComponent::OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal)
     {
         m_centerViewportDebugTextColor = AZ::Colors::Yellow;
-        m_centerViewportDebugText = OnEditorSendingLevelDataMessage;
+        m_centerViewportDebugText =
+            AZStd::fixed_string<MaxMessageLength>::format(OnEditorSendingLevelDataMessage, bytesSent, bytesTotal);
     }   
 
     void MultiplayerConnectionViewportMessageSystemComponent::OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts)

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
@@ -37,7 +37,7 @@ namespace Multiplayer
         static constexpr char OnServerLaunchFailMessage[] = "(1/3) Could not launch editor server.\nSee console for more info.";
         static constexpr char OnEditorConnectionAttemptMessage[] = "(2/3) Attempting to connect to server in order to send level data.\nAttempt %i of %i";
         static constexpr char OnEditorConnectionAttemptsFailedMessage[] = "(2/3) Failed to connect to server after %i attempts!\nPlease exit play mode and try again.";  
-        static constexpr char OnEditorSendingLevelDataMessage[] = "(3/3) Editor is sending the editor-server the level data packet.";
+        static constexpr char OnEditorSendingLevelDataMessage[] = "(3/3) Editor is sending the editor-server the level data packet.\n Bytes %u / %u sent.";
         static constexpr char OnConnectToSimulationFailMessage[] = "EditorServerReady packet was received, but connecting to the editor-server's network simulation failed! Is the editor and server using the same sv_port (%i)?";
         static constexpr char OnEditorServerStoppedUnexpectedly[] ="Editor server has unexpectedly stopped running!";
 
@@ -87,7 +87,7 @@ namespace Multiplayer
         void OnServerLaunchFail() override;
         void OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts) override;
         void OnEditorConnectionAttemptsFailed(uint16_t failedAttempts) override;
-        void OnEditorSendingLevelData() override;
+        void OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal) override;
         void OnConnectToSimulationSuccess() override;
         void OnConnectToSimulationFail(uint16_t serverPort) override;
         void OnPlayModeEnd() override;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
@@ -47,9 +47,9 @@ namespace Multiplayer::Automation
         Call(FN_OnEditorConnectionAttemptsFailed, failedAttempts);
     }
 
-    void MultiplayerEditorAutomationHandler::OnEditorSendingLevelData()
+    void MultiplayerEditorAutomationHandler::OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal)
     {
-        Call(FN_OnEditorSendingLevelData);
+        Call(FN_OnEditorSendingLevelData, bytesSent, bytesTotal);
     }
 
     void MultiplayerEditorAutomationHandler::OnConnectToSimulationSuccess()

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
@@ -43,7 +43,7 @@ namespace Multiplayer::Automation
         void OnServerLaunchFail() override;
         void OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts) override;
         void OnEditorConnectionAttemptsFailed(uint16_t failedAttempts) override;
-        void OnEditorSendingLevelData() override;
+        void OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal) override;
         void OnConnectToSimulationSuccess() override;
         void OnConnectToSimulationFail(uint16_t serverPort) override;
         void OnPlayModeEnd() override;


### PR DESCRIPTION
## What does this PR do?

When connecting from the Editor to a multiplayer server, we would see intermittent timeouts during the level send causing the Editor/server connection to fail, even though the level send would retry multiple times over 20 seconds. Upon further investigation, the root cause was that the output of the server was being piped back to the Editor process. If these pipes fill up, the entire server process locks up on outputting to the pipe until the pipe is free to send again. So if the server attempted to print too much to stdout during the connection process, and the client was in a tight loop attempting to retry level sends without processing the pipes, the connection would fail.

The solution is to add "m_serverProcessTracePrinter->Pump();" in the retry loop to ensure that the pipes continue to get processed.

While adding and testing this, I also added more display information to show how many bytes were sent to the server. I've left this in the PR because it seems like a helpful addition. There aren't any screen redraws during the level send so the numbers don't refresh, but it's now more clear where any delays are happening at.

## How was this PR tested?

Ran the MPS level from the Editor several times with a 100% success rate.

![image](https://user-images.githubusercontent.com/82224783/229637650-e156f418-242d-4f7f-945b-7532d01e5545.png)

