### PR TITLE
Allow selecting test installer path via Jenkins

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -483,7 +483,7 @@
     "COMMAND": "pytest_windows.cmd",
     "PARAMETERS": {
       "PYTEST_PATH": "cmake\\Platform\\Windows\\Packaging\\Tests",
-      "PYTEST_PARAMETERS": "--capture=no --log-file=%WORKSPACE%\\installer_test.log --install-root=%WORKSPACE%\\o3de_install --installer-uri=!INSTALLER_S3_BUCKET!/development/Latest/Windows/o3de_installer.exe --project-path=%WORKSPACE%\\TestProject"
+      "PYTEST_PARAMETERS": "--capture=no --log-file=%WORKSPACE%\\installer_test.log --install-root=%WORKSPACE%\\o3de_install --installer-uri=!INSTALLER_S3_BUCKET!!INSTALLER_S3_PATH! --project-path=%WORKSPACE%\\TestProject"
     }
   },
   "install_profile_pipe": {

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -99,6 +99,13 @@
                 "default_value": "",
                 "use_last_run_value": true,
                 "description": "The O3DE version shown in the splash screens"
+            },
+            {
+                "parameter_name": "INSTALLER_S3_PATH",
+                "parameter_type": "string",
+                "default_value": "/development/Latest/Windows/o3de_installer.exe",
+                "use_last_run_value": true,
+                "description": "The path to the O3DE installer executable in S3"
             }
         ]
     }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the installer test was hard coded to use the development installer.
The following change allows setting the path to the installer inside the bucket using a Jenkins job parameter `INSTALLER_S3_PATH`

## How was this PR tested?

Used a test Jenkins job to verify with these changes Jenkins uses the correct installer
https://jenkins.build.o3de.org/view/Tools/job/O3DE-test_nightly-installer/102/execution/node/229/log/?consoleFull
```
12:15:29  [ci_build] Executing "D:\workspace\o3de\scripts\build\Platform/Windows/pytest_windows.cmd"
12:15:29    cwd = D:\workspace\o3de
12:15:29    engine_dir = D:\workspace\o3de
12:15:29    parameters:
12:15:29      PYTEST_PATH = cmake\Platform\Windows\Packaging\Tests 
12:15:29      PYTEST_PARAMETERS = --capture=no 
--log-file=%WORKSPACE%\installer_test.log 
--install-root=%WORKSPACE%\o3de_install 
--installer-uri=!INSTALLER_S3_BUCKET!!INSTALLER_S3_PATH! 
--project-path=%WORKSPACE%\TestProject 
12:15:29  --------------------------------------------------------------------------------
12:15:29  [ci_build] python/python.cmd -m pytest cmake\Platform\Windows\Packaging\Tests --capture=no 
--log-file=%WORKSPACE%\installer_test.log 
--install-root=%WORKSPACE%\o3de_install 
--installer-uri=s3://o3de-prism-prod-us-west-2/stabilization-2305/Latest/Windows/o3de_installer.exe 
--project-path=%WORKSPACE%\TestProject
```
