### PR TITLE
[Terrain] - Fixing terrain mesh manager cleanup

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -158,10 +158,10 @@ namespace Terrain
         }
         m_candidateSectors.clear();
         m_sectorsThatNeedSrgCompiled.clear();
+        RemoveRayTracedMeshes();
         m_sectorLods.clear();
         m_xyPositions.clear();
         m_cachedDrawData.clear();
-        RemoveRayTracedMeshes();
 
         m_rebuildSectors = true;
     }


### PR DESCRIPTION
## What does this PR do?

Previous terrain ray tracing meshes are were cleaned up after the sectors they relied on were already destroyed. This led to UB. It's kind of amazing it took several weeks to notice, possible that in many cases the memory hasn't actually been wiped and was in a good enough state to "work"

Fixes #15702 

## How was this PR tested?

Tested in a couple terrain levels. Verified that ray tracing meshes were being cleaned up while sectors still existed.