### PR TITLE
Cache parent instance DOM upon prefab instantiation

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -428,14 +428,13 @@ namespace AzToolsFramework
             filePath, instanceToParentUnder,
             [this](const EntityList& entities)
             {
-                HandleEntitiesAdded(entities);
+                HandleEntitiesAdded(entities); // includes container entity
             });
 
         if (instantiatedPrefabInstance)
         {
             Prefab::Instance& addedInstance = instanceToParentUnder->get().AddInstance(
                 AZStd::move(instantiatedPrefabInstance));
-            HandleEntitiesAdded({addedInstance.m_containerEntity.get()});
             return addedInstance;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -545,7 +545,7 @@ namespace AzToolsFramework
                 return prefabBuffer.GetString();
             }
 
-            bool AddOrUpdateNestedInstance(
+            void AddNestedInstance(
                 PrefabDom& prefabDom,
                 const InstanceAlias& nestedInstanceAlias,
                 PrefabDomValueConstReference nestedInstanceDom)
@@ -574,16 +574,13 @@ namespace AzToolsFramework
                         nestedInstanceDom.has_value() ? rapidjson::Value(nestedInstanceDom->get(), prefabDom.GetAllocator())
                                                       : PrefabDomValue(),
                         prefabDom.GetAllocator());
-                    return true;
                 }
-                else if (nestedInstanceDom.has_value())
+                else
                 {
-                    // Nested instance already exists in the prefab DOM, so just update its contents
-                    instanceMember->value.CopyFrom(nestedInstanceDom->get(), prefabDom.GetAllocator());
-                    return true;
+                    AZ_Assert(
+                        false,
+                        "PrefabDomUtils::AddNestedInstance - Nested instance already exists in prefab DOM.");
                 }
-
-                return false;
             }
         } // namespace PrefabDomUtils
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -214,6 +214,16 @@ namespace AzToolsFramework
 
             AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue);
 
+            //! Adds a nested instance to the the prefab DOM if it doesn't already exist and optionally update its contents.
+            //! @param prefabDom The prefab DOM to udpate.
+            //! @param nestedInstanceAlias The alias of the nested instance to be added or updated.
+            //! @param nestedInstanceDom An optional value to assign to the nested instance in the prefab DOM.
+            //! @return bool on whether the prefab DOM was updated.
+            bool AddOrUpdateNestedInstance(
+                PrefabDom& prefabDom,
+                const InstanceAlias& nestedInstanceAlias,
+                PrefabDomValueConstReference nestedInstanceDom = AZStd::nullopt);
+
             //! An empty struct for passing to JsonSerializerSettings.m_metadata that is consumed by InstanceSerializer::Store.
             //! If present in metadata, linkIds will be stored to instance dom.
             struct LinkIdMetadata

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -214,12 +214,11 @@ namespace AzToolsFramework
 
             AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue);
 
-            //! Adds a nested instance to the the prefab DOM if it doesn't already exist and optionally update its contents.
+            //! Adds a nested instance to the prefab DOM and optionally initialize its contents.
             //! @param prefabDom The prefab DOM to udpate.
-            //! @param nestedInstanceAlias The alias of the nested instance to be added or updated.
-            //! @param nestedInstanceDom An optional value to assign to the nested instance in the prefab DOM.
-            //! @return bool on whether the prefab DOM was updated.
-            bool AddOrUpdateNestedInstance(
+            //! @param nestedInstanceAlias The alias of the nested instance to be added.
+            //! @param nestedInstanceDom An optional value to assign to the added nested instance in the prefab DOM.
+            void AddNestedInstance(
                 PrefabDom& prefabDom,
                 const InstanceAlias& nestedInstanceAlias,
                 PrefabDomValueConstReference nestedInstanceDom = AZStd::nullopt);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -575,7 +575,7 @@ namespace AzToolsFramework
                     const PrefabDomValue* instanceValue = instancePath.Get(targetTemplatePrefabDom);
                     if (instanceValue)
                     {
-                        PrefabDomUtils::AddOrUpdateNestedInstance(
+                        PrefabDomUtils::AddNestedInstance(
                             cachedOwningInstanceDom->get(), instanceToCreate->get().GetInstanceAlias(), *instanceValue);
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -810,34 +810,8 @@ namespace AzToolsFramework
             PrefabDom& targetTemplateDom = targetTemplate.GetPrefabDom();
             auto memberFound = targetTemplateDom.FindMember(PrefabDomUtils::InstancesName);
 
-            PrefabDomValueReference instancesValue;
-            if (memberFound == targetTemplateDom.MemberEnd())
+            if (PrefabDomUtils::AddOrUpdateNestedInstance(targetTemplateDom, instanceAlias))
             {
-                //add the instance alias to the template dom
-                instancesValue = targetTemplateDom.AddMember(rapidjson::StringRef(PrefabDomUtils::InstancesName),
-                    PrefabDomValue(),
-                    targetTemplateDom.GetAllocator());
-
-                //when AddMember returns, it returns the object that the member was added to, not the added
-                //member itself, so we need to move instancesValue to the correct position for the next insert
-                memberFound = instancesValue->get().FindMember(PrefabDomUtils::InstancesName);
-                instancesValue = memberFound->value;
-            }
-            else
-            {
-                instancesValue = memberFound->value;
-            }
-
-            if (!instancesValue->get().IsObject())
-            {
-                instancesValue->get().SetObject();
-            }
-            // Only add the instance if it's not there already
-            if (instancesValue->get().FindMember(rapidjson::StringRef(instanceAlias.c_str())) == instancesValue->get().MemberEnd())
-            {
-                instancesValue->get().AddMember(
-                    rapidjson::Value(instanceAlias.c_str(), targetTemplateDom.GetAllocator()), PrefabDomValue(),
-                    targetTemplateDom.GetAllocator());
                 SetTemplateDirtyFlag(linkTargetId, true);
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -810,8 +810,34 @@ namespace AzToolsFramework
             PrefabDom& targetTemplateDom = targetTemplate.GetPrefabDom();
             auto memberFound = targetTemplateDom.FindMember(PrefabDomUtils::InstancesName);
 
-            if (PrefabDomUtils::AddOrUpdateNestedInstance(targetTemplateDom, instanceAlias))
+            PrefabDomValueReference instancesValue;
+            if (memberFound == targetTemplateDom.MemberEnd())
             {
+                //add the instance alias to the template dom
+                instancesValue = targetTemplateDom.AddMember(rapidjson::StringRef(PrefabDomUtils::InstancesName),
+                    PrefabDomValue(),
+                    targetTemplateDom.GetAllocator());
+
+                //when AddMember returns, it returns the object that the member was added to, not the added
+                //member itself, so we need to move instancesValue to the correct position for the next insert
+                memberFound = instancesValue->get().FindMember(PrefabDomUtils::InstancesName);
+                instancesValue = memberFound->value;
+            }
+            else
+            {
+                instancesValue = memberFound->value;
+            }
+
+            if (!instancesValue->get().IsObject())
+            {
+                instancesValue->get().SetObject();
+            }
+            // Only add the instance if it's not there already
+            if (instancesValue->get().FindMember(rapidjson::StringRef(instanceAlias.c_str())) == instancesValue->get().MemberEnd())
+            {
+                instancesValue->get().AddMember(
+                    rapidjson::Value(instanceAlias.c_str(), targetTemplateDom.GetAllocator()), PrefabDomValue(),
+                    targetTemplateDom.GetAllocator());
                 SetTemplateDirtyFlag(linkTargetId, true);
             }
 


### PR DESCRIPTION
## What does this PR do?

The PR prevents recreation of an instantiated prefab by caching the instance DOM of the parent instance.
Also container entity was being set up twice.

## How was this PR tested?

Tested in Editor.