### PR TITLE
Multi-select in the Asset Browser

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
@@ -25,6 +25,7 @@ namespace AzQtComponents
     {
         setSortingEnabled(true);
         setContextMenuPolicy(Qt::CustomContextMenu);
+        setSelectionMode(ExtendedSelection);
     }
 
     void AssetFolderTableView::setRootIndex(const QModelIndex& index)
@@ -59,7 +60,7 @@ namespace AzQtComponents
         const auto p = event->pos();
         if (auto idx = indexAt(p); idx.isValid())
         {
-            selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+            selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect | QItemSelectionModel::Rows);
             emit doubleClicked(idx);
         }
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -13,6 +13,7 @@
 AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: 'initializing': conversion from 'int' to 'float', possible loss of data
                                                                     // 4251: 'QInputEvent::modState': class 'QFlags<Qt::KeyboardModifier>' needs to have dll-interface to be used by clients of class 'QInputEvent'
                                                                     // 4800: 'QFlags<QPainter::RenderHint>::Int': forcing value to bool 'true' or 'false' (performance warning)
+#include <QGuiApplication>
 #include <QLineEdit>
 #include <QMenu>
 #include <QMouseEvent>
@@ -164,7 +165,6 @@ namespace AzQtComponents
             if (const auto& path = qVariant.value<QString>(); !path.isEmpty())
             {
                 icon.addFile(path, imageRect.size(), QIcon::Normal, QIcon::Off);
-                AZ_Assert(!icon.isNull(), "Asset Browser Icon not found for file '%s'", path.toUtf8().constData());
                 icon.paint(painter, imageRect);
             }
             else if (const auto& pixmap = qVariant.value<QPixmap>(); !pixmap.isNull())
@@ -412,7 +412,7 @@ namespace AzQtComponents
         , m_config(defaultConfig())
     {
         setItemDelegate(m_delegate);
-
+        setSelectionMode(ExtendedSelection);
         connect(
             m_delegate,
             &AssetFolderThumbnailViewDelegate::RenameThumbnail,
@@ -755,7 +755,6 @@ namespace AzQtComponents
         const auto p = event->pos() + QPoint{horizontalOffset(), verticalOffset()};
 
         // check the expand/collapse buttons on one of the top level items was clicked
-
         {
             auto it = std::find_if(
                 m_itemGeometry.keyBegin(),
@@ -791,7 +790,38 @@ namespace AzQtComponents
         auto idx = indexAtPos(p);
         if (idx.isValid())
         {
-            selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+            if (selectionMode() == ExtendedSelection && QGuiApplication::queryKeyboardModifiers() == Qt::ControlModifier)
+            {
+                selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::Toggle);
+            }
+            else if (selectionMode() == ExtendedSelection && QGuiApplication::queryKeyboardModifiers() == Qt::ShiftModifier)
+            {
+                auto selectedIndex =
+                    (selectionModel()->hasSelection() ? selectionModel()->currentIndex() : model()->index(0, 0, rootIndex()));
+                QItemSelectionRange indexRange;
+                if (selectedIndex.row() < idx.row())
+                {
+                    indexRange = QItemSelectionRange(selectedIndex, idx);
+                }
+                else if (selectedIndex.row() > idx.row())
+                {
+                    indexRange = QItemSelectionRange(idx, selectedIndex);
+                }
+                if (!indexRange.isEmpty())
+                {
+                    auto selectionFlag =
+                        (selectionModel()->isSelected(idx) ? QItemSelectionModel::SelectionFlag::Deselect
+                                                           : QItemSelectionModel::SelectionFlag::Select);
+                    for (auto index : indexRange.indexes())
+                    {
+                        selectionModel()->select(index, selectionFlag);
+                    }
+                }
+            }
+            else
+            {
+                selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+            }
             emit clicked(idx);
             update();
             // Pass event to base class to enable drag/drop selections.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -260,34 +260,78 @@ namespace AzToolsFramework
 
                 if (Utils::FromMimeData(data, entries))
                 {
-                    for (auto entry : entries)
+                    if (entries.empty())
                     {
-                        using namespace AZ::IO;
-                        Path fromPath;
-                        Path toPath;
-                        bool isFolder{ true };
- 
-                        if (entry && (entry->RTTI_IsTypeOf(SourceAssetBrowserEntry::RTTI_Type())))
-                        {
-                            fromPath = entry->GetFullPath();
-                            PathView filename = fromPath.Filename();
-                            toPath = item->GetFullPath();
-                            toPath /= filename;
-                            isFolder = false;
-                        }
-                        else
-                        {
-                            fromPath = entry->GetFullPath() + "/*";
-                            Path filename = static_cast<Path>(entry->GetFullPath()).Filename();
-                            toPath = item->GetFullPath() + "/" + filename.c_str() + "/*";
-                        }
-                        AssetBrowserViewUtils::MoveEntry(fromPath.c_str(), toPath.c_str(), isFolder);
+                        return false;
                     }
-                    return true;
+
+                    if (entries.size() > 1)
+                    {
+                        for (auto assetEntry : entries)
+                        {
+                            if (assetEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                    bool isFolder = entries[0]->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder;
+                    if (isFolder && AssetBrowserViewUtils::IsEngineOrProjectFolder(entries[0]->GetFullPath()))
+                    {
+                        return false;
+                    }
+                    using namespace AzFramework::AssetSystem;
+                    EntryTypeFilter* foldersFilter = new EntryTypeFilter();
+                    foldersFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Folder);
+
+                    AZStd::string folderPath = item->GetFullPath();
+                    bool connectedToAssetProcessor = false;
+                    AzFramework::AssetSystemRequestBus::BroadcastResult(
+                        connectedToAssetProcessor, &AzFramework::AssetSystemRequestBus::Events::AssetProcessorIsReady);
+
+                    if (connectedToAssetProcessor)
+                    {
+                        for (auto entry : entries)
+                        {
+                            using namespace AZ::IO;
+                            bool isEmptyFolder = isFolder && AssetBrowserViewUtils::IsFolderEmpty(entry->GetFullPath());
+                            Path fromPath;
+                            Path toPath;
+                            if (isFolder)
+                            {
+                                Path filename = static_cast<Path>(entry->GetFullPath()).Filename();
+                                if (isEmptyFolder)
+                                // There is currently a bug in AssetProcessorBatch that doesn't handle empty folders
+                                // This code is needed until that bug is fixed. GHI 13340
+                                {
+                                    fromPath = entry->GetFullPath();
+                                    toPath = AZStd::string::format(
+                                        "%.*s/%.*s", AZ_STRING_ARG(folderPath), AZ_STRING_ARG(filename.Native()));
+                                    AZ::IO::SystemFile::CreateDir(toPath.c_str());
+                                    AZ::IO::SystemFile::DeleteDir(fromPath.c_str());
+                                    return true;
+                                }
+                                else
+                                {
+                                    fromPath = AZStd::string::format("%.*s/*", AZ_STRING_ARG(entry->GetFullPath()));
+                                    toPath = AZStd::string::format(
+                                        "%.*s/%.*s/*", AZ_STRING_ARG(folderPath), AZ_STRING_ARG(filename.Native()));
+                                }
+                            }
+                            else
+                            {
+                                fromPath = entry->GetFullPath();
+                                PathView filename = fromPath.Filename();
+                                toPath = folderPath;
+                                toPath /= filename;
+                            }
+                            AssetBrowserViewUtils::MoveEntry(fromPath.c_str(), toPath.c_str(), isFolder);
+                        }
+                        return true;
+                    }
                 }
             }
             return QAbstractItemModel::dropMimeData(data, action, row, column, parent);
-
         }
 
         Qt::DropActions AssetBrowserModel::supportedDropActions() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.cpp
@@ -86,8 +86,7 @@ namespace AzToolsFramework
                      if (auto index = m_expandedTableViewWidget->indexAt(pos); index.isValid())
                      {
                          QMenu menu(this);
-                         const AssetBrowserEntry* entry = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                         AZStd::vector<const AssetBrowserEntry*> entries{ entry };
+                         AZStd::vector<const AssetBrowserEntry*> entries = GetSelectedAssets();
                          AssetBrowserInteractionNotificationBus::Broadcast(
                              &AssetBrowserInteractionNotificationBus::Events::AddContextMenuActions, this, &menu, entries);
 
@@ -267,15 +266,18 @@ namespace AzToolsFramework
 
         AZStd::vector<const AssetBrowserEntry*> AssetBrowserExpandedTableView::GetSelectedAssets() const
         {
-            // There are no product assets in the expanded table view, just get the first item selected
+            // No need to check for product assets since they do not appear in the table view
             AZStd::vector<const AssetBrowserEntry*> entries;
             if (m_expandedTableViewWidget->selectionModel())
             {
-                auto index = m_expandedTableViewWidget->selectionModel()->selectedIndexes()[0];
-                const AssetBrowserEntry* item = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                if (item)
+                auto indexes = m_expandedTableViewWidget->selectionModel()->selectedRows();
+                for (const auto index : indexes)
                 {
-                    entries.push_back(item);
+                    const AssetBrowserEntry* item = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+                    if (item)
+                    {
+                        entries.push_back(item);
+                    }
                 }
             }
             return entries;
@@ -287,7 +289,7 @@ namespace AzToolsFramework
 
             if (proxyIndex.isValid())
             {
-                m_expandedTableViewWidget->selectionModel()->select(proxyIndex, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+                m_expandedTableViewWidget->selectionModel()->select(proxyIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 
                 m_expandedTableViewWidget->scrollTo(proxyIndex, QAbstractItemView::ScrollHint::PositionAtCenter);
 
@@ -453,7 +455,6 @@ namespace AzToolsFramework
                     if (const auto& path = qVariant.value<QString>(); !path.isEmpty())
                     {
                         icon.addFile(path, iconSize, QIcon::Normal, QIcon::Off);
-                        AZ_Assert(!icon.isNull(), "Asset Browser Icon not found for file '%s'", path.toUtf8().constData());
                         icon.paint(painter, iconRect, Qt::AlignLeft | Qt::AlignVCenter);
                     }
                     else if (const auto& pixmap = qVariant.value<QPixmap>(); !pixmap.isNull())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -75,7 +75,7 @@ namespace AzToolsFramework
                     {
                         QMenu menu(this);
                         const AssetBrowserEntry* entry = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                        AZStd::vector<const AssetBrowserEntry*> entries{ entry };
+                        AZStd::vector<const AssetBrowserEntry*> entries = GetSelectedAssets();
                         if (m_thumbnailViewWidget->InSearchResultsMode())
                         {
                             auto action = menu.addAction(tr("Show In Folder"));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
@@ -222,12 +222,17 @@ namespace AzToolsFramework
                 return;
             }
 
-            bool isFolder = entries[0]->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder;
-            if (isFolder && entries.size() != 1)
+            if (entries.size() > 1)
             {
-                return;
+                for (auto assetEntry : entries)
+                {
+                    if (assetEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
+                    {
+                        return;
+                    }
+                }
             }
-
+            bool isFolder = entries[0]->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder;
             if (isFolder && IsEngineOrProjectFolder(entries[0]->GetFullPath()))
             {
                 return;
@@ -342,12 +347,19 @@ namespace AzToolsFramework
             {
                 return;
             }
-            bool isFolder = entries[0]->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder;
-            if (isFolder && entries.size() != 1)
-            {
-                return;
-            }
 
+            if (entries.size() > 1)
+            {
+                for (auto assetEntry : entries)
+                {
+                    if (assetEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
+                    {
+                        return;
+                    }
+                    
+                }
+            }
+            bool isFolder = entries[0]->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder;
             if (isFolder && IsEngineOrProjectFolder(entries[0]->GetFullPath()))
             {
                 return;
@@ -393,6 +405,7 @@ namespace AzToolsFramework
                                         AZStd::string::format("%.*s/%.*s", AZ_STRING_ARG(folderPath), AZ_STRING_ARG(filename.Native()));
                                     AZ::IO::SystemFile::CreateDir(toPath.c_str());
                                     AZ::IO::SystemFile::DeleteDir(fromPath.c_str());
+                                    return;
                                 }
                                 else
                                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
@@ -27,10 +27,10 @@ namespace AzToolsFramework
             static void DuplicateEntries(const AZStd::vector<const AssetBrowserEntry*>& entries);
             static void MoveEntry(AZStd::string_view fromPath, AZStd::string_view toPath, bool isFolder, QWidget* parent = nullptr);
 
-            static QVariant GetThumbnail(const AssetBrowserEntry* entry);
-        private:
             static bool IsFolderEmpty(AZStd::string_view path);
             static bool IsEngineOrProjectFolder(AZStd::string_view path);
+
+            static QVariant GetThumbnail(const AssetBrowserEntry* entry);
         };
     } // namespace AssetBrowser
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -148,7 +148,6 @@ namespace AzToolsFramework
                 {
                     QIcon icon;
                     icon.addFile(path, size, QIcon::Normal, QIcon::Off);
-                    AZ_Assert(!icon.isNull(), "Asset Browser Icon not found for file '%s'", path.toUtf8().constData());
                     icon.paint(painter, QRect(point.x(), point.y(), size.width(), size.height()));
                 }
                 else if (const auto& pixmap = qVariant.value<QPixmap>(); !pixmap.isNull())


### PR DESCRIPTION
## What does this PR do?

- Enables multi-select in the thumbnail view and table view of the Asset Browser.
- Fixes a bug where folders could be deleted if they were part of a multi-select and were moved via drag and drop.
- Fixes drag and drop to move empty folders.
- Disables move, delete, and duplicate operations if the multi-selection has a folder in it.

Fixes #15674 

## How was this PR tested?

Locally
