### PR TITLE
Fix NetBindComponent leaks / crashes

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetBindComponent.h
@@ -50,7 +50,7 @@ namespace Multiplayer
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         NetBindComponent();
-        ~NetBindComponent() override = default;
+        ~NetBindComponent() override;
 
         //! AZ::Component overrides.
         //! @{
@@ -223,6 +223,9 @@ namespace Multiplayer
 
         void StopEntity();
 
+        void Register(AZ::Entity* entity);
+        void Unregister();
+
         ReplicationRecord m_currentRecord = NetEntityRole::InvalidRole;
         ReplicationRecord m_totalRecord = NetEntityRole::InvalidRole;
         ReplicationRecord m_predictableRecord = NetEntityRole::Autonomous;
@@ -267,6 +270,7 @@ namespace Multiplayer
         bool m_isMigrationDataValid = false;
         bool m_needsToBeStopped     = false;
         bool m_playerHostAutonomyEnabled = false; // Set to true for the host's controlled entity
+        bool m_isRegistered = false;
 
         friend class NetworkEntityManager;
         friend class EntityReplicationManager;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -559,7 +559,10 @@ namespace Multiplayer
         {
             if (entityReplicator->IsMarkedForRemoval())
             {
-                AZLOG_WARN("Entity replicator for id %llu is already marked for deletion on remote host %s", static_cast<AZ::u64>(updateMessage.GetEntityId()), GetRemoteHostId().GetString().c_str());
+                AZLOG_WARN("Entity replicator for id %llu (%s) is already marked for deletion on remote host %s",
+                    static_cast<AZ::u64>(updateMessage.GetEntityId()),
+                    entityReplicator->GetEntityHandle().GetEntity()->GetName().c_str(),
+                    GetRemoteHostId().GetString().c_str());
                 return true;
             }
             else if (entityReplicator->OwnsReplicatorLifetime())

--- a/Gems/Multiplayer/Code/Tests/ClientHierarchyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/ClientHierarchyTests.cpp
@@ -25,18 +25,62 @@ namespace Multiplayer
     using namespace ::UnitTest;
 
     /*
+     * Test NetBindComponent creation / destruction without activation. This must work before more complicated tests.
+     */
+    TEST_F(HierarchyTests, On_Client_NetBindComponent_Init)
+    {
+        auto multiplayer = AZ::Interface<IMultiplayer>::Get();
+        auto networkEntityManager = multiplayer->GetNetworkEntityManager();
+        auto netTracker = networkEntityManager->GetNetworkEntityTracker();
+
+        // At the start, there shouldn't be anything in the Network Entity Manager.
+        EXPECT_EQ(networkEntityManager->GetEntityCount(), 0);
+
+        AZStd::unique_ptr<AZ::Entity> entity = AZStd::make_unique<AZ::Entity>();
+        AZ::Entity* rawEntityPtr = entity.get();
+        auto netBindComponent = entity->CreateComponent<NetBindComponent>();
+        SetupEntity(entity, NetEntityId{ 1 }, NetEntityRole::Client);
+
+        // After the netBindComponent is initialized, it should appear in the NetworkEntityManager and the NetworkEntityTracker.
+        EXPECT_EQ(networkEntityManager->GetEntityCount(), 1);
+        EXPECT_EQ(netBindComponent, netTracker->GetNetBindComponent(rawEntityPtr));
+
+        StopEntity(entity);
+        entity.reset();
+
+        // After the entity is destroyed, it should no longer appear in the NetworkEntityManager and the NetworkEntityTracker.
+        // This should be true whether or not the entity was ever activated.
+        EXPECT_EQ(networkEntityManager->GetEntityCount(), 0);
+        EXPECT_EQ(netTracker->GetNetBindComponent(rawEntityPtr), nullptr);
+    }
+
+    /*
      * Test NetBindComponent activation. This must work before more complicated tests.
      */
     TEST_F(HierarchyTests, On_Client_NetBindComponent_Activate)
     {
+        auto multiplayer = AZ::Interface<IMultiplayer>::Get();
+        auto networkEntityManager = multiplayer->GetNetworkEntityManager();
+        auto netTracker = networkEntityManager->GetNetworkEntityTracker();
+
+        // At the start, there shouldn't be anything in the Network Entity Manager.
+        EXPECT_EQ(networkEntityManager->GetEntityCount(), 0);
+
         AZStd::unique_ptr<AZ::Entity> entity = AZStd::make_unique<AZ::Entity>();
+        AZ::Entity* rawEntityPtr = entity.get();
         entity->CreateComponent<NetBindComponent>();
+
         SetupEntity(entity, NetEntityId{ 1 }, NetEntityRole::Client);
         entity->Activate();
 
         StopEntity(entity);
-
         entity->Deactivate();
+        entity.reset();
+
+        // After the entity is destroyed, it should no longer appear in the NetworkEntityManager and the NetworkEntityTracker.
+        // This should be true whether or not the entity was ever activated.
+        EXPECT_EQ(networkEntityManager->GetEntityCount(), 0);
+        EXPECT_EQ(netTracker->GetNetBindComponent(rawEntityPtr), nullptr);
     }
 
     /*

--- a/Gems/Multiplayer/Code/Tests/CommonHierarchySetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonHierarchySetup.h
@@ -114,7 +114,9 @@ namespace Multiplayer
             AZ::Interface<INetworkEntityManager>::Register(m_mockNetworkEntityManager.get());
 
             ON_CALL(*m_mockNetworkEntityManager, AddEntityToEntityMap(_, _)).WillByDefault(Invoke(this, &HierarchyTests::AddEntityToEntityMap));
+            ON_CALL(*m_mockNetworkEntityManager, RemoveEntityFromEntityMap(_)).WillByDefault(Invoke(this, &HierarchyTests::RemoveEntityFromEntityMap));
             ON_CALL(*m_mockNetworkEntityManager, GetEntity(_)).WillByDefault(Invoke(this, &HierarchyTests::GetEntity));
+            ON_CALL(*m_mockNetworkEntityManager, GetEntityCount()).WillByDefault(Invoke(this, &HierarchyTests::GetEntityCount));
             ON_CALL(*m_mockNetworkEntityManager, GetNetEntityIdById(_)).WillByDefault(Invoke(this, &HierarchyTests::GetNetEntityIdById));
 
             m_mockTime = AZStd::make_unique<AZ::NiceTimeSystemMock>();
@@ -223,6 +225,16 @@ namespace Multiplayer
         {
             m_networkEntityMap[netEntityId] = entity;
             return NetworkEntityHandle(entity, m_networkEntityTracker.get());
+        }
+
+        void RemoveEntityFromEntityMap(NetEntityId netEntityId)
+        {
+            m_networkEntityMap.erase(netEntityId);
+        }
+
+        uint32_t GetEntityCount() const
+        {
+            return aznumeric_cast<uint32_t>(m_networkEntityMap.size());
         }
 
         ConstNetworkEntityHandle GetEntity(NetEntityId netEntityId) const


### PR DESCRIPTION
## What does this PR do?

Multiplayer Sample experienced infrequent, intermittent crashes in NetBindComponent::NotifyPreRender ( https://github.com/o3de/o3de-multiplayersample/issues/349 ). These crashes appear to be caused through "leaked" pointers to the NetBindComponent and its entity, where the component registered itself with the NetworkEntityManager and NetworkEntityTracker but then never unregistered itself prior to deletion.

Upon investigation, it appears that this case was caused by deleting networked entities that had been initialized but not Activated. The registration occured in PreInit(), but the deregistration occured in Deactivate(), so if the entity was initialized but not activated, the Deactivate() would never get called and the deregistration would get skipped.

This PR fixes the problem by ensuring that the NetBindComponent always calls Deregister() on destruction.

## How was this PR tested?

1. Added a new unit test demonstrating that initializing but not activating the NetBindComponent was leaving remnants in the NetworkEntityManager and NetworkEntityTracker. Verified that with the new changes, the unit test passes, and no remnants remain.
2. Verified in MPS that there were occasional cases of the NetworkEntityManager marking enitites for removal while they were in the Init state, and verified in the NetBindComponent destructor that in those cases, it was getting destroyed while still registered.

There are still other entity lifetime issues occuring in MPS in development right now, but I haven't seen any more occurrences of this specific crash with this fix.