### PR TITLE
Fix for corrupt binaries in a snap package

### DIFF
--- a/cmake/Platform/Linux/Packaging_Snapcraft.cmake
+++ b/cmake/Platform/Linux/Packaging_Snapcraft.cmake
@@ -15,28 +15,6 @@ execute_process (COMMAND lsb_release -a)
 
 execute_process (COMMAND bash ${CPACK_TEMPORARY_DIRECTORY}/O3DE/${CPACK_PACKAGE_VERSION}/python/get_python.sh)
 
-# Patch binaries to setup rpath and interpreter. Once snapcraft 7.3 is in stable, it should be possible to remove 
-# these 4 processes since automatic elf patching will be available for core22
-
-# setup the rpath
-execute_process (COMMAND find ./O3DE/${CPACK_PACKAGE_VERSION}/bin/Linux -type f -executable -exec patchelf --force-rpath --set-rpath \$ORIGIN:/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu {} \;
-                 WORKING_DIRECTORY ${CPACK_TEMPORARY_DIRECTORY}
-)
-
-# setup the correct elf interpreter
-execute_process (COMMAND find ./O3DE/${CPACK_PACKAGE_VERSION}/bin/Linux -type f -executable -exec patchelf --set-interpreter /snap/core22/current/lib64/ld-linux-x86-64.so.2 {} \;
-                 WORKING_DIRECTORY ${CPACK_TEMPORARY_DIRECTORY}
-)
-
-execute_process (COMMAND find ./O3DE/${CPACK_PACKAGE_VERSION}/python/runtime -type f -executable -exec patchelf --force-rpath --set-rpath \$ORIGIN:/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu {} \;
-                 WORKING_DIRECTORY ${CPACK_TEMPORARY_DIRECTORY}
-)
-
-# setup the correct elf interpreter
-execute_process (COMMAND find ./O3DE/${CPACK_PACKAGE_VERSION}/python/runtime -type f -executable -exec patchelf --set-interpreter /snap/core22/current/lib64/ld-linux-x86-64.so.2 {} \;
-                 WORKING_DIRECTORY ${CPACK_TEMPORARY_DIRECTORY}
-)
-
 # make sure that all files have the correct permissions
 execute_process (COMMAND chmod -R 755 O3DE
                  WORKING_DIRECTORY ${CPACK_TEMPORARY_DIRECTORY}


### PR DESCRIPTION
## What does this PR do?

The failure described https://github.com/o3de/o3de/issues/15856 the binaries that were copied into the bin folder (not compiled) were corrupted, most likely due to a conflict with the fixes to the package with manual rpath processing and snap-crafts own auto-rpath feature.

Removing the rpath manual work-around since the build nodes for the snap packaging is on a stable version of snap craft 7.3.1

## How was this PR tested?

Generated a test snap package and install locally, created a new project and new level

fixes https://github.com/o3de/o3de/issues/15856 
