### PR TITLE
Fix editor crash on quit

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -570,8 +570,8 @@ void EditorActionsHandler::OnActionRegistrationHook()
     {
         AzToolsFramework::ActionProperties actionProperties;
         actionProperties.m_name = "Exit";
-        actionProperties.m_description = "Open a different project in the Project Manager.";
-        actionProperties.m_category = "Project";
+        actionProperties.m_description = "Exit the Editor";
+        actionProperties.m_category = "Editor";
 
         m_actionManagerInterface->RegisterAction(
             EditorIdentifiers::MainWindowActionContextIdentifier,

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -604,7 +604,7 @@ void CGameEngine::HandleQuitRequest(IConsoleCmdArgs* /*args*/)
     }
     else
     {
-        MainWindow::instance()->GetActionManager()->GetAction(ID_APP_EXIT)->trigger();
+        MainWindow::instance()->window()->close();
     }
 }
 

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -312,6 +312,9 @@ MainWindow::MainWindow(QWidget* parent)
         m_actionManager = new ActionManager(this, QtViewPaneManager::instance(), m_shortcutDispatcher);
         m_toolbarManager = new ToolbarManager(m_actionManager, this);
         m_levelEditorMenuHandler = new LevelEditorMenuHandler(this, m_viewPaneManager);
+        connect(m_levelEditorMenuHandler, &LevelEditorMenuHandler::ActivateAssetImporter, this, [this]() {
+            m_assetImporterManager->Exec();
+        });
     }
 
     setObjectName("MainWindow"); // For IEditor::GetEditorMainWindow to work in plugins, where we can't link against MainWindow::instance()
@@ -334,10 +337,6 @@ MainWindow::MainWindow(QWidget* parent)
 
     AssetImporterDragAndDropHandler* assetImporterDragAndDropHandler = new AssetImporterDragAndDropHandler(this, m_assetImporterManager);
     connect(assetImporterDragAndDropHandler, &AssetImporterDragAndDropHandler::OpenAssetImporterManager, this, &MainWindow::OnOpenAssetImporterManager);
-
-    connect(m_levelEditorMenuHandler, &LevelEditorMenuHandler::ActivateAssetImporter, this, [this]() {
-        m_assetImporterManager->Exec();
-    });
 
     setFocusPolicy(Qt::StrongFocus);
 

--- a/cmake/Platform/Windows/Packaging/Tests/conftest.py
+++ b/cmake/Platform/Windows/Packaging/Tests/conftest.py
@@ -54,10 +54,10 @@ class SessionContext:
         self.project_bin_path = self.project_build_path / 'bin/profile'
 
         # start a log reader thread to print the output to screen
+        self.log_reader_shutdown = False
         self.log_reader = io.open(self.temp_file.name, 'r', buffering=1)
         self.log_reader_thread = threading.Thread(target=self._tail_log, daemon=True)
         self.log_reader_thread.start()
-        self.log_reader_shutdown = False
     
     def _tail_log(self):
         """ Tail the log file and print to screen for easy viewing in Jenkins. """


### PR DESCRIPTION
## What does this PR do?

When the 'quit' console command is used, the Editor crashes with a non-zero exit code.

`GetActionManager()` returns null when the new action manager is active, which is the default.

Other fixes:
- fix trying to connect signal to nullptr object
- fix inaccurate Exit menu text
- fix missing variable error in the installer test logging thread

## How was this PR tested?

- Ran tests that relied on the quit command and were failing (e.g. installer test)
- used the quit command in the Editor
