### PR TITLE
Remove EditorEntityId from serialized content

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -37,7 +37,6 @@ namespace Camera
                 ->Field("SpecifyDimensions", &CameraComponentConfig::m_specifyFrustumDimensions)
                 ->Field("FrustumWidth", &CameraComponentConfig::m_frustumWidth)
                 ->Field("FrustumHeight", &CameraComponentConfig::m_frustumHeight)
-                ->Field("EditorEntityId", &CameraComponentConfig::m_editorEntityId)
                 ->Field("MakeActiveViewOnActivation", &CameraComponentConfig::m_makeActiveViewOnActivation)
                 ->Field("RenderToTexture", &CameraComponentConfig::m_renderTextureAsset)
                 ->Field("PipelineTemplate", &CameraComponentConfig::m_pipelineTemplate)

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -28,7 +28,7 @@ namespace Camera
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<CameraComponentConfig, AZ::ComponentConfig>()
-                ->Version(5)
+                ->Version(6)
                 ->Field("Orthographic", &CameraComponentConfig::m_orthographic)
                 ->Field("Orthographic Half Width", &CameraComponentConfig::m_orthographicHalfWidth)
                 ->Field("Field of View", &CameraComponentConfig::m_fov)

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -54,10 +54,11 @@ namespace Camera
         float m_frustumWidth = DefaultFrustumDimension;
         float m_frustumHeight = DefaultFrustumDimension;
         bool m_specifyFrustumDimensions = false;
-        AZ::u64 m_editorEntityId = AZ::EntityId::InvalidEntityId;
         bool m_makeActiveViewOnActivation = true;
         bool m_orthographic = false;
         float m_orthographicHalfWidth = 5.f;
+
+        AZ::u64 m_editorEntityId = AZ::EntityId::InvalidEntityId;
 
         // Members for render to texture
         // The texture assets which is used for render to texture feature. It defines the resolution, format etc.


### PR DESCRIPTION
## What does this PR do?

Remove EditorEntityId from being serialized. This property is not visible to the user and does not seem necessary to serialize. When serialized, it causes prefab override visualization to be displayed on the entity because the Camera component assigns the EditorEntityId property on activation which differs from the default.

## How was this PR tested?

Tested in Editor.
