### PR TITLE
Atom Tools: Prevent asset selection widgets from displaying non existent assets

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -77,10 +77,15 @@ namespace AtomToolsFramework
         }
 
         const auto& pathWithAlias = GetPathWithAlias(path);
+        const auto& pathWithoutAlias = GetPathWithoutAlias(path);
+        if (!QFileInfo::exists(pathWithoutAlias.c_str()))
+        {
+            return;
+        }
+
         const QVariant pathItemData(QString::fromUtf8(pathWithAlias.c_str(), static_cast<int>(pathWithAlias.size())));
         if (const int index = findData(pathItemData); index < 0)
         {
-            const auto& pathWithoutAlias = GetPathWithoutAlias(path);
             const auto& title = GetDisplayNameFromPath(pathWithoutAlias);
 
             // Compare the item title against all other items and append a suffix until the new title is unique

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -91,6 +91,11 @@ namespace AtomToolsFramework
 
         const auto& pathWithAlias = GetPathWithAlias(path);
         const auto& pathWithoutAlias = GetPathWithoutAlias(path);
+        if (!QFileInfo::exists(pathWithoutAlias.c_str()))
+        {
+            return;
+        }
+
         const QVariant pathItemData(QString::fromUtf8(pathWithAlias.c_str(), static_cast<int>(pathWithAlias.size())));
         const QString title(GetDisplayNameFromPath(pathWithAlias).c_str());
 


### PR DESCRIPTION
## What does this PR do?

This may happen if settings are saved referencing lighting and model presets or other files that were deleted since the settings were saved.

## How was this PR tested?

Confirmed that asset selection controls in material editor and material canvas still operate as expected and reject nonexistent files.