### PR TITLE
Fix warnings when loading component editor settings

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditorSettings.cpp
@@ -64,23 +64,26 @@ namespace AzToolsFramework
 
     bool DocumentPropertyEditorSettings::LoadExpanderStates()
     {
+        bool loaded = false;
         auto loadOutcome = m_settingsRegistrar.LoadSettingsFromFile(m_settingsFilepath);
         if (loadOutcome.IsSuccess())
         {
             auto getOutcome = m_settingsRegistrar.GetObjectSettings(this, m_fullSettingsRegistryPath);
-            if (!getOutcome.IsSuccess())
+            if (getOutcome.IsSuccess())
+            {
+                loaded = getOutcome.GetValue();   
+            }
+            else
             {
                 AZ_Warning("DocumentPropertyEditorSettings", false, getOutcome.GetError().c_str());
-                return false;
             }
         }
         else
         {
             AZ_Warning("DocumentPropertyEditorSettings", false, loadOutcome.GetError().c_str());
-            return false;
         }
 
-        return true;
+        return loaded;
     }
 
     void DocumentPropertyEditorSettings::SaveAndCleanExpanderStates()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -59,7 +59,7 @@ namespace AzToolsFramework
         return AZ::Success();
     }
 
-    AZ::Outcome<void, AZStd::string> SettingsRegistrar::LoadSettingsFromFile(
+    AZ::Outcome<bool, AZStd::string> SettingsRegistrar::LoadSettingsFromFile(
         AZ::IO::PathView relativeFilepath,
         AZStd::string_view anchorKey,
         AZ::SettingsRegistryInterface* registry,
@@ -73,7 +73,19 @@ namespace AzToolsFramework
 
         AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
         fullSettingsPath /= relativeFilepath;
-        return registry->MergeSettingsFile(fullSettingsPath.Native(), format, anchorKey);
+
+        bool fileExists = AZ::IO::SystemFile::Exists(fullSettingsPath.Native().c_str());
+
+        if (fileExists)
+        {
+            if (auto mergeResult = registry->MergeSettingsFile(fullSettingsPath.Native(), format, anchorKey);
+                !mergeResult.IsSuccess())
+            {
+                return AZ::Failure(mergeResult.GetError());
+            }
+        }
+
+        return AZ::Success(fileExists);
     }
 
     bool SettingsRegistrar::RemoveSettingFromRegistry(AZStd::string_view registryPath, AZ::SettingsRegistryInterface* registry) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -74,7 +74,7 @@ namespace AzToolsFramework
         AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
         fullSettingsPath /= relativeFilepath;
 
-        bool fileExists = AZ::IO::SystemFile::Exists(fullSettingsPath.Native().c_str());
+        const bool fileExists = AZ::IO::SystemFile::Exists(fullSettingsPath.c_str());
 
         if (fileExists)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
@@ -37,7 +37,9 @@ namespace AzToolsFramework
         //! Loads settings from the provided '.setreg' file and merges settings into the SettingsRegistry
         //! at the given anchor key.
         //! The path passed to this function is expected to be relative to the project root.
-        AZ::Outcome<void, AZStd::string> LoadSettingsFromFile(
+        //! Succeedds if the file was loaded or if the file does not exist.
+        //! Upon success, returns whether the file exists or not.
+        AZ::Outcome<bool, AZStd::string> LoadSettingsFromFile(
             AZ::IO::PathView relativeFilepath,
             AZStd::string_view anchorKey = {},
             AZ::SettingsRegistryInterface* registry = nullptr,
@@ -46,8 +48,10 @@ namespace AzToolsFramework
         //! Attempts to retrieve settings stored at the given registry path and put them in the provided object.
         //! The provided object is expected to be intialized before being passed to this function and it must
         //! be AZ_RTTI enabled.
+        //! Succeeds if the given entry was read or if it does not exist.
+        //! Upon success, returns whether the given settings entry exists or not.
         template<typename AzRttiEnabled_T>
-        AZ::Outcome<void, AZStd::string> GetObjectSettings(
+        AZ::Outcome<bool, AZStd::string> GetObjectSettings(
             AzRttiEnabled_T* outSettingsObject,
             AZStd::string_view registryPath,
             AZ::SettingsRegistryInterface* registry = nullptr) const
@@ -58,14 +62,14 @@ namespace AzToolsFramework
                 return AZ::Failure(AZStd::string::format("Failed to access global settings registry for data retrieval"));
             }
 
-            if (registry->GetObject(*outSettingsObject, registryPath))
-            {
-                return AZ::Success();
-            }
-            else
+            bool entryExists = registry->GetType(registryPath) != AZ::SettingsRegistryInterface::Type::NoType;
+
+            if (entryExists && !registry->GetObject(*outSettingsObject, registryPath))
             {
                 return AZ::Failure(AZStd::string::format("Failed to retrieve settings at path '%s'", registryPath.data()));
             }
+
+            return AZ::Success(entryExists);
         }
 
         //! Attempts to store reflected properties of the given AZ_RTTI enabled object at the given registry path.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.h
@@ -37,7 +37,7 @@ namespace AzToolsFramework
         //! Loads settings from the provided '.setreg' file and merges settings into the SettingsRegistry
         //! at the given anchor key.
         //! The path passed to this function is expected to be relative to the project root.
-        //! Succeedds if the file was loaded or if the file does not exist.
+        //! Succeeds if the file was loaded or if the file does not exist.
         //! Upon success, returns whether the file exists or not.
         AZ::Outcome<bool, AZStd::string> LoadSettingsFromFile(
             AZ::IO::PathView relativeFilepath,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -626,7 +626,7 @@ namespace AzToolsFramework
 
         m_componentType = componentType;
 
-        GetPropertyEditor()->SetSavedStateKey(AZ::Crc32(componentType.ToString<AZStd::string>().data()));
+        GetPropertyEditor()->SetSavedStateKey(AZ::Crc32(componentType.ToString<AZStd::string>().data()), "componenteditor");
 
         GetHeader()->SetTitle(GetFriendlyComponentName(&componentInstance).c_str());
 


### PR DESCRIPTION
## What does this PR do?

A warning was being output to the console when trying to load a DPE inspector settings file or an entry in the settings file that didn't exist yet.

## How was this PR tested?

Testing in editor.
