### PR TITLE
Thumbnailview Context Menu Fixes

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -188,12 +188,12 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             this,
             [this](const AssetBrowserEntry* entry)
             {
-                if (!entry)
+                if (entry && entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)
                 {
-                    return;
+                    entry = entry->GetParent();
                 }
 
-                if (!entry->GetParent())
+                if (!entry || !entry->GetParent())
                 {
                     return;
                 }
@@ -692,6 +692,7 @@ void AzAssetBrowserWindow::SetOneColumnMode()
         }
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
         m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
+        m_ui->m_searchWidget->setDisabled(false);
     }
 }
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -288,7 +288,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             if (selected.indexes().size() > 0)
             {
                 CurrentIndexChangedSlot(selected.indexes()[0]);
-                m_ui->m_createButton->setDisabled(false);
+                m_ui->m_createButton->setEnabled(true);
             }
             else
             {
@@ -669,7 +669,7 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(true);
         m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
-        m_ui->m_searchWidget->setDisabled(false);
+        m_ui->m_searchWidget->setEnabled(true);
     }
     else if (expandedTableView)
     {
@@ -692,7 +692,7 @@ void AzAssetBrowserWindow::SetOneColumnMode()
         }
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
         m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
-        m_ui->m_searchWidget->setDisabled(false);
+        m_ui->m_searchWidget->setEnabled(true);
     }
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -1047,7 +1047,7 @@ namespace AzQtComponents
         m_showSearchResultsMode = searchMode;
     }
 
-    bool AssetFolderThumbnailView::InSearchResultsMode()
+    bool AssetFolderThumbnailView::InSearchResultsMode() const
     {
         return m_showSearchResultsMode;
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -849,29 +849,9 @@ namespace AzQtComponents
 
     void AssetFolderThumbnailView::contextMenuEvent(QContextMenuEvent* event)
     {
-
         const auto p = event->pos() + QPoint{ horizontalOffset(), verticalOffset() };
         auto idx = indexAtPos(p);
-
-        if (idx.isValid() && m_showSearchResultsMode)
-        {
-            QMenu* menu = new QMenu;
-            auto action = menu->addAction("Show In Folder");
-            connect(
-                action,
-                &QAction::triggered,
-                this,
-                [this, idx]()
-                {
-                    emit showInFolderTriggered(idx);
-                });
-            menu->exec(event->globalPos());
-            delete menu;
-        }
-        else
-        {
-            emit contextMenu(idx);
-        }
+        emit contextMenu(idx);
     }
 
     int AssetFolderThumbnailView::rootThumbnailSizeInPixels() const
@@ -1065,6 +1045,11 @@ namespace AzQtComponents
     void AssetFolderThumbnailView::SetShowSearchResultsMode(bool searchMode)
     {
         m_showSearchResultsMode = searchMode;
+    }
+
+    bool AssetFolderThumbnailView::InSearchResultsMode()
+    {
+        return m_showSearchResultsMode;
     }
 } // namespace AzQtComponents
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -113,7 +113,7 @@ namespace AzQtComponents
         void setRootIndex(const QModelIndex &index) override;
 
         void SetShowSearchResultsMode(bool searchMode);
-        bool InSearchResultsMode();
+        bool InSearchResultsMode() const;
 
     signals:
         void rootIndexChanged(const QModelIndex& idx);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h
@@ -113,10 +113,10 @@ namespace AzQtComponents
         void setRootIndex(const QModelIndex &index) override;
 
         void SetShowSearchResultsMode(bool searchMode);
+        bool InSearchResultsMode();
 
     signals:
         void rootIndexChanged(const QModelIndex& idx);
-        void showInFolderTriggered(const QModelIndex& idx);
         void contextMenu(const QModelIndex& idx);
         void afterRename(const QString& value) const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -78,7 +78,7 @@ namespace AzToolsFramework
                         AZStd::vector<const AssetBrowserEntry*> entries{ entry };
                         if (m_thumbnailViewWidget->InSearchResultsMode())
                         {
-                            auto action = menu.addAction("Show In Folder");
+                            auto action = menu.addAction(tr("Show In Folder"));
                             connect(
                                 action,
                                 &QAction::triggered,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -67,16 +67,6 @@ namespace AzToolsFramework
 
             connect(
                 m_thumbnailViewWidget,
-                &AzQtComponents::AssetFolderThumbnailView::showInFolderTriggered,
-                this,
-                [this](const QModelIndex& index)
-                {
-                    auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                    emit showInFolderTriggered(indexData);
-                });
-
-            connect(
-                m_thumbnailViewWidget,
                 &AzQtComponents::AssetFolderThumbnailView::contextMenu,
                 this,
                 [this](const QModelIndex& index)
@@ -86,6 +76,19 @@ namespace AzToolsFramework
                         QMenu menu(this);
                         const AssetBrowserEntry* entry = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
                         AZStd::vector<const AssetBrowserEntry*> entries{ entry };
+                        if (m_thumbnailViewWidget->InSearchResultsMode())
+                        {
+                            auto action = menu.addAction("Show In Folder");
+                            connect(
+                                action,
+                                &QAction::triggered,
+                                this,
+                                [this, entry]()
+                                {
+                                    emit showInFolderTriggered(entry);
+                                });
+                            menu.addSeparator();
+                        }
                         AssetBrowserInteractionNotificationBus::Broadcast(
                             &AssetBrowserInteractionNotificationBus::Events::AddContextMenuActions, this, &menu, entries);
 


### PR DESCRIPTION
## What does this PR do?

Now correctly populates the context menu when user is in search mode.
Fixed Show In Folder context menu action not working correctly for product assets
Fixes search widget not being re-enabled if view was switched to list view

## How was this PR tested?

Locally
