### PR TITLE
Atom Tools: Change file enumeration to add logging and use extension checks instead of wild cards

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -290,8 +290,8 @@ namespace AtomToolsFramework
     // Visits all scan folders asynchronously, gathering all of the paths matching the filter. 
     AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingFilter(const AZStd::function<bool(const AZStd::string&)> filterFn);
 
-    //! Collect a set of file paths from all project safe folders matching a wild card
-    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard);
+    //! Collect a set of file paths from all project safe folders matching an extension
+    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingExtension(const AZStd::string& extension);
 
     //! Return a list of all asset safe folders except for those underneath the cache folder, usually intermediate asset folders.
     AZStd::vector<AZStd::string> GetNonCacheSourceFolders();

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportSettingsSystem.cpp
@@ -589,6 +589,7 @@ namespace AtomToolsFramework
         AZ::Job* job = AZ::CreateJobFunction(
             [toolId = m_toolId]()
             {
+                AZ_TracePrintf("EntityPreviewViewportSettingsSystem", "Enumerating presets started.");
                 auto filterFn = [](const AZStd::string& path)
                 {
                     return
@@ -598,6 +599,8 @@ namespace AtomToolsFramework
                 };
 
                 const auto& paths = GetPathsInSourceFoldersMatchingFilter(filterFn);
+                AZ_TracePrintf("EntityPreviewViewportSettingsSystem", "Enumerating presets finished.");
+
                 AZ::TickBus::QueueFunction(
                     [toolId, paths]()
                     {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/DynamicNode/DynamicNodeManager.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/DynamicNode/DynamicNodeManager.cpp
@@ -76,7 +76,7 @@ namespace AtomToolsFramework
     void DynamicNodeManager::LoadConfigFiles(const AZStd::string& extension)
     {
         // Load and register all discovered dynamic node configuration
-        for (const auto& configPath : GetPathsInSourceFoldersMatchingWildcard(AZStd::string::format("*.%s", extension.c_str())))
+        for (const auto& configPath : GetPathsInSourceFoldersMatchingExtension(extension))
         {
             DynamicNodeConfig config;
             if (config.Load(configPath))

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/DynamicNode/DynamicNodeManager.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/DynamicNode/DynamicNodeManager.cpp
@@ -75,6 +75,8 @@ namespace AtomToolsFramework
 
     void DynamicNodeManager::LoadConfigFiles(const AZStd::string& extension)
     {
+        AZ_TracePrintf("DynamicNodeManager", "Load %s config files started.", extension.c_str());
+
         // Load and register all discovered dynamic node configuration
         for (const auto& configPath : GetPathsInSourceFoldersMatchingExtension(extension))
         {
@@ -89,6 +91,8 @@ namespace AtomToolsFramework
                 RegisterConfig(config);
             }
         }
+
+        AZ_TracePrintf("DynamicNodeManager", "Load %s config files finished.", extension.c_str());
     }
 
     bool DynamicNodeManager::RegisterConfig(const DynamicNodeConfig& config)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -718,11 +718,10 @@ namespace AtomToolsFramework
     {
         const auto& scanFolders = GetNonCacheSourceFolders();
 
-        AZStd::mutex resultsMutex;
         AZStd::vector<AZStd::string> results;
         results.reserve(scanFolders.size());
 
-        AZ::parallel_for_each(
+        AZStd::for_each(
             scanFolders.begin(),
             scanFolders.end(),
             [&](const AZStd::string& scanFolder)
@@ -733,7 +732,6 @@ namespace AtomToolsFramework
                     {
                         if (!filterFn || filterFn(path))
                         {
-                            AZStd::scoped_lock lock(resultsMutex);
                             results.emplace_back(path);
                         }
                         return true;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -748,12 +748,18 @@ namespace AtomToolsFramework
         return results;
     }
 
-    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingWildcard(const AZStd::string& wildcard)
+    AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingExtension(const AZStd::string& extension)
     {
+        if (extension.empty())
+        {
+            return {};
+        }
+
+        const AZStd::string& extensionWithDot = (extension[0] == '.') ? extension : AZStd::string::format(".%s", extension.c_str());
         return GetPathsInSourceFoldersMatchingFilter(
             [&](const AZStd::string& path)
             {
-                return AZ::IO::NameMatchesFilter(path, wildcard) && IsDocumentPathEditable(path);
+                return path.ends_with(extensionWithDot) && IsDocumentPathEditable(path);
             });
     }
 
@@ -859,7 +865,7 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetPathToExteralReference", GetPathToExteralReference, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithoutAlias", GetPathWithoutAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithAlias", GetPathWithAlias, nullptr, ""));
-            addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingWildcard", GetPathsInSourceFoldersMatchingWildcard, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingExtension", GetPathsInSourceFoldersMatchingExtension, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetNonCacheSourceFolders", GetNonCacheSourceFolders, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSettingsValue_bool", GetSettingsValue<bool>, nullptr, ""));
             addUtilFunc(behaviorContext->Method("SetSettingsValue_bool", SetSettingsValue<bool>, nullptr, ""));

--- a/Gems/Atom/Tools/MaterialCanvas/Scripts/TestOpenClose.py
+++ b/Gems/Atom/Tools/MaterialCanvas/Scripts/TestOpenClose.py
@@ -13,7 +13,7 @@ import collections
 import random
 
 def main():
-    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.materialgraph')
+    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingExtension('materialgraph')
     for path in paths.copy():
         if 'cache' in path.lower():
             paths.remove(path)

--- a/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
+++ b/Gems/Atom/Tools/MaterialEditor/Scripts/UpgradeAllMaterials.py
@@ -12,7 +12,7 @@ import azlmbr.paths
 import collections
 
 def main():
-    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingWildcard('*.material')
+    paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingExtension('material')
     for path in paths.copy():
         if 'cache' in path.lower():
             paths.remove(path)


### PR DESCRIPTION
## What does this PR do?

This PR changes file enumeration functions to use a faster extension filter instead of a wild card filter. 
Logging was also added to record how long it takes to enumerate files in different systems.
Parallelization was removed from directory traversal.
This is all in an ever dude determine what might cause extended startup times on some machines.
The extended delay is usually on the first run after downloading the engine or setting up a new project where Python symbols and other data have not been saved yet.

## How was this PR tested?

Launched affected tools and ran included Python scripts