### PR TITLE
Cherry-Pick: Fix handler pool issues for multiple-DPE case

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -508,7 +508,6 @@ namespace AzToolsFramework
                 auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(childWidget);
                 if (!handlerInfo.IsNull())
                 {
-                    // propertyHandlers own their widgets, so don't destroy them here. Set them free!
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
                 else if (auto rowWidget = qobject_cast<DPERowWidget*>(childWidget))
@@ -1617,9 +1616,15 @@ namespace AzToolsFramework
         message.Match(AZ::DocumentPropertyEditor::Nodes::Adapter::QueryKey, showKeyQueryDialog);
     }
 
-    void DocumentPropertyEditor::RegisterHandlerPool(AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
+    void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
     {
-        m_handlerPools.push_back(handlerPool);
+        AZ_Assert(
+            m_handlerPools.find(handlerName) == m_handlerPools.end() || m_handlerPools[handlerName] == handlerPool,
+            "Attempted to register a new handler pool to a handler name that is already in use.");
+
+        // insertion to the handler pool hash map only succeeds if the handler name is a new key
+        // so it won't overwrite any existing registered handler pool for that handler name
+        m_handlerPools.insert({ handlerName, handlerPool });
     }
 
     DocumentPropertyEditor::HandlerInfo DocumentPropertyEditor::GetInfoFromWidget(const QWidget* widget)
@@ -1634,7 +1639,11 @@ namespace AzToolsFramework
 
     AZ::Name DocumentPropertyEditor::GetNameForHandlerId(PropertyEditorToolsSystemInterface::PropertyHandlerId handlerId)
     {
-        return AZ::Name(AZStd::to_string(reinterpret_cast<uintptr_t>(handlerId)));
+        auto name = AZStd::to_string(reinterpret_cast<uintptr_t>(handlerId));
+        auto moduleId = AZ::Environment::GetModuleId();
+
+        auto nameWithModuleId = AZStd::fixed_string<256>::format("%s%p", name.c_str(), moduleId);
+        return AZ::Name(nameWithModuleId);
     }
 
     QWidget* DocumentPropertyEditor::CreateWidgetForHandler(
@@ -1644,9 +1653,12 @@ namespace AzToolsFramework
         // if we found a valid handler, grab its widget to add to the column layout
         if (handlerId)
         {
+            // first try to get the instance pool from pool manager
             auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
             auto handlerName = GetNameForHandlerId(handlerId);
             auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
+
+            // create the pool if it does not exist
             if (!handlerPool)
             {
                 AZStd::function<void(PropertyHandlerWidgetInterface&)> resetHandler = [](PropertyHandlerWidgetInterface& handler)
@@ -1665,10 +1677,12 @@ namespace AzToolsFramework
                 };
 
                 handlerPool = poolManager->CreatePool<PropertyHandlerWidgetInterface>(handlerName, resetHandler, createHandler).GetValue();
-                RegisterHandlerPool(handlerPool);
             }
 
-            // store, then reference the unique_ptr that will manage the handler's lifetime
+            // register the handler pool in DPE view to co-own the handler pool
+            // the registration is needed in case the handler pool is released by other DPE views
+            RegisterHandlerPool(handlerName, handlerPool);
+
             auto handler = handlerPool->GetInstance();
             handler->SetValueFromDom(domValue);
             createdWidget = handler->GetWidget();
@@ -1682,18 +1696,16 @@ namespace AzToolsFramework
         auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
         auto handlerName = GetNameForHandlerId(handler.handlerId);
         auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
+
         if (handlerPool)
         {
             handlerPool->RecycleInstance(handler.handlerInterface);
         }
         else
         {
-            QTimer::singleShot(
-                0,
-                [interfacePointer = handler.handlerInterface]()
-                {
-                    delete interfacePointer;
-                });
+            // if there is no handler pool, then delete the handler immediately; parent widgets won't delete it twice
+            delete handler.handlerInterface;
+            handler.handlerInterface = nullptr;
         }
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -231,7 +231,7 @@ namespace AzToolsFramework
                 ->GetPool<AzQtComponents::ElidingLabel>();
         }
 
-        void RegisterHandlerPool(AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool);
+        void RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool);
 
         struct HandlerInfo
         {
@@ -280,7 +280,8 @@ namespace AzToolsFramework
         static AZ::Name GetNameForHandlerId(PropertyEditorToolsSystemInterface::PropertyHandlerId handlerId);
         static void ReleaseHandler(HandlerInfo& handler);
 
-        AZStd::vector<AZStd::shared_ptr<AZ::InstancePoolBase>> m_handlerPools;
+        // Co-owns the handler pool that is needed in DPE and the ownership would be released when the DPE is deleted
+        AZStd::unordered_map<AZ::Name, AZStd::shared_ptr<AZ::InstancePoolBase>> m_handlerPools;
     };
 } // namespace AzToolsFramework
 


### PR DESCRIPTION
## What does this PR do?

Cherry picks the commit from PR https://github.com/o3de/o3de/pull/15662. It fixed https://github.com/o3de/o3de/issues/15097 in development.

It was reported that destructor of `ContainerActionButtonHandler` _sometimes_ crashes in stab due to double deletion, which is showing a similar call stack.

```
  Qt5Widgets.dll!QWidget::~QWidget() Line 1442	C++
> EitorLib.dll!AzToolsFramework::ContainerActionButtonHandler::`scalar deleting destructor'(unsigned int)	C++
  [Inline Frame] Qt5Core.dll!QtPrivate::QSlotObjectBase::call(QObject *) Line 398	C++
  Qt5Core.dll!QMetaCallEvent::placeMetaCall(QObject * object) Line 622	C++
  Qt5Core.dll!QObject::event(QEvent * e) Line 1314	C++
  Qt5Widgets.dll!QApplicationPrivate::notify_helper(QObject * receiver, QEvent * e) Line 3632	C++
  Qt5Widgets.dll!QApplication::notify(QObject * receiver, QEvent * e) Line 3584	C++
  Qt5Core.dll!QCoreApplication::notifyInternal2(QObject * receiver, QEvent * event) Line 1063	C++
  [Inline Frame] Qt5Core.dll!QCoreApplication::sendEvent(QObject *) Line 1458	C++
  Qt5Core.dll!QCoreApplicationPrivate::sendPostedEvents(QObject * receiver, int event_type, QThreadData * data) Line 1817	C++
  qwindows.dll!QWindowsGuiEventDispatcher::sendPostedEvents() Line 81	C++
  Qt5Core.dll!QEventDispatcherWin32::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 530	C++
  qwindows.dll!QWindowsGuiEventDispatcher::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 74	C++
  [Inline Frame] Qt5Core.dll!QEventLoop::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag>) Line 139	C++
  Qt5Core.dll!QEventLoop::exec(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 232	C++
```
