### PR TITLE
Fixed CMake configuration when configuring for monolithic

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -16,7 +16,7 @@ set_property(GLOBAL PROPERTY LAUNCHER_UNIFIED_BINARY_DIR ${CMAKE_CURRENT_BINARY_
 # When using an installed engine, this file will be included by the FindLauncherGenerator.cmake script
 get_property(O3DE_PROJECTS_NAME GLOBAL PROPERTY O3DE_PROJECTS_NAME)
 foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
-    
+
     # Computes the realpath to the project
     # If the project_path is relative, it is evaluated relative to the ${LY_ROOT_FOLDER}
     # Otherwise the the absolute project_path is returned with symlinks resolved
@@ -28,16 +28,16 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
     if(PAL_TRAIT_BUILD_HOST_TOOLS)
         add_custom_target(${project_name}.Assets
             COMMENT "Processing ${project_name} assets..."
-            COMMAND "${CMAKE_COMMAND}" 
+            COMMAND "${CMAKE_COMMAND}"
                 -DLY_LOCK_FILE=$<GENEX_EVAL:$<TARGET_FILE_DIR:AZ::AssetProcessorBatch>>/project_assets.lock
                 -P ${LY_ROOT_FOLDER}/cmake/CommandExecution.cmake
                     EXEC_COMMAND $<GENEX_EVAL:$<TARGET_FILE:AZ::AssetProcessorBatch>>
-                        --zeroAnalysisMode 
-                        --project-path=${project_real_path} 
+                        --zeroAnalysisMode
+                        --project-path=${project_real_path}
                         --platforms=${LY_ASSET_DEPLOY_ASSET_TYPE}
         )
         set_target_properties(${project_name}.Assets
-            PROPERTIES 
+            PROPERTIES
                 EXCLUDE_FROM_ALL TRUE
                 FOLDER ${project_name}
         )
@@ -53,7 +53,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
         set_property(GLOBAL APPEND PROPERTY LY_STATIC_MODULE_PROJECTS_NAME ${project_name})
         get_property(game_gem_dependencies GLOBAL PROPERTY LY_DELAYED_DEPENDENCIES_${project_name}.GameLauncher)
 
-        set(game_build_dependencies 
+        set(game_build_dependencies
             ${game_gem_dependencies}
             Legacy::CrySystem
         )
@@ -61,7 +61,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
         if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
             get_property(server_gem_dependencies GLOBAL PROPERTY LY_DELAYED_DEPENDENCIES_${project_name}.ServerLauncher)
 
-            set(server_build_dependencies 
+            set(server_build_dependencies
                 ${server_gem_dependencies}
                 Legacy::CrySystem
             )
@@ -70,7 +70,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
         if(PAL_TRAIT_BUILD_UNIFIED_SUPPORTED)
             get_property(unified_gem_dependencies GLOBAL PROPERTY LY_DELAYED_DEPENDENCIES_${project_name}.UnifiedLauncher)
 
-            set(unified_build_dependencies 
+            set(unified_build_dependencies
                 ${unified_gem_dependencies}
                 Legacy::CrySystem
             )
@@ -128,7 +128,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
     )
     # Needs to be set manually after ly_add_target to prevent the default location overriding it
     set_target_properties(${project_name}.GameLauncher
-        PROPERTIES 
+        PROPERTIES
             FOLDER ${project_name}
             LY_PROJECT_NAME ${project_name}
     )
@@ -145,7 +145,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME LY_PROJECTS)
             endif()
         endif()
 
-        set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
+        set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS
             "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${additional_game_vs_debugger_args}")
     endif()
 
@@ -288,7 +288,9 @@ function(ly_delayed_generate_static_modules_inl)
             unset(module_invocations)
 
             unset(all_game_gem_dependencies)
-            ly_get_gem_load_dependencies(all_game_gem_dependencies ${project_name}.GameLauncher)
+            o3de_get_gem_load_dependencies(
+                GEM_LOAD_DEPENDENCIES_VAR all_game_gem_dependencies
+                TARGET "${project_name}.GameLauncher")
 
             foreach(game_gem_dependency ${all_game_gem_dependencies})
                 # Sometimes, a gem's Client variant may be an interface library
@@ -317,17 +319,15 @@ function(ly_delayed_generate_static_modules_inl)
 
             ly_target_link_libraries(${project_name}.GameLauncher PRIVATE ${all_game_gem_dependencies})
             if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
-                get_property(server_gem_dependencies GLOBAL PROPERTY LY_STATIC_MODULE_PROJECTS_DEPENDENCIES_${project_name}.ServerLauncher)
 
                 unset(extern_module_declarations)
                 unset(module_invocations)
 
                 unset(all_server_gem_dependencies)
-                ly_get_gem_load_dependencies(all_server_gem_dependencies ${project_name}.ServerLauncher)
-                foreach(server_gem_dependency ${server_gem_dependencies})
-                    ly_get_gem_load_dependencies(server_gem_load_dependencies ${server_gem_dependency})
-                    list(APPEND all_server_gem_dependencies ${server_gem_load_dependencies} ${server_gem_dependency})
-                endforeach()
+
+                o3de_get_gem_load_dependencies(
+                    GEM_LOAD_DEPENDENCIES_VAR all_server_gem_dependencies
+                    TARGET "${project_name}.ServerLauncher")
                 foreach(server_gem_dependency ${all_server_gem_dependencies})
                     # Skip interface libraries
                     if(TARGET ${server_gem_dependency})
@@ -353,17 +353,14 @@ function(ly_delayed_generate_static_modules_inl)
             endif()
 
             if(PAL_TRAIT_BUILD_UNIFIED_SUPPORTED)
-                get_property(unified_gem_dependencies GLOBAL PROPERTY LY_STATIC_MODULE_PROJECTS_DEPENDENCIES_${project_name}.UnifiedLauncher)
 
                 unset(extern_module_declarations)
                 unset(module_invocations)
 
                 unset(all_unified_gem_dependencies)
-                ly_get_gem_load_dependencies(all_unified_gem_dependencies ${project_name}.UnifiedLauncher)
-                foreach(unified_gem_dependency ${unified_gem_dependencies})
-                    ly_get_gem_load_dependencies(unified_gem_load_dependencies ${unified_gem_dependency})
-                    list(APPEND all_unified_gem_dependencies ${unified_gem_load_dependencies} ${unified_gem_dependency})
-                endforeach()
+                o3de_get_gem_load_dependencies(
+                    GEM_LOAD_DEPENDENCIES_VAR all_unified_gem_dependencies
+                    TARGET "${project_name}.UnifiedLauncher")
                 foreach(unified_gem_dependency ${all_unified_gem_dependencies})
                     # Skip interface libraries
                     if(TARGET ${unified_gem_dependency})


### PR DESCRIPTION
The launcher_generator.cmake needed to be updated to use the renamed `o3de_get_gem_load_dependencies` command.


## How was this PR tested?

Configured in an engine-centric workflow with the `windows-mono-default` preset and the LY_PROJECTS project path set to AutomatedTesting

```powershell
PS D:\o3de>cmake --preset windows-mono-default -DLY_PROJECTS=.\AutomatedTesting
```
