### PR TITLE
Merge phases of AssImpSkinWeightsImporter

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h
@@ -45,24 +45,8 @@ namespace AZ
                 static void Reflect(ReflectContext* context);
 
                 Events::ProcessingResult ImportSkinWeights(AssImpSceneNodeAppendedContext& context);
-                Events::ProcessingResult SetupNamedBoneLinks(AssImpFinalizeSceneContext& context);
 
             protected:
-                struct Pending
-                {
-                    const aiBone* m_bone = nullptr;
-                    AZStd::string m_sanitizedName;
-                    unsigned m_numVertices = 0;
-                    unsigned m_vertOffset = 0;
-                    AZStd::shared_ptr<SceneData::GraphData::SkinWeightData> m_skinWeightData;
-                };
-
-                //! List of skin weights that still need to be filled in. Setting the data for skin weights is
-                //! delayed until after the tree has been fully constructed as bones are linked by name, but until
-                //! the graph has been fully filled in, those names can change which would break the names recorded
-                //! for the skin.
-                AZStd::vector<Pending> m_pendingSkinWeights;
-
                 static const AZStd::string s_skinWeightName;
             };
         } // namespace SceneBuilder


### PR DESCRIPTION
## What does this PR do?

The `AssimpSkinWeightsImporter` class currently searches for skin weights in the `AssImpSceneNodeAppendedContext`. These weights are then added to a list of pending skin weights. The weight data is added in the `AssImpFinalizeSceneContext`.

The justification for splitting this into two phases is given in the 'AssImpSkinWeightsImporter.h' file. According to that, the name of the bones, may change after the `AssImpSceneNodeAppendedContext` is executed. However, the name of the bones is sanitized in the first phase, and then stored in the pending work items. Which means that renamed bones will not work anyhow. I assume that bone renaming no longer happens? Is this true?

Why do we need this change: We do some processing of the meshes in our own Gem. For this we need to modify the skin weights as well. It's currently not possible to do this, as the `AssImpFinalizeSceneContext` is the last context in the `SceneImporter`. An alternative to this PR would be to add another context after the `AssImpFinalizeSceneContext`.

## How was this PR tested?

Windows. Imported a mesh with skeletal animation into a scene, using the Actor component and SimpleMotion component.
