### PR TITLE
Fix decal crash #15190

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -32,14 +32,13 @@ namespace AZ
                     if (elem.Is<Data::Asset<RPI::ImageAsset>>())
                     {
                         const auto& imageBinding = elem.GetValue<Data::Asset<RPI::ImageAsset>>();
-                        const auto& assetId = imageBinding.GetId();
-                        if (assetId.IsValid())
+                        if (imageBinding && imageBinding.IsReady())
                         {
                             return imageBinding->GetImageDescriptor().m_size;
                         }
                     }
                 }
-                AZ_Assert(false, "GetSizeFromMaterial() unable to find an image in the given material.");
+                AZ_Error("DecalTextureArrayFeatureProcessor", false, "GetTextureSizeFromMaterialAsset() unable to find an image in the given material.")
                 return {};
             }
 


### PR DESCRIPTION

## What does this PR do?

Fix decal crash #15190 
- Changed how the image asset is verified to correctly catch the missing image error
- Changed Assert to Error so console can report missing image and Editor can continue safely

## How was this PR tested?

Tested manually by doing the following steps: 
Setup: 
1. Created a new material with a base color texture
2. Added the Decal component to the default ShaderBall
3. Added the material to the Decal component
4. Deleted the base color texture
5. Saved and closed Editor.
6. Relaunched Editor. 

Before this fix, the Editor would crash after loading a level. After the fix, the level loads and the "missing image" error is output to the console. 


