### PR TITLE
Asset Processor - Replace FixedMaxPath with Path in SourceAssetReference

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.cpp
@@ -152,17 +152,17 @@ namespace AssetProcessor
 
     AZ::IO::FixedMaxPath SourceAssetReference::AbsolutePath() const
     {
-        return m_absolutePath;
+        return AZ::IO::FixedMaxPath(m_absolutePath);
     }
 
     AZ::IO::FixedMaxPath SourceAssetReference::RelativePath() const
     {
-        return m_relativePath;
+        return AZ::IO::FixedMaxPath(m_relativePath);
     }
 
     AZ::IO::FixedMaxPath SourceAssetReference::ScanFolderPath() const
     {
-        return m_scanFolderPath;
+        return AZ::IO::FixedMaxPath(m_scanFolderPath);
     }
 
     AZ::s64 SourceAssetReference::ScanFolderId() const

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceAssetReference.h
@@ -74,9 +74,9 @@ namespace AssetProcessor
     private:
         void Normalize();
 
-        AZ::IO::FixedMaxPath m_absolutePath;
-        AZ::IO::FixedMaxPath m_relativePath;
-        AZ::IO::FixedMaxPath m_scanFolderPath;
+        AZ::IO::Path m_absolutePath;
+        AZ::IO::Path m_relativePath;
+        AZ::IO::Path m_scanFolderPath;
         AZ::s64 m_scanFolderId{};
     };
 }


### PR DESCRIPTION
## What does this PR do?

Profiling showed FixedMaxPath was resulting in high memory usage as part of QueueElementID in RCController's Cached Job list

## How was this PR tested?

Memory profiling on AutomatedTesting project.
Memory usage before: 460MB
Memory usage after: 348MB
