### PR TITLE
Save DPE inspector settings before loading

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1386,6 +1386,10 @@ namespace AzToolsFramework
     {
         // We need to append some alphabetical characters to the key or it will be treated as a very large json array index
         AZStd::string_view keyStr = AZStd::string::format("uuid%s", AZStd::to_string(key).c_str());
+        // Free the settings ptr before creating a new one. If the registry key is the same, we want
+        // the in-memory settings to be saved to disk (in settings destructor) before they're loaded
+        // from disk (in settings constructor)
+        m_dpeSettings.reset();
         m_dpeSettings = AZStd::make_unique<DocumentPropertyEditorSettings>(keyStr, propertyEditorName);
 
         if (m_dpeSettings && m_dpeSettings->WereSettingsLoaded())


### PR DESCRIPTION
## What does this PR do?

The DPE settings are loaded and saved during construction/destruction. This PR makes sure that settings are saved to disk before they're loaded from disk again.

## How was this PR tested?

Testing in Editor.