### PR TITLE
Project Manager: Remote Template SHA265 Compare Using Case Insensitive Hash Check

### DIFF
--- a/scripts/o3de/o3de/download.py
+++ b/scripts/o3de/o3de/download.py
@@ -57,9 +57,9 @@ def validate_downloaded_zip_sha256(download_uri_json_data: dict, download_zip_pa
 
         with download_zip_path.open('rb') as f:
             sha256B = hashlib.sha256(f.read()).hexdigest()
-            if sha256A != sha256B:
+            if sha256A.lower() != sha256B.lower():
                 logger.error(f'SECURITY VIOLATION: Downloaded zip sha256 {sha256B} does not match'
-                            f' the advertised "sha256":{sha256A} in the f{manifest_json_name}.')
+                            f' the advertised "sha256":{sha256A} in the {manifest_json_name}.')
                 return 0
 
     unzipped_manifest_json_data = unzip_manifest_json_data(download_zip_path, manifest_json_name)


### PR DESCRIPTION
- Ensure SHA256 remote template checks are case insensitive.
[Powershell's Get-FileHash](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.3) method used for generating the zip SHA265 outputs uppercase, whereas the ProjectManager's python script using lowercase.
- Corrected a small fypo
Fixes #12443

## How was this PR tested?
Attempted to download the MultiplayerTemplate and see that it successfully matches its uppercase hash.