### PR TITLE
Settings Registry Builder log improvements

### DIFF
--- a/Code/Editor/Core/QtEditorApplication.cpp
+++ b/Code/Editor/Core/QtEditorApplication.cpp
@@ -240,14 +240,13 @@ namespace Editor
         AZ::IO::FixedMaxPath engineRootPath;
         {
             using namespace AZ::SettingsRegistryMergeUtils;
-            constexpr bool executeRegDumpCommands = false;
             AZ::SettingsRegistryImpl settingsRegistry;
             AZ::CommandLine commandLine;
             commandLine.Parse(argc, argv);
 
             ParseCommandLine(commandLine);
             StoreCommandLineToRegistry(settingsRegistry, commandLine);
-            MergeSettingsToRegistry_CommandLine(settingsRegistry, commandLine, executeRegDumpCommands);
+            MergeSettingsToRegistry_CommandLine(settingsRegistry, commandLine, {});
             MergeSettingsToRegistry_AddRuntimeFilePaths(settingsRegistry);
 
             settingsRegistry.Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp
@@ -37,7 +37,7 @@ namespace AZ::ComponentApplicationLifecycle
         auto eventSignalKey = FixedValueString::format("%.*s/%.*s", AZ_STRING_ARG(ApplicationLifecycleEventSignalKey),
             AZ_STRING_ARG(eventName));
 
-        return settingsRegistry.MergeSettings(eventValue, Format::JsonMergePatch, eventSignalKey);
+        return static_cast<bool>(settingsRegistry.MergeSettings(eventValue, Format::JsonMergePatch, eventSignalKey));
     }
 
     bool RegisterEvent(AZ::SettingsRegistryInterface& settingsRegistry, AZStd::string_view eventName)
@@ -50,7 +50,7 @@ namespace AZ::ComponentApplicationLifecycle
             FixedValueString eventRegistrationKey{ ApplicationLifecycleEventRegistrationKey };
             eventRegistrationKey += '/';
             eventRegistrationKey += eventName;
-            return settingsRegistry.MergeSettings(R"({})", Format::JsonMergePatch, eventRegistrationKey);
+            return static_cast<bool>(settingsRegistry.MergeSettings(R"({})", Format::JsonMergePatch, eventRegistrationKey));
         }
 
         return true;

--- a/Code/Framework/AzCore/AzCore/IO/FileReader.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/FileReader.cpp
@@ -42,6 +42,13 @@ namespace AZ::IO
         return *this;
     }
 
+    FileReader FileReader::GetStdin()
+    {
+        FileReader fileReader;
+        fileReader.m_file.emplace<AZ::IO::SystemFile>(AZ::IO::SystemFile::GetStdin());
+        return fileReader;
+    }
+
     bool FileReader::Open(AZ::IO::FileIOBase* fileIoBase, const char* filePath)
     {
         // Close file if the FileReader has an instance open

--- a/Code/Framework/AzCore/AzCore/IO/FileReader.h
+++ b/Code/Framework/AzCore/AzCore/IO/FileReader.h
@@ -27,7 +27,7 @@ namespace AZ::IO
     public:
         using SizeType = AZ::u64;
 
-        //! Creates FileReader instance in the default state with no file opend
+        //! Creates FileReader instance in the default state with no file opened
         FileReader();
         ~FileReader();
 
@@ -43,12 +43,17 @@ namespace AZ::IO
         //! Moves ownership of FileReader handle to this instance
         FileReader& operator=(FileReader&& other);
 
+        //! Returns a FileReader which wraps the SystemFile handle to stdin
+        //! descriptor
+        static FileReader GetStdin();
+
         //! Opens a File using the FileIOBase instance if non-nullptr
         //! Otherwise fall back to use SystemFile
         //! @param fileIOBase pointer to fileIOBase instance
         //! @param null-terminated filePath to open
         //! @return true if the File is opened successfully
         bool Open(AZ::IO::FileIOBase* fileIoBase, const char* filePath);
+
 
         //! Returns true if a file is currently open
         //! @return true if the file is open

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.cpp
@@ -85,6 +85,7 @@ namespace AZ::IO
     {
         AZStd::swap(m_fileName, other.m_fileName);
         AZStd::swap(m_handle, other.m_handle);
+        AZStd::swap(m_closeOnDestruction, other.m_closeOnDestruction);
     }
 
     SystemFile& SystemFile::operator=(SystemFile&& other)
@@ -93,8 +94,10 @@ namespace AZ::IO
         Close();
         m_fileName = AZStd::move(other.m_fileName);
         m_handle = AZStd::move(other.m_handle);
+        m_closeOnDestruction = other.m_closeOnDestruction;
         other.m_fileName = {};
         other.m_handle = AZ_TRAIT_SYSTEMFILE_INVALID_HANDLE;
+        other.m_closeOnDestruction = true;
 
         return *this;
     }

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.cpp
@@ -117,4 +117,73 @@ namespace AZ
             return pathValue;
         };
     }
+
+    // Settings Registry MergeSettings result implementtion
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SettingsRegistryInterface::MergeSettingsReturnCode);
+
+    SettingsRegistryInterface::MergeSettingsResult::operator bool() const
+    {
+        return m_returnCode > MergeSettingsReturnCode::Unset;
+    }
+
+    auto SettingsRegistryInterface::MergeSettingsResult::Combine(MergeSettingsResult other) &
+        -> MergeSettingsResult&
+    {
+        // The other return code isn't set so combining is not needed
+        if (other.m_returnCode == MergeSettingsReturnCode::Unset)
+        {
+            return *this;
+        }
+
+        // The merge settings return code is unset so take its return code
+        if (m_returnCode == MergeSettingsReturnCode::Unset)
+        {
+            m_returnCode = other.m_returnCode;
+        }
+        else
+        {
+            // Combining a successful rc with a failure rc
+            // results in partial success
+            // The above if blocks validates that neither
+            // this->m_returnCode nor other.m_returnCode is equal to Unset
+            // so the checks below reduces to a two-state bool
+            bool selfSuccess = (m_returnCode > MergeSettingsReturnCode::Unset);
+            bool otherSuccess = (other.m_returnCode > MergeSettingsReturnCode::Unset);
+
+            if ((selfSuccess && !otherSuccess)
+                || (!selfSuccess && otherSuccess))
+            {
+                m_returnCode = MergeSettingsReturnCode::PartialSuccess;
+            }
+            else if (selfSuccess)
+            {
+                m_returnCode = MergeSettingsReturnCode::Success;
+            }
+            else
+            {
+                m_returnCode = MergeSettingsReturnCode::Failure;
+            }
+        }
+
+        // add a newline between messages if the operation message is not empty
+        if (!m_operationMessages.empty())
+        {
+            m_operationMessages += '\n';
+        }
+
+        m_operationMessages += AZStd::move(other.m_operationMessages);
+
+        return *this;
+    }
+
+    auto SettingsRegistryInterface::MergeSettingsResult::Combine(MergeSettingsResult other) &&
+        -> MergeSettingsResult
+    {
+        return static_cast<MergeSettingsResult&>(*this).Combine(AZStd::move(other));
+    }
+
+    const AZStd::string& SettingsRegistryInterface::MergeSettingsResult::GetMessages() const
+    {
+        return m_operationMessages;
+    }
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -368,12 +368,45 @@ namespace AZ
         //! @return True if the command line argument could be parsed, otherwise false.
         virtual bool MergeCommandLineArgument(AZStd::string_view argument, AZStd::string_view anchorKey = "",
             const CommandLineArgumentSettings& commandLineSettings = {}) = 0;
+
+        //! List of possible return codes from MergeSettings/MergeSettingsFolder
+        //! The unset value is always 0
+        //! Failure values should be < 0 and success values > 0
+        enum class MergeSettingsReturnCode
+        {
+            Unset = 0,
+            Success = 1,
+            PartialSuccess,
+            Failure = -1,
+        };
+
+        //! Encapsulates the result of a JSON Patch or JSON Merge Patch opreations
+        //! into the Settings Registry
+        struct MergeSettingsResult
+        {
+            explicit operator bool() const;
+
+            // Combine MergeSettingsResult together by concatenating the
+            // operation messages and updating the return code based on the
+            // success and failure enum values of both results
+            // Chaining can be performed on a non-const lvalue reference
+            MergeSettingsResult& Combine(MergeSettingsResult otherResult) &;
+            // rvalue reference of combine returns a copy
+            MergeSettingsResult Combine(MergeSettingsResult otherResult) &&;
+
+            // Return a reference to the operation messages string
+            const AZStd::string& GetMessages() const;
+
+            MergeSettingsReturnCode m_returnCode{ MergeSettingsReturnCode::Unset };
+            AZStd::string m_operationMessages;
+        };
+
         //! Merges the json data provided into the settings registry.
         //! @param data The json data stored in a string.
         //! @param format The format of the provided data.
         //! @param anchorKey The key where the merged json content will be anchored under.
         //! @return True if the data was successfully merged, otherwise false.
-        virtual bool MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey = "") = 0;
+        virtual MergeSettingsResult MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey = "") = 0;
         //! Loads a settings file and merges it into the registry.
         //! @param path The path to the registry file.
         //! @param format The format of the text data in the file at the provided path.
@@ -381,7 +414,7 @@ namespace AZ
         //! @param scratchBuffer An optional buffer that's used to load the file into. Use this when loading multiple patches to
         //!     reduce the number of intermediate memory allocations.
         //! @return An AZ::Success if the registry file was successfully merged, or AZ::Failure with an error message.
-        virtual AZ::Outcome<void, AZStd::string> MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view anchorKey = "",
+        virtual MergeSettingsResult MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view anchorKey = "",
             AZStd::vector<char>* scratchBuffer = nullptr) = 0;
         //! Loads all settings files in a folder and merges them into the registry.
         //!     With the specializations "a" and "b" and platform "c" the files would be loaded in the order:
@@ -400,7 +433,7 @@ namespace AZ
         //! @param scratchBuffer An optional buffer that's used to load the file into. Use this when loading multiple patches to
         //!     reduce the number of intermediate memory allocations.
         //! @return True if the registry folder was successfully merged, otherwise false.
-        virtual bool MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
+        virtual MergeSettingsResult MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
             AZStd::string_view platform = {}, AZStd::string_view anchorKey = "", AZStd::vector<char>* scratchBuffer = nullptr) = 0;
 
         //! Indicates whether the Merge functions should send notification events for individual operations

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -405,7 +405,9 @@ namespace AZ
         //! @param data The json data stored in a string.
         //! @param format The format of the provided data.
         //! @param anchorKey The key where the merged json content will be anchored under.
-        //! @return True if the data was successfully merged, otherwise false.
+        //! @return MergeSettingsResult value that is convertible to bool(true) if the data was successfully merged.
+        //!         If the json string was not merged successfully, the `MergeSettingsResult::GetMessages()` function
+        //!         contains messages around why the operation has failed.
         virtual MergeSettingsResult MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey = "") = 0;
         //! Loads a settings file and merges it into the registry.
         //! @param path The path to the registry file.
@@ -413,7 +415,9 @@ namespace AZ
         //! @param anchorKey The key where the content of the settings file will be anchored.
         //! @param scratchBuffer An optional buffer that's used to load the file into. Use this when loading multiple patches to
         //!     reduce the number of intermediate memory allocations.
-        //! @return An AZ::Success if the registry file was successfully merged, or AZ::Failure with an error message.
+        //! @return MergeSettingsResult value that is convertible to bool(true) if the registry file was successfully merged.
+        //!         If the file is is not merged successfully the MergeSettingsResult messages structure will be populated
+        //!         with error messages of why the operation failed
         virtual MergeSettingsResult MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view anchorKey = "",
             AZStd::vector<char>* scratchBuffer = nullptr) = 0;
         //! Loads all settings files in a folder and merges them into the registry.
@@ -432,7 +436,7 @@ namespace AZ
         //! @param anchorKey The registry path location where the settings will be anchored
         //! @param scratchBuffer An optional buffer that's used to load the file into. Use this when loading multiple patches to
         //!     reduce the number of intermediate memory allocations.
-        //! @return True if the registry folder was successfully merged, otherwise false.
+        //! @return MergeSettingsResult value that is convertible to bool(true) if the registry folder was successfully merged.
         virtual MergeSettingsResult MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
             AZStd::string_view platform = {}, AZStd::string_view anchorKey = "", AZStd::vector<char>* scratchBuffer = nullptr) = 0;
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -1323,7 +1323,18 @@ namespace AZ
 
         Pointer pointer(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/-");
 
-        FileReader fileReader(m_useFileIo ? AZ::IO::FileIOBase::GetInstance() : nullptr, path);
+        FileReader fileReader;
+        // If the path of "-" is supplied, then use a FileReader
+        // that reads from stdin
+        if (AZ::IO::PathView pathView(path);
+            pathView == "-")
+        {
+            fileReader = FileReader::GetStdin();
+        }
+        else
+        {
+            fileReader = FileReader(m_useFileIo ? AZ::IO::FileIOBase::GetInstance() : nullptr, path);
+        }
         if (!fileReader.IsOpen())
         {
             pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -700,16 +700,20 @@ namespace AZ
         return Set(key, value);
     }
 
-    bool SettingsRegistryImpl::MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey)
+    auto SettingsRegistryImpl::MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey)
+        -> MergeSettingsResult
     {
         rapidjson::Document jsonPatch;
         constexpr int flags = rapidjson::kParseStopWhenDoneFlag | rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
         jsonPatch.Parse<flags>(data.data(), data.length());
         if (jsonPatch.HasParseError())
         {
-            AZ_Error("Settings Registry", false, R"(Unable to parse data due to json error "%s" at offset %llu.)",
+            MergeSettingsResult mergeResult;
+            mergeResult.m_returnCode = MergeSettingsReturnCode::Failure;
+            mergeResult.m_operationMessages = AZStd::string::format(
+                R"(Unable to parse data due to json error "%s" at offset %llu.)",
                 GetParseError_En(jsonPatch.GetParseError()), jsonPatch.GetErrorOffset());
-            return false;
+            return mergeResult;
         }
 
         JsonMergeApproach mergeApproach;
@@ -722,8 +726,12 @@ namespace AZ
             mergeApproach = JsonMergeApproach::JsonMergePatch;
             break;
         default:
-            AZ_Assert(false, "Provided format for merging settings into the Setting Registry is unsupported.");
-            return false;
+            MergeSettingsResult mergeResult;
+            mergeResult.m_returnCode = MergeSettingsReturnCode::Failure;
+            mergeResult.m_operationMessages = AZStd::string::format(
+                R"(Provided format for merging settings into the Setting Registry is unsupported. Format enum value is %d)",
+                static_cast<int>(format));
+            return mergeResult;
         }
 
         rapidjson::Pointer anchorPath;
@@ -732,15 +740,20 @@ namespace AZ
             anchorPath = rapidjson::Pointer(anchorKey.data(), anchorKey.size());
             if (!anchorPath.IsValid())
             {
+                MergeSettingsResult mergeResult;
+                mergeResult.m_returnCode = MergeSettingsReturnCode::Failure;
+                mergeResult.m_operationMessages = AZStd::string::format(R"(Anchor path "%.*s" is invalid.)",
+                    AZ_STRING_ARG(anchorKey));
+
                 rapidjson::Pointer pointer(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/-");
-                AZ_Error("Settings Registry", false, R"(Anchor path "%.*s" is invalid.)", AZ_STRING_ARG(anchorKey));
                 AZStd::scoped_lock lock(LockForWriting());
                 pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                     .AddMember(rapidjson::StringRef("Error"), rapidjson::StringRef("Invalid anchor key."), m_settings.GetAllocator())
                     .AddMember(rapidjson::StringRef("Path"),
                     rapidjson::Value(anchorKey.data(), aznumeric_caster(anchorKey.size()), m_settings.GetAllocator()),
                     m_settings.GetAllocator());
-                return false;
+
+                return mergeResult;
             }
         }
 
@@ -789,8 +802,12 @@ namespace AZ
                 JsonSerialization::ApplyPatch(anchorRoot, m_settings.GetAllocator(), jsonPatch, mergeApproach, applyPatchSettings);
             if (mergeResult.GetProcessing() != JsonSerializationResult::Processing::Completed)
             {
-                AZ_Error("Settings Registry", false, "Failed to fully merge data into registry.");
-                return false;
+                MergeSettingsResult result;
+                result.m_returnCode = MergeSettingsReturnCode::Failure;
+                result.m_operationMessages = AZStd::string::format(R"(Failed to fully merge data into registry.)",
+                    " Merge failed with resultCode %s.",
+                    mergeResult.ToString(anchorKey).c_str());
+                return result;
             }
 
             // The settings have been successfully merged, query the type at the anchor key
@@ -799,17 +816,23 @@ namespace AZ
 
         SignalNotifier(anchorKey, anchorType);
 
-        return true;
+        MergeSettingsResult mergeResult;
+        mergeResult.m_returnCode = MergeSettingsReturnCode::Success;
+        return mergeResult;
     }
 
-    AZ::Outcome<void, AZStd::string> SettingsRegistryImpl::MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view rootKey,
+    auto SettingsRegistryImpl::MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view rootKey,
         AZStd::vector<char>* scratchBuffer)
+        -> MergeSettingsResult
     {
         using namespace rapidjson;
 
         if (path.empty())
         {
-            return AZ::Failure("Path provided for MergeSettingsFile is empty.");
+            MergeSettingsResult errorResult;
+            errorResult.m_returnCode = MergeSettingsReturnCode::Failure;
+            errorResult.m_operationMessages = "Path provided for MergeSettingsFile is empty.";
+            return errorResult;
         }
 
         AZStd::vector<char> buffer;
@@ -818,18 +841,20 @@ namespace AZ
             scratchBuffer = &buffer;
         }
 
-        AZ::Outcome<void, AZStd::string> result;
+        MergeSettingsResult result;
+        result.m_returnCode = MergeSettingsReturnCode::Success;
         if (path[path.length()] == 0)
         {
             result = MergeSettingsFileInternal(path.data(), format, rootKey, *scratchBuffer);
         }
         else
         {
-            if (AZ::IO::MaxPathLength < path.length() + 1)
+            if (AZ::IO::MaxPathLength < path.size())
             {
-                AZ_Error("Settings Registry", false,
+                result.m_returnCode = MergeSettingsReturnCode::Failure;
+                result.m_operationMessages += AZStd::string::format(
                     R"(Path "%.*s" is too long. Either make sure that the provided path is terminated or use a shorter path.)",
-                    static_cast<int>(path.length()), path.data());
+                    AZ_STRING_ARG(path));
                 Pointer pointer(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/-");
 
                 AZStd::scoped_lock lock(LockForWriting());
@@ -837,9 +862,8 @@ namespace AZ
                 pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                     .AddMember(StringRef("Error"), StringRef("Unable to read registry file."), m_settings.GetAllocator())
                     .AddMember(StringRef("Path"), AZStd::move(pathValue), m_settings.GetAllocator());
-                return AZ::Failure(AZStd::string::format(
-                    R"(Path "%.*s" is too long. Either make sure that the provided path is terminated or use a shorter path.)",
-                    static_cast<int>(path.length()), path.data()));
+
+                return result;
             }
             AZ::IO::FixedMaxPathString filePath(path);
             result = MergeSettingsFileInternal(filePath.c_str(), format, rootKey, *scratchBuffer);
@@ -849,18 +873,20 @@ namespace AZ
         return result;
     }
 
-    bool SettingsRegistryImpl::MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
+    auto SettingsRegistryImpl::MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
         AZStd::string_view platform, AZStd::string_view rootKey, AZStd::vector<char>* scratchBuffer)
+        -> MergeSettingsResult
     {
         using namespace AZ::IO;
         using namespace rapidjson;
 
         if (path.empty())
         {
-            AZ_Error("Settings Registry", false, "Path provided for MergeSettingsFolder is empty.");
-            return false;
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages += "Path provided for MergeSettingsFolder is empty.";
+            return result;
         }
-
 
         AZStd::vector<char> buffer;
         if (!scratchBuffer)
@@ -878,13 +904,17 @@ namespace AZ
 
         if (path.length() + additionalSpaceRequired > AZ::IO::MaxPathLength)
         {
-            AZ_Error("Settings Registry", false, "Folder path for the Setting Registry is too long: %.*s",
-                static_cast<int>(path.size()), path.data());
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages += AZStd::string::format(
+                "Folder path for the Setting Registry is too long: %.*s",
+                AZ_STRING_ARG(path));
+
             AZStd::scoped_lock lock(LockForWriting());
             pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                 .AddMember(StringRef("Error"), StringRef("Folder path for the Setting Registry is too long."), m_settings.GetAllocator())
                 .AddMember(StringRef("Path"), Value(path.data(), aznumeric_caster(path.length()), m_settings.GetAllocator()), m_settings.GetAllocator());
-            return false;
+            return result;
         }
 
         RegistryFileList fileList;
@@ -974,20 +1004,22 @@ namespace AZ
             }
         }
 
+        MergeSettingsResult multiFileResult;
         if (!fileList.empty())
         {
             // Sort the registry files in the order
-            bool collisionFound = false;
-            auto sorter = [this, &collisionFound, &specializations, &pointer, path](
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Success;
+            auto sorter = [this, &result, &specializations, &pointer, path](
                 const RegistryFile& lhs, const RegistryFile& rhs) -> bool
             {
-                return IsLessThan(collisionFound, lhs, rhs, specializations, pointer, path);
+                return IsLessThan(result, lhs, rhs, specializations, pointer, path);
             };
             AZStd::sort(fileList.begin(), fileList.end(), sorter);
 
-            if (collisionFound)
+            if (!result)
             {
-                return false;
+                return result;
             }
 
             // Load the registry files in the sorted order.
@@ -1002,18 +1034,26 @@ namespace AZ
 
                 folderPath /= registryFile.m_relativePath;
 
+                // Combine the MergeSettings result of each MergeSettingsFileInternal
+                // operation
                 if (!registryFile.m_isPatch)
                 {
-                    MergeSettingsFileInternal(folderPath.c_str(), Format::JsonMergePatch, rootKey, *scratchBuffer);
+                    multiFileResult.Combine(MergeSettingsFileInternal(folderPath.c_str(), Format::JsonMergePatch, rootKey, *scratchBuffer));
                 }
                 else
                 {
-                    MergeSettingsFileInternal(folderPath.c_str(), Format::JsonPatch, rootKey, *scratchBuffer);
+                    multiFileResult.Combine(MergeSettingsFileInternal(folderPath.c_str(), Format::JsonPatch, rootKey, *scratchBuffer));
                 }
                 scratchBuffer->clear();
             }
         }
-        return true;
+        else
+        {
+            // Default the multi file merge result to success
+            // if there there are no files to merge
+            multiFileResult.m_returnCode = MergeSettingsReturnCode::Success;
+        }
+        return multiFileResult;
     }
 
     SettingsRegistryInterface::VisitResponse SettingsRegistryImpl::Visit(Visitor& visitor, StackedString& path, AZStd::string_view valueName,
@@ -1168,7 +1208,7 @@ namespace AZ
         return result;
     }
 
-    bool SettingsRegistryImpl::IsLessThan(bool& collisionFound, const RegistryFile& lhs, const RegistryFile& rhs,
+    bool SettingsRegistryImpl::IsLessThan(MergeSettingsResult& collisionFoundResult, const RegistryFile& lhs, const RegistryFile& rhs,
         const Specializations& specializations, const rapidjson::Pointer& historyPointer, AZStd::string_view folderPath)
     {
         using namespace rapidjson;
@@ -1215,8 +1255,9 @@ namespace AZ
             return !lhs.m_isPlatformFile;
         }
 
-        collisionFound = true;
-        AZ_Error("Settings Registry", false, R"(Two registry files in "%.*s" point to the same specialization: "%s" and "%s")",
+        collisionFoundResult.m_returnCode = MergeSettingsReturnCode::Failure;
+        // Append to the error message each pair of registry files with specialization conflicts
+        collisionFoundResult.m_operationMessages += AZStd::string::format(R"(Two registry files in "%.*s" point to the same specialization: "%s" and "%s")",
             AZ_STRING_ARG(folderPath), lhs.m_relativePath.c_str(), rhs.m_relativePath.c_str());
 
         AZStd::scoped_lock lock(LockForWriting());
@@ -1315,8 +1356,9 @@ namespace AZ
         }
     }
 
-    AZ::Outcome<void, AZStd::string>  SettingsRegistryImpl::MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey,
+    auto SettingsRegistryImpl::MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey,
         AZStd::vector<char>& scratchBuffer)
+        -> MergeSettingsResult
     {
         using namespace AZ::IO;
         using namespace rapidjson;
@@ -1340,7 +1382,11 @@ namespace AZ
             pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                 .AddMember(StringRef("Error"), StringRef("Unable to open registry file."), m_settings.GetAllocator())
                 .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
-            return AZ::Failure(AZStd::string::format(R"(Unable to open registry file "%s".)", path));
+
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages = AZStd::string::format(R"(Unable to open registry file "%s".)", path);
+            return result;
         }
 
         u64 fileSize = fileReader.Length();
@@ -1350,7 +1396,11 @@ namespace AZ
                 .SetObject()
                 .AddMember(StringRef("Error"), StringRef("registry file is 0 bytes."), m_settings.GetAllocator())
                 .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
-            return AZ::Failure(AZStd::string::format(R"(Registry file "%s" is 0 bytes in length. There is no nothing to merge)", path));
+
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages = AZStd::string::format(R"(Registry file "%s" is 0 bytes in length. There is no nothing to merge)", path);
+            return result;
         }
 
         scratchBuffer.clear();
@@ -1360,7 +1410,11 @@ namespace AZ
             pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                 .AddMember(StringRef("Error"), StringRef("Unable to read registry file."), m_settings.GetAllocator())
                 .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
-            return AZ::Failure(AZStd::string::format(R"(Unable to read registry file "%s".)", path));
+
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages = AZStd::string::format(R"(Unable to read registry file "%s".)", path);
+            return result;
         }
         scratchBuffer[fileSize] = 0;
 
@@ -1369,26 +1423,26 @@ namespace AZ
         jsonPatch.ParseInsitu<flags>(scratchBuffer.data());
         if (jsonPatch.HasParseError())
         {
-            AZ::Outcome<void, AZStd::string> result;
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+
             auto nativeUI = AZ::Interface<NativeUI::NativeUIRequests>::Get();
             if (jsonPatch.GetParseError() == rapidjson::kParseErrorDocumentEmpty)
             {
-                result = AZ::Failure(AZStd::string::format(
+                result.m_operationMessages = AZStd::string::format(
                     R"(Unable to parse registry file "%s" due to json error "%s" at offset %zu.)",
                     path,
                     GetParseError_En(jsonPatch.GetParseError()),
-                    jsonPatch.GetErrorOffset()));
+                    jsonPatch.GetErrorOffset());
             }
             else
             {
-                using ErrorString = AZStd::fixed_string<4096>;
-                auto jsonError = ErrorString::format(R"(Unable to parse registry file "%s" due to json error "%s" at offset %zu.)", path,
+                result.m_operationMessages = AZStd::string::format(R"(Unable to parse registry file "%s" due to json error "%s" at offset %zu.)", path,
                     GetParseError_En(jsonPatch.GetParseError()), jsonPatch.GetErrorOffset());
-                result = AZ::Failure(jsonError.c_str());
 
                 if (nativeUI)
                 {
-                    nativeUI->DisplayOkDialog("Setreg(Patch) Merge Issue", AZStd::string_view(jsonError), false);
+                    nativeUI->DisplayOkDialog("Setreg(Patch) Merge Issue", result.m_operationMessages, false);
                 }
             }
 
@@ -1418,17 +1472,23 @@ namespace AZ
                         " See RFC 7386 for more information"), m_settings.GetAllocator())
                     .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
 
-                return AZ::Failure(AZStd::string::format( R"(Attempting to merge the settings registry file "%s" where the root element is a)"
+                MergeSettingsResult result;
+                result.m_returnCode = MergeSettingsReturnCode::Failure;
+                result.m_operationMessages = AZStd::string::format(
+                    R"(Attempting to merge the settings registry file "%s" where the root element is a)"
                     R"( non-JSON Object using the JSON MergePatch approach. The JSON MergePatch algorithm would therefore)"
                     R"( overwrite all settings at the supplied root-key path and therefore merging has been)"
                     R"( disallowed to prevent field destruction.)" "\n"
                     R"(To merge the supplied settings registry file, the settings within it must be placed within a JSON Object '{}')"
-                    R"( in order to allow moving of its fields using the root-key as an anchor.)", path));
+                    R"( in order to allow moving of its fields using the root-key as an anchor.)", path);
+                return result;
             }
             break;
         default:
-            AZ_Assert(false, "Provided format for merging settings into the Setting Registry is unsupported.");
-            return AZ::Failure("Provided format for merging settings into the Setting Registry is unsupported.");
+            MergeSettingsResult errorResult;
+            errorResult.m_returnCode = MergeSettingsReturnCode::Failure;
+            errorResult.m_operationMessages = "Provided format for merging settings into the Setting Registry is unsupported.";
+            return errorResult;
         }
 
         // Add a reporting callback to capture JSON patch operations while merging if the merge operations notify
@@ -1494,23 +1554,31 @@ namespace AZ
             }
             else
             {
+                MergeSettingsResult result;
+                result.m_returnCode = MergeSettingsReturnCode::Failure;
+                result.m_operationMessages = AZStd::string::format(R"(Failed to root path "%.*s" is invalid.)",
+                    AZ_STRING_ARG(rootKey));
+
                 AZStd::scoped_lock lock(LockForWriting());
                 pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                     .AddMember(StringRef("Error"), StringRef("Invalid root key."), m_settings.GetAllocator())
                     .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
 
-                return AZ::Failure(AZStd::string::format(R"(Failed to root path "%.*s" is invalid.)",
-                    aznumeric_cast<int>(rootKey.length()), rootKey.data()));
+                return result;
             }
         }
         if (mergeResult.GetProcessing() != JsonSerializationResult::Processing::Completed)
         {
+            MergeSettingsResult result;
+            result.m_returnCode = MergeSettingsReturnCode::Failure;
+            result.m_operationMessages = AZStd::string::format(R"(Failed to fully merge registry file "%s".)", path);
+
             AZStd::scoped_lock lock(LockForWriting());
             pointer.Create(m_settings, m_settings.GetAllocator()).SetObject()
                 .AddMember(StringRef("Error"), StringRef("Failed to fully merge registry file."), m_settings.GetAllocator())
                 .AddMember(StringRef("Path"), Value(path, m_settings.GetAllocator()), m_settings.GetAllocator());
-            
-           return AZ::Failure(AZStd::string::format(R"(Failed to fully merge registry file "%s".)", path));
+
+            return result;
         }
 
         {
@@ -1526,7 +1594,9 @@ namespace AZ
 
         SignalNotifier(rootKey, anchorType);
 
-        return AZ::Success();
+        MergeSettingsResult successResult;
+        successResult.m_returnCode = MergeSettingsReturnCode::Success;
+        return successResult;
     }
 
     void SettingsRegistryImpl::SetNotifyForMergeOperations(bool notify)

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -711,7 +711,7 @@ namespace AZ
             MergeSettingsResult mergeResult;
             mergeResult.m_returnCode = MergeSettingsReturnCode::Failure;
             mergeResult.m_operationMessages = AZStd::string::format(
-                R"(Unable to parse data due to json error "%s" at offset %llu.)",
+                R"(Unable to parse data due to json error "%s" at offset %zu.)",
                 GetParseError_En(jsonPatch.GetParseError()), jsonPatch.GetErrorOffset());
             return mergeResult;
         }
@@ -804,7 +804,7 @@ namespace AZ
             {
                 MergeSettingsResult result;
                 result.m_returnCode = MergeSettingsReturnCode::Failure;
-                result.m_operationMessages = AZStd::string::format(R"(Failed to fully merge data into registry.)",
+                result.m_operationMessages = AZStd::string::format(R"(Failed to fully merge data into registry.)"
                     " Merge failed with resultCode %s.",
                     mergeResult.ToString(anchorKey).c_str());
                 return result;

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -79,10 +79,10 @@ namespace AZ
 
         bool MergeCommandLineArgument(AZStd::string_view argument, AZStd::string_view anchorKey,
             const CommandLineArgumentSettings& commandLineSettings) override;
-        bool MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey = "") override;
-        AZ::Outcome<void, AZStd::string> MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view anchorKey = "",
+        MergeSettingsResult MergeSettings(AZStd::string_view data, Format format, AZStd::string_view anchorKey = "") override;
+        MergeSettingsResult MergeSettingsFile(AZStd::string_view path, Format format, AZStd::string_view anchorKey = "",
             AZStd::vector<char>* scratchBuffer = nullptr) override;
-        bool MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
+        MergeSettingsResult MergeSettingsFolder(AZStd::string_view path, const Specializations& specializations,
             AZStd::string_view platform, AZStd::string_view anchorKey = "", AZStd::vector<char>* scratchBuffer = nullptr) override;
 
         void SetNotifyForMergeOperations(bool notify) override;
@@ -111,10 +111,10 @@ namespace AZ
             const rapidjson::Value& value) const;
 
         // Compares if lhs is less than rhs in terms of processing order. This can also detect and report conflicts.
-        bool IsLessThan(bool& collisionFound, const RegistryFile& lhs, const RegistryFile& rhs, const Specializations& specializations,
+        bool IsLessThan(MergeSettingsResult& collisionFoundResult, const RegistryFile& lhs, const RegistryFile& rhs, const Specializations& specializations,
             const rapidjson::Pointer& historyPointer, AZStd::string_view folderPath);
         bool ExtractFileDescription(RegistryFile& output, AZStd::string_view filename, const Specializations& specializations);
-        AZ::Outcome<void, AZStd::string> MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey, AZStd::vector<char>& scratchBuffer);
+        MergeSettingsResult MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey, AZStd::vector<char>& scratchBuffer);
 
         void SignalNotifier(AZStd::string_view jsonPath, SettingsType type);
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
@@ -249,6 +249,15 @@ namespace AZ::SettingsRegistryMergeUtils
         const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
         -> SettingsRegistryInterface::MergeSettingsResult;
 
+    //! Filter for determining whether the current invocation of MergeSettingsToRegistry_CommandLine
+    //! should parse run the regdump and regset-file commands
+    struct CommandsToParse
+    {
+        bool m_parseRegdumpCommands{};
+        bool m_parseRegsetCommands{ true };
+        bool m_parseRegremoveCommands{ true };
+        bool m_parseRegsetFileCommands{};
+    };
     //! Adds the settings set through the command line to the Settings Registry. This will also execute any Settings
     //! Registry related arguments. Note that --regset, --regset-file and -regremove will run in the order in which they are parsed
     //! --regset <arg> Sets a value in the registry. See MergeCommandLineArgument for options for <arg>
@@ -266,7 +275,8 @@ namespace AZ::SettingsRegistryMergeUtils
     //!     example: --regdump /My/Array/With/Objects
     //! --regdumpall Dumps the entire settings registry to output.
     //! Note that this function is only called in development builds and is compiled out in release builds.
-    void MergeSettingsToRegistry_CommandLine(SettingsRegistryInterface& registry, AZ::CommandLine commandLine, bool executeCommands);
+    void MergeSettingsToRegistry_CommandLine(SettingsRegistryInterface& registry, AZ::CommandLine commandLine,
+        const CommandsToParse& commandsToParse = {});
 
     //! Stores the command line settings into the Setting Registry
     //! The arguments can be used later anywhere the command line is needed

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
@@ -216,32 +216,38 @@ namespace AZ::SettingsRegistryMergeUtils
     //! Merges the registry folder which contains the build targets that the active project depends on for loading
     //! In most cases these build targets are the gem modules and are generated automatically by the build system(CMake in this case)
     //! The files are normally generated in a Registry next to the executable
-    void MergeSettingsToRegistry_TargetBuildDependencyRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_TargetBuildDependencyRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Adds the engine settings to the Settings Registry.
-    void MergeSettingsToRegistry_EngineRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_EngineRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Merges all the registry folders found in the listed gems.
-    void MergeSettingsToRegistry_GemRegistries(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_GemRegistries(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Merges all the registry folders found in the listed gems.
-    void MergeSettingsToRegistry_ProjectRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_ProjectRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Adds the development settings added by individual users of the project to the Settings Registry.
     //! Note that this function is only called in development builds and is compiled out in release builds.
-    void MergeSettingsToRegistry_ProjectUserRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_ProjectUserRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Adds the user settings from the users home directory of "~/.o3de/Registry"
     //! '~' corresponds to %USERPROFILE% on Windows and $HOME on Unix-like platforms(Linux, Mac)
     //! Note that this function is only called in development builds and is compiled out in release builds.
     //! It is merged before the command line settings are merged so that the command line always takes precedence
-    void MergeSettingsToRegistry_O3deUserRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
-        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr);
+    auto MergeSettingsToRegistry_O3deUserRegistry(SettingsRegistryInterface& registry, const AZStd::string_view platform,
+        const SettingsRegistryInterface::Specializations& specializations, AZStd::vector<char>* scratchBuffer = nullptr)
+        -> SettingsRegistryInterface::MergeSettingsResult;
 
     //! Adds the settings set through the command line to the Settings Registry. This will also execute any Settings
     //! Registry related arguments. Note that --regset, --regset-file and -regremove will run in the order in which they are parsed

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
@@ -270,10 +270,16 @@ namespace AZ::SettingsRegistryMergeUtils
     //!     example: --regset-file="relative/path/other.setregpatch::/O3DE/settings"
     //! --regremove <arg> Removes a value in the registry
     //!    example: --regremove "/My/String/Value"
-    //! only when executeCommands is true are the following options supported:
     //! --regdump <path> Dumps the content of the key at path and all it's content/children to output.
     //!     example: --regdump /My/Array/With/Objects
     //! --regdumpall Dumps the entire settings registry to output.
+    //! 
+    //! The CommandsToParse structure determines which options should be processed from the command line
+    //! `CommandsToParse::m_parseRegdumpCommands=true` allows the --regdump and --regdumpall commands to be processed
+    //! `CommandsToParse::m_parseRegsetCommands=true` allows the --regset command to be processed
+    //! `CommandsToParse::m_parseRegremveCommands=true` allows the --regremove command to be processed
+    //! `CommandsToParse::m_parseRegsetFileCommands=true` allows the --regset-file command to be processed
+    //! 
     //! Note that this function is only called in development builds and is compiled out in release builds.
     void MergeSettingsToRegistry_CommandLine(SettingsRegistryInterface& registry, AZ::CommandLine commandLine,
         const CommandsToParse& commandsToParse = {});

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockSettingsRegistry.h
@@ -49,11 +49,11 @@ namespace AZ
         MOCK_METHOD1(Remove, bool(AZStd::string_view));
 
         MOCK_METHOD3(MergeCommandLineArgument, bool(AZStd::string_view, AZStd::string_view, const CommandLineArgumentSettings&));
-        MOCK_METHOD3(MergeSettings, bool(AZStd::string_view, Format, AZStd::string_view));
-        MOCK_METHOD4(MergeSettingsFile, AZ::Outcome<void,AZStd::string>(AZStd::string_view, Format, AZStd::string_view, AZStd::vector<char>*));
+        MOCK_METHOD3(MergeSettings, MergeSettingsResult(AZStd::string_view, Format, AZStd::string_view));
+        MOCK_METHOD4(MergeSettingsFile, MergeSettingsResult(AZStd::string_view, Format, AZStd::string_view, AZStd::vector<char>*));
         MOCK_METHOD5(
             MergeSettingsFolder,
-            bool(AZStd::string_view, const Specializations&, AZStd::string_view, AZStd::string_view, AZStd::vector<char>*));
+            MergeSettingsResult(AZStd::string_view, const Specializations&, AZStd::string_view, AZStd::string_view, AZStd::vector<char>*));
 
         MOCK_METHOD1(SetNotifyForMergeOperations, void(bool));
         MOCK_CONST_METHOD0(GetNotifyForMergeOperations, bool());

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
@@ -733,13 +733,13 @@ tags=tools,renderer,metal)"
         AZ::CommandLine commandLine;
         commandLine.Parse({ "--regset-file", regsetFile });
 
-        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*m_registry, commandLine, false);
+        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*m_registry, commandLine, {});
 
         // Add a settings path to anchor loaded settings underneath
         regsetFile = AZStd::string::format("%s::/AnchorPath/Of/Settings", AZ::IO::SystemFile::GetNullFilename());
         commandLine.Parse({ "--regset-file", regsetFile });
 
-        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*m_registry, commandLine, false);
+        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*m_registry, commandLine, {});
         EXPECT_EQ(AZ::SettingsRegistryInterface::Type::NoType, m_registry->GetType("/AnchorPath/Of/Settings"));
     }
 

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
@@ -1716,10 +1716,10 @@ namespace SettingsRegistryTests
     {
         constexpr AZStd::fixed_string<AZ::IO::MaxPathLength + 1> path(AZ::IO::MaxPathLength + 1, 'a');
         
-        AZ_TEST_START_TRACE_SUPPRESSION;
         auto result = m_registry->MergeSettingsFolder(path, { "editor", "test" }, {});
-        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         EXPECT_FALSE(result);
+        // The message structure should contain the error message
+        EXPECT_FALSE(result.GetMessages().empty());
 
         EXPECT_EQ(AZ::SettingsRegistryInterface::Type::Object, m_registry->GetType(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/0"));
         EXPECT_EQ(AZ::SettingsRegistryInterface::Type::String, m_registry->GetType(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/0/Error"));
@@ -1731,10 +1731,10 @@ namespace SettingsRegistryTests
         CreateTestFile("Memory.test.editor.setreg", "{}");
         CreateTestFile("Memory.editor.test.setreg", "{}");
 
-        AZ_TEST_START_TRACE_SUPPRESSION;
         auto result = m_registry->MergeSettingsFolder((m_tempDirectory.GetDirectoryAsFixedMaxPath() / AZ::SettingsRegistryInterface::RegistryFolder).Native(), { "editor", "test" }, {});
-        EXPECT_GT(::UnitTest::TestRunner::Instance().StopAssertTests(), 0);
         EXPECT_FALSE(result);
+        // The message structure should contain the error message
+        EXPECT_FALSE(result.GetMessages().empty());
 
         EXPECT_EQ(AZ::SettingsRegistryInterface::Type::Object, m_registry->GetType(AZ_SETTINGS_REGISTRY_HISTORY_KEY "/0")); // Folder and specialization settings.
 

--- a/Code/Framework/AzFramework/AzFramework/ProjectManager/ProjectManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/ProjectManager/ProjectManager.cpp
@@ -38,7 +38,7 @@ namespace AzFramework::ProjectManager
             // Retrieve Command Line from Settings Registry, it may have been updated by the call to FindEngineRoot()
             // in MergeSettingstoRegistry_ConfigFile
             AZ::SettingsRegistryMergeUtils::GetCommandLineFromRegistry(settingsRegistry, commandLine);
-            AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(settingsRegistry, commandLine, false);
+            AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(settingsRegistry, commandLine, {});
             // Look for the engine first in case the project path is relative
             AZ::SettingsRegistryMergeUtils::FindEngineRoot(settingsRegistry);
             projectRootPath = AZ::SettingsRegistryMergeUtils::FindProjectRoot(settingsRegistry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -79,9 +79,9 @@ namespace AzToolsFramework
         if (fileExists)
         {
             if (auto mergeResult = registry->MergeSettingsFile(fullSettingsPath.Native(), format, anchorKey);
-                !mergeResult.IsSuccess())
+                !mergeResult)
             {
-                return AZ::Failure(mergeResult.GetError());
+                return AZ::Failure(mergeResult.GetMessages());
             }
         }
 

--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -244,9 +244,20 @@ namespace AssetProcessor
                     CopySettingsToLocalRegistry(AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey);
                 }
 
-                AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_EngineRegistry(registry, platform, specialization, &scratchBuffer);
-                AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_GemRegistries(registry, platform, specialization, &scratchBuffer);
-                AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ProjectRegistry(registry, platform, specialization, &scratchBuffer);
+                AZ::SettingsRegistryInterface::MergeSettingsResult mergeResult;
+                mergeResult.Combine(AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_EngineRegistry(registry, platform, specialization, &scratchBuffer));
+                mergeResult.Combine(AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_GemRegistries(registry, platform, specialization, &scratchBuffer));
+                mergeResult.Combine(AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ProjectRegistry(registry, platform, specialization, &scratchBuffer));
+
+                // Output any Settings Registry Merge result messages using the info log level if not empty
+                if (auto& operationMessages = mergeResult.GetMessages();
+                    !operationMessages.empty())
+                {
+                    AZStd::string_view buildConfiguration(specialization.GetSpecialization(0));
+                    AZ_Info("Settings Registry Builder", R"(Configuration: "%.*s")" "\n"
+                        "Merging the Engine, Gem, Project Registry directories resulted in the following messages:\n%s\n",
+                        AZ_STRING_ARG(buildConfiguration), operationMessages.c_str());
+                }
 
                 // The Gem Root Key and Manifest Gems Root is removed now that each gems "<gem-root>/Registry" directory
                 // have been merged to the local Settings Registry

--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -264,7 +264,6 @@ namespace AssetProcessor
                 registry.Remove(AZ::SettingsRegistryMergeUtils::ActiveGemsRootKey);
                 registry.Remove(AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey);
 
-                constexpr bool executeRegDumpCommands = false;
                 AZ::CommandLine* commandLine{};
                 AZ::ComponentApplicationBus::Broadcast([&commandLine](AZ::ComponentApplicationRequests* appRequests)
                 {
@@ -273,7 +272,7 @@ namespace AssetProcessor
 
                 if (commandLine)
                 {
-                    AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(registry, *commandLine, executeRegDumpCommands);
+                    AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(registry, *commandLine, {});
                 }
 
                 if (AZ::IO::ByteContainerStream outputStream(&outputBuffer);

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1347,7 +1347,7 @@ namespace AssetProcessor
         // file to the settings registry
         if (configFile.Extension() == ".setreg")
         {
-            return settingsRegistry.MergeSettingsFile(configFile.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch).IsSuccess();
+            return static_cast<bool>(settingsRegistry.MergeSettingsFile(configFile.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch));
         }
 
         AZ::SettingsRegistryMergeUtils::ConfigParserSettings configParserSettings;

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -705,7 +705,7 @@ namespace AssetProcessor
     #if defined(AZ_DEBUG_BUILD) || defined(AZ_PROFILE_BUILD)
         if (commandLine)
         {
-            AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*settingsRegistry, *commandLine, true);
+            AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_CommandLine(*settingsRegistry, *commandLine, {});
         }
     #endif
 

--- a/engine.json
+++ b/engine.json
@@ -7,7 +7,7 @@
     "version": "2.0.0",
     "api_versions": {
         "editor": "1.0.0",
-        "framework": "1.0.0",
+        "framework": "1.1.0",
         "launcher": "1.0.0",
         "tools": "1.0.0"
     },


### PR DESCRIPTION
Updated the AZ::IO::FileReader to support reading from stdin.
Fix the SystemFile move constructor/assignment to properly copy the `m_closeOnDestruction` bool.

Updated the Settings Registry Merge* functions to return a result structure with a message string containing user relevant merge messages.
Updated the Settings Registry Builder to output messages related to merging the Engine, Gems and Project registry folders at the info log level.

Updated MergeSettingsToRegistry_CommandLine argument parsing
The `MergeSettingsToRegistry_CommandLine` now accepts a struct instead of a boolean which indicates which command line settings registry arguments to parse.

## How was this PR tested?

Verified that specifying a --regset-file option with the `-` argument successfully merges the JSON blob to stdin correctly.
The command used was:
`C:\code\o3de>echo '{"Test": {} }' | build\windows\bin\profile\SerializeContextTools.exe --regset-file=-`

Verified the Settings Registry builder logged the messages related any warnings output from merging files to the Settings Registry
![settings_registry_merge_error](https://user-images.githubusercontent.com/56135373/234917930-7e74144e-0444-4a46-b8f1-a95072a988ce.png)

