### PR TITLE
EditorComponentAPIBus::SetProperty is mapping to string_view

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -392,6 +392,11 @@ namespace AzToolsFramework
         }
 
         AZ_Warning("PropertyTreeEditor", false, "SetProperty - value type cannot be converted to the property's type.");
+        auto valRepr = value.type().ToFixedString();
+        AZ_Warning("PropertyTreeEditor", false, "SetProperty - value type %s", valRepr.c_str());
+        auto propRepr = pteNode.m_nodePtr->GetClassMetadata()->m_typeId.ToFixedString();
+        AZ_Warning("PropertyTreeEditor", false, "SetProperty - property's type %s", propRepr.c_str());
+
         return PropertyAccessOutcome{ AZStd::unexpect, PropertyAccessOutcome::ErrorType("SetProperty - value type cannot be converted to the property's type.") };
 
     }
@@ -801,6 +806,13 @@ namespace AzToolsFramework
         {
             AZ::s64 value = *static_cast<const AZ::s64*>(sourceValuePtr);
             return HandleTypeConversion(value, toType, convertedValue);
+        }
+
+        if (fromType == AZ::AzTypeInfo<AZStd::string_view>::Uuid() && toType == AZ::AzTypeInfo<AZStd::string>::Uuid())
+        {
+            AZStd::string_view value = *static_cast<const AZStd::string_view*>(sourceValuePtr);
+            convertedValue = AZStd::string{ value };
+            return &convertedValue;
         }
 
         return nullptr;


### PR DESCRIPTION
## What does this PR do?

* at some rare occasions value passed to Python API was mapped to `any<string_view>` instead of `any<string>` which causes API to fail:
```
E   [editor_test.log]  <10:53:57> [Warning] (PropertyTreeEditor) - SetProperty - value type {7114E998-A8B4-519B-9342-A86D1587B4F7}
E   [editor_test.log]  <10:53:57> [Warning] (PropertyTreeEditor) - SetProperty - property's type {03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}
```

## How was this PR tested?

Tests were based on `AutomatedTesting/Gem/PythonTests/EditorPythonBindings/tests/Editor_ComponentPropertyCommands_Works.py` however I don't have a clear and concise replication scenario, hence I'll keep this PR as a draft
