### PR TITLE
Removed unnecessary call to GetRemainingJobs that was causing tests to sometimes fail.

### DIFF
--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -1122,6 +1122,11 @@ namespace UnitTest
 
             asset1CopyContainer = {};
             asset1 = {};
+
+            // Make sure events are dispatched after releasing the asset handles, so they get destroyed.
+            // This addresses a rare race condition, a test failure roughly once every 2,000 runs on Linux.
+            m_testAssetManager->DispatchEvents();
+
             // We've released the references for one asset and its dependency
             EXPECT_EQ(m_assetHandlerAndCatalog->m_numDestructions, AssetsPerContainer);
             asset1 = m_testAssetManager->FindOrCreateAsset(MyAsset1Id, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::Default);

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -1079,13 +1079,10 @@ namespace UnitTest
                 }
                 AZStd::this_thread::yield();
             }
-            EXPECT_EQ(m_testAssetManager->GetRemainingJobs(), 0);
 
             EXPECT_EQ(asset1Container->IsReady(), true);
             EXPECT_EQ(asset2Container->IsReady(), true);
             EXPECT_EQ(asset3Container->IsReady(), true);
-
-            EXPECT_EQ(m_testAssetManager->GetRemainingJobs(), 0);
 
             auto rootAsset = asset1Container->GetRootAsset();
             EXPECT_EQ(rootAsset->GetId(), MyAsset1Id);

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -1113,7 +1113,6 @@ namespace UnitTest
 
             // We've now created the dependencies for each asset in the container as well
             EXPECT_EQ(m_assetHandlerAndCatalog->m_numCreations, NumTestAssets * AssetsPerContainer);
-            EXPECT_EQ(m_testAssetManager->GetRemainingJobs(), 0);
             EXPECT_EQ(asset1CopyContainer->GetDependencies().size(), 1);
 
             asset1Container = {};

--- a/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.cpp
@@ -45,11 +45,6 @@ namespace UnitTest
         return AZ::Data::AssetData::AssetStatus::NotLoaded;
     }
 
-    size_t TestAssetManager::GetRemainingJobs() const
-    {
-        return m_activeJobs.size();
-    }
-
     const AZ::Data::AssetManager::OwnedAssetContainerMap& TestAssetManager::GetAssetContainers() const
     {
         return m_ownedAssetContainers;

--- a/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.h
+++ b/Code/Framework/AzCore/Tests/Asset/BaseAssetManagerTest.h
@@ -35,9 +35,6 @@ namespace UnitTest
         // Find the current status of the reload
         AZ::Data::AssetData::AssetStatus GetReloadStatus(const AssetId& assetId);
 
-        // Get the number of jobs left to process
-        size_t GetRemainingJobs() const;
-
         const AZ::Data::AssetManager::OwnedAssetContainerMap& GetAssetContainers() const;
 
         const AssetMap& GetAssets() const;

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestEngine/Common/TestImpactTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestEngine/Common/TestImpactTestEngine.h
@@ -9,6 +9,8 @@
 #include <Process/Scheduler/TestImpactProcessScheduler.h>
 #include <TestEngine/Common/TestImpactTestEngineBus.h>
 #include <TestEngine/Common/TestImpactTestEngineException.h>
+#include <TestImpactFramework/TestImpactPolicy.h>
+#include <TestImpactFramework/TestImpactTestSequence.h>
 
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/vector.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
@@ -17,6 +17,8 @@
 #include <TestEngine/Common/Run/TestImpactTestEngineInstrumentedRun.h>
 #include <TestEngine/Common/Run/TestImpactTestEngineRegularRun.h>
 
+#include <TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h>
+
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
@@ -26,6 +28,7 @@ namespace TestImpact
     class NativeTestEnumerationJobInfoGenerator;
     class NativeRegularTestRunJobInfoGenerator;
     class NativeInstrumentedTestRunJobInfoGenerator;
+    struct NativeShardedArtifactDir;
     class NativeShardedRegularTestRunJobInfoGenerator;
     class NativeShardedInstrumentedTestRunJobInfoGenerator;
     class NativeTestEnumerator;


### PR DESCRIPTION
## What does this PR do?

Removed unnecessary call to GetRemainingJobs that was causing tests to sometimes fail.
Fixed compile errors in the Test Impact Framework.

https://github.com/o3de/o3de/issues/15549

## How was this PR tested?

Ran this test locally on Windows a few thousand times with and without this change. It doesn't fail for me locally with and without this fix on Windows:
bin\debug\AzTestRunner.exe C:/git3/o3de/windows_vs2019/bin/debug/AzCore.Tests.dll AzRunUnitTests --gtest_output=xml:C:/git23/o3de/windows_vs2019/testing/Gtest/AZ_AzCore.Tests.xml --gtest_filter=*BasicDependencyManagement* --gtest_break_on_failure --gtest_repeat=5000

I'm building Linux now to test there as well.

My build fails without the Test Impact Analysis Framework changes, and builds with them.
