### PR TITLE
Fix SDK layout not activing required engine gems

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -481,14 +481,30 @@ function(ly_setup_cmake_install)
             list(APPEND relative_external_subdirs "\"${engine_rel_external_subdir}\"")
         endif()
     endforeach()
+    # Sort the external subdirectories before joining them with commas
+    list(SORT relative_external_subdirs CASE INSENSITIVE)
     list(JOIN relative_external_subdirs ",\n${indent}" O3DE_INSTALL_EXTERNAL_SUBDIRS)
+
+    # Use the cache list of "gem_names" from the engine.json to populate
+    # the generated engine.json file
+    # The O3DE_INSTALL_ENGINE_GEMS is the configure placeholder that needs to be set
+    # at the end
+    get_property(active_engine_gems GLOBAL PROPERTY "O3DE_EXPLICIT_ACTIVE_GEMS_ENGINE")
+    if (active_engine_gems)
+        foreach(active_engine_gem IN LISTS active_engine_gems)
+            list(APPEND quoted_active_engine_gems "\"${active_engine_gem}\"")
+        endforeach()
+        list(SORT quoted_active_engine_gems CASE INSENSITIVE)
+        list(JOIN quoted_active_engine_gems ",\n${indent}" O3DE_INSTALL_ENGINE_GEMS)
+    endif()
 
     # Read the "templates" key from the source engine.json
     o3de_read_json_array(engine_templates ${LY_ROOT_FOLDER}/engine.json "templates")
     if(engine_templates)
-        foreach(template_path ${engine_templates})
+        foreach(template_path IN LISTS engine_templates)
             list(APPEND relative_templates "\"${template_path}\"")
         endforeach()
+        list(SORT relative_templates CASE INSENSITIVE)
         list(JOIN relative_templates ",\n${indent}" O3DE_INSTALL_TEMPLATES)
     endif()
 

--- a/cmake/Subdirectories.cmake
+++ b/cmake/Subdirectories.cmake
@@ -337,8 +337,18 @@ function(get_all_external_subdirectories_for_o3de_object output_subdirs object_t
         resolve_gem_dependencies(${object_type} "${object_path}")
     endif()
 
-    foreach(gem_name_with_version_specifier IN LISTS initial_gem_names)
+    # Cache the "gem_names" field entries as read from the <o3de_object>.json file
+    # This will be used in the Install code to generate an "engine.json" with the same
+    # set of active gems into its "gem_names" field
+    get_property(explicit_active_gems GLOBAL PROPERTY "O3DE_EXPLICIT_ACTIVE_GEMS_${object_type}")
+    # Append to any existing active gems mapped using the ${object_type} key
+    list(APPEND explicit_active_gems ${initial_gem_names})
+    # Make the list of active gems unique
+    list(REMOVE_DUPLICATES explicit_active_gems)
+    # Update the ${object_type} -> active gem GLOBAL property
+    set_property(GLOBAL PROPERTY "O3DE_EXPLICIT_ACTIVE_GEMS_${object_type}" "${explicit_active_gems}")
 
+    foreach(gem_name_with_version_specifier IN LISTS initial_gem_names)
         # Use the ERROR_VARIABLE to catch the common case when it's a simple string and not a json type.
         string(JSON json_type ERROR_VARIABLE json_error TYPE ${gem_name_with_version_specifier})
         set(gem_optional FALSE)

--- a/cmake/install/engine.json.in
+++ b/cmake/install/engine.json.in
@@ -8,6 +8,7 @@
     "copyright_year": @O3DE_COPYRIGHT_YEAR@,
     "build": @O3DE_INSTALL_BUILD_VERSION@,
     "external_subdirectories": [@O3DE_INSTALL_EXTERNAL_SUBDIRS@],
+    "gem_names": [@O3DE_INSTALL_ENGINE_GEMS@],
     "projects": [@O3DE_INSTALL_PROJECTS@],
     "templates": [@O3DE_INSTALL_TEMPLATES@]
 }

--- a/engine.json
+++ b/engine.json
@@ -68,7 +68,6 @@
         "Gems/Prefab/PrefabBuilder",
         "Gems/Presence",
         "Gems/PrimitiveAssets",
-        "Gems/Streamer",
         "Gems/Profiler",
         "Gems/PythonAssetBuilder",
         "Gems/QtForPython",
@@ -89,6 +88,7 @@
         "Gems/StartingPointCamera",
         "Gems/StartingPointInput",
         "Gems/StartingPointMovement",
+        "Gems/Streamer",
         "Gems/SurfaceData",
         "Gems/Terrain",
         "Gems/TestAssetBuilder",
@@ -102,10 +102,10 @@
         "Gems/WhiteBox"
     ],
     "gem_names": [
-        "AtomShader",
         "Atom_Bootstrap",
-        "CommonFeaturesAtom",
+        "AtomShader",
         "Camera",
+        "CommonFeaturesAtom",
         "Maestro",
         "PrefabBuilder",
         "SceneProcessing"
@@ -114,15 +114,16 @@
         "AutomatedTesting"
     ],
     "templates": [
-        "Templates/PrebuiltGem",
-        "Templates/GemRepo",
         "Templates/AssetGem",
+        "Templates/CppToolGem",
         "Templates/DefaultComponent",
         "Templates/DefaultGem",
         "Templates/DefaultProject",
-        "Templates/CppToolGem",
+        "Templates/GemRepo",
         "Templates/MinimalProject",
+        "Templates/PrebuiltGem",
+        "Templates/PythonToolGem",
         "Templates/ScriptCanvasNode",
-        "Templates/PythonToolGem"
+        "Templates/UnifiedMultiplayerGem"
     ]
 }


### PR DESCRIPTION
The SDK layout `engine.json` file was not having the list of required engine gems listed in the "gem_names" field generated into its engine.json file.

Therefore the GameLauncher and ServerLauncher of a project built against the engine SDK did not set required engine gems such as the "Camera" gem as active.

Therefore loading any level in the launcher would log an assert about the Camera component being unable to be deserialized.

fixes #15166

## How was this PR tested?

Created a new project using the DefaultProject template, saved a level for that project using the pre-built SDK Editor and then loaded that level using the project's GameLauncher successfully.
![image](https://user-images.githubusercontent.com/56135373/232930800-bfd596fa-7465-4d69-9427-385da7ab087a.png)
