### PR TITLE
Temporary fix ready for release

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -272,6 +272,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             const bool hasFilter = !m_ui->m_searchWidget->GetFilterString().isEmpty();
             const bool selectFirstFilteredIndex = false;
             m_ui->m_assetBrowserTreeViewWidget->UpdateAfterFilter(hasFilter, selectFirstFilteredIndex);
+            m_ui->m_expandedTableViewButton->setDisabled(hasFilter);
         });
 
     connect(m_ui->m_assetBrowserTreeViewWidget->selectionModel(), &QItemSelectionModel::currentChanged,
@@ -655,11 +656,13 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(true);
         m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
+        m_ui->m_searchWidget->setDisabled(false);
     }
     else if (qobject_cast<AssetBrowserExpandedTableView*>(viewToShow))
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
         m_ui->m_expandedTableView->SetExpandedTableViewActive(true);
+        m_ui->m_searchWidget->setDisabled(true);
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Temporary fix for "Basic search is broken in table view #15524" to allow release. Permanent fix is in progress. 

From the bug description:-
"If we are unable to fix this bug before the general release, Luis, Daniel and I spoke about a good back up plan being that we disable search in table view until we can get the feature working. We would also need to prevent a user from switching into table view IF a use started a search in a different view and then tried to switch into table view while a search is in process."

## How was this PR tested?

Checked that search is not available in Table View mode and TableView button is disabled if a search is in progress.
