### PR TITLE
Fixes dropping a folder on itself in Asset Browser

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -181,7 +181,7 @@ namespace AzToolsFramework
             CaptureTreeViewSnapshot();
         }
 
-        void AssetBrowserTreeView::dropEvent([[maybe_unused]] QDropEvent* event)
+        void AssetBrowserTreeView::dropEvent(QDropEvent* event)
         {
             QModelIndex sourceIndex = currentIndex();
             QModelIndex targetIndex = indexAt(event->pos());
@@ -189,6 +189,7 @@ namespace AzToolsFramework
             {
                 event->setDropAction(Qt::IgnoreAction);
                 event->accept();
+                return;
             }
             QTreeView::dropEvent(event);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -181,6 +181,18 @@ namespace AzToolsFramework
             CaptureTreeViewSnapshot();
         }
 
+        void AssetBrowserTreeView::dropEvent([[maybe_unused]] QDropEvent* event)
+        {
+            QModelIndex sourceIndex = currentIndex();
+            QModelIndex targetIndex = indexAt(event->pos());
+            if ((sourceIndex.internalPointer() == targetIndex.internalPointer()) && (sourceIndex.row() == targetIndex.row()))
+            {
+                event->setDropAction(Qt::IgnoreAction);
+                event->accept();
+            }
+            QTreeView::dropEvent(event);
+        }
+
         AZStd::vector<const AssetBrowserEntry*> AssetBrowserTreeView::GetSelectedAssets(bool includeProducts) const
         {
             const QModelIndexList& selectedIndexes = selectionModel()->selectedRows();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -116,6 +116,7 @@ namespace AzToolsFramework
 
         protected:
             QModelIndexList selectedIndexes() const override;
+            void dropEvent(QDropEvent* event) override;
 
         protected Q_SLOTS:
             void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;


### PR DESCRIPTION
## What does this PR do?

Fixes a bug that happened because the editor allowed a folder to be dropped on itself in the Asset Browser Treeview.

## How was this PR tested?

Tried dropping a folder on itself and it no longer does anything.
