### PR TITLE
Added "OrderOnly" job dependency.

### DIFF
--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -1435,7 +1435,8 @@ namespace AssetBuilderSDK
                 ->Property("type", BehaviorValueProperty(&JobDependency::m_type))
                 ->Enum<aznumeric_cast<int>(JobDependencyType::Fingerprint)>("Fingerprint")
                 ->Enum<aznumeric_cast<int>(JobDependencyType::Order)>("Order")
-                ->Enum<aznumeric_cast<int>(JobDependencyType::OrderOnce)>("OrderOnce");
+                ->Enum<aznumeric_cast<int>(JobDependencyType::OrderOnce)>("OrderOnce")
+                ->Enum<aznumeric_cast<int>(JobDependencyType::OrderOnly)>("OrderOnly");
         }
     }
 

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.h
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.h
@@ -373,8 +373,12 @@ namespace AssetBuilderSDK
 
         //! This is similiar to Order where the dependent job should only run after all the jobs it depends on are processed by the Asset Processor.
         //! The difference is that here only those dependent jobs matter that have never been processed by the Asset Processor.
-        //! Also important to note is the fingerprint of the dependent jobs will not alter the the fingerprint of the job.
+        //! Also important to note is the fingerprint of the dependent jobs will not alter the fingerprint of the job.
         OrderOnce,
+
+        //! Similar to Order, except that the dependent jobs do not rebuild when the jobs they depend on are processed.
+        //! Also important to note is the fingerprint of the dependent jobs will not alter the fingerprint of the job.
+        OrderOnly,
     };
 
     //! Job dependency information that the builder will send to the Asset Processor.

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.cpp
@@ -93,7 +93,9 @@ namespace AssetProcessor
                 bool canProcessJob = true;
                 for (const JobDependencyInternal& jobDependencyInternal : actualJob->GetJobDependencies())
                 {
-                    if (jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::Order || jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnce)
+                    if (jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::Order ||
+                        jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnce ||
+                        jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnly)
                     {
                         const AssetBuilderSDK::JobDependency& jobDependency = jobDependencyInternal.m_jobDependency;
                         AZ_Assert(

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -1075,9 +1075,10 @@ namespace AssetUtilities
         // now the other jobs, which this job depends on:
         for (const AssetProcessor::JobDependencyInternal& jobDependencyInternal : jobDetail.m_jobDependencyList)
         {
-            if (jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnce)
+            if (jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnce ||
+                jobDependencyInternal.m_jobDependency.m_type == AssetBuilderSDK::JobDependencyType::OrderOnly)
             {
-                // we do not want to include the fingerprint of dependent jobs if the job dependency type is OrderOnce.
+                // We do not want to include the fingerprint of dependent jobs if the job dependency type is OrderOnce or OrderOnly.
                 continue;
             }
             AssetProcessor::JobDesc jobDesc(AssetProcessor::SourceAssetReference(jobDependencyInternal.m_jobDependency.m_sourceFile.m_sourceFileDependencyPath.c_str()),

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -108,7 +108,7 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 35; // // Half float support
+                shaderVariantAssetBuilderDescriptor.m_version = 36; // The ShaderVariantAsset declares OrderOnly dependency on ShaderVariantTreeAsset.
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -195,27 +195,15 @@ namespace AZ
                 jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
             
                 // The ShaderVariantAssets should be built AFTER the ShaderVariantTreeAsset.
-                // But unfortunately we can not declare job dependency because it will cause
-                // recompilation of all ShaderVariantAssets whenever the ShaderVariantTreeAsset
-                // changes.
-                // Ideally, what we need is a mode for job dependencies which says:
-                // "make sure X completes before Y runs, but don't re-run Y just because X ran".
+                // With "OrderOnly" dependency, We make sure ShaderVariantTreeAsset completes before ShaderVariantAsset runs,
+                // but don't re-run ShaderVariantAsset just because ShaderVariantTreeAsset ran.
                 //
-                // Temporary workaround: We set the job priority to -5000 (very low) for ShaderVariantAssets
-                // and job priority 1 (very high) for ShaderVariantTreeAssets.
-                //
-                // TODO: Add "OrderOnly" job dependency type to the Asset System so we can:
-                //  "make sure X completes before Y runs, but don't re-run Y just because X ran".
-                // https://github.com/o3de/o3de/issues/15428
-                // 
-                // **************************************************************************
-                //AssetBuilderSDK::JobDependency variantTreeJobDependency;
-                //variantTreeJobDependency.m_jobKey = GetShaderVariantTreeAssetJobKey();
-                //variantTreeJobDependency.m_platformIdentifier = info.m_identifier;
-                //variantTreeJobDependency.m_sourceFile.m_sourceFileDependencyPath = hashedVariantListFullPath;
-                //variantTreeJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                //jobDescriptor.m_jobDependencyList.emplace_back(variantTreeJobDependency);
-                // ***************************************************************************
+                AssetBuilderSDK::JobDependency variantTreeJobDependency;
+                variantTreeJobDependency.m_jobKey = GetShaderVariantTreeAssetJobKey();
+                variantTreeJobDependency.m_platformIdentifier = info.m_identifier;
+                variantTreeJobDependency.m_sourceFile.m_sourceFileDependencyPath = hashedVariantListFullPath;
+                variantTreeJobDependency.m_type = AssetBuilderSDK::JobDependencyType::OrderOnly;
+                jobDescriptor.m_jobDependencyList.emplace_back(variantTreeJobDependency);
 
                 // If the *.shader file changes, all the variants need to be rebuilt.
                 AssetBuilderSDK::JobDependency shaderAssetJobDependency;


### PR DESCRIPTION
## What does this PR do?

Added `OrderOnly` job dependency.

This new job dependency is helpful when it is needed that **Asset A** completes before **Asset B** runs,
but don't re-run **Asset B** just because **Asset A** ran. In other words, **Asset A** does not modify the
fingerprint of **Asset B**.

The `ShaderVariantAssetBuilder` is the first builder that takes advantage of this new job dependency because it needs the `ShaderVariantTreeAsset` to complete before any `ShaderVariantAsset` job starts, But `ShaderVariantAsset`s do not rebuild simply because the `ShaderVariantTreeAsset` was rebuilt.

Solves #15428

## How was this PR tested?

1. Added two unit tests:
1.1. TEST_F(AssetProcessorManagerTest, JobDependencyOrderOnly_MultipleJobs_EmitOK), based on TEST_F(AssetProcessorManagerTest, JobDependencyOrderOnce_MultipleJobs_EmitOK) with proper adjustments.  
1.2. TEST_F(AssetUtilitiesTest, GenerateFingerprint_OrderOnlyJobDependency_NoChange), based on TEST_F(AssetUtilitiesTest, GenerateFingerprint_OrderOnceJobDependency_NoChange) with proper adjustments.

3. Validated that when modifying a `shadervariantlist` by adding a new variant and modifying an existing one, the ShaderVariantTreeAsset was always built first, AND only the new/modified variant was built/rebuilt.
