### PR TITLE
Fix for GHI-15531: Vulkan Validation Error: Push Constants not set

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -392,7 +392,7 @@ namespace AZ
                     AZ_Error(
                         "MeshDrawPacket",
                         (!m_rootConstantsLayout && !pipelineStateDescriptor.m_pipelineLayoutDescriptor->GetRootConstantsLayout()) ||
-                        m_rootConstantsLayout->GetHash() == pipelineStateDescriptor.m_pipelineLayoutDescriptor->GetRootConstantsLayout()->GetHash(),
+                        (m_rootConstantsLayout && m_rootConstantsLayout->GetHash() == pipelineStateDescriptor.m_pipelineLayoutDescriptor->GetRootConstantsLayout()->GetHash()),
                         "All draw items in a draw packet need to share the same root constants layout. This means that each pass "
                         "(e.g. Depth, Shadows, Forward, MotionVectors) for a given materialtype should use the same layout.");
                 }


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/o3de/o3de/issues/15531

The mesh draw packet wasn't properly setting the initial root constant data, leading to a vulkan validation error.

## How was this PR tested?
Tested in the editor and material canvas on the branch from https://github.com/o3de/o3de/pull/15491, which adds a root constant to the default draw srg.
