### PR TITLE
Switch trace processing to use threads for editor/server connection without impacting AP or asset builders

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicator.h
@@ -82,13 +82,13 @@ namespace AzFramework
         // Reads into process output until the communicator's output handles are no longer valid
         void ReadIntoProcessOutput(ProcessOutput& processOutput);
 
-    protected:
-        AZ_DISABLE_COPY(ProcessCommunicator);
-        
         // Waits for stdout or stderr to be ready for reading.  Note that its non-const
         // because it can detect if the outputs break and update them to be "broken".
         virtual void WaitForReadyOutputs(OutputStatus& outputStatus) = 0;
 
+    protected:
+        AZ_DISABLE_COPY(ProcessCommunicator);
+        
         void ReadFromOutputs(ProcessOutput& processOutput, OutputStatus& status);
 
     private:

--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/std/parallel/thread.h>
+#include <AzCore/std/parallel/atomic.h>
 #include <AzFramework/Process/ProcessCommunicator.h>
 
 //! ProcessCommunicatorTracePrinter listens to stderr and stdout of a running process and writes its output to the AZ_Trace system
@@ -15,26 +17,50 @@
 class ProcessCommunicatorTracePrinter
 {
 public:
+    enum class TraceProcessing
+    {
+        Poll,
+        Threaded
+    };
+
     //! Wraps a ProcessCommunicatorTracePrinter around an existing ProcessCommunicator, which it will then
     //! invoke to read from stdout/stderr.
     //! Because it is going to invoke functions on the given ProcessCommuncator which you pass in, it is important
     //! that the 'communicator' you pass in is only destroyed after you destroyProcessCommunicatorTracePrinter.
-    ProcessCommunicatorTracePrinter(AzFramework::ProcessCommunicator* communicator, const char* window);
+    ProcessCommunicatorTracePrinter(
+        AzFramework::ProcessCommunicator* communicator, const char* window, TraceProcessing processingType = TraceProcessing::Poll);
     ~ProcessCommunicatorTracePrinter();
 
     //! Call this periodically to drain the buffers and write them.
+    //! If using threaded trace printing, this should not get called
     void Pump();
 
+    //! Output any remaining data that exists.
+    //! If using threaded trace printing, the pump thread will continue to run after calling this.
+    void Flush();
+
+private:
     //! Drains the buffer into the string that's being built, then traces the string when it hits a newline.
     void ParseDataBuffer(AZ::u32 readSize, bool isFromStdErr);
 
     //! Prints the current buffer to AZ_Error or AZ_TracePrintf so that it can be picked up by AZ::Debug::Trace
     void WriteCurrentString(bool isFromStdError);
 
-private:
+    //! Start the thread for monitoring the output / error pipes.
+    void StartPumpThread();
+
+    //! End the thread for monitoring the output / error pipes.
+    void EndPumpThread();
+
+    //! End the pump thread and flush the current data.
+    void FlushInternal();
+
     AZStd::string m_window;
     AzFramework::ProcessCommunicator* m_communicator;
     char m_streamBuffer[128];
     AZStd::string m_stringBeingConcatenated;
     AZStd::string m_errorStringBeingConcatenated;
+    AZStd::thread m_pumpThread;
+    AZStd::atomic_bool m_runThread = true;
+    const TraceProcessing m_processingType;
 };

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
@@ -121,9 +121,7 @@ namespace AssetProcessor
     {
         if (m_tracePrinter)
         {
-            // flush both STDOUT and STDERR
-            m_tracePrinter->WriteCurrentString(true);
-            m_tracePrinter->WriteCurrentString(false);
+            m_tracePrinter->Flush();
         }
     }
 
@@ -162,7 +160,11 @@ namespace AssetProcessor
             return AZ::Failure(AZStd::string::format("Failed to start process watcher for Builder %.*s.", AZ_STRING_ARG(UuidString())));
         }
 
-        m_tracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_processWatcher->GetCommunicator(), "AssetBuilder");
+        // Currently, this uses polling for managing the trace printing output because the job log redirections rely on thread local
+        // storage to route different jobs to different logs. If the trace printing spins up a new thread for printing, it won't
+        // redirect to the correct job logs.
+        m_tracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(
+            m_processWatcher->GetCommunicator(), "AssetBuilder", ProcessCommunicatorTracePrinter::TraceProcessing::Poll);
 
         return WaitForConnection();
     }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -345,7 +345,10 @@ namespace Multiplayer
 
             if (editorsv_print_server_logs)
             {
-                m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(m_serverProcessWatcher->GetCommunicator(), "EditorServer");
+                // Create a threaded trace printer so that it will keep the output pipes flowing smoothly even while sending the
+                // editor data over to the server.
+                m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(
+                    m_serverProcessWatcher->GetCommunicator(), "EditorServer", ProcessCommunicatorTracePrinter::TraceProcessing::Threaded);
                 AZ::TickBus::Handler::BusConnect();
             }
         }
@@ -444,13 +447,6 @@ namespace Multiplayer
 
                     // Force the networking buffers to try and flush before sending the packet again.
                     AZ::Interface<AzNetworking::INetworking>::Get()->ForceUpdate();
-
-                    // Also, process the trace printing communication from server->client. Without this, if the piped trace
-                    // buffer is completely full, the server process will be completely halted waiting to send more trace
-                    // information. All retries here would fail indefinitely waiting for the server process to become available
-                    // again. With the Pump(), the trace pipes can be kept flowing, and retries can be processed by the server
-                    // in a timely manner.
-                    m_serverProcessTracePrinter->Pump();
                 }
             }
             AZ_Assert(packetSent, "Failed to send level packet after %d tries. Server will fail to run the level correctly.", numRetries);
@@ -480,18 +476,6 @@ namespace Multiplayer
             AZ::TickBus::Handler::BusDisconnect();
             MultiplayerEditorServerNotificationBus::Broadcast(&MultiplayerEditorServerNotificationBus::Events::OnEditorServerProcessStoppedUnexpectedly);
             AZ_Warning("MultiplayerEditorSystemComponent", false, "The editor server process has unexpectedly stopped running. Did it crash or get accidentally closed?")
-        }
-
-        if (m_serverProcessTracePrinter)
-        {
-            m_serverProcessTracePrinter->Pump();
-        }
-        else
-        {
-            AZ::TickBus::Handler::BusDisconnect();
-            AZ_Warning(
-                "MultiplayerEditorSystemComponent", false,
-                "The server process trace printer is NULL so we won't be able to pipe server logs to the editor. Please update the code to call AZ::TickBus::Handler::BusDisconnect whenever the editor-server is terminated.")
         }
     }
 

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -349,8 +349,10 @@ namespace Multiplayer
                 // editor data over to the server.
                 m_serverProcessTracePrinter = AZStd::make_unique<ProcessCommunicatorTracePrinter>(
                     m_serverProcessWatcher->GetCommunicator(), "EditorServer", ProcessCommunicatorTracePrinter::TraceProcessing::Threaded);
-                AZ::TickBus::Handler::BusConnect();
             }
+
+            // Connect to the tick bus to listen for unexpected server process disconnections
+            AZ::TickBus::Handler::BusConnect();
         }
         else
         {


### PR DESCRIPTION
## What does this PR do?

This improves upon a previous PR by introducing threaded trace printing for the editor/server connection instead of relying on well-placed Pump() calls. Also fixed a tiny bug where the tick bus wouldn't get connected to if server logging wasn't enabled, so the detection of unexpected server disconnects also wouldn't happen in that case.

In adding this support, I also left the previous pump-based trace printing because the Asset Builders rely on it pretty deeply, since they expect the trace printing to occur on specific threads. The change was spiraling out too far to get the Asset Builders to use the threaded trace printing, so I left them working the same as before with a comment explaining the situation.

## How was this PR tested?

Rebuilt the entire cache in the AP to verify that builder logging still works.
Ran Multiplayersample and verified that there are still no timeouts when starting up the Editor/server connection.
