### PR TITLE
Prefab/DPE: Set the RevertOverride message handler correctly

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -82,6 +82,7 @@ namespace AzToolsFramework::Prefab
         }
 
         adapterBuilder->Attribute(PrefabOverrideLabel::RelativePath, relativePathFromEntity.ToString());
+        adapterBuilder->AddMessageHandler(this, PrefabOverrideLabel::RevertOverride);
 
         // Do not show override visualization on container entities or for empty serialized paths.
         if (m_prefabPublicInterface->IsInstanceContainerEntity(m_entityId) || relativePathFromEntity.IsEmpty())
@@ -92,11 +93,6 @@ namespace AzToolsFramework::Prefab
         {
             bool isOverridden = m_prefabOverridePublicInterface->AreOverridesPresent(m_entityId, relativePathFromEntity.ToString());
             adapterBuilder->Attribute(PrefabOverrideLabel::IsOverridden, isOverridden);
-
-            if (isOverridden)
-            {
-                adapterBuilder->AddMessageHandler(this, PrefabOverrideLabel::RevertOverride);
-            }
         }
 
         adapterBuilder->EndPropertyEditor();

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
@@ -45,8 +45,9 @@ namespace UnitTest
             EXPECT_EQ(labelPropertyEditor[PropertyEditor::Type.GetName()].GetString(), PrefabOverrideLabel::Name);
             EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Text.GetName()].GetString(), "Translate");
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RelativePath.GetName()].GetString().empty());
-            EXPECT_TRUE(labelPropertyEditor[PrefabOverrideLabel::IsOverridden.GetName()].GetBool());
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RevertOverride.GetName()].IsNull());
+
+            EXPECT_TRUE(labelPropertyEditor[PrefabOverrideLabel::IsOverridden.GetName()].GetBool());
 
             AZ::Dom::Value valuePropertyEditor = translateRow[1];
             EXPECT_EQ(valuePropertyEditor[PropertyEditor::Value.GetName()][0].GetDouble(), 10.0);
@@ -82,8 +83,9 @@ namespace UnitTest
             EXPECT_EQ(labelPropertyEditor[PropertyEditor::Type.GetName()].GetString(), PrefabOverrideLabel::Name);
             EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Text.GetName()].GetString(), "Translate");
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RelativePath.GetName()].GetString().empty());
+            EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RevertOverride.GetName()].IsNull());
+
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::IsOverridden.GetName()].GetBool());
-            EXPECT_TRUE(labelPropertyEditor[PrefabOverrideLabel::RevertOverride.GetName()].IsNull());
 
             AZ::Dom::Value valuePropertyEditor = translateRow[1];
             EXPECT_EQ(valuePropertyEditor[PropertyEditor::Value.GetName()][0].GetDouble(), 10.0);


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15661

This PR changes to set up the `RevertOverride` message handler by default in 'PrefabComponentAdapter::CreateLabel'.

Whether or not the context menu can be shown is still checked in [PrefabOverrideLabelHandler::ShowContextMenu](https://github.com/o3de/o3de/blob/development/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp#L58).

When a property value is edited as override, 'PrefabComponentAdapter::UpdateDomContents' will generate a patch to set `IsOverridden` to true and can notify to call 'PrefabOverrideLabelHandler::SetValueFrom' to update the cached node such that the context menu can be shown.

PR that adds revert support: https://github.com/o3de/o3de/pull/14917

## How was this PR tested?

Tested in editor

https://user-images.githubusercontent.com/11157226/231304249-b76d7d92-1815-4893-934b-2e1658ac1b53.mp4