### PR TITLE
Disable NodeCategory_ExpandOnClick when running test suite in Linux

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
@@ -4,7 +4,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
-
+import ly_test_tools
 import pytest
 import os
 import sys
@@ -170,6 +170,7 @@ class TestScriptCanvasTests(object):
     The following tests use hydra_test_utils.py to launch the editor and validate the results.
     """
 
+    @pytest.mark.skipif(ly_test_tools.LINUX, reason="investigate and update https://github.com/o3de/o3de/issues/15553")
     def test_NodeCategory_ExpandOnClick(self, request, editor, launcher_platform):
         expected_lines = [
             "Script Canvas pane successfully opened",


### PR DESCRIPTION
## What does this PR do?
disables a test in the script canvas periodic test suite when run from linux. This test fails the incremental daily builds. Associated GHI to investigate and fix the failing test: https://github.com/o3de/o3de/issues/15553

## How was this PR tested?
Test suite run successfully through pytest runner in win10 environment
