### PR TITLE
No cross-prefab reparenting in editor transform component

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
@@ -216,4 +216,7 @@ namespace AzToolsFramework
     /// e.g. This is useful for getting a concise set of entities that need to be duplicated.
     EntityIdSet GetCulledEntityHierarchy(const EntityIdList& entities);
 
+    /// Checks if the selected entities and the new parent entity belong to the same prefab.
+    bool EntitiesBelongToSamePrefab(const EntityIdList& selectedEntities, const AZ::EntityId newParentId);
+
 }; // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -934,36 +934,45 @@ namespace AzToolsFramework
                 return AZ::Failure(AZStd::string("Trying to set an entity ID to something that isn't an entity ID."));
             }
 
-            AZ::EntityId actualValue = static_cast<AZ::EntityId>(*((AZ::EntityId*)newValue));
+            AZ::EntityId newParentId = static_cast<AZ::EntityId>(*((AZ::EntityId*)newValue));
 
-            if (!actualValue.IsValid())
+            if (!newParentId.IsValid())
             {
                 // Handled by the calling code.
                 return AZ::Success();
             }
 
-            // Only allow reparenting the selected entities if they are all under the same instance.
-            // We check the parent entity separately because it may be a container entity and
-            // container entities consider their owning instance to be the parent instance
-            EntityIdList entitiesToCheck;
-            entitiesToCheck.reserve(2);
-            entitiesToCheck.push_back(actualValue);
-            entitiesToCheck.push_back(GetEntityId());
-            const Prefab::PrefabPublicInterface* prefabPublicInterface = AZ::Interface<Prefab::PrefabPublicInterface>::Get();
-            if (prefabPublicInterface && !prefabPublicInterface->EntitiesBelongToSameInstance(entitiesToCheck))
-            {
-                return AZ::Failure(AZStd::string("An entity in one prefab cannot be a child to an entity in another prefab"));
-            }
+            AZ::EntityId selectedEntityId = GetEntityId();
 
             // Prevent setting the parent to the entity itself.
-            if (actualValue == GetEntityId())
+            if (newParentId == selectedEntityId)
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity's parent to itself."));
             }
 
+            // Prevent parenting to a different owning prefab instance.
+            // Note: The logic should be the same as defined in EntityOutlinerListModel::CanReparentEntities()
+            if (auto prefabPublicInterface = AZ::Interface<Prefab::PrefabPublicInterface>::Get())
+            {
+                AZ::EntityId selectedContainerId = prefabPublicInterface->GetInstanceContainerEntityId(selectedEntityId);
+                AZ::EntityId newParentContainerId = prefabPublicInterface->GetInstanceContainerEntityId(newParentId);
+                 
+                // If the selected entity id is a container entity id, then we need to get its parent owning instance.
+                // This is because a container entity is actually owned by the prefab instance itself.
+                if (selectedContainerId == selectedEntityId && !prefabPublicInterface->IsLevelInstanceContainerEntity(selectedEntityId))
+                {
+                    selectedContainerId = prefabPublicInterface->GetInstanceContainerEntityId(GetParentId());
+                }
+
+                if (selectedContainerId != newParentContainerId)
+                {
+                    return AZ::Failure(AZStd::string("You cannot set an entity to be a child of an entity owned by a different prefab."));
+                }
+            }
+
             // Don't allow the change if it will result in a cycle hierarchy
-            auto potentialParentTransformComponent = GetTransformComponent(actualValue);
-            if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(GetEntityId()))
+            auto potentialParentTransformComponent = GetTransformComponent(newParentId);
+            if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(selectedEntityId))
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children."));
             }
@@ -971,20 +980,20 @@ namespace AzToolsFramework
             // Don't allow read-only entities to be re-parented at all.
             // Also don't allow entities to be parented under read-only entities.
             if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
-                readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()) || readOnlyEntityPublicInterface->IsReadOnly(actualValue))
+                readOnlyEntityPublicInterface->IsReadOnly(selectedEntityId) || readOnlyEntityPublicInterface->IsReadOnly(newParentId))
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a read-only entity."));
             }
 
             // Don't allow entities to be parented under closed containers.
             if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
-                !containerEntityInterface->IsContainerOpen(actualValue))
+                !containerEntityInterface->IsContainerOpen(newParentId))
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container."));
             }
 
             // Don't allow entities to be parented outside their container.
-            if (m_focusModeInterface && !m_focusModeInterface->IsInFocusSubTree(actualValue))
+            if (m_focusModeInterface && !m_focusModeInterface->IsInFocusSubTree(newParentId))
             {
                 return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab."));
             }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15260 issue ([previous fix](https://github.com/o3de/o3de/pull/15726) did not fix all cases)

This PR blocks users from parenting an entity or a nested prefab to an entity owned by a different prefab in TransformComponent's parent field.

Previously, there was a PR https://github.com/o3de/o3de/pull/14411 blocking this, but it was only for drag-and-drop in Entity Outliner.

**Change List:**
- Add new check in editor's transform component
- Improve the existing check in EntityOutlinerListModel (remove `InstanceEntityMapperInterface` dependency)

## How was this PR tested?

- [x] TransformComponent: Tested in editor (as shown in video)
- [x] TransformComponent: Tested reparenting for multi-selected entities. It works for selected entities that might belong to different prefabs. Blocking still take effect.
- [x] EntityOutlinerListModel: Passed reparenting unit tests

https://user-images.githubusercontent.com/11157226/236561106-70ad77bb-ad3c-459e-b555-1524c473d8a7.mp4