### PR TITLE
RayTracing Callable Shader support

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
@@ -24,6 +24,7 @@ namespace AZ
 
             AZ::Name m_rayGenerationShaderName;
             AZ::Name m_missShaderName;
+            AZ::Name m_callableShaderName;
             AZ::Name m_closestHitShaderName;
             AZ::Name m_anyHitShaderName;
         };
@@ -100,6 +101,7 @@ namespace AZ
 
             RayTracingPipelineStateDescriptor* RayGenerationShaderName(const AZ::Name& name);
             RayTracingPipelineStateDescriptor* MissShaderName(const AZ::Name& name);
+            RayTracingPipelineStateDescriptor* CallableShaderName(const AZ::Name& callableShaderName);
             RayTracingPipelineStateDescriptor* ClosestHitShaderName(const AZ::Name& closestHitShaderName);
             RayTracingPipelineStateDescriptor* AnyHitShaderName(const AZ::Name& anyHitShaderName);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
@@ -61,6 +61,9 @@ namespace AZ
             const RayTracingShaderTableRecordList& GetMissRecords() const { return m_missRecords; }
             RayTracingShaderTableRecordList& GetMissRecords() { return m_missRecords; }
 
+            const RayTracingShaderTableRecordList& GetCallableRecords() const { return m_callableRecords; }
+            RayTracingShaderTableRecordList& GetCallableRecords() { return m_callableRecords; }
+
             const RayTracingShaderTableRecordList& GetHitGroupRecords() const { return m_hitGroupRecords; }
             RayTracingShaderTableRecordList& GetHitGroupRecords() { return m_hitGroupRecords; }
 
@@ -70,6 +73,7 @@ namespace AZ
             RayTracingShaderTableDescriptor* Build(const AZ::Name& name, const RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState);
             RayTracingShaderTableDescriptor* RayGenerationRecord(const AZ::Name& name);
             RayTracingShaderTableDescriptor* MissRecord(const AZ::Name& name);
+            RayTracingShaderTableDescriptor* CallableRecord(const AZ::Name& name);
             RayTracingShaderTableDescriptor* HitGroupRecord(const AZ::Name& name, uint32_t key = RayTracingShaderTableRecord::InvalidKey);
             RayTracingShaderTableDescriptor* ShaderResourceGroup(const RHI::ShaderResourceGroup* shaderResourceGroup);
 
@@ -78,6 +82,7 @@ namespace AZ
             RHI::Ptr<RayTracingPipelineState> m_rayTracingPipelineState;
             RayTracingShaderTableRecordList m_rayGenerationRecord;  // limited to one record, but stored as a list to simplify processing
             RayTracingShaderTableRecordList m_missRecords;
+            RayTracingShaderTableRecordList m_callableRecords;
             RayTracingShaderTableRecordList m_hitGroupRecords;
 
             RayTracingShaderTableRecord* m_buildContext = nullptr;

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -69,6 +69,13 @@ namespace AZ
             return this;
         }
 
+        RayTracingPipelineStateDescriptor* RayTracingPipelineStateDescriptor::CallableShaderName(const AZ::Name& callableShaderName)
+        {
+            AZ_Assert(m_shaderLibraryBuildContext && m_hitGroupBuildContext == nullptr, "CallableShaderName can only be added to a ShaderLibrary");
+            m_shaderLibraryBuildContext->m_callableShaderName = callableShaderName;
+            return this;
+        }
+
         RayTracingPipelineStateDescriptor* RayTracingPipelineStateDescriptor::ClosestHitShaderName(const AZ::Name& closestHitShaderName)
         {
             AZ_Assert(m_shaderLibraryBuildContext || m_hitGroupBuildContext, "ClosestHitShaderName can only be added to a ShaderLibrary or a HitGroup");

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -50,6 +50,14 @@ namespace AZ
             return this;
         }
 
+        RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::CallableRecord(const AZ::Name& name)
+        {
+            m_callableRecords.emplace_back();
+            m_buildContext = &m_callableRecords.back();
+            m_buildContext->m_shaderExportName = name;
+            return this;
+        }
+
         RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::HitGroupRecord(const AZ::Name& name, uint32_t key /* = RayTracingShaderTableRecord::InvalidKey */)
         {
             m_hitGroupRecords.emplace_back();

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -419,9 +419,13 @@ namespace AZ
             desc.RayGenerationShaderRecord.StartAddress = shaderTableBuffers.m_rayGenerationTable->GetMemoryView().GetGpuAddress();
             desc.RayGenerationShaderRecord.SizeInBytes = shaderTableBuffers.m_rayGenerationTableSize;
             
-            desc.MissShaderTable.StartAddress = shaderTableBuffers.m_missTable->GetMemoryView().GetGpuAddress();
+            desc.MissShaderTable.StartAddress = shaderTableBuffers.m_missTable ? shaderTableBuffers.m_missTable->GetMemoryView().GetGpuAddress() : 0;
             desc.MissShaderTable.SizeInBytes = shaderTableBuffers.m_missTableSize;
             desc.MissShaderTable.StrideInBytes = shaderTableBuffers.m_missTableStride;
+
+            desc.CallableShaderTable.StartAddress = shaderTableBuffers.m_callableTable ? shaderTableBuffers.m_callableTable->GetMemoryView().GetGpuAddress() : 0;
+            desc.CallableShaderTable.SizeInBytes = shaderTableBuffers.m_callableTableSize;
+            desc.CallableShaderTable.StrideInBytes = shaderTableBuffers.m_callableTableStride;
             
             desc.HitGroupTable.StartAddress = shaderTableBuffers.m_hitGroupTable->GetMemoryView().GetGpuAddress();
             desc.HitGroupTable.SizeInBytes = shaderTableBuffers.m_hitGroupTableSize;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -57,6 +57,11 @@ namespace AZ
 
             uint32_t shaderTableSize = shaderRecordSize * static_cast<uint32_t>(recordList.size());
 
+            if (shaderTableSize == 0)
+            {
+                return nullptr;
+            }
+
             // create shader table buffer
             RHI::Ptr<RHI::Buffer> shaderTableBuffer = RHI::Factory::Get().CreateBuffer();
             AZ::RHI::BufferDescriptor shaderTableBufferDescriptor;
@@ -130,6 +135,9 @@ namespace AZ
                 buffers.m_missTable = nullptr;
                 buffers.m_missTableSize = 0;
                 buffers.m_missTableStride = 0;
+                buffers.m_callableTable = nullptr;
+                buffers.m_callableTableSize = 0;
+                buffers.m_callableTableStride = 0;
                 buffers.m_hitGroupTable = nullptr;
                 buffers.m_hitGroupTableSize = 0;
                 buffers.m_hitGroupTableStride = 0;
@@ -162,7 +170,16 @@ namespace AZ
                 buffers.m_missTableSize = shaderRecordSize * static_cast<uint32_t>(m_descriptor->GetMissRecords().size());
                 buffers.m_missTableStride = shaderRecordSize;
             }
-            
+
+            // callable shader table
+            {
+                uint32_t shaderRecordSize = RHI::AlignUp(FindLargestRecordSize(m_descriptor->GetCallableRecords()), D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);
+
+                buffers.m_callableTable = BuildTable(GetDevice(), *m_bufferPools, m_descriptor->GetCallableRecords(), shaderRecordSize, L"Callable Shader Table", stateObjectProperties);
+                buffers.m_callableTableSize = shaderRecordSize * static_cast<uint32_t>(m_descriptor->GetCallableRecords().size());
+                buffers.m_callableTableStride = shaderRecordSize;
+            }
+
             // hit group shader table
             {
                 uint32_t shaderRecordSize = RHI::AlignUp(FindLargestRecordSize(m_descriptor->GetHitGroupRecords()), D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.h
@@ -35,6 +35,10 @@ namespace AZ
                 uint32_t m_missTableSize = 0;
                 uint32_t m_missTableStride = 0;
 
+                RHI::Ptr<Buffer> m_callableTable;
+                uint32_t m_callableTableSize = 0;
+                uint32_t m_callableTableStride = 0;
+
                 RHI::Ptr<Buffer> m_hitGroupTable;
                 uint32_t m_hitGroupTableSize = 0;
                 uint32_t m_hitGroupTableStride = 0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -517,13 +517,30 @@ namespace AZ
             rayGenerationTable.size = shaderTableBuffers.m_rayGenerationTableSize;
 
             // miss table
-            addressInfo.buffer = static_cast<Buffer*>(shaderTableBuffers.m_missTable.get())->GetBufferMemoryView()->GetNativeBuffer();
-            VkDeviceAddress missTableAddress = context.GetBufferDeviceAddress(m_descriptor.m_device->GetNativeDevice(), &addressInfo);
+            VkDeviceAddress missTableAddress = 0;
+            if (shaderTableBuffers.m_missTable)
+            {
+                addressInfo.buffer = static_cast<Buffer*>(shaderTableBuffers.m_missTable.get())->GetBufferMemoryView()->GetNativeBuffer();
+                missTableAddress = context.GetBufferDeviceAddress(m_descriptor.m_device->GetNativeDevice(), &addressInfo);
+            }
 
             VkStridedDeviceAddressRegionKHR missTable = {};
             missTable.deviceAddress = missTableAddress;
             missTable.stride = shaderTableBuffers.m_missTableStride;
             missTable.size = shaderTableBuffers.m_missTableSize;
+
+            // callable table
+            VkDeviceAddress callableTableAddress = 0;
+            if (shaderTableBuffers.m_callableTable)
+            {
+                addressInfo.buffer = static_cast<Buffer*>(shaderTableBuffers.m_callableTable.get())->GetBufferMemoryView()->GetNativeBuffer();
+                callableTableAddress = context.GetBufferDeviceAddress(m_descriptor.m_device->GetNativeDevice(), &addressInfo);
+            }
+
+            VkStridedDeviceAddressRegionKHR callableTable = {};
+            callableTable.deviceAddress = callableTableAddress;
+            callableTable.stride = shaderTableBuffers.m_callableTableStride;
+            callableTable.size = shaderTableBuffers.m_callableTableSize;
 
             // hit group table
             addressInfo.buffer = static_cast<Buffer*>(shaderTableBuffers.m_hitGroupTable.get())->GetBufferMemoryView()->GetNativeBuffer();
@@ -533,8 +550,6 @@ namespace AZ
             hitGroupTable.deviceAddress = hitGroupTableAddress;
             hitGroupTable.stride = shaderTableBuffers.m_hitGroupTableStride;
             hitGroupTable.size = shaderTableBuffers.m_hitGroupTableSize;
-
-            VkStridedDeviceAddressRegionKHR callableTable = {};
 
             context.CmdTraceRaysKHR(
                 m_nativeCommandBuffer,

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingShaderTable.h
@@ -34,6 +34,10 @@ namespace AZ
                 uint32_t m_missTableSize = 0;
                 uint32_t m_missTableStride = 0;
 
+                RHI::Ptr<RHI::Buffer> m_callableTable;
+                uint32_t m_callableTableSize = 0;
+                uint32_t m_callableTableStride = 0;
+
                 RHI::Ptr<RHI::Buffer> m_hitGroupTable;
                 uint32_t m_hitGroupTableSize = 0;
                 uint32_t m_hitGroupTableStride = 0;


### PR DESCRIPTION
Added support for callable shaders to the RayTracing PipelineState and ShaderTable.

Tested AtomSampleViewer DX12/Vulkan
Tested Editor DX12/Vulkan
