### PR TITLE
Changed the max number of concurrent thumbnail loads

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -26,7 +26,7 @@ namespace AzToolsFramework
             : m_missingThumbnail(new MissingThumbnail())
             , m_loadingThumbnail(new LoadingThumbnail())
             , m_currentJobsCount(0)
-            , m_maxThumbnailJobs(std::thread::hardware_concurrency())
+            , m_maxThumbnailJobs(AZStd::thread::hardware_concurrency())
         {
             // Increase the maximum number of QThreads to support the number of
             // concurrent jobs needed here.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -26,7 +26,7 @@ namespace AzToolsFramework
             : m_missingThumbnail(new MissingThumbnail())
             , m_loadingThumbnail(new LoadingThumbnail())
             , m_currentJobsCount(0)
-            , m_maxThumbnailJobs(AZStd::thread::hardware_concurrency())
+            , m_maxThumbnailJobs(AZStd::max(8, static_cast<int>(AZStd::thread::hardware_concurrency())))
         {
             // Increase the maximum number of QThreads to support the number of
             // concurrent jobs needed here.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -26,6 +26,7 @@ namespace AzToolsFramework
             : m_missingThumbnail(new MissingThumbnail())
             , m_loadingThumbnail(new LoadingThumbnail())
             , m_currentJobsCount(0)
+            , m_maxThumbnailJobs(std::thread::hardware_concurrency())
         {
             // Increase the maximum number of QThreads to support the number of
             // concurrent jobs needed here.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
@@ -69,7 +69,7 @@ namespace AzToolsFramework
             //! Default loading thumbnail used when thumbnail is found by is not yet generated
             SharedThumbnail m_loadingThumbnail;
             //! Maximum number of concurrent jobs allowed.
-            const int m_maxThumbnailJobs{ 64 };
+            int m_maxThumbnailJobs;
             //! Current number of jobs running.
             int m_currentJobsCount;
         };


### PR DESCRIPTION
## What does this PR do?

There was a bug that in certain circumstances the AssetBrowser Thumbnail view could hang if too many concurrent loads occurred. This is now set to the number of hardware threads available.

## How was this PR tested?
Tested under circumstances that previously failed. All working now,
