### PR TITLE
Skip warning of missing entity referenced from sort order component

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/EntityIdSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Component/EntityIdSerializer.h
@@ -13,6 +13,8 @@
 
 namespace AZ
 {
+    class EntityId;
+
     class JsonEntityIdSerializer
         : public BaseJsonSerializer
     {
@@ -28,10 +30,13 @@ namespace AZ
             virtual JsonSerializationResult::Result MapJsonToId(EntityId& outputValue, const rapidjson::Value& inputValue, JsonDeserializerContext& context) = 0;
             virtual JsonSerializationResult::Result MapIdToJson(rapidjson::Value& outputValue, const EntityId& inputValue, JsonSerializerContext& context) = 0;
 
-            inline void SetIsEntityReference(bool isEntityReference) { m_isEntityReference = isEntityReference; };
+            inline void SetIsEntityReference(bool isEntityReference) { m_isEntityReference = isEntityReference; }
+            inline bool GetAcceptUnregisteredEntity() { return m_acceptUnregisteredEntity; }
+            inline void SetAcceptUnregisteredEntity(bool acceptUnregisteredEntity) { m_acceptUnregisteredEntity = acceptUnregisteredEntity; }
 
         protected:
             bool m_isEntityReference = true;
+            bool m_acceptUnregisteredEntity = false;
         };
 
         JsonSerializationResult::Result Load(void* outputValue, const Uuid& outputValueTypeId, const rapidjson::Value& inputValue,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceEntityIdMapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceEntityIdMapper.cpp
@@ -167,7 +167,7 @@ namespace AzToolsFramework
 
                 if (!owningInstanceReference)
                 {
-                    AZ_Warning("Prefabs", false,
+                    AZ_Warning("Prefabs", m_acceptUnregisteredEntity,
                         "Prefab - EntityIdMapper: Entity with Id %s has no registered owning instance",
                         entityId.ToString().c_str());
 


### PR DESCRIPTION
## What does this PR do?

Add an option to skip serialization warning when an entity reference does not match any registered entities. Skip these warnings when serializing the sort order component because undoing prefab overrides may leave stale entity Ids in the sort order array.

Fixes #5652

## How was this PR tested?

Tested in Editor using repro steps in ticket.
