### PR TITLE
Fix Hide Engine Assets Filter

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -472,10 +472,10 @@ void AzAssetBrowserWindow::CreateToolsMenu()
         connect(projectSourceAssets, &QAction::triggered, this,
             [this, projectSourceAssets]
             {
-                m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(projectSourceAssets->isChecked());
+                m_ui->m_searchWidget->ToggleEngineFilter(projectSourceAssets->isChecked());
             });
         m_toolsMenu->addAction(projectSourceAssets);
-        m_ui->m_searchWidget->ToggleProjectSourceAssetFilter(projectSourceAssets->isChecked());
+        m_ui->m_searchWidget->ToggleEngineFilter(projectSourceAssets->isChecked());
 
         auto* unusableProductAssets = new QAction(tr("Hide Unusable Product Assets"), this);
         unusableProductAssets->setCheckable(true);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -415,36 +415,38 @@ namespace AzToolsFramework
         }
 
         //////////////////////////////////////////////////////////////////////////
-        // AssetPathFilter
+        // EngineFilter
         //////////////////////////////////////////////////////////////////////////
-        AssetPathFilter::AssetPathFilter()
-            : m_assetPath("")
+        EngineFilter::EngineFilter()
+            : m_enginePath("")
+            , m_projectPath("")
         {
         }
 
-        void AssetPathFilter::SetAssetPath(AZ::IO::Path path)
+        void EngineFilter::SetEngineAndProject(AZ::IO::Path enginePath, AZ::IO::Path projectPath)
         {
-            m_assetPath = path.LexicallyNormal();
+            m_enginePath = enginePath.LexicallyNormal();
+            m_projectPath = projectPath.LexicallyNormal();
         }
 
-        QString AssetPathFilter::GetNameInternal() const
+        QString EngineFilter::GetNameInternal() const
         {
-            return QString::fromUtf8(m_assetPath.c_str(), static_cast<int32_t>(m_assetPath.Native().size()));
+            return QString::fromUtf8(m_enginePath.c_str(), static_cast<int32_t>(m_enginePath.Native().size()));
         }
 
-        bool AssetPathFilter::MatchInternal(const AssetBrowserEntry* entry) const
+        bool EngineFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
-            if (m_assetPath.empty())
+            if (m_enginePath.empty() || m_projectPath.empty())
             {
-                return false;
+                return true;
             }
 
             AZ::IO::Path absolutePath =
                 (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product && entry->GetParent()
                     ? entry->GetParent()->GetFullPath()
-                    : AZ::IO::Path(entry->GetFullPath()));
+                    : entry->GetFullPath());
 
-            return absolutePath.IsRelativeTo(m_assetPath);
+            return (absolutePath.IsRelativeTo(m_projectPath) ? true : !absolutePath.IsRelativeTo(m_enginePath));
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -230,23 +230,25 @@ namespace AzToolsFramework
         };
 
         //////////////////////////////////////////////////////////////////////////
-        // AssetPathFilter
+        // EngineFilter
         //////////////////////////////////////////////////////////////////////////
-        class AssetPathFilter : public AssetBrowserEntryFilter
+        //! EngineFilter filters assets in the engine directory, excluding project directory
+        class EngineFilter : public AssetBrowserEntryFilter
         {
             Q_OBJECT
         public:
-            AssetPathFilter();
-            ~AssetPathFilter() override = default;
+            EngineFilter();
+            ~EngineFilter() override = default;
 
-            void SetAssetPath(AZ::IO::Path path);
+            void SetEngineAndProject(AZ::IO::Path enginePath, AZ::IO::Path projectPath);
 
         protected:
             QString GetNameInternal() const override;
             bool MatchInternal(const AssetBrowserEntry* entry) const override;
 
         private:
-            AZ::IO::Path m_assetPath;
+            AZ::IO::Path m_enginePath;
+            AZ::IO::Path m_projectPath;
         };
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -83,7 +83,7 @@ namespace AzToolsFramework
             , m_filter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_stringFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_typesFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR))
-            , m_projectSourceFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
+            , m_engineFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_unusableProductsFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_folderFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
         {
@@ -95,8 +95,8 @@ namespace AzToolsFramework
             m_typesFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
             m_typesFilter->SetTag("AssetTypes");
 
-            m_projectSourceFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-            m_projectSourceFilter->SetTag("ProjectAssets");
+            m_engineFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            m_engineFilter->SetTag("ProjectAssets");
 
             m_unusableProductsFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
             m_unusableProductsFilter->SetTag("UnusableProducts");
@@ -174,9 +174,11 @@ namespace AzToolsFramework
                 SetTypeFilters(buildTypesFilterList());
             }
 
-            auto pathFilter = new AssetPathFilter();
-            pathFilter->SetAssetPath(AZ::IO::Path(AZ::Utils::GetProjectPath()));
-            m_projectSourceFilter->AddFilter(FilterConstType(pathFilter));
+            AZ::IO::Path projectPath{ AZ::Utils::GetProjectPath() };
+            AZ::IO::Path enginePath{ AZ::Utils::GetEnginePath() };
+            auto engineFilter = new EngineFilter();
+            engineFilter->SetEngineAndProject(enginePath, projectPath);
+            m_engineFilter->AddFilter(FilterConstType(engineFilter));
 
             AZStd::vector<AZ::Data::AssetType> types = BuildAssetTypeList();
             auto compositeTypeFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::OR);
@@ -197,15 +199,15 @@ namespace AzToolsFramework
             m_folderFilter->AddFilter(FilterConstType(directoryFilter));
         }
 
-        void SearchWidget::ToggleProjectSourceAssetFilter(bool checked)
+        void SearchWidget::ToggleEngineFilter(bool checked)
         {
             if (!checked)
             {
-                m_filter->RemoveFilter(FilterConstType(m_projectSourceFilter));
+                m_filter->RemoveFilter(FilterConstType(m_engineFilter));
             }
             else
             {
-                m_filter->AddFilter(FilterConstType(m_projectSourceFilter));
+                m_filter->AddFilter(FilterConstType(m_engineFilter));
             }
         }
 
@@ -274,9 +276,9 @@ namespace AzToolsFramework
             return m_typesFilter;
         }
 
-        QSharedPointer<CompositeFilter> SearchWidget::GetProjectSourceFilter() const
+        QSharedPointer<CompositeFilter> SearchWidget::GetEngineFilter() const
         {
-            return m_projectSourceFilter;
+            return m_engineFilter;
         }
 
         QSharedPointer<CompositeFilter> SearchWidget::GetUnusableProductsFilter() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.h
@@ -33,7 +33,7 @@ namespace AzToolsFramework
 
             void Setup(bool stringFilter, bool assetTypeFilter);
 
-            void ToggleProjectSourceAssetFilter(bool checked);
+            void ToggleEngineFilter(bool checked);
 
             void ToggleUnusableProductsFilter(bool checked);
 
@@ -49,7 +49,7 @@ namespace AzToolsFramework
 
             QSharedPointer<CompositeFilter> GetTypesFilter() const;
 
-            QSharedPointer<CompositeFilter> GetProjectSourceFilter() const;
+            QSharedPointer<CompositeFilter> GetEngineFilter() const;
 
             QSharedPointer<CompositeFilter> GetUnusableProductsFilter() const;
 
@@ -62,7 +62,7 @@ namespace AzToolsFramework
             QSharedPointer<CompositeFilter> m_filter;
             QSharedPointer<CompositeFilter> m_stringFilter;
             QSharedPointer<CompositeFilter> m_typesFilter;
-            QSharedPointer<CompositeFilter> m_projectSourceFilter;
+            QSharedPointer<CompositeFilter> m_engineFilter;
             QSharedPointer<CompositeFilter> m_unusableProductsFilter;
             QSharedPointer<CompositeFilter> m_folderFilter;
         };


### PR DESCRIPTION
## What does this PR do?

Fixes Asset Browser's "Hide Engine Assets" toggleable filter to hide folders inside the o3de engine path, excluding the project folder, rather than hiding everything outside of the project.

## How was this PR tested?

Locally with AutomatedTesting. Testing with Asset Gems and a project-centric build to ensure everything works.
