### PR TITLE
Updated the SerializeContext `createuuid` options

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/GenericStreams.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/GenericStreams.cpp
@@ -160,10 +160,13 @@ namespace AZ::IO
         Open(path, mode);
     }
 
-    SystemFileStream::~SystemFileStream()
-    {
-        m_file.Close();
-    }
+    // Let the SystemFile destructor close or not close any files based
+    // on its destruction logic
+    SystemFileStream::~SystemFileStream() = default;
+
+    // Default the move constructor and assignment operator
+    SystemFileStream::SystemFileStream(SystemFileStream&&) = default;
+    SystemFileStream& SystemFileStream::operator=(SystemFileStream&&) = default;
 
     bool SystemFileStream::IsOpen() const
     {

--- a/Code/Framework/AzCore/AzCore/IO/GenericStreams.h
+++ b/Code/Framework/AzCore/AzCore/IO/GenericStreams.h
@@ -80,6 +80,10 @@ namespace AZ::IO
         SystemFileStream(SystemFile&& file, OpenMode mode);
         ~SystemFileStream() override;
 
+        //! Move constructor and assignment which is defaulted in the cpp file
+        SystemFileStream(SystemFileStream&&);
+        SystemFileStream& operator=(SystemFileStream&&);
+
         bool Open(const char* path, OpenMode mode);
 
         void Close() override;

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
@@ -74,7 +74,7 @@ namespace AZ::IO
 
     SystemFile::~SystemFile()
     {
-        if (IsOpen())
+        if (IsOpen() && m_closeOnDestruction)
         {
             Close();
         }
@@ -113,6 +113,10 @@ namespace AZ::IO
         }
 
         AZ_Assert(!IsOpen(), "This file (%s) is already open!", m_fileName.c_str());
+
+        // Sets the close on destruction option if
+        // the skip close on destruction mode is set
+        m_closeOnDestruction = (mode & OpenMode::SF_SKIP_CLOSE_ON_DESTRUCTION) == 0;
 
         return PlatformOpen(mode, platformFlags);
     }

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.h
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.h
@@ -42,6 +42,7 @@ namespace AZ
                 SF_OPEN_CREATE      = (1 << 5),   ///< Create a file, if file exists it will overwrite it's content.
                 SF_OPEN_TRUNCATE    = (1 << 6),   ///< Opens a file and truncate it's size to zero. If file doesn't exist an error is returned.
                 SF_OPEN_CREATE_PATH = (1 << 7),   ///< Also create any intermediate paths that are part of the file path. Must be used in conjunction with SF_OPEN_CREATE or SF_OPEN_CREATE_NEW.
+                SF_SKIP_CLOSE_ON_DESTRUCTION = (1 << 8), ///< SystemFile destructor will not invoke Close() on an open handle
             };
 
             enum SeekMode
@@ -94,42 +95,61 @@ namespace AZ
             /// Return disc offset if possible, otherwise 0
             SizeType DiskOffset() const;
             /// Return file name or NULL if file is not open.
-            AZ_FORCE_INLINE const char* Name() const    { return m_fileName.c_str(); }
+            const char* Name() const { return m_fileName.c_str(); }
             bool IsOpen() const;
 
             /// Return native handle to the file.
-            AZ_FORCE_INLINE const FileHandleType&   NativeHandle() const    { return m_handle; }
+            const FileHandleType& NativeHandle() const { return m_handle; }
 
             //////////////////////////////////////////////////////////////////////////
             //////////////////////////////////////////////////////////////////////////
             // Utility functions
             /// Check if a file or directory exists.
-            static bool     Exists(const char* path);
+            static bool Exists(const char* path);
             /// Check if path is a directory
-            static bool     IsDirectory(const char* path);
+            static bool IsDirectory(const char* path);
             /// FindFiles
-            typedef AZStd::function<bool /* true to continue to enumerate otherwise false */ (const char* /* fileName*/, bool /* true if file, false if folder*/)>  FindFileCB;
-            static void     FindFiles(const char* filter, FindFileCB cb);
+            using FindFileCB = AZStd::function<bool /* true to continue to enumerate otherwise false */ (const char* /* fileName*/, bool /* true if file, false if folder*/)>;
+            static void FindFiles(const char* filter, FindFileCB cb);
             /// Get the time the file was last modified.
-            static AZ::u64  ModificationTime(const char* fileName);
+            static AZ::u64 ModificationTime(const char* fileName);
             /// Return a length of a file. 0 if files has 0 length or doesn't exits.
             static SizeType Length(const char* fileName);
             /// Read content from a file. If byteSize is 0 it reads the entire file.
             static SizeType Read(const char* fileName, void* buffer, SizeType byteSize = 0, SizeType byteOffset = 0);
             /// Delete a file, returns true if file was actually deleted.
-            static bool     Delete(const char* fileName);
+            static bool Delete(const char* fileName);
             /// Rename a file, returns true if the file was successfully renamed. If overwrite is true, rename even if target exists.
-            static bool     Rename(const char* sourceFileName, const char* targetFileName, bool overwrite = false);
+            static bool Rename(const char* sourceFileName, const char* targetFileName, bool overwrite = false);
             /// Returns true if a file is writable, false if it doesn't exist or is read only
-            static bool     IsWritable(const char* sourceFileName);
+            static bool IsWritable(const char* sourceFileName);
             /// Returns true if able to modify readonly attribute. Can fail if file doesn't exist.
-            static bool     SetWritable(const char* sourceFileName, bool writable);
+            static bool SetWritable(const char* sourceFileName, bool writable);
             /// Recursively creates a directory hierarchy
-            static bool     CreateDir(const char* dirName);
+            static bool CreateDir(const char* dirName);
             /// Delete a directory
-            static bool     DeleteDir(const char* dirName);
+            static bool DeleteDir(const char* dirName);
             /// Retrieves platform specific Null device path (ex: "/dev/null")
             static const char* GetNullFilename();
+
+            //! Opens stdin for read
+            //! The destructor of SystemFile will not close the handle
+            //! This allows stdin to continue to remain open even if the instance scope ends
+            //! NOTE: However the handle can be explicitly closed using the Close() function
+            //! Invoking that function will close the stdin handle
+            static SystemFile GetStdin();
+            //! Opens stdout for write
+            //! The destructor of SystemFile will not close the handle
+            //! This allows stdout to continue to remain open even if the instance scope ends
+            //! NOTE: However the handle can be explicitly closed using the Close() function
+            //! Invoking that function will close the stdout handle
+            static SystemFile GetStdout();
+            //! Opens stderr for write
+            //! The destructor of SystemFile will not close the handle
+            //! This allows stderr to continue to remain open even if the instance scope ends
+            //! NOTE: However the handle can be explicitly closed using the Close() function
+            //! Invoking that function will close the stderr handle
+            static SystemFile GetStderr();
 
         private:
             static void CreatePath(const char * fileName);
@@ -139,6 +159,8 @@ namespace AZ
 
             FileHandleType m_handle;
             AZ::IO::FixedMaxPathString m_fileName;
+            //! If true the destructor will invoke Close if the Handle is open
+            bool m_closeOnDestruction{ true };
         };
 
         /**

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
@@ -19,14 +19,30 @@ namespace AZ
 {
     /**
     * Given a commandline, this allows uniform parsing of it into parameter values and extra values.
-    * When parsed, the commandline becomes a series of "switches" or "extra values"
-    * For example, a switch may be specified as either 
-    *      /switchName=value1[,value2...]
-    *      /switchname value[,value2...]
-    *      --switchname value[,value2...]
+    * When parsed, the commandline becomes a series of "options" or "extra values"
+    * For example, a option may be specified as either
+    *      /optionName=value1[,value2...]
+    *      /optionname value[,value2...]
+    *      --optionname value[,value2...]
     *    or other combinations of the above
-    * You may NOT use a colon as a switch separator since file names may easily contain them.
-    * any additional parameters which are not associated with any switch are considered "misc values"
+    * You may NOT use a colon as a option separator since file names may easily contain them.
+    * any additional parameters which are not associated with any option are considered "misc values"
+    *
+    * NOTE: "flags" options which doesn't specify a value need care when using
+    * This is because the Parse() methods don't accept external metadata indicating actions to perform
+    * on flag arguments unlike python argparse
+    * https://docs.python.org/3/library/argparse.html#action
+    * For example the command line of
+    * `app.exe --verbose <PositionalArg>` would parse <PositionalArg> as the value of the "verbose" flag
+    * The workaround is to either
+    * 1. specify the flag options at the end of the command line
+    * `app.exe <PositionalArg> --verbose`
+    * 2. specify second option right after the previous flag option with and add a value to it
+    * `app.exe --verbose --count 2 <PositionalArg>`
+    * 3. specify a value for the 'verbose'option
+    *     here only the 1 is parse as part of the verbose option, the <PositionalArg>
+    *     separated by whitespace is a new argument
+    * `app.exe --verbose 1 <PositionalArg>`  or `app.exe --verbose=1 <PositionalArg>`
     */
     class CommandLine
     {
@@ -132,7 +148,8 @@ namespace AZ
         auto crend() const -> ArgumentVector::const_reverse_iterator;
 
     private:
-        void AddArgument(AZStd::string_view currentArg, AZStd::string& currentSwitch);
+        struct ArgumentParserState;
+        void AddArgument(AZStd::string_view currentArg, ArgumentParserState&);
         void ParseOptionArgument(AZStd::string_view newOption, AZStd::string_view newValue, CommandArgument* inProgressArgument);
 
         ArgumentVector m_allValues;

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -78,7 +78,7 @@ namespace AZ::Settings
 
     ParseOutcome ParseConfigFile(AZ::IO::GenericStream& configStream, const ConfigParserSettings& configParserSettings)
     {
-        // The trace system is not being used here as this function INI system is available
+        // The trace system is not being used here as this function is available
         // before any allocators or initialization of any systems take place
 
         ParseOutcome parseOutcome;

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
@@ -67,8 +67,9 @@ namespace AZ::Settings
         //! So it is recommmended that users binding a lambda bind at most 2 reference or pointer members
         //! to avoid dynamic heap allocations
         //!
+        //! NOTE: This function will not be called if the key is empty
         //! @return True should be returned from this function to indicate that parsing of the config entry
-        //! has a succeed
+        //! has succeeded
         using ParseConfigEntryFunc = AZStd::function<bool(const ConfigEntry&)>;
 
         ParseConfigEntryFunc m_parseConfigEntryFunc;
@@ -128,7 +129,7 @@ namespace AZ::Settings
 
         //! Function which is invoked on the config line after filtering through the SectionHeaderFunc
         //! to determine the delimiter of the line
-        //! The structure contains a functor which returns true if a character is a valid delimiter
+        //! The structure contains a functor which returns a ConfigKeyValuePair to split the key value pair
         DelimiterFunc m_delimiterFunc = &DefaultDelimiterFunc;
     };
 

--- a/Code/Framework/AzCore/AzCore/Settings/TextParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/TextParser.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/Settings/TextParser.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/string/fixed_string.h>
+#include <AzCore/std/containers/fixed_vector.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+namespace AZ::Settings
+{
+    // Text Parsing support
+    bool TextParserSettings::DefaultTokenDelimiterFunc(char element)
+    {
+        return element == '\n';
+    }
+
+    TextParseOutcome ParseTextFile(AZ::IO::GenericStream& textStream, const TextParserSettings& textParserSettings)
+    {
+        TextParseOutcome parseOutcome;
+        if (!textParserSettings.m_parseTextEntryFunc)
+        {
+            return AZStd::unexpected(TextParseErrorString::format("The Parse Text Entry function is not valid for parsing a text file"));
+        }
+
+        // The TextFile is parsed into a fixed_vector of TextEntryBufferMaxSize below
+        // which avoids performing any dynamic memory allocations during parsing
+        // Only the user supplied callback functions as part of the TexctParserSettings can potentially allocate memory
+        size_t remainingFileLength = textStream.GetLength();
+        if (remainingFileLength == 0)
+        {
+            return AZStd::unexpected(TextParseErrorString::format(R"(text stream "%s" is empty, no text entries exist)" "\n", textStream.GetFilename()));
+        }
+
+        constexpr size_t TextEntryBufferMaxSize = 4096;
+        AZStd::fixed_vector<char, TextEntryBufferMaxSize> textBuffer;
+        size_t readSize = (AZStd::min)(textBuffer.max_size(), remainingFileLength);
+        textBuffer.resize_no_construct(readSize);
+
+        size_t bytesRead = textStream.Read(textBuffer.size(), textBuffer.data());
+        remainingFileLength -= bytesRead;
+
+        do
+        {
+            decltype(textBuffer)::iterator frontIter{};
+            for (frontIter = textBuffer.begin(); frontIter != textBuffer.end();)
+            {
+                if (AZStd::isspace(*frontIter, {}))
+                {
+                    ++frontIter;
+                    continue;
+                }
+
+                // Find end of text entry
+                auto lineStartIter = frontIter;
+                auto lineEndIter = AZStd::find_if(frontIter, textBuffer.end(), textParserSettings.m_tokenDelimiterFunc);
+                bool foundTextEntry = lineEndIter != textBuffer.end();
+                if (!foundTextEntry && remainingFileLength > 0)
+                {
+                    // No newline has been found in the remaining characters in the buffer,
+                    // Read the next chunk(up to TextBufferMaxSize) of the text file and look for a new line
+                    // if the file has remaining content
+                    // Otherwise if the file has no more remaining content, then it is improperly terminated
+                    // text file according to the posix standard
+                    // Therefore the final text after the final newline will be parsed
+                    break;
+                }
+
+
+                AZStd::string_view line(lineStartIter, lineEndIter);
+
+                //! Invoke the parse text entry function to allow the caller to parse a single entry
+                //! If m_invokeParseTextEntryForEmptyLine is false, empty entries are skipped
+                if ((!line.empty() || textParserSettings.m_invokeParseTextEntryForEmptyLine)
+                    && !textParserSettings.m_parseTextEntryFunc(line))
+                {
+                    parseOutcome = AZStd::unexpected(TextParseErrorString::format("The ParseTextEntry callback returned false"
+                        R"( indicating that the parsing of text entry (value="%.*s") has failed)",
+                        AZ_STRING_ARG(line)));
+                    // Do not break and continue to parse the text file
+                }
+
+                // Skip past the text entry character if found
+                frontIter = lineEndIter + (foundTextEntry ? 1 : 0);
+            }
+
+            // Read in more data from the text file if available.
+            // If the parsing was in the middle of a parsing line, then move the remaining data of that line to the beginning
+            // of the fixed_vector buffer
+            if (frontIter == textBuffer.begin())
+            {
+                parseOutcome = AZStd::unexpected(TextParseErrorString::format(R"(The text stream "%s")"
+                    "contains a line which is longer than the max line length of %zu.\n"
+                    R"(Parsing will halt.)" "\n", textStream.GetFilename(), textBuffer.max_size()));
+                break;
+            }
+            const size_t readOffset = AZStd::distance(frontIter, textBuffer.end());
+            if (readOffset > 0)
+            {
+                memmove(textBuffer.begin(), frontIter, readOffset);
+            }
+
+            // Read up to minimum of remaining file length or 4K in the textBuffer
+            readSize = (AZStd::min)(textBuffer.max_size() - readOffset, remainingFileLength);
+            bytesRead = textStream.Read(readSize, textBuffer.data() + readOffset);
+            // resize_no_construct fixes the size value
+            textBuffer.resize_no_construct(readOffset + readSize);
+            remainingFileLength -= bytesRead;
+        } while (bytesRead > 0);
+
+        return parseOutcome;
+    }
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/Settings/TextParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/TextParser.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/functional.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/utility/expected.h>
+
+namespace AZStd
+{
+    // Forward declare basic_fixed_string to avoid including fixed_string.h
+    // in the header
+    template <class Element, size_t MaxElementCount, class Traits>
+    class basic_fixed_string;
+}
+
+namespace AZ::IO
+{
+    class GenericStream;
+}
+
+namespace AZ::Settings
+{
+    //! Settings structure for parsing a text file.
+    //! By default the user supplied ParseTextEntryFunc callback is invoked for every line parsed
+    //! The TokenDelimiterFunc can be modified to change the token used to determine a text entry
+    //! For example if the TokenDelimiterFunc returns true of '\0', then every time a NUL delimited blob is found
+    //! the ParseTextEntryFunc will be invoked
+    struct TextParserSettings
+    {
+        //! Function which is invoked for each "text entry" of the text file
+        //! A text entry is determined as a block of text delimited by the result of the TokenDelimiterFunc
+        //! By default a "text entry" is line based, but other delimiters can be used such as NUL('\0')
+        using ParseTextEntryFunc = AZStd::function<bool(AZStd::string_view token)>;
+
+        //! Callback function which is invoked for each text entry found in the text file
+        //! This is only required member that needs to be set for the TextParserSettings
+        ParseTextEntryFunc m_parseTextEntryFunc;
+
+        //! Returns if the character matches the linefeed character
+        //! @param element character being checked
+        //! @return true if the character matches line feed
+        static bool DefaultTokenDelimiterFunc(char element);
+        //! Token Delimiter which determines a token from a text file
+        //! The default token delimiter is a linefeed '\n'
+        using TokenDelimiterFunc = AZStd::function<bool(char element)>;
+
+        //! Callback function which is invoked to determine the end of the text entry
+        TokenDelimiterFunc m_tokenDelimiterFunc = &DefaultTokenDelimiterFunc;
+
+        //! If set to true, the ParseTextEntryFunc callback will be invoked even when
+        //! the empty text is empty("line" size = 0)
+        bool m_invokeParseTextEntryForEmptyLine = false;
+    };
+
+    // Expected structure which encapsulates the result of the ParseConfigFile function
+    using TextParseErrorString = AZStd::basic_fixed_string<char, 512, AZStd::char_traits<char>>;
+    using TextParseOutcome = AZStd::expected<void, TextParseErrorString>;
+
+    //! Loads text file and invokes parse entry config callback
+    //! This function will NOT allocate any dynamic memory.
+    //! It is safe to call without any AZ Allocators
+    //! NOTE: The max length for any one text entry is 4096
+    //!
+    //! @param stream GenericStream derived class where the configuration data will be read from
+    //! @param textParserSettings structure which contains functions on how the to split "lines" of text file
+    //!        as well as the callback function to invoke on each split "line"
+    //! @return success outcome if the text file was parsed without error,
+    //! otherwise a failure string is provided with the parse error
+    TextParseOutcome ParseTextFile(AZ::IO::GenericStream& stream, const TextParserSettings& textParserSettings);
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -639,6 +639,8 @@ set(FILES
     Settings/SettingsRegistryScriptUtils.h
     Settings/SettingsRegistryVisitorUtils.cpp
     Settings/SettingsRegistryVisitorUtils.h
+    Settings/TextParser.cpp
+    Settings/TextParser.h
     Slice/SliceAsset.cpp
     Slice/SliceAsset.h
     Slice/SliceAssetHandler.cpp

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
@@ -19,156 +19,188 @@
 namespace AZ::IO
 {
     using FixedMaxPathWString = AZStd::fixed_wstring<MaxPathLength>;
-namespace
-{
-    //=========================================================================
-    // GetAttributes
-    //  Internal utility to avoid code duplication. Returns result of win32
-    //  GetFileAttributes
-    //=========================================================================
-    DWORD GetAttributes(const char* fileName)
+    namespace
     {
-        FixedMaxPathWString fileNameW;
-        AZStd::to_wstring(fileNameW, fileName);
-        return GetFileAttributesW(fileNameW.c_str());
-    }
-
-    //=========================================================================
-    // SetAttributes
-    //  Internal utility to avoid code duplication. Returns result of win32
-    //  SetFileAttributes
-    //=========================================================================
-    BOOL SetAttributes(const char* fileName, DWORD fileAttributes)
-    {
-        FixedMaxPathWString fileNameW;
-        AZStd::to_wstring(fileNameW, fileName);
-        return SetFileAttributesW(fileNameW.c_str(), fileAttributes);
-    }
-
-    //=========================================================================
-    // CreateDirRecursive
-    // [2/3/2013]
-    //  Internal utility to create a folder hierarchy recursively without
-    //  any additional string copies.
-    //  If this function fails (returns false), the error will be available via:
-    //   * GetLastError() on Windows-like platforms
-    //   * errno on Unix platforms
-    //=========================================================================
-    bool CreateDirRecursive(AZ::IO::FixedMaxPathWString& dirPath)
-    {
-        if (CreateDirectoryW(dirPath.c_str(), nullptr))
+        //=========================================================================
+        // GetAttributes
+        //  Internal utility to avoid code duplication. Returns result of win32
+        //  GetFileAttributes
+        //=========================================================================
+        DWORD GetAttributes(const char* fileName)
         {
-            return true;    // Created without error
+            FixedMaxPathWString fileNameW;
+            AZStd::to_wstring(fileNameW, fileName);
+            return GetFileAttributesW(fileNameW.c_str());
         }
-        DWORD error = GetLastError();
-        if (error == ERROR_PATH_NOT_FOUND)
+
+        //=========================================================================
+        // SetAttributes
+        //  Internal utility to avoid code duplication. Returns result of win32
+        //  SetFileAttributes
+        //=========================================================================
+        BOOL SetAttributes(const char* fileName, DWORD fileAttributes)
         {
-            // try to create our parent hierarchy
-            if (size_t i = dirPath.find_last_of(LR"(/\)"); i != FixedMaxPathWString::npos)
+            FixedMaxPathWString fileNameW;
+            AZStd::to_wstring(fileNameW, fileName);
+            return SetFileAttributesW(fileNameW.c_str(), fileAttributes);
+        }
+
+        //=========================================================================
+        // CreateDirRecursive
+        // [2/3/2013]
+        //  Internal utility to create a folder hierarchy recursively without
+        //  any additional string copies.
+        //  If this function fails (returns false), the error will be available via:
+        //   * GetLastError() on Windows-like platforms
+        //   * errno on Unix platforms
+        //=========================================================================
+        bool CreateDirRecursive(AZ::IO::FixedMaxPathWString& dirPath)
+        {
+            if (CreateDirectoryW(dirPath.c_str(), nullptr))
             {
-                wchar_t delimiter = dirPath[i];
-                dirPath[i] = 0; // null-terminate at the previous slash
-                const bool ret = CreateDirRecursive(dirPath);
-                dirPath[i] = delimiter; // restore slash
-                if (ret)
-                {
-                    // now that our parent is created, try to create again
-                    return CreateDirectoryW(dirPath.c_str(), nullptr) != 0;
-                }
+                return true;    // Created without error
             }
-            // if we reach here then there was no parent folder to create, so we failed for other reasons
+            DWORD error = GetLastError();
+            if (error == ERROR_PATH_NOT_FOUND)
+            {
+                // try to create our parent hierarchy
+                if (size_t i = dirPath.find_last_of(LR"(/\)"); i != FixedMaxPathWString::npos)
+                {
+                    wchar_t delimiter = dirPath[i];
+                    dirPath[i] = 0; // null-terminate at the previous slash
+                    const bool ret = CreateDirRecursive(dirPath);
+                    dirPath[i] = delimiter; // restore slash
+                    if (ret)
+                    {
+                        // now that our parent is created, try to create again
+                        return CreateDirectoryW(dirPath.c_str(), nullptr) != 0;
+                    }
+                }
+                // if we reach here then there was no parent folder to create, so we failed for other reasons
+            }
+            else if (error == ERROR_ALREADY_EXISTS)
+            {
+                DWORD attributes = GetFileAttributesW(dirPath.c_str());
+                return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+            }
+            return false;
         }
-        else if (error == ERROR_ALREADY_EXISTS)
-        {
-            DWORD attributes = GetFileAttributesW(dirPath.c_str());
-            return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-        }
-        return false;
+
+        static const SystemFile::FileHandleType PlatformSpecificInvalidHandle = INVALID_HANDLE_VALUE;
     }
+} // namespace AZ::IO
 
-    static const SystemFile::FileHandleType PlatformSpecificInvalidHandle = INVALID_HANDLE_VALUE;
-}
-
-
-bool SystemFile::PlatformOpen(int mode, int platformFlags)
+namespace AZ::IO
 {
-    DWORD dwDesiredAccess = 0;
-    DWORD dwShareMode = FILE_SHARE_READ;
-    DWORD dwFlagsAndAttributes = platformFlags;
-    DWORD dwCreationDisposition = OPEN_EXISTING;
+    bool SystemFile::PlatformOpen(int mode, int platformFlags)
+    {
+        DWORD dwDesiredAccess = 0;
+        DWORD dwShareMode = FILE_SHARE_READ;
+        DWORD dwFlagsAndAttributes = platformFlags;
+        DWORD dwCreationDisposition = OPEN_EXISTING;
 
-    bool createPath = false;
-    if (mode & SF_OPEN_READ_ONLY)
-    {
-        dwDesiredAccess |= GENERIC_READ;
-        // Always open files for reading with file shared write flag otherwise it may result in a sharing violation if 
-        // either some process has already opened the file for writing or if some process will later on try to open the file for writing. 
-        dwShareMode |= FILE_SHARE_WRITE;
-    }
-    if (mode & SF_OPEN_READ_WRITE)
-    {
-        dwDesiredAccess |= GENERIC_READ;
-    }
-    if ((mode & SF_OPEN_WRITE_ONLY) || (mode & SF_OPEN_READ_WRITE) || (mode & SF_OPEN_APPEND))
-    {
-        dwDesiredAccess |= GENERIC_WRITE;
-    }
-
-    if ((mode & SF_OPEN_CREATE_NEW))
-    {
-        dwCreationDisposition = CREATE_NEW;
-        createPath = (mode & SF_OPEN_CREATE_PATH) == SF_OPEN_CREATE_PATH;
-    }
-    else if ((mode & SF_OPEN_CREATE))
-    {
-        dwCreationDisposition = CREATE_ALWAYS;
-        createPath = (mode & SF_OPEN_CREATE_PATH) == SF_OPEN_CREATE_PATH;
-    }
-    else if ((mode & SF_OPEN_TRUNCATE))
-    {
-        dwCreationDisposition = TRUNCATE_EXISTING;
-    }
-
-    if (createPath)
-    {
-        CreatePath(m_fileName.c_str());
-    }
-
-    AZ::IO::FixedMaxPathWString fileNameW;
-    AZStd::to_wstring(fileNameW, m_fileName);
-    m_handle = INVALID_HANDLE_VALUE;
-    m_handle = CreateFileW(fileNameW.c_str(), dwDesiredAccess, dwShareMode, 0, dwCreationDisposition, dwFlagsAndAttributes, 0);
-
-    if (m_handle == INVALID_HANDLE_VALUE)
-    {
-        return false;
-    }
-    else
-    {
-        if (mode & SF_OPEN_APPEND)
+        bool createPath = false;
+        if (mode & SF_OPEN_READ_ONLY)
         {
-            SetFilePointer(m_handle, 0, NULL, FILE_END);
+            dwDesiredAccess |= GENERIC_READ;
+            // Always open files for reading with file shared write flag otherwise it may result in a sharing violation if
+            // either some process has already opened the file for writing or if some process will later on try to open the file for writing.
+            dwShareMode |= FILE_SHARE_WRITE;
         }
-    }
+        if (mode & SF_OPEN_READ_WRITE)
+        {
+            dwDesiredAccess |= GENERIC_READ;
+        }
+        if ((mode & SF_OPEN_WRITE_ONLY) || (mode & SF_OPEN_READ_WRITE) || (mode & SF_OPEN_APPEND))
+        {
+            dwDesiredAccess |= GENERIC_WRITE;
+        }
 
-    return true;
-}
+        if ((mode & SF_OPEN_CREATE_NEW))
+        {
+            dwCreationDisposition = CREATE_NEW;
+            createPath = (mode & SF_OPEN_CREATE_PATH) == SF_OPEN_CREATE_PATH;
+        }
+        else if ((mode & SF_OPEN_CREATE))
+        {
+            dwCreationDisposition = CREATE_ALWAYS;
+            createPath = (mode & SF_OPEN_CREATE_PATH) == SF_OPEN_CREATE_PATH;
+        }
+        else if ((mode & SF_OPEN_TRUNCATE))
+        {
+            dwCreationDisposition = TRUNCATE_EXISTING;
+        }
 
-void SystemFile::PlatformClose()
-{
-    if (m_handle != PlatformSpecificInvalidHandle)
-    {
-        CloseHandle(m_handle);
+        if (createPath)
+        {
+            CreatePath(m_fileName.c_str());
+        }
+
+        AZ::IO::FixedMaxPathWString fileNameW;
+        AZStd::to_wstring(fileNameW, m_fileName);
         m_handle = INVALID_HANDLE_VALUE;
+        m_handle = CreateFileW(fileNameW.c_str(), dwDesiredAccess, dwShareMode, 0, dwCreationDisposition, dwFlagsAndAttributes, 0);
+
+        if (m_handle == INVALID_HANDLE_VALUE)
+        {
+            return false;
+        }
+        else
+        {
+            if (mode & SF_OPEN_APPEND)
+            {
+                SetFilePointer(m_handle, 0, NULL, FILE_END);
+            }
+        }
+
+        return true;
     }
-}
 
-const char* SystemFile::GetNullFilename()
-{
-    return "NUL";
-}
+    void SystemFile::PlatformClose()
+    {
+        if (m_handle != PlatformSpecificInvalidHandle)
+        {
+            CloseHandle(m_handle);
+            m_handle = INVALID_HANDLE_VALUE;
+        }
+    }
 
-namespace Platform
+    const char* SystemFile::GetNullFilename()
+    {
+        return "NUL";
+    }
+
+    SystemFile SystemFile::GetStdin()
+    {
+        SystemFile systemFile;
+        systemFile.m_handle = GetStdHandle(STD_INPUT_HANDLE);
+        systemFile.m_fileName = "/dev/stdin";
+        // The destructor of the SystemFile will not close the stdin handle
+        systemFile.m_closeOnDestruction = false;
+        return systemFile;
+    }
+
+    SystemFile SystemFile::GetStdout()
+    {
+        SystemFile systemFile;
+        systemFile.m_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        systemFile.m_fileName = "/dev/stdout";
+        // The destructor of the SystemFile will not close the stdout handle
+        systemFile.m_closeOnDestruction = false;
+        return systemFile;
+    }
+    SystemFile SystemFile::GetStderr()
+    {
+        SystemFile systemFile;
+        systemFile.m_handle = GetStdHandle(STD_ERROR_HANDLE);
+        systemFile.m_fileName = "/dev/stderr";
+        // The destructor of the SystemFile will not close the stderr handle
+        systemFile.m_closeOnDestruction = false;
+        return systemFile;
+    }
+} // namespace AZ::IO
+
+namespace AZ::IO::Platform
 {
     using FileHandleType = AZ::IO::SystemFile::FileHandleType;
 
@@ -477,8 +509,6 @@ namespace Platform
 
         return false;
     }
-
-}
 } // namespace AZ::IO
 
 namespace AZ::IO::PosixInternal

--- a/Code/Framework/AzCore/Tests/Platform/Android/Tests/IO/SystemFileTest_Android.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Android/Tests/IO/SystemFileTest_Android.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/Utils.h>
+
+namespace UnitTest
+{
+    class SystemFilePlatformFixture
+        : public LeakDetectionFixture
+    {
+    protected:
+        AZ::Test::ScopedAutoTempDirectory m_tempDirectory;
+    };
+
+    TEST_F(SystemFilePlatformFixture, SkipCloseOnDestructionMode_DoesNotCloseOpenHandle_Succeeds)
+    {
+        constexpr AZStd::string_view testData{ "Testing 1 2 3\n"};
+        auto testFileName = m_tempDirectory.GetDirectoryAsFixedMaxPath() / "TestFile.txt";
+        {
+            // Seed the test file with data
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            testFile.Write(testData.data(), testData.size());
+        }
+
+        AZ::IO::SystemFile::FileHandleType fileHandle;
+        {
+            // Open the test file in read mode and retrieve the file handle
+            // The skip close on destruction option should skip closing the file
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_READ_ONLY | AZ::IO::SystemFile::SF_SKIP_CLOSE_ON_DESTRUCTION);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            fileHandle = testFile.NativeHandle();
+        }
+
+        // Use the PosixInternal::Read function to read from from the open descriptor
+        AZStd::string readData;
+        auto ReadFromFile = [fileHandle](char* buffer, size_t capacity) -> size_t
+        {
+            return fread(buffer, 1, capacity, fileHandle);
+        };
+        // Make sure the capacity can fit all the data written to the test file
+        readData.resize_and_overwrite(testData.size(), AZStd::move(ReadFromFile));
+
+        // Close the file descriptor
+        fclose(fileHandle);
+
+        EXPECT_EQ(testData, readData);
+    }
+}   // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Tests/Platform/Android/platform_android_files.cmake
@@ -8,6 +8,7 @@
 
 set(FILES
     ../Common/UnixLike/Tests/Process/ProcessInfoTests_UnixLike.cpp
+    Tests/IO/SystemFileTest_Android.cpp
     Tests/UtilsTests_Android.cpp
     Tests/Memory/AllocatorBenchmarks_Android.cpp
 )

--- a/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/Utils.h>
+
+namespace UnitTest
+{
+    class SystemFilePlatformFixture
+        : public LeakDetectionFixture
+    {
+    protected:
+        AZ::Test::ScopedAutoTempDirectory m_tempDirectory;
+    };
+
+    TEST_F(SystemFilePlatformFixture, SkipCloseOnDestructionMode_DoesNotCloseOpenHandle_Succeeds)
+    {
+        constexpr AZStd::string_view testData{ "Testing 1 2 3\n"};
+        auto testFileName = m_tempDirectory.GetDirectoryAsFixedMaxPath() / "TestFile.txt";
+        {
+            // Seed the test file with data
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            testFile.Write(testData.data(), testData.size());
+        }
+
+        AZ::IO::SystemFile::FileHandleType fileHandle;
+        {
+            // Open the test file in read mode and retrieve the file handle
+            // The skip close on destruction option should skip closing the file
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_READ_ONLY | AZ::IO::SystemFile::SF_SKIP_CLOSE_ON_DESTRUCTION);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            fileHandle = testFile.NativeHandle();
+        }
+
+        // Use the PosixInternal::Read function to read from from the open descriptor
+        AZStd::string readData;
+        auto ReadFromFile = [fileHandle](char* buffer, size_t capacity) -> size_t
+        {
+            return AZ::IO::PosixInternal::Read(fileHandle, buffer, capacity);
+        };
+        // Make sure the capacity can fit all the data written to the test file
+        readData.resize_and_overwrite(testData.size(), AZStd::move(ReadFromFile));
+
+        // Close the file descriptor
+        AZ::IO::PosixInternal::Close(fileHandle);
+
+        EXPECT_EQ(testData, readData);
+    }
+}   // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/IO/SystemFileTest_WinAPI.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/IO/SystemFileTest_WinAPI.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/PlatformIncl.h>
+
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/Utils.h>
+
+namespace UnitTest
+{
+    class SystemFilePlatformFixture
+        : public LeakDetectionFixture
+    {
+    protected:
+        AZ::Test::ScopedAutoTempDirectory m_tempDirectory;
+    };
+
+    TEST_F(SystemFilePlatformFixture, SkipCloseOnDestructionMode_DoesNotCloseOpenHandle_Succeeds)
+    {
+        constexpr AZStd::string_view testData{ "Testing 1 2 3\n"};
+        auto testFileName = m_tempDirectory.GetDirectoryAsFixedMaxPath() / "TestFile.txt";
+        {
+            // Seed the test file with data
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            testFile.Write(testData.data(), testData.size());
+        }
+
+        AZ::IO::SystemFile::FileHandleType fileHandle;
+        {
+            // Open the test file in read mode and retrieve the file handle
+            // The skip close on destruction option should skip closing the file
+            AZ::IO::SystemFile testFile(testFileName.c_str(),
+                AZ::IO::SystemFile::SF_OPEN_READ_ONLY | AZ::IO::SystemFile::SF_SKIP_CLOSE_ON_DESTRUCTION);
+            ASSERT_TRUE(testFile.IsOpen());
+
+            fileHandle = testFile.NativeHandle();
+        }
+
+        // Use the PosixInternal::Read function to read from from the open descriptor
+        AZStd::string readData;
+        auto ReadFromFile = [fileHandle](char* buffer, size_t capacity) -> DWORD
+        {
+            DWORD numBytesRead{};
+            if (!ReadFile(fileHandle, buffer, static_cast<DWORD>(capacity), &numBytesRead, nullptr))
+            {
+                return 0;
+            }
+            return numBytesRead;
+        };
+        // Make sure the capacity can fit all the data written to the test file
+        readData.resize_and_overwrite(testData.size(), AZStd::move(ReadFromFile));
+
+        // Close the file handle
+        CloseHandle(fileHandle);
+
+        EXPECT_EQ(testData, readData);
+    }
+}   // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzCore/Tests/Platform/Linux/platform_linux_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    ../Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
     ../Common/UnixLike/Tests/Process/ProcessInfoTests_UnixLike.cpp
     Tests/UtilsTests_Linux.cpp
     ../Common/UnixLike/Tests/UtilsTests_UnixLike.cpp

--- a/Code/Framework/AzCore/Tests/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzCore/Tests/Platform/Mac/platform_mac_files.cmake
@@ -9,6 +9,7 @@
 set(FILES
     ../Common/Apple/Tests/Process/ProcessInfoTests_Apple.cpp
     ../Common/Apple/Tests/UtilsTests_Apple.cpp
+    ../Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
     ../Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
     ../Common/Apple/Tests/Memory/AllocatorBenchmarks_Apple.cpp
 )

--- a/Code/Framework/AzCore/Tests/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/platform_windows_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    ../Common/WinAPI/Tests/IO/SystemFileTest_WinAPI.cpp
     ../Common/WinAPI/Tests/Process/ProcessInfoTests_WinAPI.cpp
     ../Common/WinAPI/Tests/UtilsTests_WinAPI.cpp
     Tests/IO/Streamer/StorageDriveTests_Windows.cpp

--- a/Code/Framework/AzCore/Tests/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzCore/Tests/Platform/iOS/platform_ios_files.cmake
@@ -9,6 +9,7 @@
 set(FILES
     ../Common/Apple/Tests/Process/ProcessInfoTests_Apple.cpp
     ../Common/Apple/Tests/UtilsTests_Apple.cpp
+    ../Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
     ../Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
     ../Common/Apple/Tests/Memory/AllocatorBenchmarks_Apple.cpp
 )

--- a/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
@@ -426,6 +426,27 @@ namespace UnitTest
         EXPECT_STREQ("2", commandLine.GetSwitchValue("foo").c_str());
         EXPECT_STREQ("2", commandLine.GetSwitchValue("foo", 1).c_str());
         EXPECT_STREQ("1", commandLine.GetSwitchValue("foo", 0).c_str());
+    }
 
+    TEST_F(CommandLineTests, ArgumentsParsed_AfterDoubleDash_ArePositionalArgumentsOnly)
+    {
+        AZ::CommandLine commandLine{ "-" };
+
+        constexpr AZStd::string_view argValues[] =
+        {
+            "programname.exe", "--foo=1", "--", "--foo=2", "bar", "--", "baz"
+        };
+
+        commandLine.Parse(argValues);
+
+        EXPECT_EQ(commandLine.GetNumSwitchValues("foo"), 1);
+        EXPECT_EQ("1", commandLine.GetSwitchValue("foo"));
+        ASSERT_EQ(5, commandLine.GetNumMiscValues());
+        // The first Misc entry is the executable name "programname.exe"
+        // ignore checking that entry since it is not relevant to this test
+        EXPECT_EQ("--foo=2",commandLine.GetMiscValue(1));
+        EXPECT_EQ("bar", commandLine.GetMiscValue(2));
+        EXPECT_EQ("--", commandLine.GetMiscValue(3));
+        EXPECT_EQ("baz", commandLine.GetMiscValue(4));
     }
 }   // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Settings/TextParserTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/TextParserTests.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/Settings/TextParser.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/containers/fixed_unordered_map.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace UnitTest
+{
+    struct TextFileParams
+    {
+        AZStd::string_view m_testTextFileName;
+        AZStd::string_view m_testTextContents;
+        // The following test below will not have more than 20
+        AZStd::fixed_vector<AZStd::string_view, 20> m_expectedLines;
+    };
+
+    class TextParserTestFixture
+        : public LeakDetectionFixture
+    {
+    protected:
+        AZStd::string m_textBuffer;
+        AZ::IO::ByteContainerStream<AZStd::string> m_textStream{ &m_textBuffer };
+    };
+
+    // Parameterized test fixture for the TextFileParams
+    class TextParserParamFixture
+        : public TextParserTestFixture
+        , public ::testing::WithParamInterface<TextFileParams>
+    {
+        void SetUp() override
+        {
+            auto textFileParam = GetParam();
+
+            // Create the test text stream
+            m_textStream.Write(textFileParam.m_testTextContents.size(),
+                textFileParam.m_testTextContents.data());
+            // Seek back to the beginning of the stream for test to read written data
+            m_textStream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
+        }
+    };
+
+    TEST_F(TextParserTestFixture, ParseTextFile_WithEmptyFunction_Fails)
+    {
+        AZ::Settings::TextParserSettings parserSettings{ AZ::Settings::TextParserSettings::ParseTextEntryFunc{} };
+
+        m_textBuffer = R"(project_path=/TestProject
+            engine_path=/TestEngine
+        )";
+        EXPECT_FALSE(AZ::Settings::ParseTextFile(m_textStream, parserSettings));
+    }
+
+    TEST_F(TextParserTestFixture, ParseTextFile_WithParseTextEntryFunctionWhichAlwaysReturnsFalse_Fails)
+    {
+        auto parseTextEntry = [](AZStd::string_view)
+        {
+            return false;
+        };
+
+        AZ::Settings::TextParserSettings parserSettings{ parseTextEntry };
+
+        m_textBuffer = R"(project_path=/TestProject
+            engine_path=/TestEngine
+        )";
+        EXPECT_FALSE(AZ::Settings::ParseTextFile(m_textStream, parserSettings));
+
+    }
+
+    TEST_F(TextParserTestFixture, ParseTextFile_WithLineLargerThan4096_Fails)
+    {
+        auto parseTextEntry = [](AZStd::string_view)
+        {
+            return true;
+        };
+
+        AZ::Settings::TextParserSettings parserSettings{ parseTextEntry };
+
+        m_textBuffer = "project_path=/TestProject\n";
+
+        // append a line longer than 4096 characters
+        m_textBuffer += "foo=";
+        m_textBuffer.append(4096, 'a');
+        m_textBuffer += '\n';
+
+        EXPECT_FALSE(AZ::Settings::ParseTextFile(m_textStream, parserSettings));
+    }
+
+    TEST_F(TextParserTestFixture, ParseTextFile_WithAllLinesSmallerThan4097_Succeeds)
+    {
+        auto parseTextEntry = [](AZStd::string_view)
+        {
+            return true;
+        };
+
+        AZ::Settings::TextParserSettings parserSettings{ parseTextEntry };
+
+        m_textBuffer = "project_path=/TestProject\n";
+
+        // append only 4000 characters
+        m_textBuffer += "foo=";
+        m_textBuffer.append(4000, 'a');
+        m_textBuffer += '\n';
+
+        EXPECT_TRUE(AZ::Settings::ParseTextFile(m_textStream, parserSettings));
+    }
+
+    TEST_P(TextParserParamFixture, ParseTextFile_ParseContents_Successfully)
+    {
+        auto textFileParam = GetParam();
+
+        // Parse Text File and write output to a vector for testing
+        using ParseSettingsVector = AZStd::fixed_vector<AZStd::string_view, 20>;
+        ParseSettingsVector parseSettingsVector;
+        auto parseTextEntry = [&parseSettingsVector](AZStd::string_view textEntry)
+        {
+            parseSettingsVector.emplace_back(textEntry);
+            return true;
+        };
+
+        AZ::Settings::TextParserSettings parserSettings{ parseTextEntry };
+
+
+        auto parseOutcome = AZ::Settings::ParseTextFile(m_textStream, parserSettings);
+        EXPECT_TRUE(parseOutcome);
+
+        // Validate that parse lines matches the expected lines
+        EXPECT_THAT(parseSettingsVector, ::testing::ContainerEq(textFileParam.m_expectedLines));
+    }
+
+INSTANTIATE_TEST_CASE_P(
+    ReadTextFile,
+    TextParserParamFixture,
+    ::testing::Values(
+        // Processes a fake text file
+        // and properly terminates the file with a newline
+        TextFileParams{ "fake_uuid.text", R"(
+engine.json
+project.json
+levels/defaultlevel.prefab
+
+)"
+        , AZStd::fixed_vector<AZStd::string_view, 20>{
+            AZStd::string_view{ "engine.json" },
+            AZStd::string_view{ "project.json" },
+            AZStd::string_view{ "levels/defaultlevel.prefab" }
+        }},
+        // Parses a fake text file
+        // and does not end with a newline
+        TextFileParams{ "fake_names.text", R"(
+shader
+material
+document property editor)"
+        , AZStd::fixed_vector<AZStd::string_view, 20>{
+            AZStd::string_view{ "shader" },
+            AZStd::string_view{ "material" },
+            AZStd::string_view{ "document property editor" }
+        }}
+        )
+    );
+
+
+}

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -235,6 +235,7 @@ set(FILES
     Settings/SettingsRegistryOriginTrackerTests.cpp
     Settings/SettingsRegistryScriptUtilsTests.cpp
     Settings/SettingsRegistryVisitorUtilsTests.cpp
+    Settings/TextParserTests.cpp
     Slice.cpp
     State.cpp
     Statistics.cpp

--- a/Code/Tools/SerializeContextTools/Dumper.cpp
+++ b/Code/Tools/SerializeContextTools/Dumper.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSerializationSettings.h>
+#include <AzCore/Settings/TextParser.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/sort.h>
@@ -277,28 +278,32 @@ namespace AZ::SerializeContextTools
         // If the output-file parameter has been supplied open the file path using FileIOStream
         if (size_t optionCount = commandLine.GetNumSwitchValues("output-file"); optionCount > 0)
         {
-            AZ::IO::FixedMaxPath outputPath;
-            if (AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
-                outputPathView.IsRelative())
+            AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
+            // If the output file name is a single dash, use the default output stream value which writes to stdout
+            if (outputPathView != "-")
             {
-                AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
-            }
-            else
-            {
-                outputPath = outputPathView.LexicallyNormal();
-            }
+                AZ::IO::FixedMaxPath outputPath;
+                if (outputPathView.IsRelative())
+                {
+                    AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
+                }
+                else
+                {
+                    outputPath = outputPathView.LexicallyNormal();
+                }
 
-            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+                constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
 
-            if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
-                !fileStream.IsOpen())
-            {
-                AZ_Printf(
-                    "dumptypes",
-                    R"(Unable to open specified output-file "%s". Object will not be dumped)"
-                    "\n",
-                    outputPath.c_str());
-                return false;
+                if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
+                    !fileStream.IsOpen())
+                {
+                    AZ_Printf(
+                        "dumptypes",
+                        R"(Unable to open specified output-file "%s". Object will not be dumped)"
+                        "\n",
+                        outputPath.c_str());
+                    return false;
+                }
             }
         }
 
@@ -447,28 +452,32 @@ namespace AZ::SerializeContextTools
         // If the output-file parameter has been supplied open the file path using FileIOStream
         if (size_t optionCount = commandLine.GetNumSwitchValues("output-file"); optionCount > 0)
         {
-            AZ::IO::FixedMaxPath outputPath;
-            if (AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
-                outputPathView.IsRelative())
+            AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
+            // If the output file name is a single dash, use the default output stream value which writes to stdout
+            if (outputPathView != "-")
             {
-                AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
-            }
-            else
-            {
-                outputPath = outputPathView.LexicallyNormal();
-            }
+                AZ::IO::FixedMaxPath outputPath;
+                if (outputPathView.IsRelative())
+                {
+                    AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
+                }
+                else
+                {
+                    outputPath = outputPathView.LexicallyNormal();
+                }
 
-            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+                constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
 
-            if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
-                !fileStream.IsOpen())
-            {
-                AZ_Printf(
-                    "createtype",
-                    R"(Unable to open specified output-file "%s". Object will not be dumped)"
-                    "\n",
-                    outputPath.c_str());
-                return false;
+                if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
+                    !fileStream.IsOpen())
+                {
+                    AZ_Printf(
+                        "createtype",
+                        R"(Unable to open specified output-file "%s". Object will not be dumped)"
+                        "\n",
+                        outputPath.c_str());
+                    return false;
+                }
             }
         }
 
@@ -606,35 +615,40 @@ namespace AZ::SerializeContextTools
         // If the output-file parameter has been supplied open the file path using FileIOStream
         if (size_t optionCount = commandLine.GetNumSwitchValues("output-file"); optionCount > 0)
         {
-            AZ::IO::FixedMaxPath outputPath;
-            if (AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
-                outputPathView.IsRelative())
+            AZ::IO::PathView outputPathView(commandLine.GetSwitchValue("output-file", optionCount - 1));
+            // If the output file name is a single dash, use the default output stream value which writes to stdout
+            if (outputPathView != "-")
             {
-                AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
-            }
-            else
-            {
-                outputPath = outputPathView.LexicallyNormal();
-            }
+                AZ::IO::FixedMaxPath outputPath;
+                if (outputPathView.IsRelative())
+                {
+                    AZ::Utils::ConvertToAbsolutePath(outputPath, outputPathView.Native());
+                }
+                else
+                {
+                    outputPath = outputPathView.LexicallyNormal();
+                }
 
-            constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
+                constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath;
 
-            if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
-                !fileStream.IsOpen())
-            {
-                AZ_Printf(
-                    "createuuid",
-                    R"(Unable to open specified output-file "%s". Uuid will not be output to stream)"
-                    "\n",
-                    outputPath.c_str());
-                return false;
+                if (auto& fileStream = outputStream.emplace<AZ::IO::SystemFileStream>(outputPath.c_str(), openMode);
+                    !fileStream.IsOpen())
+                {
+                    AZ_Printf(
+                        "createuuid",
+                        R"(Unable to open specified output-file "%s". Uuid will not be output to stream)"
+                        "\n",
+                        outputPath.c_str());
+                    return false;
+                }
             }
         }
 
         size_t valuesOptionCount = commandLine.GetNumSwitchValues("values");
-        if (valuesOptionCount == 0)
+        size_t valuesFileOptionCount = commandLine.GetNumSwitchValues("values-file");
+        if (valuesOptionCount == 0 && valuesFileOptionCount == 0)
         {
-            AZ_Error("createuuid", false, "The following options must be supplied: --values ");
+            AZ_Error("createuuid", false, "One of following options must be supplied: --values or --values-file");
             return false;
         }
 
@@ -655,23 +669,69 @@ namespace AZ::SerializeContextTools
         const bool quietOutput = commandLine.HasSwitch("q") || commandLine.HasSwitch("quiet");
 
         bool result = true;
+
+        struct UuidStringPair
+        {
+            AZ::Uuid m_uuid;
+            AZStd::string m_value;
+        };
+        AZStd::vector<UuidStringPair> uuidsToWrite;
         for (size_t i = 0; i < valuesOptionCount; ++i)
         {
             AZStd::string value = commandLine.GetSwitchValue("values", i);
             auto uuidFromName = AZ::Uuid::CreateName(value);
+            uuidsToWrite.push_back({ AZStd::move(uuidFromName), AZStd::move(value) });
+        }
 
-            auto VisitStream = [&uuidFromName, &value, withCurlyBraces, withDashes, quietOutput](auto&& stream) -> bool
+        // Read string values from each --values-file argument
+        for (size_t i = 0; i < valuesFileOptionCount; ++i)
+        {
+            AZ::IO::FixedMaxPath inputValuePath(AZ::IO::PathView(commandLine.GetSwitchValue("values-file", i)));
+            AZ::IO::SystemFileStream valuesFileStream;
+            if (inputValuePath == "-")
+            {
+                // If the input file is dash read from stdin
+                valuesFileStream = AZ::IO::SystemFileStream(AZ::IO::SystemFile::GetStdin());
+            }
+            else
+            {
+                // Open the path from the values-file option
+                constexpr AZ::IO::OpenMode openMode = AZ::IO::OpenMode::ModeRead;
+                valuesFileStream.Open(inputValuePath.c_str(), openMode);
+            }
+
+            if (valuesFileStream.IsOpen())
+            {
+                // Use the text parser to parse plain text lines
+                AZ::Settings::TextParserSettings textParserSettings;
+                textParserSettings.m_parseTextEntryFunc = [&uuidsToWrite](AZStd::string_view token)
+                {
+                    // Remove leading and surrounding spaces and carriage returns
+                    token = AZ::StringFunc::StripEnds(token, " \r");
+                    auto uuidFromName = AZ::Uuid::CreateName(token);
+                    uuidsToWrite.push_back({ AZStd::move(uuidFromName), token });
+                    return true;
+                };
+
+                AZ::Settings::ParseTextFile(valuesFileStream, textParserSettings);
+            }
+        }
+
+        for (const UuidStringPair& uuidStringPair : uuidsToWrite)
+        {
+            auto VisitStream = [&uuidToWrite = uuidStringPair.m_uuid, &value = uuidStringPair.m_value,
+                withCurlyBraces, withDashes, quietOutput](auto&& stream) -> bool
             {
                 AZStd::fixed_string<256> uuidString;
                 if (quietOutput)
                 {
                     uuidString = AZStd::fixed_string<256>::format("%s\n",
-                        uuidFromName.ToFixedString(withCurlyBraces, withDashes).c_str());
+                        uuidToWrite.ToFixedString(withCurlyBraces, withDashes).c_str());
                 }
                 else
                 {
                     uuidString = AZStd::fixed_string<256>::format(R"(%s %s)" "\n",
-                        uuidFromName.ToFixedString(withCurlyBraces, withDashes).c_str(),
+                        uuidToWrite.ToFixedString(withCurlyBraces, withDashes).c_str(),
                         value.c_str());
                 }
 

--- a/Code/Tools/SerializeContextTools/Runner.cpp
+++ b/Code/Tools/SerializeContextTools/Runner.cpp
@@ -99,8 +99,11 @@ namespace SerializeContextTools
         AZ_Printf("Help", R"(        Ex. --values "engine.json" --values "project.json")" "\n");
         AZ_Printf("Help", R"(        Ex. --values engine.json,project.json)" "\n");
         AZ_Printf("Help", R"(        Ex. --values engine.json,project.json --values gem.json)" "\n");
+        AZ_Printf("Help", "    [opt] --values-file=<filepath>: Path to file containing linefeed delimited strings to convert to UUD.\n");
+        AZ_Printf("Help", "          specifying an argument of dash '-' reads input from stdin\n");
         AZ_Printf("Help", "    [opt] --output-file=<filepath>: Path to the file to output constructed uuids.\n");
         AZ_Printf("Help", "          If not supplied, output is written to stdout.\n");
+        AZ_Printf("Help", "          specifying an argument of dash '-' writes output to stdout\n");
         AZ_Printf("Help", "    [opt] --with-curly-braces=<true|false> Outputs the Uuid with curly braces. Defaults to true\n");
         AZ_Printf("Help", "         Ex. when true = {0123456789abcdef0123456789abcdef}\n");
         AZ_Printf("Help", "         Ex. when false = 0123456789abcdef0123456789abcdef\n");


### PR DESCRIPTION
### SerializeContextTools changes
Updated the createuuid options

Support has been added for a `--values-file` option which allows
specifying a text file which contains lines which should be converted to
Uuids using the SHA1 hash algorithm

With the support, was also added the ability to specify stdin as an
input file to the `--values-file` option using the `-` value.

The `--output-file` option for the createuuid, dumptypes, createtype
also supports using the value `-` to specify stdout as output file to
open

### SystemFile changes
Adding support for SystemFile API to support wraping Std handles

The `stdin`, `stdout` and `stderr` file handles are wrapped by static
functions on the SystemFile class that allows using the SystemFile class
to read from stdin or write to stdout/stderr using its API.

The Std handles are setup to not close on destruction of the SystemFile
class by default.

So it is safe to store these SystemFiles instances by value.

Finally a "skip close on destruction" flag has been added to the SystemFile open
mode flags to allow an open SystemFile to skip closing an open file
handle in the SystemFile destructor.

### Command Line parsing changes
Add support to CommandLine parsing to support the -- argument

The psuedo argument of `--` is used by the AZ::CommandLine parser to
force any arguments that come afterwards to be parsed as positional
arguments only

### Text Parser addition

Add TextParser class that can parse "line" delimited text entries

The TextParser supports AZ::IO::GenericStream classes and works
similarly to the AzFramework FileFunc ReadTextFile function.

However the TextParser supports additional configuration operations such
as changing the "text entry" delimiter, which is useful for NUL '\0'
delimited content as well as an option to skip over empty text entries.

The TextParser is being used by the SerializeContext `createuuid` command to read the list of line delimited string values from input files provided by the user using the code in [Dumper.cpp](https://github.com/o3de/o3de/blob/c4caf6717795c72595b196adcedc68e80abf1285/Code/Tools/SerializeContextTools/Dumper.cpp#L686-L718)

## How was this PR tested?

Added new UnitTest for the TextParser, CommandLine and SystemFile changes

Verified the SerializeContextTools `--values-file` option using a input file that progressive grew in content.
The first iteration of the `input.txt` file was empty.

input.txt - First iteration
---
```
```


input.txt - Second iteration
---
```
engine.json
```

input.txt - Third iteration(only difference is newline at the end of the file
---
```
engine.json

```

input.txt - Fourth iteration
---
```
engine.json
project.json
```

```PS
C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json
{B076CDDC-14DF-50F4-A5E9-7518ABB3E851} project.json

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt --output-file=-
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json
{B076CDDC-14DF-50F4-A5E9-7518ABB3E851} project.json

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=../input.txt --output-file=../output.txt

C:\code\o3de>build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-

C:\code\o3de>echo "engine.json" | build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-
{3506B64A-308F-5661-9BB5-E9E8EAC2F41E} "engine.json"

C:\code\o3de>echo engine.json | build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json

C:\code\o3de>printf "engine.json\nproject.json" | build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-

C:\code\o3de>printf "engine.json\nproject.json" | build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json
{B076CDDC-14DF-50F4-A5E9-7518ABB3E851} project.json

C:\code\o3de>printf "engine.json\nproject.json\n" | build\windows\bin\debug\SerializeContextTools.exe createuuid --values-file=-
{3B28A661-E723-5EBE-AB52-EC5829D88C31} engine.json
{B076CDDC-14DF-50F4-A5E9-7518ABB3E851} project.json
```
