### PR TITLE
Gather by component node

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -1596,6 +1596,10 @@ namespace {{ Component.attrib['Namespace'] }}
         AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
         if (behaviorContext)
         {
+            behaviorContext->ConstantProperty("{{ ComponentName }}TypeId", BehaviorConstant(s_{{ LowerFirst(ComponentName) }}ConcreteUuid))
+                ->Attribute(AZ::Script::Attributes::Module, "{{ LowerFirst(Component.attrib['Namespace']) }}")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common);
+
             {{ ReflectRpcEventDescs(Component, ComponentName, 'Server', 'Authority')|indent(4) -}}
             {{ ReflectRpcEventDescs(Component, ComponentName, 'Autonomous', 'Authority')|indent(4) -}}
             {{ ReflectRpcEventDescs(Component, ComponentName, 'Authority', 'Autonomous')|indent(4) -}}

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.ScriptCanvasNodeable.xml
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.ScriptCanvasNodeable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Class Name="GatherEntitiesByComponentAabb"
+           QualifiedName="ScriptCanvasMultiplayer::GatherEntitiesByComponentAabb"
+           PreferredClassName="Gather Entities by Component AABB"
+           Category="Multiplayer"
+           Description="Gathers entites that have the provided component type using an axis-aligned bounding box. Use a For-Each node to iterate the results.">
+
+        <Input Name="In" DisplayGroup="In" Description="Parameters controlling the entity gather">
+            <Parameter Name="ComponentId" Type="AZ::Uuid" Description="The typeId of the components to look for."/>
+            <Parameter Name="Minimum" Type="AZ::Vector3" Description="The minimum point of the AABB used to gather."/>
+            <Parameter Name="Maximum" Type="AZ::Vector3" Description="The maximum point of the AABB used to gather."/>
+            <Return Name="Entities" Type="AZStd::vector&lt;AZ::EntityId&gt;" Shared="true"/>
+        </Input>
+    </Class>
+</ScriptCanvas>

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.cpp
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.h>
+#include <AzFramework/Visibility/IVisibilitySystem.h>
+#include <AzCore/Math/ShapeIntersection.h>
+
+namespace ScriptCanvasMultiplayer
+{
+    AZStd::vector<AZ::EntityId> GatherEntitiesByComponentAabb::In(AZ::Uuid componentGuid, AZ::Vector3 minimum, AZ::Vector3 maximum)
+    {
+        const AZ::Aabb bound = AZ::Aabb::CreateFromMinMax(minimum, maximum);
+
+        AZStd::vector<AZ::EntityId> gatheredEntities;
+        AZ::Interface<AzFramework::IVisibilitySystem>::Get()->GetDefaultVisibilityScene()->Enumerate(bound,
+            [bound, componentGuid, &gatheredEntities](const AzFramework::IVisibilityScene::NodeData& nodeData)
+        {
+            gatheredEntities.reserve(gatheredEntities.size() + nodeData.m_entries.size());
+            for (AzFramework::VisibilityEntry* visEntry : nodeData.m_entries)
+            {
+                if (AZ::ShapeIntersection::Overlaps(visEntry->m_boundingVolume, bound))
+                {
+                    if (visEntry->m_typeFlags & AzFramework::VisibilityEntry::TypeFlags::TYPE_Entity)
+                    {
+                        AZ::Entity* entity = static_cast<AZ::Entity*>(visEntry->m_userData);
+                        if (entity->FindComponent(componentGuid) != nullptr)
+                        {
+                            gatheredEntities.push_back(entity->GetId());
+                        }
+                    }
+                }
+            }
+        });
+
+        return gatheredEntities;
+    }
+}

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.h
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+#include <Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.generated.h>
+
+namespace ScriptCanvasMultiplayer
+{
+    class GatherEntitiesByComponentAabb
+        : public ScriptCanvas::Nodeable
+    {
+        SCRIPTCANVAS_NODE_GatherEntitiesByComponentAabb;
+    };
+}

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.ScriptCanvasNodeable.xml
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.ScriptCanvasNodeable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Class Name="GatherEntitiesByComponentSphere"
+           QualifiedName="ScriptCanvasMultiplayer::GatherEntitiesByComponentSphere"
+           PreferredClassName="Gather Entities by Component Sphere"
+           Category="Multiplayer"
+           Description="Gathers entites that have the provided component type using an sphere shape. Use a For-Each node to iterate the results.">
+
+        <Input Name="In" DisplayGroup="In" Description="Parameters controlling the entity gather">
+            <Parameter Name="ComponentId" Type="AZ::Uuid" Description="The typeId of the components to look for."/>
+            <Parameter Name="Position" Type="AZ::Vector3" Description="The position of the sphere used to gather."/>
+            <Parameter Name="Radius" Type="float" Description="The radius of the sphere used to gather."/>
+            <Return Name="Entities" Type="AZStd::vector&lt;AZ::EntityId&gt;" Shared="true"/>
+        </Input>
+    </Class>
+</ScriptCanvas>

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.cpp
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.h>
+#include <AzFramework/Visibility/IVisibilitySystem.h>
+#include <AzCore/Math/ShapeIntersection.h>
+
+namespace ScriptCanvasMultiplayer
+{
+    AZStd::vector<AZ::EntityId> GatherEntitiesByComponentSphere::In(AZ::Uuid componentGuid, AZ::Vector3 position, float radius)
+    {
+        const AZ::Sphere bound(position, radius);
+
+        AZStd::vector<AZ::EntityId> gatheredEntities;
+        AZ::Interface<AzFramework::IVisibilitySystem>::Get()->GetDefaultVisibilityScene()->Enumerate(bound,
+            [bound, componentGuid, &gatheredEntities](const AzFramework::IVisibilityScene::NodeData& nodeData)
+        {
+            gatheredEntities.reserve(gatheredEntities.size() + nodeData.m_entries.size());
+            for (AzFramework::VisibilityEntry* visEntry : nodeData.m_entries)
+            {
+                if (AZ::ShapeIntersection::Overlaps(visEntry->m_boundingVolume, bound))
+                {
+                    if (visEntry->m_typeFlags & AzFramework::VisibilityEntry::TypeFlags::TYPE_Entity)
+                    {
+                        AZ::Entity* entity = static_cast<AZ::Entity*>(visEntry->m_userData);
+                        if (entity->FindComponent(componentGuid) != nullptr)
+                        {
+                            gatheredEntities.push_back(entity->GetId());
+                        }
+                    }
+                }
+            }
+        });
+
+        return gatheredEntities;
+    }
+}

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.h
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+#include <Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.generated.h>
+
+namespace ScriptCanvasMultiplayer
+{
+    class GatherEntitiesByComponentSphere
+        : public ScriptCanvas::Nodeable
+    {
+        SCRIPTCANVAS_NODE_GatherEntitiesByComponentSphere;
+    };
+}

--- a/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/scriptcanvas_multiplayer_files.cmake
+++ b/Gems/Multiplayer/Multiplayer_ScriptCanvas/Code/scriptcanvas_multiplayer_files.cmake
@@ -10,6 +10,14 @@ set(FILES
     Source/ScriptCanvasMultiplayerSystemComponent.cpp
     Source/ScriptCanvasMultiplayerSystemComponent.h
 
+    Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.cpp
+    Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.h
+    Source/Nodes/Nodeables/GatherEntitiesByComponentAabb.ScriptCanvasNodeable.xml
+    
+    Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.cpp
+    Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.h
+    Source/Nodes/Nodeables/GatherEntitiesByComponentSphere.ScriptCanvasNodeable.xml
+
     Source/Nodes/Nodeables/IfNetRoleNodeable.cpp
     Source/Nodes/Nodeables/IfNetRoleNodeable.h
     Source/Nodes/Nodeables/IfNetRoleNodeable.ScriptCanvasNodeable.xml


### PR DESCRIPTION
Adds new script-canvas nodes that can gather entities based on the presence of a provided component guid. This is used to fix the shield generator trap in the multiplayer sample.

## What does this PR do?

This allows the shield generator trap to precisely query for players within its explosion proximity. The previous implementation used physx queries combined with complex collision layer setup that often returned duplicated or incorrect results. This new implementation uses the IVisibility system and by filtering using componentIds requires no additional setup of collision layers.

![image](https://user-images.githubusercontent.com/82241079/230236107-e35ce102-0b08-4319-b9ba-338cfdd1e954.png)
