### PR TITLE
Re-enable one prefab instantiation unit test

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
@@ -33,8 +33,7 @@ namespace UnitTest
         CompareInstances(*firstInstance, *secondInstance, true, false);
     }
 
-    // TODO: Issue #3398 will re-enable
-    TEST_F(PrefabInstantiateTest, DISABLED_PrefabInstantiate_TripleNestingTemplate_InstantiateSucceeds)
+    TEST_F(PrefabInstantiateTest, PrefabInstantiate_TripleNestingTemplate_InstantiateSucceeds)
     {
         AZ::Entity* newEntity = CreateEntity("New Entity");
         AddRequiredEditorComponents({ newEntity->GetId() });


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/3398

Link comparison should work as expected, so I enable the disabled prefab unit test that failed before.

## How was this PR tested?

Tested that it can pass now.
