### PR TITLE
Fix non-unity build

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/BufferPool.h
@@ -12,9 +12,8 @@
 
 #ifdef USE_AMD_D3D12MA
 #include <RHI/BufferD3D12MemoryAllocator.h>
-#else
-#include <RHI/BufferMemoryAllocator.h>
 #endif
+#include <RHI/BufferMemoryAllocator.h>
 
 namespace AZ
 {


### PR DESCRIPTION
BufferMemoryAllocator::Descriptor still needs to be defined for BufferD3D12MemoryAllocator path

Feature is already tested, this fixed non-unity build.