### PR TITLE
Minor fix related to lower bit variable type related to bytes associated with Pool budget

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/ResourcePool/ResourcePoolSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/ResourcePool/ResourcePoolSourceData.h
@@ -37,7 +37,7 @@ namespace AZ
 
             ResourcePoolAssetType m_poolType = ResourcePoolAssetType::Unknown;
             AZStd::string m_poolName = "Unknown";
-            uint32_t m_budgetInBytes = 0;
+            AZ::u64 m_budgetInBytes = 0;
 
             // Configuration for buffer pool
             RHI::HeapMemoryLevel m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;


### PR DESCRIPTION
## What does this PR do?

- Fix m_budgetInBytes to be 64 bits

## How was this PR tested?

Tested ASV
