### PR TITLE
Only enable splash screen in game

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SplashScreen/SplashScreenFeatureProcessor.cpp
@@ -26,7 +26,7 @@ namespace AZ::Render
     {
         AZ::ApplicationTypeQuery appType;
         AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
-        if (!appType.IsValid() || appType.IsEditor())
+        if (!appType.IsGame())
         {
             return;
         }


### PR DESCRIPTION
## What does this PR do?

Updates the splash screen feature processor to only be enabled in game.
Resolves https://github.com/o3de/o3de/issues/15897

## How was this PR tested?
Confirmed that splash screen no longer appears in material editor or material canvas
