### PR TITLE
Move the msaa custom sample count check assert within the "if" branch.

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.cpp
@@ -48,9 +48,9 @@ namespace AZ
                 return;
             }
 
-            AZ_Assert(GetDevice().GetFeatures().m_customSamplePositions, "Custom sample positions are not supported on this device");
             if (multisampleState.m_customPositionsCount > 0)
             {
+                AZ_Assert(GetDevice().GetFeatures().m_customSamplePositions, "Custom sample positions are not supported on this device");
                 AZStd::vector<D3D12_SAMPLE_POSITION> samplePositions;
                 AZStd::transform(
                     multisampleState.m_customPositions.begin(),


### PR DESCRIPTION
## What does this PR do?

Fix for an asserting firing off in case hw/driver did not support msaa sample count. 

## How was this PR tested?

Tested on ASV
