### PR TITLE
Added PAL OS Environment Variable functions in AzCore

### DIFF
--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -164,20 +164,20 @@ namespace AZ
             AZStd::string_view filePath, size_t maxFileSize = AZStd::numeric_limits<size_t>::max());
 
         //! error code value returned when GetEnv fails
-        enum GetEnvErrorCode
+        enum class GetEnvErrorCode
         {
             EnvNotSet = 1,
             BufferTooSmall
         };
 
-        //! Return result from GetEnv when an environment variable values
+        //! Return result from GetEnv when an environment variable value
         //! fails to be returned
         //! The `m_requiredSize` value is set to the needed size of the buffer
         //! when the GetEnvErrorCode is set to `BufferTooSmall`
         struct GetEnvErrorResult
         {
             //! Contains the error code of the GetEnv operation
-            GetEnvErrorCode m_ec{};
+            GetEnvErrorCode m_errorCode{};
             //! Set only when the error code is `BufferTooSmall`
             size_t m_requiredSize{};
         };
@@ -191,7 +191,7 @@ namespace AZ
         //! variable value, a GetEnvErrorResult will be returned
         GetEnvOutcome GetEnv(AZStd::span<char> envvalueBuffer, const char* envname);
 
-        //! Queries if envirnment variable is set
+        //! Queries if environment variable is set
         //! @param envname The environment variable name
         //! @return Return true if successful, otherwise false
         bool IsEnvSet(const char* envname);

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -163,9 +163,42 @@ namespace AZ
         AZ::Outcome<Container, AZStd::string> ReadFile(
             AZStd::string_view filePath, size_t maxFileSize = AZStd::numeric_limits<size_t>::max());
 
+        //! error code value returned when GetEnv fails
+        enum GetEnvErrorCode
+        {
+            EnvNotSet = 1,
+            BufferTooSmall
+        };
+
+        //! Return result from GetEnv when an environment variable values
+        //! fails to be returned
+        //! The `m_requiredSize` value is set to the needed size of the buffer
+        //! when the GetEnvErrorCode is set to `BufferTooSmall`
+        struct GetEnvErrorResult
+        {
+            //! Contains the error code of the GetEnv operation
+            GetEnvErrorCode m_ec{};
+            //! Set only when the error code is `BufferTooSmall`
+            size_t m_requiredSize{};
+        };
+        using GetEnvOutcome = AZ::Outcome<AZStd::string_view, GetEnvErrorResult>;
+
+        //! Queries the value of an environment variable
+        //! @param envvalueBuffer Span of buffer to populate with environment variable value if found
+        //! @param envname The environment variable name
+        //! @return Return an outcome with a string_view of the environment varaible if successful,
+        //! otherwise if the environment variable is not set or the span size cannot fit the environment
+        //! variable value, a GetEnvErrorResult will be returned
+        GetEnvOutcome GetEnv(AZStd::span<char> envvalueBuffer, const char* envname);
+
+        //! Queries if envirnment variable is set
+        //! @param envname The environment variable name
+        //! @return Return true if successful, otherwise false
+        bool IsEnvSet(const char* envname);
+
         //! Create or modify environment variable.
         //! @param envname The environment variable name
-        //! @param envvalue The environment variable name
+        //! @param envvalue The environment variable value
         //! @param overwrite If name does exist in the environment, then its value is changed to value if overwrite is nonzero;
         //! if overwrite is zero, then the value of name is not changed
         //! @returns Return true if successful, otherwise false

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Utils/Utils_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Utils/Utils_WinAPI.cpp
@@ -73,14 +73,74 @@ namespace AZ
             return result != nullptr;
         }
 
+        GetEnvOutcome GetEnv(AZStd::span<char> valueBuffer, const char* envname)
+        {
+            // Set the environment value capacity to 64KiB which is larger
+            // than any value that can be stored
+            constexpr size_t envValueCapacity = 1024 * 64;
+            wchar_t envValueBuffer[envValueCapacity];
+            // Restrict the environment variable key to 1024 characters
+            AZStd::fixed_wstring<1024> wEnvname;
+            AZStd::to_wstring(wEnvname, envname);
+            size_t variableSize = 0;
+
+            if (auto err = _wgetenv_s(&variableSize, envValueBuffer, envValueCapacity, wEnvname.c_str());
+                !err && variableSize > 0)
+            {
+                const size_t envValueLen = AZStd::min(AZStd::char_traits<wchar_t>::length(envValueBuffer), variableSize);
+                AZStd::fixed_string<envValueCapacity> utf8Value;
+                AZStd::to_string(utf8Value, AZStd::wstring_view(envValueBuffer, envValueLen));
+
+                // Now copy the string to the span if it has enough capacity
+                if (valueBuffer.size() >= utf8Value.size())
+                {
+                    // copy the utf8 string value over to the value buffer
+                    utf8Value.copy(valueBuffer.data(), valueBuffer.size());
+                    // return a string that points the beginning of the span buffer
+                    // with a size that is set to the environment variable value string
+                    return AZStd::string_view(valueBuffer.data(), utf8Value.size());
+                }
+
+                return AZ::Failure(GetEnvErrorResult{ GetEnvErrorCode::BufferTooSmall, utf8Value.size() });
+            }
+
+            return AZ::Failure(GetEnvErrorResult{ GetEnvErrorCode::EnvNotSet });
+        }
+
+        bool IsEnvSet(const char* envname)
+        {
+            // Set the environment value capacity to 64KiB which is larger
+            // than any value that can be stored
+            constexpr size_t envValueCapacity = 1024 * 64;
+            wchar_t envValueBuffer[envValueCapacity];
+            // Restrict the environment variable key to 1024 characters
+            AZStd::fixed_wstring<1024> wKey;
+            AZStd::to_wstring(wKey, AZStd::string_view(envname));
+            size_t variableSize = 0;
+            errno_t err = _wgetenv_s(&variableSize, envValueBuffer, envValueCapacity, wKey.c_str());
+            // A required size of zero indicates the environment variable is not set according
+            // to the microsoft example for _wgetenv_s
+            // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getenv-s-wgetenv-s?view=msvc-170#example
+            return !err && variableSize > 0;
+        }
+
         bool SetEnv(const char* envname, const char* envvalue, [[maybe_unused]] bool overwrite)
         {
-            return _putenv_s(envname, envvalue);
+            constexpr size_t envValueCapacity = 1024 * 64;
+            // Copy over the envvalue to a wide character string ubffer
+            AZStd::fixed_wstring<envValueCapacity> wEnvvalue;
+            AZStd::to_wstring(wEnvvalue, envvalue);
+
+            // Restrict the environment variable key to 1024 characters
+            AZStd::fixed_wstring<1024> wEnvname;
+            AZStd::to_wstring(wEnvname, AZStd::string_view(envname));
+            // Use the _wputenv_s version to get unicode support
+            return _wputenv_s(wEnvname.c_str(), wEnvvalue.c_str()) == 0;
         }
 
         bool UnsetEnv(const char* envname)
         {
-            return SetEnv(envname, "", 1);
+            return SetEnv(envname, "", true);
         }
     }
 }

--- a/Code/Framework/AzCore/Tests/Platform/Common/Apple/Tests/UtilsTests_Apple.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/Apple/Tests/UtilsTests_Apple.cpp
@@ -74,7 +74,7 @@ namespace UnitTest
         char testValue[1024];
         auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_errorCode);
     }
 
     TEST_F(UtilsTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
@@ -97,7 +97,7 @@ namespace UnitTest
         testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
 
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_errorCode);
         EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
         EXPECT_NE(expectedValue, testValue);
 

--- a/Code/Framework/AzCore/Tests/Platform/Common/Apple/Tests/UtilsTests_Apple.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/Apple/Tests/UtilsTests_Apple.cpp
@@ -46,4 +46,85 @@ namespace UnitTest
         EXPECT_TRUE(AZStd::string_view(executablePath).starts_with(executableDirectory));
         EXPECT_LT(strlen(executableDirectory), strlen(executablePath));
     }
+
+    TEST_F(UtilsTestFixture, GetEnv_CanReadEnvironment_Succeeds)
+    {
+        // First set an env value using SetEnv
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [](char* buffer, size_t size) -> size_t
+        {
+            auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // Resize and overwrite will update the fixed_string to point at the environment variable value
+        testValue.resize_and_overwrite(testValue.capacity(), StoreEnvironmentValue);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, GetEnv_ReadsUnsetEnvKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        char testValue[1024];
+        auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+    }
+
+    TEST_F(UtilsTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        // Initialize get env outcome to failure
+        AZ::Utils::GetEnvOutcome getEnvOutcome{ AZStd::unexpect };
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [&getEnvOutcome](char* buffer, size_t size) -> size_t
+        {
+            // Negate the GetEnv call and store it in the captured variable
+            // to validate the call has failed
+            getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // The testValue string is explicitly being resized to be less than the environment variable value size
+        testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
+
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
+        EXPECT_NE(expectedValue, testValue);
+
+        // Now try to retrieve the environment variable value again this time with a buffer
+        // that can fit all the characters
+        testValue.resize_and_overwrite(getEnvOutcome.GetError().m_requiredSize, StoreEnvironmentValue);
+        EXPECT_TRUE(getEnvOutcome);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, IsEnvSet_WithExistingKey_Succeeds)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+        EXPECT_TRUE(AZ::Utils::IsEnvSet(envKey));
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, IsEnvSet_WithNonExistentKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        EXPECT_FALSE(AZ::Utils::IsEnvSet(envKey));
+    }
 }

--- a/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
@@ -66,7 +66,7 @@ namespace UnitTest
         char testValue[1024];
         auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_errorCode);
     }
 
     TEST_F(UtilsUnixLikeTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
@@ -89,7 +89,7 @@ namespace UnitTest
         testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
 
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);\
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_errorCode);
         EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
         EXPECT_NE(expectedValue, testValue);
 

--- a/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/UtilsTests_UnixLike.cpp
@@ -38,4 +38,85 @@ namespace UnitTest
             "_PathWhichShouldNotExistButIsOkIfItDoesExist");
         ASSERT_TRUE(absolutePath);
     }
+
+    TEST_F(UtilsUnixLikeTestFixture, GetEnv_CanReadEnvironment_Succeeds)
+    {
+        // First set an env value using SetEnv
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [](char* buffer, size_t size) -> size_t
+        {
+            auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // Resize and overwrite will update the fixed_string to point at the environment variable value
+        testValue.resize_and_overwrite(testValue.capacity(), StoreEnvironmentValue);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsUnixLikeTestFixture, GetEnv_ReadsUnsetEnvKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        char testValue[1024];
+        auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+    }
+
+    TEST_F(UtilsUnixLikeTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        // Initialize get env outcome to failure
+        AZ::Utils::GetEnvOutcome getEnvOutcome{ AZStd::unexpect };
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [&getEnvOutcome](char* buffer, size_t size) -> size_t
+        {
+            // Negate the GetEnv call and store it in the captured variable
+            // to validate the call has failed
+            getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // The testValue string is explicitly being resized to be less than the environment variable value size
+        testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
+
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);\
+        EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
+        EXPECT_NE(expectedValue, testValue);
+
+        // Now try to retrieve the environment variable value again this time with a buffer
+        // that can fit all the characters
+        testValue.resize_and_overwrite(getEnvOutcome.GetError().m_requiredSize, StoreEnvironmentValue);
+        EXPECT_TRUE(getEnvOutcome);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsUnixLikeTestFixture, IsEnvSet_WithExistingKey_Succeeds)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+        EXPECT_TRUE(AZ::Utils::IsEnvSet(envKey));
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsUnixLikeTestFixture, IsEnvSet_WithNonExistentKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        EXPECT_FALSE(AZ::Utils::IsEnvSet(envKey));
+    }
 }

--- a/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/UtilsTests_WinAPI.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/UtilsTests_WinAPI.cpp
@@ -69,4 +69,85 @@ namespace UnitTest
         ASSERT_TRUE(absolutePath);
         EXPECT_STRCASEEQ(executableDirectory, absolutePath->c_str());
     }
+
+    TEST_F(UtilsTestFixture, GetEnv_CanReadEnvironment_Succeeds)
+    {
+        // First set an env value using SetEnv
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [](char* buffer, size_t size) -> size_t
+        {
+            auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // Resize and overwrite will update the fixed_string to point at the environment variable value
+        testValue.resize_and_overwrite(testValue.capacity(), StoreEnvironmentValue);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, GetEnv_ReadsUnsetEnvKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        char testValue[1024];
+        auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+    }
+
+    TEST_F(UtilsTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+
+        // Initialize get env outcome to failure
+        AZ::Utils::GetEnvOutcome getEnvOutcome{ AZStd::unexpect };
+        AZStd::fixed_string<1024> testValue;
+        auto StoreEnvironmentValue = [&getEnvOutcome](char* buffer, size_t size) -> size_t
+        {
+            // Negate the GetEnv call and store it in the captured variable
+            // to validate the call has failed
+            getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(buffer, size), envKey);
+            return getEnvOutcome ? getEnvOutcome.GetValue().size() : 0;
+        };
+        // The testValue string is explicitly being resized to be less than the environment variable value size
+        testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
+
+        EXPECT_FALSE(getEnvOutcome);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
+        EXPECT_NE(expectedValue, testValue);
+
+        // Now try to retrieve the environment variable value again this time with a buffer
+        // that can fit all the characters
+        testValue.resize_and_overwrite(getEnvOutcome.GetError().m_requiredSize, StoreEnvironmentValue);
+        EXPECT_TRUE(getEnvOutcome);
+        EXPECT_EQ(expectedValue, testValue);
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, IsEnvSet_WithExistingKey_Succeeds)
+    {
+        constexpr const char* envKey = "O3DE_TEST_KEY";
+        AZStd::fixed_string<1024> expectedValue(512, 'a');
+        EXPECT_TRUE(AZ::Utils::SetEnv(envKey, expectedValue.c_str(), true));
+        EXPECT_TRUE(AZ::Utils::IsEnvSet(envKey));
+
+        // Make sure to unset the key at the end of the test
+        EXPECT_TRUE(AZ::Utils::UnsetEnv(envKey));
+    }
+
+    TEST_F(UtilsTestFixture, IsEnvSet_WithNonExistentKey_Fails)
+    {
+        constexpr const char* envKey = "_~~~~O3DE_TEST_KEY_FOO$#%";
+        EXPECT_FALSE(AZ::Utils::IsEnvSet(envKey));
+    }
 }

--- a/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/UtilsTests_WinAPI.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/WinAPI/Tests/UtilsTests_WinAPI.cpp
@@ -97,7 +97,7 @@ namespace UnitTest
         char testValue[1024];
         auto getEnvOutcome = AZ::Utils::GetEnv(AZStd::span(testValue), envKey);
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::EnvNotSet, getEnvOutcome.GetError().m_errorCode);
     }
 
     TEST_F(UtilsTestFixture, GetEnv_WithSpanSizeThatLessThanEnvValueSize_Fails)
@@ -120,7 +120,7 @@ namespace UnitTest
         testValue.resize_and_overwrite(expectedValue.size() / 2, StoreEnvironmentValue);
 
         EXPECT_FALSE(getEnvOutcome);
-        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_ec);
+        EXPECT_EQ(AZ::Utils::GetEnvErrorCode::BufferTooSmall, getEnvOutcome.GetError().m_errorCode);
         EXPECT_EQ(512, getEnvOutcome.GetError().m_requiredSize);
         EXPECT_NE(expectedValue, testValue);
 


### PR DESCRIPTION
The Utils.h header now exposes a `GetEnv` and a `IsEnvSet` function that can query the value of an OS environmnent and whether it is set respectively.

Fixed the return value `SetEnv` function on Windows to return true when the environment variable is successfully set.

## How was this PR tested?

Added UnitTest to that validates the `GetEnv`, `IsEnvSet`, `SetEnv` and `UnsetEnv` functions.
