### PR TITLE
removed psutils from utils.py to make debug build of project manager compatible

### DIFF
--- a/scripts/o3de/tests/test_utils.py
+++ b/scripts/o3de/tests/test_utils.py
@@ -8,7 +8,6 @@
 
 import pytest
 import pathlib
-import psutil
 # import subprocess
 import logging
 import unittest.mock as mock
@@ -173,8 +172,6 @@ def test_load_and_execute_script(input_script_path, context_vars_dict, raisedExc
     # the successful case
     pytest.param({"args":['cmake', '--version'], "pid":0}, None),
     # these raise exceptions, but safe_kill_processes should intercept and log instead
-    pytest.param({"args":['cmake', '--version'], "pid":0}, psutil.AccessDenied),
-    pytest.param({"args":['cmake', '--version'], "pid":0}, psutil.NoSuchProcess),
     pytest.param({"args":['cmake', '--version'], "pid":0}, RuntimeError)
 ])
 def test_safe_kill_processes(process_obj, raisedException):


### PR DESCRIPTION


## What does this PR do?
@AMZN-daimini recently discovered a bug where the debug build of Project Manager failed to start, due to the following error:
```
System: Trace::Assert
 D:/git/o3de-dev-worktree/Code/Tools/ProjectManager/Source/PythonBindings.cpp(347): (65360) 'bool __cdecl O3DE::ProjectManager::PythonBindings::StartPython(void)'
System: Py_Initialize() failed with ModuleNotFoundError: No module named 'psutil._psutil_windows'

At:
  D:\git\o3de-dev-worktree\python\runtime\python-3.10.5-rev1-windows\python\lib\site-packages\psutil\_pswindows.py(35): <module>
  D:\git\o3de-dev-worktree\python\runtime\python-3.10.5-rev1-windows\python\lib\site-packages\psutil\__init__.py(109): <module>
  d:\git\o3de-dev-worktree\scripts\o3de\o3de\utils.py(16): <module>
```
For some reason, `psutil` is correctly imported if `profile` version of Project Manager was built, but not `debug` version. This points to a deeper issue with our current python setup for O3DE, but in the meantime this PR is a patch to unblock users of Debug builds. 

## How was this PR tested?

All unit tests passed, and ran a sample execution of project export tool to ensure nothing was broken:
```
C:\workspace\o3de(ReleaseFix/RemovePsutilsFromUtils -> origin)
λ .\scripts\o3de.bat export-project -es C:\workspace\projects\NewspaperDeliveryGame\export_rules\test_export.py hi there --gary -ll INFO
[INFO] root: Begin loading script 'C:\workspace\projects\NewspaperDeliveryGame\export_rules\test_export.py'...
[INFO] root: Running process 'cmake' with PID(9196): ['cmake', '--version']
[INFO] root: cmake version 3.24.1

[INFO] root:

[INFO] root: CMake suite maintained and supported by Kitware (kitware.com/cmake).

[INFO] root:
[INFO] root: Terminating process 'cmake' with PID(9196)
[INFO] root: process 'cmake' with PID(9196) terminated with exit code 0
[INFO] root: Begin loading script 'C:\Users\tankotha\Desktop\hello.py'...
hi 0:: 22
hi 1:: 22
hi 2:: 22
hi 3:: 22
hi 4:: 22
hi 5:: 22
hi 6:: 22
hi 7:: 22
hi 8:: 22
hi 9:: 22
[INFO] root: hi there!
[INFO] root: This is a message!
[INFO] root: C:\workspace\projects\NewspaperDeliveryGame
[INFO] root: Now running the export code C:\workspace\projects\NewspaperDeliveryGame
[INFO] root: Engine path: C:\workspace\integration\o3de
[INFO] root: Hello to you too!
[INFO] root: hiya!
[INFO] o3de: Success!
```