### PR TITLE
Fixes to support msaa count 1 and misc

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.shader
@@ -37,5 +37,15 @@
                 "type": "Fragment"
             }
         ]
-    }
+    }, 
+
+    "Supervariants":
+    [
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments": {
+                "azslc": ["--no-ms"]
+            }
+        }
+    ]  
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.shader
@@ -30,5 +30,15 @@
                 "type": "Fragment"
             }
         ]
-    }
+    },
+	
+    "Supervariants":
+    [
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments": {
+                "azslc": ["--no-ms"]
+            }
+        }
+    ]  
 }

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -60,11 +60,6 @@ namespace AZ::Render
 
         m_filterParamBufferHandler = GpuBufferHandler(desc);
 
-        for (RPI::RenderPipelinePtr pipeline : GetParentScene()->GetRenderPipelines())
-        {
-            CachePasses(pipeline.get());
-        }
-
         EnableSceneNotification();
     }
     


### PR DESCRIPTION
## What does this PR do?

Add msaa super variant for reflection shaders since they are using msaa textures.

Remove cachePass in projected shadow feature processor since it's called from render pipeline change event when connect scene notification bus. (otherwise it may report error when it's called twice)

## How was this PR tested?

_Please describe any testing performed._
