### PR TITLE
Asset Processor - Optimize initial startup time

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
@@ -15,6 +15,7 @@
 #include <QFileInfo>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/EBus/Event.h>
+#include <AzCore/IO/FileIO.h>
 
 namespace AssetProcessor
 {
@@ -55,7 +56,7 @@ namespace AssetProcessor
         /// Convenience function to check if a file or directory exists.
         virtual bool Exists(const QString& absolutePath) const = 0;
         virtual bool GetHash(const QString& absolutePath, FileHash* foundHash) = 0;
-        
+
         //! Called when the caller knows a hash and file info already.
         //! This can for example warm up the cache so that it can return hashes without actually hashing.
         //! (optional for implementations)
@@ -90,7 +91,7 @@ namespace AssetProcessor
 
         /// Removes a file from the cache
         virtual void RemoveFile(const QString& /*absolutePath*/) {}
-        
+
         virtual void WarmUpCache(const AssetFileInfo& /*existingInfo*/, const FileHash /*hash*/) {}
     };
 
@@ -111,7 +112,7 @@ namespace AssetProcessor
         void AddFile(const QString& absolutePath) override;
         void UpdateFile(const QString& absolutePath) override;
         void RemoveFile(const QString& absolutePath) override;
-        
+
         void WarmUpCache(const AssetFileInfo& existingInfo, const FileHash hash = IFileStateRequests::InvalidFileHash) override;
 
     private:
@@ -134,6 +135,10 @@ namespace AssetProcessor
         QHash<QString, FileHash> m_fileHashMap;
 
         AZ::Event<FileStateInfo> m_deleteEvent;
+
+        /// Cache of input path values to their final, normalized map key format.
+        /// Profiling has shown path normalization to be a hotspot.
+        mutable QHash<QString, QString> m_keyCache;
 
         using LockGuardType = AZStd::lock_guard<decltype(m_mapMutex)>;
     };

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -690,6 +690,11 @@ namespace AssetProcessor
 
         AZStd::unique_ptr<ExcludedFolderCache> m_excludedFolderCache{};
 
+        // Cache of source -> list of dependencies for startup
+        AZStd::unordered_map<AZ::Uuid, AZStd::vector<AzToolsFramework::AssetDatabase::PathOrUuid>> m_dependencyCache;
+        // Cache is turned off after initial idle, it is not meant to handle invalidation or mixed dependency type queries.
+        bool m_dependencyCacheEnabled = true;
+
 protected Q_SLOTS:
         void FinishAnalysis(SourceAssetReference sourceAsset);
         //////////////////////////////////////////////////////////

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -1869,6 +1869,7 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_BasicTe
 
     // eliminate b --> c
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->RemoveSourceFileDependency(newEntry2.m_sourceDependencyID));
+    m_assetProcessorManager->m_dependencyCache = {};
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
@@ -1882,6 +1883,9 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_WithDif
 {
     // test to make sure that different TYPES of dependencies work as expected.
     using namespace AzToolsFramework::AssetDatabase;
+
+    // Cache does not handle mixed dependency types
+    m_assetProcessorManager->m_dependencyCacheEnabled = false;
 
     UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/a.txt"), QString("tempdata\n"));
     UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/b.txt"), QString("tempdata\n"));
@@ -1995,6 +1999,7 @@ TEST_F(AssetProcessorManagerTest, QueryAbsolutePathDependenciesRecursive_Missing
 
     // eliminate b --> c
     ASSERT_TRUE(m_assetProcessorManager->m_stateData->RemoveSourceFileDependency(newEntry2.m_sourceDependencyID));
+    m_assetProcessorManager->m_dependencyCache = {};
 
     dependencies.clear();
     m_assetProcessorManager->QueryAbsolutePathDependenciesRecursive(m_aUuid, dependencies, SourceFileDependencyEntry::DEP_SourceToSource);
@@ -2405,7 +2410,7 @@ bool SearchDependencies(AzToolsFramework::AssetDatabase::ProductDependencyDataba
 
 void VerifyDependencies(
     AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntryContainer dependencyContainer,
-    AZStd::vector<AZ::Data::AssetId> assetIds, 
+    AZStd::vector<AZ::Data::AssetId> assetIds,
     AZStd::initializer_list<const char*> unresolvedPaths = {})
 {
     EXPECT_EQ(dependencyContainer.size(), assetIds.size() + unresolvedPaths.size());
@@ -3997,6 +4002,9 @@ void SourceFileDependenciesTest::SetUp()
     QFile(m_assetRootDir.absoluteFilePath("subfolder1/b.txt")).remove();
     QFile(m_assetRootDir.absoluteFilePath("subfolder1/c.txt")).remove();
     QFile(m_assetRootDir.absoluteFilePath("subfolder1/d.txt")).remove();
+
+    // Cache does not handle mixed dependency types
+    m_assetProcessorManager->m_dependencyCacheEnabled = false;
 }
 
 void SourceFileDependenciesTest::SetupData(
@@ -5110,6 +5118,9 @@ TEST_F(AssetProcessorManagerTest, UpdateSourceFileDependenciesDatabase_WildcardM
     // This test checks that wildcard source dependencies are added to the database as "SourceLikeMatch",
     // find existing files which match the dependency and add them as either job or source file dependencies,
     // And recognize matching files as dependencies
+
+    // Cache does not handle mixed dependency types
+    m_assetProcessorManager->m_dependencyCacheEnabled = false;
 
     AZ::Uuid dummyBuilderUUID = AZ::Uuid::CreateRandom();
     UnitTestUtils::CreateDummyFile(m_assetRootDir.absoluteFilePath("subfolder1/wildcardTest.txt"));

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1606,7 +1606,7 @@ namespace AssetProcessor
     // This function is one of the most frequently called ones in the entire application
     // and is invoked several times per file.  It can frequently become a bottleneck, so
     // avoid doing expensive operations here, especially memory or IO operations.
-    QString PlatformConfiguration::FindFirstMatchingFile(QString relativeName, bool skipIntermediateScanFolder) const
+    QString PlatformConfiguration::FindFirstMatchingFile(QString relativeName, bool skipIntermediateScanFolder, const ScanFolderInfo** outScanFolderInfo) const
     {
         if (relativeName.isEmpty())
         {
@@ -1671,6 +1671,11 @@ namespace AssetProcessor
             {
                 if (fileStateInterface->GetFileInfo(absolutePath, &fileStateInfo))
                 {
+                    if (outScanFolderInfo)
+                    {
+                        *outScanFolderInfo = &scanFolderInfo;
+                    }
+
                     return AssetUtilities::NormalizeFilePath(fileStateInfo.m_absolutePath);
                 }
             }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -242,7 +242,7 @@ namespace AssetProcessor
         QString GetOverridingFile(QString relativeName, QString scanFolderName) const;
 
         //! given a relative name, loop over folders and resolve it to a full path with the first existing match.
-        QString FindFirstMatchingFile(QString relativeName, bool skipIntermediateScanFolder = false) const;
+        QString FindFirstMatchingFile(QString relativeName, bool skipIntermediateScanFolder = false, const AssetProcessor::ScanFolderInfo** scanFolderInfo = nullptr) const;
 
         //! given a relative name with wildcard characters (* allowed) find a set of matching files or optionally folders
         QStringList FindWildcardMatches(const QString& sourceFolder, QString relativeName, bool includeFolders = false,
@@ -300,7 +300,7 @@ namespace AssetProcessor
         void PopulatePlatformsForScanFolder(AZStd::vector<AssetBuilderSDK::PlatformInfo>& platformsList, QStringList includeTagsList = QStringList(), QStringList excludeTagsList = QStringList());
 
         // uses const + mutability since its a cache.
-        void CacheIntermediateAssetsScanFolderId() const; 
+        void CacheIntermediateAssetsScanFolderId() const;
         AZStd::optional<AZ::s64> GetIntermediateAssetsScanFolderId() const;
         void ReadMetaDataFromSettingsRegistry();
 


### PR DESCRIPTION
## What does this PR do?

* Added a string path cache to the FileStateCache to avoid re-normalizing and lowercasing the same string many times.  Profiling showed this as a hot spot and it was being called over 5M times during startup.
* Added a dependency cache to QueryAbsolutePathDependenciesRecursive.  Profiling also showed this as a hotspot for several different items.  The cache only applies during startup and is cleared/disabled after reaching idle state.
* Switched from a queue to an unordered_set as the order doesn't actually matter and profiling showed unordered_set to be faster.
* Added an optional return of the scanfolder for FindFirstMatchingFile to optimize one of the SourceAssetReference calls during the above.

## How was this PR tested?

Manually ran AP, wrote some verification code to compare the old and new results to make sure the cache was still returning the same values.

Before: 9157ms
After: 4530ms
Speedup: 2.02x

Times above are for AutomatedTesting project on an already-populated cache
