### PR TITLE
Don't expose overrides on container entities in the DPE inspector

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1862,10 +1862,18 @@ namespace AzToolsFramework
     {
         if (auto prefabOverridePublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabOverridePublicInterface>::Get())
         {
-            // Get icon path based on current component override state
-            AZStd::string iconOverlayPath;
             const AZStd::vector<AZ::Component*>& components = componentEditor.GetComponents();
             AZ_Assert(!components.empty() && components[0], "ComponentEditor should have at least one component.");
+
+            // Overrides on container entities are for internal use only and should not be exposed
+            AZ::EntityId entityId = components[0]->GetEntityId();
+            if (m_prefabPublicInterface->IsInstanceContainerEntity(entityId))
+            {
+                return;
+            }
+
+            // Get icon path based on current component override state
+            AZStd::string iconOverlayPath;
             AZ::EntityComponentIdPair entityComponentIdPair(components[0]->GetEntityId(), components[0]->GetId());
             if (auto overrideType = prefabOverridePublicInterface->GetComponentOverrideType(entityComponentIdPair);
                 overrideType.has_value())


### PR DESCRIPTION
## What does this PR do?

Skip override visualization/interaction for container entities in the DPE inspector because they are not meant to be changed by the user. This prevents errors being output to the console.

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

Tested in Editor.
