### PR TITLE
Fix add-component crashes for disabled and pending components

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -52,7 +52,7 @@ namespace AzToolsFramework::Prefab
         AZ_Assert(componentInstance, "PrefabComponentAdapter::SetComponent - component is null.")
         m_componentAlias = componentInstance->GetSerializedIdentifier();
 
-        // Do not assert on empty alias for disbaled or pending component.
+        // Do not assert on empty alias for disabled or pending components.
         // See GHI: https://github.com/o3de/o3de/issues/15546
         if (!IsComponentDisabled(componentInstance) && !IsComponentPending(componentInstance))
         {
@@ -276,8 +276,8 @@ namespace AzToolsFramework::Prefab
         AZ_Assert(component, "Unable to check a component that is nullptr");
 
         bool result = false;
-        AzToolsFramework::EditorDisabledCompositionRequestBus::EventResult(
-            result, component->GetEntityId(), &AzToolsFramework::EditorDisabledCompositionRequests::IsComponentDisabled, component);
+        EditorDisabledCompositionRequestBus::EventResult(
+            result, component->GetEntityId(), &EditorDisabledCompositionRequests::IsComponentDisabled, component);
         return result;
     }
 
@@ -286,8 +286,8 @@ namespace AzToolsFramework::Prefab
         AZ_Assert(component, "Unable to check a component that is nullptr");
 
         bool result = false;
-        AzToolsFramework::EditorPendingCompositionRequestBus::EventResult(
-            result, component->GetEntityId(), &AzToolsFramework::EditorPendingCompositionRequests::IsComponentPending, component);
+        EditorPendingCompositionRequestBus::EventResult(
+            result, component->GetEntityId(), &EditorPendingCompositionRequests::IsComponentPending, component);
         return result;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -19,6 +19,8 @@
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyEdit.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.h>
+#include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
 
 namespace AzToolsFramework::Prefab
 {
@@ -49,7 +51,11 @@ namespace AzToolsFramework::Prefab
         // Otherwise, an empty component alias will be used in DOM data.
         AZ_Assert(componentInstance, "PrefabComponentAdapter::SetComponent - component is null.")
         m_componentAlias = componentInstance->GetSerializedIdentifier();
-        AZ_Assert(!m_componentAlias.empty(), "PrefabComponentAdapter::SetComponent - Component alias should not be empty.");
+
+        if (!IsComponentDisabled(componentInstance) && !IsComponentPending(componentInstance))
+        {
+            AZ_Assert(!m_componentAlias.empty(), "PrefabComponentAdapter::SetComponent - Component alias should not be empty.");
+        }
 
         ComponentAdapter::SetComponent(componentInstance);
     }
@@ -63,10 +69,8 @@ namespace AzToolsFramework::Prefab
         adapterBuilder->Attribute(PrefabOverrideLabel::Text, labelText);
 
         AZ::Dom::Path relativePathFromEntity;
-        if (!serializedPath.empty())
+        if (!m_componentAlias.empty() && !serializedPath.empty())
         {
-            AZ_Assert(!m_componentAlias.empty(), "PrefabComponentAdapter::CreateLabel - Component alias should not be empty.");
-
             relativePathFromEntity /= PrefabDomUtils::ComponentsName;
             relativePathFromEntity /= m_componentAlias;
             relativePathFromEntity /= AZ::Dom::Path(serializedPath);
@@ -264,4 +268,25 @@ namespace AzToolsFramework::Prefab
             return false;
         }
     }
+
+    bool PrefabComponentAdapter::IsComponentDisabled(const AZ::Component* component)
+    {
+        AZ_Assert(component, "Unable to check a component that is nullptr");
+
+        bool result = false;
+        AzToolsFramework::EditorDisabledCompositionRequestBus::EventResult(
+            result, component->GetEntityId(), &AzToolsFramework::EditorDisabledCompositionRequests::IsComponentDisabled, component);
+        return result;
+    }
+
+    bool PrefabComponentAdapter::IsComponentPending(const AZ::Component* component)
+    {
+        AZ_Assert(component, "Unable to check a component that is nullptr");
+
+        bool result = false;
+        AzToolsFramework::EditorPendingCompositionRequestBus::EventResult(
+            result, component->GetEntityId(), &AzToolsFramework::EditorPendingCompositionRequests::IsComponentPending, component);
+        return result;
+    }
+
 } // namespace AzToolsFramework::Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -52,6 +52,8 @@ namespace AzToolsFramework::Prefab
         AZ_Assert(componentInstance, "PrefabComponentAdapter::SetComponent - component is null.")
         m_componentAlias = componentInstance->GetSerializedIdentifier();
 
+        // Do not assert on empty alias for disbaled or pending component.
+        // See GHI: https://github.com/o3de/o3de/issues/15546
         if (!IsComponentDisabled(componentInstance) && !IsComponentPending(componentInstance))
         {
             AZ_Assert(!m_componentAlias.empty(), "PrefabComponentAdapter::SetComponent - Component alias should not be empty.");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.h
@@ -53,6 +53,12 @@ namespace AzToolsFramework::Prefab
             AZ::Dom::Path relativePathFromOwningPrefab,
             const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& propertyChangeInfo);
 
+        //! Checks if the component is disabled.
+        static bool IsComponentDisabled(const AZ::Component* component);
+
+        //! Checks if the component is pending.
+        static bool IsComponentPending(const AZ::Component* component);
+
         AZStd::string m_entityAlias;
         AZStd::string m_componentAlias;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h
@@ -19,6 +19,7 @@ namespace AzToolsFramework
         virtual void GetDisabledComponents(AZStd::vector<AZ::Component*>& components) = 0;
         virtual void AddDisabledComponent(AZ::Component* componentToAdd) = 0;
         virtual void RemoveDisabledComponent(AZ::Component* componentToRemove) = 0;
+        virtual bool IsComponentDisabled(const AZ::Component* component) = 0;
     };
 
     using EditorDisabledCompositionRequestBus = AZ::EBus<EditorDisabledCompositionRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -67,6 +67,13 @@ namespace AzToolsFramework
             }
         };
 
+        bool EditorDisabledCompositionComponent::IsComponentDisabled(const AZ::Component* component)
+        {
+            AZ_Assert(component, "Unable to check a component that is nullptr");
+            return component &&
+                AZStd::find(m_disabledComponents.begin(), m_disabledComponents.end(), component) != m_disabledComponents.end();
+        }
+
         EditorDisabledCompositionComponent::~EditorDisabledCompositionComponent()
         {
             for (auto disabledComponent : m_disabledComponents)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
@@ -31,6 +31,7 @@ namespace AzToolsFramework
             void GetDisabledComponents(AZStd::vector<AZ::Component*>& components) override;
             void AddDisabledComponent(AZ::Component* componentToAdd) override;
             void RemoveDisabledComponent(AZ::Component* componentToRemove) override;
+            bool IsComponentDisabled(const AZ::Component* component) override;
             ////////////////////////////////////////////////////////////////////
 
             ~EditorDisabledCompositionComponent() override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h
@@ -19,6 +19,7 @@ namespace AzToolsFramework
         virtual void GetPendingComponents(AZStd::vector<AZ::Component*>& components) = 0;
         virtual void AddPendingComponent(AZ::Component* componentToAdd) = 0;
         virtual void RemovePendingComponent(AZ::Component* componentToRemove) = 0;
+        virtual bool IsComponentPending(const AZ::Component* component) = 0;
     };
 
     using EditorPendingCompositionRequestBus = AZ::EBus<EditorPendingCompositionRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -80,6 +80,13 @@ namespace AzToolsFramework
             }
         };
 
+        bool EditorPendingCompositionComponent::IsComponentPending(const AZ::Component* component)
+        {
+            AZ_Assert(component, "Unable to check a component that is nullptr");
+            return component &&
+                AZStd::find(m_pendingComponents.begin(), m_pendingComponents.end(), component) != m_pendingComponents.end();
+        }
+
         EditorPendingCompositionComponent::~EditorPendingCompositionComponent()
         {
             for (auto pendingComponent : m_pendingComponents)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
@@ -31,6 +31,7 @@ namespace AzToolsFramework
             void GetPendingComponents(AZStd::vector<AZ::Component*>& components) override;
             void AddPendingComponent(AZ::Component* componentToAdd) override;
             void RemovePendingComponent(AZ::Component* componentToRemove) override;
+            bool IsComponentPending(const AZ::Component* component) override;
             ////////////////////////////////////////////////////////////////////
 
             ~EditorPendingCompositionComponent() override;

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.cpp
@@ -65,4 +65,8 @@ namespace UnitTest
 
     void ComponentModeTestFixture::AddDisabledComponent([[maybe_unused]] AZ::Component* componentToAdd){};
     void ComponentModeTestFixture::RemoveDisabledComponent([[maybe_unused]] AZ::Component* componentToRemove){};
+    bool ComponentModeTestFixture::IsComponentDisabled([[maybe_unused]] const AZ::Component* component)
+    {
+        return false;
+    };
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.h
@@ -25,6 +25,7 @@ namespace UnitTest
         void GetDisabledComponents(AZStd::vector<AZ::Component*>& components) override;
         void AddDisabledComponent(AZ::Component* componentToAdd) override;
         void RemoveDisabledComponent(AZ::Component* componentToRemove) override;
+        bool IsComponentDisabled(const AZ::Component* component) override;
 
         void Connect(AZ::EntityId entityId);
         void Disconnect();


### PR DESCRIPTION
## What does this PR do?

Fixes and unblocks https://github.com/o3de/o3de/issues/15509

This PR is a temp fix for crashes that happen when we add pending/disabled components to an entity because of empty component alias assertions in `PrefabComponentAdapter`. See the ticket for more details.

It is a temp fix that keeps the component alias empty for pending and disabled components, but instead in adapter it changes to assert only when the component is not disabled or pending.

I created another issue to address the empty component alias issue: https://github.com/o3de/o3de/issues/15546, which I feel like it might not be easily fixed.

## How was this PR tested?

Tested in editor. Crashes no longer happen for these operations:
- Add a pending component 'AudioAnimation' (or 'VegetationSurfaceMaskFilter') to an entity, disable and enable it.
- Add a 'Comment' component to an entity, disable and enable it.
- Add a pending component 'AudioAnimation' and a disabled 'Comment' component to an entity. Reload the level to reload the entity.
