### PR TITLE
DPE: Prevent nullptr node crash in DPEDebugModel

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.cpp
@@ -401,13 +401,12 @@ namespace AzToolsFramework
     DPEModelNode* DPEDebugModel::GetNodeFromPath(const AZ::Dom::Path& thePath) const
     {
         DPEModelNode* returnedNode = m_rootNode;
-        for (auto pathIter = thePath.begin(), endIter = thePath.end(); pathIter != endIter && returnedNode != nullptr; ++pathIter)
+        for (auto pathIter = thePath.begin(), endIter = thePath.end();
+             pathIter != endIter && returnedNode != nullptr && pathIter->IsIndex();
+             ++pathIter)
         {
             // non-index subpaths are for properties not nodes, so only handle the index paths
-            if (pathIter->IsIndex())
-            {
-                returnedNode = returnedNode->GetChildFromDomIndex(pathIter->GetIndex());
-            }
+            returnedNode = returnedNode->GetChildFromDomIndex(pathIter->GetIndex());
         }
         return returnedNode;
     }


### PR DESCRIPTION
Resolves https://github.com/o3de/o3de/issues/15157

**Description**
This PR fixes a crash in the DPEDebugModel caused by paths that have path entries beyond their property. This meant that a particular `for` loop was continuing after finding the last keyed PathEntry and eventually returning nullptr.

**Testing**
- Verified no crash occurs when doing things that previously crashed in the DPEDebugViewStandalone app
- Verified that the for loop no longer continues after encountering the first keyed PathEntry