### PR TITLE
Fix off-by-one error when truncating string when printing the stack

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -644,8 +644,9 @@ namespace AZ::Debug
                     continue;
                 }
 
-                size_t endOfStr = AZStd::min(strlen(lines[i]), AZ_ARRAY_SIZE(lines[i]) - 1);
+                const size_t endOfStr = AZStd::min(strlen(lines[i]), AZ_ARRAY_SIZE(lines[i]) - 2);
                 lines[i][endOfStr] = '\n';
+                lines[i][endOfStr + 1] = '\0';
 
                 // Use Output instead of AZ_Printf to be consistent with the exception output code and avoid
                 // this accidentally being suppressed as a normal message


### PR DESCRIPTION
In commit 4b655211 / #15834, the way that the stack lines were truncated were changed to fix a case in Linux where the whole buffer was used, causing `azstrcat` to fail. That implementation was off by 1, this fixes it.
