### PR TITLE
DPE: BoundContainer fixes and improvements

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -59,10 +59,12 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::InternalEnumValueKey);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::AddNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::RemoveNotify);
-        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ClearNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueHashed);
+
+        system->RegisterNode<Container>();
+        system->RegisterNodeAttribute<PropertyEditor>(Container::AddNotify);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::RemoveNotify);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::ClearNotify);
 
         system->RegisterPropertyEditor<UIElement>();
         system->RegisterNodeAttribute<UIElement>(UIElement::Handler);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -49,7 +49,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr AZStd::string_view Name = "Adapter";
         static constexpr auto QueryKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("QueryKey");
         static constexpr auto AddContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("AddContainerKey");
-        static constexpr auto RejectContainerKey = CallbackAttributeDefinition<void(DocumentAdapterPtr*, AZ::Dom::Path)>("RejectContainerKey");
+        static constexpr auto RejectContainerKey = CallbackAttributeDefinition<void(AZ::Dom::Path)>("RejectContainerKey");
 
         //! Use this callback attribute if there is need to enable/disable an adapter's nodes at runtime.
         static constexpr auto SetNodeDisabled =
@@ -102,6 +102,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
         FinishedEdit,
     };
 
+    struct Container : NodeWithVisiblityControl
+    {
+        static constexpr auto AddNotify = CallbackAttributeDefinition<void()>("AddNotify");
+        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void()>("RemoveNotify");
+        static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
+    };
+
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,
     //! that can edit an associated value.
     struct PropertyEditor : NodeWithVisiblityControl
@@ -147,11 +154,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
-
-        // Container attributes
-        static constexpr auto AddNotify = CallbackAttributeDefinition<void()>("AddNotify");
-        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t)>("RemoveNotify");
-        static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
     };
 
     struct UIElement : PropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -102,10 +102,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
         FinishedEdit,
     };
 
+    //! Container: A node representing a container instance.
     struct Container : NodeWithVisiblityControl
     {
+        // These notify callback attributes may be invoked when a container is modified and handled
+        // alongside other messages in the adapter's message handler.
         static constexpr auto AddNotify = CallbackAttributeDefinition<void()>("AddNotify");
-        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void()>("RemoveNotify");
+        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t /*index*/)>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
     };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -108,7 +108,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         // These notify callback attributes may be invoked when a container is modified and handled
         // alongside other messages in the adapter's message handler.
         static constexpr auto AddNotify = CallbackAttributeDefinition<void()>("AddNotify");
-        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t /*index*/)>("RemoveNotify");
+        static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t index)>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
     };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -836,13 +836,15 @@ namespace AZ::Reflection
                 if (nodeData.m_disableEditor)
                 {
                     nodeData.m_cachedAttributes.push_back(
-                        { group, AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Disabled.GetName(), Dom::Value(true) });
+                        { group, AZ::DocumentPropertyEditor::Nodes::NodeWithVisiblityControl::Disabled.GetName(), Dom::Value(true) });
                 }
 
                 if (nodeData.m_isAncestorDisabled)
                 {
                     nodeData.m_cachedAttributes.push_back(
-                        { group, AZ::DocumentPropertyEditor::Nodes::PropertyEditor::AncestorDisabled.GetName(), Dom::Value(true) });
+                        { group,
+                          AZ::DocumentPropertyEditor::Nodes::NodeWithVisiblityControl::AncestorDisabled.GetName(),
+                          Dom::Value(true) });
                 }
 
                 if (nodeData.m_classData->m_container)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -259,19 +259,7 @@ namespace AZ::DocumentPropertyEditor
 
             void OnRemoveElement(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
             {
-                void* instanceToRemove = m_elementInstance;
-
-                auto associativeContainer = m_container->GetAssociativeContainerInterface();
-                if (associativeContainer)
-                {
-                    const AZ::SerializeContext::ClassElement* containerClassElement =
-                        m_container->GetElement(m_container->GetDefaultElementNameCrc());
-                    instanceToRemove = associativeContainer->GetElementByKey(m_containerInstance, containerClassElement, m_elementInstance);
-
-                }
-
-                m_container->RemoveElement(m_containerInstance, instanceToRemove, impl->m_serializeContext);
-
+                m_container->RemoveElement(m_containerInstance, m_elementInstance, impl->m_serializeContext);
                 auto containerNode = GetContainerNode(impl, path);
                 Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
                 impl->m_adapter->NotifyResetDocument();
@@ -566,7 +554,7 @@ namespace AZ::DocumentPropertyEditor
                 parentContainerInstanceAttribute && !parentContainerInstanceAttribute->IsNull())
             {
                 auto containerEntry = m_containers.ValueAtPath(m_builder.GetCurrentPath(), AZ::Dom::PrefixTreeMatch::ExactPath);
-                if (containerEntry && containerEntry->m_element)
+                if (containerEntry)
                 {
                     containerEntry->m_element = ContainerElement::CreateContainerElement(instance, attributes);
                 }

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -158,6 +158,7 @@ namespace DPEDebugView
         int m_readOnlyInt = 33;
         double m_doubleSlider = 3.25;
         AZStd::vector<AZStd::string> m_vector;
+        AZStd::vector<AZStd::vector<int>> m_vectorOfVectors;
         AZStd::map<AZStd::string, float> m_map;
         AZStd::map<AZStd::string, float> m_readOnlyMap;
         AZStd::unordered_map<AZStd::pair<int, double>, int> m_unorderedMap;
@@ -189,6 +190,7 @@ namespace DPEDebugView
                     ->Field("simpleInt", &TestContainer::m_simpleInt)
                     ->Field("doubleSlider", &TestContainer::m_doubleSlider)
                     ->Field("vector", &TestContainer::m_vector)
+                    ->Field("vectorOfVectors", &TestContainer::m_vectorOfVectors)
                     ->Field("map", &TestContainer::m_map)
                     ->Field("unorderedMap", &TestContainer::m_unorderedMap)
                     ->Field("simpleEnum", &TestContainer::m_simpleEnumMap)
@@ -226,6 +228,7 @@ namespace DPEDebugView
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Containers")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_vector, "vector<string>", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_vectorOfVectors, "vector<vector<int>>", "")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_map, "map<string, float>", "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
@@ -336,6 +339,9 @@ int main(int argc, char** argv)
     testContainer.m_vector.push_back("one");
     testContainer.m_vector.push_back("two");
     testContainer.m_vector.push_back("the third");
+
+    testContainer.m_vectorOfVectors.push_back({ 0, 1 });
+    testContainer.m_vectorOfVectors.push_back({ 2, 3 });
 
     testContainer.m_map["One"] = 1.f;
     testContainer.m_map["Two"] = 2.f;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1610,7 +1610,7 @@ namespace AzToolsFramework
             else
             {
                 AZ::DocumentPropertyEditor::Nodes::Adapter::RejectContainerKey.InvokeOnDomNode(
-                    m_adapter->GetContents(), adapter, containerPath);
+                    m_adapter->GetContents(), containerPath);
             }
         };
 


### PR DESCRIPTION
**Description**
Prior to this PR, there were some issues with containers in the DPE such as broken nested container action buttons and the inability to remove nested associative containers elements from their parent container.

This PR fixes those issues and makes some improvements to the `ReflectionAdapter`'s `BoundContainer` including:
- Fix for broken nested container action buttons which weren't working due to BoundContainer combining the state for root containers, nested containers, and non-container elements
- Fix for using the IDataContainer API with a nested container by storing its element instance override (from the LegacyReflectionBridge) separately from its container instance 
- Refactored BoundContainer's element responsibilities into struct ContainerElement
  - A ContainerNode wrapper is now being used in the ReflectionAdapterReflectionImpl m_containers prefix tree so access to a BoundContainer and/or a ContainerEntry can be had
  - This solves issues brought about by having both container and element behavior contained in the same struct
- Created BoundContainer/ContainerElement factory methods to simplify their creation and maintenance in the ReflectionAdapter
- Updated usage of IDataContainer API to use the element instances it expects; previously we were passing in the key instance ptr only, which happened to work in some cases but caused undefined behavior in others
- Remove unused Add/Remove/ClearNotify notifications from the BoundContainer methods
  - These were unused, and an attempt at implementing them introduced bugs
  - They also now live in the Container node inside of PropertyNodes.h for future use
- Now passes the class size to VisitValue for instance hashes instead of using size of void*

Terms for reference:
Nested Container = `AZStd::unordered_map<int, AZStd::vector<int>>`
Non-Nested Container = `AZStd::unordered_map<int, int>`
Non-Container elements = `typename AZStd::unordered_map<int, int>::value_type` i.e the type is `AZStd::pair<const int, int>` or for `AZStd::vector<int>` the element type is `int`

**Testing**
- Verified that all action buttons function properly in the debug DPE standalone app
- Verified that all container functions such as add, remove, and clear function properly in the debug DPE standalone app
- Verified DPE containers and the DPE in general function as before in the editor