### PR TITLE
Detect CPU architecture in LyTestTools

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/__init__.py
+++ b/Tools/LyTestTools/ly_test_tools/__init__.py
@@ -8,6 +8,7 @@ OS and devices are detected and set as constants when ly_test_tools.__init__() c
 """
 import logging
 import sys
+import platform
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,9 @@ IOS = False  # Not implemented - see SPEC-2505
 LINUX = sys.platform.startswith('linux')
 MAC = sys.platform.startswith('darwin')
 WINDOWS = sys.platform.startswith('win')
+
+# CPU architecture
+ARM64 = platform.machine.lower() == 'arm64'
 
 # Detect available platforms
 HOST_OS_PLATFORM = 'unknown'

--- a/Tools/LyTestTools/ly_test_tools/__init__.py
+++ b/Tools/LyTestTools/ly_test_tools/__init__.py
@@ -22,9 +22,6 @@ LINUX = sys.platform.startswith('linux')
 MAC = sys.platform.startswith('darwin')
 WINDOWS = sys.platform.startswith('win')
 
-# CPU architecture
-ARM64 = platform.machine.lower() == 'arm64'
-
 # Detect available platforms
 HOST_OS_PLATFORM = 'unknown'
 HOST_OS_EDITOR = 'unknown'
@@ -50,6 +47,7 @@ if WINDOWS:
     LAUNCHERS['windows_atom_tools'] = WinAtomToolsLauncher
     LAUNCHERS['android'] = AndroidLauncher
 elif MAC:
+    ARM64 = platform.machine() == 'arm64'
     HOST_OS_PLATFORM = 'mac'
     HOST_OS_EDITOR = NotImplementedError('LyTestTools does not yet support Mac editor')
     HOST_OS_DEDICATED_SERVER = NotImplementedError('LyTestTools does not yet support Mac dedicated server')
@@ -57,6 +55,7 @@ elif MAC:
     from ly_test_tools.launchers import MacLauncher
     LAUNCHERS['mac'] = MacLauncher
 elif LINUX:
+    ARM64 = platform.machine() == 'aarch64'
     HOST_OS_PLATFORM = 'linux'
     HOST_OS_EDITOR = 'linux_editor'
     HOST_OS_DEDICATED_SERVER = 'linux_dedicated'
@@ -68,5 +67,6 @@ elif LINUX:
     LAUNCHERS['linux_dedicated'] = DedicatedLinuxLauncher
     LAUNCHERS['linux_atom_tools'] = LinuxAtomToolsLauncher
 else:
+    ARM64 = False
     logger.warning(f'WARNING: LyTestTools only supports Windows, Mac, and Linux. '
                    f'Unexpectedly detected HOST_OS_PLATFORM: "{HOST_OS_PLATFORM}".')


### PR DESCRIPTION
Make LyTestTools be able to isolate tests that are specific to or disabled on Linux ARM64.

Example usage:
Skip a test on Linux arm64 machine:
@pytest.mark.skipif(ly_test_tools.LINUX, reason="Python based file locking does not function on Linux")
@pytest.mark.skipif(ly_test_tools.ARM64, reason="Python based file locking does not function on ARM64")

Skip a test on Linux non-arm64 machine:
@pytest.mark.skipif(ly_test_tools.LINUX, reason="Python based file locking does not function on Linux")
@pytest.mark.skipif(not ly_test_tools.ARM64, reason="Python based file locking does not function on ARM64")