### PR TITLE
Fix for rendering UI text that is completely clipped

### DIFF
--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -710,8 +710,8 @@ namespace
                         pBuf = drawBatch.text.data() + bytesProcessed; // In case reallocation occurs, we ensure we are inside the new buffer
                         assert(*pBuf == '\n');
                         pChar = Utf8::Unchecked::octet_iterator(pBuf); // pChar once again points inside the target string, at the current character
-                        assert(*pChar == ch);
                         ++pChar;
+                        assert(*pChar == ch);
                         ++curChar;
                         ++batchCurChar;
 
@@ -4092,6 +4092,12 @@ void UiTextComponent::RenderDrawBatchLines(
                         cacheBatch->m_position.GetX(), cacheBatch->m_position.GetY(), 1.0f, cacheBatch->m_text.c_str(), true, fontContext);
 
                     AZ_Assert(numQuadsWritten <= numQuads, "value returned from WriteTextQuadsToBuffers is larger than size allocated");
+
+                    if (numQuadsWritten == 0)
+                    {
+                        delete cacheBatch;
+                        continue;
+                    }
 
                     int numVertices = numQuadsWritten * 4;
                     FontVertexToUiVertex(vertices.data(), cacheBatch->m_cachedPrimitive.m_vertices, numVertices);


### PR DESCRIPTION
## What does this PR do?

Fix a couple of issues with UI text rendering.
- Move an assert to correct place
- Don't add draw batch to render graph if there are no vertices to draw. This can happen if there are characters to draw, but they are all clipped out of view

Fixes #15755.

## How was this PR tested?

Tested in UI Editor.
