### PR TITLE
Syntax issue in shader: can't use a non-class enum as qualifier prefix.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -31,7 +31,7 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
     // Only calculate shading if light is in range
     if (falloff < 1.0f && angleFalloff > 0.0f)
     {
-        bool useConeAngle = light.m_flags & DiskLightFlag::UseConeAngle;
+        bool useConeAngle = light.m_flags & UseConeAngle;
         float3 dirToConeTip;
         float dotWithDirection;
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
@@ -86,7 +86,7 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared
     float falloff = distanceToLight2 * light.m_invAttenuationRadiusSquared;
 
-    bool doubleSided = (light.m_flags & QuadLightFlag::EmitsBothDirections) > 0;
+    bool doubleSided = (light.m_flags & EmitsBothDirections) > 0;
     if (doubleSided)
     {
         lightDirection *= sign(posToLightDotLightDirection);
@@ -108,7 +108,7 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
         float3 p2 = posToLight +  left + -up;
         float3 p3 = posToLight +  left +  up;
 
-        bool useFastApproximation = (light.m_flags & QuadLightFlag::UseFastApproximation) > 0;
+        bool useFastApproximation = (light.m_flags & UseFastApproximation) > 0;
         if (!useFastApproximation && o_enableQuadLightLTC)
         {
             float3 p[4] = {p0, p1, p2, p3};
@@ -231,7 +231,7 @@ void ValidateQuadLight(ViewSrg::QuadLight light, Surface surface, inout Lighting
     float3 specularAcc = float3(0.0, 0.0, 0.0);
     float3 translucentAcc = float3(0.0, 0.0, 0.0);
 
-    bool emitsBothDirections = (light.m_flags & QuadLightFlag::EmitsBothDirections) > 0;
+    bool emitsBothDirections = (light.m_flags & EmitsBothDirections) > 0;
     float bothDirectionsFactor = emitsBothDirections ? -1.0 : 0.0;
 
     for (uint i = 0; i < sampleCount; ++i)


### PR DESCRIPTION
## What does this PR do?

Straighten a nit point of code syntax in shaders

## How was this PR tested?

Ran the sample viewer and material editor to have the asset processor re-treat the change.
