### PR TITLE
Asset Processor - Updated missing dependency scanner to use the job system.

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QStringLiteral>
 #include <QUrl>
+#include <AzCore/Jobs/JobFunction.h>
 
 namespace AssetProcessor
 {
@@ -455,9 +456,8 @@ namespace AssetProcessor
         QString pathOnDisk = cacheRootDir.filePath(productItemData->m_databaseInfo.m_productName.c_str());
 
         AddProductIdToScanCount(productItemData->m_databaseInfo.m_productID, scanName);
-
         // Run the scan on another thread so the UI remains responsive.
-        AZStd::thread scanningThread = AZStd::thread([=]() {
+        auto* job = AZ::CreateJobFunction([=]() {
             MissingDependencyScannerRequestBus::Broadcast(&MissingDependencyScannerRequestBus::Events::ScanFile,
                 pathOnDisk.toUtf8().constData(),
                 MissingDependencyScanner::DefaultMaxScanIteration,
@@ -480,8 +480,9 @@ namespace AssetProcessor
                     }
                 }
             });
-        });
-        scanningThread.detach();
+        }, true);
+
+        job->Start();
     }
 
     void ProductAssetDetailsPanel::AddProductIdToScanCount(AZ::s64 scannedProductId, QString scanName)


### PR DESCRIPTION
## What does this PR do?

Running the scanner on the entire output folder was previously locking up AP.  Profiling showed this was due to a thread per file being spawned. This change moves the work to the AZ Job system to prevent spawning an unlimited number of threads. This process is still essentially single-threaded due to the use of ebuses and a database connection that can't be shared across threads, but this at least improves the UI performance.

## How was this PR tested?

Manually opening the AP Asset Products tab and clicking Scan button when the "pc" folder is selected (top level asset folder)
