### PR TITLE
Fix SimplePlayerSpawner to always return valid transform

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/SimplePlayerSpawnerComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/SimplePlayerSpawnerComponent.cpp
@@ -88,7 +88,17 @@ namespace Multiplayer
         }
 
         const AZ::EntityId spawnPointEntityId = m_spawnPoints[m_spawnIndex];
-        AZ::Transform spawnPointTransform;
+
+        if (!spawnPointEntityId.IsValid())
+        {
+            AZ_Assert(
+                false,
+                "Empty spawner entry at m_spawnIndex %i. Please ensure spawn index is always valid.",
+                m_spawnIndex);
+            return AZ::Transform::Identity();
+        }
+
+        AZ::Transform spawnPointTransform = AZ::Transform::Identity();
         AZ::TransformBus::EventResult(spawnPointTransform, spawnPointEntityId, &AZ::TransformInterface::GetWorldTM);
         return spawnPointTransform;
     }


### PR DESCRIPTION
## What does this PR do?

If the Simple Player Spawner component had an empty entry in its list, the Respawn code would return an uninitialized transform. This fixes the logic so that invalid entity IDs will assert and return an Identity(), and missing entities will also return an Identity() instead of uninitialized data.

## How was this PR tested?

Tried spawning in MPS with an empty entry and verified that it asserted and spawned at the Identity() location.
