### PR TITLE
Test Impact Analysis Divide by zero fix

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/AnsiTerminalUtils.h>
+
+namespace AZ::IO::Posix
+{
+    bool SupportsAnsiEscapes(int fileDescriptor)
+    {
+        return IsAtty(fileDescriptor) && TerminalSupportsColor();
+    }
+}

--- a/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.cpp
@@ -12,6 +12,6 @@ namespace AZ::IO::Posix
 {
     bool SupportsAnsiEscapes(int fileDescriptor)
     {
-        return IsAtty(fileDescriptor) && TerminalSupportsColor();
+        return IsATty(fileDescriptor) && TerminalSupportsColor();
     }
 }

--- a/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
+++ b/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
@@ -19,7 +19,7 @@ namespace AZ::IO::Posix
     bool TerminalSupportsColor();
 
     //! return true if the open file descriptor is a terminal
-    bool IsAtty(int fileDescriptor);
+    bool IsATty(int fileDescriptor);
 
     //! return true if the file descriptor supports ANSI escape sequences
     bool SupportsAnsiEscapes(int fileDescriptor);

--- a/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
+++ b/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
@@ -10,15 +10,17 @@
 
 namespace AZ::IO::Posix
 {
-    //! Turns of Virtual Terminal Processing on Windows
+    //! Enables Virtual Terminal Processing on Windows for th specified file descriptor
     //! This allows ANSI escapes to be supported
     //! https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
     void EnableVirtualTerminalProcessing(int fileDescriptor);
+
     //! return true the terminal supports color ANSI escape codes
     bool TerminalSupportsColor();
-    //! return if the open file descriptor is a terminal
+
+    //! return true if the open file descriptor is a terminal
     bool IsAtty(int fileDescriptor);
-    //! return true if the file descriptor represents a terminal
-    //! and it supports ANSI escapes
+
+    //! return true if the file descriptor supports ANSI escape sequences
     bool SupportsAnsiEscapes(int fileDescriptor);
 }

--- a/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
+++ b/Code/Framework/AzCore/AzCore/IO/AnsiTerminalUtils.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ::IO::Posix
+{
+    //! Turns of Virtual Terminal Processing on Windows
+    //! This allows ANSI escapes to be supported
+    //! https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+    void EnableVirtualTerminalProcessing(int fileDescriptor);
+    //! return true the terminal supports color ANSI escape codes
+    bool TerminalSupportsColor();
+    //! return if the open file descriptor is a terminal
+    bool IsAtty(int fileDescriptor);
+    //! return true if the file descriptor represents a terminal
+    //! and it supports ANSI escapes
+    bool SupportsAnsiEscapes(int fileDescriptor);
+}

--- a/Code/Framework/AzCore/AzCore/IO/SystemFile.h
+++ b/Code/Framework/AzCore/AzCore/IO/SystemFile.h
@@ -225,7 +225,7 @@ namespace AZ
          *   redirectStdout.Stop(StdoutVisitor); // Invokes visitor 0 or more times with captured data
          *   EXPECT_TRUE(testWasOutput);
          */
-        class FileDescriptorCapturer 
+        class FileDescriptorCapturer
         {
         public:
 
@@ -237,7 +237,7 @@ namespace AZ
 
             //! Redirects file descriptor to a visitor callback
             //! Internally a pipe is used to send output to the visitor
-            //! 
+            //!
             //! NOTE: This function will be called on a different thread than the one used to invoke Start()
             //! The caller is responsible for ensuring thread safety with the callback function
             using OutputRedirectVisitor = AZStd::function<void(AZStd::span<AZStd::byte>)>;
@@ -296,4 +296,10 @@ namespace AZ
             OutputRedirectVisitor m_redirectCallback;
         };
     }
+}
+
+namespace AZ::IO::Posix
+{
+    // Returns file descriptor from C FILE* struct
+    int Fileno(FILE* stream);
 }

--- a/Code/Framework/AzCore/AzCore/Utils/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Utils/Utils.h
@@ -167,7 +167,8 @@ namespace AZ
         enum class GetEnvErrorCode
         {
             EnvNotSet = 1,
-            BufferTooSmall
+            BufferTooSmall,
+            NotImplemented
         };
 
         //! Return result from GetEnv when an environment variable value

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -148,6 +148,8 @@ set(FILES
     EBus/Internal/StoragePolicies.h
     Instance/InstancePool.h
     Interface/Interface.h
+    IO/AnsiTerminalUtils.cpp
+    IO/AnsiTerminalUtils.h
     IO/ByteContainerStream.h
     IO/CompressionBus.h
     IO/CompressionBus.cpp

--- a/Code/Framework/AzCore/Platform/Android/AzCore/Utils/Utils_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Utils/Utils_Android.cpp
@@ -16,78 +16,113 @@
 #include <AzCore/Android/JNI/Internal/ClassName.h>
 #include <AzCore/Android/Utils.h>
 
-namespace AZ
+namespace AZ::Utils
 {
-    namespace Utils
+    void RequestAbnormalTermination()
     {
-        void RequestAbnormalTermination()
+        abort();
+    }
+
+    void NativeErrorMessageBox(const char*, const char*) {}
+
+    GetExecutablePathReturnType GetExecutablePath(char* exeStorageBuffer, size_t exeStorageSize)
+    {
+        GetExecutablePathReturnType result;
+        result.m_pathIncludesFilename = false;
+        const char* privateStoragePath  = AZ::Android::AndroidEnv::Get()->GetAppPrivateStoragePath();
+        if(exeStorageSize > strlen(privateStoragePath))
         {
-            abort();
+            azstrcpy(exeStorageBuffer, exeStorageSize, privateStoragePath);
+        }
+        else
+        {
+            result.m_pathStored = ExecutablePathResult::BufferSizeNotLargeEnough;
         }
 
-        void NativeErrorMessageBox(const char*, const char*) {}
+        return result;
+    }
 
-        GetExecutablePathReturnType GetExecutablePath(char* exeStorageBuffer, size_t exeStorageSize)
+    // Android attempts to find a bootstrap.cfg file within the public storage for an application
+    // in non-release builds.
+    // If a bootstrap.cfg file is not found in the public storage, it is then searched for
+    // within the APK itself
+    AZStd::optional<AZ::IO::FixedMaxPathString> GetDefaultAppRootPath()
+    {
+        const char* appRoot = AZ::Android::Utils::FindAssetsDirectory();
+        return appRoot ? AZStd::make_optional<AZ::IO::FixedMaxPathString>(appRoot) : AZStd::nullopt;
+    }
+
+    AZStd::optional<AZ::IO::FixedMaxPathString> GetDevWriteStoragePath()
+    {
+        const char* writeStorage = AZ::Android::Utils::GetAppPublicStoragePath();
+        return writeStorage ? AZStd::make_optional<AZ::IO::FixedMaxPathString>(writeStorage) : AZStd::nullopt;
+    }
+
+    bool ConvertToAbsolutePath(const char* path, char* absolutePath, AZ::u64 maxLength)
+    {
+        if (AZ::Android::Utils::IsApkPath(path))
         {
-            GetExecutablePathReturnType result;
-            result.m_pathIncludesFilename = false;
-            const char* privateStoragePath  = AZ::Android::AndroidEnv::Get()->GetAppPrivateStoragePath();
-            if(exeStorageSize > strlen(privateStoragePath))
+            azstrcpy(absolutePath, maxLength, path);
+            return true;
+        }
+
+#ifdef PATH_MAX
+        static constexpr size_t UnixMaxPathLength = PATH_MAX;
+#else
+        // Fallback to 4096 if the PATH_MAX macro isn't defined on the Unix System
+        static constexpr size_t UnixMaxPathLength = 4096;
+#endif
+        if (!AZ::IO::PathView(path).IsAbsolute())
+        {
+            // note that realpath fails if the path does not exist and actually changes the return value
+            // to be the actual place that FAILED, which we don't want.
+            // if we fail, we'd prefer to fall through and at least use the original path.
+            char absolutePathBuffer[UnixMaxPathLength];
+            if (const char* result = realpath(path, absolutePathBuffer); result != nullptr)
             {
-                azstrcpy(exeStorageBuffer, exeStorageSize, privateStoragePath);
+                azstrcpy(absolutePath, maxLength, absolutePathBuffer);
+                return true;
+            }
+        }
+        azstrcpy(absolutePath, maxLength, path);
+        return AZ::IO::PathView(absolutePath).IsAbsolute();
+    }
+
+    GetEnvOutcome GetEnv(AZStd::span<char> valueBuffer, const char* envname)
+    {
+        if (const char* envValue = std::getenv(envname);
+            envValue != nullptr)
+        {
+            if (AZStd::string_view utf8Value(envValue);
+                valueBuffer.size() >= utf8Value.size())
+            {
+                // copy the utf8 string value over to the value buffer
+                utf8Value.copy(valueBuffer.data(), valueBuffer.size());
+                // return a string that points the beginning of the span buffer
+                // with a size that is set to the environment variable value string
+                return AZStd::string_view(valueBuffer.data(), utf8Value.size());
             }
             else
             {
-                result.m_pathStored = ExecutablePathResult::BufferSizeNotLargeEnough;
+                return AZ::Failure(GetEnvErrorResult{ GetEnvErrorCode::BufferTooSmall, utf8Value.size() });
             }
-
-            return result;
         }
 
-        // Android attempts to find a bootstrap.cfg file within the public storage for an application
-        // in non-release builds.
-        // If a bootstrap.cfg file is not found in the public storage, it is then searched for
-        // within the APK itself
-        AZStd::optional<AZ::IO::FixedMaxPathString> GetDefaultAppRootPath()
-        {
-            const char* appRoot = AZ::Android::Utils::FindAssetsDirectory();
-            return appRoot ? AZStd::make_optional<AZ::IO::FixedMaxPathString>(appRoot) : AZStd::nullopt;
-        }
-
-        AZStd::optional<AZ::IO::FixedMaxPathString> GetDevWriteStoragePath()
-        {
-            const char* writeStorage = AZ::Android::Utils::GetAppPublicStoragePath();
-            return writeStorage ? AZStd::make_optional<AZ::IO::FixedMaxPathString>(writeStorage) : AZStd::nullopt;
-        }
-
-        bool ConvertToAbsolutePath(const char* path, char* absolutePath, AZ::u64 maxLength)
-        {
-            if (AZ::Android::Utils::IsApkPath(path))
-            {
-                azstrcpy(absolutePath, maxLength, path);
-                return true;
-            }
-
-#ifdef PATH_MAX
-            static constexpr size_t UnixMaxPathLength = PATH_MAX;
-#else
-            // Fallback to 4096 if the PATH_MAX macro isn't defined on the Unix System
-            static constexpr size_t UnixMaxPathLength = 4096;
-#endif
-            if (!AZ::IO::PathView(path).IsAbsolute())
-            {
-                // note that realpath fails if the path does not exist and actually changes the return value
-                // to be the actual place that FAILED, which we don't want.
-                // if we fail, we'd prefer to fall through and at least use the original path.
-                char absolutePathBuffer[UnixMaxPathLength];
-                if (const char* result = realpath(path, absolutePathBuffer); result != nullptr)
-                {
-                    azstrcpy(absolutePath, maxLength, absolutePathBuffer);
-                    return true;
-                }
-            }
-            azstrcpy(absolutePath, maxLength, path);
-            return AZ::IO::PathView(absolutePath).IsAbsolute();
-        }
+        return AZ::Failure(GetEnvErrorResult{ GetEnvErrorCode::EnvNotSet });
     }
-}
+
+    bool IsEnvSet(const char* envname)
+    {
+        return std::getenv(envname) != nullptr;
+    }
+
+    bool SetEnv(const char* envname, const char* envvalue, bool overwrite)
+    {
+        return setenv(envname, envvalue, overwrite) != -1;
+    }
+
+    bool UnsetEnv(const char* envname)
+    {
+        return unsetenv(envname) != -1;
+    }
+} // namespace AZ::Utils

--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -34,6 +34,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerConfiguration_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
+    ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -60,7 +60,6 @@ set(FILES
     AzCore/Socket/AzSocket_Platform.h
     ../Common/UnixLike/AzCore/std/time_UnixLike.cpp
     AzCore/Utils/Utils_Android.cpp
-    ../Common/Unimplemented/AzCore/Utils/Utils_Unimplemented.cpp
     AzCore/Android/AndroidEnv.cpp
     AzCore/Android/AndroidEnv.h
     AzCore/Android/APKFileHandler.cpp

--- a/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Utils/Utils_Unimplemented.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/Utils/Utils_Unimplemented.cpp
@@ -15,6 +15,16 @@ namespace AZ::Utils
         return {};
     }
 
+    GetEnvOutcome GetEnv(AZStd::span<char>, const char*)
+    {
+        return AZ::Failure(GetEnvErrorResult{ GetEnvErrorCode::NotImplemented });
+    }
+
+    bool IsEnvSet(const char*)
+    {
+        return false;
+    }
+
     bool SetEnv([[maybe_unused]] const char* envname, [[maybe_unused]] const char* envvalue, [[maybe_unused]] bool overwrite)
     {
         return false;

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
@@ -37,8 +37,8 @@ namespace AZ::IO::Posix
         return false;
     }
     // return true if the file descriptor is referring to a terminal
-    bool IsAtty(int fileDescriptor)
+    bool IsATty(int fileDescriptor)
     {
-        return is_atty(fileDescriptor);
+        return isatty(fileDescriptor);
     }
 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/Utils/Utils.h>
+
+namespace AZ::IO::Posix
+{
+    void EnableVirtualTerminalProcessing(int)
+    {
+        // Terminals on UnixLike platforms support virtual terminal
+        // sequences by default
+    }
+
+    bool TerminalSupportsColor()
+    {
+        char envBuffer[256];
+        if (auto termEnvOutcome = AZ::Utils::GetEnv(envBuffer, "TERM");
+            termEnvOutcome)
+        {
+            AZStd::string_view termView = termEnvOutcome.GetValue();
+            return termView == "xterm"
+                || termView == "xterm-color"
+                || termView == "xterm-256color"
+                || termView == "screen"
+                || termView == "screen-256color"
+                || termView == "tmux"
+                || termView == "tmux-256color"
+                || termView == "rxvt-unicode"
+                || termView == "rxvt-unicode-256color"
+                || termView == "linux";
+        }
+
+        return false;
+    }
+    // return true if the file descriptor is refering to a terminal
+    bool IsAtty(int fileDescriptor)
+    {
+        return is_atty(fileDescriptor);
+    }
+}

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
@@ -36,7 +36,7 @@ namespace AZ::IO::Posix
 
         return false;
     }
-    // return true if the file descriptor is refering to a terminal
+    // return true if the file descriptor is referring to a terminal
     bool IsAtty(int fileDescriptor)
     {
         return is_atty(fileDescriptor);

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
@@ -323,3 +323,11 @@ namespace AZ::IO
         // At this point it is now safe to call Start() again on this Capturer
     }
 } // namespace AZ::IO
+
+namespace AZ::IO::Posix
+{
+    int Fileno(FILE* stream)
+    {
+        return fileno(stream);
+    }
+}

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/PlatformIncl.h>
+
+#include <io.h>
+
+namespace AZ::IO::Posix
+{
+    void EnableVirtualConsoleProcessing(int fileDescriptor)
+    {
+        const auto fileHandle = reinterpret_cast<HANDLE>(_get_osfhandle(fileDescriptor));
+        DWORD currentMode{};
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+        GetConsoleMode(fileHandle, &currentMode);
+        SetConsoleMode(fileHandle, currentMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+#endif
+    }
+
+    bool TerminalSupportsColor()
+    {
+        return true;
+    }
+    // return true if the file descriptor is refering to a terminal
+    bool IsAtty(int fileDescriptor)
+    {
+        return _isatty(fileDescriptor);
+    }
+}

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
@@ -11,7 +11,7 @@
 
 namespace AZ::IO::Posix
 {
-    void EnableVirtualConsoleProcessing(int fileDescriptor)
+    void EnableVirtualTerminalProcessing(int fileDescriptor)
     {
         const auto fileHandle = reinterpret_cast<HANDLE>(_get_osfhandle(fileDescriptor));
         DWORD currentMode{};
@@ -26,7 +26,7 @@ namespace AZ::IO::Posix
         return true;
     }
     // return true if the file descriptor is refering to a terminal
-    bool IsAtty(int fileDescriptor)
+    bool IsATty(int fileDescriptor)
     {
         return _isatty(fileDescriptor);
     }

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp
@@ -758,3 +758,11 @@ namespace AZ::IO
         // At this point it is now safe to call Start() again on this Capturer
     }
 } // namespace AZ::IO
+
+namespace AZ::IO::Posix
+{
+    int Fileno(FILE* stream)
+    {
+        return _fileno(stream);
+    }
+}

--- a/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
@@ -35,6 +35,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerConfiguration_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
+    ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
@@ -36,6 +36,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerConfiguration_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
+    ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
@@ -34,6 +34,7 @@ set(FILES
     ../Common/WinAPI/AzCore/Process/ProcessInfo_WinAPI.cpp
     AzCore/Debug/StackTracer_Windows.cpp
     ../Common/WinAPI/AzCore/Debug/Trace_WinAPI.cpp
+    ../Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/Streamer/StreamerContext_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/Streamer/StreamerContext_WinAPI.h
     ../Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp

--- a/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
@@ -36,6 +36,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
     ../Common/Apple/AzCore/IO/SystemFile_Apple.cpp
     ../Common/Apple/AzCore/IO/SystemFile_Apple.h
+    ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactConsoleUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactConsoleUtils.cpp
@@ -9,22 +9,38 @@
 #include <TestImpactConsoleUtils.h>
 
 #include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/IO/AnsiTerminalUtils.h>
+#include <AzCore/IO/SystemFile.h>
 
 namespace TestImpact::Console
 {
     AZStd::string SetColor(Foreground foreground, Background background)
     {
-        return AZStd::string::format("\033[%u;%um", aznumeric_cast<uint32_t>(foreground), aznumeric_cast<uint32_t>(background));
+        if (AZ::IO::Posix::SupportsAnsiEscapes(AZ::IO::Posix::Fileno(stdout)))
+        {
+            return AZStd::string::format("\033[%u;%um", aznumeric_cast<uint32_t>(foreground), aznumeric_cast<uint32_t>(background));
+        }
+
+        // ANSI escapes aren't supported
+        return AZStd::string{};
     }
 
     AZStd::string SetColorForString(Foreground foreground, Background background, const AZStd::string& str)
     {
-        return AZStd::string::format("%s%s%s", SetColor(foreground, background).c_str(), str.c_str(), ResetColor().c_str());
+        if (AZ::IO::Posix::SupportsAnsiEscapes(AZ::IO::Posix::Fileno(stdout)))
+        {
+            return AZStd::string::format("%s%s%s", SetColor(foreground, background).c_str(), str.c_str(), ResetColor().c_str());
+        }
+
+        // Return the string without ANSI escapes when they are not supported
+        return str;
     }
 
     AZStd::string ResetColor()
     {
-        return "\033[0m";
+        return AZ::IO::Posix::SupportsAnsiEscapes(AZ::IO::Posix::Fileno(stdout))
+            ? AZStd::string("\033[0m")
+            : AZStd::string{};
     }
 
     ReturnCode GetReturnCodeForTestSequenceResult(TestSequenceResult result)

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
@@ -45,7 +45,7 @@ namespace TestImpact
                 }
                 else
                 {
-                    std::cout << "There are 0 total test\n";
+                    std::cout << "There are 0 total tests\n";
                 }
             }
 

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Source/TestImpactTestSequenceNotificationHandler.cpp
@@ -11,6 +11,9 @@
 #include <TestImpactTestSequenceNotificationHandler.h>
 #include <TestImpactConsoleUtils.h>
 
+#include <AzCore/IO/AnsiTerminalUtils.h>
+#include <AzCore/IO/SystemFile.h>
+
 #include <iostream>
 
 namespace TestImpact
@@ -32,11 +35,18 @@ namespace TestImpact
 
             void ImpactAnalysisTestSelection(size_t numSelectedTests, size_t numDiscardedTests, size_t numExcludedTests, size_t numDraftedTests)
             {
-                const float totalTests = static_cast<float>(numSelectedTests + numDiscardedTests);
-                const float saving = (1.0f - (numSelectedTests / totalTests)) * 100.0f;
+                if (const size_t totalTests = numSelectedTests + numDiscardedTests;
+                    totalTests > 0)
+                {
+                    const float saving = (1.0f - float(numSelectedTests) / totalTests) * 100.0f;
 
-                std::cout << numSelectedTests << " tests selected, " << numDiscardedTests << " tests discarded (" << saving << "% test saving)\n";
-                std::cout << "Of which " << numExcludedTests << " tests have been excluded and " << numDraftedTests << " tests have been drafted.\n";
+                    std::cout << numSelectedTests << " tests selected, " << numDiscardedTests << " tests discarded (" << saving << "% test saving)\n";
+                    std::cout << "Of which " << numExcludedTests << " tests have been excluded and " << numDraftedTests << " tests have been drafted.\n";
+                }
+                else
+                {
+                    std::cout << "There are 0 total test\n";
+                }
             }
 
             void FailureReport(const Client::TestRunReport& testRunReport)
@@ -119,9 +129,10 @@ namespace TestImpact
             : m_consoleOutputMode(consoleOutputMode)
         {
             TestSequenceNotificationsBaseBus::Handler::BusConnect();
+            // Enable Virtual Terminal Processing, so that ANSI color sequences can be used
+            AZ::IO::Posix::EnableVirtualTerminalProcessing(AZ::IO::Posix::Fileno(stdout));
         }
 
-        
         TestSequenceNotificationHandlerBase::~TestSequenceNotificationHandlerBase()
         {
             TestSequenceNotificationsBaseBus::Handler::BusDisconnect();


### PR DESCRIPTION
Fixed potential divide by zero in the Test Impact Analysis Framework when outputting which test were selected.

This was causing the Test Impact Analysis Framework run to crash with return code 0xc0000094 which is the return code for integer divide by zero on Windows

The error can be seen on Jenkins at https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/detail/development/4331/pipeline/819

```
[2023-05-16T21:48:21.363Z] BuildTargetDependencyGraph: Trace::Warning

[2023-05-16T21:48:33.592Z]  D:\workspace\o3de\Code\Tools\TestImpactFramework\Runtime\Common\Code\Include\Static\BuildTarget/Common/TestImpactBuildGraph.h(156): 'auto __cdecl TestImpact::BuildGraph<class TestImpact::NativeProductionTarget,class TestImpact::NativeTestTarget>::{ctor}::<lambda_2>::operator ()(const class AZStd::vector<class AZStd::basic_string<char,struct AZStd::char_traits<char>,class AZStd::allocator>,class AZStd::allocator> &,class AZStd::unordered_set<struct TestImpact::BuildGraphVertex<class TestImpact::NativeProductionTarget,class TestImpact::NativeTestTarget> const *,struct AZStd::hash<struct TestImpact::BuildGraphVertex<class TestImpact::NativeProductionTarget,class TestImpact::NativeTestTarget> const *>,struct AZStd::equal_to<struct TestImpact::B[2023-05-16 21:48:31,702][TIAF][ERROR] The test impact analysis runtime returned with error: '3221225620'.
```

Added detection to the Test Impact console utilities to only output ANSI color escapes if the terminal supports it.
