### PR TITLE
Handle component aliases in editor composition components

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Component.cpp
@@ -163,7 +163,7 @@ namespace AZ
         }
     }
 
-    void Component::OnPrepareForAdditionToEntity(Entity*)
+    void Component::OnAfterEntitySet()
     {
     }
 

--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -240,9 +240,8 @@ namespace AZ
          */
         virtual void SetEntity(Entity* entity);
 
-        //! Function to call before adding this component to the provided entity.
-        //! @param entity The entity to add the component to.
-        virtual void OnPrepareForAdditionToEntity(Entity* entity);
+        //! Function to call after setting the entity in this component.
+        virtual void OnAfterEntitySet();
 
         /**
          * Reflects the Component class.

--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -341,7 +341,8 @@ namespace AZ
         }
         component->SetEntity(this);
 
-        component->OnPrepareForAdditionToEntity(this);
+        component->OnAfterEntitySet();
+
         m_components.push_back(component);
 
         if (m_state == State::Init)

--- a/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityIdSerializer.h>
 #include <AzCore/Component/EntitySerializer.h>
+#include <AzCore/Component/EntityUtils.h>
 
 namespace AZ
 {
@@ -165,11 +166,11 @@ namespace AZ
             AZStd::unordered_map<AZStd::string, AZ::Component*> componentMap;
             AZStd::unordered_map<AZStd::string, AZ::Component*> defaultComponentMap;
 
-            ConvertComponentVectorToMap(*components, componentMap);
+            EntityUtils::ConvertComponentVectorToMap(*components, componentMap);
 
             if (defaultComponents)
             {
-                ConvertComponentVectorToMap(*defaultComponents, defaultComponentMap);
+                EntityUtils::ConvertComponentVectorToMap(*defaultComponents, defaultComponentMap);
             }
 
             JSR::ResultCode resultComponents =
@@ -197,24 +198,6 @@ namespace AZ
         return context.Report(result,
             result.GetProcessing() != JSR::Processing::Halted ? "Successfully stored Entity information." :
             "Failed to store Entity information.");
-    }
-
-    void JsonEntitySerializer::ConvertComponentVectorToMap(const AZ::Entity::ComponentArrayType& components,
-        AZStd::unordered_map<AZStd::string, AZ::Component*>& componentMapOut)
-    {
-        for (AZ::Component* component : components)
-        {
-            if (component)
-            {
-                AZStd::string componentAlias = component->GetSerializedIdentifier();
-                if (componentAlias.empty())
-                {
-                    // Component alias can be empty for non-editor components
-                    componentAlias = AZStd::string::format("Component_[%llu]", component->GetId());
-                }
-                componentMapOut.emplace(componentAlias, component);
-            }
-        }
     }
 
     void DeprecatedComponentMetadata::SetEnableDeprecationTrackingCallback(EnableDeprecationTrackingCallback callback)

--- a/Code/Framework/AzCore/AzCore/Component/EntitySerializer.h
+++ b/Code/Framework/AzCore/AzCore/Component/EntitySerializer.h
@@ -26,10 +26,6 @@ namespace AZ
 
         JsonSerializationResult::Result Store(rapidjson::Value& outputValue, const void* inputValue, const void* defaultValue, const Uuid& valueTypeId,
             JsonSerializerContext& context) override;
-
-    private:
-        void ConvertComponentVectorToMap(const AZ::Entity::ComponentArrayType& components,
-            AZStd::unordered_map<AZStd::string, AZ::Component*>& componentMapOut);
     };
 
     //! Helper class to track components that have been skipped during loading.

--- a/Code/Framework/AzCore/AzCore/Component/EntityUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntityUtils.cpp
@@ -295,4 +295,23 @@ namespace AZ::EntityUtils
         }
         return duplicateFound;
     }
+
+    void ConvertComponentVectorToMap(
+        const AZ::Entity::ComponentArrayType& components, AZStd::unordered_map<AZStd::string, AZ::Component*>& componentMapOut)
+    {
+        for (AZ::Component* component : components)
+        {
+            if (component)
+            {
+                AZStd::string componentAlias = component->GetSerializedIdentifier();
+                if (componentAlias.empty())
+                {
+                    // Component alias can be empty for non-editor components. Fallback to use the id as the component alias.
+                    componentAlias = AZStd::string::format("Component_[%llu]", component->GetId());
+                }
+                componentMapOut.emplace(AZStd::move(componentAlias), component);
+            }
+        }
+    }
+
 } // namespace AZ::EntityUtils

--- a/Code/Framework/AzCore/AzCore/Component/EntityUtils.h
+++ b/Code/Framework/AzCore/AzCore/Component/EntityUtils.h
@@ -214,5 +214,11 @@ namespace AZ
             ComponentDescriptor::DependencyArrayType& providedServiceArray,
             const Entity* entity);
 
+        //! Converts a vector of components to a map of pairs of component alias and component.
+        //! \param components Component vector to be converted.
+        //! \param[out] componentMapOut Component map that stores a component alias as key and a component as value.
+        void ConvertComponentVectorToMap(
+            const AZ::Entity::ComponentArrayType& components, AZStd::unordered_map<AZStd::string, AZ::Component*>& componentMapOut);
+
     } // namespace EntityUtils
 }   // namespace AZ

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -694,6 +694,9 @@ namespace AzToolsFramework
                     // Set the entity on the component (but do not add yet) so that existing systems such as UI will work properly and understand who this component belongs to.
                     GetEditorComponent(component)->SetEntity(entity);
 
+                    // Needed to set up the serialized identifier for the pending component.
+                    GetEditorComponent(component)->OnAfterEntitySet();
+
                     // Add component to pending for entity
                     AzToolsFramework::EditorPendingCompositionRequestBus::Event(entityId, &AzToolsFramework::EditorPendingCompositionRequests::AddPendingComponent, component);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -108,7 +108,6 @@ namespace AzToolsFramework
             captureExistingIdentifiersFunc(disabledComponents);
 
             // Generates a component typename string and updates its suffix count to avoid duplication.
-            // For example, if 'EditorCommentComponent' exists, it generates 'EditorCommentComponent_2', 'EditorCommentComponent_3', and so on.
             const AZStd::string componentTypeName = GetNameFromComponentClassData(this);
             AZStd::string serializedIdentifier = componentTypeName;
             AZ::u64 suffixOfNewComponent = 1;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -53,7 +53,11 @@ namespace AzToolsFramework
 
         void EditorComponentBase::OnAfterEntitySet()
         {
-            AZ_Assert(m_entity, "OnAfterEntitySet - Entity should not be nullptr.");
+            if (!m_entity)
+            {
+                AZ_Assert(false, "OnAfterEntitySet - Entity should not be nullptr.");
+                return;
+            }
 
             // Sets up only if the component alias is empty to avoid setting the alias twice.
             // For a component added as a pending component, there are two places trying to call this function to set up the alias:
@@ -68,7 +72,11 @@ namespace AzToolsFramework
 
         AZStd::string EditorComponentBase::GenerateComponentSerializedIdentifier()
         {
-            AZ_Assert(m_entity, "GenerateComponentSerializedIdentifier - Entity should not be nullptr.");
+            if (!m_entity)
+            {
+                AZ_Assert(false, "GenerateComponentSerializedIdentifier - Entity should not be nullptr.");
+                return {};
+            }
 
             AZStd::unordered_set<AZStd::string> existingSerializedIdentifiers;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
 
 DECLARE_EBUS_INSTANTIATION_WITH_TRAITS(AzToolsFramework::Components::EditorComponentDescriptor, AZ::ComponentDescriptorBusTraits);
 
@@ -49,45 +51,74 @@ namespace AzToolsFramework
             m_transform = nullptr;
         }
 
-        void EditorComponentBase::OnPrepareForAdditionToEntity(AZ::Entity* entity)
+        void EditorComponentBase::OnAfterEntitySet()
         {
-            if (entity && m_alias.empty())
+            AZ_Assert(m_entity, "OnAfterEntitySet - Entity should not be nullptr.");
+
+            // Sets up only if the component alias is empty to avoid setting the alias twice.
+            // For a component added as a pending component, there are two places trying to call this function to set up the alias:
+            // - EditorEntityActionComponent::AddExistingComponentsToEntityById()
+            // - Entity::AddComponent()
+            if (m_alias.empty())
             {
-                AZStd::unordered_set<AZStd::string> serializedIdentifiersMatchingType;
-
-                for (const AZ::Component* componentInEntity : entity->GetComponents())
-                {
-                    if (componentInEntity == this)
-                    {
-                        // If the alias is not empty and the component is already added to the entity, there's nothing to do here.
-                        return;
-                    }
-                    if (RTTI_GetType() == componentInEntity->RTTI_GetType())
-                    {
-                        serializedIdentifiersMatchingType.emplace(componentInEntity->GetSerializedIdentifier());
-                    }
-                }
-
-                AZStd::string typeName = GetNameFromComponentClassData(this);
-
-                AZStd::string serializedIdentifier;
-                if (serializedIdentifiersMatchingType.size() == 0)
-                {
-                    serializedIdentifier = typeName;
-                }
-                else
-                {
-                    AZ::u64 suffixOfNewComponent = serializedIdentifiersMatchingType.size() + 1;
-                    serializedIdentifier = AZStd::string::format("%s_%llu", typeName.c_str(), suffixOfNewComponent);
-                    while (serializedIdentifiersMatchingType.find(serializedIdentifier) != serializedIdentifiersMatchingType.end())
-                    {
-                        suffixOfNewComponent++;
-                        serializedIdentifier = AZStd::string::format("%s_%llu", typeName.c_str(), suffixOfNewComponent);
-                    }
-                }
-
-                SetSerializedIdentifier(AZStd::move(serializedIdentifier));
+                AZStd::string newIdentifier = GenerateComponentSerializedIdentifier();
+                SetSerializedIdentifier(AZStd::move(newIdentifier));
             }
+        }
+
+        AZStd::string EditorComponentBase::GenerateComponentSerializedIdentifier()
+        {
+            AZ_Assert(m_entity, "GenerateComponentSerializedIdentifier - Entity should not be nullptr.");
+
+            AZStd::unordered_set<AZStd::string> existingSerializedIdentifiers;
+
+            // Defines the function to add existing serialized identifiers from a given component list.
+            auto captureExistingIdentifiersFunc =
+                [&existingSerializedIdentifiers, this](const AZStd::vector<AZ::Component*>& componentsToCapture)
+            {
+                for (const AZ::Component* component : componentsToCapture)
+                {                    
+                    AZ_Assert(
+                        component != this,
+                        "GenerateComponentSerializedIdentifier - "
+                        "Attempting to generate an identifier for a component that is already owned by the entity. ");
+
+                    AZStd::string existingIdentifier = component->GetSerializedIdentifier();
+
+                    if (!existingIdentifier.empty() && RTTI_GetType() == component->RTTI_GetType())
+                    {
+                        existingSerializedIdentifiers.emplace(AZStd::move(existingIdentifier));
+                    }
+                }
+            };
+
+            // Checks all components of the entity, including pending components and disabled components.
+            captureExistingIdentifiersFunc(m_entity->GetComponents());
+
+            AZStd::vector<AZ::Component*> pendingComponents;
+            AzToolsFramework::EditorPendingCompositionRequestBus::Event(
+                m_entity->GetId(), &AzToolsFramework::EditorPendingCompositionRequests::GetPendingComponents, pendingComponents);
+
+            captureExistingIdentifiersFunc(pendingComponents);
+
+            AZStd::vector<AZ::Component*> disabledComponents;
+            AzToolsFramework::EditorDisabledCompositionRequestBus::Event(
+                m_entity->GetId(), &AzToolsFramework::EditorDisabledCompositionRequests::GetDisabledComponents, disabledComponents);
+
+            captureExistingIdentifiersFunc(disabledComponents);
+
+            // Generates a component typename string and updates its suffix count to avoid duplication.
+            // For example, if 'EditorCommentComponent' exists, it generates 'EditorCommentComponent_2', 'EditorCommentComponent_3', and so on.
+            const AZStd::string componentTypeName = GetNameFromComponentClassData(this);
+            AZStd::string serializedIdentifier = componentTypeName;
+            AZ::u64 suffixOfNewComponent = 1;
+
+            while (existingSerializedIdentifiers.find(serializedIdentifier) != existingSerializedIdentifiers.end())
+            {
+                serializedIdentifier = AZStd::string::format("%s_%llu", componentTypeName.c_str(), ++suffixOfNewComponent);
+            }
+
+            return serializedIdentifier;
         }
 
         void EditorComponentBase::SetDirty()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
@@ -115,7 +115,9 @@ namespace AzToolsFramework
              */
             virtual void Deactivate() override;
 
-            void OnPrepareForAdditionToEntity(AZ::Entity* entity) override final;
+            //! Function to call after setting the entity in this component.
+            //! For an editor component, this would set up the serialized identifier.
+            void OnAfterEntitySet() override final;
 
             //! Sets the provided string as the serialized identifier for the component.
             //! @param serializedIdentifer The unique identifier for this component within the entity it lives in.
@@ -197,6 +199,11 @@ namespace AzToolsFramework
              * @param context A pointer to the reflection context.
              */
             static void Reflect(AZ::ReflectContext* context);
+
+        private:
+            //! Generates a component serialized identifier based on existing components of the same type.
+            //! @return Serialized identifier string that can be used as a component alias.
+            AZStd::string GenerateComponentSerializedIdentifier();
 
         private:
             AZStd::string m_alias;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -133,15 +133,15 @@ namespace AzToolsFramework
 
         void EditorDisabledCompositionComponent::AddDisabledComponent(AZ::Component* componentToAdd)
         {
-            AZ_Assert(componentToAdd, "Unable to add a disabled component that is nullptr.");
+            if (!componentToAdd)
+            {
+                AZ_Assert(false, "Unable to add a disabled component that is nullptr.");
+                return;
+            }
 
             AZStd::string componentAlias = componentToAdd->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to add a disabled component that has an empty component alias.");
 
-            bool found = m_disabledComponents.find(componentAlias) != m_disabledComponents.end();
-            AZ_Assert(!found, "Unable to add a disabled component that was added already.");
-
-            if (componentToAdd && !found)
+            if (!componentAlias.empty() && m_disabledComponents.find(componentAlias) == m_disabledComponents.end())
             {
                 m_disabledComponents.emplace(AZStd::move(componentAlias), componentToAdd);
             }
@@ -149,15 +149,15 @@ namespace AzToolsFramework
 
         void EditorDisabledCompositionComponent::RemoveDisabledComponent(AZ::Component* componentToRemove)
         {
-            AZ_Assert(componentToRemove, "Unable to remove a disabled component that is nullptr.");
+            if (!componentToRemove)
+            {
+                AZ_Assert(false, "Unable to remove a disabled component that is nullptr.");
+                return;
+            }
 
             AZStd::string componentAlias = componentToRemove->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to add a disabled component that has an empty component alias.");
 
-            bool found = m_disabledComponents.find(componentAlias) != m_disabledComponents.end();
-            AZ_Assert(found, "Unable to remove a disabled component that has not been added.");
-
-            if (componentToRemove && found)
+            if (!componentAlias.empty())
             {
                 m_disabledComponents.erase(componentAlias);
             }
@@ -165,23 +165,21 @@ namespace AzToolsFramework
 
         bool EditorDisabledCompositionComponent::IsComponentDisabled(const AZ::Component* componentToCheck)
         {
-            AZ_Assert(componentToCheck, "Unable to check a component that is nullptr.");
-
-            AZStd::string componentAlias = componentToCheck->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to check a component that has an empty component alias.");
-
-            auto componentIt = m_disabledComponents.find(componentAlias);
-
-            if (componentIt != m_disabledComponents.end())
+            if (!componentToCheck)
             {
-                bool sameComponent = componentIt->second == componentToCheck;
-                AZ_Assert(sameComponent, "The component to check shares the same alias but is a different object "
-                    "compared to the one referenced in the composition component.");
-
-                return sameComponent;
+                AZ_Assert(false, "Unable to check a component that is nullptr.");
+                return false;
             }
 
-            return false;
+            AZStd::string componentAlias = componentToCheck->GetSerializedIdentifier();
+
+            if (componentAlias.empty())
+            {
+                return false;
+            }
+
+            auto componentIt = m_disabledComponents.find(componentAlias);
+            return componentIt != m_disabledComponents.end() && componentIt->second == componentToCheck;
         }
 
         EditorDisabledCompositionComponent::~EditorDisabledCompositionComponent()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -74,6 +74,12 @@ namespace AzToolsFramework
                 result.Combine(disabledComponentsResult);
             }
 
+            {
+                JSR::ResultCode componentIdResult = ContinueLoadingFromJsonObjectField(
+                    &componentInstance->m_id, azrtti_typeid<decltype(componentInstance->m_id)>(), inputValue, "Id", context);
+                result.Combine(componentIdResult);
+            }
+
             return context.Report(
                 result,
                 result.GetProcessing() != JSR::Processing::Halted ? "Successfully loaded EditorDisabledCompositionComponent information."

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             void GetDisabledComponents(AZStd::vector<AZ::Component*>& components) override;
             void AddDisabledComponent(AZ::Component* componentToAdd) override;
             void RemoveDisabledComponent(AZ::Component* componentToRemove) override;
-            bool IsComponentDisabled(const AZ::Component* component) override;
+            bool IsComponentDisabled(const AZ::Component* componentToCheck) override;
             ////////////////////////////////////////////////////////////////////
 
             ~EditorDisabledCompositionComponent() override;
@@ -43,7 +43,8 @@ namespace AzToolsFramework
             void Deactivate() override;
             ////////////////////////////////////////////////////////////////////
 
-            AZStd::vector<AZ::Component*> m_disabledComponents;
+            // Map that stores a pair of component alias (serialized identifier) and component pointer.
+            AZStd::unordered_map<AZStd::string, AZ::Component*> m_disabledComponents;
         };
     } // namespace Components
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h
@@ -10,17 +10,34 @@
 #include "EditorComponentBase.h"
 #include "EditorDisabledCompositionBus.h"
 
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
 namespace AzToolsFramework
 {
     namespace Components
     {
-        /**
-        * Contains Disabled components to be added to the entity we are attached to.
-        */
+        //! Custom serializer to handle component data in the composition component.
+        class EditorDisabledCompositionComponentSerializer
+            : public AZ::BaseJsonSerializer
+        {
+        public:
+            AZ_RTTI(EditorDisabledCompositionComponentSerializer, "{D6A44ED5-2B3B-422C-A4F2-DDDAE48ED04C}", BaseJsonSerializer);
+            AZ_CLASS_ALLOCATOR_DECL;
+            
+            AZ::JsonSerializationResult::Result Load(
+                void* outputValue,
+                const AZ::Uuid& outputValueTypeId,
+                const rapidjson::Value& inputValue,
+                AZ::JsonDeserializerContext& context) override;
+        };
+
+        //! Contains Disabled components to be added to the entity we are attached to.
         class EditorDisabledCompositionComponent
             : public AzToolsFramework::Components::EditorComponentBase
             , public EditorDisabledCompositionRequestBus::Handler
         {
+            friend class EditorDisabledCompositionComponentSerializer;
+
         public:
             AZ_COMPONENT(EditorDisabledCompositionComponent, "{E77AE6AC-897D-4035-8353-637449B6DCFB}", EditorComponentBase);
             static void Reflect(AZ::ReflectContext* context);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -75,6 +75,12 @@ namespace AzToolsFramework
                 result.Combine(pendingComponentsResult);
             }
 
+            {
+                JSR::ResultCode componentIdResult = ContinueLoadingFromJsonObjectField(
+                    &componentInstance->m_id, azrtti_typeid<decltype(componentInstance->m_id)>(), inputValue, "Id", context);
+                result.Combine(componentIdResult);
+            }
+
             return context.Report(
                 result,
                 result.GetProcessing() != JSR::Processing::Halted ? "Successfully loaded EditorPendingCompositionComponent information."

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -134,15 +134,15 @@ namespace AzToolsFramework
 
         void EditorPendingCompositionComponent::AddPendingComponent(AZ::Component* componentToAdd)
         {
-            AZ_Assert(componentToAdd, "Unable to add a pending component that is nullptr.");
+            if (!componentToAdd)
+            {
+                AZ_Assert(false, "Unable to add a pending component that is nullptr.");
+                return;
+            }
 
             AZStd::string componentAlias = componentToAdd->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to add a pending component that has an empty component alias.");
 
-            bool found = m_pendingComponents.find(componentAlias) != m_pendingComponents.end();
-            AZ_Assert(!found, "Unable to add a pending component that was added already.");
-
-            if (componentToAdd && !found)
+            if (!componentAlias.empty() && m_pendingComponents.find(componentAlias) == m_pendingComponents.end())
             {
                 m_pendingComponents.emplace(AZStd::move(componentAlias), componentToAdd);
 
@@ -157,15 +157,15 @@ namespace AzToolsFramework
 
         void EditorPendingCompositionComponent::RemovePendingComponent(AZ::Component* componentToRemove)
         {
-            AZ_Assert(componentToRemove, "Unable to remove a pending component that is nullptr.");
+            if (!componentToRemove)
+            {
+                AZ_Assert(false, "Unable to remove a pending component that is nullptr.");
+                return;
+            }
 
             AZStd::string componentAlias = componentToRemove->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to remove a pending component that has an empty component alias.");
 
-            bool found = m_pendingComponents.find(componentAlias) != m_pendingComponents.end();
-            AZ_Assert(found, "Unable to remove a pending component that has not been added.");
-
-            if (componentToRemove && found)
+            if (!componentAlias.empty())
             {
                 m_pendingComponents.erase(componentAlias);
 
@@ -180,23 +180,21 @@ namespace AzToolsFramework
 
         bool EditorPendingCompositionComponent::IsComponentPending(const AZ::Component* componentToCheck)
         {
-            AZ_Assert(componentToCheck, "Unable to check a component that is nullptr.");
-
-            AZStd::string componentAlias = componentToCheck->GetSerializedIdentifier();
-            AZ_Assert(!componentAlias.empty(), "Unable to check a component that has an empty component alias.");
-
-            auto componentIt = m_pendingComponents.find(componentAlias);
-
-            if (componentIt != m_pendingComponents.end())
+            if (!componentToCheck)
             {
-                bool sameComponent = componentIt->second == componentToCheck;
-                AZ_Assert(sameComponent, "The component to check shares the same alias but is a different object "
-                    "compared to the one referenced in the composition component.");
-
-                return sameComponent;
+                AZ_Assert(false, "Unable to check a component that is nullptr.");
+                return false;
             }
 
-            return false;
+            AZStd::string componentAlias = componentToCheck->GetSerializedIdentifier();
+
+            if (componentAlias.empty())
+            {
+                return false;
+            }
+            
+            auto componentIt = m_pendingComponents.find(componentAlias);
+            return componentIt != m_pendingComponents.end() && componentIt->second == componentToCheck;
         }
 
         EditorPendingCompositionComponent::~EditorPendingCompositionComponent()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
@@ -10,17 +10,34 @@
 #include "EditorComponentBase.h"
 #include "EditorPendingCompositionBus.h"
 
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
 namespace AzToolsFramework
 {
     namespace Components
     {
-        /**
-        * Contains pending components to be added to the entity we are attached to.
-        */
+        //! Custom serializer to handle component data in the composition component.
+        class EditorPendingCompositionComponentSerializer
+            : public AZ::BaseJsonSerializer
+        {
+        public:
+            AZ_RTTI(EditorPendingCompositionComponentSerializer, "{9084611C-7011-4906-9EE6-EF10019ABADD}", BaseJsonSerializer);
+            AZ_CLASS_ALLOCATOR_DECL;
+
+            AZ::JsonSerializationResult::Result Load(
+                void* outputValue,
+                const AZ::Uuid& outputValueTypeId,
+                const rapidjson::Value& inputValue,
+                AZ::JsonDeserializerContext& context) override;
+        };
+
+        //! Contains pending components to be added to the entity we are attached to.
         class EditorPendingCompositionComponent
             : public AzToolsFramework::Components::EditorComponentBase
             , public EditorPendingCompositionRequestBus::Handler
         {
+            friend class EditorPendingCompositionComponentSerializer;
+
         public:
             AZ_COMPONENT(EditorPendingCompositionComponent, "{D40FCB35-153D-45B3-AF6D-7BA576D8AFBB}", EditorComponentBase);
             static void Reflect(AZ::ReflectContext* context);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             void GetPendingComponents(AZStd::vector<AZ::Component*>& components) override;
             void AddPendingComponent(AZ::Component* componentToAdd) override;
             void RemovePendingComponent(AZ::Component* componentToRemove) override;
-            bool IsComponentPending(const AZ::Component* component) override;
+            bool IsComponentPending(const AZ::Component* componentToCheck) override;
             ////////////////////////////////////////////////////////////////////
 
             ~EditorPendingCompositionComponent() override;
@@ -43,7 +43,8 @@ namespace AzToolsFramework
             void Deactivate() override;
             ////////////////////////////////////////////////////////////////////
 
-            AZStd::vector<AZ::Component*> m_pendingComponents;
+            // Map that stores a pair of component alias (serialized identifier) and component pointer.
+            AZStd::unordered_map<AZStd::string, AZ::Component*> m_pendingComponents;
         };
     } // namespace Components
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/Tests/ComponentAddRemove.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentAddRemove.cpp
@@ -1427,7 +1427,9 @@ namespace UnitTest
 
         // now add a socks component to the pending set which will fulfill the boots' dependency
         testEntity->CreateComponent<AzToolsFramework::Components::GenericComponentWrapper>(aznew LeatherBootsComponent());
-        AzToolsFramework::EditorPendingCompositionRequestBus::Event(testEntity->GetId(), &AzToolsFramework::EditorPendingCompositionRequests::AddPendingComponent, aznew WoolSocksComponent());
+        WoolSocksComponent* woolSocksComponent = aznew WoolSocksComponent();
+        woolSocksComponent->SetSerializedIdentifier("WoolSocksComponent"); // pending composition component cannot store an empty serialized identifier.
+        AzToolsFramework::EditorPendingCompositionRequestBus::Event(testEntity->GetId(), &AzToolsFramework::EditorPendingCompositionRequests::AddPendingComponent, woolSocksComponent);
 
         pendingComponents.clear();
         AzToolsFramework::EditorPendingCompositionRequestBus::Event(testEntity->GetId(), &AzToolsFramework::EditorPendingCompositionRequests::GetPendingComponents, pendingComponents);


### PR DESCRIPTION
## What does this PR do?

Fixes empty component alias issue: https://github.com/o3de/o3de/issues/15546

This PR aims to fix the empty component alias issue that happens to components stored in pending and disabled composition components. The issue started to occur after we changed to use component type names as component aliases in PR https://github.com/o3de/o3de/pull/15256.

A non-empty component alias for a component stored in the composition component is required for ensuring correctness of override patching because patches have paths that contain component aliases. They can't be empty. Note that before using component type name as aliases, there was no issue since we used component ids as the aliases. To learn more, see the attached GHI.

**Change List:**
1. Changed to use map (not vector) to store component data, which enables us storing aliases in the serialized data.
1. Updated functions in the two composition components to work with the map and component aliases.
1. Added to set up the component alias for a new pending component in `EditorEntityActionComponent`.
1. Changed `OnPrepareForAdditionToEntity` to `OnAfterEntitySet` to indicate more clearly that it is called after 'entity is set', not 'added to entity'.
1. Improved component type name alias generation in `OnAfterEntitySet` and Changed to reuse unused suffix count.
1. Added custom serializers for composition components to support reading array type and object type data.

```cpp
// Before - EditorPendingCompositionComponent
"PendingComponents": [                                  // vector (array)
    {
        "$type": "EditorSurfaceMaskFilterComponent",
        "Id": 7435484230423003242
    }
]

// After - EditorPendingCompositionComponent
"PendingComponents": {                                  // map (object)
    "EditorSurfaceMaskFilterComopnent": {               // component alias
        "$type": "EditorSurfaceMaskFilterComponent",
        "Id": 7435484230423003242
    }
}
```

## How was this PR tested?

**Tested in editor**

Pending composition component:
1. Added a new component that is pending (e.g. `EditorSurfaceMaskFilterComponent`); Verified it has valid type name alias and could be saved to file; Reloaded the level and verified the same alias could be loaded from file.
1. Assuming there are multiple components of the same type (e.g. `EditorSurfaceMaskFilterComponent`, `_2`, `_3`), deleted the second one and added a new one; Verified `_2` would be reused, while previously it was `_4`.

Disabled composition component:
1. Same as above.
1. Assuming adding two components of the same type (e.g. `EditorCommentComponent`, `_2`), disabled the first then the second, then enabled the second then the first, and verified that they won't swap component aliases.

Other test cases:
1. Verified for RPE entity inspector, DPE inspector, and DPE inspector w/ prefab inspector override enabled. 
1. Verified that changing a pending component to disabled and back to enabled could function without issues.
1. Verified it worked for generic type component wrapper (e.g. FlyCameraInputComponent).

**Backward compatibility testing**

Added the custom serializers. I tested that it can read old array data without any issue. For example, it can read the below data and can save back to the file with the new data.

```cpp
"DisabledComponents": [                             // old array data
    {
        "$type": "EditorCommentComponent",
        "Id": 8548758530932447835,
        "Configuration": "1"
    }
]

"DisabledComponents": {                             // new map data
    "Component_[8548758530932447835]": {
        "$type": "EditorCommentComponent",
        "Id": 8548758530932447835,
        "Configuration": "1"
    }
}
```