### PR TITLE
Fix handler pool issues for multiple-DPE case

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -508,7 +508,6 @@ namespace AzToolsFramework
                 auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(childWidget);
                 if (!handlerInfo.IsNull())
                 {
-                    // propertyHandlers own their widgets, so don't destroy them here. Set them free!
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
                 else if (auto rowWidget = qobject_cast<DPERowWidget*>(childWidget))
@@ -1684,7 +1683,6 @@ namespace AzToolsFramework
             // the registration is needed in case the handler pool is released by other DPE views
             RegisterHandlerPool(handlerName, handlerPool);
 
-            // store, then reference the unique_ptr that will manage the handler's lifetime
             auto handler = handlerPool->GetInstance();
             handler->SetValueFromDom(domValue);
             createdWidget = handler->GetWidget();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1707,6 +1707,7 @@ namespace AzToolsFramework
         {
             // if there is no handler pool, then delete the handler immediately; parent widgets won't delete it twice
             delete handler.handlerInterface;
+            handler.handlerInterface = nullptr;
         }
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1618,12 +1618,12 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
     {
-        if (m_handlerPools.find(handlerName) != m_handlerPools.end())
-        {
-            AZ_Assert(m_handlerPools[handlerName] == handlerPool, "Registering a handler name for a different handler pool.");
-        }
+        AZ_Assert(
+            m_handlerPools.find(handlerName) == m_handlerPools.end() || m_handlerPools[handlerName] == handlerPool,
+            "Attempted to register a new handler pool to a handler name that is already in use.");
 
-        // will not overwrite if there is a registered handler pool for the handler name
+        // insertion to the handler pool hash map only succeeds if the handler name is a new key
+        // so it won't overwrite any existing registered handler pool for that handler name
         m_handlerPools.insert({ handlerName, handlerPool });
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1617,9 +1617,15 @@ namespace AzToolsFramework
         message.Match(AZ::DocumentPropertyEditor::Nodes::Adapter::QueryKey, showKeyQueryDialog);
     }
 
-    void DocumentPropertyEditor::RegisterHandlerPool(AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
+    void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
     {
-        m_handlerPools.push_back(handlerPool);
+        if (m_handlerPools.find(handlerName) != m_handlerPools.end())
+        {
+            AZ_Assert(m_handlerPools[handlerName] == handlerPool, "Registering a handler name for a different handler pool.");
+        }
+
+        // will not overwrite if there is a registered handler pool for the handler name
+        m_handlerPools.insert({ handlerName, handlerPool });
     }
 
     DocumentPropertyEditor::HandlerInfo DocumentPropertyEditor::GetInfoFromWidget(const QWidget* widget)
@@ -1634,7 +1640,11 @@ namespace AzToolsFramework
 
     AZ::Name DocumentPropertyEditor::GetNameForHandlerId(PropertyEditorToolsSystemInterface::PropertyHandlerId handlerId)
     {
-        return AZ::Name(AZStd::to_string(reinterpret_cast<uintptr_t>(handlerId)));
+        auto name = AZStd::to_string(reinterpret_cast<uintptr_t>(handlerId));
+        auto moduleId = AZ::Environment::GetModuleId();
+
+        auto nameWithModuleId = AZStd::fixed_string<256>::format("%s%p", name.c_str(), moduleId);
+        return AZ::Name(nameWithModuleId);
     }
 
     QWidget* DocumentPropertyEditor::CreateWidgetForHandler(
@@ -1644,9 +1654,12 @@ namespace AzToolsFramework
         // if we found a valid handler, grab its widget to add to the column layout
         if (handlerId)
         {
+            // first try to get the instance pool from pool manager
             auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
             auto handlerName = GetNameForHandlerId(handlerId);
             auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
+
+            // create the pool if it does not exist
             if (!handlerPool)
             {
                 AZStd::function<void(PropertyHandlerWidgetInterface&)> resetHandler = [](PropertyHandlerWidgetInterface& handler)
@@ -1665,8 +1678,11 @@ namespace AzToolsFramework
                 };
 
                 handlerPool = poolManager->CreatePool<PropertyHandlerWidgetInterface>(handlerName, resetHandler, createHandler).GetValue();
-                RegisterHandlerPool(handlerPool);
             }
+
+            // register the handler pool in DPE view to co-own the handler pool
+            // the registration is needed in case the handler pool is released by other DPE views
+            RegisterHandlerPool(handlerName, handlerPool);
 
             // store, then reference the unique_ptr that will manage the handler's lifetime
             auto handler = handlerPool->GetInstance();
@@ -1682,18 +1698,15 @@ namespace AzToolsFramework
         auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
         auto handlerName = GetNameForHandlerId(handler.handlerId);
         auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
+
         if (handlerPool)
         {
             handlerPool->RecycleInstance(handler.handlerInterface);
         }
         else
         {
-            QTimer::singleShot(
-                0,
-                [interfacePointer = handler.handlerInterface]()
-                {
-                    delete interfacePointer;
-                });
+            // if there is no handler pool, then delete the handler immediately; parent widgets won't delete it twice
+            delete handler.handlerInterface;
         }
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -231,7 +231,7 @@ namespace AzToolsFramework
                 ->GetPool<AzQtComponents::ElidingLabel>();
         }
 
-        void RegisterHandlerPool(AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool);
+        void RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool);
 
         struct HandlerInfo
         {
@@ -280,7 +280,8 @@ namespace AzToolsFramework
         static AZ::Name GetNameForHandlerId(PropertyEditorToolsSystemInterface::PropertyHandlerId handlerId);
         static void ReleaseHandler(HandlerInfo& handler);
 
-        AZStd::vector<AZStd::shared_ptr<AZ::InstancePoolBase>> m_handlerPools;
+        // Co-owns the handler pool that is needed in DPE and the ownership would be released when the DPE is deleted
+        AZStd::unordered_map<AZ::Name, AZStd::shared_ptr<AZ::InstancePoolBase>> m_handlerPools;
     };
 } // namespace AzToolsFramework
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15097

This PR fixes issues that would occur if there are multiple DPE views are being used. In the Entity Inspector, there is one DPE view for each component. The pool manager is responsible for creating the pool and holds a weak pointer to it. Each DPE view co-owns the instance pool if it uses its handler.

- **Why it crashes?** - The single-shot delete would cause double deletion after DPE view widget deletes the prefab label handler.
- **Why it does deletion rather than recycling?** - Pool manager's GetPoot() returns nullptr during the deletion of second DPE view, which would lead to delete the handler rather then recycling it. It happens because the prefab label handler pool has already been destroyed in the first DPE view's deletion (upon closing Entity Inspector). There is a bug in handler pool setup code in DPE that the second DPE view does not correctly co-own the shared_ptr of the pool if the pool has already been created by the first DPE view in pool manager.


**Change List:**
1. Replace Qt's single-shot call with direct delete call to prevent deletion from parent widget.
2. Make sure DPE view is registering (co-owning) the handler pool that it needs during setup.
3. Use a hash map to store the owning handler pools. Previously it was a vector.
4. Add module id to the returned handler name (similar to https://github.com/o3de/o3de/pull/15254).

## How was this PR tested?

Tested in editor. No more crash. Tested in standalone app. Didn't see new issues.
