### PR TITLE
Fix for a generic handling of invokable attributes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -200,18 +200,21 @@ namespace AZ::DocumentPropertyEditor
             {
                 return AZ::Reflection::ReadGenericAttributeToDomValue(instance, attribute).value_or(AZ::Dom::Value());
             }
-            // Handle the attribute providing an invokable function instead of the value directly
-            else if (attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
-            {
-                return attribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
-            }
             else
             {
                 AZ::AttributeReader reader(instance, attribute);
                 AttributeType value;
                 if (!reader.Read<AttributeType>(value))
                 {
-                    return AZ::Dom::Value();
+                    // Handle the attribute providing an invokable function instead of the value directly
+                    if (attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
+                    {
+                        return attribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
+                    }
+                    else
+                    {
+                        return AZ::Dom::Value();
+                    }
                 }
                 return ValueToDom(value);
             }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -200,6 +200,11 @@ namespace AZ::DocumentPropertyEditor
             {
                 return AZ::Reflection::ReadGenericAttributeToDomValue(instance, attribute).value_or(AZ::Dom::Value());
             }
+            // Handle the attribute providing an invokable function instead of the value directly
+            else if (attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
+            {
+                return attribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
+            }
             else
             {
                 AZ::AttributeReader reader(instance, attribute);

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -60,6 +60,11 @@ namespace DPEDebugView
         return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 
+    AZStd::string GetButtonText()
+    {
+        return "Button 2 (should be at bottom)";
+    }
+
     class TestContainer
     {
     public:
@@ -155,9 +160,11 @@ namespace DPEDebugView
             return enumValuesList;
         }
 
+        bool m_toggle = false;
         int m_simpleInt = 5;
         int m_readOnlyInt = 33;
         double m_doubleSlider = 3.25;
+        AZStd::string m_simpleString = "test";
         AZStd::vector<AZStd::string> m_vector;
         AZStd::vector<AZStd::vector<int>> m_vectorOfVectors;
         AZStd::map<AZStd::string, float> m_map;
@@ -183,13 +190,20 @@ namespace DPEDebugView
             return true;
         }
 
+        AZ::Crc32 IsToggleEnabled() const
+        {
+            return m_toggle ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        }
+
         static void Reflect(AZ::ReflectContext* context)
         {
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<TestContainer>()
+                    ->Field("toggle", &TestContainer::m_toggle)
                     ->Field("simpleInt", &TestContainer::m_simpleInt)
                     ->Field("doubleSlider", &TestContainer::m_doubleSlider)
+                    ->Field("simpleString", &TestContainer::m_simpleString)
                     ->Field("vector", &TestContainer::m_vector)
                     ->Field("vectorOfVectors", &TestContainer::m_vectorOfVectors)
                     ->Field("map", &TestContainer::m_map)
@@ -222,8 +236,12 @@ namespace DPEDebugView
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button1)
                         ->Attribute(AZ::Edit::Attributes::ButtonText, "Button 1 (should be at top)")
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Simple Types")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_toggle, "toggle switch", "")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleInt, "simple int", "")
                         ->DataElement(AZ::Edit::UIHandlers::Slider, &TestContainer::m_doubleSlider, "double slider", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleString, "simple string", "")
+                            ->Attribute(AZ::Edit::Attributes::Visibility, &TestContainer::IsToggleEnabled)
                         ->Attribute(AZ::Edit::Attributes::Min, -10.0)
                         ->Attribute(AZ::Edit::Attributes::Max, 10.0)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Containers")
@@ -276,7 +294,7 @@ namespace DPEDebugView
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_entityId, "entityId", "")
                         ->UIElement(AZ::Edit::UIHandlers::Button, "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button2)
-                        ->Attribute(AZ::Edit::Attributes::ButtonText, "Button 2 (should be at bottom)")
+                        ->Attribute(AZ::Edit::Attributes::ButtonText, &GetButtonText)
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "ReadOnly")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyInt, "readonly int", "")


### PR DESCRIPTION
## What does this PR do?

Fixes #15717, #15660

Added handling in `LegacyAttributeToDomValue` to check if the attribute is an invokable function as opposed to a value passed directly. This will fix several cases where attributes such as `Visibility` and `ButtonText` are supplied as a function.

Also added some additional properties to the DPE standalone view to exercise these paths.

![DPEInvokableAttributes](https://github.com/o3de/o3de/assets/7519264/4929200d-2f72-42cc-bfc9-8134c25f3f97)

## How was this PR tested?

Tested the properties in the DPE standalone, as well as the buttons in the Camera component and Landscape Canvas component.