### PR TITLE
Fixed a vulkan image streaming issue

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
@@ -40,7 +40,7 @@ namespace AZ
             //! This helper function checks whether a new allocation is within the budget
             bool CanAllocate(size_t sizeInBytes) const
             {
-                if (m_budgetInBytes && (m_totalResidentInBytes + sizeInBytes) > m_budgetInBytes)
+                if (m_budgetInBytes && (m_usedResidentInBytes + sizeInBytes) > m_budgetInBytes)
                 {
                     return false;
                 }
@@ -53,12 +53,8 @@ namespace AZ
                 if (Validation::IsEnabled())
                 {
                     AZ_Assert(
-                        m_budgetInBytes >= m_totalResidentInBytes || m_budgetInBytes == 0,
-                        "Total resident memory is larger than memory budget. Memory budget %zu Total resident %zu", m_budgetInBytes, m_totalResidentInBytes.load());
-                    AZ_Assert(
-                        m_totalResidentInBytes >= m_usedResidentInBytes,
-                        "Used resident memory is larger than total resident memory. Total Resident Memory %zu Used Resident memory %zu", m_totalResidentInBytes.load(),
-                        m_usedResidentInBytes.load());
+                        m_budgetInBytes >= m_usedResidentInBytes || m_budgetInBytes == 0,
+                        "Used resident memory is larger than memory budget. Memory budget %zu resident %zu", m_budgetInBytes, m_usedResidentInBytes.load());
                 }
             }
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -124,7 +124,7 @@ namespace AZ
             //! User could provide such a callback function which releases some resources from the pool
             //! If some resources are released, the function may return true.
             //! If nothing is released, the function should return false.
-            using LowMemoryCallback = AZStd::function<bool()>;
+            using LowMemoryCallback = AZStd::function<bool(size_t targetMemoryUsage)>;
             void SetLowMemoryCallback(LowMemoryCallback callback);
             
             //! Set memory budget

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
@@ -645,6 +645,7 @@ namespace AZ
             }
 
             bool releaseSuccess = true;
+            // If the new budget is smaller than the memory are in use, we need to release some memory
             if (newBudget < heapMemoryUsage.m_usedResidentInBytes)
             {
                 releaseSuccess = m_memoryReleaseCallback(newBudget);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
@@ -218,27 +218,14 @@ namespace AZ
             bool canAllocate = memoryAllocatorUsage.CanAllocate(pageAllocationInBytes);
             if (!canAllocate && m_memoryReleaseCallback)
             {
-                bool releaseSuccess = false;
-                while (!canAllocate)
-                {
-                    // Request to release some memory
-                    releaseSuccess = m_memoryReleaseCallback();
-
-                    // break out of the loop if memory release did not happen
-                    if (!releaseSuccess)
-                    {
-                        break;
-                    }
-
-                    // re-evaluation page memory allocation since there are tiles were released.
-                    pageAllocationInBytes = m_tileAllocator.EvaluateMemoryAllocation(totalTiles);
-                    canAllocate = memoryAllocatorUsage.CanAllocate(pageAllocationInBytes);
-                }
+                // only try to release tiles the resource need
+                uint32_t maxUsedTiles = m_tileAllocator.GetTotalTileCount() - totalTiles;
+                bool releaseSuccess = m_memoryReleaseCallback(maxUsedTiles * m_tileAllocator.GetDescriptor().m_tileSizeInBytes);
 
                 if (!releaseSuccess)
                 {
-                    AZ_Warning("DX12::StreamingImagePool", false, "There isn't enough memory to allocate the image subresource. "
-                        "Using the default tile for the subresource. Try increase the StreamingImagePool memory budget");
+                    AZ_Warning("DX12::StreamingImagePool", false, "There isn't enough memory to allocate the image [%s]'s subresource %d. "
+                        "Using the default tile for the subresource. Try increase the StreamingImagePool memory budget", image.GetName().GetCStr(), subresourceIndex);
                 }
             }
 
@@ -498,30 +485,6 @@ namespace AZ
                 GetDevice().GetImageAllocationInfo(request.m_descriptor, allocationInfo);
 
                 auto& memoryAllocatorUsage = GetDeviceHeapMemoryUsage();
-                
-                bool canAllocate = memoryAllocatorUsage.CanAllocate(allocationInfo.SizeInBytes);
-                if (!canAllocate && m_memoryReleaseCallback)
-                {
-                    bool releaseSuccess = false;
-                    while (!canAllocate)
-                    {
-                        releaseSuccess = m_memoryReleaseCallback();
-                        if (!releaseSuccess)
-                        {
-                            AZ_Warning("DX12::StreamingImagePool", false, "Failed to release any memory from the StreamngImagePool");
-                            break;
-                        }
-                        // Re-evaluation the allocation after some memory got release
-                        canAllocate = memoryAllocatorUsage.CanAllocate(allocationInfo.SizeInBytes);
-                    }
-                }
-
-                if (!canAllocate)
-                {
-                    // Can't resolve the memory issue.
-                    AZ_Error("DX12::StreamingImagePool", false, "StreamingImagePool doesn't have enough memory to allocate image. Try increase the StreamingImagePool's memory budget");
-                    return RHI::ResultCode::OutOfMemory;
-                }
 
                 memoryView = GetDevice().CreateImageCommitted(request.m_descriptor, nullptr, D3D12_RESOURCE_STATE_COMMON, D3D12_HEAP_TYPE_DEFAULT);
                 
@@ -681,24 +644,16 @@ namespace AZ
                 return RHI::ResultCode::Success;
             }
 
-            // Can't set to new budget if the new budget is smaller than allocated and there is no memory release handling
-            if (newBudget < heapMemoryUsage.m_totalResidentInBytes && !m_memoryReleaseCallback)
-            {
-                AZ_Warning("StreamingImagePool", false, "Can't set pool memory budget to %u because the memory release callback wasn't set", newBudget);
-                return RHI::ResultCode::InvalidArgument;
-            }
-
             bool releaseSuccess = true;
-            while (newBudget < heapMemoryUsage.m_totalResidentInBytes && releaseSuccess)
+            if (newBudget < heapMemoryUsage.m_usedResidentInBytes)
             {
-                // Request to release some memory
-                releaseSuccess = m_memoryReleaseCallback();
+                releaseSuccess = m_memoryReleaseCallback(newBudget);
             }
 
-            // Failed to release memory to desired budget. Set current budget to current total resident.
+            size_t resident = heapMemoryUsage.m_usedResidentInBytes;
             if (!releaseSuccess)
             {
-                heapMemoryUsage.m_budgetInBytes = heapMemoryUsage.m_totalResidentInBytes;
+                heapMemoryUsage.m_budgetInBytes = resident;
                 AZ_Warning("StreamingImagePool", false, "Failed to set pool memory budget to %u, set to %u instead", newBudget, heapMemoryUsage.m_budgetInBytes);
             }
             else

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
@@ -49,22 +49,8 @@ namespace AZ
             bool canAllocate = heapMemoryUsage.CanAllocate(pageAllocationInBytes);
             if (!canAllocate && m_memoryReleaseCallback)
             {
-                bool releaseSuccess = false;
-                while (!canAllocate)
-                {
-                    // Request to release some memory
-                    releaseSuccess = m_memoryReleaseCallback();
-
-                    // break out of the loop if memory release did not happen
-                    if (!releaseSuccess)
-                    {
-                        break;
-                    }
-
-                    // re-evaluation page memory allocation since there are tiles were released.
-                    pageAllocationInBytes = m_tileAllocator.EvaluateMemoryAllocation(blockCount);
-                    canAllocate = heapMemoryUsage.CanAllocate(pageAllocationInBytes);
-                }
+                uint32_t maxUsedTiles = m_tileAllocator.GetTotalTileCount() - blockCount;
+                bool releaseSuccess = m_memoryReleaseCallback(maxUsedTiles * m_tileAllocator.GetDescriptor().m_tileSizeInBytes);
 
                 if (!releaseSuccess)
                 {
@@ -93,7 +79,6 @@ namespace AZ
         {
             m_tileAllocator.DeAllocate(heapTiles);
             heapTiles.clear();
-            m_tileAllocator.GarbageCollect();
         }
 
         RHI::ResultCode StreamingImagePool::InitInternal(RHI::Device& deviceBase, [[maybe_unused]] const RHI::StreamingImagePoolDescriptor& descriptor)
@@ -245,6 +230,7 @@ namespace AZ
         void StreamingImagePool::OnFrameEnd()
         {
             m_memoryAllocator.GarbageCollect();
+            m_tileAllocator.GarbageCollect();
             Base::OnFrameEnd();
         }
 
@@ -262,51 +248,36 @@ namespace AZ
         RHI::ResultCode StreamingImagePool::SetMemoryBudgetInternal(size_t newBudget)
         {
             RHI::HeapMemoryUsage& heapMemoryUsage = m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device);
-
+            
             if (newBudget == 0)
             {
-                heapMemoryUsage.m_budgetInBytes = newBudget;
                 return RHI::ResultCode::Success;
             }
 
             // Can't set to new budget if the new budget is smaller than allocated and there is no memory release handling
-            if (newBudget < heapMemoryUsage.m_totalResidentInBytes && !m_memoryReleaseCallback)
+            if (newBudget < heapMemoryUsage.m_usedResidentInBytes && !m_memoryReleaseCallback)
             {
                 AZ_Warning("StreamingImagePool", false, "Can't set pool memory budget to %u because the memory release callback wasn't set", newBudget);
                 return RHI::ResultCode::InvalidArgument;
             }
 
             bool releaseSuccess = true;
-            while (newBudget < heapMemoryUsage.m_totalResidentInBytes && releaseSuccess)
+            if (newBudget < heapMemoryUsage.m_usedResidentInBytes)
             {
-                size_t previousTotalResidentInBytes = heapMemoryUsage.m_totalResidentInBytes;
-                size_t previousUsedResidentInBytes = heapMemoryUsage.m_usedResidentInBytes;
-
                 // Request to release some memory
-                releaseSuccess = m_memoryReleaseCallback();
-
-                // Ensure there were memory released in the m_memoryReleaseCallback() call
-                if (releaseSuccess)
-                {
-                    releaseSuccess = previousTotalResidentInBytes > heapMemoryUsage.m_totalResidentInBytes
-                        || previousUsedResidentInBytes > heapMemoryUsage.m_usedResidentInBytes;
-                    if (!releaseSuccess)
-                    {
-                        AZ_Warning("StreamingImagePool", false, "bad release function");
-                    }
-                }
+                releaseSuccess = m_memoryReleaseCallback(newBudget);
             }
 
-            // Failed to release memory to desired budget. Set current budget to current total resident.
             if (!releaseSuccess)
             {
-                heapMemoryUsage.m_budgetInBytes = heapMemoryUsage.m_totalResidentInBytes;
+                heapMemoryUsage.m_budgetInBytes = heapMemoryUsage.m_usedResidentInBytes;
                 AZ_Warning("StreamingImagePool", false, "Failed to set pool memory budget to %u, set to %u instead", newBudget, heapMemoryUsage.m_budgetInBytes);
             }
             else
             {
                 heapMemoryUsage.m_budgetInBytes = newBudget;
             }
+            
             return RHI::ResultCode::Success;
         }
         

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
@@ -262,9 +262,9 @@ namespace AZ
             }
 
             bool releaseSuccess = true;
+            // If the new budget is smaller than the memory are in use, we need to release some memory
             if (newBudget < heapMemoryUsage.m_usedResidentInBytes)
             {
-                // Request to release some memory
                 releaseSuccess = m_memoryReleaseCallback(newBudget);
             }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
@@ -51,6 +51,7 @@ namespace AZ
 
             friend class ImageSystem;
             friend class StreamingImageController;
+            friend class StreamingImageContext;
         public:
             AZ_INSTANCE_DATA(StreamingImage, "{E48A7FF0-3065-42C6-9673-4FE7C8905629}", Image);
             AZ_CLASS_ALLOCATOR(StreamingImage, SystemAllocator);
@@ -97,6 +98,9 @@ namespace AZ
             
             //! Queues an expansion to the mip chain that is one level higher than the resident mip chain.
             void QueueExpandToNextMipChainLevel();
+
+            //! Cancel ongoing mip expanding
+            void CancelExpanding();
 
             //! Performs the GPU mip chain expansion for any contiguous range of ready (loaded) mip chain assets. Returns
             //! the result of the RHI pool residency update. If no new mip chains are available, this will no-op

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageContext.h
@@ -54,7 +54,9 @@ namespace AZ
             //! Returns the timestamp of last access.
             size_t GetLastAccessTimestamp() const;
 
-            //! Update mip stats
+            //! Calculate some mip stats which are used for determinate their expansion or eviction orders
+            //! The stats include: m_mipLevelTargetAdjusted, m_residentMip, m_evictableMips, m_missingMips, m_residentMipSize
+            //! This function need to be called every time after a mip is expanded or evicted or when the global mip bias is changed
             void UpdateMipStats();
 
         private:
@@ -71,20 +73,17 @@ namespace AZ
 
             // Tracks the last timestamp the image was requested.
             AZStd::atomic_size_t m_lastAccessTimestamp = {0};
-
-            // Stats which need to be updated every time after a mip is expanded or evicted.
-            // These stats are used to decide the image's streaming priority in StreamingImageController
-            
+                        
             // The target mip level which applied global mip bias
-            uint16_t m_mipLevelTargetAdjusted = {0};
+            uint16_t m_mipLevelTargetAdjusted = 0;
             // The most detailed mip which is resident
-            uint16_t m_residentMip;
+            uint16_t m_residentMip = 0;
             // The number of mips which can be evicted
-            uint16_t m_evictableMips;
+            uint16_t m_evictableMips = 0;
             // The mips which are missing to reach m_mipLevelTargetAdjusted 
-            uint16_t m_missingMips;
+            uint16_t m_missingMips = 0;
             // The size of the most detailed mip
-            uint32_t m_residentMipSize;
+            uint32_t m_residentMipSize = 1;
         };
 
         using StreamingImageContextPtr = AZStd::intrusive_ptr<StreamingImageContext>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageContext.h
@@ -20,6 +20,7 @@ namespace AZ
     namespace RPI
     {
         class StreamingImage;
+        class StreamingImageController;
 
         //! A context owned by a streaming controller which tracks a streaming image asset instance.
         //! The context has shared ownership between the streaming image and the streaming image controller.
@@ -53,6 +54,9 @@ namespace AZ
             //! Returns the timestamp of last access.
             size_t GetLastAccessTimestamp() const;
 
+            //! Update mip stats
+            void UpdateMipStats();
+
         private:
 
             // Holds a weak (raw) reference to the parent streaming image.
@@ -67,6 +71,20 @@ namespace AZ
 
             // Tracks the last timestamp the image was requested.
             AZStd::atomic_size_t m_lastAccessTimestamp = {0};
+
+            // Stats which need to be updated every time after a mip is expanded or evicted.
+            // These stats are used to decide the image's streaming priority in StreamingImageController
+            
+            // The target mip level which applied global mip bias
+            uint16_t m_mipLevelTargetAdjusted = {0};
+            // The most detailed mip which is resident
+            uint16_t m_residentMip;
+            // The number of mips which can be evicted
+            uint16_t m_evictableMips;
+            // The mips which are missing to reach m_mipLevelTargetAdjusted 
+            uint16_t m_missingMips;
+            // The size of the most detailed mip
+            uint32_t m_residentMipSize;
         };
 
         using StreamingImageContextPtr = AZStd::intrusive_ptr<StreamingImageContext>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -34,6 +34,7 @@ namespace AZ
         {
             friend class StreamingImagePool;
             friend class StreamingImage;
+            friend class StreamingImageContext;
 
         public:
             //! Create a StreamingImageController
@@ -63,6 +64,9 @@ namespace AZ
             //! Returns the number of images which are expanding their mipmaps
             uint32_t GetExpandingImageCount() const;
 
+            //! Returns the number of streamable images attached to this controller
+            uint32_t GetStreamableImageCount() const;
+
             //! Set mipmap bias to streaming images's streaming target
             //! For example, if the streaming image's streaming target is 0, and mipmap bias is 1, then the actual streaming target is 0+1
             //! The mipBias can be a negative value.
@@ -70,7 +74,7 @@ namespace AZ
             void SetMipBias(int16_t mipBias);
 
             int16_t GetMipBias() const;
-
+            
             //! Returns a streaming image's target mip level (with the global mip bias)
             uint16_t GetImageTargetMip(const StreamingImage* image) const;
 
@@ -87,24 +91,21 @@ namespace AZ
             // Stream in one mip chain for the streaming image with highest priority
             bool ExpandOneMipChain();
 
-            // For all the streaming images, evict mipmaps which are not needed (mips which have higher details than target mip level)
-            void EvictUnusedMips();
-
             // Evict mipmaps for specific image
             // Return true if any mipmaps were evicted
             bool EvictUnusedMips(StreamingImage* image);
 
             // Called when the RHI::StreamingImagePool is low on memory for new allocation
-            bool OnHandleLowMemory();
+            bool ReleaseMemory(size_t targetMemoryUsage);
 
             // Get gpu memory usage of the streaming image pool
             size_t GetPoolMemoryUsage();
 
-            // Update image's priority
-            void UpdateImagePriority(StreamingImage* image);
+            // Insert image to expandable and evictable lists
+            void ReinsertImageToLists(StreamingImage* image);
 
-            // Calculate image's streaming priority value
-            StreamingImage::Priority CalculateImagePriority(StreamingImage* image) const;
+            // Called when the expanding of an image is finished or canceled
+            void EndExpandImage(StreamingImage* image);
 
             // Return whether an image need to expand its mipmap
             bool NeedExpand(const StreamingImage* image) const;
@@ -130,18 +131,36 @@ namespace AZ
             AZStd::mutex m_mipExpandMutex;
             AZStd::queue<StreamingImageContextPtr> m_mipExpandQueue;
 
-            // A sorted list of streaming images which mips can be streamed in/out.
-            // The images are sorted by their priority key, last access timestamp and their address (so there won't be same key from different images)
-            struct ImagePriorityComparator
+            // All the images which are managed by StreamingImageController
+            AZStd::set<StreamingImage*> m_streamableImages;
+
+            // All the images which are managed by StreamingImageController can be one or few of the following lists
+            // m_expandableImages, m_evictableImages or m_expandingImages
+            // - When an image hasn't reached its target mipmap level, it will be in the m_expandableImages list
+            // - When an image has mipmaps can be evicted, it's in m_evictableImages list
+            // - When an image is in the process of expanding, it will be removed from m_expandableImages and added to m_expandingImages list
+            // - It's possible for an image to be in both m_expandableImages and m_evictableImages list.
+            // - Expanding will be canceled when memory is low
+            // - When an image is done expanding or evicted, they will get re-insert to m_expandableImages and m_evictableImages list
+            
+            // A list of expandable images which are sorted by their expanding priority
+            struct ExpandPriorityComparator
             {
                 bool operator()(const StreamingImage* lhs, const StreamingImage* rhs) const;
             };
-            AZStd::set<StreamingImage*, ImagePriorityComparator> m_streamableImages;
-            // mutex for access the m_streamableImages
+            AZStd::set<StreamingImage*, ExpandPriorityComparator> m_expandableImages;
+            // A list of images which have evictable mipmap. They are sorted by their evicting priority.
+            struct EvictPriorityComparator
+            {
+                bool operator()(const StreamingImage* lhs, const StreamingImage* rhs) const;
+            };
+
+            AZStd::set<StreamingImage*, EvictPriorityComparator> m_evictableImages;
+            // mutex for access the image lists
             AZStd::mutex m_imageListAccessMutex;
 
             // The images which are expanding will be added to this list and removed from m_streamableImages list.
-            // Once their expanding are finished, they would be removed from this list and added back to m_streamableImages list
+            // Once their expanding are finished, they would be removed from this list and added back to m_evictableImages or/and m_expandableImages list
             AZStd::unordered_set<StreamingImage*> m_expandingImages;
 
             // A monotonically increasing counter used to track image mip requests. Useful for sorting contexts by LRU.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -157,7 +157,7 @@ namespace AZ
 
             AZStd::set<StreamingImage*, EvictPriorityComparator> m_evictableImages;
             // mutex for access the image lists
-            AZStd::mutex m_imageListAccessMutex;
+            AZStd::recursive_mutex m_imageListAccessMutex;
 
             // The images which are expanding will be added to this list and removed from m_streamableImages list.
             // Once their expanding are finished, they would be removed from this list and added back to m_evictableImages or/and m_expandableImages list

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -95,7 +95,7 @@ namespace AZ
             // Return true if any mipmaps were evicted
             bool EvictUnusedMips(StreamingImage* image);
 
-            // Called when the RHI::StreamingImagePool is low on memory for new allocation
+            // A callback function to release memory until the StreamingImagePool's device memory usage is same or less than the input number
             bool ReleaseMemory(size_t targetMemoryUsage);
 
             // Get gpu memory usage of the streaming image pool
@@ -134,14 +134,14 @@ namespace AZ
             // All the images which are managed by StreamingImageController
             AZStd::set<StreamingImage*> m_streamableImages;
 
-            // All the images which are managed by StreamingImageController can be one or few of the following lists
+            // All the images which are managed by StreamingImageController can be in one or few of the following lists
             // m_expandableImages, m_evictableImages or m_expandingImages
             // - When an image hasn't reached its target mipmap level, it will be in the m_expandableImages list
-            // - When an image has mipmaps can be evicted, it's in m_evictableImages list
+            // - When an image has mipmaps that can be evicted, it's in m_evictableImages list
             // - When an image is in the process of expanding, it will be removed from m_expandableImages and added to m_expandingImages list
             // - It's possible for an image to be in both m_expandableImages and m_evictableImages list.
             // - Expanding will be canceled when memory is low
-            // - When an image is done expanding or evicted, they will get re-insert to m_expandableImages and m_evictableImages list
+            // - When an image is done expanding or evicted, they will get re-inserted back into m_expandableImages and m_evictableImages list
             
             // A list of expandable images which are sorted by their expanding priority
             struct ExpandPriorityComparator
@@ -160,7 +160,7 @@ namespace AZ
             AZStd::recursive_mutex m_imageListAccessMutex;
 
             // The images which are expanding will be added to this list and removed from m_streamableImages list.
-            // Once their expanding are finished, they would be removed from this list and added back to m_evictableImages or/and m_expandableImages list
+            // Once their expansion is finished, they would be removed from this list and added back to m_evictableImages or/and m_expandableImages list
             AZStd::unordered_set<StreamingImage*> m_expandingImages;
 
             // A monotonically increasing counter used to track image mip requests. Useful for sorting contexts by LRU.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
@@ -98,9 +98,6 @@ namespace AZ
 
             // The controller used to manage streaming events on the pool.
             AZStd::unique_ptr<StreamingImageController> m_controller;
-
-            // The streamable image count
-            AZStd::atomic_uint m_streamableImageCount = 0;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -353,6 +353,11 @@ namespace AZ
             QueueExpandToMipChainLevel(m_mipChainState.m_streamingTarget - 1);
         }
 
+        void StreamingImage::CancelExpanding()
+        {
+            TrimToMipChainLevel(m_mipChainState.m_residencyTarget);
+        }
+
         RHI::ResultCode StreamingImage::ExpandMipChain()
         {
             AZ_Assert(m_mipChainState.m_streamingTarget <= m_mipChainState.m_residencyTarget, "The target mip chain cannot be less detailed than the resident mip chain.")

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageContext.cpp
@@ -32,7 +32,7 @@ namespace AZ
         {
             m_mipLevelTargetAdjusted = m_streamingImage->m_streamingController->GetImageTargetMip(m_streamingImage);
             m_residentMip = m_streamingImage->GetResidentMipLevel();
-            AZ_Assert(m_residentMip == m_streamingImage->m_imageAsset->GetMipLevel(m_streamingImage->m_mipChainState.m_residencyTarget), "something wrong");
+
             if (m_residentMip > m_mipLevelTargetAdjusted)
             {
                 m_missingMips = m_residentMip - m_mipLevelTargetAdjusted;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageContext.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/RPI.Public/Image/StreamingImageContext.h>
+#include <Atom/RPI.Public/Image/StreamingImageController.h>
 
 namespace AZ
 {
@@ -25,6 +26,36 @@ namespace AZ
         size_t StreamingImageContext::GetLastAccessTimestamp() const
         {
             return m_lastAccessTimestamp;
+        }
+
+        void StreamingImageContext::UpdateMipStats()
+        {
+            m_mipLevelTargetAdjusted = m_streamingImage->m_streamingController->GetImageTargetMip(m_streamingImage);
+            m_residentMip = m_streamingImage->GetResidentMipLevel();
+            AZ_Assert(m_residentMip == m_streamingImage->m_imageAsset->GetMipLevel(m_streamingImage->m_mipChainState.m_residencyTarget), "something wrong");
+            if (m_residentMip > m_mipLevelTargetAdjusted)
+            {
+                m_missingMips = m_residentMip - m_mipLevelTargetAdjusted;
+            }
+            else
+            {
+                m_missingMips = 0;
+            }
+
+            const size_t mipChainTailIndex = m_streamingImage->m_imageAsset->GetMipChainCount() - 1;
+            size_t tailMip = m_streamingImage->m_imageAsset->GetMipLevel(mipChainTailIndex);
+            if (tailMip > m_residentMip)
+            {
+                m_evictableMips = aznumeric_cast<uint16_t>(tailMip) - m_residentMip;
+            }
+            else
+            {
+                m_evictableMips = 0;
+            }
+
+            // get the length of the resident mip
+            RHI::Size mipSize = m_streamingImage->m_imageAsset->GetImageDescriptor().m_size.GetReducedMip(aznumeric_cast<uint32_t>(m_residentMip));
+            m_residentMipSize = mipSize.m_width > mipSize.m_height? mipSize.m_width : mipSize.m_height;
         }
     }
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
@@ -31,7 +31,7 @@ namespace AZ
         {
             AZStd::unique_ptr<StreamingImageController> controller = AZStd::make_unique<StreamingImageController>();
             controller->m_pool = &pool;
-            controller->m_pool->SetLowMemoryCallback(AZStd::bind(&StreamingImageController::OnHandleLowMemory, controller.get()));
+            controller->m_pool->SetLowMemoryCallback(AZStd::bind(&StreamingImageController::ReleaseMemory, controller.get(), AZStd::placeholders::_1));
             return controller;
         }
 
@@ -51,13 +51,10 @@ namespace AZ
                 image->m_streamingController = this;
                 image->m_streamingContext = AZStd::move(context);
             }
-
-            // Add the image to the streaming image
-            {
-                AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-                UpdateImagePriority(image);
-                m_streamableImages.insert(image);
-            }
+            
+            AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
+            m_streamableImages.insert(image);
+            ReinsertImageToLists(image);
         }
 
         void StreamingImageController::DetachImage(StreamingImage* image)
@@ -65,11 +62,13 @@ namespace AZ
             AZ_Assert(image, "Image must not be null.");
 
             // Remove image from the list first before clearing the image streaming context
-            // since the compare function uses the context
+            // since the compare functions may use the image's StreamingImageContext
             {
                 AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-                m_expandingImages.erase(image);
                 m_streamableImages.erase(image);
+                m_expandingImages.erase(image);
+                m_expandableImages.erase(image);
+                m_evictableImages.erase(image);
             }
 
             const StreamingImageContextPtr& context = image->m_streamingContext;
@@ -86,6 +85,37 @@ namespace AZ
             image->m_streamingContext = nullptr;
         }
 
+        void StreamingImageController::ReinsertImageToLists(StreamingImage* image)
+        {
+            AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
+            m_expandableImages.erase(image);
+            m_evictableImages.erase(image);
+
+            if (!image->IsExpanding())
+            {
+                image->m_streamingContext->UpdateMipStats();
+
+                if (NeedExpand(image))
+                {
+                    m_expandableImages.insert(image);
+                }
+                if (image->IsTrimmable())
+                {
+                    m_evictableImages.insert(image);
+                }
+            }
+        }
+
+        void StreamingImageController::EndExpandImage(StreamingImage* image)
+        {
+            // remove unused mips in case global mip bias was changed during expanding
+            EvictUnusedMips(image);
+
+            image->m_streamingContext->m_queuedForMipExpand = false;
+
+            ReinsertImageToLists(image);
+        }
+
         void StreamingImageController::Update()
         {
             AZ_PROFILE_FUNCTION(RPI);
@@ -93,6 +123,25 @@ namespace AZ
             // Limit the amount of upload image per update to avoid internal queue being too long
             const uint32_t c_jobCount = 30;
             uint32_t jobCount = 0;
+
+            // if the memory was low, cancel all expanding images
+            if (m_lastLowMemory)
+            {
+                // clear the gpu expand queue
+                {
+                    AZStd::lock_guard<AZStd::mutex> mipExpandlock(m_mipExpandMutex);
+                    m_mipExpandQueue = AZStd::queue<StreamingImageContextPtr>();
+                }
+
+                // clear the expanding images
+                AZStd::lock_guard<AZStd::mutex> imageListAccesslock(m_imageListAccessMutex);
+                for (auto image:m_expandingImages)
+                {
+                    image->CancelExpanding();
+                    EndExpandImage(image);
+                }
+                m_expandingImages.clear();
+            }
 
             // Finalize the mip expansion events generated from the controller. This is done once per update. Anytime
             // a new mip chain asset is ready, the streaming image will notify the controller, which will then queue
@@ -113,18 +162,13 @@ namespace AZ
 
                             if (!image->IsExpanding())
                             {
-                                AZStd::lock_guard<AZStd::mutex> imageListAccesslock(m_imageListAccessMutex);
+                                EndExpandImage(image);
                                 m_expandingImages.erase(image);
-                                // remove unused mips in case global mip bias changed 
-                                EvictUnusedMips(image);
-                                UpdateImagePriority(image);
-                                m_streamableImages.insert(image);
 
                                 StreamingDebugOutput("StreamingImageController", "Image [%s] expanded mip level to %d\n",
                                     image->GetRHIImage()->GetName().GetCStr(), image->m_imageAsset->GetMipChainIndex(image->m_mipChainState.m_residencyTarget));
                             }
                         }
-                        context->m_queuedForMipExpand = false;
                     }
                     m_mipExpandQueue.pop();
 
@@ -135,24 +179,25 @@ namespace AZ
                     }
                 }
             }
-            
-            // Try to expand if the memory usage is dropping or there are enough free memory
-            jobCount = 0;
-            if (m_lastLowMemory == 0 || m_lastLowMemory > GetPoolMemoryUsage())
+
+            // reset low memory state if the memory is dropping since last low memory state
+            if (m_lastLowMemory > GetPoolMemoryUsage())
             {
-                while (jobCount < c_jobCount)
-                {
-                    if (ExpandOneMipChain())
-                    {
-                        jobCount++;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-                // reset last low memory
                 m_lastLowMemory = 0;
+            }
+            
+            // Try to expand if it's not in low memory state
+            jobCount = 0;
+            while (jobCount < c_jobCount && m_lastLowMemory == 0)
+            {
+                if (ExpandOneMipChain())
+                {
+                    jobCount++;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             ++m_timestamp;
@@ -175,51 +220,66 @@ namespace AZ
             {
                 AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
                 EvictUnusedMips(image);
-                if (m_streamableImages.erase(image))
-                {
-                    UpdateImagePriority(image);
-                    m_streamableImages.insert(image);
-                }
             }
+
+            // reinsert the image since the priority might be changed after mip target changed
+            ReinsertImageToLists(image);
         }
 
-        void StreamingImageController::UpdateImagePriority(StreamingImage* image)
+        bool StreamingImageController::ExpandPriorityComparator::operator()(const StreamingImage* lhs, const StreamingImage* rhs) const
         {
-            StreamingImage::Priority newPriority = CalculateImagePriority(image);
-            image->SetStreamingPriority(newPriority);
-        }
+            // use the resident mip size and missing mip count to decide the expand priority
+            auto lhsMipSize = lhs->m_streamingContext->m_residentMipSize;
+            auto rhsMipSize = rhs->m_streamingContext->m_residentMipSize;
 
-        bool StreamingImageController::ImagePriorityComparator::operator()(const StreamingImage* lhs, const StreamingImage* rhs) const
-        {
-            auto lhsPriority = lhs->GetStreamingPriority();
-            auto rhsPriority = rhs->GetStreamingPriority();
-            auto lhsTimestamp = lhs->m_streamingContext->GetLastAccessTimestamp();
-            auto rhsTimestamp = rhs->m_streamingContext->GetLastAccessTimestamp();
-            if (lhsPriority == rhsPriority)
+            if (lhsMipSize == rhsMipSize)
             {
-                if (lhsTimestamp == rhsTimestamp)
+                auto lhsMissingMips = lhs->m_streamingContext->m_missingMips;
+                auto rhsMissingMips = rhs->m_streamingContext->m_missingMips;
+                if (lhsMissingMips == rhsMissingMips)
                 {
-                    return lhs > rhs;
+                    auto lhsTimestamp = lhs->m_streamingContext->GetLastAccessTimestamp();
+                    auto rhsTimestamp = rhs->m_streamingContext->GetLastAccessTimestamp();
+                    if (lhsTimestamp == rhsTimestamp)
+                    {
+                        // we need this to avoid same key in the AZStd::set
+                        return lhs < rhs;
+                    }
+                    // latest accessed image has higher priority
+                    return lhsTimestamp > rhsTimestamp;
                 }
                 else
                 {
-                    return lhsTimestamp > rhsTimestamp;
+                    // image with more missing mips has higher priority
+                    return lhsMissingMips > rhsMissingMips; 
                 }
             }
-            return lhsPriority > rhsPriority; 
-        }
 
-        StreamingImage::Priority StreamingImageController::CalculateImagePriority(StreamingImage* image) const
+            // image has smaller resolution has higher priority
+            return lhsMipSize < rhsMipSize;
+        }
+        
+        bool StreamingImageController::EvictPriorityComparator::operator()(const StreamingImage* lhs, const StreamingImage* rhs) const
         {
-            StreamingImage::Priority newPriority = 0; // 0 means lowest priority and the image mip would be evicted first
-            size_t residentMip = image->m_imageAsset->GetMipLevel(image->m_mipChainState.m_residencyTarget);
-            size_t targetMip = image->m_streamingContext->GetTargetMip();
-            if (residentMip >= targetMip)
+            auto lhsEvictableMips = lhs->m_streamingContext->m_evictableMips;
+            auto rhsEvictableMips = rhs->m_streamingContext->m_evictableMips;
+
+            if (lhsEvictableMips == rhsEvictableMips)
             {
-                newPriority = residentMip - targetMip;
+                auto lhsTimestamp = lhs->m_streamingContext->GetLastAccessTimestamp();
+                auto rhsTimestamp = rhs->m_streamingContext->GetLastAccessTimestamp();
+                if (lhsTimestamp == rhsTimestamp)
+                {
+                    // we need this to avoid same key in the AZStd::set
+                    return lhs < rhs;
+                }
+
+                // Last visited image will be evicted later
+                return lhsTimestamp < rhsTimestamp;
             }
 
-            return newPriority;
+            // images with higher evictable mip count will be evict first
+            return lhsEvictableMips > rhsEvictableMips; 
         }
 
         void StreamingImageController::OnMipChainAssetReady(StreamingImage* image)
@@ -236,6 +296,11 @@ namespace AZ
                 m_mipExpandQueue.push(context);
             }
         }
+        
+        uint32_t StreamingImageController::GetStreamableImageCount() const
+        {
+            return aznumeric_cast<uint32_t>(m_streamableImages.size());
+        }
 
         uint32_t StreamingImageController::GetExpandingImageCount() const
         {
@@ -244,13 +309,33 @@ namespace AZ
 
         void StreamingImageController::SetMipBias(int16_t mipBias)
         {
-            int16_t prevMipBias = m_globalMipBias;
-            m_globalMipBias = mipBias;
-            // if the mipBias increased (using smaller size of mips), go throw each streaming image and evict unneeded mips
-            if (m_globalMipBias > prevMipBias)
+            if (m_globalMipBias == mipBias)
             {
-                StreamingDebugOutput("StreamingImageController", "SetMipBias. EvictUnusedMips %u\n");
-                EvictUnusedMips();
+                return;
+            }
+
+            m_globalMipBias = mipBias;
+
+            // we need go through all the streamable image to update their streaming context and regenerate the lists
+            AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
+            m_expandableImages.clear();
+            m_evictableImages.clear();
+
+            for (auto image : m_streamableImages)
+            {
+                EvictUnusedMips(image);
+                image->m_streamingContext->UpdateMipStats();
+                if (!image->IsExpanding())
+                {
+                    if (NeedExpand(image))
+                    {
+                        m_expandableImages.insert(image);
+                    }
+                    if (image->IsTrimmable())
+                    {
+                        m_evictableImages.insert(image);
+                    }
+                }
             }
         }
 
@@ -272,26 +357,27 @@ namespace AZ
         bool StreamingImageController::EvictOneMipChain()
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-            for (auto ritr = m_streamableImages.rbegin(); ritr != m_streamableImages.rend(); ritr++)
+            for (auto itr = m_evictableImages.begin(); itr != m_evictableImages.end(); itr++)
             {
-                StreamingImage* image = *ritr;
+                StreamingImage* image = *itr;
 
-                if (image->IsTrimmable())
+                RHI::ResultCode success = image->TrimOneMipChain();
+
+                if (success == RHI::ResultCode::Success)
                 {
-                    RHI::ResultCode success = image->TrimOneMipChain();
-                    if (success == RHI::ResultCode::Success)
-                    {
-                        StreamingDebugOutput(
-                            "StreamingImageController",
-                            "Image [%s] has one mipchain released; Current resident mip: %d\n",
-                            image->GetRHIImage()->GetName().GetCStr(),
-                            image->GetRHIImage()->GetResidentMipLevel());
-                        // update the image's priority and re-insert the image
-                        m_streamableImages.erase(image);
-                        UpdateImagePriority(image);
-                        m_streamableImages.insert(image);
-                        return true;
-                    }
+                    // update the image's priority and re-insert the image
+                    ReinsertImageToLists(image);
+
+                    StreamingDebugOutput(
+                        "StreamingImageController",
+                        "Image [%s] has one mipchain released; Current resident mip: %d\n",
+                        image->GetRHIImage()->GetName().GetCStr(),
+                        image->GetRHIImage()->GetResidentMipLevel());
+                    return true;
+                }
+                else
+                {
+                    AZ_Assert(false, "failed to evict an evictable image!");
                 }
             }
 
@@ -308,26 +394,21 @@ namespace AZ
         bool StreamingImageController::ExpandOneMipChain()
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-            if (m_streamableImages.size() == 0)
+            if (m_expandableImages.size() == 0)
             {
                 return false; 
             }
-            auto itr = m_streamableImages.begin();
+            auto itr = m_expandableImages.begin();
             StreamingImage* image = *itr;
-
-            if (NeedExpand(image))
+            image->QueueExpandToNextMipChainLevel();
+            if (image->IsExpanding())
             {
-                image->QueueExpandToNextMipChainLevel();
-                if (image->IsExpanding())
-                {
-                    StreamingDebugOutput("StreamingImageController", "Image [%s] is expanding mip level to %d\n",
-                        image->GetRHIImage()->GetName().GetCStr(), image->m_imageAsset->GetMipChainIndex(image->m_mipChainState.m_streamingTarget));
-                    m_streamableImages.erase(image);
-                    m_expandingImages.insert(image);
-                }
-                return true;
+                StreamingDebugOutput("StreamingImageController", "Image [%s] is expanding mip level to %d\n",
+                    image->GetRHIImage()->GetName().GetCStr(), image->m_imageAsset->GetMipChainIndex(image->m_mipChainState.m_streamingTarget));
+                m_expandingImages.insert(image);
+                ReinsertImageToLists(image);
             }
-            return false;
+            return true;
         }
 
         uint16_t StreamingImageController::GetImageTargetMip(const StreamingImage* image) const
@@ -358,54 +439,32 @@ namespace AZ
             return true;
         }
 
-        void StreamingImageController::EvictUnusedMips()
-        {
-            AZStd::lock_guard<AZStd::mutex> lock(m_imageListAccessMutex);
-            if (m_streamableImages.size() == 0)
-            {
-                return; 
-            }
-
-            AZStd::vector<StreamingImage*> evictedImages;
-
-            auto itr = m_streamableImages.begin();
-            while (itr != m_streamableImages.end())
-            {
-                StreamingImage* image = *itr;
-                if (EvictUnusedMips(image))
-                {
-                    itr = m_streamableImages.erase(itr);
-                    evictedImages.push_back(image);
-                }
-                else
-                {
-                    itr++;
-                }
-            }
-
-            for (auto image : evictedImages)
-            {
-                UpdateImagePriority(image);
-                m_streamableImages.insert(image);
-            }
-        }
-
-        bool StreamingImageController::OnHandleLowMemory()
+        bool StreamingImageController::ReleaseMemory(size_t targetMemoryUsage)
         {
             StreamingDebugOutput("StreamingImageController", "Handle low memory\n");
 
-            // Evict some mips
-            bool evicted = EvictOneMipChain();
+            size_t currentResident = GetPoolMemoryUsage();
 
-            // Save the memory 
-            m_lastLowMemory = GetPoolMemoryUsage();
+            while (currentResident > targetMemoryUsage)
+            {
+                // Evict some mips
+                bool evicted = EvictOneMipChain();
+                if (!evicted)
+                {
+                    // nothing to be evicted anymore
+                    m_lastLowMemory = currentResident;
+                    return false;
+                }
+                currentResident = GetPoolMemoryUsage();
+            }
 
-            return evicted;
+            m_lastLowMemory = currentResident;
+            return true;
         }
 
         size_t StreamingImageController::GetPoolMemoryUsage()
         {
-            size_t totalResident = m_pool->GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device).m_totalResidentInBytes.load();
+            size_t totalResident = m_pool->GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device).m_usedResidentInBytes.load();
             return totalResident;
         }
     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
@@ -74,7 +74,6 @@ namespace AZ
             // Add image to controller only if the image is streamable 
             if (image->IsStreamable())
             {
-                m_streamableImageCount++;
                 m_controller->AttachImage(image);
             }
         }
@@ -83,7 +82,6 @@ namespace AZ
         {
             if (image->IsStreamable())
             {
-                m_streamableImageCount--;
                 m_controller->DetachImage(image);
             }
         }
@@ -110,7 +108,7 @@ namespace AZ
 
         uint32_t StreamingImagePool::GetStreamableImageCount() const
         {
-            return m_streamableImageCount;
+            return m_controller->GetStreamableImageCount();
         }
 
         bool StreamingImagePool::SetMemoryBudget(size_t newBudgetInBytes)


### PR DESCRIPTION
## What does this PR do?

Fixed a vulkan image streaming issue: https://github.com/o3de/o3de-atom-sampleviewer/issues/605
Improved image streaming control by using two separate sorted list for mip expand and evict.
Change the heap memory usage validation so the budget only limits the used memory

## How was this PR tested?
DX12/Vulkan
ASV RPI/StreamingImage sample
LoftScene level
