### PR TITLE
Separating TAA history buffer copy into its own scope.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -559,6 +559,10 @@
             {
                 "Name": "SplashScreenPassTemplate",
                 "Path": "Passes/SplashScreen.pass"
+            },
+            {
+                "Name": "TaaParentTemplate",
+                "Path": "Passes/TaaParent.pass"
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
@@ -86,7 +86,7 @@
                 },
                 {
                     "Name": "TaaPass",
-                    "TemplateName": "TaaTemplate",
+                    "TemplateName": "TaaParentTemplate",
                     "Enabled": false,
                     "Connections": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/TaaParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/TaaParent.pass
@@ -1,0 +1,100 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "TaaParentTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "DepthStencil"
+                },
+                {
+                    "Name": "MotionVectors",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "TaaPass",
+                        "Attachment": "OutputColor"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input": "InputColor",
+                    "Output": "OutputColor"
+                }
+            ],
+            "PassRequests": [
+                {
+                    "Name": "TaaPass",
+                    "TemplateName": "TaaTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputColor"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "MotionVectors",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "MotionVectors"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TaaCopyPass",
+                    "TemplateName": "CopyPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "TaaPass",
+                                "Attachment": "OutputColor"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "TaaPass",
+                                "Attachment": "LastFrameAccumulation"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "CloneInput": false
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -73,25 +73,6 @@ namespace AZ::Render
         Base::CompileResources(context);
     }
 
-    void TaaPass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
-    {
-        Base::BuildCommandListInternal(context);
-        if (ShouldCopyHistoryBuffer)
-        {
-            context.GetCommandList()->Submit(m_copyItem);
-        }
-    }
-
-    void TaaPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
-    {
-        Base::SetupFrameGraphDependencies(frameGraph);
-        if (ShouldCopyHistoryBuffer)
-        {
-            // Override the estimated item count to include the copy item.
-            frameGraph.SetEstimatedItemCount(2);
-        }
-    }
-
     void TaaPass::FrameBeginInternal(FramePrepareParams params)
     {
         RHI::Size inputSize = m_inputColorBinding->GetAttachment()->m_descriptor.m_image.m_size;
@@ -162,13 +143,6 @@ namespace AZ::Render
         AZ_Error("TaaPass", m_lastFrameAccumulationBinding, "TaaPass requires a slot for LastFrameAccumulation.");
         m_outputColorBinding = FindAttachmentBinding(Name("OutputColor"));
         AZ_Error("TaaPass", m_outputColorBinding, "TaaPass requires a slot for OutputColor.");
-
-        RHI::CopyImageDescriptor desc;
-        desc.m_sourceImage = m_attachmentImages[1]->GetRHIImage();
-        desc.m_destinationImage = m_attachmentImages[0]->GetRHIImage();
-        desc.m_sourceSize = desc.m_sourceImage->GetDescriptor().m_size;
-
-        m_copyItem = RHI::CopyItem(desc);
 
         // Set up the attachment for last frame accumulation and output color if it's never been done to
         // ensure SRG indices are set up correctly by the pass system.

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
@@ -61,10 +61,8 @@ namespace AZ::Render
         
         // Scope producer functions...
         void CompileResources(const RHI::FrameGraphCompileContext& context) override;
-        void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 
         // Pass behavior overrides...
-        void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
         void FrameBeginInternal(FramePrepareParams params) override;
         void ResetInternal() override;
         void BuildInternal() override;
@@ -84,8 +82,6 @@ namespace AZ::Render
         RPI::PassAttachmentBinding* m_inputColorBinding = nullptr;
         RPI::PassAttachmentBinding* m_lastFrameAccumulationBinding = nullptr;
         RPI::PassAttachmentBinding* m_outputColorBinding = nullptr;
-
-        RHI::CopyItem m_copyItem; // Can be removed when ShouldCopyHistoryBuffer is no longer needed.
 
         struct Offset
         {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -21,8 +21,6 @@ namespace AZ
     namespace RPI
     {
         //! A copy pass is a leaf pass (pass with no children) used for copying images and buffers on the GPU.
-        // [GFX TODO] ATOM-1188 (antonmic): Current implementation only supports image to image copying. With
-        // ATOM-1188 we will also enable image to buffer, buffer to image and buffer to buffer copies.
         class CopyPass
             : public RenderPass
         {


### PR DESCRIPTION
This PR fixes an issue where the TAA history buffer copy is done in the same scope as TAA itself, which isn't technically allowed. While these "works" it causes validation errors.

Fixes #15083 

Tested with TAA on/off in dx12/vulkan.