### PR TITLE
DPE: Fix various readonly issues in the EntityInspector

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -354,11 +354,11 @@ namespace AZ::Reflection
                         Dom::Value readOnlyValue;
                         if (readOnlyAttribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
                         {
-                            readOnlyValue = readOnlyAttribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
+                            readOnlyValue = readOnlyAttribute->DomInvoke(parentData.m_instance, Dom::Value(Dom::Type::Array));
                         }
                         else
                         {
-                            readOnlyValue = readOnlyAttribute->GetAsDomValue(instance);
+                            readOnlyValue = readOnlyAttribute->GetAsDomValue(parentData.m_instance);
                         }
 
                         if (readOnlyValue.IsBool())


### PR DESCRIPTION
**Description**
Prior to this PR, the wrong instance pointer was being used to invoke/access ReadOnly attributes from inside the LegacyReflectionBridge. This meant that the DPE was attempting to invoke functions, or otherwise access members, on the member of the class instead of the class itself.

This PR changes the instance ptr being used to the parent data's instance ptr, which is the class that owns the reflected member being accessed.

**Testing**
- Verified that component readonly issues recently found in the EntityInspector are fixed
- Verified that readonly functionality in the DPE debug standalone app is still intact and correct