### PR TITLE
Test fixes for the `BasicEditorWorkflows_LevelEntityComponentCRUD` test

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -644,7 +644,8 @@ namespace AZ::Debug
                     continue;
                 }
 
-                azstrcat(lines[i], AZ_ARRAY_SIZE(lines[i]), "\n");
+                size_t endOfStr = AZStd::min(strlen(lines[i]), AZ_ARRAY_SIZE(lines[i]) - 1);
+                lines[i][endOfStr] = '\n';
 
                 // Use Output instead of AZ_Printf to be consistent with the exception output code and avoid
                 // this accidentally being suppressed as a normal message

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -1749,7 +1749,8 @@ namespace AZ
                     classData->m_serializer->DataToText(memStream, m_outStream, false);
 
                     char* rawText = static_cast<char*>(m_outStream.GetData()->data());
-                    char* xmlString = m_xmlDoc->allocate_string(rawText, static_cast<size_t>(m_outStream.GetCurPos() + 1));
+                    char* xmlString = m_xmlDoc->allocate_string(nullptr, static_cast<size_t>(m_outStream.GetCurPos() + 1));
+                    AZStd::copy(rawText, rawText + m_outStream.GetCurPos(), xmlString);
                     xmlString[m_outStream.GetCurPos()] = 0;
 
                     attr = m_xmlDoc->allocate_attribute(m_xmlDoc->allocate_string("value"), xmlString);

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
@@ -317,7 +317,8 @@ namespace AZ
 
         void LuaMaterialFunctorAPI::RuntimeContext::Reflect(BehaviorContext* behaviorContext)
         {
-            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::RuntimeContext>()
+            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::RuntimeContext>();
+            builder
                 ->Method("SetShaderConstant_bool", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<bool>)
                 ->Method("SetShaderConstant_int", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<int32_t>)
                 ->Method("SetShaderConstant_uint", &LuaMaterialFunctorAPI::RuntimeContext::SetShaderConstant<uint32_t>)
@@ -342,8 +343,8 @@ namespace AZ
                 ->Method("SetInternalMaterialPropertyValue_Image", &LuaMaterialFunctorAPI::RuntimeContext::SetInternalMaterialPropertyValue<Image*>)
                 ;
 
-            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(builder);
-            LuaMaterialFunctorAPI::ConfigureShaders::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(builder);
+            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(&builder);
+            LuaMaterialFunctorAPI::ConfigureShaders::ReflectSubclass<LuaMaterialFunctorAPI::RuntimeContext>(&builder);
         }
 
         template<typename LuaApiClass>
@@ -571,7 +572,8 @@ namespace AZ
 
         void LuaMaterialFunctorAPI::EditorContext::EditorContext::Reflect(BehaviorContext* behaviorContext)
         {
-            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::EditorContext>()
+            auto builder = behaviorContext->Class<LuaMaterialFunctorAPI::EditorContext>();
+            builder
                 ->Method("SetMaterialPropertyVisibility", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyVisibility)
                 ->Method("SetMaterialPropertyDescription", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyDescription)
                 ->Method("SetMaterialPropertyMinValue_int", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyMinValue<int32_t>)
@@ -589,7 +591,7 @@ namespace AZ
                 ->Method("SetMaterialPropertyGroupVisibility", &LuaMaterialFunctorAPI::EditorContext::SetMaterialPropertyGroupVisibility)
                 ;
 
-            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::EditorContext>(builder);
+            LuaMaterialFunctorAPI::ReadMaterialPropertyValues::ReflectSubclass<LuaMaterialFunctorAPI::EditorContext>(&builder);
         }
 
         LuaMaterialFunctorAPI::EditorContext::EditorContext(


### PR DESCRIPTION
## What does this PR do?

This PR fixes a few violations found with the address sanitizer on Linux of the `BasicEditorWorkflows_LevelEntityComponentCRUD` test.

## How was this PR tested?
By running the test in a build with the address sanitizer enabled, and fixing the violations until the test passed.
