### PR TITLE
Moved joint motor properties reflection to proper place

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -36,7 +36,6 @@ namespace PhysX
         EditorJointLimitLinearPairConfig::Reflect(context);
         EditorJointLimitConeConfig::Reflect(context);
         EditorJointConfig::Reflect(context);
-        JointMotorProperties::Reflect(context);
         JointsComponentMode::Reflect(context);
 
         EditorMaterialAsset::Reflect(context);

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -1801,6 +1801,7 @@ namespace PhysX
             D6JointLimitConfiguration::Reflect(context);
             JointGenericProperties::Reflect(context);
             JointLimitProperties::Reflect(context);
+            JointMotorProperties::Reflect(context);
             FixedJointConfiguration::Reflect(context);
             BallJointConfiguration::Reflect(context);
             HingeJointConfiguration::Reflect(context);


### PR DESCRIPTION
## What does this PR do?

This PR fixes a critical issue with all Hinge and Prismatic joint components in GameLauncher (not Editor / Game mode). The issue causes failure in components serialization (these components are not reflected).

Fixes #15798.

## How was this PR tested?

It was tested in both Editor (to confirm no regression) and GameLauncher. I looked whether there are critical errors (as before this PR) and whether the joints move as intended (confirmed that). I used [ROSConDemo](https://github.com/o3de/ROSConDemo) for testing.
