### PR TITLE
Give undo batch handling responsibility to PropertyManagerComponent

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -119,28 +119,17 @@ namespace AzToolsFramework::Prefab
                 instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(true);
             }
 
-            if (m_currentUndoBatch)
+            AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+                m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetCurrentUndoBatch);
+            if (!m_currentUndoBatch)
             {
+                AZ_Warning(
+                    "Prefab",
+                    false,
+                    "New undo batch is being created in PrefabComponentAdapter. This is unusual. An undo batch should already have "
+                    "existed by this point.");
                 AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch,
-                    &AzToolsFramework::ToolsApplicationRequests::ResumeUndoBatch,
-                    m_currentUndoBatch,
-                    "Modify Component Property");
-            }
-            else
-            {
-                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetCurrentUndoBatch);
-                if (!m_currentUndoBatch)
-                {
-                    AZ_Warning(
-                        "Prefab",
-                        false,
-                        "New undo batch is being created in PrefabComponentAdapter. This is unusual. An undo batch should already have "
-                        "existed by this point.");
-                    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                        m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Component Property");
-                }
+                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Component Property");
             }
 
             AZ::Dom::Path serializedPath = propertyChangeInfo.path / AZ::Reflection::DescriptorAttributes::SerializedPath;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -125,12 +125,22 @@ namespace AzToolsFramework::Prefab
                     m_currentUndoBatch,
                     &AzToolsFramework::ToolsApplicationRequests::ResumeUndoBatch,
                     m_currentUndoBatch,
-                    "Modify Entity Property");
+                    "Modify Component Property");
             }
             else
             {
                 AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Entity Property");
+                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetCurrentUndoBatch);
+                if (!m_currentUndoBatch)
+                {
+                    AZ_Warning(
+                        "Prefab",
+                        false,
+                        "New undo batch is being created in PrefabComponentAdapter. This is unusual. An undo batch should already have "
+                        "existed by this point.");
+                    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+                        m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Component Property");
+                }
             }
 
             AZ::Dom::Path serializedPath = propertyChangeInfo.path / AZ::Reflection::DescriptorAttributes::SerializedPath;
@@ -185,8 +195,6 @@ namespace AzToolsFramework::Prefab
                     NotifyContentsChanged(patches);
                 }
             }
-
-            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::EndUndoBatch);
         }
         else if (propertyChangeInfo.changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -8,6 +8,7 @@
 #include "PropertyManagerComponent.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ToolsComponents/EditorEntityIdContainer.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrlTypes.h>
@@ -183,6 +184,9 @@ namespace AzToolsFramework
 
         void PropertyManagerComponent::RequestWrite(QWidget* editorGUI)
         {
+            AzToolsFramework::UndoSystem::URSequencePoint* undoBatch = nullptr;
+            AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+                undoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Property");
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
                 AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit);
@@ -193,6 +197,7 @@ namespace AzToolsFramework
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
                 AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit);
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::EndUndoBatch);
         }
 
         void PropertyManagerComponent::RequestPropertyNotify(QWidget* editorGUI)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/Component.h>
 #include "PropertyEditorAPI.h"
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
 
 // the property manager component's job is to provide the services for registration of property editors.
 // it also registers all of our built-in property manager types
@@ -80,6 +81,8 @@ namespace AzToolsFramework
             DefaultHandlerMap m_DefaultHandlers;
 
             AZStd::vector<PropertyHandlerBase*> m_builtInHandlers; // exists purely to delete them later.
+
+            AzToolsFramework::UndoSystem::URSequencePoint* m_currentUndoBatch = nullptr;
 
             void CreateBuiltInHandlers();
         };


### PR DESCRIPTION
## What does this PR do?

This PR fixes one of the issues listed in https://github.com/o3de/o3de/issues/15918 where undoing a multi-edit action requires hitting undo 'n' times, where n is the number of entities being modified

This PR gives the responsibility of creating and ending undo batch to PropertyManagerComponent, which is the source for all DPE property edits.

This PR needs to go along with https://github.com/o3de/o3de/pull/15943 to fix the issue fully.

Another cool benefit we get with this approach is that we can do both direct template edits and overrides together using multi-edit. The prefab adapter takes care of doing the right calls. But the undo system doesn't need to know anything about it rightfully so.

## How was this PR tested?

Manually along with https://github.com/o3de/o3de/pull/15943
