### PR TITLE
Fix CfnBuild.StorageLocationProperty in gamelift_stack

### DIFF
--- a/Gems/AWSGameLift/cdk/aws_gamelift/gamelift_stack.py
+++ b/Gems/AWSGameLift/cdk/aws_gamelift/gamelift_stack.py
@@ -134,7 +134,7 @@ class GameLiftStack(Stack):
                 id=f'{self._stack_name}-GameLiftBuild{identifier}',
                 name=f'{self._stack_name}-GameLiftBuild{identifier}',
                 operating_system=build_configuration.get('operating_system'),
-                storage_location=gamelift.CfnBuild.S3LocationProperty(
+                storage_location=gamelift.CfnBuild.StorageLocationProperty(
                     **build_configuration['storage_location']
                 )
             )


### PR DESCRIPTION
## What does this PR do?

Fixes `AttributeError: type object 'CfnBuild' has no attribute 'S3LocationProperty'` in AWSGameLift gem `gamelift_stack.

Currently, running `cdk deploy -c upload-with-support-stack=true` results in the following error:
```
Traceback (most recent call last):
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\app.py", line 43, in <module>
    feature_struct = AWSGameLift(
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\.venv\lib\site-packages\jsii\_runtime.py", line 112, in __call__
    inst = super().__call__(*args, **kwargs)
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\aws_gamelift\aws_gamelift_construct.py", line 50, in __init__
    self._feature_stack = GameLiftStack(
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\.venv\lib\site-packages\jsii\_runtime.py", line 112, in __call__
    inst = super().__call__(*args, **kwargs)
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\aws_gamelift\gamelift_stack.py", line 41, in __init__
    fleet_ids.append(self._create_fleet(fleet_configuration, index).attr_fleet_id)
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\aws_gamelift\gamelift_stack.py", line 88, in _create_fleet
    build_id=self._get_gamelift_build_id(fleet_configuration.get('build_configuration', {}), identifier),
  File "C:\Users\USER\source\o3de\gems\AWSGameLift\cdk\aws_gamelift\gamelift_stack.py", line 137, in _get_gamelift_build_id
    storage_location=gamelift.CfnBuild.S3LocationProperty(
AttributeError: type object 'CfnBuild' has no attribute 'S3LocationProperty'
```
According to [the CDK docs](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_gamelift/CfnBuild.html), the correct property name is `StorageLocationProperty`. 

This change corrects the property name.

## How was this PR tested?

Running `cdk deploy -c upload-with-support-stack=true --all` successfully kicks of a CloudFormation deployment.
