### PR TITLE
Adding missing `close()` call for FileDescriptorCapturer UnixLike pipe data

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
@@ -385,11 +385,6 @@ namespace AZ::IO
 namespace AZ::IO
 {
     // Captures File Descriptor output through a pipe
-    FileDescriptorCapturer::FileDescriptorCapturer(int sourceDescriptor)
-        : m_sourceDescriptor(sourceDescriptor)
-    {
-    }
-
     FileDescriptorCapturer::~FileDescriptorCapturer()
     {
         Reset();

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
@@ -290,7 +290,11 @@ namespace AZ::IO
         }
 
         m_redirectCallback = {};
-        m_pipeData = -1;
+        if (m_pipeData > 0)
+        {
+            PosixInternal::Close(static_cast<int>(m_pipeData));
+            m_pipeData = 0;
+        }
 
         // Reset the file descriptors after any flush thread
         // operations have been complete, so correct descriptor value

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
@@ -517,6 +517,13 @@ namespace AZ::IO::Internal
 namespace AZ::IO
 {
     // FileDescriptorCapturer WinAPI Impl
+
+    FileDescriptorCapturer::FileDescriptorCapturer(int sourceDescriptor)
+        : m_sourceDescriptor(sourceDescriptor)
+        , m_pipeData(0)
+    {
+    }
+
     void FileDescriptorCapturer::Start(OutputRedirectVisitor redirectCallback,
         AZStd::chrono::milliseconds waitTimeout,
         int pipeSize)


### PR DESCRIPTION
## How was this PR tested?

Validated that running the [SystemFileTest.FileDescriptorCapturer_DoesNotDeadlock_WhenMoreThanPipeSizeContent_IsCaptured](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/Tests/SystemFileTest.cpp#L254) closes the epoll descriptor when running the UnitTest on Linux.
