### PR TITLE
Prefab/ActionManager: Fix error message in various prefab operations

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1072,6 +1072,12 @@ namespace AzToolsFramework
             }
         }
 
+        bool PrefabPublicHandler::IsOwnedByPrefabInstance(AZ::EntityId entityId) const
+        {
+            InstanceOptionalReference instanceReference = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
+            return instanceReference.has_value();
+        }
+
         bool PrefabPublicHandler::IsOwnedByProceduralPrefabInstance(AZ::EntityId entityId) const
         {
             if (InstanceOptionalReference instanceReference = m_instanceEntityMapperInterface->FindOwningInstance(entityId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -53,6 +53,7 @@ namespace AzToolsFramework
             
             PrefabOperationResult GenerateUndoNodesForEntityChangeAndUpdateCache(AZ::EntityId entityId, UndoSystem::URSequencePoint* parentUndoBatch) override;
 
+            bool IsOwnedByPrefabInstance(AZ::EntityId entityId) const override;
             bool IsOwnedByProceduralPrefabInstance(AZ::EntityId entityId) const override;
             bool IsInstanceContainerEntity(AZ::EntityId entityId) const override;
             bool IsLevelInstanceContainerEntity(AZ::EntityId entityId) const override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
@@ -106,6 +106,13 @@ namespace AzToolsFramework
                 AZ::EntityId entityId, UndoSystem::URSequencePoint* parentUndoBatch) = 0;
 
             /**
+             * Detects if an entity is owned by a prefab.
+             * @param entityId The entity to query.
+             * @return True if the entity is owned by a prefab instance, false otherwise.
+             */
+            virtual bool IsOwnedByPrefabInstance(AZ::EntityId entityId) const = 0;
+
+            /**
              * Detects if an entity is owned by a procedural prefab.
              * @param entityId The entity to query.
              * @return True if the entity is owned by a procedural prefab instance, false otherwise.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -860,6 +860,11 @@ namespace AzToolsFramework
 
                             AZ::EntityId selectedEntityId = selectedEntities.front();
 
+                            if (!s_prefabPublicInterface->IsOwnedByPrefabInstance(selectedEntityId))
+                            {
+                                return;
+                            }
+
                             if (!s_prefabPublicInterface->IsInstanceContainerEntity(selectedEntityId) &&
                                 m_prefabOverridePublicInterface->AreOverridesPresent(selectedEntityId) &&
                                 m_prefabOverridePublicInterface->GetEntityOverrideType(selectedEntityId) != OverrideType::AddEntity)
@@ -884,6 +889,13 @@ namespace AzToolsFramework
                             }
 
                             AZ::EntityId selectedEntityId = selectedEntities.front();
+
+                            // Returns false if the selected entity is not owned by a prefab instance. This could happen when the callback is
+                            // triggered after entity selection changes, but prefab propagation does not finish yet to create/reload the entity.
+                            if (!prefabPublicInterface->IsOwnedByPrefabInstance(selectedEntityId))
+                            {
+                                return false;
+                            }
 
                             return !prefabPublicInterface->IsInstanceContainerEntity(selectedEntityId) &&
                                 prefabOverridePublicInterface->AreOverridesPresent(selectedEntityId) &&
@@ -1382,7 +1394,9 @@ namespace AzToolsFramework
                 if (IsOutlinerOverrideManagementEnabled() && selectedEntities.size() == 1)
                 {
                     AZ::EntityId selectedEntity = selectedEntities[0];
-                    if (!s_prefabPublicInterface->IsInstanceContainerEntity(selectedEntity) &&
+
+                    if (s_prefabPublicInterface->IsOwnedByPrefabInstance(selectedEntity) &&
+                        !s_prefabPublicInterface->IsInstanceContainerEntity(selectedEntity) &&
                         m_prefabOverridePublicInterface->AreOverridesPresent(selectedEntity))
                     {
                         QAction* revertAction = menu->addAction(QObject::tr("Revert Overrides"));


### PR DESCRIPTION
## What does this PR do?

Fixes minor issues: https://github.com/o3de/o3de/issues/15087, https://github.com/o3de/o3de/issues/15606

This PR fixes the error messages that show up in console after various prefab operations. 

> [Error] (Prefab) - Failed to find an owning instance for entity with id 17089810523390950905.

The error message shows up when AM is turned on by default and 'Revert Override' action (in context menu) would then use that feature. There is a new 'Enabled State' callback in AM that checks an action's availability. For 'Revert Override' action, the callback gets invoked when entity selection changes or prefab propagation ends.

In some prefab editor operations, selection change might happen before the prefab propagation ends, then the callback invoked by the 'selection change' event would try to query override existence for a selected entity id that references an entity that is not yet owned by a prefab instance. Eventually, prefab override API would complain that the entity to check is not owned by any prefab instance.

**Why should we target it for stabilization?**

1. Although it just fixes minor issues, I think it would be good to keep console warning-and-error free for different entity/prefab operations in editor, if possible. Since this is a major improvement in prefab system in this upcoming release, I think we can try to maintain that effort we made.
2. The error message would show up quite frequently in various prefab operations including undo/redo, 'Create Entity', 'Detach Prefab', etc. It is misleading to editor users. (see [video attached](https://github.com/o3de/o3de/issues/15087))

**Any Risk?**

No. Prefab override is a feature that belongs to prefab system. Before doing 'AreOverridesPresent' query, it makes senses to check if an entity is owned by a prefab.

## How was this PR tested?

Passed existing tests. Manually tested in editor.

https://user-images.githubusercontent.com/11157226/233146536-5d736dd1-b1a2-4042-94a1-ea478617fbb6.mp4

## Exception Tracking

- [x] 1. Owning SIG requests the exception, by a Sig Representative (Chair/co-chair) adding the PR to the exception requests queue board.
- [x] 2. (@forkercat, SIG-Content) Owning SIG comments on the PR explaining impact if this code does not go into stabilization. (explained in description)
- [x] 3. Unrelated SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] 4. UX SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] 5. Testing SIG representative (chair/cochair) approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] (Must occur at some point before SIG-Release approval) Code has been approved for merging by maintainers
- [x] 6. SIG-Release Release Manager or co-Release Manager approves the exception, adding a comment indicating approval and the SIG they represent.
- [ ] 7. If all approvals are accepted, then the exception PR may be merged
- [ ] 8. Merged PR is verified successful via testing. If Merged PR verification testing failed, consult reps from step 3-5 and discussion occurs on fixing the failure vs backing out change
- [ ] 9. Exception is complete
