### PR TITLE
Prompt the user to build newly downloaded project

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -140,7 +140,7 @@ namespace O3DE::ProjectManager
         void CopyProject(const ProjectInfo& projectInfo);
         void RemoveProject(const QString& projectName);
         void DeleteProject(const QString& projectName);
-        void BuildProject(const ProjectInfo& projectInfo);
+        void BuildProject(const ProjectInfo& projectInfo, bool skipDialogBox = false);
         void OpenCMakeGUI(const ProjectInfo& projectInfo);
 
     private:

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -645,7 +645,7 @@ namespace O3DE::ProjectManager
         SuggestBuildProjectMsg(projectInfo, true);
     }
 
-    void ProjectsScreen::QueueBuildProject(const ProjectInfo& projectInfo)
+    void ProjectsScreen::QueueBuildProject(const ProjectInfo& projectInfo, bool skipDialogBox)
     {
         auto requiredIter = RequiresBuildProjectIterator(projectInfo.m_path);
         if (requiredIter != m_requiresBuild.end())
@@ -657,7 +657,7 @@ namespace O3DE::ProjectManager
         {
             if (m_buildQueue.empty() && !m_currentBuilder)
             {
-                StartProjectBuild(projectInfo);
+                StartProjectBuild(projectInfo, skipDialogBox);
                 // Projects Content is already reset in function
             }
             else
@@ -717,7 +717,7 @@ namespace O3DE::ProjectManager
 
                             if ((*foundButton).second->GetState() == ProjectButtonState::DownloadingBuildQueued)
                             {
-                                QueueBuildProject(projectInfo);
+                                QueueBuildProject(projectInfo, true);
                             }
                             else
                             {
@@ -865,17 +865,23 @@ namespace O3DE::ProjectManager
         return displayFirstTimeContent;
     }
 
-    bool ProjectsScreen::StartProjectBuild(const ProjectInfo& projectInfo)
+    bool ProjectsScreen::StartProjectBuild(const ProjectInfo& projectInfo, bool skipDialogBox)
     {
         if (ProjectUtils::FindSupportedCompiler(this))
         {
-            QMessageBox::StandardButton buildProject = QMessageBox::information(
-                this,
-                tr("Building \"%1\"").arg(projectInfo.GetProjectDisplayName()),
-                tr("Ready to build \"%1\"?").arg(projectInfo.GetProjectDisplayName()),
-                QMessageBox::No | QMessageBox::Yes);
+            bool proceedToBuild = skipDialogBox;
+            if (!proceedToBuild)
+            {
+                QMessageBox::StandardButton buildProject = QMessageBox::information(
+                    this,
+                    tr("Building \"%1\"").arg(projectInfo.GetProjectDisplayName()),
+                    tr("Ready to build \"%1\"?").arg(projectInfo.GetProjectDisplayName()),
+                    QMessageBox::No | QMessageBox::Yes);
 
-            if (buildProject == QMessageBox::Yes)
+                proceedToBuild = buildProject == QMessageBox::Yes;
+            }
+            
+            if (proceedToBuild)
             {
                 m_currentBuilder = new ProjectBuilderController(projectInfo, nullptr, this);
                 UpdateWithProjects(GetAllProjects());

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -678,6 +678,8 @@ namespace O3DE::ProjectManager
     {
         m_downloadController->AddObjectDownload(projectName, destinationPath, DownloadController::DownloadObjectType::Project);
 
+        UpdateIfCurrentScreen();
+
         auto foundButton = AZStd::ranges::find_if(m_projectButtons,
             [&projectName](const AZStd::unordered_map<AZ::IO::Path, ProjectButton*>::value_type& value)
             {

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.h
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.h
@@ -61,7 +61,7 @@ namespace O3DE::ProjectManager
         void HandleDeleteProject(const QString& projectPath);
 
         void SuggestBuildProject(const ProjectInfo& projectInfo);
-        void QueueBuildProject(const ProjectInfo& projectInfo);
+        void QueueBuildProject(const ProjectInfo& projectInfo, bool skipDialogBox = false);
         void UnqueueBuildProject(const ProjectInfo& projectInfo);
 
         void StartProjectDownload(const QString& projectName, const QString& destinationPath, bool queueBuild);
@@ -84,7 +84,7 @@ namespace O3DE::ProjectManager
         bool ShouldDisplayFirstTimeContent(bool projectsFound);
         void RemoveProjectButtonsFromFlowLayout(const QVector<ProjectInfo>& projectsToKeep);
 
-        bool StartProjectBuild(const ProjectInfo& projectInfo);
+        bool StartProjectBuild(const ProjectInfo& projectInfo, bool skipDialogBox = false);
         QList<ProjectInfo>::iterator RequiresBuildProjectIterator(const QString& projectPath);
         bool BuildQueueContainsProject(const QString& projectPath);
         bool WarnIfInBuildQueue(const QString& projectPath);


### PR DESCRIPTION


## What does this PR do?

This is a single line fix to address the bug discovered in https://github.com/o3de/o3de/issues/13035.

In essence, auto-build did not occur because once the download happened, the current cache of projects did not account for the newly added repo. This requires updating the project information so that it is present before searching for projects to mark as needing to build.

## How was this PR tested?

Testing was done manually. Behavior was confirmed as shown in the following gif:
![ProjectManagerAutoBuildRemote](https://user-images.githubusercontent.com/112996779/234756841-e862edc3-52fc-455a-b478-7a10437ada1c.gif)
