### PR TITLE
Fix PopcornFX loading and registration

### DIFF
--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -236,6 +236,7 @@ function(ly_enable_gems)
 
     # Remove any version specifiers before looking for variants
     # e.g. "Atom==1.2.3" becomes "Atom"
+    unset(GEM_NAMES)
     foreach(gem_name_with_version_specifier IN LISTS ly_enable_gems_GEMS)
         o3de_get_name_and_version_specifier(${gem_name_with_version_specifier} gem_name spec_op spec_version)
         list(APPEND GEM_NAMES "${gem_name}")

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -234,6 +234,14 @@ function(ly_enable_gems)
         set(ENABLED_GEMS ${store_temp}) # restore value of ENABLED_GEMS just in case...
     endif()
 
+    # Remove any version specifiers before looking for variants
+    # e.g. "Atom==1.2.3" becomes "Atom"
+    foreach(gem_name_with_version_specifier IN LISTS ly_enable_gems_GEMS)
+        o3de_get_name_and_version_specifier(${gem_name_with_version_specifier} gem_name spec_op spec_version)
+        list(APPEND GEM_NAMES "${gem_name}")
+    endforeach()
+    set(ly_enable_gems_GEMS ${GEM_NAMES})
+
     # all the actual work has to be done later.
     set_property(GLOBAL APPEND PROPERTY LY_DELAYED_ENABLE_GEMS "${ly_enable_gems_PROJECT_NAME}")
     define_property(GLOBAL PROPERTY LY_DELAYED_ENABLE_GEMS_"${ly_enable_gems_PROJECT_NAME}"

--- a/scripts/o3de/o3de/download.py
+++ b/scripts/o3de/o3de/download.py
@@ -209,12 +209,14 @@ def download_o3de_object(object_name: str, default_folder_name: str, dest_path: 
                 return 1
 
     if not skip_auto_register:
+        # force register with the o3de_manifest to prevent accidentally registering 
+        # to a gem.json that was previously downloaded in some parent folder
         if object_type == 'gem':
-            return register.register(gem_path=dest_path)
+            return register.register(gem_path=dest_path, force_register_with_o3de_manifest=True)
         elif object_type == 'project':
-            return register.register(project_path=dest_path)
+            return register.register(project_path=dest_path, force_register_with_o3de_manifest=True)
         elif object_type == 'template':
-            return register.register(template_path=dest_path)
+            return register.register(template_path=dest_path, force_register_with_o3de_manifest=True)
 
     return 0
 

--- a/scripts/o3de/tests/test_download.py
+++ b/scripts/o3de/tests/test_download.py
@@ -553,7 +553,7 @@ class TestObjectDownload:
             git_provider_mock.clone_from_git = MagicMock(side_effect=clone_from_git)
             return git_provider_mock
 
-        def register(gem_path: pathlib.Path = None):
+        def register(gem_path: pathlib.Path = None, force_register_with_o3de_manifest:bool = False ):
             self.registered_path = gem_path
             return 0
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15893

When a specific version of a gem is used in ProjectManager the `project.json` `gem_names` entry looks like `PopcornFX==2.16.2` but when CMake is looking for all the variants to load the `==2.16.2` part was not stripped and so none of the load targets were found.  This change removes the version specifiers so the gem name alone is used in the search for variants.

Fixes https://github.com/o3de/o3de/issues/15925

The default gem registration will not use the `o3de_manifest.json` in the case when the user downloads a version of a gem into a folder that has a `gem.json` in a parent folder - this can happen for downloaded gems that were previously downloaded without gem versions, and then a subsequent versioned gem is downloaded and ends up in a versioned subfolder.  The fix is to always register downloaded content in the `o3de_manifest.json`.  The user can re-register the content if they want to register it with a project or engine, but that would be uncommon behavior when most downloaded content is meant to be available for multiple engines and projects.

## How was this PR tested?

Reproduced the issue in python debugger, then applied the fix to verify it no longer repros and the gem appears in the `o3de_manifest.json`
Used cmake configure with Python 2.16.2. and verified the Python dlls appear in the .setreg like they should and get loaded
