### PR TITLE
TIAF: Test target and changelist bug fixes

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTargetListCompiler.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTargetListCompiler.cpp
@@ -25,18 +25,32 @@ namespace TestImpact
         AZStd::vector<NativeProductionTarget> productionTargets;
         AZStd::vector<NativeTestTarget> testTargets;
 
+        size_t numDiscardedTestTargets = 0;
         for (auto&& descriptor : buildTargetDescriptors)
         {
-            // If this build target has an associated test artifact then it is a test target, otherwise it is a production target
             if (auto&& testTargetMeta = testTargetMetaMap.find(descriptor.m_name); testTargetMeta != testTargetMetaMap.end())
             {
                 AZ_TestImpact_Eval(descriptor.m_type == TargetType::TestTarget, ArtifactException, "Target has associated target meta but is a production target");
                 testTargets.emplace_back(AZStd::move(descriptor), AZStd::move(testTargetMeta->second));
             }
-            else
+            else if (descriptor.m_type == TargetType::ProductionTarget)
             {
                 productionTargets.emplace_back(AZStd::move(descriptor));
             }
+            else
+            {
+                // Test targets without an associated test target meta artifact are either not opted in to TIAF or not in the
+                // suite(s) to be run so will be skipped
+                numDiscardedTestTargets++;
+            }
+        }
+
+        if (numDiscardedTestTargets)
+        {
+            AZ_Info(
+                "CompileNativeTargetLists",
+                "%zu test targets were either opted-out of TIAF or not in the suite(s) selected for this run.\n",
+                numDiscardedTestTargets);
         }
 
         return { { AZStd::move(productionTargets) }, { AZStd::move(testTargets) } };

--- a/scripts/build/TestImpactAnalysis/git_utils.py
+++ b/scripts/build/TestImpactAnalysis/git_utils.py
@@ -43,7 +43,7 @@ class Repo:
             # output_path.unlink(missing_ok=True) # missing_ok is only available in Python 3.8+
             if output_path.is_file():
                 output_path.unlink()
-            output_path.parent.mkdir(exist_ok=True)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
         except EnvironmentError as e:
             raise RuntimeError(f"Could not create path for output file '{output_path}'")
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes two bugs with TIAF:

1. When a test target has coverage in the historical data (either in an s3 bucket or using local persistent storage) and is subsequently removed or no longer a member of the suites being run (for which the coverage data exists for), it was mistakenly being treated as a production target which causes the test selector to try and retrieve the test target for said coverage data, only to draw a `nullptr` due to the mistaken categorization of being a production target. With this fix, test targets that are not in the `testTargetMetaMap` (due to either being removed or no longer being part of the suite's coverage data) are simply not included in the build target list used by the dynamic dependency map.
2. When creating the changelist, the TIAF python script responsible was missing the `parents=True` flag to create any non-existent parent directories, meaning that under certain circumstances this call would fail, causing TIAF to fallback to a regular test run instead of a test impact analysis run. 

## How was this PR tested?

This PR was tested locally, as well as tested in AR to fix the PR that was being blocked by the first bug.
