### PR TITLE
bugfix(Whitebox): correctly save file with extension *.wbm

### DIFF
--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -577,7 +577,7 @@ namespace WhiteBox
         const auto absoluteSavePathFn = [](const AZStd::string& initialAbsolutePath)
         {
             const QString fileFilter =
-                AZStd::string::format("*.%s", Pipeline::WhiteBoxMeshAssetHandler::AssetFileExtension).c_str();
+                AZStd::string::format("WhiteBoxMesh (*.%s)", Pipeline::WhiteBoxMeshAssetHandler::AssetFileExtension).c_str();
             const QString absolutePath = AzQtComponents::FileDialog::GetSaveFileName(
                 nullptr, "Save As Asset...", QString(initialAbsolutePath.c_str()), fileFilter);
 


### PR DESCRIPTION
## What does this PR do?

the file extension for wbm is not appended correctly if the file is missing the extension when saving a whitebox mesh.

this regex expression is what drives how the extension is appended: https://github.com/o3de/o3de/blob/development/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/FileDialog.cpp#L113

documentation: https://doc.qt.io/qt-6/qfiledialog.html#getSaveFileName

follow the instruction in the issue below to reproduce. 
ref: https://github.com/o3de/o3de/issues/15788
