### PR TITLE
Remove entities without a parent from instance object

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -159,6 +159,9 @@ namespace AzToolsFramework
             //! @param filter A user provided filter used to decide whether an entity should be detached. Returns true to detach.
             void RemoveEntitiesInHierarchy(const AZStd::function<bool(const AZStd::unique_ptr<AZ::Entity>&)>& filter);
 
+            //! Detaches entities based on a user provided filter. Returns true to detach.
+            void RemoveEntities(const AZStd::function<bool(const AZStd::unique_ptr<AZ::Entity>&)>& filter);
+
             //! Adds a new nested instance.
             //! @param instance The new nested instance.
             //! @return Reference to the new nested instance.
@@ -331,9 +334,6 @@ namespace AzToolsFramework
 
             //! Unregisters and erases all entities owned by this instance.
             void ClearEntities();
-
-            //! Detaches entities based on a user provided filter. Returns true to detach.
-            void RemoveEntities(const AZStd::function<bool(const AZStd::unique_ptr<AZ::Entity>&)>& filter);
 
             //! Functions for get-entity implementation.
             //! @{


### PR DESCRIPTION
## What does this PR do?

When using the "add/remove entity as override" prefab feature, a prefab instance can end up with child entities that do not have a valid parent. This PR removes the invalid entities from their instance object if they do not have a parent. Otherwise, the Entity Outliner places the entities on the root, and the level is not arranged correctly in the outliner tree.

Note: Warnings on invalid patch paths will still show up in the console when propagating changes to an instance, or in the error dialog when loading the level. We may want to address this in a separate PR.

Fixes #15627, #15625

## How was this PR tested?

Tested in Editor using repro steps in ticket.