### PR TITLE
Action Manager | Fix assigning widgets to action contexts at startup

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.cpp
@@ -131,6 +131,8 @@ namespace AzToolsFramework
             m_hotKeyManager = AZStd::make_unique<HotKeyManager>();
             m_menuManager = AZStd::make_unique<MenuManager>(m_defaultParentObject);
             m_toolBarManager = AZStd::make_unique<ToolBarManager>(m_defaultParentObject);
+
+            m_hotKeyWidgetRegistrationHelper = AZStd::make_unique<HotKeyWidgetRegistrationHelper>();
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/ActionManagerSystemComponent.h
@@ -14,6 +14,7 @@
 
 #include <AzToolsFramework/ActionManager/Action/ActionManager.h>
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManager.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManager.h>
 #include <AzToolsFramework/ActionManager/ToolBar/ToolBarManager.h>
 
@@ -46,6 +47,8 @@ namespace AzToolsFramework
         AZStd::unique_ptr<HotKeyManager> m_hotKeyManager = nullptr;
         AZStd::unique_ptr<MenuManager> m_menuManager = nullptr;
         AZStd::unique_ptr<ToolBarManager> m_toolBarManager = nullptr;
+
+        AZStd::unique_ptr<HotKeyWidgetRegistrationHelper> m_hotKeyWidgetRegistrationHelper = nullptr;
 
         QWidget* m_defaultParentObject = nullptr;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.cpp
@@ -14,6 +14,12 @@
 
 namespace AzToolsFramework
 {
+    struct HotKeyWidgetRegistrationHelper::HotKeyActionContextPair
+    {
+        AZStd::string actionContextIdentifier;
+        QWidget* widget;
+    };
+
     HotKeyWidgetRegistrationHelper::HotKeyWidgetRegistrationHelper()
     {
         m_hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get();
@@ -36,15 +42,13 @@ namespace AzToolsFramework
         if (m_isRegistrationCompleted)
         {
             // If the registration hooks were already run, just proceed with the call directly.
-            auto outcome = m_hotKeyManagerInterface->AssignWidgetToActionContext(actionContextIdentifier, widget);
-            if (outcome.IsSuccess())
-            {
-                return;
-            }
+            m_hotKeyManagerInterface->AssignWidgetToActionContext(actionContextIdentifier, widget);
         }
-
-        // If we're before the registration has been completed, or the assignment failed, store the data and do it later.
-        m_widgetContextQueue.push_back({ actionContextIdentifier, widget });
+        else
+        {
+            // If we're before the registration has been completed, store the data and call the API later.
+            m_widgetContextQueue.push_back({ actionContextIdentifier, widget });
+        }
     }
 
     void HotKeyWidgetRegistrationHelper::OnPostActionManagerRegistrationHook()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h>
+
+#include <AzCore/Interface/Interface.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h>
+
+namespace AzToolsFramework
+{
+    HotKeyWidgetRegistrationHelper::HotKeyWidgetRegistrationHelper()
+    {
+        m_hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get();
+        AZ_Assert(
+            m_hotKeyManagerInterface, "HotKeyWidgetRegistrationHelper - could not get HotKeyManagerInterface on HotKeyWidgetRegistrationHelper construction.");
+
+        ActionManagerRegistrationNotificationBus::Handler::BusConnect();
+        AZ::Interface<HotKeyWidgetRegistrationInterface>::Register(this);
+    }
+
+    HotKeyWidgetRegistrationHelper::~HotKeyWidgetRegistrationHelper()
+    {
+        AZ::Interface<HotKeyWidgetRegistrationInterface>::Unregister(this);
+        ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
+    }
+
+    void HotKeyWidgetRegistrationHelper::AssignWidgetToActionContext(
+        const AZStd::string& actionContextIdentifier, QWidget* widget)
+    {
+        if (m_isRegistrationCompleted)
+        {
+            // If the registration hooks were already run, just proceed with the call directly.
+            auto outcome = m_hotKeyManagerInterface->AssignWidgetToActionContext(actionContextIdentifier, widget);
+            if (outcome.IsSuccess())
+            {
+                return;
+            }
+        }
+
+        // If we're before the registration has been completed, or the assignment failed, store the data and do it later.
+        m_widgetContextQueue.push_back({ actionContextIdentifier, widget });
+    }
+
+    void HotKeyWidgetRegistrationHelper::OnPostActionManagerRegistrationHook()
+    {
+        for (auto request : m_widgetContextQueue)
+        {
+            m_hotKeyManagerInterface->AssignWidgetToActionContext(request.actionContextIdentifier, request.widget);
+        }
+
+        m_widgetContextQueue.clear();
+        m_isRegistrationCompleted = true;
+    }
+
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h
@@ -38,11 +38,7 @@ namespace AzToolsFramework
 
         bool m_isRegistrationCompleted = false;
 
-        struct HotKeyActionContextPair
-        {
-            AZStd::string actionContextIdentifier;
-            QWidget* widget;
-        };
+        struct HotKeyActionContextPair;
         AZStd::vector<HotKeyActionContextPair> m_widgetContextQueue;
 
         HotKeyManagerInterface* m_hotKeyManagerInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+#include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h>
+
+class QWidget;
+
+namespace AzToolsFramework
+{
+    class HotKeyManagerInterface;
+    class HotKeyWidgetRegistrationInterface;
+
+    class HotKeyWidgetRegistrationHelper final
+        : private ActionManagerRegistrationNotificationBus::Handler
+        , public HotKeyWidgetRegistrationInterface
+    {
+    public:
+        HotKeyWidgetRegistrationHelper();
+        virtual ~HotKeyWidgetRegistrationHelper();
+
+        // HotKeyWidgetRegistrationInterface overrides ...
+        void AssignWidgetToActionContext(const AZStd::string& actionContextIdentifier, QWidget* widget) override;
+
+    private:
+        // ActionManagerRegistrationNotificationBus overrides ...
+        void OnPostActionManagerRegistrationHook() override;
+
+        bool m_isRegistrationCompleted = false;
+
+        struct HotKeyActionContextPair
+        {
+            AZStd::string actionContextIdentifier;
+            QWidget* widget;
+        };
+        AZStd::vector<HotKeyActionContextPair> m_widgetContextQueue;
+
+        HotKeyManagerInterface* m_hotKeyManagerInterface = nullptr;
+    };
+
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/TypeInfoSimple.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/std/string/string.h>
+
+class QWidget;
+
+namespace AzToolsFramework
+{
+    //! HotKeyWidgetRegistrationInterface
+    //! Interface to manage hotkeys in the Editor.
+    class HotKeyWidgetRegistrationInterface
+    {
+    public:
+        AZ_RTTI(HotKeyWidgetRegistrationInterface, "{B9197853-9655-4B72-885C-F02B9B63164F}");
+
+        //! Tries assigning a widget to an Action Context.
+        //! If the system has not yet been initialized, the system will store the arguments and assign the widgets
+        //! after the registration hooks have been called.
+        //! @param contextIdentifier The identifier of the action context to assign the widget to.
+        //! @param widget The widget to assign to the action context.
+        virtual void AssignWidgetToActionContext(const AZStd::string& actionContextIdentifier, QWidget* widget) = 0;
+    };
+
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -105,15 +105,6 @@ namespace AzToolsFramework
 
             connect(m_thumbnailViewWidget, &AzQtComponents::AssetFolderThumbnailView::afterRename, this, &AssetBrowserThumbnailView::AfterRename);
 
-              if (AzToolsFramework::IsNewActionManagerEnabled())
-              {
-                  if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-                  {
-                      // Assign this widget to the Editor Asset Browser Action Context.
-                      hotKeyManagerInterface->AssignWidgetToActionContext(
-                          EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
-                  }
-              }
 
               QAction* deleteAction = new QAction("Delete Action", this);
               deleteAction->setShortcut(QKeySequence::Delete);
@@ -164,17 +155,18 @@ namespace AzToolsFramework
             auto layout = new QVBoxLayout();
             layout->addWidget(m_thumbnailViewWidget);
             setLayout(layout);
+
+            if (AzToolsFramework::IsNewActionManagerEnabled())
+            {
+                AssignWidgetToActionContextHelper(EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
+            }
         }
 
         AssetBrowserThumbnailView::~AssetBrowserThumbnailView()
         {
             if (AzToolsFramework::IsNewActionManagerEnabled())
             {
-                  if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-                  {
-                      hotKeyManagerInterface->RemoveWidgetFromActionContext(
-                          EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
-                  }
+                RemoveWidgetFromActionContextHelper(EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -89,12 +89,8 @@ namespace AzToolsFramework
 
             if (AzToolsFramework::IsNewActionManagerEnabled())
             {
-                if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-                {
-                    // Assign this widget to the Editor Asset Browser Action Context.
-                    hotKeyManagerInterface->AssignWidgetToActionContext(
-                        EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
-                }
+                // Assign this widget to the Editor Asset Browser Action Context.
+                AzToolsFramework::AssignWidgetToActionContextHelper(EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
             }
 
             QAction* deleteAction = new QAction("Delete Action", this);
@@ -132,11 +128,7 @@ namespace AzToolsFramework
         {
             if (AzToolsFramework::IsNewActionManagerEnabled())
             {
-                if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-                {
-                    hotKeyManagerInterface->RemoveWidgetFromActionContext(
-                        EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
-                }
+                AzToolsFramework::RemoveWidgetFromActionContextHelper(EditorIdentifiers::EditorAssetBrowserActionContextIdentifier, this);
             }
 
             AssetBrowserViewRequestBus::Handler::BusDisconnect();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerUtils.cpp
@@ -9,6 +9,10 @@
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
 
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h>
+
+#include <QWidget>
 
 namespace AzToolsFramework
 {
@@ -25,6 +29,22 @@ namespace AzToolsFramework
         }
 
         return isNewActionManagerEnabled;
+    }
+
+    void AssignWidgetToActionContextHelper(const AZStd::string& actionContextIdentifier, QWidget* widget)
+    {
+        if (auto hotKeyWidgetRegistrationInterface = AZ::Interface<HotKeyWidgetRegistrationInterface>::Get())
+        {
+            hotKeyWidgetRegistrationInterface->AssignWidgetToActionContext(actionContextIdentifier, widget);
+        }
+    }
+
+    void RemoveWidgetFromActionContextHelper(const AZStd::string& actionContextIdentifier, QWidget* widget)
+    {
+        if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
+        {
+            hotKeyManagerInterface->RemoveWidgetFromActionContext(actionContextIdentifier, widget);
+        }
     }
 
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerUtils.h
@@ -8,8 +8,15 @@
 
 #pragma once
 
+#include <AzCore/std/string/string.h>
+
+class QWidget;
+
 namespace AzToolsFramework
 {
     bool IsNewActionManagerEnabled();
+
+    void AssignWidgetToActionContextHelper(const AZStd::string& actionContextIdentifier, QWidget* widget);
+    void RemoveWidgetFromActionContextHelper(const AZStd::string& actionContextIdentifier, QWidget* widget);
 
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -645,29 +645,22 @@ namespace AzToolsFramework
             GetEntityContextId());
         ViewportEditorModeNotificationsBus::Handler::BusConnect(GetEntityContextId());
 
-        if (AzToolsFramework::IsNewActionManagerEnabled())
+        if (IsNewActionManagerEnabled())
         {
             m_actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
 
-            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-            {
-                // Assign this widget to the Editor Entity Property Editor Action Context.
-                hotKeyManagerInterface->AssignWidgetToActionContext(
+            // Assign this widget to the Editor Entity Property Editor Action Context.
+            AssignWidgetToActionContextHelper(
                     EditorIdentifiers::EditorEntityPropertyEditorActionContextIdentifier, this);
-            }
         }
     }
 
     EntityPropertyEditor::~EntityPropertyEditor()
     {
-        if (AzToolsFramework::IsNewActionManagerEnabled())
+        if (IsNewActionManagerEnabled())
         {
-            if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-            {
-                // Assign this widget to the Editor Entity Property Editor Action Context.
-                hotKeyManagerInterface->RemoveWidgetFromActionContext(
+            RemoveWidgetFromActionContextHelper(
                     EditorIdentifiers::EditorEntityPropertyEditorActionContextIdentifier, this);
-            }
         }
 
         qApp->removeEventFilter(this);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
@@ -8,8 +8,8 @@
 
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Interface/Interface.h>
-#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/UI/UICore/ConsoleTextEdit.hxx>
 
 #include <QMenu>
@@ -90,18 +90,12 @@ namespace AzToolsFramework
             }
         );
 
-        if (auto hotKeyManagerInterface = AZ::Interface<HotKeyManagerInterface>::Get())
-        {
-            hotKeyManagerInterface->AssignWidgetToActionContext(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
-        }
+        AssignWidgetToActionContextHelper(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
     }
 
     ConsoleTextEdit::~ConsoleTextEdit()
     {
-        if (auto hotKeyManagerInterface = AZ::Interface<HotKeyManagerInterface>::Get())
-        {
-            hotKeyManagerInterface->RemoveWidgetFromActionContext(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
-        }
+        RemoveWidgetFromActionContextHelper(EditorIdentifiers::EditorConsoleActionContextIdentifier, this);
     }
 
     bool ConsoleTextEdit::searchEnabled()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -26,6 +26,9 @@ set(FILES
     ActionManager/HotKey/HotKeyManager.h
     ActionManager/HotKey/HotKeyManagerInterface.h
     ActionManager/HotKey/HotKeyManagerInternalInterface.h
+    ActionManager/HotKey/HotKeyWidgetRegistrationHelper.cpp
+    ActionManager/HotKey/HotKeyWidgetRegistrationHelper.h
+    ActionManager/HotKey/HotKeyWidgetRegistrationInterface.h
     ActionManager/Menu/EditorMenu.cpp
     ActionManager/Menu/EditorMenu.h
     ActionManager/Menu/EditorMenuBar.cpp

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -54,10 +54,10 @@
 #include <AzCore/std/sort.h>
 #include <AzFramework/API/ApplicationAPI.h>
 
-#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
+#include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <EMotionFX/CommandSystem/Source/ActorCommands.h>
 #include <EMotionFX/CommandSystem/Source/AnimGraphCommands.h>
@@ -186,19 +186,13 @@ namespace EMStudio
         m_saveWorkspaceCallback          = nullptr;
 
         // Register this window as the widget for the Animation Editor Action Context.
-        if(auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-        {
-            hotKeyManagerInterface->AssignWidgetToActionContext(AnimationEditorActionContextIdentifier, this);
-        }
+        AzToolsFramework::AssignWidgetToActionContextHelper(AnimationEditorActionContextIdentifier, this);
     }
 
     MainWindow::~MainWindow()
     {
         // Unregister this window as the widget for the Animation Editor Action Context.
-        if (auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get())
-        {
-            hotKeyManagerInterface->RemoveWidgetFromActionContext(AnimationEditorActionContextIdentifier, this);
-        }
+        AzToolsFramework::RemoveWidgetFromActionContextHelper(AnimationEditorActionContextIdentifier, this);
 
         DisableUpdatingPlugins();
 


### PR DESCRIPTION
## What does this PR do?

Fixes a regression due to changes in the order of operations during editor initialization - widgets were initialized before the action manager registration hooks were called, making it so that the assignment would fail when the editor layout is restored at startup.

Introduced a new helper function that correctly delays registration if the system has not been initialized when the widget is created.

## How was this PR tested?

Manual testing.
