### PR TITLE
Asset Processor - Add retry logic for jobs that conflicted due to same outputs

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests.py
@@ -336,9 +336,7 @@ class TestsAssetProcessorBatch_AllPlatforms(object):
                                    os.path.join(source_folder, "b.fbx")]
 
             result, output = asset_processor.batch_process(capture_output=True,
-                                                           skip_atom_output=True,
-                                                           extra_params=[f"--reprocessFileList={reprocess_file_list}",
-                                                                         "--regset=\"/Amazon/AssetProcessor/Settings/Jobs/maxJobs=1\""])
+                                                           skip_atom_output=True)
 
             # If the test fails, it's helpful to have the output from asset processor in the logs, to track the failure down.
             if not result:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -1394,7 +1394,7 @@ namespace AzToolsFramework
                 m_platform.c_str(),
                 m_builderGuid.ToString<AZStd::string>().c_str(),
                 AssetSystem::JobStatusString(m_status),
-                m_failureCauseSourcePK,
+                static_cast<int64_t>(m_failureCauseSourcePK),
                 m_failureCauseFingerprint,
                 m_warningCount,
                 m_errorCount);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -290,6 +290,14 @@ namespace AzToolsFramework
                     SqlParam<AZ::s64>(":sourceid"),
                     SqlParam<const char*>(":platform"));
 
+            static const char* QUERY_JOBS_BY_FAILURECAUSESOURCEID = "AzToolsFramework::AssetDatabase::QueryJobByFailureCauseSourceID";
+            static const char* QUERY_JOBS_BY_FAILURECAUSESOURCEID_STATEMENT =
+                "SELECT * FROM Jobs WHERE "
+                "FailureCauseSourcePK = :sourceid;";
+
+            static const auto s_queryJobsByFailureCauseSourceId = MakeSqlQuery(QUERY_JOBS_BY_FAILURECAUSESOURCEID, QUERY_JOBS_BY_FAILURECAUSESOURCEID_STATEMENT, LOG_NAME,
+                SqlParam<AZ::s64>(":sourceid"));
+
             // lookup by primary key
             static const char* QUERY_PRODUCT_BY_PRODUCTID = "AzToolsFramework::AssetDatabase::QueryProductByProductID";
             static const char* QUERY_PRODUCT_BY_PRODUCTID_STATEMENT =
@@ -1375,10 +1383,21 @@ namespace AzToolsFramework
 
         AZStd::string JobDatabaseEntry::ToString() const
         {
-            return AZStd::string::format("JobDatabaseEntry id:%" PRId64 " sourcepk:%" PRId64 " jobkey: %s fingerprint: %i platform: %s builderguid: %s status: %s, warnings: %u, errors %u",
-                static_cast<int64_t>(m_jobID), static_cast<int64_t>(m_sourcePK), m_jobKey.c_str(), m_fingerprint, m_platform.c_str(),
-                m_builderGuid.ToString<AZStd::string>().c_str(), AssetSystem::JobStatusString(m_status),
-                m_warningCount, m_errorCount);
+            return AZStd::string::format(
+                "JobDatabaseEntry id:%" PRId64 " sourcepk:%" PRId64
+                " jobkey: %s fingerprint: %i platform: %s builderguid: %s status: %s, failurecausesource: %" PRId64
+                ", failurecausefingerprint: %i, warnings: %u, errors %u",
+                static_cast<int64_t>(m_jobID),
+                static_cast<int64_t>(m_sourcePK),
+                m_jobKey.c_str(),
+                m_fingerprint,
+                m_platform.c_str(),
+                m_builderGuid.ToString<AZStd::string>().c_str(),
+                AssetSystem::JobStatusString(m_status),
+                m_failureCauseSourcePK,
+                m_failureCauseFingerprint,
+                m_warningCount,
+                m_errorCount);
         }
 
         auto JobDatabaseEntry::GetColumns()
@@ -1392,6 +1411,8 @@ namespace AzToolsFramework
                 MakeColumn("BuilderGuid", m_builderGuid),
                 MakeColumn("Status", m_status),
                 MakeColumn("JobRunKey", m_jobRunKey),
+                MakeColumn("FailureCauseSourcePK", m_failureCauseSourcePK),
+                MakeColumn("FailureCauseFingerprint", m_failureCauseFingerprint),
                 MakeColumn("FirstFailLogTime", m_firstFailLogTime),
                 MakeColumn("FirstFailLogFile", m_firstFailLogFile),
                 MakeColumn("LastFailLogTime", m_lastFailLogTime),
@@ -1889,6 +1910,7 @@ namespace AzToolsFramework
             AddStatement(m_databaseConnection, s_queryJobByProductid);
             AddStatement(m_databaseConnection, s_queryJobBySourceid);
             AddStatement(m_databaseConnection, s_queryJobBySourceidPlatform);
+            AddStatement(m_databaseConnection, s_queryJobsByFailureCauseSourceId);
 
             AddStatement(m_databaseConnection, s_queryProductByProductid);
             AddStatement(m_databaseConnection, s_queryProductByJobid);
@@ -2248,6 +2270,11 @@ namespace AzToolsFramework
             }
 
             return s_queryJobBySourceid.BindAndThen(*m_databaseConnection, handler, sourceID).Query(&GetJobResult, builderGuid, jobKey, status);
+        }
+
+        bool AssetDatabaseConnection::QueryJobsByFailureCauseSourceID(AZ::s64 sourceID, jobHandler handler)
+        {
+            return s_queryJobsByFailureCauseSourceId.BindAndQuery(*m_databaseConnection, handler, &GetJobResultSimple, sourceID);
         }
 
         bool AssetDatabaseConnection::QueryProductByProductID(AZ::s64 productid, productHandler handler)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h
@@ -73,6 +73,7 @@ namespace AzToolsFramework
             ChangedSourceDependencySourceColumn,
             SplitMaterialBuilderAndMaterialAssetBuilder,
             NewMaterialTypeBuildPipeline,
+            AddedJobFailureSourceColumn,
             //Add all new versions before this
             DatabaseVersionCount,
             LatestVersion = DatabaseVersionCount - 1
@@ -187,6 +188,8 @@ namespace AzToolsFramework
             AZ::Uuid m_builderGuid;
             AssetSystem::JobStatus m_status = AssetSystem::JobStatus::Queued;
             AZ::u64 m_jobRunKey = 0;
+            AZ::s64 m_failureCauseSourcePK = InvalidEntryId;
+            AZ::u32 m_failureCauseFingerprint = 0;
             AZ::s64 m_firstFailLogTime = 0;
             AZStd::string m_firstFailLogFile;
             AZ::s64 m_lastFailLogTime = 0;
@@ -582,6 +585,7 @@ namespace AzToolsFramework
             bool QueryJobByJobRunKey(AZ::u64 jobRunKey, jobHandler handler);
             bool QueryJobByProductID(AZ::s64 productID, jobHandler handler);
             bool QueryJobBySourceID(AZ::s64 sourceID, jobHandler handler, AZ::Uuid builderGuid = AZ::Uuid::CreateNull(), const char* jobKey = nullptr, const char* platform = nullptr, AssetSystem::JobStatus status = AssetSystem::JobStatus::Any);
+            bool QueryJobsByFailureCauseSourceID(AZ::s64 sourceID, jobHandler handler);
 
             //product
             bool QueryProductByProductID(AZ::s64 productID, productHandler handler);

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -65,6 +65,8 @@ namespace AssetProcessor
             "    BuilderGuid      BLOB NOT NULL, "
             "    Status           INTEGER NOT NULL, "
             "    JobRunKey        INTEGER NOT NULL, "
+            "    FailureCauseSourcePK INTEGER, "
+            "    FailureCauseFingerprint INTEGER, "
             "    FirstFailLogTime INTEGER NOT NULL, "
             "    FirstFailLogFile TEXT collate nocase, "
             "    LastFailLogTime  INTEGER NOT NULL, "
@@ -335,8 +337,8 @@ namespace AssetProcessor
 
         static const char* INSERT_JOB = "AssetProcessor::InsertJob";
         static const char* INSERT_JOB_STATEMENT =
-            "INSERT INTO Jobs (SourcePK, JobKey, Fingerprint, Platform, BuilderGuid, Status, JobRunKey, FirstFailLogTime, FirstFailLogFile, LastFailLogTime, LastFailLogFile, LastLogTime, LastLogFile, WarningCount, ErrorCount) "
-            "VALUES (:sourceid, :jobkey, :fingerprint, :platform, :builderguid, :status, :jobrunkey, :firstfaillogtime, :firstfaillogfile, :lastfaillogtime, :lastfaillogfile, :lastlogtime, :lastlogfile, :warningcount, :errorcount);";
+            "INSERT INTO Jobs (SourcePK, JobKey, Fingerprint, Platform, BuilderGuid, Status, JobRunKey, FailureCauseSourcePK, FailureCauseFingerprint, FirstFailLogTime, FirstFailLogFile, LastFailLogTime, LastFailLogFile, LastLogTime, LastLogFile, WarningCount, ErrorCount) "
+            "VALUES (:sourceid, :jobkey, :fingerprint, :platform, :builderguid, :status, :jobrunkey, :failurecausesourcepk, :failurecausefingerprint, :firstfaillogtime, :firstfaillogfile, :lastfaillogtime, :lastfaillogfile, :lastlogtime, :lastlogfile, :warningcount, :errorcount);";
 
         static const auto s_InsertJobQuery = MakeSqlQuery(INSERT_JOB, INSERT_JOB_STATEMENT, LOG_NAME,
             SqlParam<AZ::s64>(":sourceid"),
@@ -346,6 +348,8 @@ namespace AssetProcessor
             SqlParam<AZ::Uuid>(":builderguid"),
             SqlParam<AZ::s32>(":status"),
             SqlParam<AZ::u64>(":jobrunkey"),
+            SqlParam<AZ::s64>(":failurecausesourcepk"),
+            SqlParam<AZ::u32>(":failurecausefingerprint"),
             SqlParam<AZ::s64>(":firstfaillogtime"),
             SqlParam<const char*>(":firstfaillogfile"),
             SqlParam<AZ::s64>(":lastfaillogtime"),
@@ -366,6 +370,8 @@ namespace AssetProcessor
             "BuilderGuid = :builderguid, "
             "Status = :status, "
             "JobRunKey = :jobrunkey, "
+            "FailureCauseSourcePK = :failurecausesourcepk, "
+            "FailureCauseFingerprint = :failurecausefingerprint, "
             "FirstFailLogTime = :firstfaillogtime, "
             "FirstFailLogFile = :firstfaillogfile, "
             "LastFailLogTime = :lastfaillogtime, "
@@ -384,6 +390,8 @@ namespace AssetProcessor
             SqlParam<AZ::Uuid>(":builderguid"),
             SqlParam<AZ::s32>(":status"),
             SqlParam<AZ::u64>(":jobrunkey"),
+            SqlParam<AZ::s64>(":failurecausesourcepk"),
+            SqlParam<AZ::u32>(":failurecausefingerprint"),
             SqlParam<AZ::s64>(":firstfaillogtime"),
             SqlParam<const char*>(":firstfaillogfile"),
             SqlParam<AZ::s64>(":lastfaillogtime"),
@@ -405,7 +413,7 @@ namespace AssetProcessor
             UPDATE_JOB_FINGERPRINT_BY_SOURCE_ID_STATEMENT,
             LOG_NAME,
             SqlParam<AZ::u64>(":fingerprint"),
-            SqlParam<AZ::s64>(":sourceid"));      
+            SqlParam<AZ::s64>(":sourceid"));
 
         static const char* DELETE_JOB = "AssetProcessor::DeleteJob";
         static const char* DELETE_JOB_STATEMENT =
@@ -781,7 +789,7 @@ namespace AssetProcessor
             SqlParam<AZ::u64>(":hash"),
             SqlParam<const char*>(":filename"),
             SqlParam<AZ::s64>(":scanfolderpk"));
-        
+
         static const char* UPDATE_FILE_HASH_BY_FILENAME_SCANFOLDER_ID = "AssetProcessor::UpdateFileHashByFileNameScanFolderId";
         static const char* UPDATE_FILE_HASH_BY_FILENAME_SCANFOLDER_ID_STATEMENT =
             "UPDATE Files SET "
@@ -794,7 +802,7 @@ namespace AssetProcessor
             LOG_NAME,
             SqlParam<AZ::u64>(":hash"),
             SqlParam<const char*>(":filename"),
-            SqlParam<AZ::s64>(":scanfolderpk"));        
+            SqlParam<AZ::s64>(":scanfolderpk"));
 
         static const char* DELETE_FILE = "AssetProcessor::DeleteFile";
         static const char* DELETE_FILE_STATEMENT =
@@ -839,6 +847,16 @@ namespace AssetProcessor
         static const char* CREATEINDEX_SOURCEDEPENDENCY_SOURCEGUID = "AssetProcessor::CreateIndexSourceGuidSourceDependency";
         static const char* CREATEINDEX_SOURCEDEPENDENCY_SOURCEGUID_STATEMENT =
             "CREATE INDEX IF NOT EXISTS SourceGuid_SourceDependency ON SourceDependency (SourceGuid);";
+
+        static const char* INSERT_COLUMN_JOBS_FAILURECAUSESOURCEID = "AssetProcessor::InsertColumnJobsFailureCauseSourceId";
+        static const char* INSERT_COLUMN_JOBS_FAILURECAUSESOURCEID_STATEMENT =
+            "ALTER TABLE Jobs "
+            "ADD FailureCauseSourcePK INTEGER;";
+
+        static const char* INSERT_COLUMN_JOBS_FAILURECAUSEFINGERPRINT = "AssetProcessor::InsertColumnJobsFailureCauseFingerprint";
+        static const char* INSERT_COLUMN_JOBS_FAILURECAUSEFINGERPRINT_STATEMENT =
+            "ALTER TABLE Jobs "
+            "Add FailureCauseFingerprint INTEGER;";
     }
 
     AssetDatabaseConnection::AssetDatabaseConnection()
@@ -1171,14 +1189,29 @@ namespace AssetProcessor
             }
         }
 
-        if(foundVersion == DatabaseVersion::AddedStatsTable)
+        if (foundVersion == DatabaseVersion::AddedStatsTable)
         {
             // Version update - change SourceDependency Source to SourceGuid column
             // Do nothing so the whole database is dropped.
             // Unfortunately we have to reprocess all assets because of the way the fingerprinting algorithm works,
             // changing from storing the path to the UUID changes the fingerprint, resulting in all assets reprocessing anyway
-            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Asset database version updated to ChangedSourceDependencySourceColumn, database will be cleared as migration is not possible for this update\n", foundVersion);
+            AZ_TracePrintf(
+                AssetProcessor::ConsoleChannel,
+                "Asset database version updated to ChangedSourceDependencySourceColumn, database will be cleared as migration is not "
+                "possible for this update\n",
+                foundVersion);
         }
+
+        if (foundVersion == DatabaseVersion::NewMaterialTypeBuildPipeline)
+        {
+            if (m_databaseConnection->ExecuteOneOffStatement(INSERT_COLUMN_JOBS_FAILURECAUSESOURCEID)
+                && m_databaseConnection->ExecuteOneOffStatement(INSERT_COLUMN_JOBS_FAILURECAUSEFINGERPRINT))
+            {
+                foundVersion = DatabaseVersion::AddedJobFailureSourceColumn;
+                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Upgraded Asset Database to version %i (AddedJobFailureSourceColumn)\n", foundVersion);
+            }
+        }
+
 
         if (foundVersion == CurrentDatabaseVersion())
         {
@@ -1303,6 +1336,8 @@ namespace AssetProcessor
         m_databaseConnection->AddStatement(INSERT_COLUMNS_JOB_WARNING_COUNT, INSERT_COLUMNS_JOB_WARNING_COUNT_STATEMENT);
         m_databaseConnection->AddStatement(INSERT_COLUMNS_JOB_ERROR_COUNT, INSERT_COLUMNS_JOB_ERROR_COUNT_STATEMENT);
         m_databaseConnection->AddStatement(UPDATE_JOB_FINGERPRINT_BY_SOURCE_ID, UPDATE_JOB_FINGERPRINT_BY_SOURCE_ID_STATEMENT);
+        m_databaseConnection->AddStatement(INSERT_COLUMN_JOBS_FAILURECAUSESOURCEID, INSERT_COLUMN_JOBS_FAILURECAUSESOURCEID_STATEMENT);
+        m_databaseConnection->AddStatement(INSERT_COLUMN_JOBS_FAILURECAUSEFINGERPRINT, INSERT_COLUMN_JOBS_FAILURECAUSEFINGERPRINT_STATEMENT);
         m_createStatements.push_back(CREATE_JOBS_TABLE);
 
         AddStatement(m_databaseConnection, s_GetHighestJobrunkeyQuery);
@@ -2040,6 +2075,21 @@ namespace AssetProcessor
         return found && succeeded;
     }
 
+    bool AssetDatabaseConnection::GetJobsByFailureCauseSourceId(AZ::s64 sourceID, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container)
+    {
+        bool found = false;
+        bool succeeded = QueryJobsByFailureCauseSourceID(
+            sourceID,
+            [&found, &container](JobDatabaseEntry& job)
+            {
+                found = true;
+                container.emplace_back() = AZStd::move(job);
+                return true;
+            });
+
+        return found && succeeded;
+    }
+
     bool AssetDatabaseConnection::GetJobsByProductName(QString exactProductName, JobDatabaseEntryContainer& container, AZ::Uuid builderGuid, QString jobKey, QString platform, JobStatus status)
     {
         bool found = false;
@@ -2111,7 +2161,7 @@ namespace AssetProcessor
             }
 
             if (!s_InsertJobQuery.BindAndStep(*m_databaseConnection, entry.m_sourcePK, entry.m_jobKey.c_str(), entry.m_fingerprint, entry.m_platform.c_str(),
-                entry.m_builderGuid, static_cast<int>(entry.m_status), entry.m_jobRunKey, entry.m_firstFailLogTime, entry.m_firstFailLogFile.c_str(),
+                entry.m_builderGuid, static_cast<int>(entry.m_status), entry.m_jobRunKey, entry.m_failureCauseSourcePK, entry.m_failureCauseFingerprint, entry.m_firstFailLogTime, entry.m_firstFailLogFile.c_str(),
                 entry.m_lastFailLogTime, entry.m_lastFailLogFile.c_str(), entry.m_lastLogTime, entry.m_lastLogFile.c_str(), entry.m_warningCount, entry.m_errorCount))
             {
                 return false;
@@ -2153,7 +2203,7 @@ namespace AssetProcessor
             }
 
             return s_UpdateJobQuery.BindAndStep(*m_databaseConnection, entry.m_sourcePK, entry.m_jobKey.c_str(), entry.m_fingerprint, entry.m_platform.c_str(),
-                entry.m_builderGuid, static_cast<int>(entry.m_status), entry.m_jobRunKey, entry.m_firstFailLogTime, entry.m_firstFailLogFile.c_str(),
+                entry.m_builderGuid, static_cast<int>(entry.m_status), entry.m_jobRunKey, entry.m_failureCauseSourcePK, entry.m_failureCauseFingerprint, entry.m_firstFailLogTime, entry.m_firstFailLogFile.c_str(),
                 entry.m_lastFailLogTime, entry.m_lastFailLogFile.c_str(), entry.m_lastLogTime, entry.m_lastLogFile.c_str(), entry.m_warningCount, entry.m_errorCount, entry.m_jobID);
         }
     }

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
@@ -114,6 +114,8 @@ namespace AssetProcessor
         bool GetJobsBySourceName(const AssetProcessor::SourceAssetReference& sourceAsset, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container, AZ::Uuid builderGuid = AZ::Uuid::CreateNull(), QString jobKey = QString(), QString platform = QString(), AzToolsFramework::AssetSystem::JobStatus status = AzToolsFramework::AssetSystem::JobStatus::Any);
         bool GetJobsLikeSourceName(QString likeSourceName, LikeType likeType, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container, AZ::Uuid builderGuid = AZ::Uuid::CreateNull(), QString jobKey = QString(), QString platform = QString(), AzToolsFramework::AssetSystem::JobStatus status = AzToolsFramework::AssetSystem::JobStatus::Any);
 
+        bool GetJobsByFailureCauseSourceId(AZ::s64 sourceID, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container);
+
         bool GetJobsByProductName(QString exactProductName, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container, AZ::Uuid builderGuid = AZ::Uuid::CreateNull(), QString jobKey = QString(), QString platform = QString(), AzToolsFramework::AssetSystem::JobStatus status = AzToolsFramework::AssetSystem::JobStatus::Any);
         bool GetJobsLikeProductName(QString likeProductName, LikeType likeType, AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer& container, AZ::Uuid builderGuid = AZ::Uuid::CreateNull(), QString jobKey = QString(), QString platform = QString(), AzToolsFramework::AssetSystem::JobStatus status = AzToolsFramework::AssetSystem::JobStatus::Any);
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -801,6 +801,9 @@ namespace AssetProcessor
         //set the random key
         job.m_jobRunKey = jobEntry.m_jobRunKey;
 
+        job.m_failureCauseSourcePK = jobEntry.m_failureCauseSourceId;
+        job.m_failureCauseFingerprint = jobEntry.m_failureCauseFingerprint;
+
         QString fullPath = jobEntry.GetAbsoluteSourcePath();
         //set the new status
         job.m_status = fullPath.length() < AP_MAX_PATH_LEN ? JobStatus::Failed : JobStatus::Failed_InvalidSourceNameExceedsMaxLimit;
@@ -1159,6 +1162,8 @@ namespace AssetProcessor
                                     m_stateData->GetProductsBySourceID(source.m_sourceID, products);
                                     DeleteProducts(products);
 
+                                    auto jobFingerprint = job.m_fingerprint;
+
                                     //set the fingerprint to failed
                                     job.m_fingerprint = FAILED_FINGERPRINT;
                                     m_stateData->SetJob(job);
@@ -1188,7 +1193,7 @@ namespace AssetProcessor
                                         fullSourcePath.c_str(),
                                         productPath.GetCachePath().c_str());
 
-                                    AutoFailJob(consoleMsg, autoFailReason, itProcessedAsset);
+                                    AutoFailJob(consoleMsg, autoFailReason, itProcessedAsset, source.m_sourceID, jobFingerprint);
 
                                     //recycle the original source
                                     AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry scanfolder;
@@ -1484,6 +1489,35 @@ namespace AssetProcessor
                 for(const auto& dependency : dependencies)
                 {
                     AssessFileInternal(dependency, false);
+                }
+            }
+
+            // Check for any jobs that previously failed due to a conflict.
+            // This allows users to fix the 'successful' job in a conflict and have the failed job reprocess automatically.
+            AzToolsFramework::AssetDatabase::JobDatabaseEntryContainer priorConflictedJobs;
+            if(m_stateData->GetJobsByFailureCauseSourceId(source.m_sourceID, priorConflictedJobs))
+            {
+                for(const auto& conflictedJob : priorConflictedJobs)
+                {
+                    // If the fingerprint has changed, try re-running the job.
+                    // The fingerprint check prevents an infinite loop because the job being queued will re-run this job if it fails again.
+                    if (conflictedJob.m_failureCauseFingerprint != job.m_fingerprint)
+                    {
+                        AzToolsFramework::AssetDatabase::SourceDatabaseEntry conflictedSource;
+                        if (m_stateData->GetSourceBySourceID(conflictedJob.m_sourcePK, conflictedSource))
+                        {
+                            SourceAssetReference conflictedSourceRef(
+                                conflictedSource.m_scanFolderPK, conflictedSource.m_sourceName.c_str());
+
+                            AZ_Info(
+                                AssetProcessor::ConsoleChannel,
+                                "Re-queuing previously conflicted source " AZ_STRING_FORMAT " - source " AZ_STRING_FORMAT
+                                " has changed and may no longer conflict\n",
+                                AZ_STRING_ARG(conflictedSource.m_sourceName),
+                                AZ_STRING_ARG(source.m_sourceName));
+                            AssessFileInternal(conflictedSourceRef.AbsolutePath().c_str(), false);
+                        }
+                    }
                 }
             }
 
@@ -4738,7 +4772,7 @@ namespace AssetProcessor
         // Scope the lock for just modifying the processing product info list.
         // This will allow other jobs to lock this list for emitting their own messages.
         // This speeds up asset processing time, by not having jobs holding this longer than they need to.
-        {        
+        {
             QMutexLocker locker(&m_processingJobMutex);
             m_processingProductInfoList.insert(productPath);
         }
@@ -5836,7 +5870,7 @@ namespace AssetProcessor
         Q_EMIT AssetToProcess(jobdetail); // forwarding this job to rccontroller to fail it
     }
 
-    void AssetProcessorManager::AutoFailJob(AZStd::string_view consoleMsg, AZStd::string_view autoFailReason, const AZStd::vector<AssetProcessedEntry>::iterator& assetIter)
+    void AssetProcessorManager::AutoFailJob(AZStd::string_view consoleMsg, AZStd::string_view autoFailReason, const AZStd::vector<AssetProcessedEntry>::iterator& assetIter, AZ::s64 failureCauseSourceId, AZ::u32 failureCauseFingerprint)
     {
         JobEntry jobEntry(
             assetIter->m_entry.m_sourceAssetReference,
@@ -5844,6 +5878,9 @@ namespace AssetProcessor
             assetIter->m_entry.m_platformInfo,
             assetIter->m_entry.m_jobKey, 0, GenerateNewJobRunKey(),
             assetIter->m_entry.m_sourceFileUUID);
+
+        jobEntry.m_failureCauseSourceId = failureCauseSourceId;
+        jobEntry.m_failureCauseFingerprint = failureCauseFingerprint;
 
         AutoFailJob(consoleMsg, autoFailReason, jobEntry);
     }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -389,7 +389,12 @@ namespace AssetProcessor
             AZStd::string_view autoFailReason,
             JobEntry jobEntry,
             AZStd::string_view jobLog = "");
-        void AutoFailJob(AZStd::string_view consoleMsg, AZStd::string_view autoFailReason, const AZStd::vector<AssetProcessedEntry>::iterator& assetIter);
+        void AutoFailJob(
+            AZStd::string_view consoleMsg,
+            AZStd::string_view autoFailReason,
+            const AZStd::vector<AssetProcessedEntry>::iterator& assetIter,
+            AZ::s64 failureCauseSourceId = AzToolsFramework::AssetDatabase::InvalidEntryId,
+            AZ::u32 failureCauseFingerprint = 0);
 
         using ProductInfoList = AZStd::vector<AZStd::pair<AzToolsFramework::AssetDatabase::ProductDatabaseEntry, const AssetBuilderSDK::JobProduct*>>;
 

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -129,6 +129,8 @@ namespace AssetProcessor
         AZ::u32 m_computedFingerprint = 0;     // what the fingerprint was at the time of job creation.
         qint64 m_computedFingerprintTimeStamp = 0; // stores the number of milliseconds since the universal coordinated time when the fingerprint was computed.
         AZ::u64 m_jobRunKey = 0;
+        AZ::s64 m_failureCauseSourceId = AzToolsFramework::AssetDatabase::InvalidEntryId; // Id of the source that caused this job to fail (typically due to a conflict).
+        AZ::u32 m_failureCauseFingerprint = 0; // Fingerprint of the job that caused this job to fail.  Used to prevent infinite retry loops.
         bool m_checkExclusiveLock = true;      ///< indicates whether we need to check the input file for exclusive lock before we process this job
         bool m_addToDatabase = true; ///< If false, this is just a UI job, and should not affect the database.
 


### PR DESCRIPTION
## What does this PR do?

AP will now store the source and job fingerprint when a job is failed due to outputting the same product(s) as another job. Whenever a job completes it will now check if it is listed as a 'conflictor' for another job, and if its fingerprint has changed since last time, will re-queue the other source.

_Before this change:_ When 2 sources produced the same product(s) one of the jobs would be failed based on which ran last.  If the user chose to fix the problem by updating the source that succeeded, they would need to manually reprocess the source that failed OR restart AP.

_After this change:_ Next time the successful job is re-run, it will also re-run the failed job provided the fingerprint has changed.

Resolves https://github.com/o3de/o3de/issues/15248
Resolves https://github.com/o3de/o3de/issues/15250

## How was this PR tested?

Manually tested by running AP with 2 FBX files having the same Mesh Group name.  Renaming the mesh group on the successful file caused the failed file to reprocess and succeed.  Also tested manually reprocessing both files without change to make sure no infinite loop occurred.

Ran test_TwoAssetsWithSameProductName_ShouldProcessAfterRename 10+ times with no failures
