### PR TITLE
Fixed DPE handling of the Label UIElement

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -49,6 +49,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
         system->RegisterNode<Label, NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<Label>(Label::Value);
+        system->RegisterNodeAttribute<Label>(Label::ValueText);
 
         system->RegisterNode<PropertyEditor, NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::OnChanged);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -88,6 +88,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         static constexpr AZStd::string_view Name = "Label";
         static constexpr auto Value = AttributeDefinition<AZStd::string_view>("Value");
+        static constexpr auto ValueText = AttributeDefinition<AZStd::string_view>("ValueText");
     };
 
     //! Specifies types describing a value change's state.

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -296,6 +296,8 @@ namespace DPEDebugView
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &Button2)
                         ->Attribute(AZ::Edit::Attributes::ButtonText, &GetButtonText)
                         ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
+                        ->UIElement(AZ::Edit::UIHandlers::Label, "")
+                        ->Attribute(AZ::Edit::Attributes::ValueText, "<h2>Label UIElement</h2>This is a test of a UIElement label<br>that can handle multiple lines of text that also can be wrapped onto newlines<br>and can also support <a href='https://doc.qt.io/qt-5/richtext-html-subset.html'>rich text</a>")
                         ->ClassElement(AZ::Edit::ClassElements::Group, "ReadOnly")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_readOnlyInt, "readonly int", "")
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, &TestContainer::IsDataReadOnly)


### PR DESCRIPTION
## What does this PR do?

Fixes #15744 

The DPE wasn't parsing the `ValueText` attribute for the `Label` handler, so it wasn't being populated, so just had to add it. Also added example of the label UIElement to the DPE example view.

![DPEDebugViewStandalone_Zwr5Pu6kte](https://github.com/o3de/o3de/assets/7519264/73c088cf-429b-46e3-b414-b2ddc80df32f)

## How was this PR tested?

Tested `PhysX Static Rigid Body` component with DPE and verified the label text is now displayed. Also tested the example usage in the DPE example view.