### PR TITLE
Updated o3de CLI register command to generate a CMakePresets file for project registration

### DIFF
--- a/AutomatedTesting/CMakePresets.json
+++ b/AutomatedTesting/CMakePresets.json
@@ -6,6 +6,6 @@
         "patch": 0
     },
     "include": [
-        "user/cmake/engine/CMakePresets.json"
+        "../CMakePresets.json"
     ]
 }

--- a/Templates/MinimalProject/Template/CMakePresets.json
+++ b/Templates/MinimalProject/Template/CMakePresets.json
@@ -4,5 +4,8 @@
         "major": 3,
         "minor": 23,
         "patch": 0
-    }
+    },
+    "include": [
+        "user/cmake/engine/CMakePresets.json"
+    ]
 }

--- a/cmake/Projects.cmake
+++ b/cmake/Projects.cmake
@@ -233,6 +233,31 @@ endif()
     ly_install_run_code("${install_engine_pak_code}")
 endfunction()
 
+#! Updates a generated <project-path>/user/cmake/engine/CMakePresets.json
+# file to include the path to the engine root CMakePresets.json
+# \arg: PROJECT_PATH path to project root.
+#       will used to form the root of the file path to the presets file that includes the engine presets
+# \arg: ENGINE_PATH path to the engine root
+function(update_cmake_presets_for_project)
+    set(options)
+    set(oneValueArgs PROJECT_PATH ENGINE_PATH)
+    set(multiValueArgs)
+    cmake_parse_arguments("${CMAKE_CURRENT_FUNCTION}" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(project_path "${${CMAKE_CURRENT_FUNCTION}_PROJECT_PATH}")
+    set(engine_path "${${CMAKE_CURRENT_FUNCTION}_ENGINE_PATH}")
+
+    execute_process(COMMAND
+        ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/scripts/o3de/o3de/cmake.py" "update-cmake-presets-for-project" -pp "${project_path}" -ep "${engine_path}"
+        WORKING_DIRECTORY ${LY_ROOT_FOLDER}
+        RESULT_VARIABLE O3DE_CLI_RESULT
+        ERROR_VARIABLE O3DE_CLI_ERROR
+        )
+
+    if(NOT O3DE_CLI_RESULT EQUAL 0)
+        message(STATUS "Unable to update the project \"${project_path}\" CMakePresets to include the engine presets:\n${O3DE_CLI_ERROR}")
+    endif()
+endfunction()
+
 # Add the projects here so the above function is found
 foreach(project ${LY_PROJECTS})
     file(REAL_PATH ${project} full_directory_path BASE_DIRECTORY ${CMAKE_SOURCE_DIR})
@@ -260,7 +285,13 @@ foreach(project ${LY_PROJECTS})
     # Append the project external directory to LY_EXTERNAL_SUBDIR_${project_name} property
     add_project_json_external_subdirectories(${full_directory_path} "${project_name}")
 
+    # Use the install(CODE) command to add cmake command to archive the project cache
+    # directory assets for use in a proejct relase layout
     install_project_asset_artifacts(${full_directory_path})
+
+    # Update the <project-path>/user/cmake/engine/CMakePresets.json
+    # to include the current engine CMakePresets.json file
+    update_cmake_presets_for_project(PROJECT_PATH "${full_directory_path}" ENGINE_PATH "${LY_ROOT_FOLDER}")
 
 endforeach()
 

--- a/cmake/Projects.cmake
+++ b/cmake/Projects.cmake
@@ -285,7 +285,7 @@ foreach(project ${LY_PROJECTS})
     # Append the project external directory to LY_EXTERNAL_SUBDIR_${project_name} property
     add_project_json_external_subdirectories(${full_directory_path} "${project_name}")
 
-    # Use the install(CODE) command to add cmake command to archive the project cache
+    # Use the install(CODE) command to archive the project cache
     # directory assets for use in a proejct relase layout
     install_project_asset_artifacts(${full_directory_path})
 

--- a/cmake/Subdirectories.cmake
+++ b/cmake/Subdirectories.cmake
@@ -207,7 +207,7 @@ function(resolve_gem_dependencies object_type object_path)
         set(user_external_subdir_option -ed "${user_external_subdirs}")
     endif()
     execute_process(COMMAND 
-        ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/scripts/o3de/o3de/cmake.py" --${object_type_lower}-path "${object_path}" --engine-path "${LY_ROOT_FOLDER}" ${user_external_subdir_option}
+        ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/scripts/o3de/o3de/cmake.py" "resolve-gem-dependencies" --${object_type_lower}-path "${object_path}" --engine-path "${LY_ROOT_FOLDER}" ${user_external_subdir_option}
         WORKING_DIRECTORY ${LY_ROOT_FOLDER}
         RESULT_VARIABLE O3DE_CLI_RESULT
         OUTPUT_VARIABLE resolved_gem_dependency_output 
@@ -215,7 +215,7 @@ function(resolve_gem_dependencies object_type object_path)
         )
 
     if(O3DE_CLI_RESULT)
-        message(WARNING "Dependecy resolution failed.\n  If needed, set the O3DE_DISABLE_GEM_DEPENDENCY_RESOLUTION variable to bypass dependency resolution.\n  Error: ${O3DE_CLI_OUT}")
+        message(WARNING "Dependency resolution failed.\n  If needed, set the O3DE_DISABLE_GEM_DEPENDENCY_RESOLUTION variable to bypass dependency resolution.\n  Error: ${O3DE_CLI_OUT}")
         return()
     endif()
 

--- a/scripts/o3de/o3de/cmake.py
+++ b/scripts/o3de/o3de/cmake.py
@@ -37,13 +37,16 @@ TEMPLATE_CMAKE_PRESETS_INCLUDE_JSON = """
 }
 """
 
+PROJECT_ENGINE_PRESET_RELATIVE_PATH = pathlib.PurePath('user/cmake/engine/CMakePresets.json')
+
 class UpdatePresetResult(enum.Enum):
     EnginePathAdded = 0
     EnginePathAlreadyIncluded = 1
     Error = 2
 
-def update_cmake_presets_for_project(preset_path: pathlib.PurePath, engine_name: str,
-                                     engine_version: str) -> UpdatePresetResult:
+def update_cmake_presets_for_project(preset_path: pathlib.PurePath, engine_name: str = '',
+                                     engine_version: str = '',
+                                     engine_path: pathlib.PurePath or None = None) -> UpdatePresetResult:
     """
     Updates a cmake-presets formated JSON file with an include that points
     to the root CMakePresets.json inside the registered engine
@@ -54,12 +57,13 @@ def update_cmake_presets_for_project(preset_path: pathlib.PurePath, engine_name:
     :return: UpdatePresetResult enum with value EnginePathAdded or EnginePathAlreadyIncluded
              if successful
     """
-    engine_with_specifier = f'{engine_name}=={engine_version}' if engine_version else engine_name
-    engine_path = manifest.get_registered(engine_name=engine_with_specifier)
     if not engine_path:
-        logger.error(f'Engine with identifier {engine_with_specifier} is not registered.\n' \
-                     f'The cmake-presets file at {preset_path} will not be modified')
-        return UpdatePresetResult.Error
+        engine_with_specifier = f'{engine_name}=={engine_version}' if engine_version else engine_name
+        engine_path = manifest.get_registered(engine_name=engine_with_specifier)
+        if not engine_path:
+            logger.error(f'Engine with identifier {engine_with_specifier} is not registered.\n'
+                         f'The cmake-presets file at {preset_path} will not be modified')
+            return UpdatePresetResult.Error
 
     engine_cmake_presets_path = engine_path / "CMakePresets.json"
     preset_json = {}
@@ -83,7 +87,7 @@ def update_cmake_presets_for_project(preset_path: pathlib.PurePath, engine_name:
         if engine_cmake_presets_path in map(lambda preset_json_include: pathlib.PurePath(preset_json_include), preset_include_list):
             # If the engine_path is already included in the preset file, return without writing to the file
             return UpdatePresetResult.EnginePathAlreadyIncluded
-        
+
         # Replace all "include" paths in the existing preset file
         # The reason this occurs is to prevent a scenario where previously registered engines
         # are being referenced by this preset file
@@ -298,8 +302,37 @@ def _resolve_gem_dependency_paths(args: argparse) -> int:
                             resolved_gem_dependencies_output_path=args.gem_paths_output_file
                              )
 
-def add_parser_args(parser):
-    group = parser.add_argument_group("resolve gem dependencies")
+def _update_project_presets_to_include_engine_presets(args: argparse) -> int:
+    project_path = args.project_path
+    if not project_path:
+        project_path = manifest.get_registered(project_name=args.project_name)
+        if not project_path:
+            logger.error(f'Project with name {args.project_name} is not registered')
+            return 1
+
+    # Form the path the CMakePresets.json that will include the engine presets
+    preset_path = project_path / PROJECT_ENGINE_PRESET_RELATIVE_PATH
+
+    # Map boolean non-error result to a return code of 0
+    return 0 if update_cmake_presets_for_project(
+        preset_path=preset_path,
+        engine_name=args.engine_name,
+        engine_version=args.engine_version,
+        engine_path=args.engine_path) != UpdatePresetResult.Error else 1
+
+def add_args(subparsers) -> None:
+    """
+    add_args is called to add expected parser arguments and subparsers arguments to each command such that it can be
+    invoked locally or aggregated by a central python file.
+    Ex. Directly run from this file alone with: <engine-root>/python/python cmake.py resolve-gem-dependencies --pp <path-to-project>
+    OR
+    o3de.py can aggregate commands by importing cmake,
+    call add_args and execute:  <engine-root>/python/python o3de.py resolve-gem-dependencies --pp <path-to-project>
+    :param subparsers: the caller instantiates subparsers and passes it in here
+    """
+    # Add command for resolving gem depenencies
+    gem_dependencies_parser = subparsers.add_parser('resolve-gem-dependencies')
+    group = gem_dependencies_parser.add_argument_group("resolve gem dependencies")
     group.add_argument('-pp', '--project-path', type=pathlib.Path, required=False,
                        help='The path to the project.')
     group.add_argument('-ep', '--engine-path', type=pathlib.Path, required=False,
@@ -308,11 +341,39 @@ def add_parser_args(parser):
                        help='Additional list of subdirectories.')
     group.add_argument('-gpof', '--gem-paths-output-file', type=pathlib.Path, required=False,
                        help='The path to the resolved gem paths output file. If not provided, the list will be output to STDOUT.')
-    parser.set_defaults(func=_resolve_gem_dependency_paths)
+    gem_dependencies_parser.set_defaults(func=_resolve_gem_dependency_paths)
+
+    # Add command for updating the project presets
+    update_cmake_presets_for_project_parser = subparsers.add_parser('update-cmake-presets-for-project')
+    project_group = update_cmake_presets_for_project_parser.add_mutually_exclusive_group(required=True)
+    project_group.add_argument('--project-path', '-pp', type=pathlib.Path,
+                               help='The path to a project.')
+    project_group.add_argument('--project-name', '-pn', type=str,
+                               help='The name of a project.')
+
+    engine_group = update_cmake_presets_for_project_parser.add_argument_group('engine identifiers')
+    # The --engine-path and --engine-name arguments are mutually exclusive and one of the are required
+    engine_path_group = engine_group.add_mutually_exclusive_group(required=True)
+    engine_path_group.add_argument('--engine-path', '-ep', type=pathlib.Path,
+                                   help='The path to the engine.')
+    engine_path_group.add_argument('--engine-name', '-en', type=str,
+                                   help='The name of the engine use to lookup the engine path.')
+    # Add the --engine-version argument directly to the `engine_group` variable
+    engine_group.add_argument('--engine-version', '-ev', type=str,
+                              help='Version of the engine to query when the --engine-name argument is used')
+
+
+    update_cmake_presets_for_project_parser.set_defaults(func=_update_project_presets_to_include_engine_presets)
 
 def main():
     the_parser = argparse.ArgumentParser()
-    add_parser_args(the_parser)
+
+    script_name = pathlib.PurePath(__file__).name
+    cmake_subparsers = the_parser.add_subparsers(
+        help=f'To get help on a sub-command:\n{script_name} <sub-command> -h',
+        title='Sub-Commands', dest='command', required=True)
+    add_args(cmake_subparsers)
+
     the_args = the_parser.parse_args()
     ret = the_args.func(the_args) if hasattr(the_args, 'func') else 1
     sys.exit(ret)

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -541,7 +541,7 @@ def register_project_path(json_data: dict,
         if not dry_run:
             # If the project.json engine is being updated, also update the user/engine/CMakePresets.json
             # file to include the location CMakePresets.json in the engine for the local user
-            cmake.update_cmake_presets_for_project(preset_path=project_path / 'user/cmake/engine/CMakePresets.json',
+            cmake.update_cmake_presets_for_project(preset_path=project_path / cmake.PROJECT_ENGINE_PRESET_RELATIVE_PATH,
                                                    engine_name=project_json_data['engine'],
                                                    engine_version=project_json_data['engine_version'])
 

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -538,6 +538,13 @@ def register_project_path(json_data: dict,
             if not manifest.save_o3de_manifest(project_json_data, project_json_path):
                 return 1
 
+        if not dry_run:
+            # If the project.json engine is being updated, also update the user/engine/CMakePresets.json
+            # file to include the location CMakePresets.json in the engine for the local user
+            cmake.update_cmake_presets_for_project(preset_path=project_path / 'user/cmake/engine/CMakePresets.json',
+                                                   engine_name=project_json_data['engine'],
+                                                   engine_version=project_json_data['engine_version'])
+
     if dry_run:
         logger.info('Project path was not registered because --dry-run option was specified')
 


### PR DESCRIPTION
When a project is registered a
`<project-root>/user/cmake/engine/CMakePresets.json` will be added/updated which contains an "include" entry to the registered engine's ``CMakePresets.json` file

The Default and Minimal Project templates have had their `<project-root>/CMakePresets.json` file to include the generated `"user/cmake/engine/CMakePresets.json"` file.

This means that new projects will now opt-in to this functionality by default.

Added a CMakePresets.json file for the AutomatedTesting project that includes the file in the CMakePresets.json it's engine root directory.

Furthermore running cmake configfure will also update the `<project-root>/user/cmake/engine/CMakePresets.json` file to include the CMakePresets.json file using the path of the current engine being configured.

This does open up the possibility of the user being surprised by an unintended modification to use a different engine presets however.

If the user has a project called "projectA" registered with engine called `o3deA` and then decides to use engine `o3deB` in an engine-centric workflow to configure "projectA" via the `LY_PROJECTS` Cache Variable, then what would occur is that the "<projectA>/user/cmake/engine/CMakePresets.json" will be updated to point at `o3deB` CMakePresets.json even though "projectA" is registers `o3deA`.

The mitigation for this case to have "projectA" to include `o3deA` presets again are to just configure the project in a project-centric workflow, which would use the engine `o3deA` again.

## How was this PR tested?

Added unit test for validating creation of the `CMakePresets-engine.json` command.

Verified that registering a project generates the `<project-root>/user/cmake/engine/CMakePresets.json` file.

Verified that registration of an existing project, does generate a `<project-root>/user/cmake/engine/CMakePresets.json` file and **does not** modify the existing `<project-root>/CMakePresets.json` file

This means that existing projects will not have to worry about their existing CMake presets being invalidated with this change.

![image](https://github.com/o3de/o3de/assets/56135373/4800d5ae-7a3c-4934-add7-0293f4e951f8)
