### PR TITLE
Update EditorAreaLightComponent.cpp

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -42,7 +42,7 @@ namespace AZ
                 if (EditContext* editContext = serializeContext->GetEditContext())
                 {
                     editContext->Class<EditorAreaLightComponent>(
-                        "Light", "A light which emits from a point or goemetric shape.")
+                        "Light", "A light which emits from a point or geometric shape.")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
                             ->Attribute(Edit::Attributes::Category, "Graphics/Lighting")
                             ->Attribute(Edit::Attributes::Icon, "Icons/Components/AreaLight.svg")


### PR DESCRIPTION
Fixed typo ("goemetric" to "geometric") as referenced in issue #14899.

## What does this PR do?

fixed a misspelling of "geometric" as "goemetric"

issue can be found here:
https://github.com/o3de/o3de/issues/14899
## How was this PR tested?

_Please describe any testing performed._
