### PR TITLE
Add additional libraries and remove LD paths for snap package

### DIFF
--- a/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
+++ b/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
@@ -65,7 +65,6 @@ apps:
   o3de:
     command: ${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default/o3de
     environment:
-      LD_LIBRARY_PATH: $SNAP/${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default:$LD_LIBRARY_PATH
       O3DE_SNAP: 1
       SNAP_BUILD: ${CPACK_PACKAGE_VERSION}
       PKG_CONFIG: $SNAP/usr/bin/pkg-config --define-variable=libdir=$SNAP/usr/lib/x86_64-linux-gnu
@@ -73,14 +72,12 @@ apps:
   editor:
     command: ${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default/Editor
     environment:
-      LD_LIBRARY_PATH: $SNAP/${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default:$LD_LIBRARY_PATH
       O3DE_SNAP: 1
       SNAP_BUILD: ${CPACK_PACKAGE_VERSION}
       DISABLE_WAYLAND: 1
   assetprocessor:
     command: ${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default/AssetProcessor
     environment:
-      LD_LIBRARY_PATH: $SNAP/${CPACK_PACKAGE_VERSION}/bin/Linux/profile/Default:$LD_LIBRARY_PATH
       O3DE_SNAP: 1
       SNAP_BUILD: ${CPACK_PACKAGE_VERSION}
       DISABLE_WAYLAND: 1

--- a/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
+++ b/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
@@ -42,6 +42,10 @@ parts:
      - pkg-config
      - libc-dev
      - libstdc++-12-dev
+     - libpng16-16
+     - libsm6
+     - libdbus-1-3
+     - libzstd-dev
 
   patch-o3de:
     plugin: nil


### PR DESCRIPTION
## What does this PR do?

Adds missing libraries that were a requirement for release such as libzstd within the snap package. Also removed `LD_LIBRARY_PATH` for the executables as they were causing issues with CMake

## How was this PR tested?
Built and installed in a Ubuntu 22.04 instance

Signed-off-by: Mike Chang <changml@amazon.com>