### PR TITLE
DPE: Fix unwanted disabling of widgets

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -248,7 +248,7 @@ namespace AzToolsFramework
             {
                 size_t currentWidget = static_cast<size_t>(layoutIndex);
                 auto* myRow = GetRow();
-                AzToolsFramework::DPERowWidget::AttributeInfo* attributes = myRow->GetAttributes(currentWidget);
+                AzToolsFramework::DPERowWidget::AttributeInfo* attributes = myRow->GetCachedAttributes(currentWidget);
 
                 //! If the current widget is the first widget of a shared column, create the shared column layout and add widgets to it
                 if (sharedVectorIndex < m_sharePriorColumn.size() &&
@@ -266,7 +266,7 @@ namespace AzToolsFramework
                     while (sharedWidgetIndex < numItems)
                     {
                         currentWidget = m_sharePriorColumn[sharedVectorIndex][sharedWidgetIndex];
-                        attributes = myRow->GetAttributes(currentWidget);
+                        attributes = myRow->GetCachedAttributes(currentWidget);
                         // Save the alignment of the last widget in the shared column with an alignment attribute
                         if (attributes)
                         {
@@ -525,7 +525,7 @@ namespace AzToolsFramework
                 }
             }
         }
-        ClearAttributes();
+        ClearCachedAttributes();
         m_domOrderedChildren.clear();
         m_columnLayout->Clear();
     }
@@ -637,7 +637,7 @@ namespace AzToolsFramework
             }
             else if (auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(childWidget); !handlerInfo.IsNull())
             {
-                RemoveAttributes(childIndex);
+                RemoveCachedAttributes(childIndex);
                 if (!newOwner)
                 {
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
@@ -725,74 +725,63 @@ namespace AzToolsFramework
 
     void DPERowWidget::SetPropertyEditorAttributes(size_t domIndex, const AZ::Dom::Value& domArray, QWidget* childWidget)
     {
-        AttributeInfo updatedInfo;
-
-        // Extract all attributes from dom value
-        updatedInfo.m_alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(domArray).value_or(
+        AttributeInfo updatedLayoutAttributes;
+        updatedLayoutAttributes.m_alignment = AZ::Dpe::Nodes::PropertyEditor::Alignment.ExtractFromDomNode(domArray).value_or(
             AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment);
-        updatedInfo.m_sharePriorColumn = AZ::Dpe::Nodes::PropertyEditor::SharePriorColumn.ExtractFromDomNode(domArray).value_or(false);
-        updatedInfo.m_minimumWidth = AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(domArray).value_or(false);
-        updatedInfo.m_descriptionString = AZ::Dpe::Nodes::PropertyEditor::Description.ExtractFromDomNode(domArray).value_or("");
-        updatedInfo.m_isDisabled = AZ::Dpe::Nodes::PropertyEditor::Disabled.ExtractFromDomNode(domArray).value_or(false) ||
-            AZ::Dpe::Nodes::PropertyEditor::AncestorDisabled.ExtractFromDomNode(domArray).value_or(false);
+        updatedLayoutAttributes.m_sharePriorColumn =
+            AZ::Dpe::Nodes::PropertyEditor::SharePriorColumn.ExtractFromDomNode(domArray).value_or(false);
+        updatedLayoutAttributes.m_minimumWidth =
+            AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(domArray).value_or(false);
 
-        AttributeInfo currentInfo;
-        auto attributeIter = m_childIndexToAttributeInfo.find(domIndex);
-        if (attributeIter != m_childIndexToAttributeInfo.end())
+        if (updatedLayoutAttributes.m_sharePriorColumn)
         {
-            currentInfo = m_childIndexToAttributeInfo[domIndex];
-        }
-
-        if (updatedInfo.m_sharePriorColumn != currentInfo.m_sharePriorColumn)
-        {
-            if (updatedInfo.m_sharePriorColumn)
+            // Check for a widget in the previous column
+            int priorColumnIndex = -1;
+            for (int searchIndex = static_cast<int>(domIndex) - 1; (priorColumnIndex == -1 && searchIndex >= 0); --searchIndex)
             {
-                // Check for a widget in the previous column
-                int priorColumnIndex = -1;
-                for (int searchIndex = static_cast<int>(domIndex) - 1; (priorColumnIndex == -1 && searchIndex >= 0); --searchIndex)
-                {
-                    priorColumnIndex = m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]);
-                }
-
-                AZ_Assert(priorColumnIndex != -1, "Tried to share column with an out of bounds index!");
-                if (priorColumnIndex != -1)
-                {
-                    m_columnLayout->AddSharePriorColumn(priorColumnIndex, domIndex);
-                }
+                priorColumnIndex = m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]);
             }
-            else
+
+            AZ_Assert(priorColumnIndex != -1, "Tried to share column with an out of bounds index!");
+            if (priorColumnIndex != -1)
             {
-                m_columnLayout->RemoveSharePriorColumn(domIndex);
+                m_columnLayout->AddSharePriorColumn(priorColumnIndex, domIndex);
             }
-        }
-
-        if (updatedInfo.m_descriptionString != currentInfo.m_descriptionString)
-        {
-            setToolTip(
-                QString::fromUtf8(updatedInfo.m_descriptionString.data(), aznumeric_cast<int>(updatedInfo.m_descriptionString.size())));
-            childWidget->setToolTip(
-                QString::fromUtf8(updatedInfo.m_descriptionString.data(), aznumeric_cast<int>(updatedInfo.m_descriptionString.size())));
-        }
-
-        if (updatedInfo.m_isDisabled != currentInfo.m_isDisabled)
-        {
-            childWidget->setEnabled(!updatedInfo.m_isDisabled);
-        }
-
-        if (attributeIter != m_childIndexToAttributeInfo.end() && updatedInfo.IsDefault())
-        {
-            m_childIndexToAttributeInfo.erase(attributeIter);
         }
         else
         {
-            m_childIndexToAttributeInfo[domIndex] = updatedInfo;
+            m_columnLayout->RemoveSharePriorColumn(domIndex);
         }
+
+        // Remove any cached attribute info that is default, else cache it for the layout to use.
+        // This way we only cache what is needed.
+        auto layoutAttributeInfoIter = m_childIndexToCachedAttributeInfo.find(domIndex);
+        if (layoutAttributeInfoIter != m_childIndexToCachedAttributeInfo.end() && updatedLayoutAttributes.IsDefault())
+        {
+            m_childIndexToCachedAttributeInfo.erase(layoutAttributeInfoIter);
+        }
+        else
+        {
+            m_childIndexToCachedAttributeInfo[domIndex] = updatedLayoutAttributes;
+        }
+
+        AZStd::string_view descriptionView = AZ::Dpe::Nodes::PropertyEditor::Description.ExtractFromDomNode(domArray).value_or("");
+        QString descriptionString = QString::fromUtf8(descriptionView.data(), aznumeric_cast<int>(descriptionView.size()));
+        if (descriptionString != childWidget->toolTip())
+        {
+            setToolTip(descriptionString);
+            childWidget->setToolTip(descriptionString);
+        }
+
+        bool isDisabled = AZ::Dpe::Nodes::PropertyEditor::Disabled.ExtractFromDomNode(domArray).value_or(false) ||
+            AZ::Dpe::Nodes::PropertyEditor::AncestorDisabled.ExtractFromDomNode(domArray).value_or(false);
+        childWidget->setEnabled(!isDisabled);
     }
 
-    DPERowWidget::AttributeInfo* DPERowWidget::GetAttributes(size_t domIndex)
+    DPERowWidget::AttributeInfo* DPERowWidget::GetCachedAttributes(size_t domIndex)
     {
-        auto foundEntry = m_childIndexToAttributeInfo.find(domIndex);
-        if (foundEntry != m_childIndexToAttributeInfo.end())
+        auto foundEntry = m_childIndexToCachedAttributeInfo.find(domIndex);
+        if (foundEntry != m_childIndexToCachedAttributeInfo.end())
         {
             return &foundEntry->second;
         }
@@ -802,19 +791,19 @@ namespace AzToolsFramework
         }
     }
 
-    void DPERowWidget::RemoveAttributes(size_t domIndex)
+    void DPERowWidget::RemoveCachedAttributes(size_t domIndex)
     {
-        auto foundEntry = m_childIndexToAttributeInfo.find(domIndex);
-        if (foundEntry != m_childIndexToAttributeInfo.end())
+        auto foundEntry = m_childIndexToCachedAttributeInfo.find(domIndex);
+        if (foundEntry != m_childIndexToCachedAttributeInfo.end())
         {
-            m_childIndexToAttributeInfo.erase(foundEntry);
+            m_childIndexToCachedAttributeInfo.erase(foundEntry);
             m_columnLayout->RemoveSharePriorColumn(domIndex);
         }
     }
 
-    void DPERowWidget::ClearAttributes()
+    void DPERowWidget::ClearCachedAttributes()
     {
-        m_childIndexToAttributeInfo.clear();
+        m_childIndexToCachedAttributeInfo.clear();
         for (AZStd::vector<size_t> sharedGroup : m_columnLayout->m_sharePriorColumn)
         {
             sharedGroup.clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -110,8 +110,8 @@ namespace AzToolsFramework
         void SetAttributesFromDom(const AZ::Dom::Value& domArray);
 
         void SetPropertyEditorAttributes(size_t domIndex, const AZ::Dom::Value& domArray, QWidget* childWidget);
-        void RemoveAttributes(size_t domIndex);
-        void ClearAttributes();
+        void RemoveCachedAttributes(size_t domIndex);
+        void ClearCachedAttributes();
 
         //! handles a patch operation at the given path, or delegates to a child that will
         void HandleOperationAtPath(const AZ::Dom::PatchOperation& domOperation, size_t pathIndex = 0);
@@ -150,17 +150,14 @@ namespace AzToolsFramework
             AZ::Dpe::Nodes::PropertyEditor::Align m_alignment = AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment;
             bool m_sharePriorColumn = false;
             bool m_minimumWidth = false;
-            AZStd::string_view m_descriptionString = {};
-            bool m_isDisabled = false;
 
             bool IsDefault() const
             {
-                return m_alignment == AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment && !m_sharePriorColumn &&
-                    !m_minimumWidth && m_descriptionString.empty() && !m_isDisabled;
+                return m_alignment == AZ::Dpe::Nodes::PropertyEditor::Align::UseDefaultAlignment && !m_sharePriorColumn && !m_minimumWidth;
             }
         };
-        AZStd::unordered_map<size_t, AttributeInfo> m_childIndexToAttributeInfo;
-        AttributeInfo* GetAttributes(size_t domIndex);
+        AZStd::unordered_map<size_t, AttributeInfo> m_childIndexToCachedAttributeInfo;
+        AttributeInfo* GetCachedAttributes(size_t domIndex);
 
         // row attributes extracted from the DOM
         AZStd::optional<bool> m_forceAutoExpand;


### PR DESCRIPTION
**Description**
Before this PR, it was possible for cached DOM attributes such as Disabled to be incorrect when a widget was pulled from the pool during a patch.

This PR refactors attribute caching in `DocumentPropertyEditor.cpp` so that we only remember layout relevant attributes and, unless default, always cache them the next time a widget is being configured here.

**Testing**
- Tested with an issue noticed in the DPE debug standalone app that caused certain controls to become enabled even though their DOM nodes contained the "Disabled" attribute