### PR TITLE
Allow usage of RT descriptors in const context

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
@@ -154,8 +154,8 @@ namespace AZ
             RayTracingTlasDescriptor* Transform(const AZ::Transform& transform);
             RayTracingTlasDescriptor* NonUniformScale(const AZ::Vector3& nonUniformScale);
             RayTracingTlasDescriptor* Transparent(bool transparent);
-            RayTracingTlasDescriptor* Blas(RHI::Ptr<RHI::RayTracingBlas>& blas);
-            RayTracingTlasDescriptor* InstancesBuffer(RHI::Ptr<RHI::Buffer>& tlasInstances);
+            RayTracingTlasDescriptor* Blas(const RHI::Ptr<RHI::RayTracingBlas>& blas);
+            RayTracingTlasDescriptor* InstancesBuffer(const RHI::Ptr<RHI::Buffer>& tlasInstances);
             RayTracingTlasDescriptor* NumInstances(uint32_t numInstancesInBuffer);
 
         private:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
@@ -67,7 +67,7 @@ namespace AZ
             void RemoveHitGroupRecords(uint32_t key);
 
             // build operations
-            RayTracingShaderTableDescriptor* Build(const AZ::Name& name, RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState);
+            RayTracingShaderTableDescriptor* Build(const AZ::Name& name, const RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState);
             RayTracingShaderTableDescriptor* RayGenerationRecord(const AZ::Name& name);
             RayTracingShaderTableDescriptor* MissRecord(const AZ::Name& name);
             RayTracingShaderTableDescriptor* HitGroupRecord(const AZ::Name& name, uint32_t key = RayTracingShaderTableRecord::InvalidKey);

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -95,14 +95,14 @@ namespace AZ
             return this;
         }
 
-        RayTracingTlasDescriptor* RayTracingTlasDescriptor::Blas(RHI::Ptr<RHI::RayTracingBlas>& blas)
+        RayTracingTlasDescriptor* RayTracingTlasDescriptor::Blas(const RHI::Ptr<RHI::RayTracingBlas>& blas)
         {
             AZ_Assert(m_buildContext, "Blas property can only be added to an Instance entry");
             m_buildContext->m_blas = blas;
             return this;
         }
 
-        RayTracingTlasDescriptor* RayTracingTlasDescriptor::InstancesBuffer(RHI::Ptr<RHI::Buffer>& instancesBuffer)
+        RayTracingTlasDescriptor* RayTracingTlasDescriptor::InstancesBuffer(const RHI::Ptr<RHI::Buffer>& instancesBuffer)
         {
             AZ_Assert(!m_buildContext, "InstancesBuffer property can only be added to the top level");
             AZ_Assert(m_instances.size() == 0, "InstancesBuffer cannot exist with instance entries");

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -26,7 +26,7 @@ namespace AZ
             }
         }
 
-        RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::Build(const AZ::Name& name, RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState)
+        RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::Build(const AZ::Name& name, const RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState)
         {
             m_name = name;
             m_rayTracingPipelineState = rayTracingPipelineState;


### PR DESCRIPTION
## What does this PR do?

This PR only changes the signature of three methods to accept a `const` reference parameter instead of a reference, all three only make copies of that parameter internally and this change allows the usage of these descriptors in contexts where a `const` resource is present.

## How was this PR tested?

Built against the newest `o3de-atom-sampleviewer` state and does not change anything else, so should not affect run-time behaviour.
