### PR TITLE
DPE Inspector: Set up parent instance as node attribute for wrapped handler

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -60,6 +60,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::InternalEnumValueKey);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueHashed);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ParentValue);
 
         system->RegisterNode<Container>();
         system->RegisterNodeAttribute<PropertyEditor>(Container::AddNotify);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -123,6 +123,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto Value = AttributeDefinition<AZ::Dom::Value>("Value");
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
+        static constexpr auto ParentValue = AttributeDefinition<AZ::Dom::Value>("ParentValue");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended
         //! to the previous column in the layout, creating a SharedColumn that can hold many PropertyEditors.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -853,6 +853,13 @@ namespace AZ::Reflection
                         { group, DescriptorAttributes::Container, Dom::Utils::ValueFromType<void*>(nodeData.m_classData->m_container) });
                 }
 
+                // RpePropertyHandlerWrapper would cache the parent info from which a wrapped handler may retrieve the parent instance.
+                if (nodeData.m_parentInstance)
+                {
+                    nodeData.m_cachedAttributes.push_back(
+                        { group, PropertyEditor::ParentValue.GetName(), Dom::Utils::ValueFromType<void*>(nodeData.m_parentInstance) });
+                }
+
                 // Calculate our visibility, going through parent nodes in reverse order to see if we should be hidden
                 for (size_t i = 1; i < m_stack.size(); ++i)
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h
@@ -86,6 +86,7 @@ namespace AzToolsFramework
         /// Check if have more than one instance for this node.
         bool    IsMultiInstance() const             { return m_instances.size() > 1; }
         size_t  GetNumInstances() const             { return m_instances.size(); }
+        bool    HasInstances() const                { return !m_instances.empty(); }
         void*   GetInstance(size_t idx) const;
         void**  GetInstanceAddress(size_t idx) const;
         void*   FirstInstance() const { return GetInstance(0); }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -244,7 +244,9 @@ namespace AzToolsFramework
                     auto parentValue = PropertyEditor::ParentValue.ExtractFromDomNode(node);
                     if (parentValue.has_value())
                     {
-                        auto parentValuePtr = AZ::Dom::Utils::ValueToType<void*>(parentValue.value()).value_or(nullptr);
+                        auto parentValuePtr = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(parentValue.value());
+                        AZ_Assert(parentValuePtr, "Parent instance was nullptr when attempting to add to instance list.");
+
                         m_proxyParentNode.m_instances.push_back(parentValuePtr);
 
                         // Set up the reference to parent node only if a parent value is available.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -233,11 +233,26 @@ namespace AzToolsFramework
             for (auto attributeIt = node.MemberBegin(); attributeIt != node.MemberEnd(); ++attributeIt)
             {
                 const AZ::Name& name = attributeIt->first;
+
                 if (name == PropertyEditor::Type.GetName() || name == PropertyEditor::Value.GetName() ||
                     name == PropertyEditor::ValueType.GetName())
                 {
                     continue;
                 }
+                else if (name == PropertyEditor::ParentValue.GetName())
+                {
+                    auto parentValue = PropertyEditor::ParentValue.ExtractFromDomNode(node);
+                    if (parentValue.has_value())
+                    {
+                        auto parentValuePtr = AZ::Dom::Utils::ValueToType<void*>(parentValue.value()).value_or(nullptr);
+                        m_proxyParentNode.m_instances.push_back(parentValuePtr);
+
+                        // Set up the reference to parent node only if a parent value is available.
+                        m_proxyNode.m_parent = &m_proxyParentNode;
+                    }
+                    continue;
+                }
+
                 AZ::Crc32 attributeId = AZ::Crc32(name.GetStringView());
 
                 AZStd::shared_ptr<AZ::Attribute> marshalledAttribute;
@@ -375,6 +390,7 @@ namespace AzToolsFramework
         AZ::Dom::Value m_domNode;
         QPointer<QWidget> m_widget;
         InstanceDataNode m_proxyNode;
+        InstanceDataNode m_proxyParentNode;
         AZ::SerializeContext::ClassData m_proxyClassData;
         AZ::SerializeContext::ClassElement m_proxyClassElement;
         WrappedType m_proxyValue;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals_Impl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals_Impl.h
@@ -28,7 +28,7 @@ namespace AzToolsFramework
         InstanceDataNode* parent = dataNode->GetParent();
 
         // Function callbacks require the instance pointer to be the first non-container ancestor.
-        while (parent && parent->GetClassMetadata()->m_container)
+        while (parent && parent->GetClassMetadata() && parent->GetClassMetadata()->m_container)
         {
             parent = parent->GetParent();
         }
@@ -39,6 +39,7 @@ namespace AzToolsFramework
             parent = dataNode;
         }
 
+        AZ_Assert(parent->HasInstances(), "No parent instance - there is no parent instance in the parent data node.");
         void* classInstance = parent->FirstInstance(); // pointer to the owner class so we can read member variables and functions
 
         void* parentClassInstance = nullptr;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -162,7 +162,12 @@ namespace ScriptCanvasEditor
         GUI->blockSignals(true);
 
         GUI->SetSelectedSourcePath(instance.RelativePath());
-        GUI->SetEditNotifyTarget(node->GetParent()->GetInstance(0));
+
+        const AzToolsFramework::InstanceDataNode* parentNode = node->GetParent();
+        AZ_Assert(parentNode && parentNode->HasInstances(), "Configuration instance is missing.");
+
+        // Set notify target to the parent configuration instance.
+        GUI->SetEditNotifyTarget(parentNode->FirstInstance());
 
         GUI->blockSignals(false);
         return false;


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15558

This PR fixes a crash that happens when we add a ScriptCanvas component in the DPE Entity Inspector.

<img width=300 src="https://user-images.githubusercontent.com/11157226/235763021-5b3bab34-d3b8-446d-8360-b3c60c63a59c.png">

The crash happens at the time when RPE property handler wrapper is trying to configure data inside the widget. The 'SourceHandle' property wants to set the edit notify target to its parent instance (i.e. a 'Configuration' instance owned by 'EditorScriptCanvasComponent'), but the parent instance that can be retrieved from the 'InstanceDataNode' turns out to be missing. See [my reply](https://github.com/o3de/o3de/issues/15558#issuecomment-1516582040) in the issue for more details.

In this PR, I added a new `ParentValue` attribute for 'PropertyEditor' node and set it up in legacy reflection bridge, so code in the RPE property handler wrapper is able to retrieve the parent value pointer and set it correctly in the node.

Note: This PR just fixes the crash to unblock add/delete component testing. There are some issues regarding the SC's functionality, but they can be addressed later.

## How was this PR tested?

Manually tested in editor
