### PR TITLE
Replaced the editor's base class with AZ::Render::EditorRenderCompone…

### DIFF
--- a/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.cpp
+++ b/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.cpp
@@ -85,4 +85,16 @@ namespace ${Name}
             return;
         }
     }
+
+    void Editor${Name}Component::OnEntityVisibilityChanged(bool visibility)
+    {
+        if (visibility)
+        {
+            m_controller.EnableFeatureProcessor(GetEntityId());
+        }
+        else
+        {
+            m_controller.DisableFeatureProcessor();
+        }
+    }
 }

--- a/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.h
+++ b/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <Atom/Feature/Utils/EditorRenderComponentAdapter.h>
+
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
@@ -22,14 +24,14 @@ namespace ${Name}
     inline constexpr AZ::TypeId EditorComponentTypeId { "{${Random_Uuid}}" };
 
     class Editor${Name}Component final
-        : public AzToolsFramework::Components::EditorComponentAdapter<${Name}ComponentController, ${Name}Component, ${Name}ComponentConfig>
+        : public AZ::Render::EditorRenderComponentAdapter<${Name}ComponentController, ${Name}Component, ${Name}ComponentConfig>
         , private AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , private AzFramework::EntityDebugDisplayEventBus::Handler
         , private AZ::TickBus::Handler
         , private AzToolsFramework::EditorEntityInfoNotificationBus::Handler
     {
     public:
-        using BaseClass = AzToolsFramework::Components::EditorComponentAdapter<${Name}ComponentController, ${Name}Component, ${Name}ComponentConfig>;
+        using BaseClass = AZ::Render::EditorRenderComponentAdapter <${Name}ComponentController, ${Name}Component, ${Name}ComponentConfig>;
         AZ_EDITOR_COMPONENT(Editor${Name}Component, EditorComponentTypeId, BaseClass);
 
         static void Reflect(AZ::ReflectContext* context);
@@ -40,6 +42,10 @@ namespace ${Name}
         // AZ::Component overrides
         void Activate() override;
         void Deactivate() override;
+
+    protected:
+
+        void OnEntityVisibilityChanged(bool visibility) override;
 
     private:
 


### PR DESCRIPTION
…ntAdapter

## What does this PR do?

`AZ::Render::EditorRenderComponentAdapter` is more consistent with other rendering components. It also offers notification of visibility changes that can be used to toggle feature processors.

