### PR TITLE
Use O3DE_EXTERNAL_SUBDIRS cmake variable correctly.

### DIFF
--- a/cmake/Subdirectories.cmake
+++ b/cmake/Subdirectories.cmake
@@ -134,7 +134,8 @@ endfunction()
 #! of the engine.json, project.json, o3de_manifest.json and any gem.json files found visiting
 function(get_all_external_subdirectories output_subdirs)
     # Gather user supplied external subdirectories via the Cache Variable
-    get_property(all_external_subdirs GLOBAL PROPERTY O3DE_EXTERNAL_SUBDIRS)
+    get_property(o3de_external_subdirs CACHE O3DE_EXTERNAL_SUBDIRS PROPERTY VALUE)
+    list(APPEND all_external_subdirs ${o3de_external_subdirs})
     get_property(manifest_external_subdirs GLOBAL PROPERTY O3DE_EXTERNAL_SUBDIRS_O3DE_MANIFEST)
     list(APPEND all_external_subdirs ${manifest_external_subdirs})
     get_property(engine_external_subdirs GLOBAL PROPERTY O3DE_EXTERNAL_SUBDIRS_ENGINE)
@@ -201,8 +202,12 @@ function(resolve_gem_dependencies object_type object_path)
 
     set(ENV{PYTHONNOUSERSITE} 1)
     string(TOLOWER ${object_type} object_type_lower)
+    get_property(user_external_subdirs CACHE O3DE_EXTERNAL_SUBDIRS PROPERTY VALUE)
+    if(user_external_subdirs)
+        set(user_external_subdir_option -ed "${user_external_subdirs}")
+    endif()
     execute_process(COMMAND 
-        ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/scripts/o3de/o3de/cmake.py" --${object_type_lower}-path "${object_path}"
+        ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/scripts/o3de/o3de/cmake.py" --${object_type_lower}-path "${object_path}" ${user_external_subdir_option}
         WORKING_DIRECTORY ${LY_ROOT_FOLDER}
         RESULT_VARIABLE O3DE_CLI_RESULT
         OUTPUT_VARIABLE resolved_gem_dependency_output 

--- a/scripts/o3de/o3de/cmake.py
+++ b/scripts/o3de/o3de/cmake.py
@@ -98,6 +98,7 @@ def remove_gem_dependency(cmake_file: pathlib.Path,
 def resolve_gem_dependency_paths(
         engine_path:pathlib.Path,
         project_path:pathlib.Path,
+        external_subdirectories:str or list or None,
         resolved_gem_dependencies_output_path:pathlib.Path or None):
     """
     Resolves gem dependencies for the given engine and project and
@@ -158,7 +159,8 @@ def resolve_gem_dependency_paths(
     all_gems_json_data = manifest.get_gems_json_data_by_name(engine_path=engine_path, 
                                                              project_path=project_path, 
                                                              include_manifest_gems=True, 
-                                                             include_engine_gems=True)
+                                                             include_engine_gems=True,
+                                                             external_subdirectories=external_subdirectories.split(';') if isinstance(external_subdirectories, str) else external_subdirectories)
 
     # First try to resolve with optional gems
     results, errors = compatibility.resolve_gem_dependencies(gem_names_with_optional_gems, 
@@ -199,6 +201,7 @@ def _resolve_gem_dependency_paths(args: argparse) -> int:
     return resolve_gem_dependency_paths(
                             engine_path=args.engine_path,
                             project_path=args.project_path,
+                            external_subdirectories=args.external_subdirectories,
                             resolved_gem_dependencies_output_path=args.gem_paths_output_file
                              )
 
@@ -208,6 +211,8 @@ def add_parser_args(parser):
                        help='The path to the project.')
     group.add_argument('-ep', '--engine-path', type=pathlib.Path, required=False,
                        help='The path to the engine.')
+    group.add_argument('-ed', '--external-subdirectories', type=str, required=False, nargs='*',
+                       help='Additional list of subdirectories.')
     group.add_argument('-gpof', '--gem-paths-output-file', type=pathlib.Path, required=False,
                        help='The path to the resolved gem paths output file. If not provided, the list will be output to STDOUT.')
     parser.set_defaults(func=_resolve_gem_dependency_paths)

--- a/scripts/o3de/tests/test_cmake.py
+++ b/scripts/o3de/tests/test_cmake.py
@@ -206,7 +206,8 @@ class TestResolveGemDependencyPaths:
                 patch('pathlib.Path.open', side_effect=lambda mode: StringBufferIOWrapper()) as pathlib_open_mock:
             result = cmake.resolve_gem_dependency_paths(
                                         engine_path=engine_path if engine_gem_names else None, 
-                                        project_path=project_path if project_gem_names else None, 
+                                        project_path=project_path if project_gem_names else None,
+                                        external_subdirectories=None,
                                         resolved_gem_dependencies_output_path=pathlib.Path('out'))
 
         assert result == expected_result


### PR DESCRIPTION
## What does this PR do?

The  O3DE_EXTERNAL_SUBDIRS` variable did not work properly for me, when I tried using it to specify a subdirectory that was not specified in the o3de manifest. This pull request fixes the issues I encountered.

## How was this PR tested?

This PR now allows me to build an engine, together with a project and an external gem that the project depends on  without having the engine and gem directories registered in the o3de manifest using the cmake variables  `O3DE_EXTERNAL_SUBDIRS` and `LY_PROJECTS`. This is useful, for example, when you want to build a project together with the engine in a CI setup since you can do it without setting up the o3de manifest. It also allows you to build multiple versions of a gem on one machine without running into issues, since registering both versions in the manifest leads to naming conflicts.
