### PR TITLE
Update AWS GameLift gem to target Windows 2016 Server by default

### DIFF
--- a/Gems/AWSGameLift/cdk/aws_gamelift/fleet_configurations.py
+++ b/Gems/AWSGameLift/cdk/aws_gamelift/fleet_configurations.py
@@ -44,8 +44,8 @@ FLEET_CONFIGURATIONS = [
             'build_path': '<build path>',
             # (Conditional) The operating system that the game server binaries are built to run on.
             # This parameter is required if the parameter build_path is defined.
-            # Choose from AMAZON_LINUX or WINDOWS_2012.
-            'operating_system': 'WINDOWS_2012'
+            # Choose from AMAZON_LINUX_2 | WINDOWS_2016 as latest OS's supported by GameLift
+            'operating_system': 'WINDOWS_2016'
         },
         # (Optional) Information about the use of a TLS/SSL certificate for a fleet.
         'certificate_configuration': {


### PR DESCRIPTION
## What does this PR do?

Amazon GameLift recently announced that Windows 2012 servers were EOL. Change default to be Windows 2016 servers.

## How was this PR tested?
```
cdk synth
cdk deploy using MPS build
```

Note: Will push doc update as the install.bat no longer requires VC_redistributables.
