### PR TITLE
Make the Atom screenshot tests parametrize the render pipeline

### DIFF
--- a/AutomatedTesting/AutomationScripts/ExpectedScreenshots/LowEndRenderPipeline/windows/dx12/Atom_DepthOfField/depth_of_field_screenshot1.png
+++ b/AutomatedTesting/AutomationScripts/ExpectedScreenshots/LowEndRenderPipeline/windows/dx12/Atom_DepthOfField/depth_of_field_screenshot1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e426871291e3657f5c5de167aac60e6ab9f80fa4fb36216577d5f8aa6b08caa1
+size 1402049

--- a/AutomatedTesting/AutomationScripts/ExpectedScreenshots/LowEndRenderPipeline/windows/vulkan/Atom_DepthOfField/depth_of_field_screenshot1.png
+++ b/AutomatedTesting/AutomationScripts/ExpectedScreenshots/LowEndRenderPipeline/windows/vulkan/Atom_DepthOfField/depth_of_field_screenshot1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3b3ae2457692f6216c36ddd4f93db3b3df8c45ca16c44a4cc81464d9a356a5c
+size 1365161

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_GPU.py
@@ -39,6 +39,11 @@ atom_feature_test_list = [
     )
 ]
 
+atom_render_pipeline_list = [
+     pytest.param("passes/MainRenderPipeline.azasset"),
+     pytest.param("passes/LowEndRenderPipeline.azasset")
+]
+
 # default names are windows
 launcher_name = "AutomatedTesting.GameLauncher.exe"
 ap_name = "AssetProcessor.exe"
@@ -51,11 +56,12 @@ if LINUX:
     ap_name = "AssetProcessor"
 
 
-def run_test(workspace, rhi, test_name, screenshot_name, test_script, level_path, compare_tolerance):
+def run_test(workspace, rhi, test_name, screenshot_name, test_script, level_path, compare_tolerance, render_pipeline):
         game_launcher = launcher_helper.create_game_launcher(workspace)
         game_launcher.args.extend([ f'--rhi={rhi} ',
                                     f'--run-automation-suite={test_script} ',
                                     '--exit-on-automation-end ',
+                                    f'--r_default_pipeline_name={render_pipeline}',
                                     f'--regset="/O3DE/ScriptAutomation/ImageCapture/LevelPath={level_path}" ',
                                     f'--regset="/O3DE/ScriptAutomation/ImageCapture/TestGroupName={test_name}" ',
                                     f'--regset="/O3DE/ScriptAutomation/ImageCapture/ImageName={screenshot_name}" ',
@@ -78,27 +84,29 @@ def run_test(workspace, rhi, test_name, screenshot_name, test_script, level_path
 @pytest.mark.skipif(not WINDOWS, reason="DX12 is only supported on windows")
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ["windows"])
+@pytest.mark.parametrize("render_pipeline", atom_render_pipeline_list)
 class TestPeriodicSuite_DX12_GPU(object):
 
     @pytest.mark.parametrize("test_name, screenshot_name, test_script, level_path, compare_tolerance", atom_feature_test_list)
     def test_Atom_FeatureTests_DX12(
-            self, workspace, launcher_platform, test_name, screenshot_name, test_script, level_path, compare_tolerance):
+            self, workspace, launcher_platform, test_name, screenshot_name, test_script, level_path, compare_tolerance, render_pipeline):
         """
         Run Atom on DX12 and screen capture tests on parameterised levels
         """
-        run_test(workspace, "dx12", test_name, screenshot_name, test_script, level_path, compare_tolerance)
+        run_test(workspace, "dx12", test_name, screenshot_name, test_script, level_path, compare_tolerance, render_pipeline)
 
 @pytest.mark.SUITE_periodic
 @pytest.mark.REQUIRES_gpu
 @pytest.mark.skipif(not WINDOWS and not LINUX, reason="Vulkan is only supported on windows, linux, & android")
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ["windows, linux"])
+@pytest.mark.parametrize("render_pipeline", atom_render_pipeline_list)
 class TestPeriodicSuite_Vulkan_GPU(object):
 
     @pytest.mark.parametrize("test_name, screenshot_name, test_script, level_path, compare_tolerance", atom_feature_test_list)
     def test_Atom_FeatureTests_Vulkan(
-            self, workspace, launcher_platform, test_name, screenshot_name, test_script, level_path, compare_tolerance):
+            self, workspace, launcher_platform, test_name, screenshot_name, test_script, level_path, compare_tolerance, render_pipeline):
         """
         Run Atom on Vulkan and screen capture tests on parameterised levels
         """
-        run_test(workspace, "vulkan", test_name, screenshot_name, test_script, level_path, compare_tolerance)
+        run_test(workspace, "vulkan", test_name, screenshot_name, test_script, level_path, compare_tolerance, render_pipeline)


### PR DESCRIPTION
This PR updates the Atom screenshot testing suite to also test the LowEndRenderPipeline.

For testing I ran the AutomatedTesting/AutomationScripts/RunAtomScreenshotTests.bat and verified it produced the expected output.
