### PR TITLE
Fix compile error in zstd_compression.cpp when using system ZStd

### DIFF
--- a/Code/Framework/AzCore/AzCore/Compression/zstd_compression.cpp
+++ b/Code/Framework/AzCore/AzCore/Compression/zstd_compression.cpp
@@ -61,7 +61,7 @@ void ZStd::StartCompressor(unsigned int compressionLevel)
 
     AZ_UNUSED(compressionLevel);
     m_streamCompression = (ZSTD_createCStream_advanced(customAlloc));
-    AZ_Assert( m_streamCompression , "ZStandard internal error - failed to create compression stream\n");
+    AZ_Assert(m_streamCompression , "ZStandard internal error - failed to create compression stream\n");
 }
 
 void ZStd::StopCompressor()
@@ -75,8 +75,14 @@ void ZStd::StopCompressor()
 void ZStd::ResetCompressor()
 {
     AZ_Assert(m_streamCompression, "Compressor not started!");
-    size_t r = ZSTD_resetCStream(m_streamCompression,0);
-    AZ_UNUSED(r);
+    // The change to ZSTD_Ctx_reset api occured first occured in ZStd version 1.3.8
+    // https://github.com/facebook/zstd/commit/ff8d37170808931cdca10846da1c23aaf27084fb#diff-e51691a217ef645007ebc5dd6db0539c32d0a531aad5823873adb12d995341b5
+#if ZSTD_VERSION_NUMBER >= 10308
+    ZSTD_CCtx_reset(m_streamCompression, ZSTD_reset_session_only);
+    [[maybe_unused]] size_t r = ZSTD_CCtx_setPledgedSrcSize(m_streamCompression, ZSTD_CONTENTSIZE_UNKNOWN);
+#else
+    [[maybe_unused]] size_t r = ZSTD_resetCStream(m_streamCompression,0);
+#endif
     AZ_Assert(!ZSTD_isError(r), "Can't reset compressor");
 }
 
@@ -155,7 +161,13 @@ unsigned int ZStd::Decompress(const void* compressedData, unsigned int compresse
 
     if (m_nextBlockSize == 0)
     {
+        // The ZSTD_DCtx_reset function was updated in 1.3.8 to support the reset directive enum
+        // https://github.com/facebook/zstd/commit/5c68639186e80469e9a426553a578864902133c4
+#if ZSTD_VERSION_NUMBER >= 10308
+        m_nextBlockSize = ZSTD_DCtx_reset(m_streamDecompression, ZSTD_reset_session_only);
+#else
         m_nextBlockSize = ZSTD_resetDStream(m_streamDecompression);
+#endif
     }
 
     m_compressedBufferIndex += azlossy_cast<unsigned int>(m_inBuffer.pos);


### PR DESCRIPTION
When the system ZStd version of 1.38 or above is used,, a compiler warning is triggered due to calling a deprecated zstd function

```
[47/2376] Building CXX object Code/Framework/AzCore/CMakeFiles/AzCore.dir/profile/Unity/unity_2_cxx.cxx.o
FAILED: Code/Framework/AzCore/CMakeFiles/AzCore.dir/profile/Unity/unity_2_cxx.cxx.o
/usr/sbin/clang++ -DAZ_BUILD_CONFIGURATION_TYPE=\"profile\" -DAZ_ENABLE_DEBUG_TOOLS -DAZ_ENABLE_TRACING -DAZ_PROFILE_BUILD -DLINUX -DLINUX64 -DNDEBUG -D_FORTIFY_SOURCE=2 -D_HAS_EXCEPTIONS=0 -D_PROFILE -D__linux__ -DCMAKE_INTDIR=\"profile\" -I/home/lumberyard-employee-dm/o3de/Code/Framework/AzCore/. -I/home/lumberyard-employee-dm/o3de/Code/Framework/AzCore/Platform/Linux -I/home/lumberyard-employee-dm/o3de/Code/Framework/AzCore/Platform/Common -isystem /home/lumberyard-employee-dm/.o3de/3rdParty/packages/Lua-5.4.4-rev1-linux/Lua/include -isystem /home/lumberyard-employee-dm/.o3de/3rdParty/packages/RapidJSON-1.1.0-rev1-multiplatform/RapidJSON/include -isystem /home/lumberyard-employee-dm/.o3de/3rdParty/packages/RapidXML-1.13-rev1-multiplatform/RapidXML/include -isystem /home/lumberyard-employee-dm/.o3de/3rdParty/packages/zlib-1.2.11-rev5-linux/zlib/include -isystem /home/lumberyard-employee-dm/.o3de/3rdParty/packages/cityhash-1.1-multiplatform/cityhash/src -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Werror -Wno-inconsistent-missing-override -Wrange-loop-analysis -Wno-unknown-warning-option -Wno-parentheses -Wno-reorder -Wno-switch -Wno-undefined-var-template -msse4.1  -O2 -g -fstack-protector-all -fstack-check -std=c++17 -fPIC -MD -MT Code/Framework/AzCore/CMakeFiles/AzCore.dir/profile/Unity/unity_2_cxx.cxx.o -MF Code/Framework/AzCore/CMakeFiles/AzCore.dir/profile/Unity/unity_2_cxx.cxx.o.d -o Code/Framework/AzCore/CMakeFiles/AzCore.dir/profile/Unity/unity_2_cxx.cxx.o -c /home/lumberyard-employee-dm/o3de/build/linux/Code/Framework/AzCore/CMakeFiles/AzCore.dir/Unity/unity_2_cxx.cxx
In file included from /home/lumberyard-employee-dm/o3de/build/linux/Code/Framework/AzCore/CMakeFiles/AzCore.dir/Unity/unity_2_cxx.cxx:9:
/home/lumberyard-employee-dm/o3de/Code/Framework/AzCore/AzCore/Compression/zstd_compression.cpp:78:16: error: 'ZSTD_resetCStream' is deprecated: use ZSTD_CCtx_reset, see zstd.h for detailed instructions [-Werror,-Wdeprecated-declarations]
    size_t r = ZSTD_resetCStream(m_streamCompression,0);
               ^
/usr/include/zstd.h:2569:1: note: 'ZSTD_resetCStream' has been explicitly marked deprecated here
ZSTD_DEPRECATED("use ZSTD_CCtx_reset, see zstd.h for detailed instructions")
^
/usr/include/zstd.h:59:40: note: expanded from macro 'ZSTD_DEPRECATED'
                                       ^
In file included from /home/lumberyard-employee-dm/o3de/build/linux/Code/Framework/AzCore/CMakeFiles/AzCore.dir/Unity/unity_2_cxx.cxx:9:
/home/lumberyard-employee-dm/o3de/Code/Framework/AzCore/AzCore/Compression/zstd_compression.cpp:158:27: error: 'ZSTD_resetDStream' is deprecated: use ZSTD_DCtx_reset, see zstd.h for detailed instructions [-Werror,-Wdeprecated-declarations]
        m_nextBlockSize = ZSTD_resetDStream(m_streamDecompression);
                          ^
/usr/include/zstd.h:2638:1: note: 'ZSTD_resetDStream' has been explicitly marked deprecated here
ZSTD_DEPRECATED("use ZSTD_DCtx_reset, see zstd.h for detailed instructions")
^
/usr/include/zstd.h:59:40: note: expanded from macro 'ZSTD_DEPRECATED'
                                       ^
2 errors generated.
```

## How was this PR tested?

Built the `install` target on ArchLinux successfully
