### PR TITLE
Added a simple welcome screen to the Asset Processor, to make it easier to onboard to this tool.

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -235,6 +235,7 @@ void MainWindow::Activate()
 
     connect(ui->supportButton, &QPushButton::clicked, this, &MainWindow::OnSupportClicked);
 
+    ui->buttonList->addTab(QStringLiteral("Welcome"));
     ui->buttonList->addTab(QStringLiteral("Jobs"));
     ui->buttonList->addTab(QStringLiteral("Assets"));
     ui->buttonList->addTab(QStringLiteral("Logs"));
@@ -244,7 +245,7 @@ void MainWindow::Activate()
     ui->buttonList->addTab(QStringLiteral("Shared Cache"));
 
     connect(ui->buttonList, &AzQtComponents::SegmentBar::currentChanged, ui->dialogStack, &QStackedWidget::setCurrentIndex);
-    const int startIndex = static_cast<int>(DialogStackIndex::Jobs);
+    const int startIndex = static_cast<int>(DialogStackIndex::Welcome);
     ui->dialogStack->setCurrentIndex(startIndex);
     ui->buttonList->setCurrentIndex(startIndex);
 

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -73,6 +73,7 @@ public:
     // If the order is changed in the UI file, it should be changed here, too.
     enum class DialogStackIndex
     {
+        Welcome, // The welcome screen provides some basic info on the Asset Processor.
         Jobs,
         Assets,
         Logs,

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -337,7 +337,61 @@
         <property name="currentIndex">
          <number>0</number>
         </property>
-        <widget class="QSplitter" name="jobDialogSplitter">
+         <widget class="QWidget" name="WelcomePage">
+           <layout class="QVBoxLayout" name="WelcomeVerticalLayout">
+             <item>
+              <widget class="QLabel" name="welcomeScreenTitle">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string># Welcome to the O3DE Asset Processor</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::MarkdownText</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+               <widget class="QLabel" name="WelcomeDescriptionLabel">
+                 <property name="text">
+                   <string>This tool converts an O3DE project's source assets to game ready content.</string>
+                 </property>
+               </widget>
+             </item>
+             <item>
+               <widget class="QLabel" name="WelcomeDescriptionLabel">
+                 <property name="text">
+                   <string>You can read more about the Asset Processor &lt;a href=&quot;https://www.o3de.org/docs/user-guide/assets/asset-processor/&quot;&gt;here.&lt;/a&gt;</string>
+                 </property>
+                 <property name="openExternalLinks">
+                   <bool>true</bool>
+                 </property>
+                 <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+                 </property>
+               </widget>
+             </item>
+             <item>
+               <spacer name="welcomeScreenVerticalSpacer">
+                 <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                   <size>
+                     <width>16</width>
+                     <height>40</height>
+                   </size>
+                 </property>
+               </spacer>
+             </item>
+           </layout>
+         </widget>
+         <widget class="QSplitter" name="jobDialogSplitter">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>


### PR DESCRIPTION
## What does this PR do?

Adds a simple welcome screen to the Asset Processor. The goal here is to provide a softer landing point in this tool, especially for new users, who find the previous default tab, the Jobs tab, confusing and overwhelming.

A screenshot of what this looks like:

![image](https://user-images.githubusercontent.com/4838196/230130931-e463f674-690e-4365-800c-a39005936208.png)

This is in draft until I hear back from UX.

## How was this PR tested?

Ran locally, saw the new screen.
