### PR TITLE
Fix querying DX12 for msaa custom sample support as well as fix ios shader build related crash

### DIFF
--- a/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
@@ -4,7 +4,8 @@
         "preprocessor": [],
         "azslc": ["--min-descriptors=64,4,-1,-1,-1" //Sets,Spaces,Samplers,Textures,Buffers
                 , "--unique-idx"
-                , "--namespace=mt,vk"
+                , "--namespace=mt"
+                , "--namespace=vk"
                 , "--pad-root-const"
         ],
         "dxc": ["-spirv"

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -137,7 +137,7 @@ namespace AZ
             m_features.m_independentBlend = true;
             m_features.m_dualSourceBlending = true;
             D3D12_FEATURE_DATA_D3D12_OPTIONS2 options2;
-            GetDevice()->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &options2, sizeof(options2));
+            GetDevice()->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS2, &options2, sizeof(options2));
             m_features.m_customSamplePositions =
                 options2.ProgrammableSamplePositionsTier != D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER_NOT_SUPPORTED;
             m_features.m_queryTypesMask[static_cast<uint32_t>(RHI::HardwareQueueClass::Graphics)] = RHI::QueryTypeFlags::All;


### PR DESCRIPTION
## What does this PR do?

- Minor fix related to passing in incorrect enum to query DX12 drivers for msaa custom sample support.
- Another minor fix related ios shader not building due to passing in multiple name spaces on the same line

## How was this PR tested?

Tested on ASV
