### PR TITLE
Asset processor now properly saves the removal of asset connections

### DIFF
--- a/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
+++ b/Code/Tools/AssetProcessor/native/connection/connectionManager.cpp
@@ -451,6 +451,15 @@ void ConnectionManager::removeConnection(const QModelIndex& index)
 
     removeConnection(key);
 
+    // Normally, removing a connection will cause RemoveConnectionFromMap to be called
+    // later, when the connection is fully removed. However, SaveConnections stores all
+    // user created connections, so this connection needs to be removed early.
+    // RemoveConnectionFromMap doesn't call SaveConnections because asset builders connect
+    // and disconnection shouldn't cause the settings to get saved constantly.
+    // This does mean RemoveConnectionFromMap is called twice, but that's OK because it won't find
+    // the key and it will safely handle that situation.
+    RemoveConnectionFromMap(key);
+
     SaveConnections();
 }
 


### PR DESCRIPTION
## What does this PR do?

Without this change: When you remove a user created connection in the asset processor, it wasn't properly saving that removal, because the connection wasn't removed from the map until later, when it was fully deleted. Now, the connection is immediately removed from the map, so that that when the settings are saved, the connection is properly deleted.

This addresses this issue https://github.com/o3de/o3de/issues/7673

## How was this PR tested?

1. Add new connection in the asset processor
2. Give it an obvious name
3. Close asset processor
4. Open asset processor again - verify the created connection is there
5. Remove the connection
6. Close asset processor
7. Open asset processor
8. View the connection tab

Without this change: The connection shows up again on step 8, because the settings were saved with the connection map that hadn't removed the connection yet.

With this change: The connection is properly removed.