### PR TITLE
Remove m_buildTimeStamp from ShaderAsset and ShaderVariantAsset

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -83,7 +83,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 119; // Half float support
+            shaderAssetBuilderDescriptor.m_version = 120; // Remove build timestamp
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -108,7 +108,7 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 36; // The ShaderVariantAsset declares OrderOnly dependency on ShaderVariantTreeAsset.
+                shaderVariantAssetBuilderDescriptor.m_version = 37; // Remove build timestamp
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -222,7 +222,7 @@ namespace AZ
                 response.m_createJobOutputs.push_back(jobDescriptor);
             }  // for all request.m_enabledPlatforms
 
-            AZ_TracePrintf(
+            AZ_Printf(
                 ShaderAssetBuilderName, "CreateJobs for %s took %llu milliseconds", shaderAssetSourceFileFullPath.c_str(),
                 AZStd::GetTimeUTCMilliSecond() - shaderAssetBuildTimestamp);
 

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -59,7 +59,6 @@ namespace AZ
     namespace ShaderBuilder
     {
         static constexpr char ShaderAssetBuilderName[] = "ShaderAssetBuilder";
-        static constexpr uint32_t ShaderAssetBuildTimestampParam = 0;
 
         //! The search will start in @currentFolderPath.
         //! if the file is not found then it searches in order of appearence in @includeDirectories.
@@ -151,18 +150,14 @@ namespace AZ
 
         void ShaderAssetBuilder::CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response) const
         {
+            // Used to measure the duration of CreateJobs
+            AZ::u64 shaderAssetBuildTimestamp = AZStd::GetTimeUTCMilliSecond();
+
             AZStd::string shaderAssetSourceFileFullPath;
             AzFramework::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), shaderAssetSourceFileFullPath, true);
             ShaderBuilderUtility::IncludedFilesParser includedFilesParser;
 
             AZ_TracePrintf(ShaderAssetBuilderName, "CreateJobs for Shader \"%s\"\n", shaderAssetSourceFileFullPath.data());
-
-            // Used to synchronize versions of the ShaderAsset and ShaderVariantTreeAsset, especially during hot-reload.
-            // Note it's probably important for this to be set once outside the platform loop so every platform's ShaderAsset
-            // has the same value, because later the ShaderVariantTreeAsset job will fetch this value from the local ShaderAsset
-            // which could cross platforms (i.e. building an android ShaderVariantTreeAsset on PC would fetch the tiemstamp from
-            // the PC's ShaderAsset).
-            AZ::u64 shaderAssetBuildTimestamp = AZStd::GetTimeUTCMilliSecond();
 
             // Need to get the name of the azsl file from the .shader source asset, to be able to declare a dependency to SRG Layout Job.
             // and the macro options to preprocess.
@@ -223,7 +218,6 @@ namespace AZ
                 jobDescriptor.m_critical = false;
                 jobDescriptor.m_jobKey = ShaderAssetBuilderJobKey;
                 jobDescriptor.SetPlatformIdentifier(platformInfo.m_identifier.c_str());
-                jobDescriptor.m_jobParameters.emplace(ShaderAssetBuildTimestampParam, AZStd::to_string(shaderAssetBuildTimestamp));
 
                 response.m_createJobOutputs.push_back(jobDescriptor);
             }  // for all request.m_enabledPlatforms
@@ -373,28 +367,6 @@ namespace AZ
                 return;
             }
 
-            // Get the time stamp string as u64, and also convert back to string to make sure it was converted correctly.
-            AZ::u64 shaderAssetBuildTimestamp = 0;
-            auto shaderAssetBuildTimestampIterator = request.m_jobDescription.m_jobParameters.find(ShaderAssetBuildTimestampParam);
-            if (shaderAssetBuildTimestampIterator != request.m_jobDescription.m_jobParameters.end())
-            {
-                shaderAssetBuildTimestamp = AZStd::stoull(shaderAssetBuildTimestampIterator->second);
-
-                if (AZStd::to_string(shaderAssetBuildTimestamp) != shaderAssetBuildTimestampIterator->second)
-                {
-                    response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
-                    AZ_Assert(false, "Incorrect conversion of ShaderAssetBuildTimestampParam");
-                    return;
-                }
-            }
-            else
-            {
-                // CreateJobs was not successful if there's no timestamp property in m_jobParameters.
-                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
-                AZ_Assert(false, "Missing ShaderAssetBuildTimestampParam");
-                return;
-            }
-
             auto supervariantList = ShaderBuilderUtility::GetSupervariantListFromShaderSourceData(shaderSourceData);
 
             RPI::ShaderAssetCreator shaderAssetCreator;
@@ -402,7 +374,6 @@ namespace AZ
 
             shaderAssetCreator.SetName(AZ::Name{shaderFileName});
             shaderAssetCreator.SetDrawListName(shaderSourceData.m_drawListName);
-            shaderAssetCreator.SetShaderAssetBuildTimestamp(shaderAssetBuildTimestamp);
 
             // The ShaderOptionGroupLayout must be the same across all supervariants because
             // there can be only a single ShaderVariantTreeAsset per ShaderAsset.
@@ -690,7 +661,6 @@ namespace AZ
                         request.m_platformInfo,
                         buildArgsManager.GetCurrentArguments(),
                         request.m_tempDirPath,
-                        shaderAssetBuildTimestamp,
                         shaderSourceData,
                         *shaderOptionGroupLayout.get(),
                         shaderEntryPoints,

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -577,8 +577,6 @@ namespace AZ
                 response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
                 return;
             }
-            
-            const AZ::u64 shaderVariantAssetBuildTimestamp = AZStd::GetTimeUTCMilliSecond();
 
             auto supervariantList = ShaderBuilderUtility::GetSupervariantListFromShaderSourceData(shaderSourceDescriptor);
 
@@ -715,7 +713,6 @@ namespace AZ
                     ShaderVariantCreationContext shaderVariantCreationContext =
                     {
                         *shaderPlatformInterface, request.m_platformInfo, buildArgsManager.GetCurrentArguments(), request.m_tempDirPath,
-                        shaderVariantAssetBuildTimestamp,
                         shaderSourceDescriptor,
                         *shaderOptionGroupLayout.get(),
                         shaderEntryPoints,
@@ -910,7 +907,6 @@ namespace AZ
             variantCreator.Begin(
                 creationContext.m_shaderVariantAssetId, optionGroup.GetShaderVariantId(), shaderVariantStableId,
                 shaderOptions.IsFullySpecified());
-            variantCreator.SetBuildTimestamp(creationContext.m_assetBuildTimestamp);
 
             const AZStd::unordered_map<AZStd::string, RPI::ShaderStageType>& shaderEntryPoints = creationContext.m_shaderEntryPoints;
             for (const auto& shaderEntryPoint : shaderEntryPoints)

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.h
@@ -36,9 +36,6 @@ namespace AZ
             const RHI::ShaderBuildArguments& m_shaderBuildArguments;
             //! Used to write temporary files during shader compilation, like *.hlsl, or *.air, or *.metallib, etc.
             const AZStd::string& m_tempDirPath;
-            //! Used to synchronize versions of the ShaderAsset and ShaderVariantAsset,
-            //! especially during hot-reload. A (ShaderVariantAsset.timestamp) >= (ShaderAsset.timestamp).
-            const AZ::u64 m_assetBuildTimestamp;
             const RPI::ShaderSourceData& m_shaderSourceDataDescriptor;
             const RPI::ShaderOptionGroupLayout& m_shaderOptionGroupLayout;
             const MapOfStringToStageType& m_shaderEntryPoints;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
@@ -52,7 +52,7 @@ namespace AZ
         //! If you need guarantee lifetime, it is safe to take a reference on the returned pipeline state.
         class Shader final
             : public Data::InstanceData
-            , public Data::AssetBus::MultiHandler
+            , public Data::AssetBus::Handler
             , public ShaderVariantFinderNotificationBus::Handler
         {
             friend class ShaderSystem;
@@ -212,11 +212,6 @@ namespace AZ
             //! PipelineLibrary file name
             char m_pipelineLibraryPath[AZ_MAX_PATH_LEN] = { 0 };
 
-            //! During OnAssetReloaded, the internal references to ShaderVariantAsset inside
-            //! ShaderAsset are not updated correctly. We store here a reference to the root ShaderVariantAsset
-            //! when it got reloaded, later when We get OnAssetReloaded for the ShaderAsset We update its internal
-            //! reference to the root variant asset.
-            Data::Asset<ShaderVariantAsset> m_reloadedRootShaderVariantAsset;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
@@ -96,10 +96,6 @@ namespace AZ
             //! ShaderAsset.
             const Name& GetDrawListName() const;
 
-            //! Return the timestamp when the shader asset was built.
-            //! This is used to synchronize versions of the ShaderAsset and ShaderVariantTreeAsset, especially during hot-reload.
-            AZStd::sys_time_t GetBuildTimestamp() const;
-
             //! Returns the shader option group layout.
             const ShaderOptionGroupLayout* GetShaderOptionGroupLayout() const;
 
@@ -227,12 +223,6 @@ namespace AZ
             void OnShaderVariantAssetReady(Data::Asset<ShaderVariantAsset> /*shaderVariantAsset*/, bool /*isError*/) override {};
             ///////////////////////////////////////////////////////////////////
 
-            // Only Shader::OnAssetReloaded() should call this function, because it is pointless for an Asset to
-            // to refresh its own "serialized references" to other assets during  OnAssetReloaded().
-            // The problem is that OnAssetReloaded() doesn't do a good job at updating "serialized references" to other assets,
-            // So some other class must update the reference and that's why Shader() is the best class to do it.
-            void UpdateRootShaderVariantAsset(SupervariantIndex SupervariantIndex, Data::Asset<ShaderVariantAsset> newRootVariant);
-
             //! A Supervariant represents a set of static shader compilation parameters.
             //! Those parameters can be predefined c-preprocessor macros or specific arguments
             //! for AZSLc.
@@ -303,10 +293,6 @@ namespace AZ
             AZStd::vector<ShaderApiDataContainer> m_perAPIShaderData;
 
             Name m_drawListName;
-
-            //! Use to synchronize versions of the ShaderAsset and ShaderVariantTreeAsset, especially during hot-reload.
-            AZ::u64 m_buildTimestamp = 0; 
-
 
             ///////////////////////////////////////////////////////////////////
             //! Do Not Serialize!

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAssetCreator.h
@@ -28,10 +28,6 @@ namespace AZ
             //! Begins creation of a shader asset.
             void Begin(const Data::AssetId& assetId);
 
-            //! [Optional] Set the timestamp for when the ShaderAsset build process began.
-            //! This is needed to synchronize between the ShaderAsset and ShaderVariantTreeAsset when hot-reloading shaders.
-            void SetShaderAssetBuildTimestamp(AZStd::sys_time_t shaderAssetBuildTimestamp);
-
             //! [Optional] Sets the name of the shader asset from content.
             void SetName(const Name& name);
             

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
@@ -81,8 +81,7 @@ namespace AZ
 
             AZStd::array<RHI::Ptr<RHI::ShaderStageFunction>, RHI::ShaderStageCount> m_functionsByStage;
 
-            //! Used to synchronize versions of the ShaderAsset and ShaderVariantAsset, especially during hot-reload.
-            AZ::u64 m_buildTimestamp = 0;
+
         };
 
         class ShaderVariantAssetHandler final

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
@@ -40,12 +40,6 @@ namespace AZ
                 return false;
             }
 
-            if (!m_asset->m_buildTimestamp)
-            {
-                ReportError("Invalid timestamp");
-                return false;
-            }
-
             bool foundDrawFunctions = false;
             bool foundDispatchFunctions = false;
 
@@ -91,14 +85,6 @@ namespace AZ
 
         /////////////////////////////////////////////////////////////////////
         // Methods for all shader variant types
-
-        void ShaderVariantAssetCreator::SetBuildTimestamp(AZ::u64 buildTimestamp)
-        {
-            if (ValidateIsReady())
-            {
-                m_asset->m_buildTimestamp = buildTimestamp;
-            }
-        }
 
         void ShaderVariantAssetCreator::SetShaderFunction(RHI::ShaderStage shaderStage, RHI::Ptr<RHI::ShaderStageFunction> shaderStageFunction)
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -135,7 +135,7 @@ namespace AZ
 
         RHI::ResultCode Shader::Init(ShaderAsset& shaderAsset)
         {
-            Data::AssetBus::MultiHandler::BusDisconnect();
+            Data::AssetBus::Handler::BusDisconnect();
             ShaderVariantFinderNotificationBus::Handler::BusDisconnect();
 
             RHI::RHISystemInterface* rhiSystem = RHI::RHISystemInterface::Get();
@@ -185,8 +185,7 @@ namespace AZ
             }
 
             ShaderVariantFinderNotificationBus::Handler::BusConnect(m_asset.GetId());
-            Data::AssetBus::MultiHandler::BusConnect(rootShaderVariantAsset.GetId());
-            Data::AssetBus::MultiHandler::BusConnect(m_asset.GetId());
+            Data::AssetBus::Handler::BusConnect(m_asset.GetId());
 
             return RHI::ResultCode::Success;
         }
@@ -194,7 +193,7 @@ namespace AZ
         void Shader::Shutdown()
         {
             ShaderVariantFinderNotificationBus::Handler::BusDisconnect();
-            Data::AssetBus::MultiHandler::BusDisconnect();
+            Data::AssetBus::Handler::BusDisconnect();
 
             if (m_pipelineLibraryHandle.IsValid())
             {
@@ -212,14 +211,6 @@ namespace AZ
                 m_drawListTag.Reset();
             }
         }
-        
-        AZStd::string MakeTimeString(AZ::u64 timestampMilliseconds, AZ::u64 nowMilliseconds)
-        {
-            AZ::u64 elapsedMilliseconds = nowMilliseconds - timestampMilliseconds;
-            double elapsedSeconds = aznumeric_cast<double>(elapsedMilliseconds) / 1'000;
-            AZStd::string timeString = AZStd::string::format("%lld (%f seconds ago)", timestampMilliseconds, elapsedSeconds);
-            return timeString;
-        };
 
         ///////////////////////////////////////////////////////////////////////
         // AssetBus overrides
@@ -227,43 +218,18 @@ namespace AZ
         {
             ShaderReloadDebugTracker::ScopedSection reloadSection("{%p}->Shader::OnAssetReloaded %s", this, asset.GetHint().c_str());
 
-            if (asset.GetAs<ShaderVariantAsset>())
+            m_asset = Data::static_pointer_cast<ShaderAsset>(asset);
+
+            if (ShaderReloadDebugTracker::IsEnabled())
             {
-                m_reloadedRootShaderVariantAsset = Data::static_pointer_cast<ShaderVariantAsset>(asset);
-                if (m_asset->m_buildTimestamp == m_reloadedRootShaderVariantAsset->GetBuildTimestamp())
-                {
-                    Init(*m_asset.Get());
-                    ShaderReloadNotificationBus::Event(asset.GetId(), &ShaderReloadNotificationBus::Events::OnShaderReinitialized, *this);
-                }
-                return;
+                AZStd::sys_time_t now = AZStd::GetTimeUTCMilliSecond();
+
+                const auto shaderVariantAsset = m_asset->GetRootVariantAsset();
+                ShaderReloadDebugTracker::Printf("{%p}->Shader::OnAssetReloaded for shader '%s' [current time %lld] found variant '%s'",
+                    this, m_asset.GetHint().c_str(), now, shaderVariantAsset.GetHint().c_str());
             }
-
-            if (asset.GetAs<ShaderAsset>())
-            {
-                m_asset = Data::static_pointer_cast<ShaderAsset>(asset);
-                if (!m_reloadedRootShaderVariantAsset.IsReady())
-                {
-                    // Do nothing, as We should not re-initilize until the root shader variant asset has been reloaded.
-                    return;
-                }
-                AZ_Assert(m_asset->m_buildTimestamp == m_reloadedRootShaderVariantAsset->GetBuildTimestamp(),
-                    "shaderAsset '%s' timeStamp=%lld, but Root ShaderVariantAsset timeStamp=%lld", m_asset.GetHint().c_str(),
-                    m_asset->m_buildTimestamp, m_reloadedRootShaderVariantAsset->GetBuildTimestamp());
-                m_asset->UpdateRootShaderVariantAsset(m_supervariantIndex, m_reloadedRootShaderVariantAsset);
-                m_reloadedRootShaderVariantAsset = {}; // Clear the temporary reference.
-
-                if (ShaderReloadDebugTracker::IsEnabled())
-                {
-                    AZStd::sys_time_t now = AZStd::GetTimeUTCMilliSecond();
-
-                    const auto shaderVariantAsset = m_asset->GetRootVariantAsset();
-                    ShaderReloadDebugTracker::Printf("{%p}->Shader::OnAssetReloaded for shader '%s' [build time %s] found variant '%s' [build time %s]", this,
-                        m_asset.GetHint().c_str(), MakeTimeString(m_asset->m_buildTimestamp, now).c_str(),
-                        shaderVariantAsset.GetHint().c_str(), MakeTimeString(shaderVariantAsset->GetBuildTimestamp(), now).c_str());
-                }
-                Init(*m_asset.Get());
-                ShaderReloadNotificationBus::Event(asset.GetId(), &ShaderReloadNotificationBus::Events::OnShaderReinitialized, *this);
-            }
+            Init(*m_asset.Get());
+            ShaderReloadNotificationBus::Event(asset.GetId(), &ShaderReloadNotificationBus::Events::OnShaderReinitialized, *this);
 
         }
         ///////////////////////////////////////////////////////////////////////
@@ -421,9 +387,8 @@ namespace AZ
             {
                 AZStd::sys_time_t now = AZStd::GetTimeUTCMilliSecond();
 
-                ShaderReloadDebugTracker::Printf("{%p}->Shader::GetVariant for shader '%s' [build time %s] found variant '%s' [build time %s]", this,
-                    m_asset.GetHint().c_str(), MakeTimeString(m_asset->GetBuildTimestamp(), now).c_str(),
-                    variant.GetShaderVariantAsset().GetHint().c_str(), MakeTimeString(variant.GetShaderVariantAsset()->GetBuildTimestamp(), now).c_str());
+                ShaderReloadDebugTracker::Printf("{%p}->Shader::GetVariant for shader '%s' [current time %lld] found variant '%s'",
+                    this, m_asset.GetHint().c_str(), now, variant.GetShaderVariantAsset().GetHint().c_str());
             }
 
             return variant;
@@ -442,14 +407,7 @@ namespace AZ
                 auto findIt = m_shaderVariants.find(shaderVariantStableId);
                 if (findIt != m_shaderVariants.end())
                 {
-                    // When rebuilding shaders we may be in a state where the ShaderAsset and root ShaderVariantAsset have been rebuilt and
-                    // reloaded, but some (or all) shader variants haven't been built yet. Since we want to use the latest version of the
-                    // shader code, ignore the old variants and fall back to the newer root variant instead. There's no need to report a
-                    // warning here because m_asset->GetVariant below will report one.
-                    if (findIt->second.GetBuildTimestamp() >= m_asset->GetBuildTimestamp())
-                    {
-                        return findIt->second;
-                    }
+                    return findIt->second;
                 }
             }
 
@@ -469,20 +427,7 @@ namespace AZ
             auto findIt = m_shaderVariants.find(shaderVariantStableId);
             if (findIt != m_shaderVariants.end())
             {
-                if (findIt->second.GetBuildTimestamp() >= m_asset->GetBuildTimestamp())
-                {
-                    return findIt->second;
-                }
-                else
-                {
-                    // This is probably very rare, but if the variant was loaded on another thread and it's out of date
-                    // we just return the root variant. Otherwise we could end up replacing the variant in the map below while
-                    // it's being used for rendering.
-                    AZ_Warning(
-                        "Shader", false,
-                        "Detected an uncommon state during shader reload. Returning the root variant instead of replacing the old one.");
-                    return m_rootVariant;
-                }
+                return findIt->second;
             }
 
             ShaderVariant newVariant;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -97,13 +97,12 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderAsset>()
-                    ->Version(1)
+                    ->Version(2)
                     ->Field("name", &ShaderAsset::m_name)
                     ->Field("pipelineStateType", &ShaderAsset::m_pipelineStateType)
                     ->Field("shaderOptionGroupLayout", &ShaderAsset::m_shaderOptionGroupLayout)
                     ->Field("defaultShaderOptionValueOverrides", &ShaderAsset::m_defaultShaderOptionValueOverrides)
                     ->Field("drawListName", &ShaderAsset::m_drawListName)
-                    ->Field("shaderAssetBuildTimestamp", &ShaderAsset::m_buildTimestamp)
                     ->Field("perAPIShaderData", &ShaderAsset::m_perAPIShaderData)
                     ;
             }
@@ -145,11 +144,6 @@ namespace AZ
             return m_drawListName;
         }
 
-        AZStd::sys_time_t ShaderAsset::GetBuildTimestamp() const
-        {
-            return m_buildTimestamp;
-        }
-        
         void ShaderAsset::SetReady()
         {
             m_status = AssetStatus::Ready;
@@ -277,16 +271,7 @@ namespace AZ
                 }
                 return GetRootVariantAsset(supervariantIndex);
             }
-            else if (variant->GetBuildTimestamp() >= m_buildTimestamp)
-            {
-                return variant;
-            }
-            else
-            {
-                // When rebuilding shaders we may be in a state where the ShaderAsset and root ShaderVariantAsset have been rebuilt and reloaded, but some (or all)
-                // shader variants haven't been built yet. Since we want to use the latest version of the shader code, ignore the old variants and fall back to the newer root variant instead.
-                return GetRootVariantAsset(supervariantIndex);
-            }
+            return variant;
         }
 
         Data::Asset<ShaderVariantAsset> ShaderAsset::GetRootVariantAsset(SupervariantIndex supervariantIndex) const
@@ -596,12 +581,6 @@ namespace AZ
             return true;
         }
 
-
-        void ShaderAsset::UpdateRootShaderVariantAsset(SupervariantIndex supervariantIndex, Data::Asset<ShaderVariantAsset> newRootVariant)
-        {
-            GetCurrentShaderApiData().m_supervariants[supervariantIndex.GetIndex()].m_rootShaderVariantAsset = newRootVariant;
-        }
-        
         ///////////////////////////////////////////////////////////////////
         /// ShaderVariantFinderNotificationBus overrides
         void ShaderAsset::OnShaderVariantTreeAssetReady(Data::Asset<ShaderVariantTreeAsset> shaderVariantTreeAsset, bool isError)

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
@@ -18,14 +18,6 @@ namespace AZ
             BeginCommon(assetId);
         }
 
-        void ShaderAssetCreator::SetShaderAssetBuildTimestamp(AZStd::sys_time_t shaderAssetBuildTimestamp)
-        {
-            if (ValidateIsReady())
-            {
-                m_asset->m_buildTimestamp = shaderAssetBuildTimestamp;
-            }
-        }
-
         void ShaderAssetCreator::SetName(const Name& name)
         {
             if (ValidateIsReady())
@@ -409,7 +401,6 @@ namespace AZ
             m_asset->m_pipelineStateType = sourceShaderAsset.m_pipelineStateType;
             m_asset->m_drawListName = sourceShaderAsset.m_drawListName;
             m_asset->m_shaderOptionGroupLayout = sourceShaderAsset.m_shaderOptionGroupLayout;
-            m_asset->m_buildTimestamp = sourceShaderAsset.m_buildTimestamp;
 
             // copy the perAPIShaderData
             for (auto& perAPIShaderData : sourceShaderAsset.m_perAPIShaderData)

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantAsset.cpp
@@ -50,19 +50,13 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderVariantAsset, AZ::Data::AssetData>()
-                    ->Version(1)
+                    ->Version(2)
                     ->Field("StableId", &ShaderVariantAsset::m_stableId)
                     ->Field("ShaderVariantId", &ShaderVariantAsset::m_shaderVariantId)
                     ->Field("IsFullyBaked", &ShaderVariantAsset::m_isFullyBaked)
                     ->Field("FunctionsByStage", &ShaderVariantAsset::m_functionsByStage)
-                    ->Field("BuildTimestamp", &ShaderVariantAsset::m_buildTimestamp)
                     ;
             }
-        }
-
-        AZ::u64 ShaderVariantAsset::GetBuildTimestamp() const
-        {
-            return m_buildTimestamp;
         }
 
         uint32_t ShaderVariantAsset::GetSupervariantIndex() const

--- a/Gems/Atom/RPI/Code/Tests/Common/ShaderAssetTestUtils.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/ShaderAssetTestUtils.cpp
@@ -62,7 +62,6 @@ namespace UnitTest
         using namespace AZ;
         RPI::ShaderVariantAssetCreator shaderVariantAssetCreator;
         shaderVariantAssetCreator.Begin(Uuid::CreateRandom(), id, stableId, false);
-        shaderVariantAssetCreator.SetBuildTimestamp(AZStd::sys_time_t(1)); // Make non-zero.
 
         for (RHI::ShaderStage rhiStage : stagesToActivate)
         {

--- a/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
@@ -396,7 +396,6 @@ namespace UnitTest
         {
             RPI::ShaderVariantAssetCreator shaderVariantAssetCreator;
             shaderVariantAssetCreator.Begin(Uuid::CreateRandom(), id, stableId, isFullyBaked);
-            shaderVariantAssetCreator.SetBuildTimestamp(AZStd::sys_time_t(1)); //Make non-zero
 
             for (RHI::ShaderStage rhiStage : stagesToActivate)
             {


### PR DESCRIPTION
## What does this PR do?

Remove m_buildTimeStamp from ShaderAsset and ShaderVariantAsset.
Having `m_buildTimeStamp` was necessary a few years ago, but with the recent improvements in the Asset System notifications it is not necessary anymore and removing it also adds stability to Asset Bundling. The main problem of having a build time stamp embedded in the asset is that the same shader built on different dates would appear as having different content, but now, regardless of the date of compilation the Shader assets will have the same binary content, assuming the code has not changed.

## How was this PR tested?

Tested empirically with AutomatedTesting (Editor) by manually changing *.shader assets and making sure the OnAssetReady and OnAssetReloaded events are processed accordingly. Also validated with AtomSampleViewer.
