### PR TITLE
Right click job -> go to builder

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/BuilderListModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderListModel.cpp
@@ -34,6 +34,22 @@ QVariant BuilderListModel::data(const QModelIndex& index, int role) const
     return {};
 }
 
+QModelIndex BuilderListModel::GetIndexForBuilder(const AZ::Uuid& builderUuid)
+{
+    AssetProcessor::BuilderInfoList builders;
+    AssetProcessor::AssetBuilderInfoBus::Broadcast(&AssetProcessor::AssetBuilderInfoBus::Events::GetAllBuildersInfo, builders);
+    
+    for (int builderRow = 0; builderRow < builders.size(); ++builderRow)
+    {
+        if (builders[builderRow].m_busId == builderUuid)
+        {
+            return createIndex(builderRow, 0);
+        }
+    }
+
+    return QModelIndex();
+}
+
 void BuilderListModel::Reset()
 {
     beginResetModel();

--- a/Code/Tools/AssetProcessor/native/ui/BuilderListModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderListModel.h
@@ -12,6 +12,11 @@
 #include <QSortFilterProxyModel>
 #endif
 
+namespace AZ
+{
+    struct Uuid;
+}
+
 struct BuilderListModel : QAbstractListModel
 {
     Q_OBJECT;
@@ -24,6 +29,8 @@ public:
     int rowCount(const QModelIndex& parent) const override;
 
     QVariant data(const QModelIndex& index, int role) const override;
+
+    QModelIndex GetIndexForBuilder(const AZ::Uuid& builderUuid);
 
     void Reset();
 };


### PR DESCRIPTION
## What does this PR do?

Right click job -> go to builder.
Fixed issue where "Show in Asset Browser" was enabled when the Editor wasn't connected.

![image](https://user-images.githubusercontent.com/4838196/231838374-871b0887-8bd4-4697-915a-fbcaea8ece74.png)

## How was this PR tested?

Tested locally - UI automation for this tool is not yet available.
