### PR TITLE
Change level send to be async and more gracefully handle errors.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
+++ b/Code/Framework/AzFramework/AzFramework/Process/ProcessCommunicatorTracePrinter.h
@@ -61,6 +61,6 @@ private:
     AZStd::string m_stringBeingConcatenated;
     AZStd::string m_errorStringBeingConcatenated;
     AZStd::thread m_pumpThread;
-    AZStd::atomic_bool m_runThread = true;
+    AZStd::atomic_bool m_runThread = false;
     const TraceProcessing m_processingType;
 };

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerEditorServerBus.h
@@ -55,6 +55,12 @@ namespace Multiplayer
         //! Notification when the Editor starts sending the current level data (spawnable) to the server.
         virtual void OnEditorSendingLevelData([[maybe_unused]] uint32_t bytesSent, [[maybe_unused]] uint32_t bytesTotal) {}
 
+        //! Notification when the Editor has failed to send the current level data to the server.
+        virtual void OnEditorSendingLevelDataFailed() {}
+
+        //! Notification when the Editor has successfully finished sending the current level data to the server.
+        virtual void OnEditorSendingLevelDataSuccess() {}
+
         //! Notification when the Editor has sent all the level data successful and is now fully connected to the multiplayer simulation.
         virtual void OnConnectToSimulationSuccess() {}
 

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.cpp
@@ -382,6 +382,18 @@ namespace Multiplayer
             AZStd::fixed_string<MaxMessageLength>::format(OnEditorSendingLevelDataMessage, bytesSent, bytesTotal);
     }   
 
+    void MultiplayerConnectionViewportMessageSystemComponent::OnEditorSendingLevelDataFailed()
+    {
+        m_centerViewportDebugTextColor = AZ::Colors::Red;
+        m_centerViewportDebugText = OnEditorSendingLevelDataFailedMessage;
+    }
+
+    void MultiplayerConnectionViewportMessageSystemComponent::OnEditorSendingLevelDataSuccess()
+    {
+        m_centerViewportDebugTextColor = AZ::Colors::Yellow;
+        m_centerViewportDebugText = OnEditorSendingLevelDataSuccessMessage;
+    }
+
     void MultiplayerConnectionViewportMessageSystemComponent::OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts)
     {
         m_centerViewportDebugTextColor = AZ::Colors::Yellow;

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerConnectionViewportMessageSystemComponent.h
@@ -33,12 +33,18 @@ namespace Multiplayer
 
         // Messaging for client during editor play mode
         static constexpr char CenterViewportDebugTitle[] = "Multiplayer Editor";
-        static constexpr char OnServerLaunchedMessage[] = "(1/3) Launching server...";
-        static constexpr char OnServerLaunchFailMessage[] = "(1/3) Could not launch editor server.\nSee console for more info.";
-        static constexpr char OnEditorConnectionAttemptMessage[] = "(2/3) Attempting to connect to server in order to send level data.\nAttempt %i of %i";
-        static constexpr char OnEditorConnectionAttemptsFailedMessage[] = "(2/3) Failed to connect to server after %i attempts!\nPlease exit play mode and try again.";  
-        static constexpr char OnEditorSendingLevelDataMessage[] = "(3/3) Editor is sending the editor-server the level data packet.\n Bytes %u / %u sent.";
-        static constexpr char OnConnectToSimulationFailMessage[] = "EditorServerReady packet was received, but connecting to the editor-server's network simulation failed! Is the editor and server using the same sv_port (%i)?";
+        static constexpr char OnServerLaunchedMessage[] = "(1/4) Launching server...";
+        static constexpr char OnServerLaunchFailMessage[] = "(1/4) Could not launch editor server.\nSee console for more info.";
+        static constexpr char OnEditorConnectionAttemptMessage[] = "(2/4) Attempting to connect to server in order to send level data.\nAttempt %i of %i";
+        static constexpr char OnEditorConnectionAttemptsFailedMessage[] = "(2/4) Failed to connect to server after %i attempts!\nPlease exit play mode and try again.";  
+        static constexpr char OnEditorSendingLevelDataMessage[] = "(3/4) Editor is sending the editor-server the level data packet.\nBytes %u / %u sent.";
+        static constexpr char OnEditorSendingLevelDataFailedMessage[] =
+            "(3/4) Editor failed to send the editor-server the level data packet.\nPlease exit play mode and try again.";
+        static constexpr char OnEditorSendingLevelDataSuccessMessage[] =
+            "(4/4) Waiting for editor-server to finish loading the level data.";
+        static constexpr char OnConnectToSimulationFailMessage[] =
+            "EditorServerReady packet was received, but connecting to the editor-server's network simulation failed! Is the editor and "
+            "server using the same sv_port (%i)?";
         static constexpr char OnEditorServerStoppedUnexpectedly[] ="Editor server has unexpectedly stopped running!";
 
         // Messaging for clients
@@ -88,6 +94,8 @@ namespace Multiplayer
         void OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts) override;
         void OnEditorConnectionAttemptsFailed(uint16_t failedAttempts) override;
         void OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal) override;
+        void OnEditorSendingLevelDataFailed() override;
+        void OnEditorSendingLevelDataSuccess() override;
         void OnConnectToSimulationSuccess() override;
         void OnConnectToSimulationFail(uint16_t serverPort) override;
         void OnPlayModeEnd() override;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.cpp
@@ -52,6 +52,16 @@ namespace Multiplayer::Automation
         Call(FN_OnEditorSendingLevelData, bytesSent, bytesTotal);
     }
 
+    void MultiplayerEditorAutomationHandler::OnEditorSendingLevelDataFailed()
+    {
+        Call(FN_OnEditorSendingLevelDataFailed);
+    }
+
+    void MultiplayerEditorAutomationHandler::OnEditorSendingLevelDataSuccess()
+    {
+        Call(FN_OnEditorSendingLevelDataSuccess);
+    }
+
     void MultiplayerEditorAutomationHandler::OnConnectToSimulationSuccess()
     {
         Call(FN_OnConnectToSimulationSuccess);

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorAutomation.h
@@ -29,6 +29,8 @@ namespace Multiplayer::Automation
             OnEditorConnectionAttempt,
             OnEditorConnectionAttemptsFailed,
             OnEditorSendingLevelData,
+            OnEditorSendingLevelDataFailed,
+            OnEditorSendingLevelDataSuccess,
             OnConnectToSimulationSuccess,
             OnConnectToSimulationFail,
             OnPlayModeEnd,
@@ -44,6 +46,8 @@ namespace Multiplayer::Automation
         void OnEditorConnectionAttempt(uint16_t connectionAttempts, uint16_t maxAttempts) override;
         void OnEditorConnectionAttemptsFailed(uint16_t failedAttempts) override;
         void OnEditorSendingLevelData(uint32_t bytesSent, uint32_t bytesTotal) override;
+        void OnEditorSendingLevelDataFailed() override;
+        void OnEditorSendingLevelDataSuccess() override;
         void OnConnectToSimulationSuccess() override;
         void OnConnectToSimulationFail(uint16_t serverPort) override;
         void OnPlayModeEnd() override;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -436,8 +436,8 @@ namespace Multiplayer
 
         // These control how many retries and how to space them out for packet send failures.
         static constexpr int MaxRetries = 20;
-        static constexpr int InitialMsDelayPerRetry = 10;
-        static constexpr int MaxMsDelayPerRetry = 1000;
+        static constexpr AZ::TimeMs InitialMsDelayPerRetry = AZ::TimeMs { 10 };
+        static constexpr AZ::TimeMs MaxMsDelayPerRetry = AZ::TimeMs { 1000 };
 
         // If there's no data left to send, exit.
         if (!m_levelSendData.m_byteStream)
@@ -476,18 +476,18 @@ namespace Multiplayer
 
             // Try to send the packet to the Editor server. Retry if necessary.
             bool packetSent = false;
-            int millisecondDelayPerRetry = InitialMsDelayPerRetry;
+            AZ::TimeMs millisecondDelayPerRetry = InitialMsDelayPerRetry;
             int numRetries = 0;
             while (!packetSent && (numRetries < MaxRetries))
             {
                 packetSent = m_levelSendData.m_sendConnection->SendReliablePacket(editorServerLevelDataPacket);
                 if (!packetSent)
                 {
-                    AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(millisecondDelayPerRetry));
+                    AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(aznumeric_cast<int>(millisecondDelayPerRetry)));
                     numRetries++;
 
                     // Keep doubling the time between retries up to the max amount, then clamp it there.
-                    millisecondDelayPerRetry = AZStd::min(millisecondDelayPerRetry * 2, MaxMsDelayPerRetry);
+                    millisecondDelayPerRetry = AZStd::min(millisecondDelayPerRetry * AZ::TimeMs{ 2 }, MaxMsDelayPerRetry);
 
                     // Force the networking buffers to try and flush before sending the packet again.
                     AZ::Interface<AzNetworking::INetworking>::Get()->ForceUpdate();

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -15,6 +15,7 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/IO/ByteContainerStream.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/Process/ProcessCommunicatorTracePrinter.h>
@@ -133,6 +134,9 @@ namespace Multiplayer
         //! Context menu handler
         void ContextMenu_NewMultiplayerEntity(AZ::EntityId parentEntityId, const AZ::Vector3& worldPosition);
 
+        void ResetLevelSendData();
+        void SendLevelDataToServer();
+
         IEditor* m_editor = nullptr;
         AZStd::unique_ptr<AzFramework::ProcessWatcher> m_serverProcessWatcher = nullptr;
         AZStd::unique_ptr<ProcessCommunicatorTracePrinter> m_serverProcessTracePrinter = nullptr;
@@ -150,5 +154,15 @@ namespace Multiplayer
         };
         
         AZStd::vector<PreAliasedSpawnableData> m_preAliasedSpawnablesForServer;
+
+        // Structure that encapsulates the data we need for sending the level data to the server when entering game mode.
+        struct LevelSendData
+        {
+            AZStd::vector<uint8_t> m_sendBuffer;
+            AZStd::unique_ptr<AZ::IO::ByteContainerStream<AZStd::vector<uint8_t>>> m_byteStream;
+            AzNetworking::IConnection* m_sendConnection = nullptr;
+        };
+
+        LevelSendData m_levelSendData;
     };
 }


### PR DESCRIPTION
## What does this PR do?

Changed the Editor->server communication to send the level data packets over a series of frames instead of in a tight loop. For large levels, this will make it clear that the Editor isn't just frozen while sending it. Also added better status messages for successful and failed sends.

## How was this PR tested?

Ran the MPS sample, manually forced failure conditions to verify the fail message worked, slowed down the time cap to verify that the intermediate status updates worked, and ran with the code as-is to verify that success worked.
