### PR TITLE
Jjjoness/restructure asset browser table to list

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -34,7 +34,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
@@ -425,10 +425,10 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
         calledFromAssetBrowser = treeView->GetIsAssetBrowserMainView();
     }
 
-    AssetBrowserListView* tableView = qobject_cast<AssetBrowserListView*>(caller);
-    if (tableView)
+    AssetBrowserListView* listView = qobject_cast<AssetBrowserListView*>(caller);
+    if (listView)
     {
-        calledFromAssetBrowser |= tableView->GetIsAssetBrowserMainView();
+        calledFromAssetBrowser |= listView->GetIsAssetBrowserMainView();
     }
 
     AssetBrowserThumbnailView* thumbnailView = qobject_cast<AssetBrowserThumbnailView*>(caller);
@@ -437,13 +437,13 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
         calledFromAssetBrowser |= thumbnailView->GetIsAssetBrowserMainView();
     }
 
-    AssetBrowserExpandedTableView* expandedTableView = qobject_cast<AssetBrowserExpandedTableView*>(caller);
-    if (expandedTableView)
+    AssetBrowserTableView* tableView = qobject_cast<AssetBrowserTableView*>(caller);
+    if (tableView)
     {
-        calledFromAssetBrowser |= expandedTableView->GetIsAssetBrowserMainView();
+        calledFromAssetBrowser |= tableView->GetIsAssetBrowserMainView();
     }
 
-    if (!treeView && !tableView && !thumbnailView && !expandedTableView)
+    if (!treeView && !listView && !thumbnailView && !tableView)
     {
         return;
     }
@@ -542,7 +542,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
 
             menu->addAction(
                 QObject::tr("Open in another Asset Browser"),
-                [fullFilePath, thumbnailView, expandedTableView]()
+                [fullFilePath, thumbnailView, tableView]()
                 {
 
                 AzAssetBrowserWindow* newAssetBrowser = AzAssetBrowserMultiWindow::OpenNewAssetBrowserWindow();
@@ -551,7 +551,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                 {
                     newAssetBrowser->SetCurrentMode(AssetBrowserMode::ThumbnailView);
                 }
-                else if (expandedTableView)
+                else if (tableView)
                 {
                     newAssetBrowser->SetCurrentMode(AssetBrowserMode::TableView);
                 }
@@ -605,23 +605,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                 // Add Rename option
                 QAction* action = menu->addAction(
                     QObject::tr("Rename asset"),
-                    [treeView, tableView, thumbnailView, expandedTableView]()
+                    [treeView, listView, thumbnailView, tableView]()
                     {
                         if (treeView)
                         {
                             treeView->RenameEntry();
                         }
-                        else if (tableView)
+                        else if (listView)
                         {
-                            tableView->RenameEntry();
+                            listView->RenameEntry();
                         }
                         else if (thumbnailView)
                         {
                             thumbnailView->RenameEntry();
                         }
-                        else if (expandedTableView)
+                        else if (tableView)
                         {
-                            expandedTableView->RenameEntry();
+                            tableView->RenameEntry();
                         }
                     });
                 action->setShortcut(Qt::Key_F2);
@@ -634,23 +634,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             // Add Delete option
             QAction* action = menu->addAction(
                 QObject::tr("Delete asset%1").arg(numOfEntries > 1 ? "s" : ""),
-                [treeView, tableView, thumbnailView, expandedTableView]()
+                [treeView, listView, thumbnailView, tableView]()
                 {
                     if (treeView)
                     {
                         treeView->DeleteEntries();
                     }
-                    else if (tableView)
+                    else if (listView)
                     {
-                        tableView->DeleteEntries();
+                        listView->DeleteEntries();
                     }
                     else if (thumbnailView)
                     {
                         thumbnailView->DeleteEntries();
                     }
-                    else if (expandedTableView)
+                    else if (tableView)
                     {
-                        expandedTableView->DeleteEntries();
+                        tableView->DeleteEntries();
                     }
                 });
             action->setShortcut(QKeySequence::Delete);
@@ -659,23 +659,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             // Add Duplicate option
             action = menu->addAction(
                 QObject::tr("Duplicate asset%1").arg(numOfEntries > 1 ? "s" : ""),
-                [treeView, tableView, thumbnailView, expandedTableView]()
+                [treeView, listView, thumbnailView, tableView]()
                 {
                     if (treeView)
                     {
                         treeView->DuplicateEntries();
                     }
-                    else if (tableView)
+                    else if (listView)
                     {
-                        tableView->DuplicateEntries();
+                        listView->DuplicateEntries();
                     }
                     else if (thumbnailView)
                     {
                         thumbnailView->DuplicateEntries();
                     }
-                    else if (expandedTableView)
+                    else if (tableView)
                     {
-                        expandedTableView->DuplicateEntries();
+                        tableView->DuplicateEntries();
                     }
                 });
             action->setShortcut(QKeySequence("Ctrl+D"));
@@ -684,23 +684,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             // Add Move to option
             menu->addAction(
                 QObject::tr("Move to"),
-                [treeView, tableView, thumbnailView, expandedTableView]()
+                [treeView, listView, thumbnailView, tableView]()
                 {
                     if (treeView)
                     {
                         treeView->MoveEntries();
                     }
-                    else if (tableView)
+                    else if (listView)
                     {
-                        tableView->MoveEntries();
+                        listView->MoveEntries();
                     }
                     else if (thumbnailView)
                     {
                         thumbnailView->MoveEntries();
                     }
-                    else if (expandedTableView)
+                    else if (tableView)
                     {
-                        expandedTableView->MoveEntries();
+                        tableView->MoveEntries();
                     }
                 });
         }
@@ -719,23 +719,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                 // Add Rename option
                 QAction* action = menu->addAction(
                     QObject::tr("Rename Folder"),
-                    [treeView, tableView, thumbnailView, expandedTableView]()
+                    [treeView, listView, thumbnailView, tableView]()
                     {
                         if (treeView)
                         {
                             treeView->RenameEntry();
                         }
-                        else if (tableView)
+                        else if (listView)
                         {
-                            tableView->RenameEntry();
+                            listView->RenameEntry();
                         }
                         else if (thumbnailView)
                         {
                             thumbnailView->RenameEntry();
                         }
-                        else if (expandedTableView)
+                        else if (tableView)
                         {
-                            expandedTableView->RenameEntry();
+                            tableView->RenameEntry();
                         }
                     });
                 action->setShortcut(Qt::Key_F2);
@@ -744,23 +744,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                 // Add Delete option
                 action = menu->addAction(
                     QObject::tr("Delete Folder"),
-                    [treeView, tableView, thumbnailView, expandedTableView]()
+                    [treeView, listView, thumbnailView, tableView]()
                     {
                         if (treeView)
                         {
                             treeView->DeleteEntries();
                         }
-                        else if (tableView)
+                        else if (listView)
                         {
-                            tableView->DeleteEntries();
+                            listView->DeleteEntries();
                         }
                         else if (thumbnailView)
                         {
                             thumbnailView->DeleteEntries();
                         }
-                        else if (expandedTableView)
+                        else if (tableView)
                         {
-                            expandedTableView->DeleteEntries();
+                            tableView->DeleteEntries();
                         }
                     });
                 action->setShortcut(QKeySequence::Delete);
@@ -769,23 +769,23 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                 // Add Move to option
                 menu->addAction(
                     QObject::tr("Move to"),
-                    [treeView, tableView, thumbnailView, expandedTableView]()
+                    [treeView, listView, thumbnailView, tableView]()
                     {
                         if (treeView)
                         {
                             treeView->MoveEntries();
                         }
-                        else if (tableView)
+                        else if (listView)
                         {
-                            tableView->MoveEntries();
+                            listView->MoveEntries();
                         }
                         else if (thumbnailView)
                         {
                             thumbnailView->MoveEntries();
                         }
-                        else if (expandedTableView)
+                        else if (tableView)
                         {
-                            expandedTableView->MoveEntries();
+                            tableView->MoveEntries();
                         }
                     });
                 AddCreateMenu(menu, fullFilePath);

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -35,7 +35,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetEditor/AssetEditorBus.h>
@@ -425,7 +425,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
         calledFromAssetBrowser = treeView->GetIsAssetBrowserMainView();
     }
 
-    AssetBrowserTableView* tableView = qobject_cast<AssetBrowserTableView*>(caller);
+    AssetBrowserListView* tableView = qobject_cast<AssetBrowserListView*>(caller);
     if (tableView)
     {
         calledFromAssetBrowser |= tableView->GetIsAssetBrowserMainView();

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -116,7 +116,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     m_filterModel->setSourceModel(m_assetBrowserModel);
     m_filterModel->SetFilter(m_ui->m_searchWidget->GetFilter());
 
-    m_ui->m_assetBrowserTableViewWidget->setVisible(false);
+    m_ui->m_assetBrowserListViewWidget->setVisible(false);
     m_ui->m_toolsMenuButton->setVisible(false);
     m_ui->m_searchWidget->SetFilterInputInterval(AZStd::chrono::milliseconds(250));
 
@@ -135,7 +135,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         m_tableModel->setFilterRole(Qt::DisplayRole);
         m_tableModel->setSourceModel(m_filterModel.data());
         m_tableModel->setDynamicSortFilter(true);
-        m_ui->m_assetBrowserTableViewWidget->setModel(m_tableModel.data());
+        m_ui->m_assetBrowserListViewWidget->setModel(m_tableModel.data());
 
         m_createMenu = new QMenu("Create New Asset Menu", this);
         m_ui->m_createButton->setMenu(m_createMenu);
@@ -148,11 +148,11 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         connect(m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterChanged,
             this, &AzAssetBrowserWindow::UpdateWidgetAfterFilter);
 
-        connect(m_ui->m_assetBrowserTableViewWidget->selectionModel(), &QItemSelectionModel::currentChanged,
+        connect(m_ui->m_assetBrowserListViewWidget->selectionModel(), &QItemSelectionModel::currentChanged,
             this, &AzAssetBrowserWindow::CurrentIndexChangedSlot);
 
         connect(
-            m_ui->m_assetBrowserTableViewWidget->selectionModel(),
+            m_ui->m_assetBrowserListViewWidget->selectionModel(),
             &QItemSelectionModel::selectionChanged,
             this,
             [this](const QItemSelection& selected, const QItemSelection& deselected)
@@ -164,16 +164,16 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
                 }
             });
 
-        connect(m_ui->m_assetBrowserTableViewWidget, &QAbstractItemView::doubleClicked,
+        connect(m_ui->m_assetBrowserListViewWidget, &QAbstractItemView::doubleClicked,
             this, &AzAssetBrowserWindow::DoubleClickedItem);
 
-        connect(m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearStringFilter,
+        connect(m_ui->m_assetBrowserListViewWidget, &AzAssetBrowser::AssetBrowserListView::ClearStringFilter,
             m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearStringFilter);
 
-        connect(m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearTypeFilter,
+        connect(m_ui->m_assetBrowserListViewWidget, &AzAssetBrowser::AssetBrowserListView::ClearTypeFilter,
             m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
 
-        m_ui->m_assetBrowserTableViewWidget->SetIsAssetBrowserMainView();
+        m_ui->m_assetBrowserListViewWidget->SetIsAssetBrowserMainView();
 
         connect(
             m_ui->m_thumbnailView,
@@ -333,7 +333,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         });
 
     connect(this, &AzAssetBrowserWindow::SizeChangedSignal,
-        m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::UpdateSizeSlot);
+        m_ui->m_assetBrowserListViewWidget, &AzAssetBrowser::AssetBrowserListView::UpdateSizeSlot);
 
     m_ui->m_assetBrowserTreeViewWidget->SetIsAssetBrowserMainView();
     m_ui->m_thumbnailView->SetIsAssetBrowserMainView();
@@ -352,7 +352,7 @@ void AzAssetBrowserWindow::AddCreateMenu()
     m_createMenu->clear();
 
     const auto& selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                                                                                 : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+                                                                                 : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
     const AssetBrowserEntry* entry = selectedAssets.empty() ? nullptr : selectedAssets.front();
     if (!entry || selectedAssets.size() != 1)
     {
@@ -427,7 +427,7 @@ QObject* AzAssetBrowserWindow::createListenerForShowAssetEditorEvent(QObject* pa
 bool AzAssetBrowserWindow::ViewWidgetBelongsTo(QWidget* viewWidget)
 {
     return m_ui->m_assetBrowserTreeViewWidget == viewWidget ||
-        m_ui->m_assetBrowserTableViewWidget == viewWidget ||
+        m_ui->m_assetBrowserListViewWidget == viewWidget ||
         m_ui->m_thumbnailView == viewWidget ||
         m_ui->m_expandedTableView == viewWidget;
 }
@@ -504,7 +504,7 @@ void AzAssetBrowserWindow::CreateToolsMenu()
         m_ui->m_searchWidget->AddFolderFilter();
 
         m_assetBrowserDisplayState = AzToolsFramework::AssetBrowser::AssetBrowserDisplayState::TreeViewMode;
-        m_ui->m_assetBrowserTableViewWidget->setVisible(false);
+        m_ui->m_assetBrowserListViewWidget->setVisible(false);
         m_ui->m_assetBrowserTreeViewWidget->setVisible(true);
         m_ui->m_thumbnailView->SetThumbnailActiveView(true);
     }
@@ -588,9 +588,9 @@ void AzAssetBrowserWindow::SetTreeViewMode()
 
     m_assetBrowserDisplayState = AzAssetBrowser::AssetBrowserDisplayState::TreeViewMode;
 
-    if (m_ui->m_assetBrowserTableViewWidget->isVisible())
+    if (m_ui->m_assetBrowserListViewWidget->isVisible())
     {
-        m_ui->m_assetBrowserTableViewWidget->setVisible(false);
+        m_ui->m_assetBrowserListViewWidget->setVisible(false);
         m_ui->m_assetBrowserTreeViewWidget->setVisible(true);
     }
 }
@@ -611,7 +611,7 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
     const bool hasFilter = !m_ui->m_searchWidget->GetFilterString().isEmpty();
     if (m_assetBrowserDisplayState == AzAssetBrowser::AssetBrowserDisplayState::ListViewMode)
     {
-        m_ui->m_assetBrowserTableViewWidget->setVisible(hasFilter);
+        m_ui->m_assetBrowserListViewWidget->setVisible(hasFilter);
         m_ui->m_assetBrowserTreeViewWidget->setVisible(!hasFilter);
     }
 
@@ -857,7 +857,7 @@ void AzAssetBrowserWindow::DoubleClickedItem([[maybe_unused]] const QModelIndex&
     namespace AzAssetBrowser = AzToolsFramework::AssetBrowser;
 
     const auto& selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                                                                                 : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+                                                                                 : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
 
     for (const AzAssetBrowser::AssetBrowserEntry* entry : selectedAssets)
     {

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -19,7 +19,7 @@
 #include <AzToolsFramework/API/ViewPaneOptions.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserListModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
@@ -101,7 +101,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::AzAssetBrowserWindowClass())
     , m_filterModel(new AzToolsFramework::AssetBrowser::AssetBrowserFilterModel(parent))
-    , m_tableModel(new AzToolsFramework::AssetBrowser::AssetBrowserTableModel(parent))
+    , m_tableModel(new AzToolsFramework::AssetBrowser::AssetBrowserListModel(parent))
 {
     m_ui->setupUi(this);
     m_ui->m_searchWidget->Setup(true, true);

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -38,7 +38,7 @@ AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AzAssetBrowser/ui_AzAssetBrowserWindow.h>
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
-AZ_CVAR_EXTERNED(bool, ed_useNewAssetBrowserTableView);
+AZ_CVAR_EXTERNED(bool, ed_useNewAssetBrowserListView);
 
 AZ_CVAR(bool, ed_useWIPAssetBrowserDesign, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Use the in-progress new Asset Browser design");
 
@@ -125,7 +125,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
 
     this->setMinimumWidth(MinimumWidth);
 
-    if (ed_useNewAssetBrowserTableView)
+    if (ed_useNewAssetBrowserListView)
     {
         m_ui->m_toolsMenuButton->setVisible(true);
         m_ui->m_toolsMenuButton->setEnabled(true);
@@ -215,7 +215,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             });
     }
 
-    connect(m_ui->m_expandedTableView, &AssetBrowserExpandedTableView::entryDoubleClicked,
+    connect(m_ui->m_tableView, &AssetBrowserTableView::entryDoubleClicked,
         this,
         [this](const AssetBrowserEntry* entry)
         {
@@ -228,14 +228,14 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         m_ui->m_middleStackWidget->hide();
         m_ui->m_treeViewButton->hide();
         m_ui->m_thumbnailViewButton->hide();
-        m_ui->m_expandedTableViewButton->hide();
+        m_ui->m_tableViewButton->hide();
         m_ui->m_createButton->hide();
         m_ui->m_searchWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     }
 
     m_ui->horizontalLayout->setAlignment(m_ui->m_toolsMenuButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_treeViewButton, Qt::AlignTop);
-    m_ui->horizontalLayout->setAlignment(m_ui->m_expandedTableViewButton, Qt::AlignTop);
+    m_ui->horizontalLayout->setAlignment(m_ui->m_tableViewButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_thumbnailViewButton, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_breadcrumbsWrapper, Qt::AlignTop);
     m_ui->horizontalLayout->setAlignment(m_ui->m_createButton, Qt::AlignTop);
@@ -258,12 +258,12 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     });
 
     connect(m_ui->m_thumbnailViewButton, &QAbstractButton::clicked, this, [this] { SetCurrentMode(AssetBrowserMode::ThumbnailView); });
-    connect(m_ui->m_expandedTableViewButton, &QAbstractButton::clicked, this, [this] { SetCurrentMode(AssetBrowserMode::TableView); });
+    connect(m_ui->m_tableViewButton, &QAbstractButton::clicked, this, [this] { SetCurrentMode(AssetBrowserMode::TableView); });
     connect(m_ui->m_treeViewButton, &QAbstractButton::clicked, this, [this] { SetCurrentMode(AssetBrowserMode::ListView); });
 
     m_ui->m_assetBrowserTreeViewWidget->setModel(m_filterModel.data());
     m_ui->m_thumbnailView->SetAssetTreeView(m_ui->m_assetBrowserTreeViewWidget);
-    m_ui->m_expandedTableView->SetAssetTreeView(m_ui->m_assetBrowserTreeViewWidget);
+    m_ui->m_tableView->SetAssetTreeView(m_ui->m_assetBrowserTreeViewWidget);
 
     connect(m_ui->m_searchWidget->GetFilter().data(), &AzAssetBrowser::AssetBrowserEntryFilter::updatedSignal,
         m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterUpdatedSlot);
@@ -274,7 +274,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             const bool hasFilter = !m_ui->m_searchWidget->GetFilterString().isEmpty();
             const bool selectFirstFilteredIndex = false;
             m_ui->m_assetBrowserTreeViewWidget->UpdateAfterFilter(hasFilter, selectFirstFilteredIndex);
-            m_ui->m_expandedTableViewButton->setDisabled(hasFilter);
+            m_ui->m_tableViewButton->setDisabled(hasFilter);
         });
 
     connect(m_ui->m_assetBrowserTreeViewWidget->selectionModel(), &QItemSelectionModel::currentChanged,
@@ -325,9 +325,9 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             {
                 m_ui->m_thumbnailView->OpenItemForEditing(index);
             }
-            else if (m_ui->m_expandedTableView->GetExpandedTableViewActive())
+            else if (m_ui->m_tableView->GetTableViewActive())
             {
-                m_ui->m_expandedTableView->OpenItemForEditing(index);
+                m_ui->m_tableView->OpenItemForEditing(index);
             }
             m_ui->m_assetBrowserTreeViewWidget->OpenItemForEditing(index);
         });
@@ -337,7 +337,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
 
     m_ui->m_assetBrowserTreeViewWidget->SetIsAssetBrowserMainView();
     m_ui->m_thumbnailView->SetIsAssetBrowserMainView();
-    m_ui->m_expandedTableView->SetIsAssetBrowserMainView();
+    m_ui->m_tableView->SetIsAssetBrowserMainView();
 }
 
 AzAssetBrowserWindow::~AzAssetBrowserWindow()
@@ -429,7 +429,7 @@ bool AzAssetBrowserWindow::ViewWidgetBelongsTo(QWidget* viewWidget)
     return m_ui->m_assetBrowserTreeViewWidget == viewWidget ||
         m_ui->m_assetBrowserListViewWidget == viewWidget ||
         m_ui->m_thumbnailView == viewWidget ||
-        m_ui->m_expandedTableView == viewWidget;
+        m_ui->m_tableView == viewWidget;
 }
 
 void AzAssetBrowserWindow::resizeEvent(QResizeEvent* resizeEvent)
@@ -621,7 +621,7 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
             m_ui->m_assetBrowserTreeViewWidget->model()->index(0, 0, {}), QItemSelectionModel::ClearAndSelect);
     }
 
-    if (ed_useNewAssetBrowserTableView)
+    if (ed_useNewAssetBrowserListView)
     {
         if (hasFilter)
         {
@@ -630,7 +630,7 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
             {
                 thumbnailWidget->setRootIndex(thumbnailWidget->model()->index(0, 0, {}));
             }
-            auto expandedTableWidget = m_ui->m_expandedTableView->GetExpandedTableViewWidget();
+            auto expandedTableWidget = m_ui->m_tableView->GetExpandedTableViewWidget();
             if (expandedTableWidget)
             {
                 expandedTableWidget->setRootIndex(expandedTableWidget->model()->index(0, 0, {}));
@@ -665,8 +665,8 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
         return;
     }
 
-    auto* expandedTableView = qobject_cast<AssetBrowserExpandedTableView*>(viewToShow);
-    if (expandedTableView && m_ui->m_expandedTableView->GetExpandedTableViewActive())
+    auto* tableView = qobject_cast<AssetBrowserTableView*>(viewToShow);
+    if (tableView && m_ui->m_tableView->GetTableViewActive())
     {
         return;
     }
@@ -678,20 +678,20 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
     if (thumbnailView)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(true);
-        m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
+        m_ui->m_tableView->SetTableViewActive(false);
         m_ui->m_searchWidget->setEnabled(true);
     }
-    else if (expandedTableView)
+    else if (tableView)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
-        m_ui->m_expandedTableView->SetExpandedTableViewActive(true);
+        m_ui->m_tableView->SetTableViewActive(true);
         m_ui->m_searchWidget->setDisabled(true);
     }
 }
 
 void AzAssetBrowserWindow::SetOneColumnMode()
 {
-    if (m_ui->m_thumbnailView->GetThumbnailActiveView() || m_ui->m_expandedTableView->GetExpandedTableViewActive())
+    if (m_ui->m_thumbnailView->GetThumbnailActiveView() || m_ui->m_tableView->GetTableViewActive())
     {
         m_ui->m_middleStackWidget->hide();
         m_ui->m_assetBrowserTreeViewWidget->SetApplySnapshot(false);
@@ -701,7 +701,7 @@ void AzAssetBrowserWindow::SetOneColumnMode()
             m_ui->m_assetBrowserTreeViewWidget->expand(m_ui->m_assetBrowserTreeViewWidget->selectionModel()->selectedRows()[0]);
         }
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
-        m_ui->m_expandedTableView->SetExpandedTableViewActive(false);
+        m_ui->m_tableView->SetTableViewActive(false);
         m_ui->m_searchWidget->setEnabled(true);
     }
 }
@@ -922,7 +922,7 @@ void AzAssetBrowserWindow::SetCurrentMode(const AssetBrowserMode mode)
         switch (mode)
         {
         case AssetBrowserMode::TableView:
-            SetTwoColumnMode(m_ui->m_expandedTableView);
+            SetTwoColumnMode(m_ui->m_tableView);
             break;
         case AssetBrowserMode::ListView:
             SetOneColumnMode();

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -27,7 +27,7 @@ namespace AzToolsFramework
     {
         class AssetBrowserEntry;
         class AssetBrowserFilterModel;
-        class AssetBrowserTableModel;
+        class AssetBrowserListModel;
         class AssetBrowserModel;
         class AssetBrowserTableFilterModel;
         class AssetBrowserTreeView;
@@ -91,7 +91,7 @@ protected slots:
 private:
     QScopedPointer<Ui::AzAssetBrowserWindowClass> m_ui;
     QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel> m_filterModel;
-    QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserTableModel> m_tableModel;
+    QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserListModel> m_tableModel;
     AzToolsFramework::AssetBrowser::AssetBrowserModel* m_assetBrowserModel;
     QMenu* m_toolsMenu = nullptr;
     QMenu* m_createMenu = nullptr;

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -321,7 +321,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="AzToolsFramework::AssetBrowser::AssetBrowserTableView" name="m_assetBrowserTableViewWidget">
+            <widget class="AzToolsFramework::AssetBrowser::AssetBrowserListView" name="m_assetBrowserListViewWidget">
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
                <horstretch>0</horstretch>
@@ -412,9 +412,9 @@
    <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h</header>
   </customwidget>
   <customwidget>
-   <class>AzToolsFramework::AssetBrowser::AssetBrowserTableView</class>
+   <class>AzToolsFramework::AssetBrowser::AssetBrowserListView</class>
    <extends>QTableView</extends>
-   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h</header>
+   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h</header>
   </customwidget>
   <customwidget>
    <class>AzToolsFramework::AssetBrowser::AssetBrowserExpandedTableView</class>

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -195,7 +195,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="m_expandedTableViewButton">
+          <widget class="QToolButton" name="m_tableViewButton">
            <property name="text">
             <string>...</string>
            </property>
@@ -383,7 +383,7 @@
            </size>
           </property>
           <widget class="AzToolsFramework::AssetBrowser::AssetBrowserThumbnailView" name="m_thumbnailView"/>
-          <widget class="AzToolsFramework::AssetBrowser::AssetBrowserExpandedTableView" name="m_expandedTableView">
+          <widget class="AzToolsFramework::AssetBrowser::AssetBrowserTableView" name="m_tableView">
            <layout class="QVBoxLayout" name="m_tableViewLayout">
             <property name="spacing">
              <number>0</number>
@@ -417,9 +417,9 @@
    <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h</header>
   </customwidget>
   <customwidget>
-   <class>AzToolsFramework::AssetBrowser::AssetBrowserExpandedTableView</class>
+   <class>AzToolsFramework::AssetBrowser::AssetBrowserTableView</class>
    <extends>AzQtComponents::TableView</extends>
-   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h</header>
+   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h</header>
   </customwidget>
   <customwidget>
    <class>AzQtComponents::BreadCrumbs</class>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -23,8 +23,8 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 AZ_POP_DISABLE_WARNING
 
 AZ_CVAR(
-    bool, ed_useNewAssetBrowserTableView, true, nullptr, AZ::ConsoleFunctorFlags::Null,
-    "Use the new AssetBrowser TableView for searching assets.");
+    bool, ed_useNewAssetBrowserListView, true, nullptr, AZ::ConsoleFunctorFlags::Null,
+    "Use the new AssetBrowser ListView for searching assets.");
 namespace AzToolsFramework
 {
     namespace AssetBrowser
@@ -35,7 +35,7 @@ namespace AzToolsFramework
             : QSortFilterProxyModel(parent)
         {
             m_shownColumns.insert(aznumeric_cast<int>(AssetBrowserEntry::Column::DisplayName));
-            if (ed_useNewAssetBrowserTableView)
+            if (ed_useNewAssetBrowserListView)
             {
                 m_shownColumns.insert(aznumeric_cast<int>(AssetBrowserEntry::Column::Path));
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.h
@@ -22,15 +22,15 @@ namespace AzToolsFramework
         class AssetBrowserFilterModel;
         class AssetBrowserEntry;
 
-        class AssetBrowserTableModel
+        class AssetBrowserListModel
             : public QSortFilterProxyModel
             , public AssetBrowserComponentNotificationBus::Handler
         {
             Q_OBJECT
 
         public:
-            AZ_CLASS_ALLOCATOR(AssetBrowserTableModel, AZ::SystemAllocator);
-            explicit AssetBrowserTableModel(QObject* parent = nullptr);
+            AZ_CLASS_ALLOCATOR(AssetBrowserListModel, AZ::SystemAllocator);
+            explicit AssetBrowserListModel(QObject* parent = nullptr);
 
             ////////////////////////////////////////////////////////////////////
             // QSortFilterProxyModel

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.cpp
@@ -14,7 +14,7 @@
 #include <AzCore/Console/IConsole.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
-#include <AzToolsFramework/AssetBrowser/AssetBrowserExpandedFilterModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 
 #include <QSharedPointer>
@@ -28,7 +28,7 @@ namespace AzToolsFramework
     {
         //////////////////////////////////////////////////////////////////////////
         //AssetBrowserFilterModel
-        AssetBrowserExpandedFilterModel::AssetBrowserExpandedFilterModel(QObject* parent)
+        AssetBrowserTableFilterModel::AssetBrowserTableFilterModel(QObject* parent)
             : AssetBrowserFilterModel(parent)
         {
             m_shownColumns.insert(aznumeric_cast<int>(AssetBrowserEntry::Column::Type));
@@ -38,7 +38,14 @@ namespace AzToolsFramework
             // The below isn't used at present but will be needed in future
             // m_shownColumns.insert(aznumeric_cast<int>(AssetBrowserEntry::Column::SourceControlStatus));
         }
+
+        bool AssetBrowserTableFilterModel::filterAcceptsRow(
+            [[maybe_unused]] int source_row, [[maybe_unused]] const QModelIndex& source_parent) const
+        {
+            return true;
+        }
+
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 
-#include "AssetBrowser/moc_AssetBrowserExpandedFilterModel.cpp"
+#include "AssetBrowser/moc_AssetBrowserTableFilterModel.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.h
@@ -17,14 +17,18 @@ namespace AzToolsFramework
     {
         using ShownColumnsSet = AZStd::fixed_unordered_set<int, 3, aznumeric_cast<int>(AssetBrowserEntry::Column::Count)>;
 
-        class AssetBrowserExpandedFilterModel
+        class AssetBrowserTableFilterModel
             : public AssetBrowserFilterModel
          {
             Q_OBJECT
 
         public:
-            AZ_CLASS_ALLOCATOR(AssetBrowserExpandedFilterModel, AZ::SystemAllocator);
-            explicit AssetBrowserExpandedFilterModel(QObject* parent = nullptr);
+            AZ_CLASS_ALLOCATOR(AssetBrowserTableFilterModel, AZ::SystemAllocator);
+            explicit AssetBrowserTableFilterModel(QObject* parent = nullptr);
+
+        protected:
+            bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
@@ -7,7 +7,7 @@
  */
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserExpandedTableViewProxyModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
@@ -16,14 +16,14 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
-        AssetBrowserExpandedTableViewProxyModel::AssetBrowserExpandedTableViewProxyModel(QObject* parent)
+        AssetBrowserTableViewProxyModel::AssetBrowserTableViewProxyModel(QObject* parent)
             : QIdentityProxyModel(parent)
         {
         }
 
-        AssetBrowserExpandedTableViewProxyModel::~AssetBrowserExpandedTableViewProxyModel() = default;
+        AssetBrowserTableViewProxyModel::~AssetBrowserTableViewProxyModel() = default;
 
-        QVariant AssetBrowserExpandedTableViewProxyModel::data(const QModelIndex& index, int role) const
+        QVariant AssetBrowserTableViewProxyModel::data(const QModelIndex& index, int role) const
         {
             auto assetBrowserEntry = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
             AZ_Assert(assetBrowserEntry, "Couldn't fetch asset entry for the given index.");
@@ -96,7 +96,7 @@ namespace AzToolsFramework
             return QAbstractProxyModel::data(index, role);
         }
 
-        QVariant AssetBrowserExpandedTableViewProxyModel::headerData(int section, Qt::Orientation orientation, int role) const
+        QVariant AssetBrowserTableViewProxyModel::headerData(int section, Qt::Orientation orientation, int role) const
         {
             switch (role)
             {
@@ -117,7 +117,7 @@ namespace AzToolsFramework
             return QVariant();
         }
 
-        bool AssetBrowserExpandedTableViewProxyModel::hasChildren(const QModelIndex& parent) const
+        bool AssetBrowserTableViewProxyModel::hasChildren(const QModelIndex& parent) const
         {
             if (parent != m_rootIndex)
             {
@@ -126,27 +126,27 @@ namespace AzToolsFramework
             return true;
         }
 
-        int AssetBrowserExpandedTableViewProxyModel::columnCount([[maybe_unused]]const QModelIndex& parent) const
+        int AssetBrowserTableViewProxyModel::columnCount([[maybe_unused]]const QModelIndex& parent) const
         {
             return ColumnCount;
         }
 
-        void AssetBrowserExpandedTableViewProxyModel::SetRootIndex(const QModelIndex& index)
+        void AssetBrowserTableViewProxyModel::SetRootIndex(const QModelIndex& index)
         {
             m_rootIndex = index;
         }
 
-        const QModelIndex AssetBrowserExpandedTableViewProxyModel::GetRootIndex() const
+        const QModelIndex AssetBrowserTableViewProxyModel::GetRootIndex() const
         {
             return m_rootIndex;
         }
 
-        bool AssetBrowserExpandedTableViewProxyModel::GetShowSearchResultsMode() const
+        bool AssetBrowserTableViewProxyModel::GetShowSearchResultsMode() const
         {
             return m_searchResultsMode;
         }
 
-        void AssetBrowserExpandedTableViewProxyModel::SetShowSearchResultsMode(bool searchMode)
+        void AssetBrowserTableViewProxyModel::SetShowSearchResultsMode(bool searchMode)
         {
             if (m_searchResultsMode != searchMode)
             {
@@ -160,7 +160,7 @@ namespace AzToolsFramework
             return AZStd::hash<AZStd::string_view>{}(AZStd::string_view{ str, len });
         }
 
-        const AZStd::string AssetBrowserExpandedTableViewProxyModel::ExtensionToType(AZStd::string_view str) const
+        const AZStd::string AssetBrowserTableViewProxyModel::ExtensionToType(AZStd::string_view str) const
         {
             switch (AZStd::hash<AZStd::string_view>{}(str))
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
@@ -15,14 +15,14 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
-        class AssetBrowserExpandedTableViewProxyModel
+        class AssetBrowserTableViewProxyModel
             : public QIdentityProxyModel
         {
             Q_OBJECT
 
         public:
-            explicit AssetBrowserExpandedTableViewProxyModel(QObject* parent = nullptr);
-            ~AssetBrowserExpandedTableViewProxyModel() override;
+            explicit AssetBrowserTableViewProxyModel(QObject* parent = nullptr);
+            ~AssetBrowserTableViewProxyModel() override;
 
             enum
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
@@ -289,8 +289,7 @@ namespace AzToolsFramework
 
         void AssetPickerDialog::UpdatePreview() const
         {
-            auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible()
-                ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
+            auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
                                                                                   : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
             ;
             if (selectedAssets.size() != 1)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
@@ -120,23 +120,23 @@ namespace AzToolsFramework
 
             m_persistentState = AZ::UserSettings::CreateFind<AzToolsFramework::QWidgetSavedState>(AZ::Crc32(("AssetBrowserTreeView_Dialog_" + name).toUtf8().data()), AZ::UserSettings::CT_GLOBAL);
 
-            m_ui->m_assetBrowserTableViewWidget->setVisible(false);
+            m_ui->m_assetBrowserListViewWidget->setVisible(false);
             if (ed_useNewAssetPickerView)
             {
-                m_ui->m_assetBrowserTreeViewWidget->setVisible(false);
-                m_ui->m_assetBrowserTableViewWidget->setVisible(true);
+                m_ui->m_assetBrowserListViewWidget->setVisible(false);
+                m_ui->m_assetBrowserListViewWidget->setVisible(true);
                 m_tableModel->setSourceModel(m_filterModel.get());
-                m_ui->m_assetBrowserTableViewWidget->setModel(m_tableModel.get());
+                m_ui->m_assetBrowserListViewWidget->setModel(m_tableModel.get());
 
-                m_ui->m_assetBrowserTableViewWidget->SetName("AssetBrowserTableView_" + name);
-                m_ui->m_assetBrowserTableViewWidget->setDragEnabled(false);
-                m_ui->m_assetBrowserTableViewWidget->setSelectionMode(
+                m_ui->m_assetBrowserListViewWidget->SetName("AssetBrowserListView_" + name);
+                m_ui->m_assetBrowserListViewWidget->setDragEnabled(false);
+                m_ui->m_assetBrowserListViewWidget->setSelectionMode(
                     selection.GetMultiselect() ? QAbstractItemView::SelectionMode::ExtendedSelection
                                                : QAbstractItemView::SelectionMode::SingleSelection);
 
                 if (ed_hideAssetPickerPathColumn)
                 {
-                    m_ui->m_assetBrowserTableViewWidget->hideColumn(1);
+                    m_ui->m_assetBrowserListViewWidget->hideColumn(1);
                 }
 
                 // if the current selection is invalid, disable the Ok button
@@ -150,27 +150,27 @@ namespace AzToolsFramework
                     });
 
                 connect(
-                    m_ui->m_assetBrowserTableViewWidget, &AssetBrowserTableView::selectionChangedSignal, this,
+                    m_ui->m_assetBrowserListViewWidget, &AssetBrowserListView::selectionChangedSignal, this,
                     [this](const QItemSelection&, const QItemSelection&)
                     {
                         SelectionChangedSlot();
                     });
 
-                connect(m_ui->m_assetBrowserTableViewWidget, &QAbstractItemView::doubleClicked, this, &AssetPickerDialog::DoubleClickedSlot);
+                connect(m_ui->m_assetBrowserListViewWidget, &QAbstractItemView::doubleClicked, this, &AssetPickerDialog::DoubleClickedSlot);
 
                 connect(
-                    m_ui->m_assetBrowserTableViewWidget, &AssetBrowserTableView::ClearStringFilter, m_ui->m_searchWidget,
+                    m_ui->m_assetBrowserListViewWidget, &AssetBrowserListView::ClearStringFilter, m_ui->m_searchWidget,
                     &SearchWidget::ClearStringFilter);
 
                 connect(
-                    m_ui->m_assetBrowserTableViewWidget, &AssetBrowserTableView::ClearTypeFilter, m_ui->m_searchWidget,
+                    m_ui->m_assetBrowserListViewWidget, &AssetBrowserListView::ClearTypeFilter, m_ui->m_searchWidget,
                     &SearchWidget::ClearTypeFilter);
 
                  connect(
-                    this, &AssetPickerDialog::SizeChangedSignal, m_ui->m_assetBrowserTableViewWidget,
-                    &AssetBrowserTableView::UpdateSizeSlot);
+                    this, &AssetPickerDialog::SizeChangedSignal, m_ui->m_assetBrowserListViewWidget,
+                    &AssetBrowserListView::UpdateSizeSlot);
 
-                m_ui->m_assetBrowserTableViewWidget->SetIsAssetBrowserMainView();
+                m_ui->m_assetBrowserListViewWidget->SetIsAssetBrowserMainView();
                 m_tableModel->UpdateTableModelMaps();
             }
 
@@ -258,7 +258,7 @@ namespace AzToolsFramework
         bool AssetPickerDialog::EvaluateSelection() const
         {
             auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                                                                                : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+                                                                                  : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
             // exactly one item must be selected, even if multi-select option is disabled, still good practice to check
             if (selectedAssets.empty())
             {
@@ -291,7 +291,7 @@ namespace AzToolsFramework
         {
             auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible()
                 ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+                                                                                  : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
             ;
             if (selectedAssets.size() != 1)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
@@ -13,7 +13,7 @@
 
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserListModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
@@ -44,7 +44,7 @@ namespace AzToolsFramework
             : QDialog(parent)
             , m_ui(new Ui::AssetPickerDialogClass())
             , m_filterModel(new AssetBrowserFilterModel(parent))
-            , m_tableModel(new AssetBrowserTableModel(parent))
+            , m_tableModel(new AssetBrowserListModel(parent))
             , m_selection(selection)
             , m_hasFilter(false)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.h
@@ -33,7 +33,7 @@ namespace AzToolsFramework
     {
         class ProductAssetBrowserEntry;
         class AssetBrowserFilterModel;
-        class AssetBrowserTableModel;
+        class AssetBrowserListModel;
         class AssetBrowserModel;
         class AssetSelectionModel;
 
@@ -74,7 +74,7 @@ namespace AzToolsFramework
             QScopedPointer<Ui::AssetPickerDialogClass> m_ui;
             AssetBrowserModel* m_assetBrowserModel = nullptr;
             QScopedPointer<AssetBrowserFilterModel> m_filterModel;
-            QScopedPointer<AssetBrowserTableModel> m_tableModel;
+            QScopedPointer<AssetBrowserListModel> m_tableModel;
             AssetSelectionModel& m_selection;
             bool m_hasFilter;
             AZStd::unique_ptr<TreeViewState> m_filterStateSaver;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.ui
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.ui
@@ -118,7 +118,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="AzToolsFramework::AssetBrowser::AssetBrowserTableView" name="m_assetBrowserTableViewWidget"/>
+        <widget class="AzToolsFramework::AssetBrowser::AssetBrowserListView" name="m_assetBrowserListViewWidget"/>
        </item>
        <item>
         <widget class="AzToolsFramework::AssetBrowser::AssetBrowserTreeView" name="m_assetBrowserTreeViewWidget">
@@ -204,9 +204,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>AzToolsFramework::AssetBrowser::AssetBrowserTableView</class>
+   <class>AzToolsFramework::AssetBrowser::AssetBrowserListView</class>
    <extends>QTableView</extends>
-   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h</header>
+   <header>AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
@@ -32,7 +32,7 @@ namespace AzToolsFramework
         const float MaxHeaderResizeProportion = .75f;
         const float DefaultHeaderResizeProportion = .5f;
 
-        static constexpr const char* const TableViewMainViewName = "AssetBrowserListView_main";
+        static constexpr const char* const ListViewMainViewName = "AssetBrowserListView_main";
 
         AssetBrowserListView::AssetBrowserListView(QWidget* parent)
             : AzQtComponents::TableView(parent)
@@ -106,12 +106,12 @@ namespace AzToolsFramework
 
         void AssetBrowserListView::setModel(QAbstractItemModel* model)
         {
-            m_tableModel = qobject_cast<AssetBrowserListModel*>(model);
-            AZ_Assert(m_tableModel, "Expecting AssetBrowserListModel");
-            m_sourceFilterModel = qobject_cast<AssetBrowserFilterModel*>(m_tableModel->sourceModel());
+            m_listModel = qobject_cast<AssetBrowserListModel*>(model);
+            AZ_Assert(m_listModel, "Expecting AssetBrowserListModel");
+            m_sourceFilterModel = qobject_cast<AssetBrowserFilterModel*>(m_listModel->sourceModel());
             m_delegate->Init();
             AzQtComponents::TableView::setModel(model);
-            connect(m_tableModel, &AssetBrowserListModel::layoutChanged, this, &AssetBrowserListView::layoutChangedSlot);
+            connect(m_listModel, &AssetBrowserListModel::layoutChanged, this, &AssetBrowserListView::layoutChangedSlot);
 
             header()->setStretchLastSection(true);
             header()->setSectionResizeMode(0, QHeaderView::ResizeMode::Interactive);
@@ -139,12 +139,12 @@ namespace AzToolsFramework
 
         void AssetBrowserListView::SetIsAssetBrowserMainView()
         {
-            SetName(TableViewMainViewName);
+            SetName(ListViewMainViewName);
         }
 
         bool AssetBrowserListView::GetIsAssetBrowserMainView()
         {
-            return GetName() == TableViewMainViewName;
+            return GetName() == ListViewMainViewName;
         }
 
         void AssetBrowserListView::DeleteEntries()
@@ -191,7 +191,7 @@ namespace AzToolsFramework
             {
                 if (index.column() == 0)
                 {
-                    sourceIndexes.push_back(m_sourceFilterModel->mapToSource(m_tableModel->mapToSource(index)));
+                    sourceIndexes.push_back(m_sourceFilterModel->mapToSource(m_listModel->mapToSource(index)));
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
@@ -106,12 +106,12 @@ namespace AzToolsFramework
 
         void AssetBrowserListView::setModel(QAbstractItemModel* model)
         {
-            m_tableModel = qobject_cast<AssetBrowserTableModel*>(model);
-            AZ_Assert(m_tableModel, "Expecting AssetBrowserTableModel");
+            m_tableModel = qobject_cast<AssetBrowserListModel*>(model);
+            AZ_Assert(m_tableModel, "Expecting AssetBrowserListModel");
             m_sourceFilterModel = qobject_cast<AssetBrowserFilterModel*>(m_tableModel->sourceModel());
             m_delegate->Init();
             AzQtComponents::TableView::setModel(model);
-            connect(m_tableModel, &AssetBrowserTableModel::layoutChanged, this, &AssetBrowserListView::layoutChangedSlot);
+            connect(m_tableModel, &AssetBrowserListModel::layoutChanged, this, &AssetBrowserListView::layoutChangedSlot);
 
             header()->setStretchLastSection(true);
             header()->setSectionResizeMode(0, QHeaderView::ResizeMode::Interactive);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.cpp
@@ -10,7 +10,7 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 #include <AzToolsFramework/AssetBrowser/Views/EntryDelegate.h>
 
@@ -32,15 +32,15 @@ namespace AzToolsFramework
         const float MaxHeaderResizeProportion = .75f;
         const float DefaultHeaderResizeProportion = .5f;
 
-        static constexpr const char* const TableViewMainViewName = "AssetBrowserTableView_main";
+        static constexpr const char* const TableViewMainViewName = "AssetBrowserListView_main";
 
-        AssetBrowserTableView::AssetBrowserTableView(QWidget* parent)
+        AssetBrowserListView::AssetBrowserListView(QWidget* parent)
             : AzQtComponents::TableView(parent)
             , m_delegate(new SearchEntryDelegate(this))
         {
             setSortingEnabled(false);
             setItemDelegate(m_delegate);
-            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserTableView::AfterRename);
+            connect(m_delegate, &EntryDelegate::RenameEntry, this, &AssetBrowserListView::AfterRename);
             setRootIsDecorated(false);
 
             //Styling the header aligning text to the left and using a bold font.
@@ -53,7 +53,7 @@ namespace AzToolsFramework
             setMouseTracking(true);
             setSelectionMode(QAbstractItemView::SingleSelection);
 
-            connect(this, &AzQtComponents::TableView::customContextMenuRequested, this, &AssetBrowserTableView::OnContextMenu);
+            connect(this, &AzQtComponents::TableView::customContextMenuRequested, this, &AssetBrowserListView::OnContextMenu);
 
             AssetBrowserViewRequestBus::Handler::BusConnect();
             AssetBrowserComponentNotificationBus::Handler::BusConnect();
@@ -98,20 +98,20 @@ namespace AzToolsFramework
             addAction(duplicateAction);
         }
 
-        AssetBrowserTableView::~AssetBrowserTableView()
+        AssetBrowserListView::~AssetBrowserListView()
         {
             AssetBrowserViewRequestBus::Handler::BusDisconnect();
             AssetBrowserComponentNotificationBus::Handler::BusDisconnect();
         }
 
-        void AssetBrowserTableView::setModel(QAbstractItemModel* model)
+        void AssetBrowserListView::setModel(QAbstractItemModel* model)
         {
             m_tableModel = qobject_cast<AssetBrowserTableModel*>(model);
             AZ_Assert(m_tableModel, "Expecting AssetBrowserTableModel");
             m_sourceFilterModel = qobject_cast<AssetBrowserFilterModel*>(m_tableModel->sourceModel());
             m_delegate->Init();
             AzQtComponents::TableView::setModel(model);
-            connect(m_tableModel, &AssetBrowserTableModel::layoutChanged, this, &AssetBrowserTableView::layoutChangedSlot);
+            connect(m_tableModel, &AssetBrowserTableModel::layoutChanged, this, &AssetBrowserListView::layoutChangedSlot);
 
             header()->setStretchLastSection(true);
             header()->setSectionResizeMode(0, QHeaderView::ResizeMode::Interactive);
@@ -121,7 +121,7 @@ namespace AzToolsFramework
             header()->setSectionsClickable(false);
         }
 
-        void AssetBrowserTableView::SetName(const QString& name)
+        void AssetBrowserListView::SetName(const QString& name)
         {
             m_name = name;
             bool isAssetBrowserComponentReady = false;
@@ -132,42 +132,42 @@ namespace AzToolsFramework
             }
         }
 
-        QString& AssetBrowserTableView::GetName()
+        QString& AssetBrowserListView::GetName()
         {
             return m_name;
         }
 
-        void AssetBrowserTableView::SetIsAssetBrowserMainView()
+        void AssetBrowserListView::SetIsAssetBrowserMainView()
         {
             SetName(TableViewMainViewName);
         }
 
-        bool AssetBrowserTableView::GetIsAssetBrowserMainView()
+        bool AssetBrowserListView::GetIsAssetBrowserMainView()
         {
             return GetName() == TableViewMainViewName;
         }
 
-        void AssetBrowserTableView::DeleteEntries()
+        void AssetBrowserListView::DeleteEntries()
         {
             auto entries = GetSelectedAssets(false); // you cannot delete product files.
 
             AssetBrowserViewUtils::DeleteEntries(entries, this);
         }
 
-        void AssetBrowserTableView::MoveEntries()
+        void AssetBrowserListView::MoveEntries()
         {
             auto entries = GetSelectedAssets(false); // you cannot move product files.
 
             AssetBrowserViewUtils::MoveEntries(entries, this);
         }
 
-        void AssetBrowserTableView::DuplicateEntries()
+        void AssetBrowserListView::DuplicateEntries()
         {
             auto entries = GetSelectedAssets(false); // you may not duplicate product files.
             AssetBrowserViewUtils::DuplicateEntries(entries);
         }
 
-        void AssetBrowserTableView::RenameEntry()
+        void AssetBrowserListView::RenameEntry()
         {
             auto entries = GetSelectedAssets(false); // you cannot rename product files.
 
@@ -177,14 +177,14 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserTableView::AfterRename(QString newVal)
+        void AssetBrowserListView::AfterRename(QString newVal)
         {
             auto entries = GetSelectedAssets(false); // you cannot rename product files.
 
             AssetBrowserViewUtils::AfterRename(newVal, entries, this);
         }
 
-        AZStd::vector<const AssetBrowserEntry*> AssetBrowserTableView::GetSelectedAssets(bool includeProducts) const
+        AZStd::vector<const AssetBrowserEntry*> AssetBrowserListView::GetSelectedAssets(bool includeProducts) const
         {
             QModelIndexList sourceIndexes;
             for (const auto& index : selectedIndexes())
@@ -213,13 +213,13 @@ namespace AzToolsFramework
             return entries;
         }
 
-        void AssetBrowserTableView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
+        void AssetBrowserListView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
         {
             AzQtComponents::TableView::selectionChanged(selected, deselected);
             Q_EMIT selectionChangedSignal(selected, deselected);
         }
 
-        void AssetBrowserTableView::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end)
+        void AssetBrowserListView::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end)
         {
             // if selected entry is being removed, clear selection so not to select (and attempt to preview) other entries potentially
             // marked for deletion
@@ -235,21 +235,21 @@ namespace AzToolsFramework
             AzQtComponents::TableView::rowsAboutToBeRemoved(parent, start, end);
         }
 
-        void AssetBrowserTableView::layoutChangedSlot(
+        void AssetBrowserListView::layoutChangedSlot(
             [[maybe_unused]] const QList<QPersistentModelIndex>& parents, [[maybe_unused]] QAbstractItemModel::LayoutChangeHint hint)
         {
             scrollToTop();
         }
 
-        void AssetBrowserTableView::SelectProduct([[maybe_unused]] AZ::Data::AssetId assetID)
+        void AssetBrowserListView::SelectProduct([[maybe_unused]] AZ::Data::AssetId assetID)
         {
         }
 
-        void AssetBrowserTableView::SelectFileAtPath([[maybe_unused]] const AZStd::string& assetPath)
+        void AssetBrowserListView::SelectFileAtPath([[maybe_unused]] const AZStd::string& assetPath)
         {
         }
 
-        void AssetBrowserTableView::ClearFilter()
+        void AssetBrowserListView::ClearFilter()
         {
             emit ClearStringFilter();
             emit ClearTypeFilter();
@@ -259,17 +259,17 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserTableView::Update()
+        void AssetBrowserListView::Update()
         {
             update();
         }
 
-        void AssetBrowserTableView::OnAssetBrowserComponentReady()
+        void AssetBrowserListView::OnAssetBrowserComponentReady()
         {
             UpdateSizeSlot(parentWidget()->width());
         }
 
-        void AssetBrowserTableView::UpdateSizeSlot(int newWidth)
+        void AssetBrowserListView::UpdateSizeSlot(int newWidth)
         {
             setColumnWidth(0, aznumeric_cast<int>(newWidth * DefaultHeaderResizeProportion));
             header()->setMinimumSectionSize(aznumeric_cast<int>(newWidth * MinHeaderResizeProportion));
@@ -277,7 +277,7 @@ namespace AzToolsFramework
         }
 
 
-        void AssetBrowserTableView::OnContextMenu([[maybe_unused]] const QPoint& point)
+        void AssetBrowserListView::OnContextMenu([[maybe_unused]] const QPoint& point)
         {
             const auto& selectedAssets = GetSelectedAssets();
             if (selectedAssets.size() != 1)
@@ -295,4 +295,4 @@ namespace AzToolsFramework
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
-#include "AssetBrowser/Views/moc_AssetBrowserTableView.cpp"
+#include "AssetBrowser/Views/moc_AssetBrowserListView.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
@@ -77,7 +77,7 @@ namespace AzToolsFramework
                 QAbstractItemModel::LayoutChangeHint hint = QAbstractItemModel::NoLayoutChangeHint);
         private:
             QString m_name;
-            QPointer<AssetBrowserListModel> m_tableModel;
+            QPointer<AssetBrowserListModel> m_listModel;
             QPointer<AssetBrowserFilterModel> m_sourceFilterModel;
             SearchEntryDelegate* m_delegate = nullptr;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
@@ -28,15 +28,15 @@ namespace AzToolsFramework
         class AssetBrowserFilterModel;
         class SearchEntryDelegate;
 
-        class AssetBrowserTableView //! Table view that displays the asset browser entries in a list.
+        class AssetBrowserListView //! List view that displays the asset browser entries in a list.
             : public AzQtComponents::TableView
             , public AssetBrowserViewRequestBus::Handler
             , public AssetBrowserComponentNotificationBus::Handler
         {
             Q_OBJECT
         public:
-            explicit AssetBrowserTableView(QWidget* parent = nullptr);
-            ~AssetBrowserTableView() override;
+            explicit AssetBrowserListView(QWidget* parent = nullptr);
+            ~AssetBrowserListView() override;
 
             void setModel(QAbstractItemModel *model) override;
             void SetName(const QString& name);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserListView.h
@@ -11,7 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserListModel.h>
 
 #include <AzQtComponents/Components/Widgets/TableView.h>
 
@@ -24,7 +24,7 @@ namespace AzToolsFramework
     namespace AssetBrowser
     {
         class AssetBrowserEntry;
-        class AssetBrowserTableModel;
+        class AssetBrowserListModel;
         class AssetBrowserFilterModel;
         class SearchEntryDelegate;
 
@@ -77,7 +77,7 @@ namespace AzToolsFramework
                 QAbstractItemModel::LayoutChangeHint hint = QAbstractItemModel::NoLayoutChangeHint);
         private:
             QString m_name;
-            QPointer<AssetBrowserTableModel> m_tableModel;
+            QPointer<AssetBrowserListModel> m_tableModel;
             QPointer<AssetBrowserFilterModel> m_sourceFilterModel;
             SearchEntryDelegate* m_delegate = nullptr;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
 
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserExpandedFilterModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserTableFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserExpandedTableViewProxyModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
@@ -38,11 +38,11 @@ namespace AzToolsFramework
     {
         static constexpr const char* const ExpandedTableViewMainViewName = "AssetBrowserExpandedTableView_main";
 
-        AssetBrowserExpandedTableView::AssetBrowserExpandedTableView(QWidget* parent)
+        AssetBrowserTableView::AssetBrowserTableView(QWidget* parent)
             : QWidget(parent)
             , m_expandedTableViewWidget(new AzQtComponents::AssetFolderTableView(parent))
-            , m_expandedTableViewProxyModel(new AssetBrowserExpandedTableViewProxyModel(parent))
-            , m_assetFilterModel(new AssetBrowserExpandedFilterModel(parent))
+            , m_expandedTableViewProxyModel(new AssetBrowserTableViewProxyModel(parent))
+            , m_assetFilterModel(new AssetBrowserTableFilterModel(parent))
             , m_expandedTableViewDelegate(new ExpandedTableViewDelegate(m_expandedTableViewWidget))
         {
             // Using our own instance of AssetBrowserFilterModel to be able to show also files when the main model
@@ -172,14 +172,14 @@ namespace AzToolsFramework
                 m_expandedTableViewWidget,
                 &AzQtComponents::AssetFolderTableView::tableRootIndexChanged,
                 m_expandedTableViewProxyModel,
-                &AssetBrowserExpandedTableViewProxyModel::SetRootIndex);
+                &AssetBrowserTableViewProxyModel::SetRootIndex);
 
             auto layout = new QVBoxLayout();
             layout->addWidget(m_expandedTableViewWidget);
             setLayout(layout);
         }
 
-        AssetBrowserExpandedTableView::~AssetBrowserExpandedTableView()
+        AssetBrowserTableView::~AssetBrowserTableView()
         {
             if (AzToolsFramework::IsNewActionManagerEnabled())
             {
@@ -191,62 +191,62 @@ namespace AzToolsFramework
             }
         }
 
-        AzQtComponents::AssetFolderTableView* AssetBrowserExpandedTableView::GetExpandedTableViewWidget() const
+        AzQtComponents::AssetFolderTableView* AssetBrowserTableView::GetExpandedTableViewWidget() const
         {
             return m_expandedTableViewWidget;
         }
 
-         void AssetBrowserExpandedTableView::SetName(const QString& name)
+         void AssetBrowserTableView::SetName(const QString& name)
         {
             m_name = name;
         }
 
-        const QString& AssetBrowserExpandedTableView::GetName() const
+        const QString& AssetBrowserTableView::GetName() const
         {
             return m_name;
         }
 
-        void AssetBrowserExpandedTableView::SetIsAssetBrowserMainView()
+        void AssetBrowserTableView::SetIsAssetBrowserMainView()
         {
             SetName(ExpandedTableViewMainViewName);
         }
 
-        bool AssetBrowserExpandedTableView::GetIsAssetBrowserMainView() const
+        bool AssetBrowserTableView::GetIsAssetBrowserMainView() const
         {
             return GetName() == ExpandedTableViewMainViewName;
         }
 
-        void AssetBrowserExpandedTableView::SetExpandedTableViewActive(bool isActiveView)
+        void AssetBrowserTableView::SetTableViewActive(bool isActiveView)
         {
             m_isActiveView = isActiveView;
         }
 
-        bool AssetBrowserExpandedTableView::GetExpandedTableViewActive() const
+        bool AssetBrowserTableView::GetTableViewActive() const
         {
             return m_isActiveView;
         }
 
-        void AssetBrowserExpandedTableView::DeleteEntries()
+        void AssetBrowserTableView::DeleteEntries()
         {
             auto entries = GetSelectedAssets();
 
             AssetBrowserViewUtils::DeleteEntries(entries, this);
         }
 
-        void AssetBrowserExpandedTableView::MoveEntries()
+        void AssetBrowserTableView::MoveEntries()
         {
             auto entries = GetSelectedAssets();
 
             AssetBrowserViewUtils::MoveEntries(entries, this);
         }
 
-        void AssetBrowserExpandedTableView::DuplicateEntries()
+        void AssetBrowserTableView::DuplicateEntries()
         {
             auto entries = GetSelectedAssets();
             AssetBrowserViewUtils::DuplicateEntries(entries);
         }
 
-        void AssetBrowserExpandedTableView::RenameEntry()
+        void AssetBrowserTableView::RenameEntry()
         {
             auto entries = GetSelectedAssets();
 
@@ -257,14 +257,14 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserExpandedTableView::AfterRename(QString newVal)
+        void AssetBrowserTableView::AfterRename(QString newVal)
         {
             auto entries = GetSelectedAssets();
 
             AssetBrowserViewUtils::AfterRename(newVal, entries, this);
         }
 
-        AZStd::vector<const AssetBrowserEntry*> AssetBrowserExpandedTableView::GetSelectedAssets() const
+        AZStd::vector<const AssetBrowserEntry*> AssetBrowserTableView::GetSelectedAssets() const
         {
             // No need to check for product assets since they do not appear in the table view
             AZStd::vector<const AssetBrowserEntry*> entries;
@@ -283,13 +283,13 @@ namespace AzToolsFramework
             return entries;
         }
 
-        void AssetBrowserExpandedTableView::OpenItemForEditing(const QModelIndex& index)
+        void AssetBrowserTableView::OpenItemForEditing(const QModelIndex& index)
         {
             QModelIndex proxyIndex = m_expandedTableViewProxyModel->mapFromSource(m_assetFilterModel->mapFromSource(index));
 
             if (proxyIndex.isValid())
             {
-                m_expandedTableViewWidget->selectionModel()->select(proxyIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+                m_expandedTableViewWidget->selectionModel()->select(proxyIndex, QItemSelectionModel::SelectionFlag::ClearAndSelect);
 
                 m_expandedTableViewWidget->scrollTo(proxyIndex, QAbstractItemView::ScrollHint::PositionAtCenter);
 
@@ -297,7 +297,7 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserExpandedTableView::SetAssetTreeView(AssetBrowserTreeView* treeView)
+        void AssetBrowserTableView::SetAssetTreeView(AssetBrowserTreeView* treeView)
         {
             if (m_assetTreeView)
             {
@@ -309,12 +309,11 @@ namespace AzToolsFramework
                         treeViewFilterModel,
                         &AssetBrowserFilterModel::filterChanged,
                         this,
-                        &AssetBrowserExpandedTableView::UpdateFilterInLocalFilterModel);
+                        &AssetBrowserTableView::UpdateFilterInLocalFilterModel);
                 }
             }
 
             m_assetTreeView = treeView;
-            m_assetTreeView->SetAttachedExpandedTableView(this);
 
             if (!m_assetTreeView)
             {
@@ -340,26 +339,26 @@ namespace AzToolsFramework
                 treeViewFilterModel,
                 &AssetBrowserFilterModel::filterChanged,
                 this,
-                &AssetBrowserExpandedTableView::UpdateFilterInLocalFilterModel);
+                &AssetBrowserTableView::UpdateFilterInLocalFilterModel);
 
             connect(
                 m_assetTreeView,
                 &AssetBrowserTreeView::selectionChangedSignal,
                 this,
-                &AssetBrowserExpandedTableView::HandleTreeViewSelectionChanged);
+                &AssetBrowserTableView::HandleTreeViewSelectionChanged);
         }
 
-        void AssetBrowserExpandedTableView::setSelectionMode(QAbstractItemView::SelectionMode mode)
+        void AssetBrowserTableView::setSelectionMode(QAbstractItemView::SelectionMode mode)
         {
             m_expandedTableViewWidget->setSelectionMode(mode);
         }
 
-        QAbstractItemView::SelectionMode AssetBrowserExpandedTableView::selectionMode() const
+        QAbstractItemView::SelectionMode AssetBrowserTableView::selectionMode() const
         {
             return m_expandedTableViewWidget->selectionMode();
         }
 
-        void AssetBrowserExpandedTableView::SelectEntry(QString assetName)
+        void AssetBrowserTableView::SelectEntry(QString assetName)
         {
             QModelIndex rootIndex = m_expandedTableViewProxyModel->GetRootIndex();
 
@@ -382,7 +381,7 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserExpandedTableView::HandleTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
+        void AssetBrowserTableView::HandleTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
         {
             Q_UNUSED(deselected);
 
@@ -405,7 +404,7 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetBrowserExpandedTableView::UpdateFilterInLocalFilterModel()
+        void AssetBrowserTableView::UpdateFilterInLocalFilterModel()
         {
             if (!m_assetTreeView)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h
@@ -26,9 +26,9 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
-        class AssetBrowserExpandedFilterModel;
+        class AssetBrowserTableFilterModel;
         class AssetBrowserTreeView;
-        class AssetBrowserExpandedTableViewProxyModel;
+        class AssetBrowserTableViewProxyModel;
         class AssetBrowserEntry;
 
         class ExpandedTableViewDelegate
@@ -46,15 +46,15 @@ namespace AzToolsFramework
             void renameTableEntry(const QString& value) const;
         };
 
-        class AssetBrowserExpandedTableView
+        class AssetBrowserTableView
             : public QWidget
         {
             Q_OBJECT
         public:
-            AZ_CLASS_ALLOCATOR(AssetBrowserExpandedTableView, AZ::SystemAllocator);
+            AZ_CLASS_ALLOCATOR(AssetBrowserTableView, AZ::SystemAllocator);
 
-            explicit AssetBrowserExpandedTableView(QWidget* parent = nullptr);
-            ~AssetBrowserExpandedTableView() override;
+            explicit AssetBrowserTableView(QWidget* parent = nullptr);
+            ~AssetBrowserTableView() override;
 
             void SetAssetTreeView(AssetBrowserTreeView* treeView);
 
@@ -62,8 +62,8 @@ namespace AzToolsFramework
             const QString& GetName() const;
             void SetIsAssetBrowserMainView();
             bool GetIsAssetBrowserMainView() const;
-            void SetExpandedTableViewActive(bool isActiveView);
-            bool GetExpandedTableViewActive() const;
+            void SetTableViewActive(bool isActiveView);
+            bool GetTableViewActive() const;
 
             void DuplicateEntries();
             void MoveEntries();
@@ -87,8 +87,8 @@ namespace AzToolsFramework
         private:
             AssetBrowserTreeView* m_assetTreeView = nullptr;
             AzQtComponents::AssetFolderTableView* m_expandedTableViewWidget = nullptr;
-            AssetBrowserExpandedTableViewProxyModel* m_expandedTableViewProxyModel = nullptr;
-            AssetBrowserExpandedFilterModel* m_assetFilterModel = nullptr;
+            AssetBrowserTableViewProxyModel* m_expandedTableViewProxyModel = nullptr;
+            AssetBrowserTableFilterModel* m_assetFilterModel = nullptr;
             ExpandedTableViewDelegate* m_expandedTableViewDelegate = nullptr;
             QString m_name;
             bool m_isActiveView = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -15,7 +15,6 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -23,7 +23,7 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeViewDialog.h>
 #include <AzToolsFramework/AssetBrowser/Views/EntryDelegate.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserExpandedTableView.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
@@ -277,9 +277,9 @@ namespace AzToolsFramework
             {
                 m_attachedThumbnailView->SelectEntry(entries.back().data());
             }
-            if (m_attachedExpandedTableView)
+            if (m_attachedTableView)
             {
-                m_attachedExpandedTableView->SelectEntry(entries.back().data());
+                m_attachedTableView->SelectEntry(entries.back().data());
             }
 
             SelectEntry(QModelIndex(), entries);
@@ -698,9 +698,9 @@ namespace AzToolsFramework
             m_attachedThumbnailView = thumbnailView;
         }
 
-        void AssetBrowserTreeView::SetAttachedExpandedTableView(AssetBrowserExpandedTableView* tableView)
+        void AssetBrowserTreeView::SetAttachedTableView(AssetBrowserTableView* tableView)
         {
-            m_attachedExpandedTableView = tableView;
+            m_attachedTableView = tableView;
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework
     {
         class AssetBrowserEntry;
         class AssetBrowserModel;
-        class AssetBrowserExpandedTableView;
+        class AssetBrowserTableView;
         class AssetBrowserFilterModel;
         class AssetBrowserThumbnailView;
         class EntryDelegate;
@@ -108,7 +108,7 @@ namespace AzToolsFramework
             void SetShowIndexAfterUpdate(QModelIndex index);
 
             void SetAttachedThumbnailView(AssetBrowserThumbnailView* thumbnailView);
-            void SetAttachedExpandedTableView(AssetBrowserExpandedTableView* tableView);
+            void SetAttachedTableView(AssetBrowserTableView* tableView);
 
             void SetApplySnapshot(bool applySnapshot);
 
@@ -142,7 +142,7 @@ namespace AzToolsFramework
             const int m_scUpdateInterval = 100;
 
             AssetBrowserThumbnailView* m_attachedThumbnailView = nullptr;
-            AssetBrowserExpandedTableView* m_attachedExpandedTableView = nullptr;
+            AssetBrowserTableView* m_attachedTableView = nullptr;
 
             QString m_name;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeViewDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeViewDialog.cpp
@@ -25,7 +25,7 @@ namespace AzToolsFramework
         {
             auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible()
                 ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
-                : m_ui->m_assetBrowserTableViewWidget->GetSelectedAssets();
+                : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
             // exactly one item must be selected, even if multi-select option is disabled, still good practice to check
             if (selectedAssets.empty())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
@@ -64,7 +64,7 @@ namespace AzToolsFramework
             int DrawThumbnail(QPainter* painter, const QPoint& point, const QSize& size, const AssetBrowserEntry* entry) const;
         };
 
-        //! SearchEntryDelegate draws a single item in AssetBrowserTableView.
+        //! SearchEntryDelegate draws a single item in AssetBrowserListView.
         class SearchEntryDelegate
             : public EntryDelegate
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -726,8 +726,8 @@ set(FILES
     AssetBrowser/Views/AssetBrowserTreeView.h
     AssetBrowser/Views/AssetBrowserTreeViewDialog.cpp
     AssetBrowser/Views/AssetBrowserTreeViewDialog.h
-    AssetBrowser/Views/AssetBrowserTableView.cpp
-    AssetBrowser/Views/AssetBrowserTableView.h
+    AssetBrowser/Views/AssetBrowserListView.cpp
+    AssetBrowser/Views/AssetBrowserListView.h
     AssetBrowser/Views/AssetBrowserExpandedTableView.cpp
     AssetBrowser/Views/AssetBrowserExpandedTableView.h
     AssetBrowser/Views/AssetBrowserThumbnailView.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -704,14 +704,14 @@ set(FILES
     AssetBrowser/AssetBrowserEntry.h
     AssetBrowser/AssetBrowserEntityInspectorWidget.h
     AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
-    AssetBrowser/AssetBrowserExpandedFilterModel.cpp
-    AssetBrowser/AssetBrowserExpandedFilterModel.h
+    AssetBrowser/AssetBrowserTableFilterModel.cpp
+    AssetBrowser/AssetBrowserTableFilterModel.h
     AssetBrowser/AssetBrowserFilterModel.cpp
     AssetBrowser/AssetBrowserFilterModel.h
     AssetBrowser/AssetBrowserListModel.cpp
     AssetBrowser/AssetBrowserListModel.h
-    AssetBrowser/AssetBrowserExpandedTableViewProxyModel.cpp
-    AssetBrowser/AssetBrowserExpandedTableViewProxyModel.h
+    AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+    AssetBrowser/AssetBrowserTableViewProxyModel.h
     AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
     AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
     AssetBrowser/AssetBrowserModel.cpp
@@ -728,8 +728,8 @@ set(FILES
     AssetBrowser/Views/AssetBrowserTreeViewDialog.h
     AssetBrowser/Views/AssetBrowserListView.cpp
     AssetBrowser/Views/AssetBrowserListView.h
-    AssetBrowser/Views/AssetBrowserExpandedTableView.cpp
-    AssetBrowser/Views/AssetBrowserExpandedTableView.h
+    AssetBrowser/Views/AssetBrowserTableView.cpp
+    AssetBrowser/Views/AssetBrowserTableView.h
     AssetBrowser/Views/AssetBrowserThumbnailView.cpp
     AssetBrowser/Views/AssetBrowserThumbnailView.h
     AssetBrowser/Views/AssetBrowserViewUtils.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -708,8 +708,8 @@ set(FILES
     AssetBrowser/AssetBrowserExpandedFilterModel.h
     AssetBrowser/AssetBrowserFilterModel.cpp
     AssetBrowser/AssetBrowserFilterModel.h
-    AssetBrowser/AssetBrowserTableModel.cpp
-    AssetBrowser/AssetBrowserTableModel.h
+    AssetBrowser/AssetBrowserListModel.cpp
+    AssetBrowser/AssetBrowserListModel.h
     AssetBrowser/AssetBrowserExpandedTableViewProxyModel.cpp
     AssetBrowser/AssetBrowserExpandedTableViewProxyModel.h
     AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp

--- a/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
@@ -14,7 +14,7 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserTableModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserListModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
@@ -75,7 +75,7 @@ namespace UnitTest
 
         AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserModel> m_assetBrowserModel;
         AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel> m_filterModel;
-        AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserTableModel> m_tableModel;
+        AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserListModel> m_tableModel;
 
         AZStd::unique_ptr<::testing::NiceMock<AZ::IO::MockFileIOBase>> m_fileIOMock;
         AZ::IO::FileIOBase* m_prevFileIO = nullptr;
@@ -95,7 +95,7 @@ namespace UnitTest
 
         m_assetBrowserModel = AZStd::make_unique<AzToolsFramework::AssetBrowser::AssetBrowserModel>();
         m_filterModel = AZStd::make_unique<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel>();
-        m_tableModel = AZStd::make_unique<AzToolsFramework::AssetBrowser::AssetBrowserTableModel>();
+        m_tableModel = AZStd::make_unique<AzToolsFramework::AssetBrowser::AssetBrowserListModel>();
 
         m_rootEntry = AZStd::make_shared<AzToolsFramework::AssetBrowser::RootAssetBrowserEntry>();
         m_assetBrowserModel->SetRootEntry(m_rootEntry);


### PR DESCRIPTION
Renames the tableView as listView and ExtendedTableView to tableview in the AssetBrowser to make the code more legible. Extending the code was more complicated than necessary because the old naming was ambiguous.

## How was this PR tested?

Built code and tested the functionality of the AssetBrowser wasn't affected.