### PR TITLE
RHI multi-device resource classes with tests.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -11,6 +11,8 @@
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
 
+#include <AzCore/std/containers/unordered_map.h>
+
 namespace AZ
 {
     namespace RHI
@@ -125,6 +127,30 @@ namespace AZ
 
             /// The number of bytes that image date is offset in a buffer.
             uint32_t m_offset = 0;
+        };
+
+        struct MultiDeviceImageSubresourceLayout
+        {
+            AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
+            static void Reflect(AZ::ReflectContext* context);
+
+            MultiDeviceImageSubresourceLayout() = default;
+
+            ImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
+            {
+                return m_deviceImageSubresourceLayout[deviceIndex];
+            }
+
+            const ImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex) const
+            {
+                AZ_Assert(
+                    m_deviceImageSubresourceLayout.find(deviceIndex) != m_deviceImageSubresourceLayout.end(),
+                    "No ImageSubresourceLayout found for device index %d\n",
+                    deviceIndex);
+                return m_deviceImageSubresourceLayout.at(deviceIndex);
+            }
+
+            AZStd::unordered_map<int, ImageSubresourceLayout> m_deviceImageSubresourceLayout;
         };
 
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -88,7 +88,13 @@ namespace AZ
 
         namespace MultiDevice
         {
-            constexpr int DefaultDeviceIndex = 0;
+            enum class DeviceMask : uint32_t
+            {
+            };
+            constexpr DeviceMask AllDevices{ static_cast<DeviceMask>(-1) };
+            constexpr DeviceMask DefaultDevice{ 1u };
+
+            constexpr int DefaultDeviceIndex { 0 };
         }
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/BufferDescriptor.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class BufferFrameAttachment;
+        struct BufferViewDescriptor;
+
+        //! A buffer corresponds to a region of linear memory and used for rendering operations. The user
+        //! manages the lifecycle of a buffer through a MultiDeviceBufferPool.
+        class MultiDeviceBuffer : public MultiDeviceResource
+        {
+            using Base = MultiDeviceResource;
+            friend class MultiDeviceBufferPool;
+            friend class MultiDeviceRayTracingTlas;
+            friend class MultiDeviceTransientAttachmentPool;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceBuffer, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceBuffer, "{8B8A544D-7819-4677-9C47-943B821DE619}", MultiDeviceResource);
+            MultiDeviceBuffer() = default;
+            virtual ~MultiDeviceBuffer() = default;
+
+            const BufferDescriptor& GetDescriptor() const;
+
+            inline const Ptr<Buffer>& GetDeviceBuffer(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceBuffer",
+                    m_deviceBuffers.find(deviceIndex) != m_deviceBuffers.end(),
+                    "No DeviceBuffer found for device index %d\n",
+                    deviceIndex);
+                return m_deviceBuffers.at(deviceIndex);
+            }
+
+            // Returns the buffer frame attachment if the buffer is currently attached.
+            const BufferFrameAttachment* GetFrameAttachment() const;
+
+            // Get the hash associated with the MultiDeviceBuffer
+            const HashValue64 GetHash() const;
+
+            // Shuts down the resource by detaching it from its parent pool.
+            void Shutdown() override final;
+
+            void InvalidateViews() override final;
+
+        protected:
+            void SetDescriptor(const BufferDescriptor& descriptor);
+
+        private:
+            void Invalidate();
+
+            // The RHI descriptor for this buffer.
+            BufferDescriptor m_descriptor;
+
+            // A map of device index to the corresponding Buffer.
+            AZStd::unordered_map<int, Ptr<Buffer>> m_deviceBuffers;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/BufferPoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/BufferPool.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceFence;
+
+        /**
+         * A structure used as an argument to MultiDeviceBufferPool::InitBuffer.
+         */
+        struct MultiDeviceBufferInitRequest
+        {
+            MultiDeviceBufferInitRequest() = default;
+
+            MultiDeviceBufferInitRequest(MultiDeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData = nullptr);
+
+            /// The buffer to initialize. The buffer must be in an uninitialized state.
+            MultiDeviceBuffer* m_buffer = nullptr;
+
+            /// The descriptor used to initialize the buffer.
+            BufferDescriptor m_descriptor;
+
+            /// [Optional] Initial data used to initialize the buffer.
+            const void* m_initialData = nullptr;
+        };
+
+        /**
+         * A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
+         */
+        struct MultiDeviceBufferMapRequest
+        {
+            MultiDeviceBufferMapRequest() = default;
+
+            MultiDeviceBufferMapRequest(MultiDeviceBuffer& buffer, size_t byteOffset, size_t byteCount);
+
+            /// The buffer instance to map for CPU access.
+            MultiDeviceBuffer* m_buffer = nullptr;
+
+            /// The number of bytes offset from the base of the buffer to map for access.
+            size_t m_byteOffset = 0;
+
+            /// The number of bytes beginning from the offset to map for access.
+            size_t m_byteCount = 0;
+        };
+
+        /**
+         * A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
+         */
+        struct MultiDeviceBufferMapResponse
+        {
+            AZStd::vector<void*> m_data;
+        };
+
+        /**
+         * A structure used as an argument to MultiDeviceBufferPool::StreamBuffer.
+         */
+        struct MultiDeviceBufferStreamRequest
+        {
+            /// A fence to signal on completion of the upload operation.
+            MultiDeviceFence* m_fenceToSignal = nullptr;
+
+            /// The buffer instance to stream up to.
+            MultiDeviceBuffer* m_buffer = nullptr;
+
+            /// The number of bytes offset from the base of the buffer to start the upload.
+            size_t m_byteOffset = 0;
+
+            /// The number of bytes to upload beginning from m_byteOffset.
+            size_t m_byteCount = 0;
+
+            /// A pointer to the source data to upload. The source data must remain valid
+            /// for the duration of the upload operation (i.e. until m_callbackFunction
+            /// is invoked).
+            const void* m_sourceData = nullptr;
+        };
+
+        /**
+         * Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
+         * contains properties defining memory characteristics of buffer pools. All buffers created on a pool
+         * share the same backing heap and buffer bind flags.
+         */
+        class MultiDeviceBufferPool : public MultiDeviceResourcePool
+        {
+            friend class MultiDeviceRayTracingBufferPools;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceBufferPool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceBufferPool, "{547F1577-0AA3-4F0D-9656-8905DE5E9E8A}", MultiDeviceResourcePool)
+            MultiDeviceBufferPool() = default;
+            virtual ~MultiDeviceBufferPool() override = default;
+
+            inline const Ptr<BufferPool>& GetDeviceBufferPool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceBufferPool",
+                    m_deviceBufferPools.find(deviceIndex) != m_deviceBufferPools.end(),
+                    "No DeviceBufferPool found for device index %d\n",
+                    deviceIndex);
+                return m_deviceBufferPools.at(deviceIndex);
+            }
+
+            /**
+             * Initializes the buffer pool with a provided descriptor. The pool must be in an uninitialized
+             * state, or this call will fail. To re-use an existing pool, you must first call Shutdown
+             * before calling Init again.
+             *
+             *  @param descriptor The descriptor containing properties used to initialize the pool.
+             *  @return A result code denoting the status of the call. If successful, the pool is considered
+             *      initialized and is able to service buffer requests. If failure, the pool remains uninitialized.
+             */
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor);
+
+            /**
+             * Initializes a buffer instance created from this pool. The buffer must be in an uninitialized
+             * state, or the call will fail. To re-use an existing buffer instance, first call Shutdown
+             * on the buffer prior to calling InitBuffer on the pool.
+             *
+             *  @param request The request used to initialize a buffer instance.
+             *  @return A result code denoting the status of the call. If successful, the buffer is considered
+             *      initialized and 'registered' with the pool. If the pool fails to secure an allocation for the
+             *      buffer, it remain in a shutdown state. If the initial data upload fails, the buffer will be
+             *      initialized, but will remain empty and the call will return ResultCode::OutOfMemory. Checking
+             *      this amounts to seeing if buffer.IsInitialized() is true.
+             */
+            ResultCode InitBuffer(const MultiDeviceBufferInitRequest& request);
+
+            /**
+             * NOTE: Only applicable to 'Host' pools. Device pools will fail with ResultCode::InvalidOperation.
+             *
+             * Instructs the pool to allocate a new backing allocation for the buffer. This enables the user to
+             * ignore tracking hazards between the CPU and GPU timelines. Call this method if the entire buffer contents
+             * are being overwritten for a new frame.
+             *
+             * The user may instead do hazard tracking manually by not overwriting regions in-flight on the GPU. To ensure
+             * that a region has flushed through the GPU, either use Fences to track when a Scope has completed, or rely
+             * on RHI::Limits::Device::FrameCountMax (for example, by N-buffering the data in a round-robin
+             * fashion).
+             *
+             * If the new allocation is small enough to be page-allocated, the buffer's debug name will be lost.
+             * If the allocation is large enough to create a new buffer object, it will call SetName() with
+             * the old name.
+             *
+             *  @param buffer The buffer whose backing allocation to orphan. The buffer must be registered and
+             *      initialized with this pool.
+             *  @return On success, the buffer is considered to have a new backing allocation. On failure, the existing
+             *      buffer allocation remains intact.
+             */
+            ResultCode OrphanBuffer(MultiDeviceBuffer& buffer);
+
+            /**
+             * Maps a buffer region for CPU access. The type of access (read or write) is dictated by the type of
+             * buffer pool. Host pools with host read access may read from the buffer--the contents of which
+             * are written by the GPU. All other modes only expose write-only access by the CPU.
+             *
+             * Is it safe to nest Map operations if the regions are disjoint. Calling Map is reference counted, so calling
+             * Unmap is required for each Map call. Map operations will block the frame scheduler from recording staging
+             * operations to the command lists. To avoid this, unmap all buffer regions before the frame execution phase.
+             *
+             *  @param request The map request structure holding properties for the map operation.
+             *  @param response The map response structure holding the mapped data pointer (if successful), or null.
+             *  @return Returns a result code specifying whether the call succeeded, or a failure code specifying
+             *      why the call failed.
+             */
+            ResultCode MapBuffer(const MultiDeviceBufferMapRequest& request, MultiDeviceBufferMapResponse& response);
+
+            /**
+             * Unmaps a buffer for CPU access. The mapped data pointer is considered invalid after this call and
+             * should not be accessed. This call unmaps the data region and unblocks the GPU for access.
+             */
+            void UnmapBuffer(MultiDeviceBuffer& buffer);
+
+            /**
+             * Asynchronously streams buffer data up to the GPU. The operation is decoupled from the frame scheduler.
+             * It is not valid to use the buffer while the upload is running. The provided fence is signaled when the
+             * upload completes.
+             */
+            ResultCode StreamBuffer(const MultiDeviceBufferStreamRequest& request);
+
+            /**
+             * Returns the buffer descriptor used to initialize the buffer pool. Descriptor contents
+             * are undefined for uninitialized pools.
+             */
+            const BufferPoolDescriptor& GetDescriptor() const override final;
+
+            /// Shuts down the pool. This method will shutdown all resources associated with the pool.
+            void Shutdown() override final;
+
+        private:
+            using MultiDeviceResourcePool::Init;
+
+            ResultCode InitBuffer(MultiDeviceBuffer* buffer, const BufferDescriptor& descriptor, PlatformMethod platformInitResourceMethod);
+
+            /// Validates that the map operation succeeded by printing a warning otherwise. Increments
+            /// the map reference counts for the buffer and the pool.
+            void ValidateBufferMap(MultiDeviceBuffer& buffer, bool isDataValid);
+
+            bool ValidateNotDeviceLevel() const;
+
+            bool ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const;
+            bool ValidateInitRequest(const MultiDeviceBufferInitRequest& initRequest) const;
+            bool ValidateIsHostHeap() const;
+            bool ValidateMapRequest(const MultiDeviceBufferMapRequest& request) const;
+
+            BufferPoolDescriptor m_descriptor;
+
+            AZStd::unordered_map<int, Ptr<BufferPool>> m_deviceBufferPools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <Atom/RHI/CopyItem.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        struct MultiDeviceCopyBufferDescriptor
+        {
+            MultiDeviceCopyBufferDescriptor() = default;
+
+            CopyBufferDescriptor GetDeviceCopyBufferDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(m_sourceBuffer, "Not initialized with source MultiDeviceBuffer\n");
+                AZ_Assert(m_destinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+                return CopyBufferDescriptor{ m_sourceBuffer ? m_sourceBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                                         m_sourceOffset,
+                                                         m_destinationBuffer ? m_destinationBuffer->GetDeviceBuffer(deviceIndex).get()
+                                                                             : nullptr,
+                                                         m_destinationOffset,
+                                                         m_size };
+            }
+
+            const MultiDeviceBuffer* m_sourceBuffer = nullptr;
+            uint32_t m_sourceOffset = 0;
+            const MultiDeviceBuffer* m_destinationBuffer = nullptr;
+            uint32_t m_destinationOffset = 0;
+            uint32_t m_size = 0;
+        };
+
+        struct MultiDeviceCopyImageDescriptor
+        {
+            MultiDeviceCopyImageDescriptor() = default;
+
+            CopyImageDescriptor GetDeviceCopyImageDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(m_sourceImage, "Not initialized with source MultiDeviceImage\n");
+                AZ_Assert(m_destinationImage, "Not initialized with destination MultiDeviceImage\n");
+
+                return CopyImageDescriptor{ m_sourceImage ? m_sourceImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                                        m_sourceSubresource,
+                                                        m_sourceOrigin,
+                                                        m_sourceSize,
+                                                        m_destinationImage ? m_destinationImage->GetDeviceImage(deviceIndex).get()
+                                                                           : nullptr,
+                                                        m_destinationSubresource,
+                                                        m_destinationOrigin };
+            }
+
+            const MultiDeviceImage* m_sourceImage = nullptr;
+            ImageSubresource m_sourceSubresource;
+            Origin m_sourceOrigin;
+            Size m_sourceSize;
+            const MultiDeviceImage* m_destinationImage = nullptr;
+            ImageSubresource m_destinationSubresource;
+            Origin m_destinationOrigin;
+        };
+
+        struct MultiDeviceCopyBufferToImageDescriptor
+        {
+            MultiDeviceCopyBufferToImageDescriptor() = default;
+
+            CopyBufferToImageDescriptor GetDeviceCopyBufferToImageDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(m_sourceBuffer, "Not initialized with source MultiDeviceBuffer\n");
+                AZ_Assert(m_destinationImage, "Not initialized with destination MultiDeviceImage\n");
+
+                return CopyBufferToImageDescriptor{
+                    m_sourceBuffer ? m_sourceBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                    m_sourceOffset,
+                    m_sourceBytesPerRow,
+                    m_sourceBytesPerImage,
+                    m_sourceSize,
+                    m_destinationImage ? m_destinationImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                    m_destinationSubresource,
+                    m_destinationOrigin
+                };
+            }
+
+            const MultiDeviceBuffer* m_sourceBuffer = nullptr;
+            uint32_t m_sourceOffset = 0;
+            uint32_t m_sourceBytesPerRow = 0;
+            uint32_t m_sourceBytesPerImage = 0;
+            Size m_sourceSize;
+            const MultiDeviceImage* m_destinationImage = nullptr;
+            ImageSubresource m_destinationSubresource;
+            Origin m_destinationOrigin;
+        };
+
+        struct MultiDeviceCopyImageToBufferDescriptor
+        {
+            MultiDeviceCopyImageToBufferDescriptor() = default;
+
+            CopyImageToBufferDescriptor GetDeviceCopyImageToBufferDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(m_sourceImage, "Not initialized with source MultiDeviceImage\n");
+                AZ_Assert(m_destinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+                return CopyImageToBufferDescriptor{ m_sourceImage ? m_sourceImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                                                m_sourceSubresource,
+                                                                m_sourceOrigin,
+                                                                m_sourceSize,
+                                                                m_destinationBuffer
+                                                                    ? m_destinationBuffer->GetDeviceBuffer(deviceIndex).get()
+                                                                    : nullptr,
+                                                                m_destinationOffset,
+                                                                m_destinationBytesPerRow,
+                                                                m_destinationBytesPerImage,
+                                                                m_destinationFormat };
+            }
+
+            const MultiDeviceImage* m_sourceImage = nullptr;
+            ImageSubresource m_sourceSubresource;
+            Origin m_sourceOrigin;
+            Size m_sourceSize;
+            const MultiDeviceBuffer* m_destinationBuffer = nullptr;
+            uint32_t m_destinationOffset = 0;
+            uint32_t m_destinationBytesPerRow = 0;
+            uint32_t m_destinationBytesPerImage = 0;
+            // The destination format is usually same as m_sourceImage's format. When source image contains more than one aspect,
+            // the format should be compatiable with the aspect of the source image's subresource
+            Format m_destinationFormat;
+        };
+
+        struct MultiDeviceCopyQueryToBufferDescriptor
+        {
+            MultiDeviceCopyQueryToBufferDescriptor() = default;
+
+            CopyQueryToBufferDescriptor GetDeviceCopyQueryToBufferDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(m_sourceQueryPool, "Not initialized with source MultiDeviceQueryPool\n");
+                AZ_Assert(m_destinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+                return CopyQueryToBufferDescriptor{
+                    m_sourceQueryPool ? m_sourceQueryPool->GetDeviceQueryPool(deviceIndex).get() : nullptr,
+                    m_firstQuery,
+                    m_queryCount,
+                    m_destinationBuffer ? m_destinationBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                    m_destinationOffset,
+                    m_destinationStride
+                };
+            }
+
+            const MultiDeviceQueryPool* m_sourceQueryPool = nullptr;
+            QueryHandle m_firstQuery = QueryHandle(0);
+            uint32_t m_queryCount = 0;
+            const MultiDeviceBuffer* m_destinationBuffer = nullptr;
+            uint32_t m_destinationOffset = 0;
+            uint32_t m_destinationStride = 0;
+        };
+
+        struct MultiDeviceCopyItem
+        {
+            MultiDeviceCopyItem()
+                : m_type{ CopyItemType::Buffer }
+                , m_buffer{}
+            {
+            }
+
+            MultiDeviceCopyItem(const MultiDeviceCopyBufferDescriptor& descriptor)
+                : m_type{ CopyItemType::Buffer }
+                , m_buffer{ descriptor }
+            {
+            }
+
+            MultiDeviceCopyItem(const MultiDeviceCopyImageDescriptor& descriptor)
+                : m_type{ CopyItemType::Image }
+                , m_image{ descriptor }
+            {
+            }
+
+            MultiDeviceCopyItem(const MultiDeviceCopyBufferToImageDescriptor& descriptor)
+                : m_type{ CopyItemType::BufferToImage }
+                , m_bufferToImage{ descriptor }
+            {
+            }
+
+            MultiDeviceCopyItem(const MultiDeviceCopyImageToBufferDescriptor& descriptor)
+                : m_type{ CopyItemType::ImageToBuffer }
+                , m_imageToBuffer{ descriptor }
+            {
+            }
+
+            MultiDeviceCopyItem(const MultiDeviceCopyQueryToBufferDescriptor& descriptor)
+                : m_type{ CopyItemType::QueryToBuffer }
+                , m_queryToBuffer{ descriptor }
+            {
+            }
+
+            CopyItem GetDeviceCopyItem(int deviceIndex) const
+            {
+                switch (m_type)
+                {
+                case CopyItemType::Buffer:
+                    return CopyItem(m_buffer.GetDeviceCopyBufferDescriptor(deviceIndex));
+                case CopyItemType::Image:
+                    return CopyItem(m_image.GetDeviceCopyImageDescriptor(deviceIndex));
+                case CopyItemType::BufferToImage:
+                    return CopyItem(m_bufferToImage.GetDeviceCopyBufferToImageDescriptor(deviceIndex));
+                case CopyItemType::ImageToBuffer:
+                    return CopyItem(m_imageToBuffer.GetDeviceCopyImageToBufferDescriptor(deviceIndex));
+                case CopyItemType::QueryToBuffer:
+                    return CopyItem(m_queryToBuffer.GetDeviceCopyQueryToBufferDescriptor(deviceIndex));
+                default:
+                    return CopyItem();
+                }
+            }
+
+            CopyItemType m_type;
+            union {
+                MultiDeviceCopyBufferDescriptor m_buffer;
+                MultiDeviceCopyImageDescriptor m_image;
+                MultiDeviceCopyBufferToImageDescriptor m_bufferToImage;
+                MultiDeviceCopyImageToBufferDescriptor m_imageToBuffer;
+                MultiDeviceCopyQueryToBufferDescriptor m_queryToBuffer;
+            };
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/MultiDeviceIndirectArguments.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/DispatchItem.h>
+#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! Arguments used when submitting an indirect dispatch call into a CommandList.
+        //! The indirect dispatch arguments are the same ones as the indirect draw ones.
+        using MultiDeviceDispatchIndirect = MultiDeviceIndirectArguments;
+
+        //! Encapsulates the arguments that are specific to a type of dispatch.
+        //! It uses a union to be able to store all possible arguments.
+        struct MultiDeviceDispatchArguments
+        {
+            AZ_TYPE_INFO(MultiDeviceDispatchArguments, "0A354A63-D2C5-4C59-B3E0-0800FA7FBA63");
+
+            MultiDeviceDispatchArguments()
+                : MultiDeviceDispatchArguments(DispatchDirect{})
+            {
+            }
+
+            MultiDeviceDispatchArguments(const DispatchDirect& direct)
+                : m_type{ DispatchType::Direct }
+                , m_direct{ direct }
+            {
+            }
+
+            MultiDeviceDispatchArguments(const MultiDeviceDispatchIndirect& indirect)
+                : m_type{ DispatchType::Indirect }
+                , m_indirect{ indirect }
+            {
+            }
+
+            DispatchArguments GetDeviceDispatchArguments(int deviceIndex) const
+            {
+                switch (m_type)
+                {
+                case DispatchType::Direct:
+                    return DispatchArguments(m_direct);
+                case DispatchType::Indirect:
+                    return DispatchArguments(m_indirect.GetDeviceIndirectArguments(deviceIndex));
+                default:
+                    return DispatchArguments();
+                }
+            }
+
+            DispatchType m_type;
+            union {
+                /// Arguments for a direct dispatch.
+                DispatchDirect m_direct;
+                /// Arguments for an indirect dispatch.
+                MultiDeviceDispatchIndirect m_indirect;
+            };
+        };
+
+        //! Encapsulates all the necessary information for doing a dispatch call.
+        //! This includes all common arguments for the different dispatch type, plus
+        //! arguments that are specific to a type.
+        class MultiDeviceDispatchItem
+        {
+        public:
+            MultiDeviceDispatchItem(MultiDevice::DeviceMask deviceMask)
+                : m_deviceMask{ deviceMask }
+            {
+                auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+                for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                    {
+                        m_deviceDispatchItems.emplace(deviceIndex, DispatchItem{});
+                    }
+                }
+            }
+
+            const DispatchItem& GetDeviceDispatchItem(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceDispatchItem",
+                    m_deviceDispatchItems.find(deviceIndex) != m_deviceDispatchItems.end(),
+                    "No DeviceDispatchItem found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceDispatchItems.at(deviceIndex);
+            }
+
+            /// Arguments specific to a dispatch type.
+            void SetArguments(const MultiDeviceDispatchArguments& arguments)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                    dispatchItem.m_arguments = arguments.GetDeviceDispatchArguments(deviceIndex);
+            }
+
+            /// The number of inline constants in each array.
+            void SetRootConstantSize(uint8_t rootConstantSize)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                    dispatchItem.m_rootConstantSize = rootConstantSize;
+            }
+
+            void SetPipelineState(const MultiDevicePipelineState* pipelineState)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                    dispatchItem.m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+
+            /// Array of shader resource groups to bind (count must match m_shaderResourceGroupCount).
+            void SetShaderResourceGroups(const AZStd::span<const MultiDeviceShaderResourceGroup*> shaderResourceGroups, uint8_t shaderResourceGroupCount)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                {
+                    dispatchItem.m_shaderResourceGroupCount = shaderResourceGroupCount;
+                    for (int i = 0; i < dispatchItem.m_shaderResourceGroupCount; ++i)
+                        dispatchItem.m_shaderResourceGroups[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+                }
+            }
+
+            /// Unique SRG, not shared within the draw packet. This is usually a per-draw SRG, populated with the shader variant fallback
+            /// key
+            void SetUniqueShaderResourceGroup(const MultiDeviceShaderResourceGroup* uniqueShaderResourceGroup)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                    dispatchItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
+            }
+
+            /// Inline constants data.
+            void SetRootConstants(const uint8_t* rootConstants)
+            {
+                for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+                    dispatchItem.m_rootConstants = rootConstants;
+            }
+
+        private:
+            MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+            AZStd::unordered_map<int, DispatchItem> m_deviceDispatchItems;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/DispatchRaysItem.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceRayTracingPipelineState;
+        class MultiDeviceRayTracingShaderTable;
+        class MultiDeviceShaderResourceGroup;
+        class ImageView;
+        class BufferView;
+
+        //! Encapsulates all the necessary information for doing a ray tracing dispatch call.
+        class MultiDeviceDispatchRaysItem
+        {
+        public:
+            MultiDeviceDispatchRaysItem(MultiDevice::DeviceMask deviceMask)
+                : m_deviceMask{ deviceMask }
+            {
+                auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+                for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                    {
+                        m_deviceDispatchRaysItems.emplace(deviceIndex, DispatchRaysItem{});
+                    }
+                }
+            }
+
+            const DispatchRaysItem& GetDeviceDispatchRaysItem(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceDispatchItem",
+                    m_deviceDispatchRaysItems.find(deviceIndex) != m_deviceDispatchRaysItems.end(),
+                    "No DeviceDispatchItem found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceDispatchRaysItems.at(deviceIndex);
+            }
+
+            /// The number of rays to cast
+            void SetDimensions(uint32_t width, uint32_t height, uint32_t depth)
+            {
+                for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+                {
+                    dispatchRaysItem.m_width = width;
+                    dispatchRaysItem.m_height = height;
+                    dispatchRaysItem.m_depth = depth;
+                }
+            }
+
+            /// Ray tracing pipeline state
+            void SetRayTracingPipelineState(const MultiDeviceRayTracingPipelineState* rayTracingPipelineState)
+            {
+                for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+                    dispatchRaysItem.m_rayTracingPipelineState = rayTracingPipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+
+            /// Ray tracing shader table
+            void SetRayTracingShaderTable(const MultiDeviceRayTracingShaderTable* rayTracingShaderTable)
+            {
+                for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+                    dispatchRaysItem.m_rayTracingShaderTable = rayTracingShaderTable->GetDeviceRayTracingShaderTable(deviceIndex).get();
+            }
+
+            /// Shader Resource Groups
+            void SetShaderResourceGroups(
+                const MultiDeviceShaderResourceGroup* const* shaderResourceGroups, uint32_t shaderResourceGroupCount)
+            {
+                for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+                {
+                    dispatchRaysItem.m_shaderResourceGroupCount = shaderResourceGroupCount;
+
+                    auto [it, insertOK]{ m_deviceShaderResourceGroups.emplace(
+                        deviceIndex, AZStd::vector<ShaderResourceGroup*>(shaderResourceGroupCount)) };
+
+                    auto& [index, deviceShaderResourceGroup]{ *it };
+
+                    for (int i = 0; i < shaderResourceGroupCount; ++i)
+                        deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+
+                    dispatchRaysItem.m_shaderResourceGroups = deviceShaderResourceGroup.data();
+                }
+            }
+
+            /// Global shader pipeline state
+            void SetPipelineState(const MultiDevicePipelineState* globalPipelineState)
+            {
+                for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+                    dispatchRaysItem.m_globalPipelineState = globalPipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+
+        private:
+            MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+            AZStd::unordered_map<int, DispatchRaysItem> m_deviceDispatchRaysItems;
+            AZStd::unordered_map<int, AZStd::vector<ShaderResourceGroup*>> m_deviceShaderResourceGroups;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceIndirectArguments.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferView.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/DrawItem.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        struct Scissor;
+        struct Viewport;
+        struct DefaultNamespaceType;
+        // Forward declaration to
+        template<typename T, typename NamespaceType>
+        struct Handle;
+
+        using MultiDeviceDrawIndirect = MultiDeviceIndirectArguments;
+
+        struct MultiDeviceDrawArguments
+        {
+            AZ_TYPE_INFO(MultiDeviceDrawArguments, "B8127BDE-513E-4D5C-98C2-027BA1DE9E6E");
+
+            MultiDeviceDrawArguments()
+                : MultiDeviceDrawArguments(DrawIndexed{})
+            {
+            }
+
+            MultiDeviceDrawArguments(const DrawIndexed& indexed)
+                : m_type{ DrawType::Indexed }
+                , m_indexed{ indexed }
+            {
+            }
+
+            MultiDeviceDrawArguments(const DrawLinear& linear)
+                : m_type{ DrawType::Linear }
+                , m_linear{ linear }
+            {
+            }
+
+            MultiDeviceDrawArguments(const MultiDeviceDrawIndirect& indirect)
+                : m_type{ DrawType::Indirect }
+                , m_indirect{ indirect }
+            {
+            }
+
+            DrawArguments GetDeviceDrawArguments(int deviceIndex) const
+            {
+                switch (m_type)
+                {
+                case DrawType::Indexed:
+                    return DrawArguments(m_indexed);
+                case DrawType::Linear:
+                    return DrawArguments(m_linear);
+                case DrawType::Indirect:
+                    return DrawArguments(m_indirect.GetDeviceIndirectArguments(deviceIndex));
+                default:
+                    return DrawArguments();
+                }
+            }
+
+            DrawType m_type;
+            union {
+                DrawIndexed m_indexed;
+                DrawLinear m_linear;
+                MultiDeviceDrawIndirect m_indirect;
+            };
+        };
+
+        class MultiDeviceDrawItem
+        {
+        public:
+            MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask)
+                : m_deviceMask{ deviceMask }
+            {
+                auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+                for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                    {
+                        m_deviceDrawItems.emplace(deviceIndex, DrawItem{});
+                    }
+                }
+            }
+
+            const DrawItem& GetDeviceDrawItem(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceDrawItem",
+                    m_deviceDrawItems.find(deviceIndex) != m_deviceDrawItems.end(),
+                    "No DeviceDrawItem found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceDrawItems.at(deviceIndex);
+            }
+
+            void SetArguments(const MultiDeviceDrawArguments& arguments)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    drawItem.m_arguments = arguments.GetDeviceDrawArguments(deviceIndex);
+            }
+
+            void SetStencilRef(uint8_t stencilRef)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    drawItem.m_stencilRef = stencilRef;
+            }
+
+            void SetPipelineState(const MultiDevicePipelineState* pipelineState)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    drawItem.m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+
+            /// The index buffer used when drawing with an indexed draw call.
+            void SetIndexBufferView(const MultiDeviceIndexBufferView* indexBufferView)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    m_deviceIndexBufferView.emplace(deviceIndex, indexBufferView->GetDeviceIndexBufferView(deviceIndex));
+
+                // Done extra so memory is not moved around any more during map resize
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    drawItem.m_indexBufferView = &m_deviceIndexBufferView[deviceIndex];
+            }
+
+            /// Array of stream buffers to bind (count must match m_streamBufferViewCount).
+            void SetStreamBufferViews(const MultiDeviceStreamBufferView* streamBufferViews, uint32_t streamBufferViewCount)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                {
+                    drawItem.m_streamBufferViewCount = static_cast<uint8_t>(streamBufferViewCount);
+
+                    auto [it, insertOK]{ m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::vector<StreamBufferView>{}) };
+
+                    auto& [index, deviceStreamBufferView]{ *it };
+
+                    for (auto i = 0u; i < streamBufferViewCount; ++i)
+                        deviceStreamBufferView.emplace_back(streamBufferViews[i].GetDeviceStreamBufferView(deviceIndex));
+
+                    drawItem.m_streamBufferViews = deviceStreamBufferView.data();
+                }
+            }
+
+            /// Shader Resource Groups
+            void SetShaderResourceGroups(
+                const MultiDeviceShaderResourceGroup* const* shaderResourceGroups, uint32_t shaderResourceGroupCount)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                {
+                    drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(shaderResourceGroupCount);
+
+                    auto [it, insertOK]{ m_deviceShaderResourceGroups.emplace(
+                        deviceIndex, AZStd::vector<ShaderResourceGroup*>(shaderResourceGroupCount)) };
+
+                    auto& [index, deviceShaderResourceGroup]{ *it };
+
+                    for (auto i = 0u; i < shaderResourceGroupCount; ++i)
+                        deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+
+                    drawItem.m_shaderResourceGroups = deviceShaderResourceGroup.data();
+                }
+            }
+
+            /// Unique SRG, not shared within the draw packet. This is usually a per-draw SRG, populated with the shader variant fallback
+            /// key
+            void SetUniqueShaderResourceGroup(const MultiDeviceShaderResourceGroup* uniqueShaderResourceGroup)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                    drawItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
+            }
+
+            /// Array of root constants to bind (count must match m_rootConstantSize).
+            void SetRootConstants(const uint8_t* rootConstants, uint8_t rootConstantSize)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                {
+                    drawItem.m_rootConstantSize = rootConstantSize;
+                    drawItem.m_rootConstants = rootConstants;
+                }
+            }
+
+            /// List of scissors to be applied to this draw item only. Scissor will be restore to the previous state
+            /// after the MultiDeviceDrawItem has been processed.
+            void SetScissors(const Scissor* scissors, uint8_t scissorsCount)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                {
+                    drawItem.m_scissorsCount = scissorsCount;
+                    drawItem.m_scissors = scissors;
+                }
+            }
+
+            /// List of viewports to be applied to this draw item only. Viewports will be restore to the previous state
+            /// after the MultiDeviceDrawItem has been processed.
+            void SetViewports(const Viewport* viewports, uint8_t viewportCount)
+            {
+                for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+                {
+                    drawItem.m_viewportsCount = viewportCount;
+                    drawItem.m_viewports = viewports;
+                }
+            }
+
+        private:
+            MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+            AZStd::unordered_map<int, DrawItem> m_deviceDrawItems;
+            AZStd::unordered_map<int, IndexBufferView> m_deviceIndexBufferView;
+            AZStd::unordered_map<int, AZStd::vector<StreamBufferView>> m_deviceStreamBufferViews;
+            AZStd::unordered_map<int, AZStd::vector<ShaderResourceGroup*>> m_deviceShaderResourceGroups;
+        };
+
+        struct MultiDeviceDrawItemProperties
+        {
+            MultiDeviceDrawItemProperties() = default;
+
+            MultiDeviceDrawItemProperties(
+                const MultiDeviceDrawItem* item, DrawItemSortKey sortKey = 0, DrawFilterMask filterMask = DrawFilterMaskDefaultValue)
+                : m_item{ item }
+                , m_sortKey{ sortKey }
+                , m_drawFilterMask{ filterMask }
+            {
+            }
+
+            bool operator==(const MultiDeviceDrawItemProperties& rhs) const
+            {
+                return m_item == rhs.m_item && m_sortKey == rhs.m_sortKey && m_depth == rhs.m_depth &&
+                    m_drawFilterMask == rhs.m_drawFilterMask;
+            }
+
+            bool operator!=(const MultiDeviceDrawItemProperties& rhs) const
+            {
+                return !(*this == rhs);
+            }
+
+            bool operator<(const MultiDeviceDrawItemProperties& rhs) const
+            {
+                return m_sortKey < rhs.m_sortKey;
+            }
+
+            DrawItemProperties GetDeviceDrawItemProperties(int deviceIndex) const
+            {
+                AZ_Assert(m_item, "Not initialized with MultiDeviceDrawItem\n");
+
+                DrawItemProperties result{ nullptr, m_sortKey, m_drawFilterMask };
+                result.m_item = &m_item->GetDeviceDrawItem(deviceIndex);
+                result.m_depth = m_depth;
+                return result;
+            }
+
+            //! A pointer to the draw item
+            const MultiDeviceDrawItem* m_item = nullptr;
+            //! A sorting key of this draw item which is used for sorting draw items in DrawList
+            // Check RHI::SortDrawList() function for detail
+            DrawItemSortKey m_sortKey = 0;
+            //! A depth value this draw item which is used for sorting draw items in DrawList
+            //! Check RHI::SortDrawList() function for detail
+            float m_depth = 0.0f;
+            //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
+            DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
+        };
+
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceFence.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <Atom/RHI/Fence.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceFence : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceFence, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceFence, "{5FF150A4-2C1E-4EC6-AE36-8EBD1CE22C31}", MultiDeviceObject);
+
+            MultiDeviceFence() = default;
+            virtual ~MultiDeviceFence() = default;
+
+            /// Initializes the fence using the provided device and initial state.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, FenceState initialState);
+
+            /// Shuts down the fence.
+            void Shutdown() override final;
+
+            /// Signals the fence from the calling thread.
+            RHI::ResultCode SignalOnCpu();
+
+            /// Waits (blocks) for the fence on the calling thread.
+            RHI::ResultCode WaitOnCpu() const;
+
+            /// Resets the fence.
+            RHI::ResultCode Reset();
+
+            using SignalCallback = AZStd::function<void()>;
+
+            /// Spawns a dedicated thread to wait on the fence. The provided callback
+            /// is invoked when the fence completes.
+            ResultCode WaitOnCpuAsync(SignalCallback callback);
+
+            const Ptr<Fence>& GetDeviceFence(int deviceIndex)
+            {
+                AZ_Error(
+                    "MultiDeviceFence",
+                    m_deviceFences.find(deviceIndex) != m_deviceFences.end(),
+                    "No Fence found for device index %d\n",
+                    deviceIndex);
+                return m_deviceFences.at(deviceIndex);
+            }
+
+        protected:
+            bool ValidateIsInitialized() const;
+
+            AZStd::thread m_waitThread;
+
+            AZStd::unordered_map<int, Ptr<Fence>> m_deviceFences;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ImageSubresource.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/Image.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class ImageFrameAttachment;
+        class MultiDeviceShaderResourceGroup;
+        class ImageView;
+        struct ImageViewDescriptor;
+
+        //! MultiDeviceImage represents a collection of MultiDeviceImage Subresources, where each subresource comprises a one to three
+        //! dimensional grid of pixels. Images are divided into an array of mip-map chains. A mip map chain is
+        //! a list of subresources, progressively halved on each axis, down to a 1x1 pixel base image. If an array is used,
+        //! each array 'slice' is its own mip chain. All mip chains in an array share the same size.
+        //!
+        //! Subresources are organized by a linear indexing scheme: mipSliceOffset + arraySliceOffset * arraySize. The total
+        //! number of subresources is equal to mipLevels * arraySize. All subresources share the same pixel format.
+        //!
+        //! @see ImageView on how to interpret contents of an image.
+        class MultiDeviceImage : public MultiDeviceResource
+        {
+            friend class MultiDeviceImagePoolBase;
+            friend class MultiDeviceImagePool;
+            friend class MultiDeviceTransientAttachmentPool;
+            friend class MultiDeviceStreamingImagePool;
+            friend class MultiDeviceSwapChain;
+
+            using Base = MultiDeviceResource;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceImage, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceImage, "{39FFE66C-805A-41AD-9092-91327D51F64B}", MultiDeviceResource);
+            MultiDeviceImage() = default;
+            virtual ~MultiDeviceImage() = default;
+
+            //! Returns the image descriptor used to initialize the image. If the image is uninitialized, the contents
+            //! are considered undefined.
+            const ImageDescriptor& GetDescriptor() const;
+
+            //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
+            //! this data represents how to store the image in a buffer resource. Naturally, if the image contents
+            //! are swizzled in device memory, the layouts will differ from the actual physical memory footprint. Use this data
+            //! to facilitate transfers between buffers and images.
+            //!
+            //!  @param subresourceRange The range of subresources in the image to consider when computing subresource layouts.
+            //!  @param subresourceLayouts
+            //!      [Optional] If specified, fills the provided array with computed subresource layout results. The size of the
+            //!      array must be at least the number of subresources specified in the subresource range (number of mip slices *
+            //!      number of array slices).
+            //!  @param totalSizeInBytes
+            //!      [Optional] If specified, will be filled with the total size necessary to contain all subresources.
+            void GetSubresourceLayout(MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags) const;
+
+            inline const Ptr<Image>& GetDeviceImage(int deviceIndex) const
+            {
+                AZ_Assert(
+                    m_deviceImages.find(deviceIndex) != m_deviceImages.end(),
+                    "No Image found for device index %d\n",
+                    deviceIndex);
+                return m_deviceImages.at(deviceIndex);
+            }
+
+            //! Returns the set of queue classes that are supported for usage as an attachment on the frame scheduler.
+            //! Effectively, for a scope of a specific hardware class to use the image as an attachment, the queue must
+            //! be present in this mask. This does not apply to non-attachment images on the Compute / Graphics queue.
+            HardwareQueueClassMask GetSupportedQueueMask() const;
+
+            //! Returns the image frame attachment if the image is currently attached. This is assigned when the image
+            //! is imported into the frame scheduler (which is reset every frame). This value will be null for non-attachment
+            //! images.
+            const ImageFrameAttachment* GetFrameAttachment() const;
+
+            //! Returns the aspects that are included in the image.
+            ImageAspectFlags GetAspectFlags() const;
+
+            //! Get the hash associated with the passed image descriptor
+            const HashValue64 GetHash() const;
+
+            // Shuts down the resource by detaching it from its parent pool.
+            void Shutdown() override final;
+
+            void InvalidateViews() override final;
+
+        protected:
+            virtual void SetDescriptor(const ImageDescriptor& descriptor);
+
+        private:
+            /// The RHI descriptor for this image.
+            ImageDescriptor m_descriptor;
+
+            /// the set of supported queue classes for this resource.
+            HardwareQueueClassMask m_supportedQueueMask = HardwareQueueClassMask::All;
+
+            /// Aspects supported by the image
+            ImageAspectFlags m_aspectFlags = ImageAspectFlags::None;
+
+            AZStd::unordered_map<int, Ptr<Image>> m_deviceImages;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePool.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ClearValue.h>
+#include <Atom/RHI.Reflect/ImagePoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+#include <Atom/RHI/ImagePool.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        /**
+         * @brief The data structure used to initialize an RHI::MultiDeviceImage on an RHI::MultiDeviceImagePool.
+         */
+        struct MultiDeviceImageInitRequest
+        {
+            MultiDeviceImageInitRequest() = default;
+
+            MultiDeviceImageInitRequest(
+                MultiDeviceImage& image, const ImageDescriptor& descriptor, const ClearValue* optimizedClearValue = nullptr);
+
+            /// The image to initialize.
+            MultiDeviceImage* m_image = nullptr;
+
+            /// The descriptor used to initialize the image.
+            ImageDescriptor m_descriptor;
+
+            /// An optional, optimized clear value for the image. Certain
+            /// platforms may use this value to perform fast clears when this
+            /// clear value is used.
+            const ClearValue* m_optimizedClearValue = nullptr;
+        };
+
+        /**
+         * @brief The data structure used to update contents of an RHI::MultiDeviceImage on an RHI::MultiDeviceImagePool.
+         */
+        struct MultiDeviceImageUpdateRequest
+        {
+            MultiDeviceImageUpdateRequest() = default;
+
+            /// A pointer to an initialized image, whose contents will be updated.
+            MultiDeviceImage* m_image = nullptr;
+
+            /// The image subresource to update.
+            ImageSubresource m_imageSubresource;
+
+            /// The offset in pixels from the start of the sub-resource in the destination image.
+            Origin m_imageSubresourcePixelOffset;
+
+            /// The source data pointer
+            const void* m_sourceData = nullptr;
+
+            /// The source sub-resource layout.
+            MultiDeviceImageSubresourceLayout m_sourceSubresourceLayout;
+        };
+
+        /**
+         * MultiDeviceImagePool is a pool of images that will be bound as attachments to the frame scheduler.
+         * As a result, they are intended to be produced and consumed by the GPU. Persistent Color / Depth Stencil / Image
+         * attachments should be created from this pool. This pool is not designed for intra-frame aliasing.
+         * If transient images are required, they can be created from the frame scheduler itself.
+         */
+        class MultiDeviceImagePool : public MultiDeviceImagePoolBase
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceImagePool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceImagePool, "{11D804D0-8332-490B-8A3E-BE279FCEFB8E}", MultiDeviceImagePoolBase);
+            MultiDeviceImagePool() = default;
+            virtual ~MultiDeviceImagePool() = default;
+
+            inline const Ptr<ImagePool>& GetDeviceImagePool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceImagePool",
+                    m_deviceImagePools.find(deviceIndex) != m_deviceImagePools.end(),
+                    "No DeviceImagePool found for device index %d\n",
+                    deviceIndex);
+                return m_deviceImagePools.at(deviceIndex);
+            }
+
+            /// Initializes the pool. The pool must be initialized before images can be registered with it.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor);
+
+            /// Initializes an image onto the pool. The pool provides backing GPU resources to the image.
+            ResultCode InitImage(const MultiDeviceImageInitRequest& request);
+
+            /// Updates image content from the CPU.
+            ResultCode UpdateImageContents(const MultiDeviceImageUpdateRequest& request);
+
+            /// Returns the descriptor used to initialize the pool.
+            const ImagePoolDescriptor& GetDescriptor() const override final;
+
+            void Shutdown() override final;
+
+        private:
+            using MultiDeviceImagePoolBase::InitImage;
+            using MultiDeviceResourcePool::Init;
+
+            bool ValidateUpdateRequest(const MultiDeviceImageUpdateRequest& updateRequest) const;
+
+            ImagePoolDescriptor m_descriptor;
+
+            AZStd::unordered_map<int, Ptr<ImagePool>> m_deviceImagePools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePoolBase.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        /**
+         * A simple base class for image pools. This mainly exists so that various
+         * image pool implementations can have some type safety separate from other
+         * resource pool types.
+         */
+        class MultiDeviceImagePoolBase : public MultiDeviceResourcePool
+        {
+        public:
+            AZ_RTTI(MultiDeviceImagePoolBase, "{CAC2167A-D65A-493F-A450-FDE2B1A883B1}", MultiDeviceResourcePool);
+            virtual ~MultiDeviceImagePoolBase() override = default;
+
+        protected:
+            MultiDeviceImagePoolBase() = default;
+
+            ResultCode InitImage(MultiDeviceImage* image, const ImageDescriptor& descriptor, PlatformMethod platformInitResourceMethod);
+
+        private:
+            using MultiDeviceResourcePool::InitResource;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndexBufferView.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/IndexBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceBuffer;
+
+        uint32_t GetIndexFormatSize(IndexFormat indexFormat);
+
+        class alignas(8) MultiDeviceIndexBufferView
+        {
+        public:
+            MultiDeviceIndexBufferView() = default;
+
+            MultiDeviceIndexBufferView(const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, IndexFormat format);
+
+            IndexBufferView GetDeviceIndexBufferView(int deviceIndex) const;
+
+            /// Returns the hash of the view. This hash is precomputed at creation time.
+            HashValue64 GetHash() const;
+
+            /// Returns the buffer associated with the data in the view.
+            const MultiDeviceBuffer* GetBuffer() const;
+
+            /// Returns the byte offset into the buffer returned by GetBuffer
+            uint32_t GetByteOffset() const;
+
+            /// Returns the number of bytes in the view.
+            uint32_t GetByteCount() const;
+
+            /// Returns the format of each index in the view.
+            IndexFormat GetIndexFormat() const;
+
+        private:
+            HashValue64 m_hash = HashValue64{ 0 };
+            const MultiDeviceBuffer* m_buffer = nullptr;
+            uint32_t m_byteOffset = 0;
+            uint32_t m_byteCount = 0;
+            IndexFormat m_format = IndexFormat::Uint32;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectArguments.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectArguments.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferView.h>
+#include <Atom/RHI/IndirectArguments.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! Encapsulates the arguments needed when doing an indirect call
+        //! (draw or dispatch) into a command list.
+        struct MultiDeviceIndirectArguments
+        {
+            MultiDeviceIndirectArguments() = default;
+
+            MultiDeviceIndirectArguments(
+                uint32_t maxSequenceCount, const MultiDeviceIndirectBufferView& indirectBuffer, uint64_t indirectBufferByteOffset)
+                : MultiDeviceIndirectArguments(maxSequenceCount, indirectBuffer, indirectBufferByteOffset, nullptr, 0)
+            {
+            }
+
+            MultiDeviceIndirectArguments(
+                uint32_t maxSequenceCount,
+                const MultiDeviceIndirectBufferView& indirectBuffer,
+                uint64_t indirectBufferByteOffset,
+                const MultiDeviceBuffer* countBuffer,
+                uint64_t countBufferByteOffset)
+                : m_maxSequenceCount(maxSequenceCount)
+                , m_indirectBufferView(&indirectBuffer)
+                , m_indirectBufferByteOffset(indirectBufferByteOffset)
+                , m_countBuffer(countBuffer)
+                , m_countBufferByteOffset(countBufferByteOffset)
+            {
+            }
+
+            IndirectArguments GetDeviceIndirectArguments(int deviceIndex) const
+            {
+                AZ_Assert(m_indirectBufferView, "No MultiDeviceIndirectBufferView available\n");
+                AZ_Assert(m_countBuffer, "No MultiDeviceBuffer available\n");
+
+                return IndirectArguments{ m_maxSequenceCount,
+                                                      m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex),
+                                                      m_indirectBufferByteOffset,
+                                                      m_countBuffer ? m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                                      m_countBufferByteOffset };
+            }
+
+            //! There are two ways that m_maxSequenceCount can be specified:
+            //! 1) If m_countBuffer is not NULL, then m_maxSequenceCount specifies the maximum number of operations which will be performed.
+            //!    The actual number of operations to be performed are defined by the minimum of this value, and a 32 bit unsigned integer
+            //!    contained in m_countBuffer(at the byte offset specified by m_countBufferByteOffset).
+            //! 2) If m_countBuffer is NULL, the m_maxSequenceCount specifies the exact number of operations which will be performed.
+            uint32_t m_maxSequenceCount = 0;
+
+            //! Specifies an offset into MultiDeviceIndirectBufferView to identify the first command argument.
+            uint64_t m_indirectBufferByteOffset = 0;
+            //! Specifies an offset into m_countBuffer, identifying the argument count.
+            uint64_t m_countBufferByteOffset = 0;
+
+            //! View over the Indirect buffer that contains the commands.
+            const MultiDeviceIndirectBufferView* m_indirectBufferView = nullptr;
+
+            //! Optional count buffer that contains the number of indirect commands in the indirect buffer.
+            const MultiDeviceBuffer* m_countBuffer = nullptr;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferSignature.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferSignature.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI.Reflect/IndirectBufferLayout.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/IndirectBufferSignature.h>
+
+#include <Atom/RHI/MultiDeviceObject.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class Device;
+        class MultiDevicePipelineState;
+
+        struct MultiDeviceIndirectBufferSignatureDescriptor
+        {
+            IndirectBufferSignatureDescriptor GetDeviceIndirectBufferSignatureDescriptor(int deviceIndex) const;
+
+            const MultiDevicePipelineState* m_pipelineState{ nullptr };
+            IndirectBufferLayout m_layout;
+        };
+
+        //! The MultiDeviceIndirectBufferSignature is an implementation object that represents
+        //! the signature of the commands contained in an Indirect Buffer.
+        //! Indirect Buffers hold the commands that will be used for
+        //! doing Indirect Rendering.
+        //!
+        //! It also exposes implementation dependent offsets for the commands in
+        //! a layout. This information is useful when writing commands into a buffer.
+        class MultiDeviceIndirectBufferSignature : public MultiDeviceObject
+        {
+            using Base = RHI::MultiDeviceObject;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceIndirectBufferSignature, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceIndirectBufferSignature, "{3CCFF81D-DC5E-4B12-AC05-DC26D5D0C65C}", Base);
+            MultiDeviceIndirectBufferSignature() = default;
+            virtual ~MultiDeviceIndirectBufferSignature() = default;
+
+            const RHI::Ptr<IndirectBufferSignature>& GetDeviceIndirectBufferSignature(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceIndirectBufferSignature",
+                    m_deviceIndirectBufferSignatures.find(deviceIndex) != m_deviceIndirectBufferSignatures.end(),
+                    "No DeviceIndirectBufferSignature found for device index %d\n",
+                    deviceIndex);
+                return m_deviceIndirectBufferSignatures.at(deviceIndex);
+            }
+
+            //! Initialize an IndirectBufferSignature object.
+            //! @param device The device that will contain the signature.
+            //! @param descriptor Descriptor with the necessary information for initializing the signature.
+            //! @return A result code denoting the status of the call. If successful, the MultiDeviceIndirectBufferSignature is considered
+            //! initialized and can be used. If failure, the MultiDeviceIndirectBufferSignature remains uninitialized.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceIndirectBufferSignatureDescriptor& descriptor);
+
+            /// Returns the stride in bytes of the command sequence defined by the provided layout.
+            uint32_t GetByteStride() const;
+
+            //! Returns the offset of the command in the position indicated by the index.
+            //! @param index The location in the layout of the command.
+            uint32_t GetOffset(IndirectCommandIndex index) const;
+
+            const MultiDeviceIndirectBufferSignatureDescriptor& GetDescriptor() const;
+
+            const IndirectBufferLayout& GetLayout() const;
+
+            void Shutdown() final;
+
+        private:
+            MultiDeviceIndirectBufferSignatureDescriptor m_descriptor;
+            AZStd::unordered_map<int, Ptr<IndirectBufferSignature>> m_deviceIndirectBufferSignatures;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Bits.h>
+#include <Atom/RHI/IndirectBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceBuffer;
+        class MultiDeviceIndirectBufferSignature;
+
+        //! Provides a view into a buffer, to be used as an indirect buffer. The content of the view is a contiguous
+        //! list of commands sequences. It is provided to the RHI back-end at draw time.
+        class alignas(8) MultiDeviceIndirectBufferView
+        {
+        public:
+            MultiDeviceIndirectBufferView() = default;
+
+            MultiDeviceIndirectBufferView(
+                const MultiDeviceBuffer& buffer,
+                const MultiDeviceIndirectBufferSignature& signature,
+                uint32_t byteOffset,
+                uint32_t byteCount,
+                uint32_t byteStride);
+
+            IndirectBufferView GetDeviceIndirectBufferView(int deviceIndex) const
+            {
+                AZ_Error("MultiDeviceIndirectBufferView", m_signature, "No MultiDeviceIndirectBufferSignature available\n");
+                AZ_Error("MultiDeviceIndirectBufferView", m_buffer, "No MultiDeviceBuffer available\n");
+
+                return IndirectBufferView(
+                    *m_buffer->GetDeviceBuffer(deviceIndex),
+                    *m_signature->GetDeviceIndirectBufferSignature(deviceIndex),
+                    m_byteOffset,
+                    m_byteCount,
+                    m_byteStride);
+            }
+
+            /// Returns the hash of the view. This hash is precomputed at creation time.
+            HashValue64 GetHash() const;
+
+            /// Returns the buffer associated with the view.
+            const MultiDeviceBuffer* GetBuffer() const;
+
+            /// Returns the byte offset into the buffer.
+            uint32_t GetByteOffset() const;
+
+            /// Returns the number of bytes in the view.
+            uint32_t GetByteCount() const;
+
+            /// Returns the distance in bytes between consecutive commands sequences.
+            /// This must be larger or equal than the stride specify by the signature.
+            uint32_t GetByteStride() const;
+
+            /// Returns the signature of the indirect buffer that is associated with the view.
+            const MultiDeviceIndirectBufferSignature* GetSignature() const;
+
+        private:
+            HashValue64 m_hash = HashValue64{ 0 };
+            const MultiDeviceIndirectBufferSignature* m_signature = nullptr;
+            const MultiDeviceBuffer* m_buffer = nullptr;
+            uint32_t m_byteOffset = 0;
+            uint32_t m_byteCount = 0;
+            uint32_t m_byteStride = 0;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferWriter.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferWriter.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI.Reflect/IndirectBufferLayout.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/Object.h>
+#include <Atom/RHI/IndirectBufferWriter.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceBuffer;
+        class MultiDeviceIndexBufferView;
+        class MultiDeviceStreamBufferView;
+        class MultiDeviceIndirectBufferSignature;
+
+        //! MultiDeviceIndirectBufferWriter is a helper class to write indirect commands
+        //! to a buffer or a memory location in a platform independent way. Different APIs may
+        //! have different layouts for the arguments of an indirect command. This class provides
+        //! a secure and simple way to write the commands without worrying about API differences.
+        //!
+        //! It also provides basic checks, like trying to write more commands than allowed, or
+        //! writing commands that are not specified in the layout.
+        class MultiDeviceIndirectBufferWriter : public Object
+        {
+            using Base = Object;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceIndirectBufferWriter, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceIndirectBufferWriter, "{096CBDFF-AB05-4E8D-9EC1-04F12CFCD85D}");
+            virtual ~MultiDeviceIndirectBufferWriter() = default;
+
+            inline Ptr<IndirectBufferWriter> GetDeviceIndirectBufferWriter(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceIndirectBufferWriter",
+                    m_deviceIndirectBufferWriter.find(deviceIndex) != m_deviceIndirectBufferWriter.end(),
+                    "No IndirectBufferWriter found for device index %d\n",
+                    deviceIndex);
+                return m_deviceIndirectBufferWriter.at(deviceIndex);
+            }
+
+            //! Initialize the MultiDeviceIndirectBufferWriter to write commands into a buffer.
+            //! @param buffer The buffer where to write the commands. Any previous values for the specified range will be overwritten.
+            //!               The buffer must be big enough to contain the max number of sequences.
+            //! @param byteOffset The offset into the buffer.
+            //! @param byteStride The stride between command sequences. Must be larger than the stride calculated from the signature.
+            //! @param maxCommandSequences The max number of sequences that the MultiDeviceIndirectBufferWriter can write.
+            //! @param signature Signature of the indirect buffer.
+            //! @return A result code denoting the status of the call. If successful, the MultiDeviceIndirectBufferWriter is considered
+            //!      initialized and is able to service write requests. If failure, the MultiDeviceIndirectBufferWriter remains
+            //!      uninitialized.
+            ResultCode Init(
+                MultiDeviceBuffer& buffer,
+                size_t byteOffset,
+                uint32_t byteStride,
+                uint32_t maxCommandSequences,
+                const MultiDeviceIndirectBufferSignature& signature);
+
+            //! Initialize the MultiDeviceIndirectBufferWriter to write commands into a memory location.
+            //! @param memoryPtr The memory location where the commands will be written. Must not be null.
+            //! @param byteStride The stride between command sequences. Must be larger than the stride calculated from the signature.
+            //! @param maxCommandSequences The max number of sequences that the MultiDeviceIndirectBufferWriter can write.
+            //! @param signature Signature of the indirect buffer.
+            //! @return A result code denoting the status of the call. If successful, the MultiDeviceIndirectBufferWriter is considered
+            //!      initialized and is able to service write requests. If failure, the MultiDeviceIndirectBufferWriter remains
+            //!      uninitialized.
+            ResultCode Init(
+                void* memoryPtr, uint32_t byteStride, uint32_t maxCommandSequences, const MultiDeviceIndirectBufferSignature& signature);
+
+            //! Writes a vertex buffer view command into the current sequence.
+            //! @param slot The stream buffer slot that the view will set.
+            //! @param view The MultiDeviceStreamBufferView that will be set.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* SetVertexView(uint32_t slot, const MultiDeviceStreamBufferView& view);
+
+            //! Writes an index buffer view command into the current sequence.
+            //! @param view The MultiDeviceIndexBufferView that will be set.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* SetIndexView(const MultiDeviceIndexBufferView& view);
+
+            //! Writes a draw command into the current sequence.
+            //! @param arguments The draw arguments that will be written.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* Draw(const DrawLinear& arguments);
+
+            //! Writes a draw indexed command into the current sequence.
+            //! @param arguments The draw indexed arguments that will be written.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* DrawIndexed(const DrawIndexed& arguments);
+
+            //! Writes a dispatch command into the current sequence.
+            //! @param arguments The dispatch arguments that will be written.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* Dispatch(const DispatchDirect& arguments);
+
+            //! Writes an inline constants command into the current sequence. This command will set
+            //! the values of all inline constants of the Pipeline.
+            //! @param data A pointer to the data that contains the values that will be written.
+            //! @param byteSize The size of the data that will be written.
+            //! @return A pointer to the MultiDeviceIndirectBufferWriter object (this).
+            MultiDeviceIndirectBufferWriter* SetRootConstants(const uint8_t* data, uint32_t byteSize);
+
+            //! Advance the current sequence index by 1.
+            //! @return True if the sequence index was increased correctly. False otherwise.
+            bool NextSequence();
+
+            //! Move the current sequence index to a specified position.
+            //! @param sequenceIndex The index where the sequence index will be moved. Must be less than maxCommandSequences.
+            //! @return True if the sequence index was updated correctly. False otherwise and the current sequence index is not modified.
+            bool Seek(const uint32_t sequenceIndex);
+
+            /// Flush changes into the destination buffer. Only valid when using a buffer.
+            void Flush();
+
+            bool IsInitialized() const;
+
+            AZStd::vector<uint32_t> GetCurrentSequenceIndex() const;
+
+            void Shutdown() override;
+
+        private:
+            AZStd::unordered_map<int, Ptr<IndirectBufferWriter>> m_deviceIndirectBufferWriter;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Device.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        /**
+         * A variant of Object associated with a DeviceMask. It provides a simple accessor API.
+         */
+        class MultiDeviceObject : public Object
+        {
+        public:
+            AZ_RTTI(MultiDeviceObject, "{17D34F71-944C-4AF5-9823-627474C4C0A6}", Object);
+            virtual ~MultiDeviceObject() = default;
+
+            /// Returns whether the device object is initialized.
+            bool IsInitialized() const;
+
+            /**
+             * Returns the device this object is associated with. It is only permitted to call
+             * this method when the object is initialized.
+             */
+            MultiDevice::DeviceMask GetDeviceMask() const;
+
+        protected:
+            MultiDeviceObject() = default;
+
+            /// The derived class should call this method to assign the device.
+            void Init(MultiDevice::DeviceMask deviceMask);
+
+            /// Clears the current bound device to null.
+            void Shutdown() override;
+
+            template<typename T>
+            void IterateDevices(T callback)
+            {
+                AZ_Error(
+                    "RPI::MultiDeviceObject",
+                    AZStd::to_underlying(m_deviceMask) != 0u,
+                    "Device mask is not initialized with a valid value.");
+
+                int deviceCount = GetDeviceCount();
+
+                for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                    {
+                        if (!callback(deviceIndex))
+                            break;
+                    }
+                }
+            }
+
+        private:
+            int GetDeviceCount() const;
+
+            MultiDevice::DeviceMask m_deviceMask{ 0u };
+        };
+    }
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <Atom/RHI/PipelineLibrary.h>
+
+#include <Atom/RHI.Reflect/PipelineLibraryData.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        /// A handle typed to the pipeline library. Used by the PipelineStateCache to abstract access.
+        using MultiDevicePipelineLibraryHandle = Handle<uint32_t, class MultiDevicePipelineLibrary>;
+
+        struct MultiDevicePipelineLibraryDescriptor
+        {
+            inline PipelineLibraryDescriptor GetDevicePipelineLibraryDescriptor(int deviceIndex) const
+            {
+                AZ_Assert(
+                    m_devicePipelineLibraryDescriptors.find(deviceIndex) != m_devicePipelineLibraryDescriptors.end(),
+                    "No DevicePipelineLibraryDescriptor found for device index %d\n",
+                    deviceIndex);
+
+                if (m_devicePipelineLibraryDescriptors.contains(deviceIndex))
+                    return m_devicePipelineLibraryDescriptors.at(deviceIndex);
+                else
+                    return PipelineLibraryDescriptor{};
+            }
+
+            // A map of DevicePipelineLibraryDescriptor for each device where available.
+            AZStd::unordered_map<int, PipelineLibraryDescriptor> m_devicePipelineLibraryDescriptors;
+        };
+
+        //! MultiDevicePipelineState initialization is an expensive operation on certain platforms. If multiple pipeline states
+        //! are created with little variation between them, the contents are still duplicated. This class is an allocation
+        //! context for pipeline states, provided at MultiDevicePipelineState::Init, which will perform de-duplication of
+        //! internal pipeline state components and cache the results.
+        //!
+        //! Practically speaking, if many pipeline states are created with shared data between them (e.g. permutations
+        //! of the same shader), then providing a MultiDevicePipelineLibrary instance will reduce the memory footprint and cost
+        //! of compilation.
+        //!
+        //! Additionally, the MultiDevicePipelineLibrary is able to serialize the internal driver-contents to and from an opaque
+        //! data blob. This enables building up a pipeline state cache on disk, which can dramatically reduce pipeline
+        //! state compilation cost when run from a pre-warmed cache.
+        //!
+        //! MultiDevicePipelineLibrary is thread-safe, in the sense that it will take a lock during compilation. It is possible
+        //! to initialize pipeline states across threads using the same MultiDevicePipelineLibrary instance, but this will
+        //! result in the two calls serializing on the mutex. Instead, see PipelineStateCache which stores
+        //! a MultiDevicePipelineLibrary instance per thread to avoid this contention.
+        class MultiDevicePipelineLibrary : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDevicePipelineLibrary, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDevicePipelineLibrary, "{B48B6A46-5976-4D7D-AA14-2179D871C567}");
+            MultiDevicePipelineLibrary() = default;
+            virtual ~MultiDevicePipelineLibrary() = default;
+
+            inline Ptr<PipelineLibrary> GetDevicePipelineLibrary(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDevicePipelineLibrary",
+                    m_devicePipelineLibraries.find(deviceIndex) != m_devicePipelineLibraries.end(),
+                    "No DevicePipelineLibrary found for device index %d\n",
+                    deviceIndex);
+
+                return m_devicePipelineLibraries.at(deviceIndex);
+            }
+
+            //! Initializes the pipeline library from a platform-specific data payload. This data is generated
+            //! by calling GetSerializedData in a previous run of the application. When run for the first
+            //! time, the serialized data should be empty. When the application completes, the library can be
+            //! serialized and the contents saved to disk. Subsequent loads will experience much faster pipeline
+            //! state creation times (on supported platforms). On success, the library is transitioned to the
+            //! initialized state. On failure, the library remains uninitialized.
+            //! @param descriptor The descriptor needed to init the MultiDevicePipelineLibrary.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const MultiDevicePipelineLibraryDescriptor& descriptor);
+
+            //! Merges the contents of other libraries into this library. This method must be called
+            //! on an initialized library. A common use case for this method is to construct thread-local
+            //! libraries and merge them into a single unified library. The serialized data can then be
+            //! extracted from the unified library. An error code is returned on failure and the behavior
+            //! is as if the method was never called.
+            ResultCode MergeInto(AZStd::span<const MultiDevicePipelineLibrary* const> librariesToMerge);
+
+            //! Serializes the platform-specific data and returns it as a new PipelineLibraryData instance.
+            //! The data is opaque to the user and can only be used to re-initialize the library. Use
+            //! this method to extract serialized data prior to application shutdown, save it to disk, and
+            //! use it when initializing on subsequent runs.
+            ConstPtr<PipelineLibraryData> GetSerializedData(int deviceIndex = RHI::MultiDevice::DefaultDeviceIndex) const
+            {
+                if (m_devicePipelineLibraries.contains(deviceIndex))
+                    return m_devicePipelineLibraries.at(deviceIndex)->GetSerializedData();
+                else
+                {
+                    AZ_Error(
+                        "MultiDevicePipelineLibrary",
+                        false,
+                        "MultiDevicePipelineLibrary is not initialized. This operation is only permitted on an initialized library.");
+                    return nullptr;
+                }
+            }
+
+            //! Returns whether the current library need to be merged
+            virtual bool IsMergeRequired() const;
+
+        private:
+            bool ValidateIsInitialized() const;
+
+            // Explicit shutdown is not allowed for this type.
+            void Shutdown() override final;
+
+            AZStd::unordered_map<int, Ptr<PipelineLibrary>> m_devicePipelineLibraries;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineState.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <Atom/RHI/PipelineStateDescriptor.h>
+#include <Atom/RHI/PipelineState.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDevicePipelineLibrary;
+
+        /**
+         * The pipeline state object is an opaque data structure representing compiled
+         * graphics or compute state. Typically called a 'PSO', it holds the following
+         * platform-specific state:
+         *
+         * - The compiled shader byte code.
+         *
+         * - The compiled pipeline layout containing shader bindings and how they map to
+         *   provided shader byte codes.
+         *
+         * - [Graphics Only] State to control the fixed function output-merger unit. This includes
+         *   Blend, Raster, and Depth-Stencil state.
+         *
+         * - [Graphics Only] State to identify stream buffers to the fixed function input assembly unit.
+         */
+        class MultiDevicePipelineState : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDevicePipelineState, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDevicePipelineState, "77B85640-C2E2-4312-AD67-68FED421F84E", MultiDeviceObject);
+            MultiDevicePipelineState() = default;
+            virtual ~MultiDevicePipelineState() = default;
+
+            /**
+             * Initializes a graphics pipeline state, associated with the provided device, using the
+             * provided descriptor. If successful, the PSO is valid to use with DrawItems within scopes
+             * executing on device used for initialization.
+             * @param pipelineLibrary An optional pipeline library used to de-duplicate and cache the internal
+             * platform pipeline state data, reducing compilation and memory cost. It can be left null.
+             */
+            ResultCode Init(
+                MultiDevice::DeviceMask deviceMask,
+                const PipelineStateDescriptorForDraw& descriptor,
+                MultiDevicePipelineLibrary* pipelineLibrary = nullptr);
+
+            /**
+             * Initializes a compute pipeline state, associated with the provided device, using the
+             * provided descriptor. If successful, the PSO is valid to use with DispatchItems within scopes
+             * executing on device used for initialization.
+             * @param pipelineLibrary An optional pipeline library used to de-duplicate and cache the internal
+             * platform pipeline state data, reducing compilation and memory cost. It can be left null.
+             */
+            ResultCode Init(
+                MultiDevice::DeviceMask deviceMask,
+                const PipelineStateDescriptorForDispatch& descriptor,
+                MultiDevicePipelineLibrary* pipelineLibrary = nullptr);
+
+            /**
+             * Initializes a ray tracing pipeline state, associated with the provided device, using the
+             * provided descriptor. If successful, the PSO is valid to use with DispatchRaysItems within scopes
+             * executing on device used for initialization.
+             * @param pipelineLibrary An optional pipeline library used to de-duplicate and cache the internal
+             * platform pipeline state data, reducing compilation and memory cost. It can be left null.
+             */
+            ResultCode Init(
+                MultiDevice::DeviceMask deviceMask,
+                const PipelineStateDescriptorForRayTracing& descriptor,
+                MultiDevicePipelineLibrary* pipelineLibrary = nullptr);
+
+            inline Ptr<PipelineState> GetDevicePipelineState(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDevicePipelineState",
+                    m_devicePipelineStates.find(deviceIndex) != m_devicePipelineStates.end(),
+                    "No DevicePipelineState found for device index %d\n",
+                    deviceIndex);
+
+                return m_devicePipelineStates.at(deviceIndex);
+            }
+
+            PipelineStateType GetType() const;
+
+        private:
+            // Pipeline states cannot be re-initialized, as they can be cached.
+            void Shutdown() override final;
+
+            bool ValidateNotInitialized() const;
+
+            PipelineStateType m_type = PipelineStateType::Count;
+
+            AZStd::unordered_map<int, Ptr<PipelineState>> m_devicePipelineStates;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/Query.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class CommandList;
+        class MultiDeviceQueryPool;
+        using QueryHandle = RHI::Handle<uint32_t>;
+
+        /**
+         * MultiDeviceQuery resource for recording gpu data like occlusion, timestamp or pipeline statistics.
+         * Queries belong to a MultiDeviceQueryPool and their types are determinated by the pool.
+         */
+        class MultiDeviceQuery : public MultiDeviceResource
+        {
+            friend class MultiDeviceQueryPool;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceQuery, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceQuery, "{F72033E8-7A91-40BF-80E2-7262223362DB}", MultiDeviceResource);
+            MultiDeviceQuery() = default;
+            virtual ~MultiDeviceQuery() override = default;
+
+            inline Ptr<Query> GetDeviceQuery(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceQuery",
+                    m_deviceQueries.find(deviceIndex) != m_deviceQueries.end(),
+                    "No DeviceQuery found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceQueries.at(deviceIndex);
+            }
+
+            /// Returns the query pool that this query belongs to.
+            const MultiDeviceQueryPool* GetQueryPool() const;
+            MultiDeviceQueryPool* GetQueryPool();
+
+            QueryHandle GetHandle(int deviceIndex)
+            {
+                AZ_Assert(
+                    m_deviceQueries.find(deviceIndex) != m_deviceQueries.end(), "No DeviceQuery found for device index %d\n", deviceIndex);
+                return m_deviceQueries.at(deviceIndex)->GetHandle();
+            }
+
+            // Shuts down the resource by detaching it from its parent pool.
+            void Shutdown() override final;
+
+            void InvalidateViews() override final;
+
+        private:
+            AZStd::unordered_map<int, Ptr<Query>> m_deviceQueries;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Interval.h>
+#include <Atom/RHI.Reflect/QueryPoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/QueryPoolSubAllocator.h>
+#include <Atom/RHI/QueryPool.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/sort.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceQuery;
+
+        //! Query pool provides backing storage and context for query instances. The QueryPoolDescriptor
+        //! contains properties defining memory characteristics of query pools. All queries created on a pool
+        //! share the same backing and type.
+        class MultiDeviceQueryPool : public MultiDeviceResourcePool
+        {
+            using Base = MultiDeviceResourcePool;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceQueryPool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceQueryPool, "{F46A756D-99F1-4A2A-AE4C-A2A8BE6845CC}", MultiDeviceResourcePool)
+            MultiDeviceQueryPool() = default;
+            virtual ~MultiDeviceQueryPool() override = default;
+
+            inline Ptr<QueryPool> GetDeviceQueryPool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceQueryPool",
+                    m_deviceQueryPools.find(deviceIndex) != m_deviceQueryPools.end(),
+                    "No DeviceQueryPool found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceQueryPools.at(deviceIndex);
+            }
+
+            //!  Initialize the MultiDeviceQueryPool.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor);
+
+            //! Initialize a query from the pool. When initializing multiple queries use the other version of InitQuery
+            //! because the pool will try to group the queries together.
+            //!  @param query MultiDeviceQuery to initialize.
+            ResultCode InitQuery(MultiDeviceQuery* query);
+
+            //!  Initialize a group of queries from the pool. The initialization will try to allocate
+            //!  the queries in a consecutive space. The reason for this is that is more efficient when requesting
+            //!  results or copying multiple query results.
+            //!  @param queries Pointer to an array of queries to initialize.
+            //!  @param queryCount Number of queries.
+            ResultCode InitQuery(MultiDeviceQuery** queries, uint32_t queryCount);
+
+            //!  Get the results from all queries in the pool. Results are always returned as uint64_t data.
+            //!  The "results" parameter must contain enough space to save the results from all queries in the pool.
+            //!  For the PipelineStatistics query type, each statistic will be copied to a uint64_t. Because of this
+            //!  the "results" array must contain enough space for numQueries * numPipelineStatistics.
+            //!  This function doesn't return partial results. In case of failure no results are returned.
+            //!  @param results Pointer to an array where the results will be copied.
+            //!  @param resultsCount Number of elements of the "results" array.
+            //!  @param QueryResultFlagBits Control how the results will be requested. If QueryResultFlagBits::Wait is used
+            //!                            the call will block until the results are done. If QueryResultFlagBits::Wait is not used
+            //!                            and the results are not ready, ResultCode::NotReady will be returned
+            ResultCode GetResults(uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags);
+
+            //!  Get the results from a query in the pool. Results are always returned as uint64_t data.
+            //!  The "results" parameter must contain enough space to save the results from all queries in the pool.
+            //!  For the PipelineStatistics query type, each statistic will be copied to a uint64_t. Because of this
+            //!  the "results" array must contain enough space for numQueries * numPipelineStatistics.
+            //!  This function doesn't return partial results. In case of failure no results are returned.
+            //!  @param results Pointer to an array where the results will be copied.
+            //!  @param resultsCount Number of elements of the "results" array.
+            //!  @param QueryResultFlagBits Control how the results will be requested. If QueryResultFlagBits::Wait is used
+            //!                            the call will block until the results are done. If QueryResultFlagBits::Wait is not used
+            //!                            and the results are not ready, ResultCode::NotReady will be returned
+            ResultCode GetResults(MultiDeviceQuery* query, uint64_t* result, uint32_t resultsCount, QueryResultFlagBits flags);
+
+            //!  Same as GetResults(uint64_t, uint32_t, QueryResultFlagBits) but for a list of queries.
+            //!  It's more efficient if the list of queries is sorted by handle in ascending order because there's no need to sort the
+            //!  results
+            //! before returning.
+            ResultCode GetResults(
+                MultiDeviceQuery** queries, uint32_t queryCount, uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags);
+
+            //!  Returns the buffer descriptor used to initialize the query pool. Descriptor contents
+            //!  are undefined for uninitialized pools.
+            const QueryPoolDescriptor& GetDescriptor() const override final;
+
+            void Shutdown() override final;
+
+        private:
+            /// Validates that the queries are not null and that they belong to this pool.
+            ResultCode ValidateQueries(MultiDeviceQuery** queries, uint32_t queryCount);
+
+            QueryPoolDescriptor m_descriptor;
+            AZStd::unordered_map<int, Ptr<QueryPool>> m_deviceQueryPools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/RayTracingAccelerationStructure.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceRayTracingBufferPools;
+
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        // Bottom Level Acceleration Structure (BLAS)
+
+        //! MultiDeviceRayTracingGeometry
+        //!
+        //! The geometry entry contains the vertex and index buffers associated with geometry in the
+        //! scene.  Each MultiDeviceRayTracingBlas contains a list of these entries.
+        struct MultiDeviceRayTracingGeometry
+        {
+            RHI::Format m_vertexFormat = RHI::Format::Unknown;
+            RHI::MultiDeviceStreamBufferView m_vertexBuffer;
+            RHI::MultiDeviceIndexBufferView m_indexBuffer;
+            // [GFX TODO][ATOM-4989] Add DXR BLAS Transform Buffer
+        };
+        using MultiDeviceRayTracingGeometryVector = AZStd::vector<MultiDeviceRayTracingGeometry>;
+
+        //! MultiDeviceRayTracingBlasDescriptor
+        //!
+        //! The Build() operation in the descriptor allows the BLAS to be initialized
+        //! using the following pattern:
+        //!
+        //! RHI::MultiDeviceRayTracingBlasDescriptor descriptor;
+        //! descriptor.Build()
+        //!    ->Geometry()
+        //!        ->VertexFormat(RHI::Format::R32G32B32_FLOAT)
+        //!        ->VertexBuffer(vertexBufferView)
+        //!        ->IndexBuffer(indexBufferView)
+        //!    ;
+        class MultiDeviceRayTracingBlasDescriptor final
+        {
+        public:
+            MultiDeviceRayTracingBlasDescriptor() = default;
+            ~MultiDeviceRayTracingBlasDescriptor() = default;
+
+            RayTracingBlasDescriptor GetDeviceRayTracingBlasDescriptor(int deviceIndex) const;
+
+            // accessors
+            const MultiDeviceRayTracingGeometryVector& GetGeometries() const
+            {
+                return m_geometries;
+            }
+            MultiDeviceRayTracingGeometryVector& GetGeometries()
+            {
+                return m_geometries;
+            }
+
+            // build operations
+            MultiDeviceRayTracingBlasDescriptor* Build();
+            MultiDeviceRayTracingBlasDescriptor* Geometry();
+            MultiDeviceRayTracingBlasDescriptor* VertexBuffer(const RHI::MultiDeviceStreamBufferView& vertexBuffer);
+            MultiDeviceRayTracingBlasDescriptor* VertexFormat(RHI::Format vertexFormat);
+            MultiDeviceRayTracingBlasDescriptor* IndexBuffer(const RHI::MultiDeviceIndexBufferView& indexBuffer);
+
+        private:
+            MultiDeviceRayTracingGeometryVector m_geometries;
+            MultiDeviceRayTracingGeometry* m_buildContext = nullptr;
+        };
+
+        //! MultiDeviceRayTracingBlas
+        //!
+        //! A MultiDeviceRayTracingBlas is created from the information in the MultiDeviceRayTracingBlasDescriptor.
+        class MultiDeviceRayTracingBlas : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingBlas, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceRayTracingBlas, "{D17E050F-ECC2-4C20-A073-F43008F2D168}", MultiDeviceObject)
+            MultiDeviceRayTracingBlas() = default;
+            virtual ~MultiDeviceRayTracingBlas() = default;
+
+            const RHI::Ptr<RayTracingBlas>& GetDeviceRayTracingBlas(int deviceIndex)
+            {
+                AZ_Error(
+                    "MultiDeviceRayTracingBlas",
+                    m_deviceRayTracingBlas.find(deviceIndex) != m_deviceRayTracingBlas.end(),
+                    "No DeviceRayTracingBlas found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceRayTracingBlas.at(deviceIndex);
+            }
+
+            //! Creates the internal BLAS buffers from the descriptor
+            ResultCode CreateBuffers(
+                MultiDevice::DeviceMask deviceMask,
+                const MultiDeviceRayTracingBlasDescriptor* descriptor,
+                const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+            //! Returns true if the MultiDeviceRayTracingBlas has been initialized
+            bool IsValid() const;
+
+        private:
+            AZStd::unordered_map<int, Ptr<RayTracingBlas>> m_deviceRayTracingBlas;
+            MultiDeviceRayTracingBlasDescriptor m_descriptor;
+        };
+
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        // Top Level Acceleration Structure (TLAS)
+
+        //! MultiDeviceRayTracingTlasInstance
+        //!
+        //! Each TLAS instance entry refers to a MultiDeviceRayTracingBlas, and can contain a transform which
+        //! will be applied to all of the geometry entries in the Blas.  It also contains a hitGroupIndex
+        //! which is used to index into the MultiDeviceRayTracingShaderTable to determine the hit shader when a
+        //! ray hits any geometry in the instance.
+        struct MultiDeviceRayTracingTlasInstance
+        {
+            uint32_t m_instanceID = 0;
+            uint32_t m_hitGroupIndex = 0;
+            AZ::Transform m_transform = AZ::Transform::CreateIdentity();
+            AZ::Vector3 m_nonUniformScale = AZ::Vector3::CreateOne();
+            bool m_transparent = false;
+            RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_blas;
+        };
+        using MultiDeviceRayTracingTlasInstanceVector = AZStd::vector<MultiDeviceRayTracingTlasInstance>;
+
+        //! MultiDeviceRayTracingTlasDescriptor
+        //!
+        //! The Build() operation in the descriptor allows the TLAS to be initialized
+        //! using the following pattern:
+        //!
+        //! RHI::MultiDeviceRayTracingTlasDescriptor descriptor;
+        //! descriptor.Build()
+        //!     ->Instance()
+        //!         ->InstanceID(0)
+        //!         ->HitGroupIndex(0)
+        //!         ->Blas(blas1)
+        //!         ->Transform(transform1)
+        //!     ->Instance()
+        //!         ->InstanceID(1)
+        //!         ->HitGroupIndex(1)
+        //!         ->Blas(blas2)
+        //!         ->Transform(transform2)
+        //!     ;
+        class MultiDeviceRayTracingTlasDescriptor final
+        {
+        public:
+            MultiDeviceRayTracingTlasDescriptor() = default;
+            ~MultiDeviceRayTracingTlasDescriptor() = default;
+
+            RayTracingTlasDescriptor GetDeviceRayTracingTlasDescriptor(int deviceIndex) const;
+
+            // accessors
+            const MultiDeviceRayTracingTlasInstanceVector& GetInstances() const
+            {
+                return m_instances;
+            }
+            MultiDeviceRayTracingTlasInstanceVector& GetInstances()
+            {
+                return m_instances;
+            }
+
+            const RHI::Ptr<RHI::MultiDeviceBuffer>& GetInstancesBuffer() const
+            {
+                return m_instancesBuffer;
+            }
+            RHI::Ptr<RHI::MultiDeviceBuffer>& GetInstancesBuffer()
+            {
+                return m_instancesBuffer;
+            }
+
+            uint32_t GetNumInstancesInBuffer() const
+            {
+                return m_numInstancesInBuffer;
+            }
+
+            // build operations
+            MultiDeviceRayTracingTlasDescriptor* Build();
+            MultiDeviceRayTracingTlasDescriptor* Instance();
+            MultiDeviceRayTracingTlasDescriptor* InstanceID(uint32_t instanceID);
+            MultiDeviceRayTracingTlasDescriptor* HitGroupIndex(uint32_t hitGroupIndex);
+            MultiDeviceRayTracingTlasDescriptor* Transform(const AZ::Transform& transform);
+            MultiDeviceRayTracingTlasDescriptor* NonUniformScale(const AZ::Vector3& nonUniformScale);
+            MultiDeviceRayTracingTlasDescriptor* Transparent(bool transparent);
+            MultiDeviceRayTracingTlasDescriptor* Blas(RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& blas);
+            MultiDeviceRayTracingTlasDescriptor* InstancesBuffer(RHI::Ptr<RHI::MultiDeviceBuffer>& tlasInstances);
+            MultiDeviceRayTracingTlasDescriptor* NumInstances(uint32_t numInstancesInBuffer);
+
+        private:
+            MultiDeviceRayTracingTlasInstanceVector m_instances;
+            MultiDeviceRayTracingTlasInstance* m_buildContext = nullptr;
+
+            // externally created Instances buffer, cannot be combined with other Instances
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_instancesBuffer;
+            uint32_t m_numInstancesInBuffer;
+        };
+
+        //! MultiDeviceRayTracingTlas
+        //!
+        //! A MultiDeviceRayTracingTlas is created from the information in the MultiDeviceRayTracingTlasDescriptor.
+        class MultiDeviceRayTracingTlas : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingTlas, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceRayTracingTlas, "{A2B0F8F1-D0B5-4D90-8AFA-CEF543D20E34}", MultiDeviceObject)
+            MultiDeviceRayTracingTlas() = default;
+            virtual ~MultiDeviceRayTracingTlas() = default;
+
+            const RHI::Ptr<RayTracingTlas>& GetDeviceRayTracingTlas(int deviceIndex)
+            {
+                AZ_Error(
+                    "MultiDeviceRayTracingTlas",
+                    m_deviceRayTracingTlas.find(deviceIndex) != m_deviceRayTracingTlas.end(),
+                    "No DeviceRayTracingTlas found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceRayTracingTlas.at(deviceIndex);
+            }
+
+            //! Creates the internal TLAS buffers from the descriptor
+            ResultCode CreateBuffers(
+                MultiDevice::DeviceMask deviceMask,
+                const MultiDeviceRayTracingTlasDescriptor* descriptor,
+                const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+            //! Returns the TLAS RHI buffer
+            const RHI::Ptr<RHI::MultiDeviceBuffer> GetTlasBuffer() const;
+            const RHI::Ptr<RHI::MultiDeviceBuffer> GetTlasInstancesBuffer() const;
+
+        private:
+            AZStd::unordered_map<int, Ptr<RayTracingTlas>> m_deviceRayTracingTlas;
+            MultiDeviceRayTracingTlasDescriptor m_descriptor;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/RayTracingBufferPools.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceBufferPool;
+
+        //! MultiDeviceRayTracingBufferPools
+        //!
+        //! This class encapsulates all of the BufferPools needed for ray tracing, freeing the application
+        //! from setting up and managing the buffers pools individually.
+        //!
+        class MultiDeviceRayTracingBufferPools : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingBufferPools, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceRayTracingBufferPools, "{59397661-F5A5-44DE-9B1D-E6F5BC32DC51}", MultiDeviceObject)
+            MultiDeviceRayTracingBufferPools() = default;
+            virtual ~MultiDeviceRayTracingBufferPools() = default;
+
+            // accessors
+            const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetShaderTableBufferPool() const;
+            const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetScratchBufferPool() const;
+            const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetBlasBufferPool() const;
+            const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetTlasInstancesBufferPool() const;
+            const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetTlasBufferPool() const;
+
+            // operations
+            void Init(MultiDevice::DeviceMask deviceMask);
+
+            inline const RHI::Ptr<RayTracingBufferPools>& GetDeviceRayTracingBufferPool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceRayTracingBufferPools",
+                    m_deviceRayTracingBufferPools.find(deviceIndex) != m_deviceRayTracingBufferPools.end(),
+                    "No RayTracingBufferPools found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceRayTracingBufferPools.at(deviceIndex);
+            }
+
+        private:
+            bool m_initialized = false;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_shaderTableBufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_scratchBufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_blasBufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_tlasInstancesBufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_tlasBufferPool;
+
+            AZStd::unordered_map<int, Ptr<RayTracingBufferPools>> m_deviceRayTracingBufferPools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/RayTracingPipelineState.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! MultiDeviceRayTracingPipelineStateDescriptor
+        //!
+        //! The Build() operation in the descriptor allows the pipeline state to be initialized
+        //! using the following pattern:
+        //!
+        //! RHI::MultiDeviceRayTracingPipelineStateDescriptor descriptor;
+        //! descriptor.Build()
+        //!     ->ShaderLibrary(shaderDescriptor)
+        //!         ->RayGenerationShaderName(AZ::Name("RayGenerationShader"))
+        //!     ->ShaderLibrary(missShaderDescriptor)
+        //!         ->MissShaderName(AZ::Name("MissShader"))
+        //!     ->ShaderLibrary(closestHitShader1Descriptor)
+        //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader1"))
+        //!     ->ShaderLibrary(closestHitShader2Descriptor)
+        //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader2"))
+        //!     ->HitGroup(AZ::Name("HitGroup1"))
+        //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader1"))
+        //!     ->HitGroup(AZ::Name("HitGroup2"))
+        //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader2"))
+        //!     ;
+        //!
+        class MultiDeviceRayTracingPipelineStateDescriptor final
+        {
+        public:
+            MultiDeviceRayTracingPipelineStateDescriptor() = default;
+            ~MultiDeviceRayTracingPipelineStateDescriptor() = default;
+
+            RayTracingPipelineStateDescriptor GetDeviceRayTracingPipelineStateDescriptor(int deviceIndex) const;
+
+            // accessors
+            const RayTracingConfiguration& GetConfiguration() const
+            {
+                return m_descriptor.GetConfiguration();
+            }
+            RayTracingConfiguration& GetConfiguration()
+            {
+                return m_descriptor.GetConfiguration();
+            }
+
+            const RHI::MultiDevicePipelineState* GetPipelineState() const
+            {
+                return m_pipelineState;
+            }
+
+            const RayTracingShaderLibraryVector& GetShaderLibraries() const
+            {
+                return m_descriptor.GetShaderLibraries();
+            }
+            RayTracingShaderLibraryVector& GetShaderLibraries()
+            {
+                return m_descriptor.GetShaderLibraries();
+            }
+
+            const RayTracingHitGroupVector& GetHitGroups() const
+            {
+                return m_descriptor.GetHitGroups();
+            }
+            RayTracingHitGroupVector& GetHitGroups()
+            {
+                return m_descriptor.GetHitGroups();
+                ;
+            }
+
+            // build operations
+            MultiDeviceRayTracingPipelineStateDescriptor* Build();
+            MultiDeviceRayTracingPipelineStateDescriptor* MaxPayloadSize(uint32_t maxPayloadSize);
+            MultiDeviceRayTracingPipelineStateDescriptor* MaxAttributeSize(uint32_t maxAttributeSize);
+            MultiDeviceRayTracingPipelineStateDescriptor* MaxRecursionDepth(uint32_t maxRecursionDepth);
+            MultiDeviceRayTracingPipelineStateDescriptor* PipelineState(const RHI::MultiDevicePipelineState* pipelineState);
+            MultiDeviceRayTracingPipelineStateDescriptor* ShaderLibrary(RHI::PipelineStateDescriptorForRayTracing& descriptor);
+
+            MultiDeviceRayTracingPipelineStateDescriptor* RayGenerationShaderName(const AZ::Name& name);
+            MultiDeviceRayTracingPipelineStateDescriptor* MissShaderName(const AZ::Name& name);
+            MultiDeviceRayTracingPipelineStateDescriptor* ClosestHitShaderName(const AZ::Name& closestHitShaderName);
+            MultiDeviceRayTracingPipelineStateDescriptor* AnyHitShaderName(const AZ::Name& anyHitShaderName);
+
+            MultiDeviceRayTracingPipelineStateDescriptor* HitGroup(const AZ::Name& name);
+
+        private:
+            const RHI::MultiDevicePipelineState* m_pipelineState = nullptr;
+            RayTracingPipelineStateDescriptor m_descriptor;
+        };
+
+        //! Defines the shaders, hit groups, and other parameters required for ray tracing operations.
+        class MultiDeviceRayTracingPipelineState : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingPipelineState, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceRayTracingPipelineState, "{22F609DF-C889-4278-9580-3D2A99E78857}", MultiDeviceObject)
+            MultiDeviceRayTracingPipelineState() = default;
+
+            virtual ~MultiDeviceRayTracingPipelineState() = default;
+
+            const RHI::Ptr<RayTracingPipelineState>& GetDevicePipelineState(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceRayTracingPipelineState",
+                    m_deviceRayTracingPipelineStates.find(deviceIndex) != m_deviceRayTracingPipelineStates.end(),
+                    "No RayTracingPipelineState found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceRayTracingPipelineStates.at(deviceIndex);
+            }
+
+            const MultiDeviceRayTracingPipelineStateDescriptor& GetDescriptor() const
+            {
+                return m_descriptor;
+            }
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingPipelineStateDescriptor& descriptor);
+
+        private:
+            // explicit shutdown is not allowed for this type
+            void Shutdown() override final;
+
+            MultiDeviceRayTracingPipelineStateDescriptor m_descriptor;
+            AZStd::unordered_map<int, Ptr<RayTracingPipelineState>> m_deviceRayTracingPipelineStates;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+// #include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RayTracingShaderTable.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceRayTracingBufferPools;
+        class MultiDeviceShaderResourceGroup;
+
+        //! Specifies the shader and any local root signature parameters that make up a record in the shader table
+        struct MultiDeviceRayTracingShaderTableRecord
+        {
+            AZ::Name m_shaderExportName; // name of the shader as described in the pipeline state
+            const RHI::MultiDeviceShaderResourceGroup* m_shaderResourceGroup; // shader resource group for this shader record
+            static const uint32_t InvalidKey = static_cast<uint32_t>(-1);
+            uint32_t m_key = InvalidKey; // key that can be used to identify this record
+        };
+        using MultiDeviceRayTracingShaderTableRecordList = AZStd::list<MultiDeviceRayTracingShaderTableRecord>;
+
+        //! MultiDeviceRayTracingShaderTableDescriptor
+        //!
+        //! The Build() operation in the descriptor allows the shader table to be initialized
+        //! using the following pattern:
+        //!
+        //! RHI::MultiDeviceRayTracingShaderTableDescriptor descriptor;
+        //! descriptor.Build(AZ::Name("RayTracingExampleShaderTable"), m_rayTracingPipelineState)
+        //!     ->RayGenerationRecord(AZ::Name("RayGenerationShader"))
+        //!     ->MissRecord(AZ::Name("MissShader"))
+        //!         ->ShaderResourceGroup(missSrg)
+        //!     ->HitGroupRecord(AZ::Name("HitGroup1"))
+        //!         ->ShaderResourceGroup(hitGroupSrg1)
+        //!     ->HitGroupRecord(AZ::Name("HitGroup2"))
+        //!         ->ShaderResourceGroup(hitGroupSrg2)
+        //!     ;
+        //!
+        class MultiDeviceRayTracingShaderTableDescriptor
+        {
+        public:
+            MultiDeviceRayTracingShaderTableDescriptor() = default;
+            ~MultiDeviceRayTracingShaderTableDescriptor() = default;
+
+            AZStd::shared_ptr<RayTracingShaderTableDescriptor> GetDeviceRayTracingShaderTableDescriptor(int deviceIndex);
+
+            // accessors
+            const RHI::Ptr<MultiDeviceRayTracingPipelineState>& GetPipelineState() const
+            {
+                return m_rayTracingPipelineState;
+            }
+
+            const MultiDeviceRayTracingShaderTableRecordList& GetRayGenerationRecord() const
+            {
+                return m_rayGenerationRecord;
+            }
+            MultiDeviceRayTracingShaderTableRecordList& GetRayGenerationRecord()
+            {
+                return m_rayGenerationRecord;
+            }
+
+            const MultiDeviceRayTracingShaderTableRecordList& GetMissRecords() const
+            {
+                return m_missRecords;
+            }
+            MultiDeviceRayTracingShaderTableRecordList& GetMissRecords()
+            {
+                return m_missRecords;
+            }
+
+            const MultiDeviceRayTracingShaderTableRecordList& GetHitGroupRecords() const
+            {
+                return m_hitGroupRecords;
+            }
+            MultiDeviceRayTracingShaderTableRecordList& GetHitGroupRecords()
+            {
+                return m_hitGroupRecords;
+            }
+
+            void RemoveHitGroupRecords(uint32_t key);
+
+            // build operations
+            MultiDeviceRayTracingShaderTableDescriptor* Build(
+                const AZ::Name& name, RHI::Ptr<MultiDeviceRayTracingPipelineState>& rayTracingPipelineState);
+            MultiDeviceRayTracingShaderTableDescriptor* RayGenerationRecord(const AZ::Name& name);
+            MultiDeviceRayTracingShaderTableDescriptor* MissRecord(const AZ::Name& name);
+            MultiDeviceRayTracingShaderTableDescriptor* HitGroupRecord(
+                const AZ::Name& name, uint32_t key = MultiDeviceRayTracingShaderTableRecord::InvalidKey);
+            MultiDeviceRayTracingShaderTableDescriptor* ShaderResourceGroup(const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup);
+
+        private:
+            AZ::Name m_name;
+            RHI::Ptr<MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            MultiDeviceRayTracingShaderTableRecordList
+                m_rayGenerationRecord; // limited to one record, but stored as a list to simplify processing
+            MultiDeviceRayTracingShaderTableRecordList m_missRecords;
+            MultiDeviceRayTracingShaderTableRecordList m_hitGroupRecords;
+
+            MultiDeviceRayTracingShaderTableRecord* m_buildContext = nullptr;
+        };
+
+        //! Shader Table
+        //! Specifies the ray generation, miss, and hit shaders used during the ray tracing process
+        class MultiDeviceRayTracingShaderTable : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingShaderTable, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceRayTracingShaderTable, "{B448997B-A8E6-446E-A333-EFD92B486D9B}", MultiDeviceObject)
+            MultiDeviceRayTracingShaderTable() = default;
+            virtual ~MultiDeviceRayTracingShaderTable() = default;
+
+            const RHI::Ptr<RayTracingShaderTable>& GetDeviceRayTracingShaderTable(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceRayTracingShaderTable",
+                    m_deviceRayTracingShaderTables.find(deviceIndex) != m_deviceRayTracingShaderTables.end(),
+                    "No RayTracingShaderTable found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceRayTracingShaderTables.at(deviceIndex);
+            }
+
+            void Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+            //! Queues this MultiDeviceRayTracingShaderTable to be built by the FrameScheduler.
+            //! Note that the descriptor must be heap allocated, preferably using make_shared.
+            void Build(const AZStd::shared_ptr<MultiDeviceRayTracingShaderTableDescriptor> descriptor);
+
+        private:
+            AZStd::unordered_map<int, Ptr<RayTracingShaderTable>> m_deviceRayTracingShaderTables;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceResourcePool;
+        class FrameAttachment;
+        class MemoryStatisticsBuilder;
+        class ResourceView;
+        class ImageView;
+        class BufferView;
+        struct ImageViewDescriptor;
+        struct BufferViewDescriptor;
+
+        //! MultiDeviceResource is a base class for pooled RHI resources (MultiDeviceImage / MultiDeviceBuffer /
+        //! MultiDeviceShaderResourceGroup, etc). It provides some common lifecycle management semantics. MultiDeviceResource creation is
+        //! separate from initialization. Resources are created separate from any pool, but its backing platform data is associated at
+        //! initialization time on a specific pool.
+        class MultiDeviceResource : public MultiDeviceObject
+        {
+            friend class FrameAttachment;
+            friend class MultiDeviceResourcePool;
+
+        public:
+            AZ_RTTI(MultiDeviceResource, "{613AED98-48FD-4453-98F8-6956D2133489}", MultiDeviceObject);
+            virtual ~MultiDeviceResource();
+
+            /// Returns whether the resource is currently an attachment on a frame graph.
+            bool IsAttachment() const;
+
+            /// Shuts down the resource by detaching it from its parent pool.
+            virtual void Shutdown() override = 0;
+
+            //! Returns the parent pool this resource is registered on. Since resource creation is
+            //! separate from initialization, this will be null until the resource is registered on a pool.
+            const MultiDeviceResourcePool* GetPool() const;
+            MultiDeviceResourcePool* GetPool();
+
+            //! Returns the version number. This number is monotonically increased anytime
+            //! new platform memory is assigned to the resource. Any dependent resource is
+            //! valid so long as the version numbers match.
+            uint32_t GetVersion() const;
+
+            /// Returns the frame attachment associated with this image (if it exists).
+            const FrameAttachment* GetFrameAttachment() const;
+
+            //! Invalidates all views referencing this resource. Invalidation is handled implicitly
+            //! on a Shutdown / Init cycle from the pool. For example, it is safe to create a resource,
+            //! create a view to that resource, and then Shutdown / Re-Init the resource. InvalidateViews is
+            //! called to synchronize views (and shader resource groups which hold them) to the new data.
+            //!
+            //! Platform back-ends which invalidate GPU-specific data on the resource without an explicit
+            //! shutdown / re-initialization will need to call this method explicitly.
+            virtual void InvalidateViews() = 0;
+
+            //! Returns true if the ResourceView is in the cache
+            bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
+            bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
+
+            //! Removes the provided ResourceView from the cache
+            void EraseResourceView(ResourceView* resourceView) const;
+
+        protected:
+            MultiDeviceResource() = default;
+
+        private:
+            /// Returns whether this resource has been initialized before.
+            bool IsFirstVersion() const;
+
+            /// Called by the parent pool at initialization time.
+            void SetPool(MultiDeviceResourcePool* pool);
+
+            /// Called by the frame attachment at frame building time.
+            void SetFrameAttachment(FrameAttachment* frameAttachment);
+
+            /// The parent pool this resource is registered with.
+            MultiDeviceResourcePool* m_pool = nullptr;
+
+            /// The current frame attachment registered on this resource.
+            FrameAttachment* m_frameAttachment = nullptr;
+
+            /// The version is monotonically incremented any time the backing resource is changed.
+            uint32_t m_version = 0;
+
+            /// Tracks whether an invalidation request is currently queued on this resource.
+            bool m_isInvalidationQueued = false;
+
+            // Cache the resourceViews in order to avoid re-creation
+            // Since ResourceView has a dependency to MultiDeviceResource this cache holds raw pointers here in order to ensure there
+            // is no circular dependency between the resource and it's resourceview.
+            mutable AZStd::unordered_map<size_t, ResourceView*> m_resourceViewCache;
+            // This should help provide thread safe access to resourceView cache
+            mutable AZStd::mutex m_cacheMutex;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResourcePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResourcePool.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ResourcePoolDescriptor.h>
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/MemoryStatisticsBus.h>
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/std/parallel/shared_mutex.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class CommandList;
+        class MultiDeviceResource;
+        class MemoryStatisticsBuilder;
+
+        /**
+         * A base class for resource pools. This class facilitates registration of resources
+         * into the pool, and allows iterating child resource instances.
+         */
+        class MultiDeviceResourcePool : public MultiDeviceObject
+        {
+            friend class MultiDeviceResource;
+
+        public:
+            AZ_RTTI(MultiDeviceResourcePool, "{BAE5442C-A312-4133-AE80-1200753A7C3E}", MultiDeviceObject);
+            virtual ~MultiDeviceResourcePool();
+
+            /// Shuts down the pool. This method will shutdown all resources associated with the pool.
+            virtual void Shutdown() override = 0;
+
+            /**
+             * Loops through every resource matching the provided resource type (RTTI casting is used) and
+             * calls the provided callback method. Both methods are thread-safe with respect to
+             * other Init calls. A shared_mutex is used to guard the internal registry. This means
+             * that multiple iterations can be done without blocking each other, but a resource Init / Shutdown
+             * will serialize with this method.
+             */
+            template<typename ResourceType>
+            void ForEach(AZStd::function<void(ResourceType&)> callback);
+
+            template<typename ResourceType>
+            void ForEach(AZStd::function<void(const ResourceType&)> callback) const;
+
+            /// Returns the number of resources in the pool.
+            uint32_t GetResourceCount() const;
+
+            /// Returns the resource pool descriptor.
+            virtual const ResourcePoolDescriptor& GetDescriptor() const = 0;
+
+        protected:
+            MultiDeviceResourcePool() = default;
+
+            //////////////////////////////////////////////////////////////////////////
+            // Middle Layer API - Used by specific RHI pools.
+
+            /// A simple functor that returns a result code.
+            using PlatformMethod = AZStd::function<RHI::ResultCode()>;
+
+            /**
+             * Validates the pool for initialization, calls the provided init method (which wraps the platform-specific
+             * resource init call). If the platform init fails, the resource pool is shutdown and an error code is returned.
+             */
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const PlatformMethod& initMethod);
+
+            /**
+             * Validates the state of resource, calls the provided init method, and registers the resource
+             * with the pool. If validation or the internal platform init method fail, the resource is not
+             * registered and an error code is returned.
+             */
+            ResultCode InitResource(MultiDeviceResource* resource, const PlatformMethod& initResourceMethod);
+
+            /**
+             * Validates the resource is registered / unregistered with the pool,
+             * and that it not null. In non-release builds this will issue a warning.
+             * Non-release builds will branch and fail the call if validation fails,
+             * but this should be treated as a bug, because release will disable
+             * validation.
+             */
+            bool ValidateIsRegistered(const MultiDeviceResource* resource) const;
+            bool ValidateIsUnregistered(const MultiDeviceResource* resource) const;
+
+            /// Validates that the resource pool is initialized and ready to service requests.
+            bool ValidateIsInitialized() const;
+
+        private:
+            /**
+             * Shuts down an resource by releasing all backing resources. This happens implicitly
+             * if the resource is released. The resource is still valid after this call, and can be
+             * re-initialized safely on another pool.
+             */
+            void ShutdownResource(MultiDeviceResource* resource);
+
+            /// Registers an resource instance with the pool (explicit pool derivations will do this).
+            void Register(MultiDeviceResource& resource);
+
+            /// Unregisters an resource instance with the pool.
+            void Unregister(MultiDeviceResource& resource);
+
+            /// The registry of resources initialized on the pool, guarded by a shared_mutex.
+            mutable AZStd::shared_mutex m_registryMutex;
+            AZStd::unordered_set<MultiDeviceResource*> m_registry;
+        };
+
+        template<typename ResourceType>
+        void MultiDeviceResourcePool::ForEach(AZStd::function<void(ResourceType&)> callback)
+        {
+            AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+            for (MultiDeviceResource* resourceBase : m_registry)
+            {
+                ResourceType* resourceType = azrtti_cast<ResourceType*>(resourceBase);
+                if (resourceType)
+                {
+                    callback(*resourceType);
+                }
+            }
+        }
+
+        template<typename ResourceType>
+        void MultiDeviceResourcePool::ForEach(AZStd::function<void(const ResourceType&)> callback) const
+        {
+            AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+            for (const MultiDeviceResource* resourceBase : m_registry)
+            {
+                const ResourceType* resourceType = azrtti_cast<const ResourceType*>(resourceBase);
+                if (resourceType)
+                {
+                    callback(*resourceType);
+                }
+            }
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupData.h>
+#include <Atom/RHI/ShaderResourceGroup.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! This class is a platform-independent base class for a shader resource group. It has a
+        //! pointer to the resource group pool, if the user initialized the group onto a pool.
+        class MultiDeviceShaderResourceGroup : public MultiDeviceResource
+        {
+            friend class MultiDeviceShaderResourceGroupPool;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceShaderResourceGroup, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceShaderResourceGroup, "{6C1B42AA-51A9-482F-9203-6415CA9373B7}", MultiDeviceResource);
+            MultiDeviceShaderResourceGroup() = default;
+            virtual ~MultiDeviceShaderResourceGroup() override = default;
+
+            using CompileMode = ShaderResourceGroup::CompileMode;
+
+            inline Ptr<ShaderResourceGroup> GetDeviceShaderResourceGroup(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroup",
+                    m_deviceShaderResourceGroups.find(deviceIndex) != m_deviceShaderResourceGroups.end(),
+                    "No ShaderResourceGroup found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceShaderResourceGroups.at(deviceIndex);
+            }
+
+            //! Compiles the SRG with the provided data.
+            //! When using Async compile mode, it queues a request that the parent pool compile this group (compilation is deferred).
+            //! When using Sync compile mode the SRG compilation will happen immediately.
+            void Compile(const MultiDeviceShaderResourceGroupData& shaderResourceGroupData, CompileMode compileMode = CompileMode::Async);
+
+            //! Returns the shader resource group pool that this group is registered on.
+            MultiDeviceShaderResourceGroupPool* GetPool();
+            const MultiDeviceShaderResourceGroupPool* GetPool() const;
+
+            //! Returns the data currently bound on the shader resource group.
+            const MultiDeviceShaderResourceGroupData& GetData() const;
+
+            //! Returns the binding slot specified by the layout associated to this shader resource group.
+            uint32_t GetBindingSlot() const;
+
+            //! Returns whether the group is currently queued for compilation.
+            bool IsQueuedForCompile() const;
+
+            //! Resets the update mask after m_updateMaskResetLatency number of compiles
+            void DisableCompilationForAllResourceTypes();
+
+            //! Returns true if any of the resource type has been enabled for compilation.
+            bool IsAnyResourceTypeUpdated() const;
+
+            //! Returns true if a specific resource type has been enabled for compilation.
+            bool IsResourceTypeEnabledForCompilation(uint32_t resourceTypeMask) const;
+
+            //! Update the m_rhiUpdateMask for a given resource type which will ensure we will compile that type for the current frame
+            void EnableRhiResourceTypeCompilation(const MultiDeviceShaderResourceGroupData::ResourceTypeMask resourceTypeMask);
+
+            //! Reset the iteration counter to 0 for a resource type which will ensure that the given type will
+            //! be compiled for another m_updateMaskResetLatency number of Compile calls
+            void ResetResourceTypeIteration(const MultiDeviceShaderResourceGroupData::ResourceType resourceType);
+
+            //! Return the view hash stored within m_viewHash
+            HashValue64 GetViewHash(const AZ::Name& viewName);
+
+            //! Update the view hash within m_viewHash
+            void UpdateViewHash(const AZ::Name& viewName, const HashValue64 viewHash);
+
+            // Shuts down the resource by detaching it from its parent pool.
+            void Shutdown() override final;
+
+            void InvalidateViews() override final;
+
+        private:
+            MultiDeviceShaderResourceGroupData m_data;
+
+            // The binding slot cached from the layout.
+            uint32_t m_bindingSlot = aznumeric_cast<uint32_t>(-1);
+
+            // Track hash related to views. This will help ensure we compile views in case they get invalidated and partial srg compilation
+            // is enabled
+            AZStd::unordered_map<AZ::Name, HashValue64> m_viewHash;
+
+            AZStd::unordered_map<int, Ptr<ShaderResourceGroup>> m_deviceShaderResourceGroups;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -1,0 +1,584 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/BufferViewDescriptor.h>
+#include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+#include <Atom/RHI/ConstantsData.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/ShaderResourceGroupData.h>
+#include <AzCore/std/containers/variant.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceShaderResourceGroup;
+        class MultiDeviceShaderResourceGroupPool;
+
+        //! Shader resource group data is a light abstraction over a flat table of shader resources
+        //! and shader constants. It utilizes basic reflection information from the shader resource group layout
+        //! to construct the table in the correct format for the platform-specific compile phase. The user
+        //! is expected to create instances of this class, fill data, and then push it to an SRG instance.
+        //!
+        //! The shader resource group (SRG) includes a set of built-in SRG constants in a single internally-managed
+        //! constant buffer. This is separate from any custom constant buffers that some SRG layouts may include
+        //! as shader resources. SRG constants can be conveniently accessed through a variety of SetConstant.
+        //!
+        //! This data structure holds strong references to the resource views bound onto it.
+        //!
+        //! NOTE [Performance Warning]: This data structure allocates memory. If compiling several SRG's in a batch,
+        //! prefer to share the data between them (i.e. within a single job).
+        //!
+        //! NOTE [SRG Constants]: The ConstantsData class is used for efficiently setting/getting the constants values of the SRG.
+        class MultiDeviceShaderResourceGroupData
+        {
+            using MultiDeviceBufferView = AZStd::pair<const MultiDeviceBuffer*, BufferViewDescriptor>;
+            using MultiDeviceImageView = AZStd::pair<const MultiDeviceImage*, ImageViewDescriptor>;
+
+        public:
+            //! By default creates an empty data structure. Must be initialized before use.
+            MultiDeviceShaderResourceGroupData() = default;
+            ~MultiDeviceShaderResourceGroupData() = default;
+
+            //! Creates shader resource group data from a layout.
+            explicit MultiDeviceShaderResourceGroupData(
+                MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* shaderResourceGroupLayout);
+
+            //! Creates shader resource group data from a pool (usable on any SRG with the same layout).
+            explicit MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroupPool& shaderResourceGroupPool);
+
+            //! Creates shader resource group data from an SRG instance (usable on any SRG with the same layout).
+            explicit MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroup& shaderResourceGroup);
+
+            AZ_DEFAULT_COPY_MOVE(MultiDeviceShaderResourceGroupData);
+
+            //! Resolves a shader input name to an index using reflection. For performance reasons, this resolve
+            //! operation should be performed once at initialization time (or as infrequently as possible).
+            //! Assignment of shader inputs is faster when done using the shader input index directly.
+            ShaderInputBufferIndex FindShaderInputBufferIndex(const Name& name) const;
+            ShaderInputImageIndex FindShaderInputImageIndex(const Name& name) const;
+            ShaderInputSamplerIndex FindShaderInputSamplerIndex(const Name& name) const;
+            ShaderInputConstantIndex FindShaderInputConstantIndex(const Name& name) const;
+
+            //! Sets one image view for the given shader input index.
+            bool SetImageView(ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex);
+
+            //! Sets an array of image view for the given shader input index.
+            bool SetImageViewArray(
+                ShaderInputImageIndex inputIndex,
+                AZStd::span<const MultiDeviceImageView* const> imageViewDescriptors,
+                uint32_t arrayIndex = 0);
+
+            //! Sets an unbounded array of image view for the given shader input index.
+            bool SetImageViewUnboundedArray(
+                ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const MultiDeviceImageView* const> imageViewDescriptors);
+
+            //! Sets one buffer view for the given shader input index.
+            bool SetBufferView(ShaderInputBufferIndex inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex = 0);
+
+            //! Sets an array of image view for the given shader input index.
+            bool SetBufferViewArray(
+                ShaderInputBufferIndex inputIndex, AZStd::span<const MultiDeviceBufferView* const> bufferView, uint32_t arrayIndex = 0);
+
+            //! Sets an unbounded array of buffer view for the given shader input index.
+            bool SetBufferViewUnboundedArray(
+                ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const MultiDeviceBufferView* const> bufferView);
+
+            //! Sets one sampler for the given shader input index, using the bindingIndex as the key.
+            bool SetSampler(ShaderInputSamplerIndex inputIndex, const SamplerState& sampler, uint32_t arrayIndex = 0);
+
+            //! Sets an array of samplers for the given shader input index.
+            bool SetSamplerArray(ShaderInputSamplerIndex inputIndex, AZStd::span<const SamplerState> samplers, uint32_t arrayIndex = 0);
+
+            //! Assigns constant data for the given constant shader input index.
+            bool SetConstantRaw(ShaderInputConstantIndex inputIndex, const void* bytes, uint32_t byteCount);
+            bool SetConstantRaw(ShaderInputConstantIndex inputIndex, const void* bytes, uint32_t byteOffset, uint32_t byteCount);
+
+            //! Assigns a value of type T to the constant shader input.
+            template<typename T>
+            bool SetConstant(ShaderInputConstantIndex inputIndex, const T& value);
+
+            //! Assigns a specified number of rows from a Matrix
+            template<typename T>
+            bool SetConstantMatrixRows(ShaderInputConstantIndex inputIndex, const T& value, uint32_t rowCount);
+
+            //! Assigns a value of type T to the constant shader input, at an array offset.
+            template<typename T>
+            bool SetConstant(ShaderInputConstantIndex inputIndex, const T& value, uint32_t arrayIndex);
+
+            //! Assigns an array of type T to the constant shader input.
+            template<typename T>
+            bool SetConstantArray(ShaderInputConstantIndex inputIndex, AZStd::span<const T> values);
+
+            //! Assigns constant data as a whole.
+            //!
+            //! CAUTION!
+            //! Different platforms might follow different packing rules for the internally-managed SRG constant buffer.
+            //! To set manually a constant buffer as a whole please use Constant Buffers in AZSL,
+            //! instead of SRG Constants, then use RHI Buffers with constant binding flag and set
+            //! the buffer memory following pragma 4 packing rule.
+            bool SetConstantData(const void* bytes, uint32_t byteCount);
+            bool SetConstantData(const void* bytes, uint32_t byteOffset, uint32_t byteCount);
+
+            const ShaderResourceGroupData& GetDeviceShaderResourceGroupData(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupData",
+                    m_deviceShaderResourceGroupDatas.find(deviceIndex) != m_deviceShaderResourceGroupDatas.end(),
+                    "No ShaderResourceGroupData found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceShaderResourceGroupDatas.at(deviceIndex);
+            }
+
+            //! Reset image and buffer views setup for this MultiDeviceShaderResourceGroupData
+            //! So it won't hold references for any RHI resources
+            void ResetViews();
+
+            //! Returns the shader resource layout for this group.
+            const ShaderResourceGroupLayout* GetLayout() const;
+
+            using ResourceType = ShaderResourceGroupData::ResourceType;
+
+            using ResourceTypeMask = ShaderResourceGroupData::ResourceTypeMask;
+
+            using BindlessResourceType = ShaderResourceGroupData::BindlessResourceType;
+
+            static const uint32_t BindlessSRGFrequencyId = ShaderResourceGroupData::BindlessSRGFrequencyId;
+
+            //! Reset the update mask
+            void ResetUpdateMask();
+
+            //! Enable compilation for a resourceType specified by resourceTypeMask
+            void EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask);
+
+            //! Returns the mask that is suppose to indicate which resource type was updated
+            uint32_t GetUpdateMask() const;
+
+            //! Update the indirect buffer view with the indices of all the image views which reside in the global gpu heap.
+            void SetBindlessViews(
+                ShaderInputBufferIndex indirectResourceBufferIndex,
+                const MultiDeviceBufferView* indirectResourceBufferView,
+                AZStd::span<const MultiDeviceImageView* const> imageViews,
+                uint32_t* outIndices,
+                bool viewReadOnly = true,
+                uint32_t arrayIndex = 0);
+
+            //! Update the indirect buffer view with the indices of all the buffer views which reside in the global gpu heap.
+            void SetBindlessViews(
+                ShaderInputBufferIndex indirectResourceBufferIndex,
+                const MultiDeviceBufferView* indirectResourceBufferView,
+                AZStd::span<const MultiDeviceBufferView* const> bufferViews,
+                uint32_t* outIndices,
+                bool viewReadOnly = true,
+                uint32_t arrayIndex = 0);
+
+        private:
+            bool ValidateSetImageView(ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex) const;
+            bool ValidateSetBufferView(
+                ShaderInputBufferIndex inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex) const;
+
+            template<typename TShaderInput, typename TShaderInputDescriptor>
+            bool ValidateImageViewAccess(TShaderInput inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex) const;
+            template<typename TShaderInput, typename TShaderInputDescriptor>
+            bool ValidateBufferViewAccess(TShaderInput inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex) const;
+
+            MultiDevice::DeviceMask m_deviceMask;
+
+            ConstPtr<ShaderResourceGroupLayout> m_shaderResourceGroupLayout;
+
+            //! Mask used to check whether to compile a specific resource type. This mask is managed by RPI and copied over to the RHI every
+            //! frame.
+            uint32_t m_updateMask = 0;
+
+            AZStd::unordered_map<int, ShaderResourceGroupData> m_deviceShaderResourceGroupDatas;
+        };
+
+        template<typename T>
+        bool MultiDeviceShaderResourceGroupData::SetConstant(ShaderInputConstantIndex inputIndex, const T& value)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstant(inputIndex, value);
+            }
+
+            return isValidAll;
+        }
+
+        template<typename T>
+        bool MultiDeviceShaderResourceGroupData::SetConstant(ShaderInputConstantIndex inputIndex, const T& value, uint32_t arrayIndex)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstant(inputIndex, value, arrayIndex);
+            }
+
+            return isValidAll;
+        }
+
+        template<typename T>
+        bool MultiDeviceShaderResourceGroupData::SetConstantMatrixRows(
+            ShaderInputConstantIndex inputIndex, const T& value, uint32_t rowCount)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstantMatrixRows(inputIndex, value, rowCount);
+            }
+
+            return isValidAll;
+        }
+
+        template<typename T>
+        bool MultiDeviceShaderResourceGroupData::SetConstantArray(ShaderInputConstantIndex inputIndex, AZStd::span<const T> values)
+        {
+            if (!values.empty())
+            {
+                EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+            }
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstantArray(inputIndex, values);
+            }
+
+            return isValidAll;
+        }
+
+        template<typename TShaderInput, typename TShaderInputDescriptor>
+        bool MultiDeviceShaderResourceGroupData::ValidateImageViewAccess(
+            TShaderInput inputIndex, const MultiDeviceImageView* imageView, [[maybe_unused]] uint32_t arrayIndex) const
+        {
+            if (!Validation::IsEnabled())
+            {
+                return true;
+            }
+
+            const TShaderInputDescriptor& shaderInputImage = GetLayout()->GetShaderInput(inputIndex);
+
+            if (!imageView)
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupData",
+                    false,
+                    "Image Array Input '%s[%d]' is null.",
+                    shaderInputImage.m_name.GetCStr(),
+                    arrayIndex);
+                return false;
+            }
+
+            const ImageViewDescriptor& imageViewDescriptor = imageView->second;
+            const MultiDeviceImage& image = *(imageView->first);
+            const ImageDescriptor& imageDescriptor = image.GetDescriptor();
+            const ImageFrameAttachment* frameAttachment = image.GetFrameAttachment();
+
+            // The image must have the correct bind flags for the slot.
+            const bool isValidAccess = (shaderInputImage.m_access == ShaderInputImageAccess::Read &&
+                                        CheckBitsAll(imageDescriptor.m_bindFlags, ImageBindFlags::ShaderRead)) ||
+                (shaderInputImage.m_access == ShaderInputImageAccess::ReadWrite &&
+                 CheckBitsAll(imageDescriptor.m_bindFlags, ImageBindFlags::ShaderReadWrite));
+
+            if (!isValidAccess)
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupData",
+                    false,
+                    "Image Input '%s[%d]': Invalid 'Read / Write' access. Expected '%s'.",
+                    shaderInputImage.m_name.GetCStr(),
+                    arrayIndex,
+                    GetShaderInputAccessName(shaderInputImage.m_access));
+                return false;
+            }
+
+            if (shaderInputImage.m_access == ShaderInputImageAccess::ReadWrite)
+            {
+                // An image view assigned to an input with read-write access must be an attachment on the frame scheduler.
+                if (!frameAttachment)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Image Input '%s[%d]': MultiDeviceImage is bound to a ReadWrite shader input, "
+                        "but it is not an attachment on the frame scheduler. All GPU-writable resources "
+                        "must be declared as attachments in order to provide hazard tracking.",
+                        shaderInputImage.m_name.GetCStr(),
+                        arrayIndex,
+                        GetShaderInputAccessName(shaderInputImage.m_access));
+                    return false;
+                }
+
+                // NOTE: We aren't able to validate the scope attachment here, because shader resource groups aren't directly
+                // associated with a scope. Instead, the CommandListValidator class will check that the access is correct at
+                // command list submission time.
+            }
+
+            auto checkImageType = [&imageDescriptor, &shaderInputImage, arrayIndex](ImageDimension expected)
+            {
+                if (imageDescriptor.m_dimension != expected)
+                {
+                    AZ_UNUSED(shaderInputImage);
+                    AZ_UNUSED(arrayIndex);
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Image Input '%s[%d]': The image is %dD but the shader expected %dD",
+                        shaderInputImage.m_name.GetCStr(),
+                        arrayIndex,
+                        static_cast<int>(imageDescriptor.m_dimension),
+                        static_cast<int>(expected));
+                    return false;
+                }
+                return true;
+            };
+
+            switch (shaderInputImage.m_type)
+            {
+            case ShaderInputImageType::Unknown:
+                // Unable to validate.
+                break;
+
+            case ShaderInputImageType::Image1DArray:
+            case ShaderInputImageType::Image1D:
+                if (!checkImageType(ImageDimension::Image1D))
+                {
+                    return false;
+                }
+                break;
+
+            case ShaderInputImageType::SubpassInput:
+                if (!checkImageType(ImageDimension::Image2D))
+                {
+                    return false;
+                }
+                break;
+
+            case ShaderInputImageType::Image2DArray:
+            case ShaderInputImageType::Image2D:
+                if (!checkImageType(ImageDimension::Image2D))
+                {
+                    return false;
+                }
+                if (imageDescriptor.m_multisampleState.m_samples != 1)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Image Input '%s[%d]': The image has multisample count %u but the shader expected 1.",
+                        shaderInputImage.m_name.GetCStr(),
+                        arrayIndex,
+                        imageDescriptor.m_multisampleState.m_samples);
+                    return false;
+                }
+                break;
+
+            case ShaderInputImageType::Image2DMultisample:
+            case ShaderInputImageType::Image2DMultisampleArray:
+                if (!checkImageType(ImageDimension::Image2D))
+                {
+                    return false;
+                }
+                if (imageDescriptor.m_multisampleState.m_samples <= 1)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Image Input '%s[%d]': The image has multisample count %u but the shader expected more than 1.",
+                        shaderInputImage.m_name.GetCStr(),
+                        arrayIndex,
+                        imageDescriptor.m_multisampleState.m_samples);
+                    return false;
+                }
+                break;
+
+            case ShaderInputImageType::Image3D:
+                if (!checkImageType(ImageDimension::Image3D))
+                {
+                    return false;
+                }
+                break;
+
+            case ShaderInputImageType::ImageCube:
+            case ShaderInputImageType::ImageCubeArray:
+                if (!checkImageType(ImageDimension::Image2D))
+                {
+                    return false;
+                }
+                if (imageViewDescriptor.m_isCubemap == 0)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Image Input '%s[%d]': The shader expected a cubemap.",
+                        shaderInputImage.m_name.GetCStr(),
+                        arrayIndex);
+                    return false;
+                }
+                break;
+
+            default:
+                AZ_Assert(false, "Image Input '%s[%d]': Invalid image type!", shaderInputImage.m_name.GetCStr(), arrayIndex);
+                return false;
+            }
+
+            return true;
+        }
+
+        template<typename TShaderInput, typename TShaderInputDescriptor>
+        bool MultiDeviceShaderResourceGroupData::ValidateBufferViewAccess(
+            TShaderInput inputIndex, const MultiDeviceBufferView* bufferView, [[maybe_unused]] uint32_t arrayIndex) const
+        {
+            if (!Validation::IsEnabled())
+            {
+                return true;
+            }
+
+            const TShaderInputDescriptor& shaderInputBuffer = GetLayout()->GetShaderInput(inputIndex);
+            const BufferViewDescriptor& bufferViewDescriptor = bufferView->second;
+            const MultiDeviceBuffer& buffer = *(bufferView->first);
+            const BufferDescriptor& bufferDescriptor = buffer.GetDescriptor();
+            const BufferFrameAttachment* frameAttachment = buffer.GetFrameAttachment();
+
+            const bool isValidAccess = (shaderInputBuffer.m_access == ShaderInputBufferAccess::Constant &&
+                                        CheckBitsAll(bufferDescriptor.m_bindFlags, BufferBindFlags::Constant)) ||
+                (shaderInputBuffer.m_access == ShaderInputBufferAccess::Read &&
+                 CheckBitsAll(bufferDescriptor.m_bindFlags, BufferBindFlags::ShaderRead)) ||
+                (shaderInputBuffer.m_access == ShaderInputBufferAccess::Read &&
+                 CheckBitsAll(bufferDescriptor.m_bindFlags, BufferBindFlags::RayTracingAccelerationStructure)) ||
+                (shaderInputBuffer.m_access == ShaderInputBufferAccess::ReadWrite &&
+                 CheckBitsAll(bufferDescriptor.m_bindFlags, BufferBindFlags::ShaderReadWrite));
+
+            if (!isValidAccess)
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupData",
+                    false,
+                    "Buffer Input '%s[%d]': Invalid 'Constant / Read / Write' access. Expected '%s'",
+                    shaderInputBuffer.m_name.GetCStr(),
+                    arrayIndex,
+                    GetShaderInputAccessName(shaderInputBuffer.m_access));
+                return false;
+            }
+
+            if (shaderInputBuffer.m_access == ShaderInputBufferAccess::ReadWrite /*&& !bufferView->IgnoreFrameAttachmentValidation()*/)
+            {
+                // A buffer view assigned to an input with read-write access must be an attachment on the frame scheduler.
+                if (!frameAttachment)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Buffer Input '%s[%d]': MultiDeviceBuffer is bound to a ReadWrite shader input, "
+                        "but it is not an attachment on the frame scheduler. All GPU-writable resources "
+                        "must be declared as attachments in order to provide hazard tracking.",
+                        shaderInputBuffer.m_name.GetCStr(),
+                        arrayIndex,
+                        GetShaderInputAccessName(shaderInputBuffer.m_access));
+                    return false;
+                }
+
+                // NOTE: We aren't able to validate the scope attachment here, because shader resource groups aren't directly
+                // associated with a scope. Instead, the CommandListValidator class will check that the access is correct at
+                // command list submission time.
+            }
+
+            if (shaderInputBuffer.m_type == ShaderInputBufferType::Constant)
+            {
+                // For Constant type the stride (full constant buffer) must be larger or equal than the buffer view size (element size x
+                // element count).
+                if (!(shaderInputBuffer.m_strideSize >= (bufferViewDescriptor.m_elementSize * bufferViewDescriptor.m_elementCount)))
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Buffer Input '%s[%d]': stride size %d must be larger than or equal to the buffer view size %d",
+                        shaderInputBuffer.m_name.GetCStr(),
+                        arrayIndex,
+                        shaderInputBuffer.m_strideSize,
+                        (bufferViewDescriptor.m_elementSize * bufferViewDescriptor.m_elementCount));
+                    return false;
+                }
+            }
+            else
+            {
+                // For any other type the buffer view's element size should match the stride.
+                if (shaderInputBuffer.m_strideSize != bufferViewDescriptor.m_elementSize)
+                {
+                    AZ_Error(
+                        "MultiDeviceShaderResourceGroupData",
+                        false,
+                        "Buffer Input '%s[%d]': Does not match expected stride size %d",
+                        shaderInputBuffer.m_name.GetCStr(),
+                        arrayIndex,
+                        bufferViewDescriptor.m_elementSize);
+                    return false;
+                }
+            }
+
+            bool isValidType = true;
+            switch (shaderInputBuffer.m_type)
+            {
+            case ShaderInputBufferType::Unknown:
+                // Unable to validate.
+                break;
+
+            case ShaderInputBufferType::Constant:
+                // Element format is not relevant for viewing a buffer as a constant buffer, any format would be valid.
+                break;
+
+            case ShaderInputBufferType::Structured:
+                isValidType &= bufferViewDescriptor.m_elementFormat == Format::Unknown;
+                break;
+
+            case ShaderInputBufferType::Typed:
+                isValidType &= bufferViewDescriptor.m_elementFormat != Format::Unknown;
+                break;
+
+            case ShaderInputBufferType::Raw:
+                isValidType &= bufferViewDescriptor.m_elementFormat == Format::R32_UINT;
+                break;
+
+            case ShaderInputBufferType::AccelerationStructure:
+                isValidType &= bufferViewDescriptor.m_elementFormat == Format::R32_UINT;
+                break;
+
+            default:
+                AZ_Assert(false, "Buffer Input '%s[%d]': Invalid buffer type!", shaderInputBuffer.m_name.GetCStr(), arrayIndex);
+                return false;
+            }
+
+            if (!isValidType)
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupData",
+                    false,
+                    "Buffer Input '%s[%d]': Does not match expected type '%s'",
+                    shaderInputBuffer.m_name.GetCStr(),
+                    arrayIndex,
+                    GetShaderInputTypeName(shaderInputBuffer.m_type));
+                return false;
+            }
+
+            return true;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupPool.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
+#include <Atom/RHI.Reflect/ShaderResourceGroupPoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/ShaderResourceGroupInvalidateRegistry.h>
+#include <Atom/RHI/ShaderResourceGroupPool.h>
+
+#include <AzCore/std/parallel/containers/concurrent_vector.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! The platform-independent base class for ShaderResourceGroupPools. Platforms
+        //! should inherit from this class to implement platform-dependent pooling of
+        //! shader resource groups.
+        class MultiDeviceShaderResourceGroupPool : public MultiDeviceResourcePool
+        {
+            friend class MultiDeviceShaderResourceGroup;
+
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceShaderResourceGroupPool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceShaderResourceGroupPool, "{5F10711E-C47A-40CC-8BEB-8AC161206A1E}", MultiDeviceResourcePool);
+            MultiDeviceShaderResourceGroupPool() = default;
+            virtual ~MultiDeviceShaderResourceGroupPool() override = default;
+
+            const RHI::Ptr<ShaderResourceGroupPool>& GetDeviceShaderResourceGroupPool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceShaderResourceGroupPool",
+                    m_deviceShaderResourceGroupPools.find(deviceIndex) != m_deviceShaderResourceGroupPools.end(),
+                    "No ShaderResourceGroupPool found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceShaderResourceGroupPools.at(deviceIndex);
+            }
+
+            //! Initializes the shader resource group pool.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupPoolDescriptor& descriptor);
+
+            //! Initializes the resource group and associates it with the pool. The resource
+            //! group must be updated on this pool.
+            ResultCode InitGroup(MultiDeviceShaderResourceGroup& srg);
+
+            //! Compile Shader Resource Group with the associated MultiDeviceShaderResourceGroupData
+            ResultCode CompileGroup(
+                MultiDeviceShaderResourceGroup& shaderResourceGroup, const MultiDeviceShaderResourceGroupData& shaderResourceGroupData);
+
+            //! Returns the descriptor passed at initialization time.
+            const ShaderResourceGroupPoolDescriptor& GetDescriptor() const override;
+
+            //! Returns the SRG layout used when initializing the pool.
+            const ShaderResourceGroupLayout* GetLayout() const;
+
+            //! Begins compilation of the pool. Cannot be called recursively.
+            //! @param groupsToCompileCount if non-null, is assigned to the number of groups needing to be compiled.
+            void CompileGroupsBegin();
+
+            //! Ends compilation of the pool. Must be preceeded by a CompileGroupsBegin() call.
+            void CompileGroupsEnd();
+
+            //////////////////////////////////////////////////////////////////////////
+            // The following methods must be called within a CompileGroups{Begin, End} region.
+
+            //! Compiles an interval [min, max) of groups.
+            void CompileGroupsForInterval(Interval interval);
+
+            //! Returns the total number of groups that need to be compiled.
+            uint32_t GetGroupsToCompileCount() const;
+
+            //////////////////////////////////////////////////////////////////////////
+
+            //! Returns whether layout in this pool has constants.
+            bool HasConstants() const;
+
+            //! Returns whether groups in this pool have an image table.
+            bool HasImageGroup() const;
+
+            //! Returns whether groups in this pool have a buffer table.
+            bool HasBufferGroup() const;
+
+            //! Returns whether groups in this pool have a sampler table.
+            bool HasSamplerGroup() const;
+
+            void Shutdown() override final;
+
+        private:
+            ShaderResourceGroupPoolDescriptor m_descriptor;
+            bool m_hasConstants = false;
+            bool m_hasBufferGroup = false;
+            bool m_hasImageGroup = false;
+            bool m_hasSamplerGroup = false;
+
+            AZStd::unordered_map<int, Ptr<ShaderResourceGroupPool>> m_deviceShaderResourceGroupPools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/StreamBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+#include <AzCore/std/containers/span.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class MultiDeviceBuffer;
+        class InputStreamLayout;
+
+        /**
+         * Provides a view into a buffer, to be used as vertex stream. The content of the view is a contiguous
+         * list of input vertex data. It is provided to the RHI back-end at draw time.
+         *
+         * Note that the buffer is further described in InputStreamLayout, through StreamChannelDescriptors
+         * and a StreamBufferDescriptor, which is provided to the RHI back-end at PSO compile time.
+         * - The view will be associated with one or more StreamChannelDescriptors to describe its specific content.
+         *   Channels maybe be stored in separate StreamBufferViews (each view having a separate StreamChannelDescriptor)
+         *   or interleaved in a single MultiDeviceStreamBufferView (one view having multiple StreamChannelDescriptors).
+         * - The view will correspond to a single StreamBufferDescriptor.
+         */
+        class alignas(8) MultiDeviceStreamBufferView
+        {
+        public:
+            MultiDeviceStreamBufferView() = default;
+
+            MultiDeviceStreamBufferView(const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, uint32_t byteStride);
+
+            StreamBufferView GetDeviceStreamBufferView(int deviceIndex) const
+            {
+                AZ_Assert(m_buffer, "No MultiDeviceBuffer available\n");
+
+                return StreamBufferView(*m_buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_byteStride);
+            }
+
+            /// Returns the hash of the view. This hash is precomputed at creation time.
+            HashValue64 GetHash() const;
+
+            /// Returns the buffer associated with the view.
+            const MultiDeviceBuffer* GetBuffer() const;
+
+            /// Returns the byte offset into the buffer.
+            uint32_t GetByteOffset() const;
+
+            /// Returns the number of bytes in the view.
+            uint32_t GetByteCount() const;
+
+            /// Returns the distance in bytes between consecutive vertex entries in the buffer.
+            /// This must match the stride value in StreamBufferDescriptor.
+            uint32_t GetByteStride() const;
+
+        private:
+            HashValue64 m_hash = HashValue64{ 0 };
+            const MultiDeviceBuffer* m_buffer = nullptr;
+            uint32_t m_byteOffset = 0;
+            uint32_t m_byteCount = 0;
+            uint32_t m_byteStride = 0;
+        };
+
+        /// Utility function for checking that the set of StreamBufferViews aligns with the InputStreamLayout
+        bool ValidateStreamBufferViews(
+            const InputStreamLayout& inputStreamLayout, AZStd::span<const MultiDeviceStreamBufferView> streamBufferViews);
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/StreamingImagePoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+#include <Atom/RHI/StreamingImagePool.h>
+
+#include <AzCore/std/containers/span.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        using CompleteCallback = AZStd::function<void()>;
+
+        /**
+         * A structure used as an argument to MultiDeviceStreamingImagePool::InitImage.
+         */
+        struct MultiDeviceStreamingImageInitRequest
+        {
+            MultiDeviceStreamingImageInitRequest() = default;
+
+            MultiDeviceStreamingImageInitRequest(
+                MultiDeviceImage& image, const ImageDescriptor& descriptor, AZStd::span<const StreamingImageMipSlice> tailMipSlices);
+
+            /// The image to initialize.
+            MultiDeviceImage* m_image = nullptr;
+
+            /// The descriptor used to to initialize the image.
+            ImageDescriptor m_descriptor;
+
+            /**
+             * An array of tail mip slices to upload. This must not be empty or the call will fail.
+             * This should only include the baseline set of mips necessary to render the image at
+             * its lowest resolution. The uploads is performed synchronously.
+             */
+            AZStd::span<const StreamingImageMipSlice> m_tailMipSlices;
+        };
+
+        /**
+         * A structure used as an argument to MultiDeviceStreamingImagePool::ExpandImage.
+         */
+        struct MultiDeviceStreamingImageExpandRequest
+        {
+            MultiDeviceStreamingImageExpandRequest() = default;
+
+            /// The image with which to expand its mip chain.
+            MultiDeviceImage* m_image = nullptr;
+
+            /**
+             * A list of image mip slices used to expand the contents. The data *must*
+             * remain valid for the duration of the upload (until m_completeCallback
+             * is triggered).
+             */
+            AZStd::span<const StreamingImageMipSlice> m_mipSlices;
+
+            /// Whether the function need to wait until the upload is finished.
+            bool m_waitForUpload = false;
+
+            /// A function to call when the upload is complete. It will be called instantly if m_waitForUpload was set to true.
+            CompleteCallback m_completeCallback;
+        };
+
+        class MultiDeviceStreamingImagePool : public MultiDeviceImagePoolBase
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceStreamingImagePool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceStreamingImagePool, "{466B4368-79D6-4363-91DE-3D0001159F7C}", MultiDeviceImagePoolBase);
+            MultiDeviceStreamingImagePool() = default;
+            virtual ~MultiDeviceStreamingImagePool() = default;
+
+            const RHI::Ptr<StreamingImagePool>& GetDeviceStreamingImagePool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceStreamingImagePool",
+                    m_deviceStreamingImagePools.find(deviceIndex) != m_deviceStreamingImagePools.end(),
+                    "No DeviceStreamingImagePool found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceStreamingImagePools.at(deviceIndex);
+            }
+
+            //! Initializes the pool. The pool must be initialized before images can be registered with it.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor);
+
+            //! Initializes the backing resources of an image.
+            ResultCode InitImage(const MultiDeviceStreamingImageInitRequest& request);
+
+            //! Expands a streaming image with new mip chain data. The expansion can be performed
+            //! asynchronously or synchronously depends on @m_waitForUpload in @MultiDeviceStreamingImageExpandRequest.
+            //! Upon completion, the views will be invalidated and map to the newly
+            //! streamed mip levels.
+            ResultCode ExpandImage(const MultiDeviceStreamingImageExpandRequest& request);
+
+            //! Trims a streaming image down to (and including) the target mip level. This occurs
+            //! immediately. The newly evicted mip levels are no longer accessible by image views
+            //! and the contents are considered undefined.
+            ResultCode TrimImage(MultiDeviceImage& image, uint32_t targetMipLevel);
+
+            const StreamingImagePoolDescriptor& GetDescriptor() const override final;
+
+        private:
+            using MultiDeviceImagePoolBase::InitImage;
+            using MultiDeviceResourcePool::Init;
+
+            bool ValidateInitRequest(const MultiDeviceStreamingImageInitRequest& initRequest) const;
+            bool ValidateExpandRequest(const MultiDeviceStreamingImageExpandRequest& expandRequest) const;
+
+            StreamingImagePoolDescriptor m_descriptor;
+
+            // Frame mutex prevents image update requests from overlapping with frame.
+            AZStd::shared_mutex m_frameMutex;
+
+            AZStd::unordered_map<int, Ptr<StreamingImagePool>> m_deviceStreamingImagePools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/SwapChainDescriptor.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+#include <Atom/RHI/SwapChain.h>
+#include <Atom/RHI/XRRenderingInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        //! The platform-independent swap chain base class. Swap chains contain a "chain" of images which
+        //! map to a platform-specific window, displayed on a physical monitor. The user is allowed
+        //! to adjust the swap chain outside of the current FrameScheduler frame. Doing so within a frame scheduler
+        //! frame results in undefined behavior.
+        //!
+        //! The frame scheduler controls presentation of the swap chain. The user may attach a swap chain to a scope
+        //! in order to render to the current image.
+        class MultiDeviceSwapChain : public MultiDeviceImagePoolBase
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceSwapChain, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceSwapChain, "{EB2B3AE5-41C0-4833-ABAD-4D964547029C}", Object);
+            MultiDeviceSwapChain() = default;
+            virtual ~MultiDeviceSwapChain() = default;
+
+            //! Initializes the swap chain, making it ready for attachment.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor);
+
+            inline Ptr<SwapChain> GetDeviceSwapChain(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceSwapChain",
+                    m_deviceSwapChains.find(deviceIndex) != m_deviceSwapChains.end(),
+                    "No DeviceSwapChain found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceSwapChains.at(deviceIndex);
+            }
+
+            //! Presents the swap chain to the display, and rotates the images.
+            void Present();
+
+            //! Sets the vertical sync interval for the swap chain.
+            //!      0 - No vsync.
+            //!      N - Sync to every N vertical refresh.
+            //!
+            //! A value of 1 syncs to the refresh rate of the monitor.
+            void SetVerticalSyncInterval(uint32_t verticalSyncInterval);
+
+            //! Resizes the display resolution of the swap chain. Ideally, this matches the platform window
+            //! resolution. Typically, the resize operation will occur in reaction to a platform window size
+            //! change. Takes effect immediately and results in a GPU pipeline flush.
+            ResultCode Resize(const SwapChainDimensions& dimensions);
+
+            //! Returns the number of images in the swap chain.
+            uint32_t GetImageCount() const;
+
+            //! Returns the current image of the swap chain.
+            MultiDeviceImage* GetCurrentImage() const;
+
+            //! Returns the image associated with the provided index, where the total number of images
+            //! is given by GetImageCount().
+            MultiDeviceImage* GetImage(uint32_t index) const;
+
+            //! Returns the ID used for the MultiDeviceSwapChain's attachment
+            const AttachmentId& GetAttachmentId() const;
+
+            //! Returns the descriptor provided when initializing the swap chain.
+            const RHI::SwapChainDescriptor& GetDescriptor() const override final;
+
+            //! Returns True if the swap chain prefers to use exclusive full screen mode.
+            bool IsExclusiveFullScreenPreferred() const;
+
+            //! Returns True if the swap chain prefers exclusive full screen mode and it is currently true, false otherwise.
+            bool GetExclusiveFullScreenState() const;
+
+            //! Return True if the swap chain prefers exclusive full screen mode and a transition happened, false otherwise.
+            bool SetExclusiveFullScreenState(bool fullScreenState);
+
+            //! Recreate the swapchain if it becomes invalid during presenting. This should happen at the end of the frame
+            //! due to images being used as attachments in the frame graph.
+            void ProcessRecreation();
+
+        protected:
+            struct InitImageRequest
+            {
+                //! Pointer to the image to initialize.
+                MultiDeviceImage* m_image = nullptr;
+
+                //! Index of the image in the swap chain.
+                uint32_t m_imageIndex = 0;
+
+                //! Descriptor for the image.
+                ImageDescriptor m_descriptor;
+            };
+
+            //! Shutdown and clear all the images.
+            void ShutdownImages();
+
+            //! Initialized all the images.
+            ResultCode InitImages();
+
+            //! Return the xr system interface
+            RHI::XRRenderingInterface* GetXRSystem() const;
+
+            //! Flag indicating if swapchain recreation is needed at the end of the frame.
+            bool m_pendingRecreation = false;
+
+        private:
+            bool ValidateDescriptor(const SwapChainDescriptor& descriptor) const;
+
+            SwapChainDescriptor m_descriptor;
+
+            //! Images corresponding to each image in the swap chain.
+            AZStd::vector<Ptr<MultiDeviceImage>> m_images;
+
+            //! Cache the XR system at initialization time
+            RHI::XRRenderingInterface* m_xrSystem = nullptr;
+
+            AZStd::unordered_map<int, Ptr<SwapChain>> m_deviceSwapChains;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/AliasedHeapEnums.h>
+#include <Atom/RHI.Reflect/TransientAttachmentStatistics.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ObjectCache.h>
+#include <Atom/RHI/Scope.h>
+#include <Atom/RHI/TransientAttachmentPool.h>
+
+#include <AzCore/std/optional.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class BufferAttachment;
+        class ImageAttachment;
+        class Scope;
+        class SwapChainAttachment;
+        struct TransientImageDescriptor;
+        struct TransientBufferDescriptor;
+
+        //! The transient attachment pool interface is used by the frame scheduler to compile the
+        //! working set of transient attachments for the frame. Each scope is iterated topologically
+        //! and transient resources are allocated and de-allocated. This is all done from within the
+        //! compile phase. Therefore, an allocation may create a resource, but a de-allocation does not
+        //! destroy resources! All de-allocation does is inform the pool that a resource can
+        //! be re-used within a subsequent scope. The final result of this process is a set of
+        //! image / buffer attachments that are backed by guaranteed memory valid *only* for the scope in
+        //! which they attached.
+        class MultiDeviceTransientAttachmentPool : public MultiDeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceTransientAttachmentPool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceTransientAttachmentPool, "{7CCD1108-B233-4D37-8A80-65CBB1988B22}");
+            MultiDeviceTransientAttachmentPool() = default;
+            virtual ~MultiDeviceTransientAttachmentPool() = default;
+
+            //! Returns true if a Transient Attachment Pool is needed according to the supplied descriptor.
+            static bool NeedsTransientAttachmentPool(const TransientAttachmentPoolDescriptor& descriptor);
+
+            const RHI::Ptr<TransientAttachmentPool>& GetDeviceTransientAttachmentPool(int deviceIndex) const
+            {
+                AZ_Error(
+                    "MultiDeviceTransientAttachmentPool",
+                    m_deviceTransientAttachmentPools.find(deviceIndex) != m_deviceTransientAttachmentPools.end(),
+                    "No DeviceTransientAttachmentPool found for device index %d\n",
+                    deviceIndex);
+
+                return m_deviceTransientAttachmentPools.at(deviceIndex);
+            }
+
+            //! Called to initialize the pool.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor);
+
+            //! Called to shutdown the pool.
+            void Shutdown();
+
+            //! This is called at the beginning of the compile phase for the current frame,
+            //! before any allocations occur. The user should clear the backing allocator to
+            //! a fresh state.
+            void Begin(
+                const TransientAttachmentPoolCompileFlags flags = TransientAttachmentPoolCompileFlags::None,
+                const TransientAttachmentStatistics::MemoryUsage* memoryHint = nullptr);
+
+            //! Called when a new scope is being allocated. Scopes are allocated in submission order.
+            void BeginScope(Scope& scopeBase);
+
+            //! Called when an image is being activated for the first time. This class should acquire
+            //! an image from the pool, configured for the provided descriptor. This may involve aliasing
+            //! from a heap, or simple object pooling.
+            virtual MultiDeviceImage* ActivateImage(const TransientImageDescriptor& descriptor);
+
+            //! Called when an buffer is being activated for the first time. This class should acquire
+            //! an buffer from the pool, configured for the provided descriptor. This may involve aliasing
+            //! from a heap, or simple object pooling.
+            virtual MultiDeviceBuffer* ActivateBuffer(const TransientBufferDescriptor& descriptor);
+
+            //! Called when a buffer is being de-allocated from the pool. Called during the last scope the attachment
+            //! is used, after all allocations for that scope have been processed.
+            virtual void DeactivateBuffer(const AttachmentId& attachmentId);
+
+            //! Called when a image is being de-allocated from the pool. Called during the last scope the attachment
+            //! is used, after all allocations for that scope have been processed.
+            virtual void DeactivateImage(const AttachmentId& attachmentId);
+
+            //! Called when all allocations for the current scope have completed.
+            void EndScope();
+
+            //! Called when the allocations / deallocations have completed for all scopes.
+            void End();
+
+            //! Get statistics for the pool (built during End).
+            AZStd::unordered_map<int, TransientAttachmentStatistics> GetStatistics() const;
+
+            //! Get pool descriptor
+            const TransientAttachmentPoolDescriptor& GetDescriptor() const;
+
+            //! Get the compile flags being used during the allocation of resources.
+            TransientAttachmentPoolCompileFlags GetCompileFlags() const;
+
+        private:
+            bool ValidateInitParameters(const TransientAttachmentPoolDescriptor& descriptor) const;
+
+            //! Remove the entry related to the provided attachmentId from the cache as it is probably stale now
+            void RemoveFromCache(RHI::AttachmentId attachmentId);
+
+            Scope* m_currentScope = nullptr;
+            TransientAttachmentPoolDescriptor m_descriptor;
+            TransientAttachmentPoolCompileFlags m_compileFlags = TransientAttachmentPoolCompileFlags::None;
+
+            ObjectCache<MultiDeviceResource> m_cache;
+
+            // This map is used to reverse look up resource hash so we can clear them out of m_cache
+            // once they have been replaced with a new resource at a different place in the heap.
+            AZStd::unordered_map<AttachmentId, HashValue64> m_reverseLookupHash;
+
+            AZStd::unordered_map<int, Ptr<TransientAttachmentPool>> m_deviceTransientAttachmentPools;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -31,7 +31,7 @@ namespace AZ
         public:
             //! This function just initializes the native device and RHI::Device as a result.
             //! We can use this device to then query for device capabilities.
-            ResultCode InitDevice();
+            ResultCode InitDevices(bool initializeMultiDevice = false);
 
             //! This function initializes the rest of the RHI/RHI backend. 
             void Init();
@@ -83,7 +83,7 @@ namespace AZ
         private:
 
             //Enumerates the Physical devices and picks one to be used to initialize the RHI::Device with
-            ResultCode InitInternalDevices();
+            ResultCode InitInternalDevices(bool initializeMultiDevice);
 
             AZStd::vector<RHI::Ptr<RHI::Device>> m_devices;
             RHI::FrameScheduler m_frameScheduler;

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -77,8 +77,6 @@ namespace AZ
             m_physicalDevice = &physicalDevice;
             m_deviceIndex = deviceIndex;
 
-            AZ_Assert(deviceIndex == 0, "Multi-device support is not implemented yet.");
-
             RHI::ResultCode resultCode = InitInternal(physicalDevice);
 
             if (resultCode == ResultCode::Success)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/BufferFrameAttachment.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        void MultiDeviceBuffer::SetDescriptor(const BufferDescriptor& descriptor)
+        {
+            m_descriptor = descriptor;
+        }
+
+        void MultiDeviceBuffer::Invalidate()
+        {
+            m_deviceBuffers.clear();
+        }
+
+        const RHI::BufferDescriptor& MultiDeviceBuffer::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        const BufferFrameAttachment* MultiDeviceBuffer::GetFrameAttachment() const
+        {
+            return static_cast<const BufferFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
+        }
+
+        const HashValue64 MultiDeviceBuffer::GetHash() const
+        {
+            HashValue64 hash = HashValue64{ 0 };
+            hash = m_descriptor.GetHash();
+            return hash;
+        }
+
+        void MultiDeviceBuffer::Shutdown()
+        {
+            for (auto& [_, deviceBuffer] : m_deviceBuffers)
+                deviceBuffer->Shutdown();
+            MultiDeviceResource::Shutdown();
+        }
+
+        void MultiDeviceBuffer::InvalidateViews()
+        {
+            for (auto& [_, deviceBuffer] : m_deviceBuffers)
+                deviceBuffer->InvalidateViews();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceFence.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceBufferInitRequest::MultiDeviceBufferInitRequest(
+            MultiDeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData)
+            : m_buffer{ &buffer }
+            , m_descriptor{ descriptor }
+            , m_initialData{ initialData }
+        {
+        }
+
+        MultiDeviceBufferMapRequest::MultiDeviceBufferMapRequest(MultiDeviceBuffer& buffer, size_t byteOffset, size_t byteCount)
+            : m_buffer{ &buffer }
+            , m_byteOffset{ byteOffset }
+            , m_byteCount{ byteCount }
+        {
+        }
+
+        bool MultiDeviceBufferPool::ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (descriptor.m_heapMemoryLevel == RHI::HeapMemoryLevel::Device &&
+                    descriptor.m_hostMemoryAccess == RHI::HostMemoryAccess::Read)
+                {
+                    AZ_Error(
+                        "MultiDeviceBufferPool",
+                        false,
+                        "When HeapMemoryLevel::Device is specified, m_hostMemoryAccess must be HostMemoryAccess::Write.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool MultiDeviceBufferPool::ValidateInitRequest(const MultiDeviceBufferInitRequest& initRequest) const
+        {
+            if (Validation::IsEnabled())
+            {
+                const BufferPoolDescriptor& poolDescriptor = GetDescriptor();
+
+                // Bind flags of the buffer must match the pool bind flags.
+                if (initRequest.m_descriptor.m_bindFlags != poolDescriptor.m_bindFlags)
+                {
+                    AZ_Error(
+                        "MultiDeviceBufferPool",
+                        false,
+                        "MultiDeviceBuffer bind flags don't match pool bind flags in pool '%s'",
+                        GetName().GetCStr());
+                    return false;
+                }
+
+                // Initial data is not allowed for read-only heaps.
+                if (initRequest.m_initialData && poolDescriptor.m_hostMemoryAccess == HostMemoryAccess::Read)
+                {
+                    AZ_Error("MultiDeviceBufferPool", false, "Initial data is not allowed with read-only pools.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool MultiDeviceBufferPool::ValidateIsHostHeap() const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (GetDescriptor().m_heapMemoryLevel != HeapMemoryLevel::Host)
+                {
+                    AZ_Error("MultiDeviceBufferPool", false, "This operation is only permitted for pools on the Host heap.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool MultiDeviceBufferPool::ValidateMapRequest(const MultiDeviceBufferMapRequest& request) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!request.m_buffer)
+                {
+                    AZ_Error("MultiDeviceBufferPool", false, "Trying to map a null buffer.");
+                    return false;
+                }
+
+                if (request.m_byteCount == 0)
+                {
+                    AZ_Warning(
+                        "MultiDeviceBufferPool",
+                        false,
+                        "Trying to map zero bytes from buffer '%s'.",
+                        request.m_buffer->GetName().GetCStr());
+                    return false;
+                }
+
+                if (request.m_byteOffset + request.m_byteCount > request.m_buffer->GetDescriptor().m_byteCount)
+                {
+                    AZ_Error(
+                        "MultiDeviceBufferPool",
+                        false,
+                        "Unable to map buffer '%s', overrunning the size of the buffer.",
+                        request.m_buffer->GetName().GetCStr());
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        ResultCode MultiDeviceBufferPool::Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor)
+        {
+            return MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor]()
+                {
+                    if (!ValidatePoolDescriptor(descriptor))
+                    {
+                        return ResultCode::InvalidArgument;
+                    }
+
+                    /**
+                     * Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                     * for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                     * possibility that users will get garbage values from GetDescriptor().
+                     */
+                    m_descriptor = descriptor;
+
+                    ResultCode result = ResultCode::Success;
+
+                    IterateDevices(
+                        [this, &descriptor, &result](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceBufferPools[deviceIndex] = Factory::Get().CreateBufferPool();
+                            result = m_deviceBufferPools[deviceIndex]->Init(*device, descriptor);
+
+                            return result == ResultCode::Success;
+                        });
+
+                    return result;
+                });
+        }
+
+        ResultCode MultiDeviceBufferPool::InitBuffer(const MultiDeviceBufferInitRequest& initRequest)
+        {
+            AZ_PROFILE_FUNCTION(RHI);
+
+            if (!ValidateInitRequest(initRequest))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode resultCode = InitBuffer(
+                initRequest.m_buffer,
+                initRequest.m_descriptor,
+                [this, &initRequest]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    for (auto& [deviceIndex, deviceBufferPool] : m_deviceBufferPools)
+                    {
+                        if (!initRequest.m_buffer->m_deviceBuffers.contains(deviceIndex))
+                            initRequest.m_buffer->m_deviceBuffers[deviceIndex] = Factory::Get().CreateBuffer();
+                        BufferInitRequest bufferInitRequest(
+                            *initRequest.m_buffer->m_deviceBuffers[deviceIndex], initRequest.m_descriptor, initRequest.m_initialData);
+                        result = deviceBufferPool->InitBuffer(bufferInitRequest);
+
+                        if (result != ResultCode::Success)
+                            break;
+                    }
+
+                    return result;
+                });
+
+            if (resultCode == ResultCode::Success && initRequest.m_initialData)
+            {
+                MultiDeviceBufferMapRequest mapRequest;
+                mapRequest.m_buffer = initRequest.m_buffer;
+                mapRequest.m_byteCount = initRequest.m_descriptor.m_byteCount;
+                mapRequest.m_byteOffset = 0;
+
+                MultiDeviceBufferMapResponse mapResponse;
+                resultCode = MapBuffer(mapRequest, mapResponse);
+                if (resultCode == ResultCode::Success)
+                {
+                    for (auto data : mapResponse.m_data)
+                    {
+                        if (data)
+                        {
+                            memcpy(data, initRequest.m_initialData, initRequest.m_descriptor.m_byteCount);
+                        }
+                    }
+
+                    UnmapBuffer(*initRequest.m_buffer);
+                }
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceBufferPool::OrphanBuffer(MultiDeviceBuffer& buffer)
+        {
+            if (!ValidateIsInitialized() || !ValidateIsHostHeap() || !ValidateNotDeviceLevel())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsRegistered(&buffer))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            AZ_PROFILE_SCOPE(RHI, "MultiDeviceBufferPool::OrphanBuffer");
+
+            buffer.Invalidate();
+            buffer.Init(GetDeviceMask());
+
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceBufferPool::MapBuffer(const MultiDeviceBufferMapRequest& request, MultiDeviceBufferMapResponse& response)
+        {
+            AZ_PROFILE_FUNCTION(RHI);
+
+            if (!ValidateIsInitialized() || !ValidateNotDeviceLevel())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsRegistered(request.m_buffer))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            if (!ValidateMapRequest(request))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode resultCode = ResultCode::Success;
+
+            BufferMapRequest deviceMapRequest{};
+            deviceMapRequest.m_byteCount = request.m_byteCount;
+            deviceMapRequest.m_byteOffset = request.m_byteOffset;
+
+            BufferMapResponse deviceMapResponse{};
+
+            for (auto& [deviceIndex, deviceBufferPool] : m_deviceBufferPools)
+            {
+                deviceMapRequest.m_buffer = request.m_buffer->m_deviceBuffers[deviceIndex].get();
+                resultCode = deviceBufferPool->MapBuffer(deviceMapRequest, deviceMapResponse);
+
+                if (resultCode != ResultCode::Success)
+                    break;
+
+                response.m_data.push_back(deviceMapResponse.m_data);
+            }
+
+            ValidateBufferMap(*request.m_buffer, !response.m_data.empty());
+            return resultCode;
+        }
+
+        void MultiDeviceBufferPool::UnmapBuffer(MultiDeviceBuffer& buffer)
+        {
+            if (ValidateIsInitialized() && ValidateNotDeviceLevel() && ValidateIsRegistered(&buffer))
+            {
+                for (auto& [deviceIndex, deviceBufferPool] : m_deviceBufferPools)
+                {
+                    deviceBufferPool->UnmapBuffer(*buffer.m_deviceBuffers[deviceIndex]);
+                }
+            }
+        }
+
+        ResultCode MultiDeviceBufferPool::StreamBuffer(const MultiDeviceBufferStreamRequest& request)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsRegistered(request.m_buffer))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode result = ResultCode::Success;
+
+            for (auto& [deviceIndex, deviceBufferPool] : m_deviceBufferPools)
+            {
+                auto* buffer = request.m_buffer->m_deviceBuffers[deviceIndex].get();
+
+                BufferStreamRequest bufferStreamRequest{ request.m_fenceToSignal
+                                                                         ? request.m_fenceToSignal->GetDeviceFence(deviceIndex).get()
+                                                                         : nullptr,
+                                                                     buffer,
+                                                                     request.m_byteOffset,
+                                                                     request.m_byteCount,
+                                                                     request.m_sourceData };
+
+                result = deviceBufferPool->StreamBuffer(bufferStreamRequest);
+
+                if (result != ResultCode::Success)
+                    break;
+            }
+
+            return result;
+        }
+
+        const BufferPoolDescriptor& MultiDeviceBufferPool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        ResultCode MultiDeviceBufferPool::InitBuffer(
+            MultiDeviceBuffer* buffer, const BufferDescriptor& descriptor, PlatformMethod platformInitResourceMethod)
+        {
+            // The descriptor is assigned regardless of whether initialization succeeds. Descriptors are considered
+            // undefined for uninitialized resources. This makes the buffer descriptor well defined at initialization
+            // time rather than leftover data from the previous usage.
+            buffer->SetDescriptor(descriptor);
+
+            return MultiDeviceResourcePool::InitResource(buffer, platformInitResourceMethod);
+        }
+
+        void MultiDeviceBufferPool::ValidateBufferMap(MultiDeviceBuffer& buffer, bool isDataValid)
+        {
+            if (Validation::IsEnabled())
+            {
+                // No need for validation for a null rhi
+                if (!isDataValid)
+                {
+                    AZ_Error("MultiDeviceBufferPool", false, "Failed to map buffer '%s'.", buffer.GetName().GetCStr());
+                }
+            }
+        }
+
+        bool MultiDeviceBufferPool::ValidateNotDeviceLevel() const
+        {
+            return GetDescriptor().m_heapMemoryLevel != HeapMemoryLevel::Device;
+        }
+
+        void MultiDeviceBufferPool::Shutdown()
+        {
+            for (auto [_, pool] : m_deviceBufferPools)
+                pool->Shutdown();
+            MultiDeviceResourcePool::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceFence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceFence.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceFence.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/Debug/Profiler.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDeviceFence::ValidateIsInitialized() const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!IsInitialized())
+                {
+                    AZ_Error("MultiDeviceFence", false, "MultiDeviceFence is not initialized!");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        ResultCode MultiDeviceFence::Init(MultiDevice::DeviceMask deviceMask, FenceState initialState)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Error("MultiDeviceFence", false, "MultiDeviceFence is already initialized!");
+                    return ResultCode::InvalidOperation;
+                }
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, initialState, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_deviceFences[deviceIndex] = Factory::Get().CreateFence();
+                    resultCode = m_deviceFences[deviceIndex]->Init(*device, initialState);
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            if (resultCode != ResultCode::Success)
+            {
+                AZ_Assert(false, "Failed to create a fence");
+            }
+
+            return resultCode;
+        }
+
+        void MultiDeviceFence::Shutdown()
+        {
+            if (IsInitialized())
+            {
+                if (m_waitThread.joinable())
+                {
+                    m_waitThread.join();
+                }
+
+                for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+                {
+                    deviceFence->Shutdown();
+                }
+
+                MultiDeviceObject::Shutdown();
+            }
+        }
+
+        ResultCode MultiDeviceFence::SignalOnCpu()
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            ResultCode resultCode;
+
+            for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+            {
+                resultCode = deviceFence->SignalOnCpu();
+
+                if (resultCode != ResultCode::Success)
+                    return resultCode;
+            }
+
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceFence::WaitOnCpu() const
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            ResultCode resultCode;
+
+            for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+            {
+                resultCode = deviceFence->WaitOnCpu();
+
+                if (resultCode != ResultCode::Success)
+                    return resultCode;
+            }
+
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceFence::WaitOnCpuAsync(SignalCallback callback)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!callback)
+            {
+                AZ_Error("MultiDeviceFence", false, "Callback is null.");
+                return ResultCode::InvalidOperation;
+            }
+
+            if (m_waitThread.joinable())
+            {
+                m_waitThread.join();
+            }
+
+            AZStd::thread_desc threadDesc{ "MultiDeviceFence WaitOnCpu Thread" };
+
+            m_waitThread = AZStd::thread(
+                threadDesc,
+                [this, callback]()
+                {
+                    ResultCode resultCode = WaitOnCpu();
+                    if (resultCode != ResultCode::Success)
+                    {
+                        AZ_Error("MultiDeviceFence", false, "Failed to call WaitOnCpu in async thread.");
+                    }
+                    callback();
+                });
+
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceFence::Reset()
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            ResultCode resultCode;
+
+            for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+            {
+                resultCode = deviceFence->Reset();
+
+                if (resultCode != ResultCode::Success)
+                    return resultCode;
+            }
+
+            return ResultCode::Success;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        void MultiDeviceImage::SetDescriptor(const ImageDescriptor& descriptor)
+        {
+            m_descriptor = descriptor;
+            m_aspectFlags = GetImageAspectFlags(descriptor.m_format);
+        }
+
+        const ImageDescriptor& MultiDeviceImage::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        void MultiDeviceImage::GetSubresourceLayout(
+            MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags) const
+        {
+            ImageSubresourceRange subresourceRange;
+            subresourceRange.m_mipSliceMin = 0;
+            subresourceRange.m_mipSliceMax = 0;
+            subresourceRange.m_arraySliceMin = 0;
+            subresourceRange.m_arraySliceMax = 0;
+            subresourceRange.m_aspectFlags = aspectFlags;
+
+            for (auto& [deviceIndex, deviceImage] : m_deviceImages)
+            {
+                deviceImage->GetSubresourceLayouts(subresourceRange, &subresourceLayout.GetDeviceImageSubresource(deviceIndex), nullptr);
+            }
+        }
+
+        const ImageFrameAttachment* MultiDeviceImage::GetFrameAttachment() const
+        {
+            return static_cast<const ImageFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
+        }
+
+        ImageAspectFlags MultiDeviceImage::GetAspectFlags() const
+        {
+            return m_aspectFlags;
+        }
+
+        const HashValue64 MultiDeviceImage::GetHash() const
+        {
+            HashValue64 hash = HashValue64{ 0 };
+            hash = m_descriptor.GetHash();
+            hash = TypeHash64(m_supportedQueueMask, hash);
+            hash = TypeHash64(m_aspectFlags, hash);
+            return hash;
+        }
+
+        void MultiDeviceImage::Shutdown()
+        {
+            for (auto& [_, deviceImage] : m_deviceImages)
+                deviceImage->Shutdown();
+            MultiDeviceResource::Shutdown();
+        }
+
+        void MultiDeviceImage::InvalidateViews()
+        {
+            for (auto& [_, deviceImage] : m_deviceImages)
+                deviceImage->InvalidateViews();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePool.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceImagePool.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceImageInitRequest::MultiDeviceImageInitRequest(
+            MultiDeviceImage& image, const ImageDescriptor& descriptor, const ClearValue* optimizedClearValue)
+            : m_image{ &image }
+            , m_descriptor{ descriptor }
+            , m_optimizedClearValue{ optimizedClearValue }
+        {
+        }
+
+        ResultCode MultiDeviceImagePool::Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor)
+        {
+            return MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor]()
+                {
+                    /**
+                     * Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                     * for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                     * possibility that users will get garbage values from GetDescriptor().
+                     */
+                    m_descriptor = descriptor;
+
+                    IterateDevices(
+                        [this, &descriptor](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceImagePools[deviceIndex] = Factory::Get().CreateImagePool();
+                            m_deviceImagePools[deviceIndex]->Init(*device, descriptor);
+
+                            return true;
+                        });
+
+                    return ResultCode::Success;
+                });
+        }
+
+        bool MultiDeviceImagePool::ValidateUpdateRequest(const MultiDeviceImageUpdateRequest& updateRequest) const
+        {
+            if (Validation::IsEnabled())
+            {
+                const ImageDescriptor& imageDescriptor = updateRequest.m_image->GetDescriptor();
+                if (updateRequest.m_imageSubresource.m_mipSlice >= imageDescriptor.m_mipLevels ||
+                    updateRequest.m_imageSubresource.m_arraySlice >= imageDescriptor.m_arraySize)
+                {
+                    AZ_Error(
+                        "MultiDeviceImagePool",
+                        false,
+                        "Updating subresource (array: %d, mip: %d), but the image dimensions are (arraySize: %d, mipLevels: %d)",
+                        updateRequest.m_imageSubresource.m_mipSlice,
+                        updateRequest.m_imageSubresource.m_arraySlice,
+                        imageDescriptor.m_arraySize,
+                        imageDescriptor.m_mipLevels);
+                    return false;
+                }
+            }
+
+            AZ_UNUSED(updateRequest);
+            return true;
+        }
+
+        ResultCode MultiDeviceImagePool::InitImage(const MultiDeviceImageInitRequest& initRequest)
+        {
+            return MultiDeviceImagePoolBase::InitImage(
+                initRequest.m_image,
+                initRequest.m_descriptor,
+                [this, &initRequest]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    for (auto& [deviceIndex, deviceImagePool] : m_deviceImagePools)
+                    {
+                        if (!initRequest.m_image->m_deviceImages.contains(deviceIndex))
+                            initRequest.m_image->m_deviceImages[deviceIndex] = Factory::Get().CreateImage();
+                        ImageInitRequest imageInitRequest(
+                            *initRequest.m_image->m_deviceImages[deviceIndex], initRequest.m_descriptor, initRequest.m_optimizedClearValue);
+                        result = deviceImagePool->InitImage(imageInitRequest);
+
+                        if (result != ResultCode::Success)
+                            break;
+                    }
+
+                    return result;
+                });
+        }
+
+        ResultCode MultiDeviceImagePool::UpdateImageContents(const MultiDeviceImageUpdateRequest& request)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsRegistered(request.m_image))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            if (!ValidateUpdateRequest(request))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode result = ResultCode::Success;
+
+            for (auto& [deviceIndex, deviceImagePool] : m_deviceImagePools)
+            {
+                ImageUpdateRequest imageUpdateRequest;
+
+                imageUpdateRequest.m_image = request.m_image->m_deviceImages[deviceIndex].get();
+                imageUpdateRequest.m_imageSubresource = request.m_imageSubresource;
+                imageUpdateRequest.m_imageSubresourcePixelOffset = request.m_imageSubresourcePixelOffset;
+                imageUpdateRequest.m_sourceData = request.m_sourceData;
+                imageUpdateRequest.m_sourceSubresourceLayout = request.m_sourceSubresourceLayout.GetDeviceImageSubresource(deviceIndex);
+
+                result = deviceImagePool->UpdateImageContents(imageUpdateRequest);
+
+                if (result != ResultCode::Success)
+                    break;
+            }
+
+            return result;
+        }
+
+        const ImagePoolDescriptor& MultiDeviceImagePool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        void MultiDeviceImagePool::Shutdown()
+        {
+            for (auto [_, pool] : m_deviceImagePools)
+                pool->Shutdown();
+            MultiDeviceResourcePool::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePoolBase.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePoolBase.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        ResultCode MultiDeviceImagePoolBase::InitImage(
+            MultiDeviceImage* image, const ImageDescriptor& descriptor, PlatformMethod platformInitResourceMethod)
+        {
+            // The descriptor is assigned regardless of whether initialization succeeds. Descriptors are considered
+            // undefined for uninitialized resources. This makes the image descriptor well defined at initialization
+            // time rather than leftover data from the previous usage.
+            image->SetDescriptor(descriptor);
+
+            return MultiDeviceResourcePool::InitResource(image, platformInitResourceMethod);
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndexBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndexBufferView.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceIndexBufferView::MultiDeviceIndexBufferView(
+            const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, IndexFormat format)
+            : m_buffer{ &buffer }
+            , m_byteOffset{ byteOffset }
+            , m_byteCount{ byteCount }
+            , m_format{ format }
+        {
+            m_hash = TypeHash64(*this);
+        }
+
+        IndexBufferView MultiDeviceIndexBufferView::GetDeviceIndexBufferView(int deviceIndex) const
+        {
+            AZ_Assert(m_buffer, "No MultiDeviceBuffer available\n");
+
+            return IndexBufferView(*m_buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_format);
+        }
+
+        AZ::HashValue64 MultiDeviceIndexBufferView::GetHash() const
+        {
+            return m_hash;
+        }
+
+        const MultiDeviceBuffer* MultiDeviceIndexBufferView::GetBuffer() const
+        {
+            return m_buffer;
+        }
+
+        uint32_t MultiDeviceIndexBufferView::GetByteOffset() const
+        {
+            return m_byteOffset;
+        }
+
+        uint32_t MultiDeviceIndexBufferView::GetByteCount() const
+        {
+            return m_byteCount;
+        }
+
+        IndexFormat MultiDeviceIndexBufferView::GetIndexFormat() const
+        {
+            return m_format;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferSignature.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferSignature.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        IndirectBufferSignatureDescriptor MultiDeviceIndirectBufferSignatureDescriptor::
+            GetDeviceIndirectBufferSignatureDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_pipelineState, "No MultiDevicePipelineState available\n");
+
+            IndirectBufferSignatureDescriptor descriptor{ m_layout };
+
+            if (m_pipelineState)
+                descriptor.m_pipelineState = m_pipelineState->GetDevicePipelineState(deviceIndex).get();
+
+            return descriptor;
+        }
+
+        ResultCode MultiDeviceIndirectBufferSignature::Init(
+            MultiDevice::DeviceMask deviceMask, const MultiDeviceIndirectBufferSignatureDescriptor& descriptor)
+        {
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode{ ResultCode::Success };
+
+            IterateDevices(
+                [this, &descriptor, &resultCode](int deviceIndex)
+                {
+                    auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_deviceIndirectBufferSignatures[deviceIndex] = Factory::Get().CreateIndirectBufferSignature();
+                    resultCode = m_deviceIndirectBufferSignatures[deviceIndex]->Init(
+                        *device, descriptor.GetDeviceIndirectBufferSignatureDescriptor(deviceIndex));
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            m_descriptor = descriptor;
+
+            return resultCode;
+        }
+
+        uint32_t MultiDeviceIndirectBufferSignature::GetByteStride() const
+        {
+            AZ_Assert(IsInitialized(), "Signature is not initialized");
+
+            uint32_t byteStride{ std::numeric_limits<uint32_t>::max() };
+
+            for (const auto& [deviceIndex, signature] : m_deviceIndirectBufferSignatures)
+            {
+                auto deviceByteStride{ signature->GetByteStride() };
+
+                if (byteStride == std::numeric_limits<uint32_t>::max())
+                    byteStride = deviceByteStride;
+
+                AZ_Assert(deviceByteStride == byteStride, "Device Signature byte strides do not match");
+            }
+
+            return byteStride;
+        }
+
+        uint32_t MultiDeviceIndirectBufferSignature::GetOffset(IndirectCommandIndex index) const
+        {
+            AZ_Assert(IsInitialized(), "Signature is not initialized");
+            if (Validation::IsEnabled())
+            {
+                if (index.IsNull())
+                {
+                    AZ_Assert(false, "Invalid index");
+                    return 0;
+                }
+
+                if (index.GetIndex() >= m_descriptor.m_layout.GetCommands().size())
+                {
+                    AZ_Assert(false, "Index %d is greater than the number of commands on the layout", index.GetIndex());
+                    return 0;
+                }
+            }
+
+            uint32_t offset{ std::numeric_limits<uint32_t>::max() };
+
+            for (const auto& [deviceIndex, signature] : m_deviceIndirectBufferSignatures)
+            {
+                auto deviceOffset{ signature->GetOffset(index) };
+
+                if (offset == std::numeric_limits<uint32_t>::max())
+                    offset = deviceOffset;
+
+                AZ_Assert(deviceOffset == offset, "Device Signature offsets do not match");
+            }
+
+            return offset;
+        }
+
+        const MultiDeviceIndirectBufferSignatureDescriptor& MultiDeviceIndirectBufferSignature::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        const AZ::RHI::IndirectBufferLayout& MultiDeviceIndirectBufferSignature::GetLayout() const
+        {
+            return m_descriptor.m_layout;
+        }
+
+        void MultiDeviceIndirectBufferSignature::Shutdown()
+        {
+            MultiDeviceObject::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferView.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferView.h>
+#include <AzCore/std/hash.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceIndirectBufferView::MultiDeviceIndirectBufferView(
+            const MultiDeviceBuffer& buffer,
+            const MultiDeviceIndirectBufferSignature& signature,
+            uint32_t byteOffset,
+            uint32_t byteCount,
+            uint32_t byteStride)
+            : m_buffer(&buffer)
+            , m_byteOffset(byteOffset)
+            , m_byteCount(byteCount)
+            , m_byteStride(byteStride)
+            , m_signature(&signature)
+        {
+            size_t seed = 0;
+            AZStd::hash_combine(seed, m_buffer);
+            AZStd::hash_combine(seed, m_byteOffset);
+            AZStd::hash_combine(seed, m_byteCount);
+            AZStd::hash_combine(seed, m_byteStride);
+            AZStd::hash_combine(seed, m_signature);
+            m_hash = static_cast<HashValue64>(seed);
+        }
+
+        HashValue64 MultiDeviceIndirectBufferView::GetHash() const
+        {
+            return m_hash;
+        }
+
+        const MultiDeviceBuffer* MultiDeviceIndirectBufferView::GetBuffer() const
+        {
+            return m_buffer;
+        }
+
+        uint32_t MultiDeviceIndirectBufferView::GetByteOffset() const
+        {
+            return m_byteOffset;
+        }
+
+        uint32_t MultiDeviceIndirectBufferView::GetByteCount() const
+        {
+            return m_byteCount;
+        }
+
+        uint32_t MultiDeviceIndirectBufferView::GetByteStride() const
+        {
+            return m_byteStride;
+        }
+
+        const MultiDeviceIndirectBufferSignature* MultiDeviceIndirectBufferView::GetSignature() const
+        {
+            return m_signature;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferWriter.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferWriter.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/IndirectBufferLayout.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferSignature.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        ResultCode MultiDeviceIndirectBufferWriter::Init(
+            MultiDeviceBuffer& buffer,
+            size_t byteOffset,
+            uint32_t byteStride,
+            uint32_t maxCommandSequences,
+            const MultiDeviceIndirectBufferSignature& signature)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Assert(false, "MultiDeviceIndirectBufferWriter cannot be initialized when calling this method.");
+                    return ResultCode::InvalidOperation;
+                }
+
+                if ((byteOffset + maxCommandSequences * byteStride) > buffer.GetDescriptor().m_byteCount)
+                {
+                    AZ_Assert(false, "MultiDeviceBuffer is too small to contain the required commands");
+                    return ResultCode::InvalidArgument;
+                }
+            }
+
+            ResultCode result{ ResultCode::Success };
+            auto deviceMask{ AZStd::to_underlying(buffer.GetDeviceMask()) };
+
+            for (auto deviceIndex{ 0 }; deviceMask && (deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount());
+                 deviceMask >>= 1, ++deviceIndex)
+            {
+                if (deviceMask & 1)
+                {
+                    m_deviceIndirectBufferWriter[deviceIndex] = Factory::Get().CreateIndirectBufferWriter();
+                    auto deviceIndirectBufferSignature{ signature.IsInitialized() ? signature.GetDeviceIndirectBufferSignature(deviceIndex)
+                                                                                  : Factory::Get().CreateIndirectBufferSignature() };
+                    result = m_deviceIndirectBufferWriter[deviceIndex]->Init(
+                        *buffer.GetDeviceBuffer(deviceIndex).get(),
+                        byteOffset,
+                        byteStride,
+                        maxCommandSequences,
+                        *deviceIndirectBufferSignature);
+
+                    if (result != ResultCode::Success)
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        ResultCode MultiDeviceIndirectBufferWriter::Init(
+            void* memoryPtr, uint32_t byteStride, uint32_t maxCommandSequences, const MultiDeviceIndirectBufferSignature& signature)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!memoryPtr)
+                {
+                    AZ_Assert(false, "Null target memory");
+                    return ResultCode::InvalidArgument;
+                }
+            }
+
+            ResultCode result{ ResultCode::Success };
+            auto deviceMask{ AZStd::to_underlying(signature.GetDeviceMask()) };
+
+            for (auto deviceIndex{ 0 }; deviceMask && (deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount());
+                 deviceMask >>= 1, ++deviceIndex)
+            {
+                if (deviceMask & 1)
+                {
+                    m_deviceIndirectBufferWriter[deviceIndex] = Factory::Get().CreateIndirectBufferWriter();
+                    auto deviceIndirectBufferSignature{ signature.IsInitialized() ? signature.GetDeviceIndirectBufferSignature(deviceIndex)
+                                                                                  : Factory::Get().CreateIndirectBufferSignature() };
+                    result = m_deviceIndirectBufferWriter[deviceIndex]->Init(
+                        memoryPtr, byteStride, maxCommandSequences, *deviceIndirectBufferSignature);
+                    if (result != ResultCode::Success)
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        bool MultiDeviceIndirectBufferWriter::NextSequence()
+        {
+            auto result{ false };
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+            {
+                result = writer->NextSequence();
+                if (!result)
+                    break;
+            }
+            return result;
+        }
+
+        void MultiDeviceIndirectBufferWriter::Shutdown()
+        {
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->Shutdown();
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::SetVertexView(
+            uint32_t slot, const MultiDeviceStreamBufferView& view)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->SetVertexView(slot, view.GetDeviceStreamBufferView(deviceIndex));
+
+            return this;
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::SetIndexView(const MultiDeviceIndexBufferView& view)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->SetIndexView(view.GetDeviceIndexBufferView(deviceIndex));
+
+            return this;
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::Draw(const DrawLinear& arguments)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->Draw(arguments);
+
+            return this;
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::DrawIndexed(const RHI::DrawIndexed& arguments)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->DrawIndexed(arguments);
+
+            return this;
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::Dispatch(const DispatchDirect& arguments)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->Dispatch(arguments);
+
+            return this;
+        }
+
+        MultiDeviceIndirectBufferWriter* MultiDeviceIndirectBufferWriter::SetRootConstants(const uint8_t* data, uint32_t byteSize)
+        {
+            if (Validation::IsEnabled() && !IsInitialized())
+                AZ_Assert(false, "MultiDeviceIndirectBufferWriter must be initialized when calling this method.");
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->SetRootConstants(data, byteSize);
+
+            return this;
+        }
+
+        bool MultiDeviceIndirectBufferWriter::Seek(const uint32_t sequenceIndex)
+        {
+            auto result{ false };
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+            {
+                result = writer->Seek(sequenceIndex);
+                if (!result)
+                    break;
+            }
+            return result;
+        }
+
+        void MultiDeviceIndirectBufferWriter::Flush()
+        {
+            // Unmap the buffer to force a flush changes into the buffer.
+            // The buffer will be remap before writing new commands.
+            // We don't remap here because we can't leave a buffer mapped during the
+            // whole frame execution.
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                writer->Flush();
+        }
+
+        bool MultiDeviceIndirectBufferWriter::IsInitialized() const
+        {
+            auto result{ false };
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+            {
+                result = writer->IsInitialized();
+                if (!result)
+                    break;
+            }
+            return result;
+        }
+
+        AZStd::vector<uint32_t> MultiDeviceIndirectBufferWriter::GetCurrentSequenceIndex() const
+        {
+            AZStd::vector<uint32_t> currentSequenceIndex;
+
+            for (const auto& [deviceIndex, writer] : m_deviceIndirectBufferWriter)
+                currentSequenceIndex.emplace_back(writer->GetCurrentSequenceIndex());
+
+            return currentSequenceIndex;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDeviceObject::IsInitialized() const
+        {
+            return AZStd::to_underlying(m_deviceMask) != 0u;
+        }
+
+        MultiDevice::DeviceMask MultiDeviceObject::GetDeviceMask() const
+        {
+            return m_deviceMask;
+        }
+
+        void MultiDeviceObject::Init(MultiDevice::DeviceMask deviceMask)
+        {
+            m_deviceMask = deviceMask;
+        }
+
+        void MultiDeviceObject::Shutdown()
+        {
+            m_deviceMask = static_cast<MultiDevice::DeviceMask>(0u);
+        }
+
+        int MultiDeviceObject::GetDeviceCount() const
+        {
+            return RHI::RHISystemInterface::Get()->GetDeviceCount();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineLibrary.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDevicePipelineLibrary.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/PipelineLibrary.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDevicePipelineLibrary::ValidateIsInitialized() const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!IsInitialized())
+                {
+                    AZ_Error(
+                        "MultiDevicePipelineLibrary",
+                        false,
+                        "MultiDevicePipelineLibrary is not initialized. This operation is only permitted on an initialized library.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        ResultCode MultiDevicePipelineLibrary::Init(
+            MultiDevice::DeviceMask deviceMask, const MultiDevicePipelineLibraryDescriptor& descriptor)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Error(
+                        "MultiDevicePipelineLibrary",
+                        false,
+                        "MultiDevicePipelineLibrary is initialized. This operation is only permitted on an uninitialized library.");
+                    return ResultCode::InvalidOperation;
+                }
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, &descriptor, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_devicePipelineLibraries[deviceIndex] = Factory::Get().CreatePipelineLibrary();
+                    resultCode =
+                        m_devicePipelineLibraries[deviceIndex]->Init(*device, descriptor.GetDevicePipelineLibraryDescriptor(deviceIndex));
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            return resultCode;
+        }
+
+        ResultCode MultiDevicePipelineLibrary::MergeInto(AZStd::span<const MultiDevicePipelineLibrary* const> librariesToMerge)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            ResultCode result = ResultCode::Success;
+
+            for (auto& [deviceIndex, devicePipelineLibrary] : m_devicePipelineLibraries)
+            {
+                AZStd::vector<const PipelineLibrary*> deviceLibrariesToMerge(librariesToMerge.size());
+
+                for (int i = 0; i < librariesToMerge.size(); ++i)
+                    deviceLibrariesToMerge[i] = librariesToMerge[i]->m_devicePipelineLibraries.at(deviceIndex).get();
+
+                result = devicePipelineLibrary->MergeInto(deviceLibrariesToMerge);
+
+                if (result != ResultCode::Success)
+                    break;
+            }
+
+            return result;
+        }
+
+        void MultiDevicePipelineLibrary::Shutdown()
+        {
+            if (IsInitialized())
+            {
+                m_devicePipelineLibraries.clear();
+                MultiDeviceObject::Shutdown();
+            }
+        }
+
+        bool MultiDevicePipelineLibrary::IsMergeRequired() const
+        {
+            bool result = false;
+
+            for (auto& [deviceIndex, devicePipelineLibrary] : m_devicePipelineLibraries)
+            {
+                result |= devicePipelineLibrary->IsMergeRequired();
+            }
+
+            return result;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineState.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/InputStreamLayout.h>
+#include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDevicePipelineLibrary.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDevicePipelineState::ValidateNotInitialized() const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Error("MultiDevicePipelineState", false, "MultiDevicePipelineState already initialized!");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        ResultCode MultiDevicePipelineState::Init(
+            MultiDevice::DeviceMask deviceMask,
+            const PipelineStateDescriptorForDraw& descriptor,
+            MultiDevicePipelineLibrary* pipelineLibrary)
+        {
+            if (!ValidateNotInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, &descriptor, &pipelineLibrary, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_devicePipelineStates[deviceIndex] = Factory::Get().CreatePipelineState();
+                    resultCode = m_devicePipelineStates[deviceIndex]->Init(
+                        *device, descriptor, pipelineLibrary ? pipelineLibrary->GetDevicePipelineLibrary(deviceIndex).get() : nullptr);
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            if (resultCode == ResultCode::Success)
+            {
+                m_type = PipelineStateType::Draw;
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDevicePipelineState::Init(
+            MultiDevice::DeviceMask deviceMask,
+            const PipelineStateDescriptorForDispatch& descriptor,
+            MultiDevicePipelineLibrary* pipelineLibrary)
+        {
+            if (!ValidateNotInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, &descriptor, &pipelineLibrary, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_devicePipelineStates[deviceIndex] = Factory::Get().CreatePipelineState();
+                    resultCode = m_devicePipelineStates[deviceIndex]->Init(
+                        *device, descriptor, pipelineLibrary->GetDevicePipelineLibrary(deviceIndex).get());
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            if (resultCode == ResultCode::Success)
+            {
+                m_type = PipelineStateType::Dispatch;
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDevicePipelineState::Init(
+            MultiDevice::DeviceMask deviceMask,
+            const PipelineStateDescriptorForRayTracing& descriptor,
+            MultiDevicePipelineLibrary* pipelineLibrary)
+        {
+            if (!ValidateNotInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, &descriptor, &pipelineLibrary, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_devicePipelineStates[deviceIndex] = Factory::Get().CreatePipelineState();
+                    resultCode = m_devicePipelineStates[deviceIndex]->Init(
+                        *device, descriptor, pipelineLibrary->GetDevicePipelineLibrary(deviceIndex).get());
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            if (resultCode == ResultCode::Success)
+            {
+                m_type = PipelineStateType::RayTracing;
+            }
+
+            return resultCode;
+        }
+
+        void MultiDevicePipelineState::Shutdown()
+        {
+            if (IsInitialized())
+            {
+                m_devicePipelineStates.clear();
+                MultiDeviceObject::Shutdown();
+            }
+        }
+
+        PipelineStateType MultiDevicePipelineState::GetType() const
+        {
+            return m_type;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        const MultiDeviceQueryPool* MultiDeviceQuery::GetQueryPool() const
+        {
+            return static_cast<const MultiDeviceQueryPool*>(GetPool());
+        }
+
+        MultiDeviceQueryPool* MultiDeviceQuery::GetQueryPool()
+        {
+            return static_cast<MultiDeviceQueryPool*>(GetPool());
+        }
+
+        void MultiDeviceQuery::Shutdown()
+        {
+            for (auto& [_, deviceQuery] : m_deviceQueries)
+                deviceQuery->Shutdown();
+            MultiDeviceResource::Shutdown();
+        }
+
+        void MultiDeviceQuery::InvalidateViews()
+        {
+            for (auto& [_, deviceQuery] : m_deviceQueries)
+                deviceQuery->InvalidateViews();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/std/parallel/lock.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        ResultCode MultiDeviceQueryPool::Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!descriptor.m_queriesCount)
+                {
+                    AZ_Error("RHI", false, "MultiDeviceQueryPool size can't be zero");
+                    return ResultCode::InvalidArgument;
+                }
+
+                if (descriptor.m_type == QueryType::PipelineStatistics &&
+                    descriptor.m_pipelineStatisticsMask == PipelineStatisticsFlags::None)
+                {
+                    AZ_Error("RHI", false, "Missing pipeline statistics flags");
+                    return ResultCode::InvalidArgument;
+                }
+
+                if (descriptor.m_type != QueryType::PipelineStatistics &&
+                    descriptor.m_pipelineStatisticsMask != PipelineStatisticsFlags::None)
+                {
+                    AZ_Warning(
+                        "RHI",
+                        false,
+                        "Pipeline statistics flags are only valid for PipelineStatistics pools. Ignoring m_pipelineStatisticsMask");
+                }
+            }
+
+            return MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor]()
+                {
+                    /**
+                     * Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                     * for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                     * possibility that users will get garbage values from GetDescriptor().
+                     */
+                    m_descriptor = descriptor;
+
+                    auto resultCode{ ResultCode::Success };
+
+                    IterateDevices(
+                        [this, &descriptor, &resultCode](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceQueryPools[deviceIndex] = Factory::Get().CreateQueryPool();
+                            resultCode = m_deviceQueryPools[deviceIndex]->Init(*device, descriptor);
+                            return resultCode == ResultCode::Success;
+                        });
+
+                    return resultCode;
+                });
+        }
+
+        ResultCode MultiDeviceQueryPool::InitQuery(MultiDeviceQuery* query)
+        {
+            return InitQuery(&query, 1);
+        }
+
+        ResultCode MultiDeviceQueryPool::InitQuery(MultiDeviceQuery** queries, uint32_t queryCount)
+        {
+            AZ_Assert(queries, "Null queries");
+            auto resultCode{ ResultCode::Success };
+
+            for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+            {
+                AZStd::vector<RHI::Ptr<Query>> deviceQueries(queryCount);
+                AZStd::vector<Query*> rawDeviceQueries(queryCount);
+                for (auto index{ 0u }; index < queryCount; ++index)
+                {
+                    deviceQueries[index] = RHI::Factory::Get().CreateQuery();
+                    rawDeviceQueries[index] = deviceQueries[index].get();
+                }
+
+                resultCode = deviceQueryPool->InitQuery(rawDeviceQueries.data(), queryCount);
+
+                for (auto index{ 0u }; index < queryCount; ++index)
+                {
+                    queries[index]->m_deviceQueries[deviceIndex] = deviceQueries[index];
+                }
+
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            if (resultCode == ResultCode::Success)
+            {
+                for (auto index{ 0u }; index < queryCount; ++index)
+                {
+                    MultiDeviceResourcePool::InitResource(
+                        queries[index],
+                        []()
+                        {
+                            return ResultCode::Success;
+                        });
+                }
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceQueryPool::ValidateQueries(MultiDeviceQuery** queries, uint32_t queryCount)
+        {
+            if (!queryCount)
+            {
+                AZ_Error("RHI", false, "MultiDeviceQuery count is 0");
+                return RHI::ResultCode::InvalidArgument;
+            }
+
+            for (uint32_t i = 0; i < queryCount; ++i)
+            {
+                auto* query = queries[i];
+                if (!query)
+                {
+                    AZ_Error("RHI", false, "Null query %i", i);
+                    return RHI::ResultCode::InvalidArgument;
+                }
+
+                if (query->GetQueryPool() != this)
+                {
+                    AZ_Error("RHI", false, "MultiDeviceQuery does not belong to this pool");
+                    return RHI::ResultCode::InvalidArgument;
+                }
+            }
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceQueryPool::GetResults(
+            MultiDeviceQuery* query, uint64_t* result, uint32_t resultsCount, QueryResultFlagBits flags)
+        {
+            auto resultCode{ ResultCode::Success };
+
+            for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+            {
+                auto deviceQuery{ query->m_deviceQueries[deviceIndex].get() };
+                auto deviceResult{ result + (deviceIndex * resultsCount) };
+                resultCode = deviceQueryPool->GetResults(&deviceQuery, 1, deviceResult, resultsCount, flags);
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceQueryPool::GetResults(
+            MultiDeviceQuery** queries, uint32_t queryCount, uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags)
+        {
+            AZ_Assert(queries && queryCount, "Null queries");
+            AZ_Assert(results && resultsCount, "Null results");
+            uint32_t perResultSize = m_descriptor.m_type == QueryType::PipelineStatistics
+                ? CountBitsSet(static_cast<uint64_t>(m_descriptor.m_pipelineStatisticsMask))
+                : 1;
+
+            if (Validation::IsEnabled())
+            {
+                auto validationResult = ValidateQueries(queries, queryCount);
+                if (validationResult != ResultCode::Success)
+                {
+                    return validationResult;
+                }
+
+                if (perResultSize * queryCount > resultsCount)
+                {
+                    AZ_Error("RHI", false, "Results count is too small. Needed at least %d", perResultSize * queryCount);
+                    return RHI::ResultCode::InvalidArgument;
+                }
+            }
+
+            auto resultCode{ ResultCode::Success };
+
+            for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+            {
+                AZStd::vector<Query*> deviceQueries(queryCount);
+                for (auto index{ 0u }; index < queryCount; ++index)
+                    deviceQueries[index] = queries[index]->m_deviceQueries[deviceIndex].get();
+
+                auto deviceResults{ results + (deviceIndex * resultsCount) };
+                resultCode = deviceQueryPool->GetResults(deviceQueries.data(), queryCount, deviceResults, resultsCount, flags);
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceQueryPool::GetResults(uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags)
+        {
+            auto resultCode{ ResultCode::Success };
+
+            for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+            {
+                auto deviceResults{ results + (deviceIndex * resultsCount) };
+                resultCode = deviceQueryPool->GetResults(deviceResults, resultsCount, flags);
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            return resultCode;
+        }
+
+        const QueryPoolDescriptor& MultiDeviceQueryPool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        void MultiDeviceQueryPool::Shutdown()
+        {
+            for (auto [_, pool] : m_deviceQueryPools)
+                pool->Shutdown();
+            MultiDeviceResourcePool::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        RayTracingBlasDescriptor MultiDeviceRayTracingBlasDescriptor::GetDeviceRayTracingBlasDescriptor(int deviceIndex) const
+        {
+            RayTracingBlasDescriptor descriptor;
+
+            for (const auto& geometry : m_geometries)
+            {
+                descriptor.Geometry()
+                    ->VertexFormat(geometry.m_vertexFormat)
+                    ->VertexBuffer(geometry.m_vertexBuffer.GetDeviceStreamBufferView(deviceIndex))
+                    ->IndexBuffer(geometry.m_indexBuffer.GetDeviceIndexBufferView(deviceIndex));
+            }
+
+            return descriptor;
+        }
+
+        MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::Build()
+        {
+            return this;
+        }
+
+        MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::Geometry()
+        {
+            m_geometries.emplace_back();
+            m_buildContext = &m_geometries.back();
+            return this;
+        }
+
+        MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::VertexBuffer(
+            const RHI::MultiDeviceStreamBufferView& vertexBuffer)
+        {
+            AZ_Assert(m_buildContext, "VertexBuffer property can only be added to a Geometry entry");
+            m_buildContext->m_vertexBuffer = vertexBuffer;
+            return this;
+        }
+
+        MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::VertexFormat(RHI::Format vertexFormat)
+        {
+            AZ_Assert(m_buildContext, "VertexFormat property can only be added to a Geometry entry");
+            m_buildContext->m_vertexFormat = vertexFormat;
+            return this;
+        }
+
+        MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::IndexBuffer(
+            const RHI::MultiDeviceIndexBufferView& indexBuffer)
+        {
+            AZ_Assert(m_buildContext, "IndexBuffer property can only be added to a Geometry entry");
+            m_buildContext->m_indexBuffer = indexBuffer;
+            return this;
+        }
+
+        RayTracingTlasDescriptor MultiDeviceRayTracingTlasDescriptor::GetDeviceRayTracingTlasDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_instancesBuffer, "No MultiDeviceBuffer available!\n");
+
+            RayTracingTlasDescriptor descriptor;
+
+            for (const auto& instance : m_instances)
+            {
+                descriptor.Instance()
+                    ->InstanceID(instance.m_instanceID)
+                    ->HitGroupIndex(instance.m_hitGroupIndex)
+                    ->Transform(instance.m_transform)
+                    ->NonUniformScale(instance.m_nonUniformScale)
+                    ->Transparent(instance.m_transparent)
+                    ->Blas(instance.m_blas->GetDeviceRayTracingBlas(deviceIndex));
+            }
+
+            if (m_instancesBuffer)
+                descriptor.InstancesBuffer(m_instancesBuffer->GetDeviceBuffer(deviceIndex))->NumInstances(m_numInstancesInBuffer);
+
+            return descriptor;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Build()
+        {
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Instance()
+        {
+            AZ_Assert(m_instancesBuffer == nullptr, "Instance cannot be combined with an instances buffer");
+            m_instances.emplace_back();
+            m_buildContext = &m_instances.back();
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstanceID(uint32_t instanceID)
+        {
+            AZ_Assert(m_buildContext, "InstanceID property can only be added to an Instance entry");
+            m_buildContext->m_instanceID = instanceID;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::HitGroupIndex(uint32_t hitGroupIndex)
+        {
+            AZ_Assert(m_buildContext, "HitGroupIndex property can only be added to an Instance entry");
+            m_buildContext->m_hitGroupIndex = hitGroupIndex;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Transform(const AZ::Transform& transform)
+        {
+            AZ_Assert(m_buildContext, "Transform property can only be added to an Instance entry");
+            m_buildContext->m_transform = transform;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::NonUniformScale(const AZ::Vector3& nonUniformScale)
+        {
+            AZ_Assert(m_buildContext, "NonUniformSCale property can only be added to an Instance entry");
+            m_buildContext->m_nonUniformScale = nonUniformScale;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Transparent(bool transparent)
+        {
+            AZ_Assert(m_buildContext, "Transparent property can only be added to a Geometry entry");
+            m_buildContext->m_transparent = transparent;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Blas(RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& blas)
+        {
+            AZ_Assert(m_buildContext, "Blas property can only be added to an Instance entry");
+            m_buildContext->m_blas = blas;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstancesBuffer(
+            RHI::Ptr<RHI::MultiDeviceBuffer>& instancesBuffer)
+        {
+            AZ_Assert(!m_buildContext, "InstancesBuffer property can only be added to the top level");
+            AZ_Assert(m_instances.size() == 0, "InstancesBuffer cannot exist with instance entries");
+            m_instancesBuffer = instancesBuffer;
+            return this;
+        }
+
+        MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::NumInstances(uint32_t numInstancesInBuffer)
+        {
+            AZ_Assert(m_instancesBuffer.get(), "NumInstances property can only be added to the InstancesBuffer entry");
+            m_numInstancesInBuffer = numInstancesInBuffer;
+            return this;
+        }
+
+        ResultCode MultiDeviceRayTracingBlas::CreateBuffers(
+            MultiDevice::DeviceMask deviceMask,
+            const MultiDeviceRayTracingBlasDescriptor* descriptor,
+            const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
+        {
+            m_descriptor = *descriptor;
+            ResultCode resultCode{ ResultCode::Success };
+
+            MultiDeviceObject::Init(deviceMask);
+
+            IterateDevices(
+                [this, &resultCode, &descriptor, &rayTracingBufferPools](int deviceIndex)
+                {
+                    auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                    m_deviceRayTracingBlas[deviceIndex] = Factory::Get().CreateRayTracingBlas();
+
+                    auto deviceDescriptor{ descriptor->GetDeviceRayTracingBlasDescriptor(deviceIndex) };
+
+                    resultCode = m_deviceRayTracingBlas[deviceIndex]->CreateBuffers(
+                        *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPool(deviceIndex).get());
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            return resultCode;
+        }
+
+        bool MultiDeviceRayTracingBlas::IsValid() const
+        {
+            if (m_deviceRayTracingBlas.empty())
+                return false;
+
+            for (const auto& [deviceIndex, blas] : m_deviceRayTracingBlas)
+            {
+                if (!blas->IsValid())
+                    return false;
+            }
+            return true;
+        }
+
+        ResultCode MultiDeviceRayTracingTlas::CreateBuffers(
+            MultiDevice::DeviceMask deviceMask,
+            const MultiDeviceRayTracingTlasDescriptor* descriptor,
+            const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
+        {
+            m_descriptor = *descriptor;
+            ResultCode resultCode{ ResultCode::Success };
+
+            MultiDeviceObject::Init(deviceMask);
+
+            IterateDevices(
+                [this, &resultCode, &descriptor, &rayTracingBufferPools](int deviceIndex)
+                {
+                    auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                    m_deviceRayTracingTlas[deviceIndex] = Factory::Get().CreateRayTracingTlas();
+
+                    auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
+
+                    resultCode = m_deviceRayTracingTlas[deviceIndex]->CreateBuffers(
+                        *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPool(deviceIndex).get());
+
+                    return resultCode == ResultCode::Success;
+                });
+            return resultCode;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasBuffer() const
+        {
+            if (m_deviceRayTracingTlas.empty())
+                return nullptr;
+
+            auto tlasBuffer = aznew RHI::MultiDeviceBuffer;
+            tlasBuffer->Init(GetDeviceMask());
+
+            for (const auto& [deviceIndex, tlas] : m_deviceRayTracingTlas)
+            {
+                tlasBuffer->m_deviceBuffers[deviceIndex] = tlas->GetTlasBuffer();
+
+                if (!tlasBuffer->m_deviceBuffers[deviceIndex])
+                    return nullptr;
+
+                tlasBuffer->SetDescriptor(tlasBuffer->m_deviceBuffers[deviceIndex]->GetDescriptor());
+            }
+            return tlasBuffer;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasInstancesBuffer() const
+        {
+            if (m_deviceRayTracingTlas.empty())
+                return nullptr;
+
+            auto tlasInstancesBuffer = aznew RHI::MultiDeviceBuffer;
+            tlasInstancesBuffer->Init(GetDeviceMask());
+
+            for (const auto& [deviceIndex, tlas] : m_deviceRayTracingTlas)
+            {
+                tlasInstancesBuffer->m_deviceBuffers[deviceIndex] = tlas->GetTlasBuffer();
+
+                if (!tlasInstancesBuffer->m_deviceBuffers[deviceIndex])
+                    return nullptr;
+
+                tlasInstancesBuffer->SetDescriptor(tlasInstancesBuffer->m_deviceBuffers[deviceIndex]->GetDescriptor());
+            }
+            return tlasInstancesBuffer;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingBufferPools.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingBufferPools.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetShaderTableBufferPool() const
+        {
+            AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+            return m_shaderTableBufferPool;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetScratchBufferPool() const
+        {
+            AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+            return m_scratchBufferPool;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetBlasBufferPool() const
+        {
+            AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+            return m_blasBufferPool;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetTlasInstancesBufferPool() const
+        {
+            AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+            return m_tlasInstancesBufferPool;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetTlasBufferPool() const
+        {
+            AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+            return m_tlasBufferPool;
+        }
+
+        void MultiDeviceRayTracingBufferPools::Init(MultiDevice::DeviceMask deviceMask)
+        {
+            if (m_initialized)
+            {
+                return;
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            // Initialize device ray tracing buffer pools
+            IterateDevices(
+                [this](int deviceIndex)
+                {
+                    RHI::Ptr<RHI::Device> device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                    m_deviceRayTracingBufferPools[deviceIndex] = Factory::Get().CreateRayTracingBufferPools();
+                    m_deviceRayTracingBufferPools[deviceIndex]->Init(device);
+                    return true;
+                });
+
+            m_shaderTableBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_shaderTableBufferPool->Init(deviceMask, [this](){
+                for (auto& [deviceIndex, pool] : m_deviceRayTracingBufferPools)
+                {
+                    m_shaderTableBufferPool->m_deviceBufferPools[deviceIndex] = pool->GetShaderTableBufferPool().get();
+                    m_shaderTableBufferPool->m_descriptor = pool->GetShaderTableBufferPool()->GetDescriptor();
+                }
+                return ResultCode::Success;
+            });
+
+            m_scratchBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_scratchBufferPool->Init(deviceMask, [this](){
+                for (auto& [deviceIndex, pool] : m_deviceRayTracingBufferPools)
+                {
+                    m_scratchBufferPool->m_deviceBufferPools[deviceIndex] = pool->GetScratchBufferPool().get();
+                    m_scratchBufferPool->m_descriptor = pool->GetScratchBufferPool()->GetDescriptor();
+                }
+                return ResultCode::Success;
+            });
+
+            m_blasBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_blasBufferPool->Init(deviceMask, [this](){
+                for (auto& [deviceIndex, pool] : m_deviceRayTracingBufferPools)
+                {
+                    m_blasBufferPool->m_deviceBufferPools[deviceIndex] = pool->GetBlasBufferPool().get();
+                    m_blasBufferPool->m_descriptor = pool->GetBlasBufferPool()->GetDescriptor();
+                }
+                return ResultCode::Success;
+            });
+
+            m_tlasInstancesBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_tlasInstancesBufferPool->Init(deviceMask, [this](){
+                for (auto& [deviceIndex, pool] : m_deviceRayTracingBufferPools)
+                {
+                    m_tlasInstancesBufferPool->m_deviceBufferPools[deviceIndex] = pool->GetTlasInstancesBufferPool().get();
+                    m_tlasInstancesBufferPool->m_descriptor = pool->GetTlasInstancesBufferPool()->GetDescriptor();
+                }
+                return ResultCode::Success;
+            });
+
+            m_tlasBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_tlasBufferPool->Init(deviceMask, [this](){
+                for (auto& [deviceIndex, pool] : m_deviceRayTracingBufferPools)
+                {
+                    m_tlasBufferPool->m_deviceBufferPools[deviceIndex] = pool->GetTlasBufferPool().get();
+                    m_tlasBufferPool->m_descriptor = pool->GetTlasBufferPool()->GetDescriptor();
+                }
+                return ResultCode::Success;
+            });
+
+            m_initialized = true;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        RayTracingPipelineStateDescriptor MultiDeviceRayTracingPipelineStateDescriptor::
+            GetDeviceRayTracingPipelineStateDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_pipelineState, "No MultiDevicePipelineState available\n");
+
+            RayTracingPipelineStateDescriptor descriptor{ m_descriptor };
+
+            if (m_pipelineState)
+                descriptor.PipelineState(m_pipelineState->GetDevicePipelineState(deviceIndex).get());
+
+            return descriptor;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::Build()
+        {
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxPayloadSize(uint32_t maxPayloadSize)
+        {
+            m_descriptor.MaxPayloadSize(maxPayloadSize);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxAttributeSize(
+            uint32_t maxAttributeSize)
+        {
+            m_descriptor.MaxAttributeSize(maxAttributeSize);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxRecursionDepth(
+            uint32_t maxRecursionDepth)
+        {
+            m_descriptor.MaxRecursionDepth(maxRecursionDepth);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::PipelineState(
+            const RHI::MultiDevicePipelineState* pipelineState)
+        {
+            m_pipelineState = pipelineState;
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::ShaderLibrary(
+            RHI::PipelineStateDescriptorForRayTracing& descriptor)
+        {
+            m_descriptor.ShaderLibrary(descriptor);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::RayGenerationShaderName(
+            const AZ::Name& name)
+        {
+            m_descriptor.RayGenerationShaderName(name);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MissShaderName(const AZ::Name& name)
+        {
+            m_descriptor.MissShaderName(name);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::ClosestHitShaderName(
+            const AZ::Name& closestHitShaderName)
+        {
+            m_descriptor.ClosestHitShaderName(closestHitShaderName);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::AnyHitShaderName(
+            const AZ::Name& anyHitShaderName)
+        {
+            m_descriptor.AnyHitShaderName(anyHitShaderName);
+            return this;
+        }
+
+        MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::HitGroup(const AZ::Name& hitGroupName)
+        {
+            m_descriptor.HitGroup(hitGroupName);
+            return this;
+        }
+
+        ResultCode MultiDeviceRayTracingPipelineState::Init(
+            MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingPipelineStateDescriptor& descriptor)
+        {
+            m_descriptor = descriptor;
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode{ ResultCode::Success };
+
+            IterateDevices(
+                [this, &resultCode](int deviceIndex)
+                {
+                    auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                    m_deviceRayTracingPipelineStates[deviceIndex] = Factory::Get().CreateRayTracingPipelineState();
+
+                    auto descriptor{ m_descriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
+                    resultCode = m_deviceRayTracingPipelineStates[deviceIndex]->Init(*device, &descriptor);
+                    return resultCode == ResultCode::Success;
+                });
+
+            return resultCode;
+        }
+
+        void MultiDeviceRayTracingPipelineState::Shutdown()
+        {
+            MultiDeviceObject::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingShaderTable.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        AZStd::shared_ptr<RayTracingShaderTableDescriptor> MultiDeviceRayTracingShaderTableDescriptor::
+            GetDeviceRayTracingShaderTableDescriptor(int deviceIndex)
+        {
+            AZ_Assert(m_rayTracingPipelineState, "No MultiDeviceRayTracingPipelineState available\n");
+
+            AZStd::shared_ptr<RayTracingShaderTableDescriptor> descriptor =
+                AZStd::make_shared<RayTracingShaderTableDescriptor>();
+
+            if (m_rayTracingPipelineState)
+                descriptor->Build(m_name, m_rayTracingPipelineState->GetDevicePipelineState(deviceIndex));
+
+            for (const auto& rayGenerationRecord : m_rayGenerationRecord)
+            {
+                descriptor->RayGenerationRecord(rayGenerationRecord.m_shaderExportName);
+                if (rayGenerationRecord.m_shaderResourceGroup)
+                    descriptor->ShaderResourceGroup(
+                        rayGenerationRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+
+            for (const auto& missRecord : m_missRecords)
+            {
+                descriptor->MissRecord(missRecord.m_shaderExportName);
+                if (missRecord.m_shaderResourceGroup)
+                    descriptor->ShaderResourceGroup(missRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+
+            for (const auto& hitGroupRecord : m_hitGroupRecords)
+            {
+                descriptor->HitGroupRecord(hitGroupRecord.m_shaderExportName, hitGroupRecord.m_key);
+                if (hitGroupRecord.m_shaderResourceGroup)
+                    descriptor->ShaderResourceGroup(hitGroupRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+
+            return descriptor;
+        }
+
+        void MultiDeviceRayTracingShaderTableDescriptor::RemoveHitGroupRecords(uint32_t key)
+        {
+            for (MultiDeviceRayTracingShaderTableRecordList::iterator itHitGroup = m_hitGroupRecords.begin();
+                 itHitGroup != m_hitGroupRecords.end();
+                 ++itHitGroup)
+            {
+                MultiDeviceRayTracingShaderTableRecord& record = *itHitGroup;
+                if (record.m_key == key)
+                {
+                    m_hitGroupRecords.erase(itHitGroup);
+                }
+            }
+        }
+
+        MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::Build(
+            const AZ::Name& name, RHI::Ptr<MultiDeviceRayTracingPipelineState>& rayTracingPipelineState)
+        {
+            m_name = name;
+            m_rayTracingPipelineState = rayTracingPipelineState;
+            return this;
+        }
+
+        MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::RayGenerationRecord(const AZ::Name& name)
+        {
+            AZ_Assert(m_rayGenerationRecord.empty(), "Ray generation record already added");
+            m_rayGenerationRecord.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name });
+            m_buildContext = &m_rayGenerationRecord.back();
+            return this;
+        }
+
+        MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::MissRecord(const AZ::Name& name)
+        {
+            m_missRecords.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name });
+            m_buildContext = &m_missRecords.back();
+            return this;
+        }
+
+        MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::HitGroupRecord(
+            const AZ::Name& name, uint32_t key /* = MultiDeviceRayTracingShaderTableRecord::InvalidKey */)
+        {
+            m_hitGroupRecords.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name, nullptr, key });
+            m_buildContext = &m_hitGroupRecords.back();
+            return this;
+        }
+
+        MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::ShaderResourceGroup(
+            const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup)
+        {
+            AZ_Assert(m_buildContext, "MultiDeviceShaderResourceGroup can only be added to a shader table record");
+            AZ_Assert(m_buildContext->m_shaderResourceGroup == nullptr, "Records can only have one MultiDeviceShaderResourceGroup");
+            m_buildContext->m_shaderResourceGroup = shaderResourceGroup;
+            return this;
+        }
+
+        void MultiDeviceRayTracingShaderTable::Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingBufferPools& bufferPools)
+        {
+            MultiDeviceObject::Init(deviceMask);
+
+            IterateDevices(
+                [this, &bufferPools](int deviceIndex)
+                {
+                    auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                    m_deviceRayTracingShaderTables[deviceIndex] = Factory::Get().CreateRayTracingShaderTable();
+
+                    auto deviceBufferPool{ bufferPools.GetDeviceRayTracingBufferPool(deviceIndex).get() };
+
+                    m_deviceRayTracingShaderTables[deviceIndex]->Init(*device, *deviceBufferPool);
+
+                    return true;
+                });
+        }
+
+        void MultiDeviceRayTracingShaderTable::Build(const AZStd::shared_ptr<MultiDeviceRayTracingShaderTableDescriptor> descriptor)
+        {
+            for (auto& [deviceIndex, shaderTable] : m_deviceRayTracingShaderTables)
+            {
+                shaderTable->Build(descriptor->GetDeviceRayTracingShaderTableDescriptor(deviceIndex));
+            }
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI.Reflect/BufferViewDescriptor.h>
+#include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ResourceView.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/hash.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceResource::~MultiDeviceResource()
+        {
+            AZ_Assert(
+                GetPool() == nullptr,
+                "MultiDeviceResource '%s' is still registered on pool. %s",
+                GetName().GetCStr(),
+                GetPool()->GetName().GetCStr());
+        }
+
+        bool MultiDeviceResource::IsAttachment() const
+        {
+            return m_frameAttachment != nullptr;
+        }
+
+        uint32_t MultiDeviceResource::GetVersion() const
+        {
+            return m_version;
+        }
+
+        bool MultiDeviceResource::IsFirstVersion() const
+        {
+            return m_version == 0;
+        }
+
+        void MultiDeviceResource::SetPool(MultiDeviceResourcePool* bufferPool)
+        {
+            m_pool = bufferPool;
+
+            const bool isValidPool = bufferPool != nullptr;
+            if (isValidPool)
+            {
+                // Only invalidate the resource if it has dependent views. It
+                // can't have any if this is the first initialization.
+                if (!IsFirstVersion())
+                {
+                    InvalidateViews();
+                }
+            }
+
+            ++m_version;
+        }
+
+        const MultiDeviceResourcePool* MultiDeviceResource::GetPool() const
+        {
+            return m_pool;
+        }
+
+        MultiDeviceResourcePool* MultiDeviceResource::GetPool()
+        {
+            return m_pool;
+        }
+
+        void MultiDeviceResource::SetFrameAttachment(FrameAttachment* frameAttachment)
+        {
+            if (Validation::IsEnabled())
+            {
+                // The frame attachment has tight control over lifecycle here.
+                [[maybe_unused]] const bool isAttach = (!m_frameAttachment && frameAttachment);
+                [[maybe_unused]] const bool isDetach = (m_frameAttachment && !frameAttachment);
+                AZ_Assert(isAttach || isDetach, "The frame attachment for resource '%s' was not assigned properly.", GetName().GetCStr());
+            }
+
+            m_frameAttachment = frameAttachment;
+        }
+
+        const FrameAttachment* MultiDeviceResource::GetFrameAttachment() const
+        {
+            return m_frameAttachment;
+        }
+
+        void MultiDeviceResource::Shutdown()
+        {
+            // Shutdown is delegated to the parent pool if this resource is registered on one.
+            if (m_pool)
+            {
+                AZ_Error(
+                    "MultiDeviceResource",
+                    m_frameAttachment == nullptr,
+                    "The resource is currently attached on a frame graph. It is not valid "
+                    "to shutdown a resource while it is being used as an Attachment. The "
+                    "behavior is undefined.");
+
+                m_pool->ShutdownResource(this);
+            }
+            MultiDeviceObject::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResourcePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResourcePool.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ResourcePoolDatabase.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceResourcePool::~MultiDeviceResourcePool()
+        {
+            AZ_Assert(m_registry.empty(), "ResourceType pool was not properly shutdown.");
+        }
+
+        uint32_t MultiDeviceResourcePool::GetResourceCount() const
+        {
+            AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+            return static_cast<uint32_t>(m_registry.size());
+        }
+
+        bool MultiDeviceResourcePool::ValidateIsRegistered(const MultiDeviceResource* resource) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!resource || resource->GetPool() != this)
+                {
+                    AZ_Error(
+                        "MultiDeviceResourcePool", false, "'%s': MultiDeviceResource is not registered on this pool.", GetName().GetCStr());
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        bool MultiDeviceResourcePool::ValidateIsUnregistered(const MultiDeviceResource* resource) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!resource || resource->GetPool() != nullptr)
+                {
+                    AZ_Error(
+                        "MultiDeviceResourcePool",
+                        false,
+                        "'%s': MultiDeviceResource is null or registered on another pool.",
+                        GetName().GetCStr());
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        bool MultiDeviceResourcePool::ValidateIsInitialized() const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized() == false)
+                {
+                    AZ_Error("MultiDeviceResourcePool", false, "MultiDeviceResource pool is not initialized.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        void MultiDeviceResourcePool::Register(MultiDeviceResource& resource)
+        {
+            resource.SetPool(this);
+
+            AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
+            m_registry.emplace(&resource);
+        }
+
+        void MultiDeviceResourcePool::Unregister(MultiDeviceResource& resource)
+        {
+            resource.SetPool(nullptr);
+
+            AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
+            m_registry.erase(&resource);
+        }
+
+        ResultCode MultiDeviceResourcePool::Init(
+            MultiDevice::DeviceMask deviceMask,
+            const PlatformMethod& platformInitMethod)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Error("MultiDeviceResourcePool", false, "MultiDeviceResourcePool '%s' is already initialized.", GetName().GetCStr());
+                    return ResultCode::InvalidOperation;
+                }
+            }
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = platformInitMethod();
+
+            return resultCode;
+        }
+
+        void MultiDeviceResourcePool::Shutdown()
+        {
+            // Multiple shutdown is allowed for pools.
+            if (IsInitialized())
+            {
+                for (MultiDeviceResource* resource : m_registry)
+                {
+                    resource->SetPool(nullptr);
+                    resource->Shutdown();
+                }
+                m_registry.clear();
+                MultiDeviceObject::Shutdown();
+            }
+        }
+
+        ResultCode MultiDeviceResourcePool::InitResource(MultiDeviceResource* resource, const PlatformMethod& platformInitResourceMethod)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsUnregistered(resource))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            const ResultCode resultCode = platformInitResourceMethod();
+            if (resultCode == ResultCode::Success)
+            {
+                resource->Init(GetDeviceMask());
+                Register(*resource);
+            }
+            return resultCode;
+        }
+
+        void MultiDeviceResourcePool::ShutdownResource(MultiDeviceResource* resource)
+        {
+            if (ValidateIsInitialized() && ValidateIsRegistered(resource))
+            {
+                Unregister(*resource);
+            }
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        void MultiDeviceShaderResourceGroup::Compile(
+            const MultiDeviceShaderResourceGroupData& groupData, CompileMode compileMode /*= CompileMode::Async*/)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                deviceShaderResourceGroup->Compile(groupData.GetDeviceShaderResourceGroupData(deviceIndex), compileMode);
+            }
+        }
+
+        uint32_t MultiDeviceShaderResourceGroup::GetBindingSlot() const
+        {
+            return m_bindingSlot;
+        }
+
+        bool MultiDeviceShaderResourceGroup::IsQueuedForCompile() const
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                if (deviceShaderResourceGroup->IsQueuedForCompile())
+                    return true;
+            }
+
+            return false;
+        }
+
+        const MultiDeviceShaderResourceGroupPool* MultiDeviceShaderResourceGroup::GetPool() const
+        {
+            return static_cast<const MultiDeviceShaderResourceGroupPool*>(MultiDeviceResource::GetPool());
+        }
+
+        MultiDeviceShaderResourceGroupPool* MultiDeviceShaderResourceGroup::GetPool()
+        {
+            return static_cast<MultiDeviceShaderResourceGroupPool*>(MultiDeviceResource::GetPool());
+        }
+
+        const MultiDeviceShaderResourceGroupData& MultiDeviceShaderResourceGroup::GetData() const
+        {
+            return m_data;
+        }
+
+        void MultiDeviceShaderResourceGroup::DisableCompilationForAllResourceTypes()
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                deviceShaderResourceGroup->DisableCompilationForAllResourceTypes();
+            }
+        }
+
+        bool MultiDeviceShaderResourceGroup::IsResourceTypeEnabledForCompilation(uint32_t resourceTypeMask) const
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                if (deviceShaderResourceGroup->IsResourceTypeEnabledForCompilation(resourceTypeMask))
+                    return true;
+            }
+
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroup::IsAnyResourceTypeUpdated() const
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                if (deviceShaderResourceGroup->IsAnyResourceTypeUpdated())
+                    return true;
+            }
+
+            return false;
+        }
+
+        void MultiDeviceShaderResourceGroup::EnableRhiResourceTypeCompilation(
+            const MultiDeviceShaderResourceGroupData::ResourceTypeMask resourceTypeMask)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                deviceShaderResourceGroup->EnableRhiResourceTypeCompilation(resourceTypeMask);
+            }
+        }
+
+        void MultiDeviceShaderResourceGroup::ResetResourceTypeIteration(const MultiDeviceShaderResourceGroupData::ResourceType resourceType)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                deviceShaderResourceGroup->ResetResourceTypeIteration(resourceType);
+            }
+        }
+
+        HashValue64 MultiDeviceShaderResourceGroup::GetViewHash(const AZ::Name& viewName)
+        {
+            return m_viewHash[viewName];
+        }
+
+        void MultiDeviceShaderResourceGroup::UpdateViewHash(const AZ::Name& viewName, const HashValue64 viewHash)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+            {
+                deviceShaderResourceGroup->UpdateViewHash(viewName, viewHash);
+            }
+
+            m_viewHash[viewName] = viewHash;
+        }
+
+        void MultiDeviceShaderResourceGroup::Shutdown()
+        {
+            for (auto& [_, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+                deviceShaderResourceGroup->Shutdown();
+            MultiDeviceResource::Shutdown();
+        }
+
+        void MultiDeviceShaderResourceGroup::InvalidateViews()
+        {
+            for (auto& [_, deviceShaderResourceGroup] : m_deviceShaderResourceGroups)
+                deviceShaderResourceGroup->InvalidateViews();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI.Reflect/Bits.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupData.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceShaderResourceGroupData::MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroup& shaderResourceGroup)
+            : MultiDeviceShaderResourceGroupData(*shaderResourceGroup.GetPool())
+        {
+        }
+
+        MultiDeviceShaderResourceGroupData::MultiDeviceShaderResourceGroupData(
+            const MultiDeviceShaderResourceGroupPool& shaderResourceGroupPool)
+            : MultiDeviceShaderResourceGroupData(shaderResourceGroupPool.GetDeviceMask(), shaderResourceGroupPool.GetLayout())
+        {
+        }
+
+        MultiDeviceShaderResourceGroupData::MultiDeviceShaderResourceGroupData(
+            MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* layout)
+            : m_shaderResourceGroupLayout(layout)
+            , m_deviceMask(deviceMask)
+        {
+            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceShaderResourceGroupDatas[deviceIndex] = ShaderResourceGroupData(layout);
+                }
+            }
+        }
+
+        const ShaderResourceGroupLayout* MultiDeviceShaderResourceGroupData::GetLayout() const
+        {
+            return m_shaderResourceGroupLayout.get();
+        }
+
+        bool MultiDeviceShaderResourceGroupData::ValidateSetImageView(
+            ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex) const
+        {
+            if (!Validation::IsEnabled())
+            {
+                return true;
+            }
+            if (!GetLayout()->ValidateAccess(inputIndex, arrayIndex))
+            {
+                return false;
+            }
+
+            if (imageView)
+            {
+                if (!ValidateImageViewAccess<ShaderInputImageIndex, ShaderInputImageDescriptor>(inputIndex, imageView, arrayIndex))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::ValidateSetBufferView(
+            ShaderInputBufferIndex inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex) const
+        {
+            if (!Validation::IsEnabled())
+            {
+                return true;
+            }
+            if (!GetLayout()->ValidateAccess(inputIndex, arrayIndex))
+            {
+                return false;
+            }
+
+            if (bufferView)
+            {
+                if (!ValidateBufferViewAccess<ShaderInputBufferIndex, ShaderInputBufferDescriptor>(inputIndex, bufferView, arrayIndex))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        ShaderInputBufferIndex MultiDeviceShaderResourceGroupData::FindShaderInputBufferIndex(const Name& name) const
+        {
+            return m_shaderResourceGroupLayout->FindShaderInputBufferIndex(name);
+        }
+
+        ShaderInputImageIndex MultiDeviceShaderResourceGroupData::FindShaderInputImageIndex(const Name& name) const
+        {
+            return m_shaderResourceGroupLayout->FindShaderInputImageIndex(name);
+        }
+
+        ShaderInputSamplerIndex MultiDeviceShaderResourceGroupData::FindShaderInputSamplerIndex(const Name& name) const
+        {
+            return m_shaderResourceGroupLayout->FindShaderInputSamplerIndex(name);
+        }
+
+        ShaderInputConstantIndex MultiDeviceShaderResourceGroupData::FindShaderInputConstantIndex(const Name& name) const
+        {
+            return m_shaderResourceGroupLayout->FindShaderInputConstantIndex(name);
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetImageView(
+            ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex = 0)
+        {
+            AZStd::array<const MultiDeviceImageView* const, 1> imageViews = { { imageView } };
+            return SetImageViewArray(inputIndex, imageViews, arrayIndex);
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetImageViewArray(
+            ShaderInputImageIndex inputIndex, AZStd::span<const MultiDeviceImageView* const> imageViews, uint32_t arrayIndex)
+        {
+            if (GetLayout()->ValidateAccess(inputIndex, static_cast<uint32_t>(arrayIndex + imageViews.size() - 1)))
+            {
+                bool isValidAll = true;
+
+                for (size_t i = 0; i < imageViews.size(); ++i)
+                    isValidAll &= ValidateSetImageView(inputIndex, imageViews[i], aznumeric_caster(arrayIndex + i));
+
+                for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+                {
+                    AZStd::vector<const ImageView*> deviceImageViews(imageViews.size());
+
+                    for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
+                    {
+                        auto [image, imageViewDescriptor]{ *imageViews[imageIndex] };
+                        deviceImageViews[imageIndex] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                    }
+
+                    isValidAll &= deviceShaderResourceGroupData.SetImageViewArray(inputIndex, deviceImageViews, arrayIndex);
+                }
+
+                if (!imageViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::ImageViewMask);
+                }
+
+                return isValidAll;
+            }
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetImageViewUnboundedArray(
+            ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const MultiDeviceImageView* const> imageViews)
+        {
+            if (GetLayout()->ValidateAccess(inputIndex))
+            {
+                bool isValidAll = true;
+
+                for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+                {
+                    AZStd::vector<const ImageView*> deviceImageViews(imageViews.size());
+
+                    for (int i = 0; i < imageViews.size(); ++i)
+                    {
+                        auto [image, imageViewDescriptor]{ *imageViews[i] };
+                        deviceImageViews[i] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                    }
+
+                    isValidAll &= deviceShaderResourceGroupData.SetImageViewUnboundedArray(inputIndex, deviceImageViews);
+                }
+
+                for (size_t i = 0; i < imageViews.size(); ++i)
+                {
+                    const bool isValid =
+                        ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(
+                            inputIndex, imageViews[i], static_cast<uint32_t>(i));
+                    isValidAll &= isValid;
+                }
+
+                if (!imageViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::ImageViewUnboundedArrayMask);
+                }
+                return isValidAll;
+            }
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetBufferView(
+            ShaderInputBufferIndex inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex)
+        {
+            AZStd::array<const MultiDeviceBufferView* const, 1> bufferViews = { { bufferView } };
+            return SetBufferViewArray(inputIndex, bufferViews, arrayIndex);
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetBufferViewArray(
+            ShaderInputBufferIndex inputIndex, AZStd::span<const MultiDeviceBufferView* const> bufferViews, uint32_t arrayIndex)
+        {
+            if (GetLayout()->ValidateAccess(inputIndex, static_cast<uint32_t>(arrayIndex + bufferViews.size() - 1)))
+            {
+                bool isValidAll = true;
+
+                for (size_t i = 0; i < bufferViews.size(); ++i)
+                    isValidAll &= ValidateSetBufferView(inputIndex, bufferViews[i], arrayIndex);
+
+                for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+                {
+                    AZStd::vector<const BufferView*> deviceBufferViews(bufferViews.size());
+
+                    for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
+                    {
+                        auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
+                        deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                    }
+
+                    isValidAll &= deviceShaderResourceGroupData.SetBufferViewArray(inputIndex, deviceBufferViews, arrayIndex);
+                }
+
+                if (!bufferViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::BufferViewMask);
+                }
+                return isValidAll;
+            }
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetBufferViewUnboundedArray(
+            ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const MultiDeviceBufferView* const> bufferViews)
+        {
+            if (GetLayout()->ValidateAccess(inputIndex))
+            {
+                bool isValidAll = true;
+
+                for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+                {
+                    AZStd::vector<const BufferView*> deviceBufferViews(bufferViews.size());
+
+                    for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
+                    {
+                        auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
+                        deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                    }
+
+                    isValidAll &= deviceShaderResourceGroupData.SetBufferViewUnboundedArray(inputIndex, deviceBufferViews);
+                }
+
+                for (size_t i = 0; i < bufferViews.size(); ++i)
+                {
+                    const bool isValid =
+                        ValidateBufferViewAccess<ShaderInputBufferUnboundedArrayIndex, ShaderInputBufferUnboundedArrayDescriptor>(
+                            inputIndex, bufferViews[i], static_cast<uint32_t>(i));
+                    isValidAll &= isValid;
+                }
+
+                if (!bufferViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::BufferViewUnboundedArrayMask);
+                }
+                return isValidAll;
+            }
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetSampler(
+            ShaderInputSamplerIndex inputIndex, const SamplerState& sampler, uint32_t arrayIndex)
+        {
+            return SetSamplerArray(inputIndex, AZStd::span<const SamplerState>(&sampler, 1), arrayIndex);
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetSamplerArray(
+            ShaderInputSamplerIndex inputIndex, AZStd::span<const SamplerState> samplers, uint32_t arrayIndex)
+        {
+            if (GetLayout()->ValidateAccess(inputIndex, static_cast<uint32_t>(arrayIndex + samplers.size() - 1)))
+            {
+                bool isValidAll = true;
+
+                for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+                {
+                    isValidAll &= deviceShaderResourceGroupData.SetSamplerArray(inputIndex, samplers, arrayIndex);
+                }
+
+                if (!samplers.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::SamplerMask);
+                }
+                return isValidAll;
+            }
+            return false;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetConstantRaw(ShaderInputConstantIndex inputIndex, const void* bytes, uint32_t byteCount)
+        {
+            return SetConstantRaw(inputIndex, bytes, 0, byteCount);
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetConstantRaw(
+            ShaderInputConstantIndex inputIndex, const void* bytes, uint32_t byteOffset, uint32_t byteCount)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstantRaw(inputIndex, bytes, byteOffset, byteCount);
+            }
+
+            return isValidAll;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetConstantData(const void* bytes, uint32_t byteCount)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstantData(bytes, byteCount);
+            }
+
+            return isValidAll;
+        }
+
+        bool MultiDeviceShaderResourceGroupData::SetConstantData(const void* bytes, uint32_t byteOffset, uint32_t byteCount)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
+
+            bool isValidAll = true;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                isValidAll &= deviceShaderResourceGroupData.SetConstantData(bytes, byteOffset, byteCount);
+            }
+
+            return isValidAll;
+        }
+
+        uint32_t MultiDeviceShaderResourceGroupData::GetUpdateMask() const
+        {
+            return m_updateMask;
+        }
+
+        void MultiDeviceShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                deviceShaderResourceGroupData.EnableResourceTypeCompilation(resourceTypeMask);
+            }
+
+            m_updateMask = RHI::SetBits(m_updateMask, static_cast<uint32_t>(resourceTypeMask));
+        }
+
+        void MultiDeviceShaderResourceGroupData::ResetUpdateMask()
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                deviceShaderResourceGroupData.ResetUpdateMask();
+            }
+
+            m_updateMask = 0;
+        }
+
+        void MultiDeviceShaderResourceGroupData::SetBindlessViews(
+            ShaderInputBufferIndex indirectResourceBufferIndex,
+            const MultiDeviceBufferView* indirectResourceBufferView,
+            AZStd::span<const MultiDeviceImageView* const> imageViews,
+            uint32_t* outIndices,
+            bool viewReadOnly,
+            uint32_t arrayIndex)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                AZStd::vector<const ImageView*> deviceImageViews(imageViews.size());
+
+                for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
+                {
+                    auto [image, imageViewDescriptor]{ *imageViews[imageIndex] };
+                    deviceImageViews[imageIndex] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                }
+
+                auto [buffer, bufferViewDescriptor]{ *indirectResourceBufferView };
+
+                deviceShaderResourceGroupData.SetBindlessViews(
+                    indirectResourceBufferIndex,
+                    buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get(),
+                    deviceImageViews,
+                    outIndices,
+                    viewReadOnly,
+                    arrayIndex);
+            }
+
+            SetBufferView(indirectResourceBufferIndex, indirectResourceBufferView);
+        }
+
+        void MultiDeviceShaderResourceGroupData::SetBindlessViews(
+            ShaderInputBufferIndex indirectResourceBufferIndex,
+            const MultiDeviceBufferView* indirectResourceBufferView,
+            AZStd::span<const MultiDeviceBufferView* const> bufferViews,
+            uint32_t* outIndices,
+            bool viewReadOnly,
+            uint32_t arrayIndex)
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+            {
+                AZStd::vector<const BufferView*> deviceBufferViews(bufferViews.size());
+
+                for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
+                {
+                    auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
+                    deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                }
+
+                auto [buffer, bufferViewDescriptor]{ *indirectResourceBufferView };
+
+                deviceShaderResourceGroupData.SetBindlessViews(
+                    indirectResourceBufferIndex,
+                    buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get(),
+                    deviceBufferViews,
+                    outIndices,
+                    viewReadOnly,
+                    arrayIndex);
+            }
+
+            SetBufferView(indirectResourceBufferIndex, indirectResourceBufferView);
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupPool.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/Console/IConsole.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        ResultCode MultiDeviceShaderResourceGroupPool::Init(
+            MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupPoolDescriptor& descriptor)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (descriptor.m_layout == nullptr)
+                {
+                    AZ_Error("MultiDeviceShaderResourceGroupPool", false, "ShaderResourceGroupPoolDescriptor::m_layout must not be null.");
+                    return ResultCode::InvalidArgument;
+                }
+            }
+
+            ResultCode resultCode = MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor]()
+                {
+                    IterateDevices(
+                        [this, &descriptor](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceShaderResourceGroupPools[deviceIndex] = Factory::Get().CreateShaderResourceGroupPool();
+                            m_deviceShaderResourceGroupPools[deviceIndex]->Init(*device, descriptor);
+
+                            return true;
+                        });
+                    return ResultCode::Success;
+                });
+
+            if (resultCode != ResultCode::Success)
+            {
+                return resultCode;
+            }
+
+            m_descriptor = descriptor;
+            m_hasBufferGroup = m_descriptor.m_layout->GetGroupSizeForBuffers() > 0;
+            m_hasImageGroup = m_descriptor.m_layout->GetGroupSizeForImages() > 0;
+            m_hasSamplerGroup = m_descriptor.m_layout->GetGroupSizeForSamplers() > 0;
+            m_hasConstants = m_descriptor.m_layout->GetConstantDataSize() > 0;
+
+            return ResultCode::Success;
+        }
+
+        ResultCode MultiDeviceShaderResourceGroupPool::InitGroup(MultiDeviceShaderResourceGroup& group)
+        {
+            ResultCode resultCode = MultiDeviceResourcePool::InitResource(
+                &group,
+                [this, &group]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    for (auto& [deviceIndex, deviceShaderResourceGroupPool] : m_deviceShaderResourceGroupPools)
+                    {
+                        group.m_deviceShaderResourceGroups[deviceIndex] = Factory::Get().CreateShaderResourceGroup();
+                        result = m_deviceShaderResourceGroupPools[deviceIndex]->InitGroup(*group.m_deviceShaderResourceGroups[deviceIndex]);
+
+                        if (result != ResultCode::Success)
+                            break;
+                    }
+
+                    return result;
+                });
+
+            if (resultCode == ResultCode::Success)
+            {
+                const ShaderResourceGroupLayout* layout = GetLayout();
+
+                // Pre-initialize the data so that we can build view diffs later.
+                group.m_data = MultiDeviceShaderResourceGroupData(GetDeviceMask(), layout);
+
+                // Cache off the binding slot for one less indirection.
+                group.m_bindingSlot = layout->GetBindingSlot();
+            }
+
+            return resultCode;
+        }
+
+        void MultiDeviceShaderResourceGroupPool::CompileGroupsBegin()
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupPool] : m_deviceShaderResourceGroupPools)
+            {
+                deviceShaderResourceGroupPool->CompileGroupsBegin();
+            }
+        }
+
+        void MultiDeviceShaderResourceGroupPool::CompileGroupsEnd()
+        {
+            for (auto& [deviceIndex, deviceShaderResourceGroupPool] : m_deviceShaderResourceGroupPools)
+            {
+                deviceShaderResourceGroupPool->CompileGroupsEnd();
+            }
+        }
+
+        uint32_t MultiDeviceShaderResourceGroupPool::GetGroupsToCompileCount() const
+        {
+            auto groupCount{ 0u };
+            for (auto& [deviceIndex, deviceShaderResourceGroupPool] : m_deviceShaderResourceGroupPools)
+                groupCount += deviceShaderResourceGroupPool->GetGroupsToCompileCount();
+
+            return groupCount;
+        }
+
+        ResultCode MultiDeviceShaderResourceGroupPool::CompileGroup(
+            MultiDeviceShaderResourceGroup& shaderResourceGroup, const MultiDeviceShaderResourceGroupData& shaderResourceGroupData)
+        {
+            ResultCode resultCode = ResultCode::Success;
+
+            for (auto& [deviceIndex, deviceShaderResourceGroup] : shaderResourceGroup.m_deviceShaderResourceGroups)
+            {
+                resultCode = m_deviceShaderResourceGroupPools[deviceIndex]->CompileGroup(
+                    *deviceShaderResourceGroup, shaderResourceGroupData.GetDeviceShaderResourceGroupData(deviceIndex));
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            return resultCode;
+        }
+
+        void MultiDeviceShaderResourceGroupPool::CompileGroupsForInterval(Interval interval)
+        {
+            auto doOverlap = [](Interval groupInterval, Interval givenInterval)
+            {
+                return (groupInterval.m_min < givenInterval.m_max) && (groupInterval.m_max > givenInterval.m_min);
+            };
+
+            auto currentStart{ 0u };
+            for (auto& [deviceIndex, deviceShaderResourceGroupPool] : m_deviceShaderResourceGroupPools)
+            {
+                auto groupsToCompile{ static_cast<int>(deviceShaderResourceGroupPool->GetGroupsToCompileCount()) };
+
+                if (doOverlap({ currentStart, currentStart + groupsToCompile }, interval))
+                {
+                    auto startOffset{ static_cast<int>(currentStart) - static_cast<int>(interval.m_min) };
+                    auto endOffset{ static_cast<int>(currentStart + groupsToCompile) - static_cast<int>(interval.m_max) };
+                    deviceShaderResourceGroupPool->CompileGroupsForInterval(
+                        { static_cast<uint32_t>((startOffset <= 0) ? 0 : startOffset),
+                          static_cast<uint32_t>((endOffset <= 0) ? groupsToCompile : groupsToCompile - endOffset) });
+                }
+                currentStart += groupsToCompile;
+            }
+        }
+
+        const ShaderResourceGroupPoolDescriptor& MultiDeviceShaderResourceGroupPool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        const ShaderResourceGroupLayout* MultiDeviceShaderResourceGroupPool::GetLayout() const
+        {
+            AZ_Assert(m_descriptor.m_layout, "Shader resource group layout is null");
+            return m_descriptor.m_layout.get();
+        }
+
+        bool MultiDeviceShaderResourceGroupPool::HasConstants() const
+        {
+            return m_hasConstants;
+        }
+
+        bool MultiDeviceShaderResourceGroupPool::HasBufferGroup() const
+        {
+            return m_hasBufferGroup;
+        }
+
+        bool MultiDeviceShaderResourceGroupPool::HasImageGroup() const
+        {
+            return m_hasImageGroup;
+        }
+
+        bool MultiDeviceShaderResourceGroupPool::HasSamplerGroup() const
+        {
+            return m_hasSamplerGroup;
+        }
+
+        void MultiDeviceShaderResourceGroupPool::Shutdown()
+        {
+            for (auto [_, pool] : m_deviceShaderResourceGroupPools)
+                pool->Shutdown();
+            MultiDeviceResourcePool::Shutdown();
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/InputStreamLayout.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        MultiDeviceStreamBufferView::MultiDeviceStreamBufferView(
+            const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, uint32_t byteStride)
+            : m_buffer{ &buffer }
+            , m_byteOffset{ byteOffset }
+            , m_byteCount{ byteCount }
+            , m_byteStride{ byteStride }
+        {
+            size_t seed = 0;
+            AZStd::hash_combine(seed, m_buffer);
+            AZStd::hash_combine(seed, m_byteOffset);
+            AZStd::hash_combine(seed, m_byteCount);
+            AZStd::hash_combine(seed, m_byteStride);
+            m_hash = static_cast<HashValue64>(seed);
+        }
+
+        HashValue64 MultiDeviceStreamBufferView::GetHash() const
+        {
+            return m_hash;
+        }
+
+        const MultiDeviceBuffer* MultiDeviceStreamBufferView::GetBuffer() const
+        {
+            return m_buffer;
+        }
+
+        uint32_t MultiDeviceStreamBufferView::GetByteOffset() const
+        {
+            return m_byteOffset;
+        }
+
+        uint32_t MultiDeviceStreamBufferView::GetByteCount() const
+        {
+            return m_byteCount;
+        }
+
+        uint32_t MultiDeviceStreamBufferView::GetByteStride() const
+        {
+            return m_byteStride;
+        }
+
+        bool ValidateStreamBufferViews(
+            const RHI::InputStreamLayout& inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView> streamBufferViews)
+        {
+            bool ok = true;
+
+            if (Validation::IsEnabled())
+            {
+                if (!inputStreamLayout.IsFinalized())
+                {
+                    AZ_Error("InputStreamLayout", false, "InputStreamLayout is not finalized.");
+                    ok = false;
+                }
+
+                if (inputStreamLayout.GetStreamBuffers().size() != streamBufferViews.size())
+                {
+                    AZ_Error(
+                        "InputStreamLayout",
+                        false,
+                        "InputStreamLayout references %d stream buffers but %d StreamBufferViews were provided.",
+                        inputStreamLayout.GetStreamBuffers().size(),
+                        streamBufferViews.size());
+                    ok = false;
+                }
+
+                for (int i = 0; i < inputStreamLayout.GetStreamBuffers().size() && i < streamBufferViews.size(); ++i)
+                {
+                    auto& bufferDescriptor = inputStreamLayout.GetStreamBuffers()[i];
+                    auto& bufferView = streamBufferViews[i];
+
+                    // It can be valid to have a null buffer if this stream is not actually used by the shader, which can be the case for
+                    // streams marked optional.
+                    if (bufferView.GetBuffer() == nullptr)
+                    {
+                        continue;
+                    }
+
+                    if (bufferDescriptor.m_byteStride != bufferView.GetByteStride())
+                    {
+                        AZ_Error(
+                            "InputStreamLayout",
+                            false,
+                            "InputStreamLayout's buffer[%d] has stride=%d but MultiDeviceStreamBufferView[%d] has stride=%d.",
+                            i,
+                            bufferDescriptor.m_byteStride,
+                            i,
+                            bufferView.GetByteStride());
+                        ok = false;
+                    }
+                }
+            }
+
+            return ok;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceStreamingImagePool.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/parallel/atomic.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+
+        MultiDeviceStreamingImageInitRequest::MultiDeviceStreamingImageInitRequest(
+            MultiDeviceImage& image, const ImageDescriptor& descriptor, AZStd::span<const StreamingImageMipSlice> tailMipSlices)
+            : m_image{ &image }
+            , m_descriptor{ descriptor }
+            , m_tailMipSlices{ tailMipSlices }
+        {
+        }
+
+        bool MultiDeviceStreamingImagePool::ValidateInitRequest(const MultiDeviceStreamingImageInitRequest& initRequest) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (initRequest.m_tailMipSlices.empty())
+                {
+                    AZ_Error(
+                        "MultiDeviceStreamingImagePool",
+                        false,
+                        "No tail mip slices were provided. You must provide at least one tail mip slice.");
+                    return false;
+                }
+
+                if (initRequest.m_tailMipSlices.size() > initRequest.m_descriptor.m_mipLevels)
+                {
+                    AZ_Error("MultiDeviceStreamingImagePool", false, "Tail mip array exceeds the number of mip levels in the image.");
+                    return false;
+                }
+
+                // Streaming images are only allowed to update via the CPU.
+                if (CheckBitsAny(
+                        initRequest.m_descriptor.m_bindFlags,
+                        ImageBindFlags::Color | ImageBindFlags::DepthStencil | ImageBindFlags::ShaderWrite))
+                {
+                    AZ_Error("MultiDeviceStreamingImagePool", false, "Streaming images may only contain read-only bind flags.");
+                    return false;
+                }
+            }
+
+            AZ_UNUSED(initRequest);
+            return true;
+        }
+
+        bool MultiDeviceStreamingImagePool::ValidateExpandRequest(const MultiDeviceStreamingImageExpandRequest& expandRequest) const
+        {
+            if (Validation::IsEnabled())
+            {
+                if (!ValidateIsRegistered(expandRequest.m_image))
+                {
+                    return false;
+                }
+            }
+
+            AZ_UNUSED(expandRequest);
+            return true;
+        }
+
+        ResultCode MultiDeviceStreamingImagePool::Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor)
+        {
+            AZ_PROFILE_FUNCTION(RHI);
+
+            return MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor]()
+                {
+                    /**
+                     * Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                     * for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                     * possibility that users will get garbage values from GetDescriptor().
+                     */
+                    m_descriptor = descriptor;
+
+                    ResultCode result = ResultCode::Success;
+
+                    IterateDevices(
+                        [this, &descriptor, &result](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceStreamingImagePools[deviceIndex] = Factory::Get().CreateStreamingImagePool();
+                            result = m_deviceStreamingImagePools[deviceIndex]->Init(*device, descriptor);
+
+                            return result == ResultCode::Success;
+                        });
+
+                    return ResultCode::Success;
+                });
+        }
+
+        ResultCode MultiDeviceStreamingImagePool::InitImage(const MultiDeviceStreamingImageInitRequest& initRequest)
+        {
+            AZ_PROFILE_FUNCTION(RHI);
+
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateInitRequest(initRequest))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode resultCode = MultiDeviceImagePoolBase::InitImage(
+                initRequest.m_image,
+                initRequest.m_descriptor,
+                [this, &initRequest]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    for (auto& [deviceIndex, deviceStreamingImagePool] : m_deviceStreamingImagePools)
+                    {
+                        initRequest.m_image->m_deviceImages[deviceIndex] = Factory::Get().CreateImage();
+                        StreamingImageInitRequest streamingImageInitRequest(
+                            *initRequest.m_image->m_deviceImages[deviceIndex], initRequest.m_descriptor, initRequest.m_tailMipSlices);
+                        result = deviceStreamingImagePool->InitImage(streamingImageInitRequest);
+
+                        if (result != ResultCode::Success)
+                            break;
+                    }
+
+                    return result;
+                });
+
+            AZ_Warning("MultiDeviceStreamingImagePool", resultCode == ResultCode::Success, "Failed to initialize image.");
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceStreamingImagePool::ExpandImage(const MultiDeviceStreamingImageExpandRequest& request)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateExpandRequest(request))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode resultCode = ResultCode::Success;
+
+            auto expandCount = AZStd::make_shared<AZStd::atomic_int>(static_cast<int>(m_deviceStreamingImagePools.size()));
+
+            auto completeCallback = [expandCount, request]() {
+                if(--*expandCount == 0)
+                {
+                    request.m_completeCallback();
+                }
+            };
+
+            for (auto& [deviceIndex, deviceStreamingImagePool] : m_deviceStreamingImagePools)
+            {
+                StreamingImageExpandRequest expandRequest;
+
+                expandRequest.m_image = request.m_image->m_deviceImages[deviceIndex].get();
+                expandRequest.m_mipSlices = request.m_mipSlices;
+                expandRequest.m_waitForUpload = request.m_waitForUpload;
+                expandRequest.m_completeCallback = completeCallback;
+
+                resultCode = deviceStreamingImagePool->ExpandImage(expandRequest);
+
+                if (resultCode != ResultCode::Success)
+                {
+                    break;
+                }
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceStreamingImagePool::TrimImage(MultiDeviceImage& image, uint32_t targetMipLevel)
+        {
+            if (!ValidateIsInitialized())
+            {
+                return ResultCode::InvalidOperation;
+            }
+
+            if (!ValidateIsRegistered(&image))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            ResultCode resultCode = ResultCode::Success;
+
+            for (auto& [deviceIndex, deviceStreamingImagePool] : m_deviceStreamingImagePools)
+            {
+                resultCode = deviceStreamingImagePool->TrimImage(*image.m_deviceImages[deviceIndex], targetMipLevel);
+
+                if (resultCode != ResultCode::Success)
+                {
+                    break;
+                }
+            }
+
+            if (resultCode == ResultCode::Success)
+            {
+                // If initialization succeeded, assign the new resident mip level. Invalidate resource views
+                // so that they no longer reference trimmed mip levels.
+                image.InvalidateViews();
+            }
+
+            return resultCode;
+        }
+
+        const StreamingImagePoolDescriptor& MultiDeviceStreamingImagePool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
+#include <Atom/RHI/RHISystemInterface.h>
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDeviceSwapChain::ValidateDescriptor(const SwapChainDescriptor& descriptor) const
+        {
+            if (Validation::IsEnabled())
+            {
+                const bool isValidDescriptor = descriptor.m_dimensions.m_imageWidth != 0 && descriptor.m_dimensions.m_imageHeight != 0 &&
+                    descriptor.m_dimensions.m_imageCount != 0;
+
+                if (!isValidDescriptor)
+                {
+                    AZ_Warning("MultiDeviceSwapChain", false, "MultiDeviceSwapChain display dimensions cannot be 0.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        ResultCode MultiDeviceSwapChain::Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor)
+        {
+            if (!ValidateDescriptor(descriptor))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            if (descriptor.m_isXrSwapChain)
+            {
+                m_xrSystem = RHI::RHISystemInterface::Get()->GetXRSystem();
+                AZ_Assert(m_xrSystem, "XR System is null");
+            }
+
+            SwapChainDimensions nativeDimensions = descriptor.m_dimensions;
+            ResultCode resultCode = MultiDeviceResourcePool::Init(
+                deviceMask,
+                [this, &descriptor, &nativeDimensions]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    IterateDevices(
+                        [this, &descriptor, &result, &nativeDimensions](int deviceIndex)
+                        {
+                            auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                            m_deviceSwapChains[deviceIndex] = Factory::Get().CreateSwapChain();
+                            result = m_deviceSwapChains[deviceIndex]->Init(*device, descriptor);
+                            nativeDimensions = m_deviceSwapChains[deviceIndex]->GetDescriptor().m_dimensions;
+
+                            return result == ResultCode::Success;
+                        });
+
+                    return result;
+                });
+
+            if (resultCode == ResultCode::Success)
+            {
+                m_descriptor = descriptor;
+                // Overwrite descriptor dimensions with the native ones (the ones assigned by the platform) returned by InitInternal.
+                // Note: dimensions of each swap chain could be different, we are taking the dimensions of the last one if there are multiple
+                m_descriptor.m_dimensions = nativeDimensions;
+
+                resultCode = InitImages();
+            }
+
+            return resultCode;
+        }
+
+        void MultiDeviceSwapChain::ShutdownImages()
+        {
+            // Shutdown existing set of images.
+            uint32_t imageSize = aznumeric_cast<uint32_t>(m_images.size());
+            for (uint32_t imageIdx = 0; imageIdx < imageSize; ++imageIdx)
+            {
+                m_images[imageIdx]->Shutdown();
+            }
+
+            m_images.clear();
+        }
+
+        ResultCode MultiDeviceSwapChain::InitImages()
+        {
+            ResultCode resultCode = ResultCode::Success;
+
+            m_images.reserve(m_descriptor.m_dimensions.m_imageCount);
+
+            // If the new display mode has more buffers, add them.
+            for (uint32_t i = 0; i < m_descriptor.m_dimensions.m_imageCount; ++i)
+            {
+                m_images.emplace_back(aznew MultiDeviceImage());
+            }
+
+            InitImageRequest request;
+
+            RHI::ImageDescriptor& imageDescriptor = request.m_descriptor;
+            imageDescriptor.m_dimension = RHI::ImageDimension::Image2D;
+            imageDescriptor.m_bindFlags = RHI::ImageBindFlags::Color;
+            imageDescriptor.m_size.m_width = m_descriptor.m_dimensions.m_imageWidth;
+            imageDescriptor.m_size.m_height = m_descriptor.m_dimensions.m_imageHeight;
+            imageDescriptor.m_format = m_descriptor.m_dimensions.m_imageFormat;
+
+            for (uint32_t imageIdx = 0; imageIdx < m_descriptor.m_dimensions.m_imageCount; ++imageIdx)
+            {
+                request.m_image = m_images[imageIdx].get();
+                request.m_imageIndex = imageIdx;
+
+                resultCode = MultiDeviceImagePoolBase::InitImage(
+                    request.m_image,
+                    imageDescriptor,
+                    [this, imageIdx]()
+                    {
+                        ResultCode result = ResultCode::Success;
+
+                        for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                        {
+                            m_images[imageIdx]->m_deviceImages[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
+                        }
+
+                        return result;
+                    });
+
+                if (resultCode != ResultCode::Success)
+                {
+                    AZ_Error("Swapchain", false, "Failed to initialize images.");
+                    Shutdown();
+                    break;
+                }
+            }
+
+            return resultCode;
+        }
+
+        ResultCode MultiDeviceSwapChain::Resize(const RHI::SwapChainDimensions& dimensions)
+        {
+            ResultCode resultCode = ResultCode::Success;
+
+            ShutdownImages();
+
+            RHI::SwapChainDimensions nativeDimensions;
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+            {
+                resultCode = deviceSwapChain->Resize(dimensions);
+                nativeDimensions = deviceSwapChain->GetDescriptor().m_dimensions;
+
+                if (resultCode != ResultCode::Success)
+                    break;
+            }
+
+            if (resultCode == ResultCode::Success)
+            {
+                m_descriptor.m_dimensions = nativeDimensions;
+                resultCode = InitImages();
+            }
+
+            return resultCode;
+        }
+
+        void MultiDeviceSwapChain::SetVerticalSyncInterval(uint32_t verticalSyncInterval)
+        {
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+            {
+                deviceSwapChain->SetVerticalSyncInterval(verticalSyncInterval);
+            }
+
+            m_descriptor.m_verticalSyncInterval = verticalSyncInterval;
+        }
+
+        const AttachmentId& MultiDeviceSwapChain::GetAttachmentId() const
+        {
+            return m_descriptor.m_attachmentId;
+        }
+
+        const SwapChainDescriptor& MultiDeviceSwapChain::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        bool MultiDeviceSwapChain::IsExclusiveFullScreenPreferred() const
+        {
+            auto result{ true };
+
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                result |= deviceSwapChain->IsExclusiveFullScreenPreferred();
+
+            return result;
+        }
+
+        bool MultiDeviceSwapChain::GetExclusiveFullScreenState() const
+        {
+            auto result{ true };
+
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                result &= deviceSwapChain->GetExclusiveFullScreenState();
+
+            return result;
+        }
+
+        bool MultiDeviceSwapChain::SetExclusiveFullScreenState(bool fullScreenState)
+        {
+            auto result{ true };
+
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                result &= deviceSwapChain->SetExclusiveFullScreenState(fullScreenState);
+
+            return result;
+        }
+
+        void MultiDeviceSwapChain::ProcessRecreation()
+        {
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                deviceSwapChain->ProcessRecreation();
+        }
+
+        uint32_t MultiDeviceSwapChain::GetImageCount() const
+        {
+            return aznumeric_cast<uint32_t>(m_images.size());
+        }
+
+        MultiDeviceImage* MultiDeviceSwapChain::GetCurrentImage() const
+        {
+            if (m_descriptor.m_isXrSwapChain)
+            {
+                return m_images[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
+            }
+            AZ_Error("Swapchain", !m_deviceSwapChains.empty(), "No device swapchain image available.");
+            // Note: Taking the current swapchain image index from the first device swap chain if there are multiple
+            auto currentImageIndex{ m_deviceSwapChains.begin()->second->GetCurrentImageIndex() };
+            return m_images[currentImageIndex].get();
+        }
+
+        MultiDeviceImage* MultiDeviceSwapChain::GetImage(uint32_t index) const
+        {
+            return m_images[index].get();
+        }
+
+        void MultiDeviceSwapChain::Present()
+        {
+            for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                deviceSwapChain->Present();
+        }
+
+        RHI::XRRenderingInterface* MultiDeviceSwapChain::GetXRSystem() const
+        {
+            return m_xrSystem;
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/AliasedAttachmentAllocator.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceTransientAttachmentPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        bool MultiDeviceTransientAttachmentPool::NeedsTransientAttachmentPool(
+            const TransientAttachmentPoolDescriptor& descriptor)
+        {
+            switch (descriptor.m_heapParameters.m_type)
+            {
+            case HeapAllocationStrategy::Fixed:
+                {
+                    // Fixed strategy must declare a budget for at least one type of resource in order to use a transient attachment pool.
+                    return descriptor.m_bufferBudgetInBytes != 0 || descriptor.m_imageBudgetInBytes != 0 ||
+                        descriptor.m_renderTargetBudgetInBytes != 0;
+                }
+            // Paging and Memory Hint strategy can work with a 0 budget.
+            case HeapAllocationStrategy::Paging:
+            case HeapAllocationStrategy::MemoryHint:
+                return true;
+            default:
+                AZ_Assert(false, "Invalid heap allocation type %d", descriptor.m_heapParameters.m_type);
+                return false;
+            }
+        }
+
+        ResultCode MultiDeviceTransientAttachmentPool::Init(
+            MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor)
+        {
+            if (Validation::IsEnabled())
+            {
+                if (IsInitialized())
+                {
+                    AZ_Error("MultiDeviceTransientAttachmentPool", false, "MultiDeviceTransientAttachmentPool is already initialized!");
+                    return ResultCode::InvalidOperation;
+                }
+            }
+
+            if (!ValidateInitParameters(descriptor))
+            {
+                return ResultCode::InvalidArgument;
+            }
+
+            m_descriptor = descriptor;
+
+            MultiDeviceObject::Init(deviceMask);
+
+            ResultCode resultCode = ResultCode::Success;
+
+            IterateDevices(
+                [this, &descriptor, &resultCode](int deviceIndex)
+                {
+                    auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                    m_deviceTransientAttachmentPools[deviceIndex] = Factory::Get().CreateTransientAttachmentPool();
+
+                    TransientAttachmentPoolDescriptor deviceDescriptor;
+                    deviceDescriptor.m_bufferBudgetInBytes = descriptor.m_bufferBudgetInBytes;
+                    deviceDescriptor.m_heapParameters = descriptor.m_heapParameters;
+                    deviceDescriptor.m_imageBudgetInBytes = descriptor.m_imageBudgetInBytes;
+                    deviceDescriptor.m_renderTargetBudgetInBytes = descriptor.m_renderTargetBudgetInBytes;
+
+                    resultCode = m_deviceTransientAttachmentPools[deviceIndex]->Init(*device, deviceDescriptor);
+
+                    return resultCode == ResultCode::Success;
+                });
+
+            return resultCode;
+        }
+
+        void MultiDeviceTransientAttachmentPool::Shutdown()
+        {
+            if (IsInitialized())
+            {
+                for (const auto& [deviceIndex, pool] : m_deviceTransientAttachmentPools)
+                    pool->Shutdown();
+                m_deviceTransientAttachmentPools.clear();
+                MultiDeviceObject::Shutdown();
+            }
+        }
+
+        void MultiDeviceTransientAttachmentPool::Begin(
+            const TransientAttachmentPoolCompileFlags compileFlags, const TransientAttachmentStatistics::MemoryUsage* memoryHint)
+        {
+            m_compileFlags = compileFlags;
+
+            m_currentScope = nullptr;
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->Begin(compileFlags, memoryHint);
+            }
+        }
+
+        void MultiDeviceTransientAttachmentPool::BeginScope(Scope& scopeBase)
+        {
+            m_currentScope = static_cast<Scope*>(&scopeBase);
+
+            // TODO: Only call for the correct device as given by the scopeBase
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->BeginScope(scopeBase);
+            }
+
+            TransientAttachmentStatistics::Scope scope;
+            scope.m_scopeId = scopeBase.GetId();
+            scope.m_hardwareQueueClass = scopeBase.GetHardwareQueueClass();
+        }
+
+        void MultiDeviceTransientAttachmentPool::EndScope()
+        {
+            m_currentScope = nullptr;
+            // TODO: Only call for the correct device as given by the scopeBase
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->EndScope();
+            }
+        }
+
+        void MultiDeviceTransientAttachmentPool::End()
+        {
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->End();
+            }
+        }
+
+        MultiDeviceImage* MultiDeviceTransientAttachmentPool::ActivateImage(const TransientImageDescriptor& descriptor)
+        {
+            MultiDeviceImage* image{};
+
+            HashValue64 hash = descriptor.GetHash();
+
+            // Check the cache for the image.
+            if (auto attachment = m_cache.Find(static_cast<uint64_t>(hash)))
+            {
+                image = static_cast<MultiDeviceImage*>(attachment);
+            }
+            // image is not in cache. Create a new one at the placed address, and add it to the cache.
+            else
+            {
+                // Remove any existing resource entries from the cache before adding a new one
+                RemoveFromCache(descriptor.m_attachmentId);
+
+                // Ownership is managed by the cache.
+                RHI::Ptr<MultiDeviceImage> imagePtr = aznew MultiDeviceImage();
+                image = imagePtr.get();
+
+                imagePtr->Init(GetDeviceMask());
+
+                for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+                {
+                    imagePtr->m_deviceImages[deviceIndex] = deviceTransientAttachmentPool->ActivateImage(descriptor);
+                    if (imagePtr->m_deviceImages[deviceIndex])
+                        imagePtr->SetDescriptor(imagePtr->m_deviceImages[deviceIndex]->GetDescriptor());
+                }
+
+                imagePtr->SetName(descriptor.m_attachmentId);
+                m_cache.Insert(static_cast<uint64_t>(hash), AZStd::move(imagePtr));
+                if (!descriptor.m_attachmentId.IsEmpty())
+                {
+                    m_reverseLookupHash.emplace(descriptor.m_attachmentId, hash);
+                }
+            }
+
+            return image;
+        }
+
+        MultiDeviceBuffer* MultiDeviceTransientAttachmentPool::ActivateBuffer(const TransientBufferDescriptor& descriptor)
+        {
+            MultiDeviceBuffer* buffer = nullptr;
+
+            HashValue64 hash = descriptor.GetHash();
+
+            // Check the cache for the buffer.
+            if (auto attachment = m_cache.Find(static_cast<uint64_t>(hash)))
+            {
+                buffer = static_cast<MultiDeviceBuffer*>(attachment);
+            }
+            // buffer is not in cache. Create a new one at the placed address, and add it to the cache.
+            else
+            {
+                // Remove any existing resource entries from the cache before adding a new one
+                RemoveFromCache(descriptor.m_attachmentId);
+
+                // Ownership is managed by the cache.
+                RHI::Ptr<MultiDeviceBuffer> bufferPtr = aznew MultiDeviceBuffer();
+                buffer = bufferPtr.get();
+
+                bufferPtr->Init(GetDeviceMask());
+
+                for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+                {
+                    bufferPtr->m_deviceBuffers[deviceIndex] = deviceTransientAttachmentPool->ActivateBuffer(descriptor);
+                    if (bufferPtr->m_deviceBuffers[deviceIndex])
+                        bufferPtr->SetDescriptor(bufferPtr->m_deviceBuffers[deviceIndex]->GetDescriptor());
+                }
+
+                bufferPtr->SetName(descriptor.m_attachmentId);
+                m_cache.Insert(static_cast<uint64_t>(hash), AZStd::move(bufferPtr));
+                if (!descriptor.m_attachmentId.IsEmpty())
+                {
+                    m_reverseLookupHash.emplace(descriptor.m_attachmentId, hash);
+                }
+            }
+
+            return buffer;
+        }
+
+        void MultiDeviceTransientAttachmentPool::DeactivateBuffer(const AttachmentId& attachmentId)
+        {
+            RemoveFromCache(attachmentId);
+
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->DeactivateBuffer(attachmentId);
+            }
+        }
+
+        void MultiDeviceTransientAttachmentPool::DeactivateImage(const AttachmentId& attachmentId)
+        {
+            RemoveFromCache(attachmentId);
+
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                deviceTransientAttachmentPool->DeactivateImage(attachmentId);
+            }
+        }
+
+        AZStd::unordered_map<int, TransientAttachmentStatistics> MultiDeviceTransientAttachmentPool::GetStatistics() const
+        {
+            AZStd::unordered_map<int, TransientAttachmentStatistics> statistics;
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                statistics.insert({ deviceIndex, deviceTransientAttachmentPool->GetStatistics() });
+            }
+            return statistics;
+        }
+
+        const TransientAttachmentPoolDescriptor& MultiDeviceTransientAttachmentPool::GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        TransientAttachmentPoolCompileFlags MultiDeviceTransientAttachmentPool::GetCompileFlags() const
+        {
+            return m_compileFlags;
+        }
+
+        bool MultiDeviceTransientAttachmentPool::ValidateInitParameters(
+            [[maybe_unused]] const TransientAttachmentPoolDescriptor& descriptor) const
+        {
+#if defined(AZ_RHI_ENABLE_VALIDATION)
+            switch (descriptor.m_heapParameters.m_type)
+            {
+            case HeapAllocationStrategy::Fixed:
+                {
+                    if (descriptor.m_bufferBudgetInBytes == 0 && descriptor.m_imageBudgetInBytes == 0 &&
+                        descriptor.m_renderTargetBudgetInBytes == 0)
+                    {
+                        AZ_Assert(false, "Invalid budget for transient attachment pool when using a Fixed allocation strategy");
+                        return false;
+                    }
+                    break;
+                }
+            case HeapAllocationStrategy::Paging:
+                {
+                    const auto& pagingParameters = descriptor.m_heapParameters.m_pagingParameters;
+                    if (pagingParameters.m_pageSizeInBytes == 0)
+                    {
+                        AZ_Assert(
+                            false, "Invalid page size %d when using a Paging allocation strategy", pagingParameters.m_pageSizeInBytes);
+                        return false;
+                    }
+
+                    if (descriptor.m_bufferBudgetInBytes && pagingParameters.m_pageSizeInBytes > descriptor.m_bufferBudgetInBytes)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Page size %d is bigger than budget for buffers %d",
+                            pagingParameters.m_pageSizeInBytes,
+                            descriptor.m_bufferBudgetInBytes);
+                        return false;
+                    }
+
+                    if (descriptor.m_imageBudgetInBytes && pagingParameters.m_pageSizeInBytes > descriptor.m_imageBudgetInBytes)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Page size %d is bigger than budget for images %d",
+                            pagingParameters.m_pageSizeInBytes,
+                            descriptor.m_imageBudgetInBytes);
+                        return false;
+                    }
+
+                    if (descriptor.m_renderTargetBudgetInBytes &&
+                        pagingParameters.m_pageSizeInBytes > descriptor.m_renderTargetBudgetInBytes)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Page size %d is bigger than budget for rendertargets %d",
+                            pagingParameters.m_pageSizeInBytes,
+                            descriptor.m_renderTargetBudgetInBytes);
+                        return false;
+                    }
+
+                    if (pagingParameters.m_initialAllocationPercentage && descriptor.m_bufferBudgetInBytes == 0 &&
+                        descriptor.m_imageBudgetInBytes == 0 && descriptor.m_renderTargetBudgetInBytes == 0)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Invalid initial allocation percentage (%lf) when using a Paging allocation strategy",
+                            pagingParameters.m_initialAllocationPercentage);
+                        return false;
+                    }
+                    break;
+                }
+            case HeapAllocationStrategy::MemoryHint:
+                {
+                    const auto& memoryHintParameters = descriptor.m_heapParameters.m_usageHintParameters;
+                    if (memoryHintParameters.m_heapSizeScaleFactor < 1.0f)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Invalid heap size scale factor (%lf) when using a MemoryHint allocation strategy",
+                            memoryHintParameters.m_heapSizeScaleFactor);
+                        return false;
+                    }
+
+                    if (memoryHintParameters.m_maxHeapWastedPercentage < 0.f || memoryHintParameters.m_maxHeapWastedPercentage > 1.f)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Invalid max heap wasted percentage (%lf) when using a MemoryHint allocation strategy",
+                            memoryHintParameters.m_maxHeapWastedPercentage);
+                        return false;
+                    }
+
+                    if ((memoryHintParameters.m_heapSizeScaleFactor - 1.0f) >= memoryHintParameters.m_maxHeapWastedPercentage)
+                    {
+                        AZ_Assert(
+                            false,
+                            "Heap scale factor (%lf) is bugger than max wasted percentage (%lf) when using a MemoryHint allocation "
+                            "strategy",
+                            memoryHintParameters.m_heapSizeScaleFactor,
+                            memoryHintParameters.m_maxHeapWastedPercentage);
+                        return false;
+                    }
+                    break;
+                }
+            default:
+                AZ_Assert(false, "Invalid heap allocation strategy %d", descriptor.m_heapParameters.m_type);
+                return false;
+            }
+#endif
+            return true;
+        }
+
+        void MultiDeviceTransientAttachmentPool::RemoveFromCache(AttachmentId attachmentId)
+        {
+            auto it = m_reverseLookupHash.find(attachmentId);
+            if (it != m_reverseLookupHash.end())
+            {
+                HashValue64 originalHash = it->second;
+                m_cache.EraseItem(aznumeric_cast<uint64_t>(originalHash));
+                m_reverseLookupHash.erase(it);
+            }
+        }
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -37,11 +37,11 @@ namespace AZ
             return Interface<RHIMemoryStatisticsInterface>::Get();
         }
 
-        ResultCode RHISystem::InitDevice()
+        ResultCode RHISystem::InitDevices(bool initializeMultiDevice)
         {
             Interface<RHISystemInterface>::Register(this);
             Interface<RHIMemoryStatisticsInterface>::Register(this);
-            return InitInternalDevices();
+            return InitInternalDevices(initializeMultiDevice);
         }
     
         void RHISystem::Init()
@@ -94,7 +94,7 @@ namespace AZ
             m_frameScheduler.Init(*m_devices[MultiDevice::DefaultDeviceIndex], frameSchedulerDescriptor);
         }
 
-        ResultCode RHISystem::InitInternalDevices()
+        ResultCode RHISystem::InitInternalDevices(bool initializeMultiDevice)
         {
             RHI::PhysicalDeviceList physicalDevices = RHI::Factory::Get().EnumeratePhysicalDevices();
 
@@ -106,12 +106,9 @@ namespace AZ
                 return ResultCode::Fail;
             }
 
-            static const char* MultiGPUCommandLineOption = "rhi-multiple-devices";
-            AZStd::string multipleDevicesValue = RHI::GetCommandLineValue(MultiGPUCommandLineOption);
-
             RHI::PhysicalDeviceList usePhysicalDevices;
 
-            if (AzFramework::StringFunc::Equal(multipleDevicesValue.c_str(), "enable"))
+            if (initializeMultiDevice)
             {
                 AZ_Printf("RHISystem", "\tUsing multiple devices\n");
 

--- a/Gems/Atom/RHI/Code/Tests/Device.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Device.cpp
@@ -24,13 +24,16 @@ namespace UnitTest
 
     RHI::PhysicalDeviceList PhysicalDevice::Enumerate()
     {
-        return RHI::PhysicalDeviceList{aznew PhysicalDevice};
+        RHI::PhysicalDeviceList devices;
+        for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            devices.emplace_back(aznew PhysicalDevice);
+        return devices;
     }
 
     RHI::Ptr<RHI::Device> MakeTestDevice()
     {
         RHI::PhysicalDeviceList physicalDevices = RHI::Factory::Get().EnumeratePhysicalDevices();
-        EXPECT_EQ(physicalDevices.size(), 1);
+        EXPECT_EQ(physicalDevices.size(), deviceCount);
 
         RHI::Ptr<RHI::Device> device = RHI::Factory::Get().CreateDevice();
         device->Init(RHI::MultiDevice::DefaultDeviceIndex, *physicalDevices[0]);

--- a/Gems/Atom/RHI/Code/Tests/Device.h
+++ b/Gems/Atom/RHI/Code/Tests/Device.h
@@ -10,9 +10,13 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <Atom/RHI/Device.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <Atom/RHI.Reflect/Limits.h>
 
 namespace UnitTest
 {
+    static constexpr auto deviceCount{8};
+    static constexpr AZ::RHI::MultiDevice::DeviceMask deviceMask{AZ::RHI::MultiDevice::AllDevices};
+
     class PhysicalDevice
         : public AZ::RHI::PhysicalDevice
     {

--- a/Gems/Atom/RHI/Code/Tests/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Factory.cpp
@@ -163,12 +163,12 @@ namespace UnitTest
 
     AZ::RHI::Ptr<AZ::RHI::IndirectBufferSignature> Factory::CreateIndirectBufferSignature()
     {
-        return aznew IndirectBufferSignature;
+        return aznew NiceIndirectBufferSignature;
     }
 
     AZ::RHI::Ptr<AZ::RHI::IndirectBufferWriter> Factory::CreateIndirectBufferWriter()
     {
-        return aznew IndirectBufferWriter;
+        return aznew NiceIndirectBufferWriter;
     }
 
     AZ::RHI::Ptr<AZ::RHI::RayTracingBufferPools> Factory::CreateRayTracingBufferPools()

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <AzCore/Debug/Timer.h>
+#include <AzCore/std/parallel/conditional_variable.h>
+#include <Tests/Device.h>
+
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/ResourceInvalidateBus.h>
+
+#include <Tests/Buffer.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceBufferTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceBufferTests()
+            : MultiDeviceRHITestFixture()
+        {
+        }
+
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceBufferTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceBuffer> noopBuffer;
+        noopBuffer = aznew RHI::MultiDeviceBuffer;
+    }
+
+    TEST_F(MultiDeviceBufferTests, TestAll)
+    {
+        RHI::Ptr<RHI::MultiDeviceBuffer> bufferA;
+        bufferA = aznew RHI::MultiDeviceBuffer;
+
+        bufferA->SetName(Name("BufferA"));
+        AZ_TEST_ASSERT(bufferA->GetName().GetStringView() == "BufferA");
+        AZ_TEST_ASSERT(bufferA->use_count() == 1);
+
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPool;
+            bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+
+            AZ_TEST_ASSERT(bufferPool->use_count() == 1);
+
+            RHI::Ptr<RHI::MultiDeviceBuffer> bufferB;
+            bufferB = aznew RHI::MultiDeviceBuffer;
+            AZ_TEST_ASSERT(bufferB->use_count() == 1);
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+            bufferPool->Init(deviceMask, bufferPoolDesc);
+
+            AZStd::vector<uint8_t> testData(32);
+            for (uint32_t i = 0; i < 32; ++i)
+            {
+                testData[i] = (uint8_t)i * 2;
+            }
+
+            AZ_TEST_ASSERT(bufferA->IsInitialized() == false);
+            AZ_TEST_ASSERT(bufferB->IsInitialized() == false);
+
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = bufferA.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 32);
+            initRequest.m_initialData = testData.data();
+            bufferPool->InitBuffer(initRequest);
+
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex) 
+            {
+                RHI::Ptr<RHI::BufferView> bufferView;
+                bufferView = bufferA->GetDeviceBuffer(deviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, 32));
+                
+                AZ_TEST_ASSERT(bufferView->IsInitialized());
+                ASSERT_FALSE(bufferView->IsStale());
+                AZ_TEST_ASSERT(bufferView->IsFullView());
+                AZ_TEST_ASSERT(bufferA->GetDeviceBuffer(deviceIndex)->use_count() == 2);
+            }
+
+            // MDBuffer still only used once
+            AZ_TEST_ASSERT(bufferA->use_count() == 1);
+            AZ_TEST_ASSERT(bufferA->IsInitialized());
+
+            initRequest.m_buffer = bufferB.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 16);
+            initRequest.m_initialData = testData.data() + 16;
+            bufferPool->InitBuffer(initRequest);
+
+            AZ_TEST_ASSERT(bufferB->IsInitialized()); 
+
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                const auto& bufferAData{static_cast<Buffer*>(bufferA->GetDeviceBuffer(deviceIndex).get())->GetData()};
+                AZ_TEST_ASSERT(AZStd::equal(testData.begin(), testData.end(), bufferAData.begin()));
+
+                const auto& bufferBData{static_cast<Buffer*>(bufferB->GetDeviceBuffer(deviceIndex).get())->GetData()};
+                AZ_TEST_ASSERT(AZStd::equal(testData.begin() + 16, testData.end(), bufferBData.begin()));
+            }
+
+            AZ_TEST_ASSERT(bufferA->GetPool() == bufferPool.get());
+            AZ_TEST_ASSERT(bufferB->GetPool() == bufferPool.get());
+            AZ_TEST_ASSERT(bufferPool->GetResourceCount() == 2);
+
+            {
+                uint32_t bufferIndex = 0;
+
+                const RHI::MultiDeviceBuffer* buffers[] =
+                {
+                    bufferA.get(),
+                    bufferB.get()
+                };
+
+                bufferPool->ForEach<RHI::MultiDeviceBuffer>([&bufferIndex, &buffers]([[maybe_unused]] RHI::MultiDeviceBuffer& buffer)
+                {
+                    AZ_UNUSED(buffers); // Prevent unused warning in release builds
+                    AZ_Assert(buffers[bufferIndex] == &buffer, "buffers don't match");
+                    bufferIndex++;
+                });
+            }
+
+            bufferB->Shutdown();
+            AZ_TEST_ASSERT(bufferB->GetPool() == nullptr);
+
+            RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPoolB;
+            bufferPoolB = aznew AZ::RHI::MultiDeviceBufferPool;
+            bufferPoolB->Init(deviceMask, bufferPoolDesc);
+
+            initRequest.m_buffer = bufferB.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 16);
+            initRequest.m_initialData = testData.data() + 16;
+            bufferPoolB->InitBuffer(initRequest);
+            AZ_TEST_ASSERT(bufferB->GetPool() == bufferPoolB.get());
+
+            //Since we are switching bufferpools for bufferB it adds a refcount and invalidates the views.
+            //We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            bufferPoolB->Shutdown();
+            AZ_TEST_ASSERT(bufferPoolB->GetResourceCount() == 0);
+        }
+
+        AZ_TEST_ASSERT(bufferA->GetPool() == nullptr);
+        AZ_TEST_ASSERT(bufferA->use_count() == 1);
+    }
+
+    TEST_F(MultiDeviceBufferTests, TestViews)
+    {
+        AZStd::vector<RHI::Ptr<RHI::BufferView>> bufferViewsA(deviceCount);
+        
+        {
+            RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool;
+            bufferPool = aznew RHI::MultiDeviceBufferPool;
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+            bufferPool->Init(deviceMask, bufferPoolDesc);
+
+            RHI::Ptr<RHI::MultiDeviceBuffer> buffer;
+            buffer = aznew RHI::MultiDeviceBuffer;
+
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = buffer.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 32);
+            bufferPool->InitBuffer(initRequest);
+
+            // Should report initialized and not stale.
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                bufferViewsA[deviceIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, 32));
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Should report as still initialized and also stale.
+            buffer->Shutdown();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale());
+            }  
+
+            // Should *still* report as stale since resource invalidation events are queued.
+            bufferPool->InitBuffer(initRequest);
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex) 
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale()); 
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Explicit invalidation should mark it stale.
+            buffer->InvalidateViews();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Create an uninitialized bufferview and let it go out of scope
+            RHI::Ptr<RHI::BufferView> uninitializedBufferViewPtr = RHI::Factory::Get().CreateBufferView();
+        }
+    }
+
+
+    struct MultiDeviceBufferAndViewBindFlags
+    {
+        RHI::BufferBindFlags bufferBindFlags;
+        RHI::BufferBindFlags viewBindFlags;
+    };
+
+    class MultiDeviceBufferBindFlagTests
+        : public MultiDeviceBufferTests
+        , public ::testing::WithParamInterface <MultiDeviceBufferAndViewBindFlags>
+    {
+    public:
+        void SetUp() override
+        {
+            MultiDeviceBufferTests::SetUp();
+
+            // Create a pool and buffer with the buffer bind flags from the parameterized test
+            m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = GetParam().bufferBindFlags;
+            m_bufferPool->Init(deviceMask, bufferPoolDesc);
+
+            m_buffer = aznew RHI::MultiDeviceBuffer;
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = m_buffer.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(GetParam().bufferBindFlags, 32);
+            m_bufferPool->InitBuffer(initRequest);
+        }
+    
+        void TearDown() override
+        {
+            m_bufferPool.reset();
+            m_buffer.reset();
+            m_bufferView.reset();
+            MultiDeviceBufferTests::TearDown();
+        }
+
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_buffer;
+        RHI::Ptr<RHI::BufferView> m_bufferView;
+    };
+
+    TEST_P(MultiDeviceBufferBindFlagTests, InitView_ViewIsCreated)
+    {
+        RHI::BufferViewDescriptor bufferViewDescriptor;
+        bufferViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            m_bufferView = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor);
+            EXPECT_EQ(m_bufferView.get()!=nullptr, true);
+        }
+    }
+
+    // This test fixture is the same as MultiDeviceBufferBindFlagTests, but exists separately so that
+    // we can instantiate different test cases that are expected to fail
+    class MultiDeviceBufferBindFlagFailureCases
+        : public MultiDeviceBufferBindFlagTests
+    {
+
+    };
+
+    TEST_P(MultiDeviceBufferBindFlagFailureCases, InitView_ViewIsNotCreated)
+    {
+        RHI::BufferViewDescriptor bufferViewDescriptor;
+        bufferViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            m_bufferView = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor);
+            EXPECT_EQ(m_bufferView.get()==nullptr, true);
+        }
+    }
+
+        // These combinations should result in a successful creation of the buffer view
+    std::vector<MultiDeviceBufferAndViewBindFlags> GenerateCompatibleMultiDeviceBufferBindFlagCombinations()
+    {
+        std::vector<MultiDeviceBufferAndViewBindFlags> testCases;
+        MultiDeviceBufferAndViewBindFlags flags;
+
+        // When the buffer bind flags are equal to or a superset of the buffer view bind flags, the view is compatible with the buffer
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::Constant;
+        testCases.push_back(flags); 
+        
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        // When the buffer view bind flags are None, they have no effect and should work with any bind flag used by the buffer
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        return testCases;
+    };
+
+    // These combinations should fail during BufferView::Init
+    std::vector<MultiDeviceBufferAndViewBindFlags> GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()
+    {
+        std::vector<MultiDeviceBufferAndViewBindFlags> testCases;
+        MultiDeviceBufferAndViewBindFlags flags;
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        return testCases;
+    }
+
+    std::string MultiDeviceBufferBindFlagsToString(RHI::BufferBindFlags bindFlags)
+    {
+        switch (bindFlags)
+        {
+        case RHI::BufferBindFlags::None:
+            return "None";
+        case RHI::BufferBindFlags::Constant:
+            return "Constant";
+        case RHI::BufferBindFlags::ShaderRead:
+            return "ShaderRead";
+        case RHI::BufferBindFlags::ShaderWrite:
+            return "ShaderWrite";
+        case RHI::BufferBindFlags::ShaderReadWrite:
+            return "ShaderReadWrite";
+        default:
+            AZ_Assert(false, "No string conversion was created for this bind flag setting.")
+            break;
+        }
+
+        return "";
+    }
+
+    std::string GenerateMultiDeviceBufferBindFlagTestCaseName(const ::testing::TestParamInfo<MultiDeviceBufferAndViewBindFlags>& info)
+    {
+        return MultiDeviceBufferBindFlagsToString(info.param.bufferBindFlags) + "BufferWith" + MultiDeviceBufferBindFlagsToString(info.param.viewBindFlags) + "BufferView";
+    }
+
+    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+
+    enum class MultiDeviceParallelGetBufferViewTestCases
+    {
+        Get,
+        GetAndDeferRemoval,
+        GetCreateAndDeferRemoval
+    };
+
+    enum class MultiDeviceParallelGetBufferViewCurrentAction
+    {
+        Get,
+        Create,
+        DeferredRemoval
+    };
+
+    MultiDeviceParallelGetBufferViewCurrentAction ParallelBufferViewGetCurrentAction(const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        switch (testCase)
+        {
+        case MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval:
+            switch (rand() % 2)
+            {
+            case 0:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+            case 1:
+                return MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval;
+            }
+        case MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval:
+            switch (rand() % 3)
+            {
+            case 0:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+            case 1:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Create;
+            case 2:
+                return MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval;
+            }
+        case MultiDeviceParallelGetBufferViewTestCases::Get:
+        default:
+            return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+        }
+    }
+
+    void ParallelGetBufferViewHelper(
+        const size_t& threadCountMax,
+        const uint32_t& bufferViewCount,
+        const uint32_t& iterations,
+        const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        // printf("Testing threads=%zu assetIds=%zu ... ", threadCountMax, assetIdCount);
+
+        AZ::Debug::Timer timer;
+        timer.Stamp();
+
+        // Create the buffer
+        constexpr uint32_t viewSize = 32;
+        constexpr uint32_t maxBufferViewCount = 100;
+        constexpr uint32_t bufferSize = viewSize * maxBufferViewCount;
+            
+        AZ_Assert(
+            maxBufferViewCount >= bufferViewCount,
+            "This test uses offsets/sizes to create unique BufferViewDescriptors. Ensure the buffer size is large enough to handle the "
+            "number of unique buffer views.");
+
+        RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool;
+        bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+
+        RHI::BufferPoolDescriptor bufferPoolDesc;
+        bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+        bufferPool->Init(deviceMask, bufferPoolDesc);
+
+        RHI::Ptr<RHI::MultiDeviceBuffer> buffer;
+        buffer = aznew RHI::MultiDeviceBuffer;
+
+        RHI::MultiDeviceBufferInitRequest initRequest;
+        initRequest.m_buffer = buffer.get();
+        initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, bufferSize);
+        bufferPool->InitBuffer(initRequest);
+
+        AZStd::vector<RHI::BufferViewDescriptor> viewDescriptors;
+        viewDescriptors.reserve(bufferViewCount);
+        for (uint32_t i = 0; i < bufferViewCount; ++i)
+        {
+            viewDescriptors.push_back(RHI::BufferViewDescriptor::CreateRaw(i * viewSize, viewSize));
+        }
+
+        AZStd::vector<AZStd::vector<RHI::Ptr<RHI::BufferView>>> referenceTable(bufferViewCount);
+
+        AZStd::vector<AZStd::thread> threads;
+        AZStd::mutex mutex;
+        AZStd::mutex referenceTableMutex;
+        AZStd::atomic<int> threadCount((int)threadCountMax);
+        AZStd::condition_variable cv;
+
+        for (size_t i = 0; i < threadCountMax; ++i)
+        {
+            threads.emplace_back(
+                [&threadCount, &cv, &buffer, &viewDescriptors, &referenceTable, &iterations, &testCase, &referenceTableMutex]()
+                {
+                    bool deferRemoval = testCase == MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval ||
+                        testCase == MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval;
+
+                    for (uint32_t i = 0; i < iterations; ++i) // queue up a bunch of work
+                    {
+                        // Pick a random buffer view from a random device to deal with
+                        const size_t index = rand() % viewDescriptors.size();
+                        const int deviceIndex = rand() % deviceCount;
+                        const RHI::BufferViewDescriptor& viewDescriptor = viewDescriptors[index];
+
+                        MultiDeviceParallelGetBufferViewCurrentAction currentAction = ParallelBufferViewGetCurrentAction(testCase);
+
+                        if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Get ||
+                            currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Create)
+                        {
+                            RHI::Ptr<RHI::BufferView> ptr = nullptr;
+                            if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Get)
+                            {
+                                ptr = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(viewDescriptor);
+                                EXPECT_EQ(ptr->GetDescriptor(), viewDescriptor);
+                            }
+                            else if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Create)
+                            {
+                                ptr = RHI::Factory::Get().CreateBufferView();
+                                // Only initialize half of the created references to validated
+                                // that uninitialized views are also threadsafe
+                                if (rand() % 2)
+                                {
+                                    RHI::ResultCode resultCode = ptr->Init(static_cast<const Buffer&>(*buffer->GetDeviceBuffer(deviceIndex)), viewDescriptor);
+                                    EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+                                    EXPECT_EQ(ptr->GetDescriptor(), viewDescriptor);
+                                }
+                            }
+
+                            // Validate the new reference
+                            EXPECT_NE(ptr, nullptr);
+
+                            if (deferRemoval)
+                            {
+                                // If this test case includes deferring the removal,
+                                // keep a reference to the instance alive so it can be removed later
+                                referenceTableMutex.lock();
+                                referenceTable[index].push_back(ptr);
+                                referenceTableMutex.unlock();
+                            }
+                        }
+                        else if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval)
+                        {
+                            // Drop the refcount to zero so the instance will be released
+                            referenceTableMutex.lock();
+                            referenceTable[index].clear();
+                            referenceTableMutex.unlock();
+                        }
+                    }
+
+                    threadCount--;
+                    cv.notify_one();
+                });
+        }
+
+        bool timedOut = false;
+
+        // Used to detect a deadlock.  If we wait for more than 10 seconds, it's likely a deadlock has occurred
+        while (threadCount > 0 && !timedOut)
+        {
+            AZStd::unique_lock<AZStd::mutex> lock(mutex);
+            timedOut =
+                (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + AZStd::chrono::seconds(1)));
+        }
+
+        EXPECT_TRUE(threadCount == 0) << "One or more threads appear to be deadlocked at " << timer.GetDeltaTimeInSeconds()
+                                      << " seconds";
+
+        for (auto& thread : threads)
+        {
+            thread.join();
+        }
+
+        // printf("Took %f seconds\n", timer.GetDeltaTimeInSeconds());
+    }
+
+    void ParallelGetBufferViewTest(const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        // This is the original test scenario from when InstanceDatabase was first implemented
+        //                           threads, bufferViews,  seconds
+        ParallelGetBufferViewHelper(8, 100, 5, testCase);
+
+        // This value is checked in as 1 so this test doesn't take too much time, but can be increased locally to soak the test.
+        const size_t attempts = 1;
+
+        for (size_t i = 0; i < attempts; ++i)
+        {
+            // printf("Attempt %zu of %zu... \n", i, attempts);
+
+            // The idea behind this series of tests is that there are two threads sharing one bufferView, and both threads try to
+            // create or release that view at the same time.
+            const uint32_t iterations = 1000;
+            //                           threads, AssetIds, iterations
+            ParallelGetBufferViewHelper(2, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 1, iterations, testCase);
+            // printf("Attempt %zu of %zu... \n", i, attempts);
+
+            // Here we try a bunch of different threadCount:bufferViewCount ratios to be thorough
+            //                           threads, views, iterations
+            ParallelGetBufferViewHelper(2, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 2, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 4, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 2, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 3, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 4, iterations, testCase);
+        }
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_Get)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::Get);
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_GetAndDeferRemoval)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval);
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_GetCreateAndDeferRemoval)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval);
+    }
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/MultiDeviceImagePool.h>
+#include <Atom/RHI/ResourceInvalidateBus.h>
+#include <Tests/Device.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceImageTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceImageTests()
+            : MultiDeviceRHITestFixture()
+        {}
+
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceImageTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceImage> noopImage;
+        noopImage = aznew RHI::MultiDeviceImage;
+    }
+
+    TEST_F(MultiDeviceImageTests, TestAll)
+    {
+        RHI::Ptr<RHI::MultiDeviceImage> imageA;
+        imageA = aznew RHI::MultiDeviceImage;
+        imageA->SetName(Name("ImageA"));
+
+        ASSERT_TRUE(imageA->GetName().GetStringView() == "ImageA");
+        ASSERT_TRUE(imageA->use_count() == 1);
+
+        {
+            RHI::Ptr<RHI::MultiDeviceImage> imageB;
+            imageB = aznew RHI::MultiDeviceImage;
+
+            ASSERT_TRUE(imageB->use_count() == 1);
+
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePool;
+            imagePool = aznew RHI::MultiDeviceImagePool;
+
+            ASSERT_TRUE(imagePool->use_count() == 1);
+
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
+            imagePool->Init(deviceMask, imagePoolDesc);
+
+            ASSERT_TRUE(imageA->IsInitialized() == false);
+            ASSERT_TRUE(imageB->IsInitialized() == false);
+
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = imageA.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 16, 16, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+            ASSERT_TRUE(imageA->use_count() == 1);
+
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex) 
+            {
+                RHI::Ptr<RHI::ImageView> imageView;
+                imageView = imageA->GetDeviceImage(deviceIndex)->GetImageView(RHI::ImageViewDescriptor(RHI::Format::R8G8B8A8_UINT));
+                AZ_TEST_ASSERT(imageView->IsStale() == false);
+                ASSERT_TRUE(imageView->IsInitialized());
+                ASSERT_TRUE(imageA->GetDeviceImage(deviceIndex)->use_count() == 2);
+            }
+
+            ASSERT_TRUE(imageA->use_count() == 1);
+            ASSERT_TRUE(imageA->IsInitialized());
+
+            initRequest.m_image = imageB.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 8, 8, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+
+            ASSERT_TRUE(imageB->IsInitialized());
+
+            ASSERT_TRUE(imageA->GetPool() == imagePool.get());
+            ASSERT_TRUE(imageB->GetPool() == imagePool.get());
+            ASSERT_TRUE(imagePool->GetResourceCount() == 2);
+
+            {
+                uint32_t imageIndex = 0;
+
+                const RHI::MultiDeviceImage* images[] =
+                {
+                    imageA.get(),
+                    imageB.get()
+                };
+
+                imagePool->ForEach<RHI::MultiDeviceImage>([&imageIndex, &images]([[maybe_unused]] const RHI::MultiDeviceImage& image)
+                {
+                    AZ_UNUSED(images); // Prevent unused warning in release builds
+                    AZ_Assert(images[imageIndex] == &image, "images don't match");
+                    imageIndex++;
+                });
+            }
+
+            imageB->Shutdown();
+            ASSERT_TRUE(imageB->GetPool() == nullptr);
+
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePoolB;
+            imagePoolB = aznew RHI::MultiDeviceImagePool;
+            imagePoolB->Init(deviceMask, imagePoolDesc);
+
+            initRequest.m_image = imageB.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 8, 8, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePoolB->InitImage(initRequest);
+            ASSERT_TRUE(imageB->GetPool() == imagePoolB.get());
+
+            //Since we are switching imagePools for imageB it adds a refcount and invalidates the views.
+            //We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            imagePoolB->Shutdown();
+            ASSERT_TRUE(imagePoolB->GetResourceCount() == 0);
+        }
+
+        ASSERT_TRUE(imageA->GetPool() == nullptr);
+        ASSERT_TRUE(imageA->use_count() == 1);
+    }
+
+    TEST_F(MultiDeviceImageTests, TestViews)
+    {
+        RHI::Ptr<RHI::ImageView> imageViewA;
+        
+        {
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePool;
+            imagePool = aznew RHI::MultiDeviceImagePool;
+
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
+            imagePool->Init(deviceMask, imagePoolDesc);
+
+            RHI::Ptr<RHI::MultiDeviceImage> image;
+            image = aznew RHI::MultiDeviceImage;
+
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = image.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2DArray(RHI::ImageBindFlags::Color, 8, 8, 2, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+
+            // Should report initialized and not stale.
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(RHI::ImageViewDescriptor{});
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+                AZ_TEST_ASSERT(imageViewA->IsFullView());
+            }
+
+            // Should report as still initialized and also stale.
+            image->Shutdown();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+            
+
+            // Should *still* report as stale since resource invalidation events are queued.
+            imagePool->InitImage(initRequest);
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Explicit invalidation should mark it stale.
+            image->InvalidateViews();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Test re-initialization.
+            RHI::ImageViewDescriptor imageViewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 0, 0, 0);
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDesc);
+                AZ_TEST_ASSERT(imageViewA->IsFullView() == false);
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Test re-initialization.
+            imageViewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 0, 0, 1);
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDesc);
+                AZ_TEST_ASSERT(imageViewA->IsFullView());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+        }
+
+        // The parent image was shut down. This should report as being stale.
+        AZ_TEST_ASSERT(imageViewA->IsStale());
+    }
+
+    struct MultiDeviceImageAndViewBindFlags
+    {
+        RHI::ImageBindFlags imageBindFlags;
+        RHI::ImageBindFlags viewBindFlags;
+    };
+
+    class MultiDeviceImageBindFlagTests
+        : public MultiDeviceImageTests
+        , public ::testing::WithParamInterface <MultiDeviceImageAndViewBindFlags>
+    {
+    public:
+        void SetUp() override
+        {
+            MultiDeviceImageTests::SetUp();
+
+            // Create a pool and image with the image bind flags from the parameterized test
+            m_imagePool = aznew RHI::MultiDeviceImagePool;
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = GetParam().imageBindFlags;
+            m_imagePool->Init(deviceMask, imagePoolDesc);
+
+            RHI::ImageDescriptor imageDescriptor;
+            imageDescriptor.m_bindFlags = GetParam().imageBindFlags;
+
+            m_image = aznew RHI::MultiDeviceImage;
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = m_image.get();
+            initRequest.m_descriptor = imageDescriptor;
+            m_imagePool->InitImage(initRequest);
+        }
+
+        void TearDown() override
+        {
+            m_imagePool.reset();
+            m_image.reset();
+            m_imageView.reset();
+            
+            MultiDeviceImageTests::TearDown();
+        }
+
+        RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
+        RHI::Ptr<RHI::MultiDeviceImage> m_image;
+        RHI::Ptr<RHI::ImageView> m_imageView;
+    };
+
+    TEST_P(MultiDeviceImageBindFlagTests, InitView_ViewIsCreated)
+    {
+        RHI::ImageViewDescriptor imageViewDescriptor;
+        imageViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            m_imageView = m_image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor);
+            EXPECT_EQ(m_imageView.get()!=nullptr, true);
+        }
+    }
+
+
+    // This test fixture is the same as MultiDeviceImageBindFlagTests, but exists separately so that
+    // we can instantiate different test cases that are expected to fail
+    class MultiDeviceImageBindFlagFailureCases
+        : public MultiDeviceImageBindFlagTests
+    {
+
+    };
+
+    TEST_P(MultiDeviceImageBindFlagFailureCases, InitView_ViewIsNotCreated)
+    {
+        RHI::ImageViewDescriptor imageViewDescriptor;
+        imageViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            m_imageView = m_image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor);
+            EXPECT_EQ(m_imageView.get()==nullptr, true);
+        }
+    }
+
+    // These combinations should result in a successful creation of the image view
+    std::vector<MultiDeviceImageAndViewBindFlags> GenerateCompatibleMultiDeviceImageBindFlagCombinations()
+    {
+        std::vector<MultiDeviceImageAndViewBindFlags> testCases;
+        MultiDeviceImageAndViewBindFlags flags;
+
+        // When the image bind flags are equal to or a superset of the image view bind flags, the view is compatible with the image
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::Color;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        // When the image view bind flags are None, they have no effect and should work with any bind flag used by the image
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        return testCases;
+    };
+
+    // These combinations should fail during ImageView::Init
+    std::vector<MultiDeviceImageAndViewBindFlags> GenerateIncompatibleMultiDeviceImageBindFlagCombinations()
+    {
+        std::vector<MultiDeviceImageAndViewBindFlags> testCases;
+        MultiDeviceImageAndViewBindFlags flags;
+
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        return testCases;
+    }
+
+    std::string MultiDeviceImageBindFlagsToString(RHI::ImageBindFlags bindFlags)
+    {
+        switch (bindFlags)
+        {
+        case RHI::ImageBindFlags::None:
+            return "None";
+        case RHI::ImageBindFlags::Color:
+            return "Color";
+        case RHI::ImageBindFlags::ShaderRead:
+            return "ShaderRead";
+        case RHI::ImageBindFlags::ShaderWrite:
+            return "ShaderWrite";
+        case RHI::ImageBindFlags::ShaderReadWrite:
+            return "ShaderReadWrite";
+        default:
+            AZ_Assert(false, "No string conversion was created for this bind flag setting.");
+        }
+
+        return "";
+    }
+
+    std::string GenerateMultiDeviceImageBindFlagTestCaseName(const ::testing::TestParamInfo<MultiDeviceImageAndViewBindFlags>& info)
+    {
+        return MultiDeviceImageBindFlagsToString(info.param.imageBindFlags) + "ImageWith" + MultiDeviceImageBindFlagsToString(info.param.viewBindFlags) + "ImageView";
+    }
+
+    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+}

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferSignature.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
+#include <Tests/Buffer.h>
+#include <Tests/Device.h>
+#include <Tests/IndirectBuffer.h>
+
+#include <Atom/RHI.Reflect/ReflectSystemComponent.h>
+
+#include <AzCore/Serialization/ObjectStream.h>
+#include <AzCore/Serialization/Utils.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceIndirectBufferTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceIndirectBufferTests()
+            : MultiDeviceRHITestFixture()
+        {
+        }
+
+        ~MultiDeviceIndirectBufferTests()
+        {
+        }
+
+    private:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+
+            m_serializeContext = AZStd::make_unique<SerializeContext>();
+            RHI::ReflectSystemComponent::Reflect(m_serializeContext.get());
+            AZ::Name::Reflect(m_serializeContext.get());
+
+            m_commands.clear();
+            m_commands.push_back(RHI::IndirectCommandType::RootConstants);
+            m_commands.push_back(RHI::IndirectBufferViewArguments{ s_vertexSlotIndex });
+            m_commands.push_back(RHI::IndirectCommandType::IndexBufferView);
+            m_commands.push_back(RHI::IndirectCommandType::DrawIndexed);
+
+            m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+            RHI::BufferPoolDescriptor poolDesc;
+            poolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+            m_bufferPool->Init(deviceMask, poolDesc);
+
+            m_buffer = aznew AZ::RHI::MultiDeviceBuffer;
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = m_buffer.get();
+            initRequest.m_descriptor.m_byteCount = m_writerCommandStride * m_writerNumCommands;
+            initRequest.m_descriptor.m_bindFlags = poolDesc.m_bindFlags;
+            m_bufferPool->InitBuffer(initRequest);
+
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            m_writerSignature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    GetByteStrideInternal())
+                    .WillRepeatedly(testing::Return(m_writerCommandStride));
+            }
+        }
+
+        void TearDown() override
+        {
+            m_buffer.reset();
+            m_bufferPool.reset();
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    ShutdownInternal())
+                    .Times(1);
+            }
+
+            m_writerSignature.reset();
+
+            m_serializeContext.reset();
+            MultiDeviceRHITestFixture::TearDown();
+        }
+
+    protected:
+        RHI::IndirectBufferLayout CreateUnfinalizedLayout()
+        {
+            RHI::IndirectBufferLayout layout;
+            for (const auto& descriptor : m_commands)
+            {
+                EXPECT_TRUE(layout.AddIndirectCommand(descriptor));
+            }
+            return layout;
+        }
+
+        RHI::IndirectBufferLayout CreateFinalizedLayout()
+        {
+            auto layout = CreateUnfinalizedLayout();
+            EXPECT_TRUE(layout.Finalize());
+            return layout;
+        }
+
+        RHI::IndirectBufferLayout CreateSerializedLayout(const RHI::IndirectBufferLayout& layout)
+        {
+            AZStd::vector<char, AZ::OSStdAllocator> buffer;
+            AZ::IO::ByteContainerStream<AZStd::vector<char, AZ::OSStdAllocator>> outStream(&buffer);
+
+            {
+                AZ::ObjectStream* objStream = AZ::ObjectStream::Create(&outStream, *m_serializeContext.get(), AZ::ObjectStream::ST_BINARY);
+
+                bool writeOK = objStream->WriteClass(&layout);
+                EXPECT_TRUE(writeOK);
+
+                bool finalizeOK = objStream->Finalize();
+                EXPECT_TRUE(finalizeOK);
+            }
+
+            outStream.Seek(0, IO::GenericStream::ST_SEEK_BEGIN);
+
+            AZ::ObjectStream::FilterDescriptor filterDesc;
+            RHI::IndirectBufferLayout deserializedLayout;
+            bool deserializedOK = AZ::Utils::LoadObjectFromStreamInPlace<RHI::IndirectBufferLayout>(
+                outStream, deserializedLayout, m_serializeContext.get(), filterDesc);
+            EXPECT_TRUE(deserializedOK);
+            return deserializedLayout;
+        }
+
+        void ValidateLayout(const RHI::IndirectBufferLayout& layout)
+        {
+            EXPECT_TRUE(layout.IsFinalized());
+            auto layoutCommands = layout.GetCommands();
+            EXPECT_EQ(m_commands.size(), layoutCommands.size());
+            for (uint32_t i = 0; i < m_commands.size(); ++i)
+            {
+                EXPECT_EQ(m_commands[i], layoutCommands[i]);
+                EXPECT_EQ(layout.FindCommandIndex(m_commands[i]), RHI::IndirectCommandIndex(i));
+            }
+        }
+
+        RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> CreateInitializedSignature()
+        {
+            using namespace ::testing;
+            auto signature = aznew AZ::RHI::MultiDeviceIndirectBufferSignature;
+            m_signatureDescriptor.m_layout = CreateFinalizedLayout();
+            EXPECT_EQ(signature->Init(deviceMask, m_signatureDescriptor), RHI::ResultCode::Success);
+
+            return signature;
+        }
+
+        RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> CreateUnInitializedSignature()
+        {
+            auto signature = aznew AZ::RHI::MultiDeviceIndirectBufferSignature;
+            return signature;
+        }
+
+        RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> CreateInitializedWriter()
+        {
+            auto writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, m_writerCommandStride, m_writerNumCommands, *m_writerSignature),
+                RHI::ResultCode::Success);
+            return writer;
+        }
+
+        void ValidateSignature(const RHI::MultiDeviceIndirectBufferSignature& signature)
+        {
+            ValidateLayout(signature.GetLayout());
+            EXPECT_TRUE(signature.IsInitialized());
+        }
+
+        void ValidateWriter(const AZ::RHI::MultiDeviceIndirectBufferWriter& writer)
+        {
+            auto currentSequenceIndices{ writer.GetCurrentSequenceIndex() };
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(
+                    static_cast<IndirectBufferWriter*>(writer.GetDeviceIndirectBufferWriter(deviceIndex).get())->GetData(),
+                    static_cast<const uint8_t*>(static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->GetData().data()));
+
+                EXPECT_EQ(currentSequenceIndices[deviceIndex], 0);
+                EXPECT_TRUE(static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->IsMapped());
+            }
+        }
+
+        static const uint32_t s_vertexSlotIndex = 3;
+        AZStd::vector<RHI::IndirectCommandDescriptor> m_commands;
+
+        AZStd::unique_ptr<SerializeContext> m_serializeContext;
+        RHI::MultiDeviceIndirectBufferSignatureDescriptor m_signatureDescriptor;
+
+        RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_buffer;
+
+        size_t m_writerOffset = 0;
+        uint32_t m_writerCommandStride = 2;
+        uint32_t m_writerNumCommands = 1024;
+
+        RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> m_writerSignature;
+    };
+
+    TEST_F(MultiDeviceIndirectBufferTests, TestSignature)
+    {
+        // Normal initialization
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            EXPECT_TRUE(signature != nullptr);
+            ValidateSignature(*signature);
+        }
+
+        // ! Cannot tests this as we do not have access to device signatures here and cannot setup mock-call
+        // // Failure initializing.
+        // {
+        //     auto signature = CreateUnInitializedSignature();
+        //     RHI::MultiDeviceIndirectBufferSignatureDescriptor descriptor;
+        //     EXPECT_TRUE(signature->Init(deviceMask, descriptor) == RHI::ResultCode::InvalidOperation);
+        //     EXPECT_FALSE(signature->IsInitialized());
+        // }
+
+        // GetByteStride()
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            uint32_t byteStride = 1337;
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(signature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    GetByteStrideInternal())
+                    .Times(1)
+                    .WillOnce(testing::Return(byteStride));
+            }
+            EXPECT_EQ(signature->GetByteStride(), byteStride);
+        }
+
+        // GetByteStride() on uninitialized signature.
+        {
+            auto signature = CreateUnInitializedSignature();
+            // ! Do not have access to members, cannot setup mock-call
+            // EXPECT_CALL(*signature, GetByteStrideInternal()).Times(1).WillOnce(testing::Return(0));
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            signature->GetByteStride();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // GetOffset()
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            uint32_t offset = 1337;
+            RHI::IndirectCommandIndex index(m_commands.size() - 1);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(signature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    GetOffsetInternal(index))
+                    .Times(1)
+                    .WillOnce(testing::Return(offset));
+            }
+            EXPECT_EQ(signature->GetOffset(index), offset);
+        }
+
+        // GetOffset with null index
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            RHI::IndirectCommandIndex index = RHI::IndirectCommandIndex::Null;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            signature->GetOffset(index);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // GetOffset with invalid index
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            RHI::IndirectCommandIndex index(m_commands.size());
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            signature->GetOffset(index);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Shutdown
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            auto signature = CreateInitializedSignature();
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(signature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    ShutdownInternal())
+                    .Times(1);
+            }
+        }
+    }
+
+    TEST_F(MultiDeviceIndirectBufferTests, TestWriter)
+    {
+        // Normal Initialization
+        {
+            auto writer = CreateInitializedWriter();
+            EXPECT_TRUE(writer != nullptr);
+            ValidateWriter(*writer);
+        }
+
+        // Initialization with invalid size
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, 1, m_writerCommandStride, m_writerNumCommands, *m_writerSignature),
+                RHI::ResultCode::InvalidArgument);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Initialization with invalid stride
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, 0, m_writerNumCommands, *m_writerSignature), RHI::ResultCode::InvalidArgument);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Initialization with invalid max num sequences
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, m_writerCommandStride, 0, *m_writerSignature), RHI::ResultCode::InvalidArgument);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Initialization with small invalid stride
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, m_writerCommandStride - 1, m_writerNumCommands, *m_writerSignature),
+                RHI::ResultCode::InvalidArgument);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Initialization with invalid signature
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            auto signature = CreateUnInitializedSignature();
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, m_writerCommandStride, m_writerNumCommands, *signature),
+                RHI::ResultCode::InvalidArgument);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Initialization with offset
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            size_t offset = 16;
+            EXPECT_EQ(writer->Init(*m_buffer, offset, m_writerCommandStride, 5, *m_writerSignature), RHI::ResultCode::Success);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(
+                    static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get())->GetData(),
+                    static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->GetData().data() + offset);
+            }
+        }
+
+        // Initialization with memory pointer
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            EXPECT_EQ(
+                writer->Init(
+                    const_cast<uint8_t*>(
+                        static_cast<Buffer*>(m_buffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex).get())->GetData().data()),
+                    m_writerCommandStride,
+                    m_writerNumCommands,
+                    *m_writerSignature),
+                RHI::ResultCode::Success);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(
+                    static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get())->GetData(),
+                    static_cast<Buffer*>(m_buffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex).get())->GetData().data());
+            }
+        }
+
+        // Double Init
+        {
+            auto writer = CreateInitializedWriter();
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            EXPECT_EQ(
+                writer->Init(*m_buffer, m_writerOffset, m_writerCommandStride, m_writerNumCommands, *m_writerSignature),
+                RHI::ResultCode::InvalidOperation);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Valid Seek
+        {
+            auto writer = CreateInitializedWriter();
+            uint32_t seekPos = 2;
+            EXPECT_TRUE(writer->Seek(seekPos));
+            {
+                auto currentSequenceIndex{ writer->GetCurrentSequenceIndex() };
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    EXPECT_EQ(currentSequenceIndex[deviceIndex], seekPos);
+                }
+            }
+
+            seekPos += 6;
+            EXPECT_TRUE(writer->Seek(seekPos));
+            {
+                auto currentSequenceIndex{ writer->GetCurrentSequenceIndex() };
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    EXPECT_EQ(currentSequenceIndex[deviceIndex], seekPos);
+                }
+            }
+        }
+
+        // Invalid Seek
+        {
+            auto writer = CreateInitializedWriter();
+            EXPECT_FALSE(writer->Seek(m_writerNumCommands + 1));
+            {
+                auto currentSequenceIndex{ writer->GetCurrentSequenceIndex() };
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    EXPECT_EQ(currentSequenceIndex[deviceIndex], 0);
+                }
+            }
+        }
+
+        // Valid NextSequence
+        {
+            auto writer = CreateInitializedWriter();
+            EXPECT_TRUE(writer->NextSequence());
+            {
+                auto currentSequenceIndex{ writer->GetCurrentSequenceIndex() };
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    EXPECT_EQ(currentSequenceIndex[deviceIndex], 1);
+                }
+            }
+        }
+
+        // Invalid NextSequence
+        {
+            auto writer = CreateInitializedWriter();
+            EXPECT_TRUE(writer->Seek(m_writerNumCommands - 1));
+            EXPECT_FALSE(writer->NextSequence());
+            {
+                auto currentSequenceIndex{ writer->GetCurrentSequenceIndex() };
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    EXPECT_EQ(currentSequenceIndex[deviceIndex], m_writerNumCommands - 1);
+                }
+            }
+        }
+
+        // Valid Command
+        {
+            auto writer = CreateInitializedWriter();
+            for (const auto& command : m_commands)
+            {
+                switch (command.m_type)
+                {
+                case RHI::IndirectCommandType::VertexBufferView:
+                    {
+                        auto index = m_signatureDescriptor.m_layout.FindCommandIndex(RHI::IndirectBufferViewArguments{ s_vertexSlotIndex });
+                        EXPECT_FALSE(index.IsNull());
+                        AZ::RHI::MultiDeviceStreamBufferView bufferView(*m_buffer, 0, 12, 10);
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get()),
+                                SetVertexViewInternal(index, testing::_))
+                                .Times(1);
+                        writer->SetVertexView(s_vertexSlotIndex, bufferView);
+                        break;
+                    }
+                case RHI::IndirectCommandType::IndexBufferView:
+                    {
+                        auto index = m_signatureDescriptor.m_layout.FindCommandIndex(command.m_type);
+                        EXPECT_FALSE(index.IsNull());
+                        AZ::RHI::MultiDeviceIndexBufferView indexView(*m_buffer, 0, 12, RHI::IndexFormat::Uint16);
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get()),
+                                SetIndexViewInternal(index, testing::_))
+                                .Times(1);
+                        writer->SetIndexView(indexView);
+                        break;
+                    }
+                case RHI::IndirectCommandType::DrawIndexed:
+                    {
+                        auto index = m_signatureDescriptor.m_layout.FindCommandIndex(command.m_type);
+                        EXPECT_FALSE(index.IsNull());
+                        AZ::RHI::DrawIndexed arguments(1, 2, 3, 4, 5);
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get()),
+                                DrawIndexedInternal(index, testing::_))
+                                .Times(1);
+                        writer->DrawIndexed(arguments);
+                        break;
+                    }
+                case RHI::IndirectCommandType::RootConstants:
+                    {
+                        auto index = m_signatureDescriptor.m_layout.FindCommandIndex(command.m_type);
+                        EXPECT_FALSE(index.IsNull());
+                        size_t rootConstant;
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferSignature*>(
+                                    m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                                GetOffsetInternal(index))
+                                .Times(1)
+                                .WillOnce(testing::Return(0));
+
+                        auto nextIndex = RHI::IndirectCommandIndex(index.GetIndex() + 1);
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferSignature*>(
+                                    m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                                GetOffsetInternal(nextIndex))
+                                .Times(1)
+                                .WillOnce(testing::Return(static_cast<uint32_t>(sizeof(rootConstant))));
+
+                        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                            EXPECT_CALL(
+                                *static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get()),
+                                SetRootConstantsInternal(index, reinterpret_cast<uint8_t*>(&rootConstant), sizeof(rootConstant)))
+                                .Times(1);
+                        writer->SetRootConstants(reinterpret_cast<uint8_t*>(&rootConstant), sizeof(rootConstant));
+                        break;
+                    }
+                default:
+                    break;
+                }
+            }
+        }
+
+        // Invalid command
+        {
+            auto writer = CreateInitializedWriter();
+            RHI::DispatchDirect args;
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            writer->Dispatch(args);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+        }
+
+        // Write command on uninitialized writer
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> writer = aznew AZ::RHI::MultiDeviceIndirectBufferWriter;
+            ;
+            AZ::RHI::DrawIndexed arguments(1, 2, 3, 4, 5);
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            writer->DrawIndexed(arguments);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        // Flush
+        {
+            auto writer = CreateInitializedWriter();
+            writer->Flush();
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_FALSE(static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->IsMapped());
+            AZ::RHI::MultiDeviceIndexBufferView indexView(*m_buffer, 0, 12, RHI::IndexFormat::Uint16);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get()),
+                    SetIndexViewInternal(testing::_, testing::_))
+                    .Times(1);
+            writer->SetIndexView(indexView);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_TRUE(static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->IsMapped());
+        }
+
+        // Inline Constants Command with incorrect size
+        {
+            auto writer = CreateInitializedWriter();
+            auto findIt = AZStd::find_if(
+                m_commands.begin(),
+                m_commands.end(),
+                [](const auto& element)
+                {
+                    return element.m_type == RHI::IndirectCommandType::RootConstants;
+                });
+            EXPECT_NE(findIt, m_commands.end());
+            auto commandIndex = m_writerSignature->GetLayout().FindCommandIndex(*findIt);
+            EXPECT_FALSE(commandIndex.IsNull());
+            auto nextCommandIndex = RHI::IndirectCommandIndex(commandIndex.GetIndex() + 1);
+            uint32_t commandOffsett = 12;
+            uint32_t nextCommandOffset = 16;
+
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    GetOffsetInternal(commandIndex))
+                    .Times(1)
+                    .WillOnce(testing::Return(commandOffsett));
+
+                EXPECT_CALL(
+                    *static_cast<IndirectBufferSignature*>(m_writerSignature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
+                    GetOffsetInternal(nextCommandIndex))
+                    .Times(1)
+                    .WillOnce(testing::Return(nextCommandOffset));
+            }
+
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            uint64_t data;
+            writer->SetRootConstants(reinterpret_cast<uint8_t*>(&data), sizeof(data));
+            AZ_TEST_STOP_TRACE_SUPPRESSION(deviceCount);
+        }
+
+        // Shutdown
+        {
+            auto writer = CreateInitializedWriter();
+            writer->Shutdown();
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_FALSE(static_cast<Buffer*>(m_buffer->GetDeviceBuffer(deviceIndex).get())->IsMapped());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_TRUE(
+                    static_cast<IndirectBufferWriter*>(writer->GetDeviceIndirectBufferWriter(deviceIndex).get())->GetData() == nullptr);
+        }
+    }
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDevicePipelineStateTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDevicePipelineStateTests.cpp
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+
+#include <Tests/Device.h>
+#include <Tests/ThreadTester.h>
+
+#include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/MultiDevicePipelineLibrary.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineStateCache.h>
+
+#include <AzCore/Math/Random.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDevicePipelineStateTests : public MultiDeviceRHITestFixture
+    {
+        static const uint32_t s_heapSizeMB = 64;
+
+    protected:
+        void ScrambleMemory(void* memory, size_t size, uint32_t seed)
+        {
+            SimpleLcgRandom random(seed);
+
+            uint8_t* bytes = reinterpret_cast<uint8_t*>(memory);
+
+            for (size_t i = 0; i < size; ++i)
+            {
+                bytes[i] = static_cast<uint8_t>(random.GetRandom());
+            }
+        }
+
+        // Generates random render state. Everything else is left empty or default as much as possible,
+        // but we do touch-up the data to make sure we don't end up with something that will fail assertions.
+        // The point here is to create a unique descriptor that will have a unique hash value.
+        RHI::PipelineStateDescriptorForDraw CreatePipelineStateDescriptor(uint32_t randomSeed)
+        {
+            RHI::PipelineStateDescriptorForDraw desc;
+            desc.m_inputStreamLayout.SetTopology(RHI::PrimitiveTopology::TriangleList);
+            desc.m_inputStreamLayout.Finalize();
+            desc.m_pipelineLayoutDescriptor = m_pipelineLayout;
+
+            ScrambleMemory(&desc.m_renderStates, sizeof(RHI::RenderStates), randomSeed++);
+
+            desc.m_renderStates.m_depthStencilState.m_depth.m_enable = true;
+            auto& renderAttachmentLayout = desc.m_renderAttachmentConfiguration.m_renderAttachmentLayout;
+            renderAttachmentLayout.m_attachmentCount = 2;
+            renderAttachmentLayout.m_attachmentFormats[0] = RHI::Format::R32_FLOAT;
+            renderAttachmentLayout.m_attachmentFormats[1] = RHI::Format::R8G8B8A8_SNORM;
+            renderAttachmentLayout.m_subpassCount = 1;
+            renderAttachmentLayout.m_subpassLayouts[0].m_rendertargetCount = 1;
+            renderAttachmentLayout.m_subpassLayouts[0].m_rendertargetDescriptors[0] =
+                RHI::RenderAttachmentDescriptor{ 1, RHI::InvalidRenderAttachmentIndex, RHI::AttachmentLoadStoreAction() };
+            renderAttachmentLayout.m_subpassLayouts[0].m_depthStencilDescriptor =
+                RHI::RenderAttachmentDescriptor{ 0, RHI::InvalidRenderAttachmentIndex, RHI::AttachmentLoadStoreAction() };
+            desc.m_renderAttachmentConfiguration.m_subpassIndex = 0;
+            return desc;
+        }
+
+        void ValidateCacheIntegrity([[maybe_unused]] RHI::Ptr<RHI::PipelineStateCache>& cache) const
+        {
+            EXPECT_TRUE(false);
+            /*
+            TODO: Once cache becomes multi-device, add that back in and also add MultiDevicePipelienStateTests as friend class to
+            PipelineStateCache
+             */
+            // cache->ValidateCacheIntegrity();
+        }
+
+    private:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+
+            m_pipelineLayout = RHI::PipelineLayoutDescriptor::Create();
+            m_pipelineLayout->Finalize();
+        }
+
+        void TearDown() override
+        {
+            m_pipelineLayout = nullptr;
+            MultiDeviceRHITestFixture::TearDown();
+        }
+
+        RHI::Ptr<RHI::PipelineLayoutDescriptor> m_pipelineLayout;
+    };
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineState_CreateEmpty_Test)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineState> empty = aznew RHI::MultiDevicePipelineState;
+        EXPECT_NE(empty.get(), nullptr);
+        EXPECT_FALSE(empty->IsInitialized());
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineState_Init_Test)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineState> pipelineState = aznew RHI::MultiDevicePipelineState;
+        RHI::ResultCode resultCode = pipelineState->Init(deviceMask, CreatePipelineStateDescriptor(0));
+        EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+
+        // Second init should fail and throw validation error.
+        AZ_TEST_START_ASSERTTEST;
+        resultCode = pipelineState->Init(deviceMask, CreatePipelineStateDescriptor(0));
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineState_Init_Subpass)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineState> pipelineState = aznew RHI::MultiDevicePipelineState;
+        auto descriptor = CreatePipelineStateDescriptor(0);
+        descriptor.m_renderAttachmentConfiguration.m_subpassIndex = 1337;
+        AZ_TEST_START_ASSERTTEST;
+        RHI::ResultCode resultCode = pipelineState->Init(deviceMask, descriptor);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineState_Init_SubpassInput)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineState> pipelineState = aznew RHI::MultiDevicePipelineState;
+        auto descriptor = CreatePipelineStateDescriptor(0);
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0].m_subpassInputCount = 1;
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0]
+            .m_subpassInputDescriptors[0]
+            .m_attachmentIndex = 1;
+        RHI::ResultCode resultCode = pipelineState->Init(deviceMask, descriptor);
+        EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+
+        AZ_TEST_START_ASSERTTEST;
+        pipelineState = aznew RHI::MultiDevicePipelineState;
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0]
+            .m_subpassInputDescriptors[0]
+            .m_attachmentIndex = 3;
+        resultCode = pipelineState->Init(deviceMask, descriptor);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineState_Init_Resolve)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineState> pipelineState = aznew RHI::MultiDevicePipelineState;
+        auto descriptor = CreatePipelineStateDescriptor(0);
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0]
+            .m_rendertargetDescriptors[0]
+            .m_resolveAttachmentIndex = 1;
+        RHI::ResultCode resultCode = pipelineState->Init(deviceMask, descriptor);
+        EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+
+        AZ_TEST_START_ASSERTTEST;
+        pipelineState = aznew RHI::MultiDevicePipelineState;
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0]
+            .m_rendertargetDescriptors[0]
+            .m_resolveAttachmentIndex = 5;
+        resultCode = pipelineState->Init(deviceMask, descriptor);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+
+        AZ_TEST_START_ASSERTTEST;
+        pipelineState = aznew RHI::MultiDevicePipelineState;
+        descriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout.m_subpassLayouts[0]
+            .m_rendertargetDescriptors[0]
+            .m_resolveAttachmentIndex = 0;
+        resultCode = pipelineState->Init(deviceMask, descriptor);
+        AZ_TEST_STOP_ASSERTTEST(1);
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineLibrary_CreateEmpty_Test)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineLibrary> empty = aznew RHI::MultiDevicePipelineLibrary;
+        EXPECT_NE(empty.get(), nullptr);
+        EXPECT_FALSE(empty->IsInitialized());
+
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(empty->MergeInto({}), RHI::ResultCode::InvalidOperation);
+        EXPECT_EQ(empty->GetSerializedData(), nullptr);
+        AZ_TEST_STOP_ASSERTTEST(2);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineLibrary_Init_Test)
+    {
+        RHI::Ptr<RHI::MultiDevicePipelineLibrary> pipelineLibrary = aznew RHI::MultiDevicePipelineLibrary;
+        AZ_TEST_START_ASSERTTEST; // Suppress asserts from default constructed library descriptor
+        RHI::ResultCode resultCode = pipelineLibrary->Init(deviceMask, RHI::MultiDevicePipelineLibraryDescriptor{});
+        AZ_TEST_STOP_ASSERTTEST(deviceCount);
+        EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+
+        // Second init should fail and throw validation error.
+        AZ_TEST_START_ASSERTTEST;
+        resultCode = pipelineLibrary->Init(deviceMask, RHI::MultiDevicePipelineLibraryDescriptor{});
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        EXPECT_EQ(resultCode, RHI::ResultCode::InvalidOperation);
+    }
+
+    // TODO: PipelineStateCache will become a Multi-device Object in subsequent commits, add these tests then alongside
+    /*
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineStateCache_Init_Test)
+    {
+        RHI::Ptr<RHI::PipelineStateCache> pipelineStateCache =
+    RHI::PipelineStateCache::Create(AZ::RHI::RHISystemInterface::Get()->GetDevice());
+
+        AZStd::array<RHI::MultiDevicePipelineLibraryHandle, RHI::PipelineStateCache::LibraryCountMax> handles;
+        for (size_t i = 0; i < handles.size(); ++i)
+        {
+            for(auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+                handles[i] = pipelineStateCache->CreateLibrary(nullptr);
+
+            EXPECT_TRUE(handles[i].IsValid());
+
+            for (size_t j = 0; j < i; ++j)
+            {
+                EXPECT_NE(handles[i], handles[j]);
+            }
+        }
+
+        // Creating more than the maximum number of libraries should assert but still function.
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(pipelineStateCache->CreateLibrary(nullptr), RHI::MultiDevicePipelineLibraryHandle{});
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Reset should no-op.
+        pipelineStateCache->Reset();
+
+        for (size_t i = 0; i < handles.size(); ++i)
+        {
+            pipelineStateCache->ResetLibrary(handles[i]);
+            pipelineStateCache->ReleaseLibrary(handles[i]);
+        }
+
+        // Test free-list by allocating another set of libraries.
+
+        for (size_t i = 0; i < handles.size(); ++i)
+        {
+            handles[i] = pipelineStateCache->CreateLibrary(nullptr);
+            EXPECT_FALSE(handles[i].IsNull());
+        }
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineStateCache_NullHandle_Test)
+    {
+        RHI::Ptr<RHI::PipelineStateCache> pipelineStateCache = RHI::PipelineStateCache::Create(deviceMask);
+
+        // Calling library methods with a null handle should early out.
+        pipelineStateCache->ResetLibrary({});
+        pipelineStateCache->ReleaseLibrary({});
+        EXPECT_EQ(pipelineStateCache->GetMergedLibrary({}), nullptr);
+        EXPECT_EQ(pipelineStateCache->AcquirePipelineState({}, CreatePipelineStateDescriptor(0)), nullptr);
+        pipelineStateCache->Compact();
+        ValidateCacheIntegrity(pipelineStateCache);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineStateCache_PipelineStateThreading_Same_Test)
+    {
+        RHI::Ptr<RHI::PipelineStateCache> pipelineStateCache = RHI::PipelineStateCache::Create(deviceMask);
+
+        static const size_t IterationCountMax = 10000;
+        static const size_t ThreadCountMax = 8;
+
+        RHI::PipelineStateDescriptorForDraw descriptor = CreatePipelineStateDescriptor(0);
+
+        RHI::MultiDevicePipelineLibraryHandle libraryHandle = pipelineStateCache->CreateLibrary(nullptr);
+
+        AZStd::mutex mutex;
+        AZStd::unordered_set<const RHI::PipelineState*> pipelineStatesMerged;
+
+        ThreadTester::Dispatch(
+            ThreadCountMax,
+            [&]([[maybe_unused]] size_t threadIndex)
+            {
+                AZStd::unordered_set<const RHI::PipelineState*> pipelineStates;
+
+                for (size_t i = 0; i < IterationCountMax; ++i)
+                {
+                    pipelineStates.insert(pipelineStateCache->AcquirePipelineState(libraryHandle, descriptor));
+                }
+
+                EXPECT_EQ(pipelineStates.size(), 1);
+                EXPECT_NE(*pipelineStates.begin(), nullptr);
+
+                mutex.lock();
+                pipelineStatesMerged.insert(*pipelineStates.begin());
+                mutex.unlock();
+            });
+
+        pipelineStateCache->Compact();
+        ValidateCacheIntegrity(pipelineStateCache);
+
+        EXPECT_EQ(pipelineStatesMerged.size(), 1);
+    }
+
+    TEST_F(MultiDevicePipelineStateTests, PipelineStateCache_PipelineStateThreading_Fuzz_Test)
+    {
+        RHI::Ptr<RHI::PipelineStateCache> pipelineStateCache = RHI::PipelineStateCache::Create(deviceMask);
+
+        static const size_t CycleIterationCountMax = 4;
+        static const size_t AcquireIterationCountMax = 2000;
+        static const size_t ThreadCountMax = 4;
+        static const size_t PipelineStateCountMax = 128;
+        static const size_t LibraryCountMax = 2;
+
+        AZStd::vector<RHI::PipelineStateDescriptorForDraw> descriptors;
+        descriptors.reserve(PipelineStateCountMax);
+        for (size_t i = 0; i < PipelineStateCountMax; ++i)
+        {
+            descriptors.push_back(CreatePipelineStateDescriptor(static_cast<uint32_t>(i)));
+        }
+
+        AZStd::vector<RHI::MultiDevicePipelineLibraryHandle> libraryHandles;
+        for (size_t i = 0; i < LibraryCountMax; ++i)
+        {
+            libraryHandles.push_back(pipelineStateCache->CreateLibrary(nullptr));
+        }
+
+        AZStd::mutex mutex;
+
+        for (size_t cycleIndex = 0; cycleIndex < CycleIterationCountMax; ++cycleIndex)
+        {
+            for (size_t libraryIndex = 0; libraryIndex < LibraryCountMax; ++libraryIndex)
+            {
+                RHI::MultiDevicePipelineLibraryHandle libraryHandle = libraryHandles[libraryIndex];
+
+                AZStd::unordered_set<const RHI::PipelineState*> pipelineStatesMerged;
+
+                ThreadTester::Dispatch(
+                    ThreadCountMax,
+                    [&](size_t threadIndex)
+                    {
+                        SimpleLcgRandom random(threadIndex);
+
+                        AZStd::unordered_set<const RHI::PipelineState*> pipelineStates;
+
+                        for (size_t i = 0; i < AcquireIterationCountMax; ++i)
+                        {
+                            size_t descriptorIndex = random.GetRandom() % descriptors.size();
+
+                            pipelineStates.emplace(pipelineStateCache->AcquirePipelineState(libraryHandle,
+                            descriptors[descriptorIndex]));
+                        }
+
+                        mutex.lock();
+                        for (const RHI::PipelineState* pipelineState : pipelineStates)
+                        {
+                            pipelineStatesMerged.emplace(pipelineState);
+                        }
+                        mutex.unlock();
+                    });
+
+                EXPECT_EQ(pipelineStatesMerged.size(), PipelineStateCountMax);
+            }
+
+            pipelineStateCache->Compact();
+            ValidateCacheIntegrity(pipelineStateCache);
+
+            // Halfway through, reset the caches.
+
+            if (cycleIndex == (CycleIterationCountMax / 2))
+            {
+                pipelineStateCache->Reset();
+            }
+        }
+    }
+
+    */
+
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <AzCore/std/containers/bitset.h>
+#include <Tests/Device.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceQueryTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceQueryTests()
+            : MultiDeviceRHITestFixture()
+        {
+        }
+
+    private:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceQueryTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceQuery> noopQuery;
+        noopQuery = aznew RHI::MultiDeviceQuery;
+        AZ_TEST_ASSERT(noopQuery);
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> noopQueryPool;
+        noopQueryPool = aznew RHI::MultiDeviceQueryPool;
+        AZ_TEST_ASSERT(noopQueryPool);
+    }
+
+    TEST_F(MultiDeviceQueryTests, Test)
+    {
+        RHI::Ptr<RHI::MultiDeviceQuery> queryA;
+        queryA = aznew RHI::MultiDeviceQuery;
+
+        queryA->SetName(Name("QueryA"));
+        AZ_TEST_ASSERT(queryA->GetName().GetStringView() == "QueryA");
+        AZ_TEST_ASSERT(queryA->use_count() == 1);
+
+        {
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+
+            EXPECT_EQ(1, queryPool->use_count());
+
+            RHI::Ptr<RHI::MultiDeviceQuery> queryB;
+            queryB = aznew RHI::MultiDeviceQuery;
+            EXPECT_EQ(1, queryB->use_count());
+
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 2;
+            queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+            queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+            queryPool->Init(deviceMask, queryPoolDesc);
+
+            EXPECT_FALSE(queryA->IsInitialized());
+            EXPECT_FALSE(queryB->IsInitialized());
+
+            queryPool->InitQuery(queryA.get());
+
+            EXPECT_EQ(1, queryA->use_count());
+            EXPECT_TRUE(queryA->IsInitialized());
+
+            queryPool->InitQuery(queryB.get());
+
+            EXPECT_TRUE(queryB->IsInitialized());
+
+            EXPECT_EQ(queryA->GetPool(), queryPool.get());
+            EXPECT_EQ(queryB->GetPool(), queryPool.get());
+            EXPECT_EQ(queryPool->GetResourceCount(), 2);
+
+            {
+                uint32_t queryIndex = 0;
+
+                const RHI::MultiDeviceQuery* queries[] = { queryA.get(), queryB.get() };
+
+                queryPool->ForEach<RHI::MultiDeviceQuery>(
+                    [&queryIndex, &queries]([[maybe_unused]] RHI::MultiDeviceQuery& query)
+                    {
+                        AZ_UNUSED(queries); // Prevent unused warning in release builds
+                        AZ_Assert(queries[queryIndex] == &query, "Queries don't match");
+                        queryIndex++;
+                    });
+            }
+
+            queryB->Shutdown();
+            EXPECT_EQ(queryB->GetPool(), nullptr);
+
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPoolB;
+            queryPoolB = aznew RHI::MultiDeviceQueryPool;
+            queryPoolB->Init(deviceMask, queryPoolDesc);
+
+            queryPoolB->InitQuery(queryB.get());
+            EXPECT_EQ(queryB->GetPool(), queryPoolB.get());
+
+            // Since we are switching queryPool for queryB it adds a refcount and invalidates the views.
+            // We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            queryPoolB->Shutdown();
+            EXPECT_EQ(queryPoolB->GetResourceCount(), 0);
+        }
+
+        EXPECT_EQ(queryA->GetPool(), nullptr);
+        EXPECT_EQ(queryA->use_count(), 1);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestAllocations)
+    {
+        static const uint32_t numQueries = 10;
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQuery>, numQueries> queries;
+        for (auto& query : queries)
+        {
+            query = aznew RHI::MultiDeviceQuery;
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = numQueries;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        queryPool->Init(deviceMask, queryPoolDesc);
+
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToInitialize(numQueries);
+        for (size_t i = 0; i < queries.size(); ++i)
+        {
+            queriesToInitialize[i] = queries[i].get();
+        }
+
+        RHI::ResultCode result = queryPool->InitQuery(queriesToInitialize.data(), static_cast<uint32_t>(queriesToInitialize.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+        auto checkSlotsFunc = [](const AZStd::vector<RHI::MultiDeviceQuery*>& queries)
+        {
+            if (queries.size() < 2)
+            {
+                return true;
+            }
+
+            AZStd::vector<uint32_t> indices;
+            for (auto& query : queries)
+            {
+                indices.push_back(query->GetHandle(AZ::RHI::MultiDevice::DefaultDeviceIndex).GetIndex());
+            }
+
+            AZStd::sort(indices.begin(), indices.end());
+            for (size_t i = 0; i < indices.size() - 1; ++i)
+            {
+                if (indices[i] != (indices[i + 1] + 1))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        checkSlotsFunc(queriesToInitialize);
+
+        RHI::Ptr<RHI::MultiDeviceQuery> extraQuery = aznew RHI::MultiDeviceQuery;
+        EXPECT_EQ(queryPool->InitQuery(extraQuery.get()), RHI::ResultCode::OutOfMemory);
+        AZ_TEST_ASSERT(!extraQuery->IsInitialized());
+
+        AZStd::vector<uint32_t> queriesIndicesToShutdown = { 5, 6 };
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToShutdown;
+        for (auto& index : queriesIndicesToShutdown)
+        {
+            queries[index]->Shutdown();
+            queriesToShutdown.push_back(queries[index].get());
+        }
+
+        EXPECT_EQ(queryPool->GetResourceCount(), numQueries - static_cast<uint32_t>(queriesIndicesToShutdown.size()));
+
+        result = queryPool->InitQuery(queriesToShutdown.data(), static_cast<uint32_t>(queriesIndicesToShutdown.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+        checkSlotsFunc(queriesToShutdown);
+
+        queriesIndicesToShutdown = { 2, 5, 9 };
+        queriesToShutdown.clear();
+        for (auto& index : queriesIndicesToShutdown)
+        {
+            queries[index]->Shutdown();
+            queriesToShutdown.push_back(queries[index].get());
+        }
+
+        EXPECT_EQ(queryPool->GetResourceCount(), (numQueries - static_cast<uint32_t>(queriesIndicesToShutdown.size())));
+
+        result = queryPool->InitQuery(queriesToShutdown.data(), static_cast<uint32_t>(queriesToShutdown.size()));
+
+        // Since we are switching queryPools for some queries it adds a refcount and invalidates the views.
+        // We need to ensure the views are fully invalidated in order to release the refcount and avoid leaks.
+        RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+        checkSlotsFunc(queriesToInitialize);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestIntervals)
+    {
+        static const uint32_t numQueries = 10;
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQuery>, numQueries> queries;
+        for (auto& query : queries)
+        {
+            query = aznew RHI::MultiDeviceQuery;
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = numQueries;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        queryPool->Init(deviceMask, queryPoolDesc);
+
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToInitialize(numQueries);
+        for (size_t i = 0; i < queries.size(); ++i)
+        {
+            queriesToInitialize[i] = queries[i].get();
+        }
+
+        RHI::ResultCode result = queryPool->InitQuery(queriesToInitialize.data(), static_cast<uint32_t>(queriesToInitialize.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+
+        uint64_t results[numQueries * deviceCount] = {};
+
+        for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            auto* testQueryPool = static_cast<UnitTest::QueryPool*>(queryPool->GetDeviceQueryPool(deviceIndex).get());
+            auto& testQueryPoolIntervals = testQueryPool->m_calledIntervals;
+            testQueryPoolIntervals.clear();
+
+            EXPECT_EQ(queryPool->GetResults(results, numQueries, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+
+            EXPECT_EQ(testQueryPoolIntervals.size(), 1);
+            EXPECT_EQ(testQueryPoolIntervals.front(), RHI::Interval(0, numQueries - 1));
+
+            testQueryPoolIntervals.clear();
+            auto* queryToTest = queries[5].get();
+            EXPECT_EQ(queryPool->GetResults(queryToTest, results, 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+
+            EXPECT_EQ(testQueryPoolIntervals.size(), 1);
+            EXPECT_EQ(
+                testQueryPoolIntervals.front(),
+                RHI::Interval(queryToTest->GetHandle(deviceIndex).GetIndex(), queryToTest->GetHandle(deviceIndex).GetIndex()));
+
+            AZStd::vector<RHI::Interval> intervalsToTest = { RHI::Interval(5, 5), RHI::Interval(0, 3), RHI::Interval(8, 9) };
+            AZStd::vector<RHI::MultiDeviceQuery*> queriesToTest;
+            for (auto& interval : intervalsToTest)
+            {
+                for (uint32_t i = interval.m_min; i <= interval.m_max; ++i)
+                {
+                    queriesToTest.push_back(queries[i].get());
+                }
+            }
+            testQueryPoolIntervals.clear();
+            EXPECT_EQ(
+                queryPool->GetResults(
+                    queriesToTest.data(), static_cast<uint32_t>(queriesToTest.size()), results, numQueries, RHI::QueryResultFlagBits::None),
+                RHI::ResultCode::Success);
+            EXPECT_EQ(testQueryPoolIntervals.size(), intervalsToTest.size());
+            for (auto& interval : intervalsToTest)
+            {
+                auto foundIt = AZStd::find(testQueryPoolIntervals.begin(), testQueryPoolIntervals.end(), interval);
+                EXPECT_NE(foundIt, testQueryPoolIntervals.end());
+            }
+        }
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestQuery)
+    {
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQueryPool>, RHI::QueryTypeCount> queryPools;
+        for (size_t i = 0; i < queryPools.size(); ++i)
+        {
+            auto& queryPool = queryPools[i];
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 1;
+            queryPoolDesc.m_type = static_cast<RHI::QueryType>(i);
+            queryPoolDesc.m_pipelineStatisticsMask = queryPoolDesc.m_type == RHI::QueryType::PipelineStatistics
+                ? RHI::PipelineStatisticsFlags::CInvocations
+                : RHI::PipelineStatisticsFlags::None;
+            queryPool->Init(deviceMask, queryPoolDesc);
+        }
+
+        auto& occlusionQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::Occlusion)];
+        auto& timestampQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::Timestamp)];
+        auto& statisticsQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::PipelineStatistics)];
+
+        uint64_t data;
+        RHI::CommandList& dummyCommandList = reinterpret_cast<RHI::CommandList&>(data);
+
+        // Correct begin and end for occlusion
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            EXPECT_EQ(occlusionQueryPool->InitQuery(query.get()), RHI::ResultCode::Success);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList), RHI::ResultCode::Success);
+                EXPECT_EQ(query->GetDeviceQuery(deviceIndex)->End(dummyCommandList), RHI::ResultCode::Success);
+            }
+        }
+
+        // Double Begin
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList);
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // End without Begin
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->End(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // End with another command list
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            uint64_t anotherData;
+            RHI::CommandList& anotherDummyCmdList = reinterpret_cast<RHI::CommandList&>(anotherData);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(RHI::ResultCode::Success, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::InvalidArgument, query->GetDeviceQuery(deviceIndex)->End(anotherDummyCmdList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid flag
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            statisticsQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(
+                    RHI::ResultCode::InvalidArgument,
+                    query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList, RHI::QueryControlFlags::PreciseOcclusion));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid Begin for Timestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid End for Timestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->End(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid WriteTimestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->WriteTimestamp(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Correct WriteTimestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(RHI::ResultCode::Success, query->GetDeviceQuery(deviceIndex)->WriteTimestamp(dummyCommandList));
+            }
+        }
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestQueryPoolInitialization)
+    {
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = 0;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        // Count of 0
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPool->Init(deviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // valid m_pipelineStatisticsMask for Occlusion QueryType
+        queryPoolDesc.m_queriesCount = 1;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::CInvocations;
+        EXPECT_EQ(queryPool->Init(deviceMask, queryPoolDesc), RHI::ResultCode::Success);
+
+        // invalid m_pipelineStatisticsMask for PipelineStatistics QueryType
+        queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPool->Init(deviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestResults)
+    {
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQueryPool>, 2> queryPools;
+        RHI::PipelineStatisticsFlags mask = RHI::PipelineStatisticsFlags::CInvocations | RHI::PipelineStatisticsFlags::CPrimitives |
+            RHI::PipelineStatisticsFlags::IAPrimitives;
+        for (auto& queryPool : queryPools)
+        {
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 2;
+            queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
+            queryPoolDesc.m_pipelineStatisticsMask = mask;
+            EXPECT_EQ(queryPool->Init(deviceMask, queryPoolDesc), RHI::ResultCode::Success);
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+        uint32_t numPipelineStatistics = RHI::CountBitsSet(static_cast<uint64_t>(mask));
+        AZStd::vector<uint64_t> results(numPipelineStatistics * 2 * deviceCount);
+        // Using uninitialized query
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(3);
+
+        // Wrong size for results count.
+        queryPools[0]->InitQuery(query.get());
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPools[0]->GetResults(results.data(), 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Using a query from another pool
+        RHI::Ptr<RHI::MultiDeviceQuery> anotherQuery = aznew RHI::MultiDeviceQuery;
+        queryPools[1]->InitQuery(anotherQuery.get());
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(anotherQuery.get(), results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Results count is too small
+        anotherQuery->Shutdown();
+        queryPools[0]->InitQuery(anotherQuery.get());
+        RHI::MultiDeviceQuery* queries[] = { query.get(), anotherQuery.get() };
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Correct usage
+        EXPECT_EQ(
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics * 5, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::Success);
+
+        // Unsorted queries
+        {
+            const size_t numQueries = 5;
+            AZStd::array<RHI::Ptr<AZ::RHI::MultiDeviceQuery>, numQueries> queries2;
+            AZStd::vector<uint64_t> results2(numQueries * deviceCount);
+
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 5;
+            queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+            EXPECT_EQ(queryPool->Init(deviceMask, queryPoolDesc), RHI::ResultCode::Success);
+
+            for (size_t i = 0; i < queries2.size(); ++i)
+            {
+                queries2[i] = aznew RHI::MultiDeviceQuery;
+                queryPool->InitQuery(queries2[i].get());
+            }
+
+            AZStd::array<RHI::MultiDeviceQuery*, numQueries> queriesPtr = {
+                queries2[2].get(), queries2[0].get(), queries2[1].get(), queries2[3].get(), queries2[4].get()
+            };
+            EXPECT_EQ(
+                queryPool->GetResults(queriesPtr.data(), numQueries, results2.data(), numQueries, RHI::QueryResultFlagBits::None),
+                RHI::ResultCode::Success);
+            for (uint32_t i = 0; i < numQueries; ++i)
+            {
+                EXPECT_EQ(results2[i], queriesPtr[i]->GetHandle(AZ::RHI::MultiDevice::DefaultDeviceIndex).GetIndex());
+            }
+        }
+
+        // Since we are switching queryPools for some queries it adds a refcount and invalidates the views.
+        // We need to ensure the views are fully invalidated in order to release the refcount and avoid leaks.
+        RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+    }
+
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
@@ -1,0 +1,889 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI.Reflect/ReflectSystemComponent.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupData.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+#include <AzCore/Math/Matrix3x3.h>
+#include <AzCore/Math/Matrix3x4.h>
+#include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector4.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/ObjectStream.h>
+#include <AzCore/Serialization/Utils.h>
+#include <Tests/Device.h>
+#include <Tests/ShaderResourceGroup.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceShaderResourceGroupTests : public MultiDeviceRHITestFixture
+    {
+    private:
+        struct NestedData
+        {
+            float m_x;
+            float m_y;
+            float m_z;
+        };
+
+        struct ConstantBufferTest
+        {
+            float m_floatValue;
+            uint32_t m_uintValue[3];
+            float m_float4Value[4];
+            NestedData m_nestedData[16];
+            AZ::Matrix3x3 m_matrix3x3;
+            AZ::Matrix4x4 m_matrix4x4;
+            AZ::Matrix3x4 m_matrix3x4;
+            AZ::Vector2 m_vector2;
+            AZ::Vector3 m_vector3;
+            AZ::Vector4 m_vector4;
+        };
+
+        const uint32_t ImageReadCount = 5;
+        const uint32_t ImageReadWriteCount = 8;
+        const uint32_t BufferConstantCount = 2;
+        const uint32_t BufferReadCount = 2;
+        const uint32_t BufferReadWriteCount = 2;
+
+        AZStd::unique_ptr<SerializeContext> m_serializeContext;
+
+    public:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+
+            m_serializeContext = AZStd::make_unique<SerializeContext>();
+
+            RHI::ReflectSystemComponent::Reflect(m_serializeContext.get());
+
+            AZ::Name::Reflect(m_serializeContext.get());
+        }
+
+        void TearDown() override
+        {
+            m_serializeContext.reset();
+            MultiDeviceRHITestFixture::TearDown();
+        }
+
+        RHI::ConstPtr<RHI::ShaderResourceGroupLayout> CreateLayout()
+        {
+            RHI::Ptr<RHI::ShaderResourceGroupLayout> layout = RHI::ShaderResourceGroupLayout::Create();
+            layout->SetBindingSlot(0);
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{
+                Name("m_floatValue"), offsetof(ConstantBufferTest, m_floatValue), sizeof(ConstantBufferTest::m_floatValue), 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{
+                Name("m_uintValue"), offsetof(ConstantBufferTest, m_uintValue), sizeof(ConstantBufferTest::m_uintValue), 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{
+                Name("m_float4Value"), offsetof(ConstantBufferTest, m_float4Value), sizeof(ConstantBufferTest::m_float4Value), 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{
+                Name("m_nestedData"), offsetof(ConstantBufferTest, m_nestedData), sizeof(ConstantBufferTest::m_nestedData), 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{
+                Name("m_matrix3x3"),
+                offsetof(ConstantBufferTest, m_matrix3x3),
+                44,
+                0,
+                0 }); // Shader packs rows into 4 floats not 3, but doesn't include the last float on the last row, hence 44
+            layout->AddShaderInput(
+                RHI::ShaderInputConstantDescriptor{ Name("m_matrix4x4"), offsetof(ConstantBufferTest, m_matrix4x4), 64, 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputConstantDescriptor{ Name("m_matrix3x4"),
+                                                                       offsetof(ConstantBufferTest, m_matrix3x4),
+                                                                       48,
+                                                                       0,
+                                                                       0 }); // Shader packs rows into 4 floats not 3, hence its 48
+            layout->AddShaderInput(
+                RHI::ShaderInputConstantDescriptor{ Name("m_vector2"), offsetof(ConstantBufferTest, m_vector2), 8, 0, 0 });
+            layout->AddShaderInput(
+                RHI::ShaderInputConstantDescriptor{ Name("m_vector3"), offsetof(ConstantBufferTest, m_vector3), 12, 0, 0 });
+            layout->AddShaderInput(
+                RHI::ShaderInputConstantDescriptor{ Name("m_vector4"), offsetof(ConstantBufferTest, m_vector4), 16, 0, 0 });
+            layout->AddShaderInput(RHI::ShaderInputImageDescriptor{
+                Name("m_readImage"), RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, ImageReadCount, 1, 1 });
+            layout->AddShaderInput(RHI::ShaderInputImageDescriptor{ Name("m_readWriteImage"),
+                                                                    RHI::ShaderInputImageAccess::ReadWrite,
+                                                                    RHI::ShaderInputImageType::Image2D,
+                                                                    ImageReadWriteCount,
+                                                                    2,
+                                                                    2 });
+            layout->AddShaderInput(RHI::ShaderInputBufferDescriptor{ Name("m_constantBuffer"),
+                                                                     RHI::ShaderInputBufferAccess::Constant,
+                                                                     RHI::ShaderInputBufferType::Constant,
+                                                                     BufferConstantCount,
+                                                                     UINT_MAX,
+                                                                     3,
+                                                                     3 });
+            layout->AddShaderInput(RHI::ShaderInputBufferDescriptor{ Name("m_readBuffer"),
+                                                                     RHI::ShaderInputBufferAccess::Read,
+                                                                     RHI::ShaderInputBufferType::Structured,
+                                                                     BufferReadCount,
+                                                                     UINT_MAX,
+                                                                     4,
+                                                                     4 });
+            layout->AddShaderInput(RHI::ShaderInputBufferDescriptor{ Name("m_readWriteBuffer"),
+                                                                     RHI::ShaderInputBufferAccess::ReadWrite,
+                                                                     RHI::ShaderInputBufferType::Typed,
+                                                                     BufferReadWriteCount,
+                                                                     UINT_MAX,
+                                                                     5,
+                                                                     5 });
+            layout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                Name("m_sampler"), RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+
+            bool success = layout->Finalize();
+            if (!success)
+            {
+                return nullptr;
+            }
+
+            return layout;
+        }
+
+        void CreateSerializedLayout(RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& serializedSrgLayout)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            AZStd::vector<char, AZ::OSStdAllocator> srgBuffer;
+            AZ::IO::ByteContainerStream<AZStd::vector<char, AZ::OSStdAllocator>> outStream(&srgBuffer);
+
+            {
+                AZ::ObjectStream* objStream = AZ::ObjectStream::Create(&outStream, *m_serializeContext.get(), AZ::ObjectStream::ST_BINARY);
+
+                bool writeOK = objStream->WriteClass(srgLayout.get());
+                ASSERT_TRUE(writeOK);
+
+                bool finalizeOK = objStream->Finalize();
+                ASSERT_TRUE(finalizeOK);
+            }
+
+            outStream.Seek(0, IO::GenericStream::ST_SEEK_BEGIN);
+
+            AZ::ObjectStream::FilterDescriptor filterDesc;
+            serializedSrgLayout =
+                AZ::Utils::LoadObjectFromStream<RHI::ShaderResourceGroupLayout>(outStream, m_serializeContext.get(), filterDesc);
+        }
+
+        void TestShaderResourceGroupLayout()
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+            TestShaderResourceGroupReflection(srgLayout);
+        }
+
+        void TestShaderResourceGroupLayoutSerialized()
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout;
+            CreateSerializedLayout(srgLayout);
+            TestShaderResourceGroupReflection(srgLayout);
+        }
+
+        void TestShaderResourceGroupPools()
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            {
+                RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> srgA = aznew AZ::RHI::MultiDeviceShaderResourceGroup;
+
+                {
+                    RHI::Ptr<RHI::MultiDeviceShaderResourceGroupPool> srgPool = aznew AZ::RHI::MultiDeviceShaderResourceGroupPool;
+
+                    RHI::ShaderResourceGroupPoolDescriptor descriptor;
+                    descriptor.m_budgetInBytes = 16;
+                    descriptor.m_layout = srgLayout.get();
+
+                    ASSERT_FALSE(srgPool->IsInitialized());
+                    srgPool->Init(deviceMask, descriptor);
+                    ASSERT_TRUE(srgPool->IsInitialized());
+                    srgPool->Shutdown();
+                    ASSERT_FALSE(srgPool->IsInitialized());
+                    srgPool->Init(deviceMask, descriptor);
+                    ASSERT_TRUE(srgPool->IsInitialized());
+                    ASSERT_TRUE(srgPool->use_count() == 1);
+
+                    ASSERT_TRUE(srgLayout->use_count() == (3 + deviceCount));
+
+                    RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> srgB = aznew AZ::RHI::MultiDeviceShaderResourceGroup;
+                    ASSERT_TRUE(srgA->GetPool() == nullptr);
+
+                    srgPool->InitGroup(*srgA);
+                    ASSERT_TRUE(srgA->IsInitialized());
+                    ASSERT_TRUE(srgA->GetPool() == srgPool.get());
+                    ASSERT_TRUE(srgPool->GetResourceCount() == 1);
+                    srgA->Shutdown();
+                    ASSERT_TRUE(srgPool->GetResourceCount() == 0);
+                    ASSERT_TRUE(srgA->IsInitialized() == false);
+                    ASSERT_TRUE(srgA->GetPool() == nullptr);
+                    srgPool->InitGroup(*srgA);
+                    ASSERT_TRUE(srgA->IsInitialized());
+                    ASSERT_TRUE(srgA->GetPool() == srgPool.get());
+                    srgPool->InitGroup(*srgB);
+
+                    // Called to flush Resource::InvalidateViews() which has an increment/decrement for the use_count
+                    RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+                    ASSERT_TRUE(srgA->use_count() == 1);
+                    ASSERT_TRUE(srgB->use_count() == 1);
+                    ASSERT_TRUE(srgPool->GetResourceCount() == 2);
+
+                    {
+                        uint32_t srgIndex = 0;
+
+                        const RHI::MultiDeviceShaderResourceGroup* srgs[] = { srgA.get(), srgB.get() };
+
+                        srgPool->ForEach<RHI::MultiDeviceShaderResourceGroup>(
+                            [&srgIndex, &srgs](const RHI::MultiDeviceShaderResourceGroup& srg)
+                            {
+                                ASSERT_TRUE(srgs[srgIndex] == &srg);
+                                srgIndex++;
+                            });
+                    }
+                }
+
+                ASSERT_TRUE(srgA->IsInitialized() == false);
+                ASSERT_TRUE(srgA->GetPool() == nullptr);
+            }
+
+            ASSERT_TRUE(srgLayout->use_count() == 1);
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> noopShaderResourceGroup = aznew AZ::RHI::MultiDeviceShaderResourceGroup;
+        }
+
+        void TestShaderResourceGroupReflection(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            EXPECT_EQ(srgLayout->GetGroupSizeForImages(), ImageReadCount + ImageReadWriteCount);
+            EXPECT_EQ(srgLayout->GetGroupSizeForBuffers(), BufferConstantCount + BufferReadCount + BufferReadWriteCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputImageIndex(0)).m_min, 0);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputImageIndex(0)).m_max, ImageReadCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputImageIndex(1)).m_min, ImageReadCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputImageIndex(1)).m_max, ImageReadCount + ImageReadWriteCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(0)).m_min, 0);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(0)).m_max, BufferConstantCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(1)).m_min, BufferConstantCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(1)).m_max, BufferConstantCount + BufferReadCount);
+            EXPECT_EQ(srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(2)).m_min, BufferConstantCount + BufferReadCount);
+            EXPECT_EQ(
+                srgLayout->GetGroupInterval(RHI::ShaderInputBufferIndex(2)).m_max,
+                BufferConstantCount + BufferReadCount + BufferReadWriteCount);
+            EXPECT_EQ(srgLayout->use_count(), 1);
+
+            RHI::ShaderInputImageIndex imageInputIndex = srgLayout->FindShaderInputImageIndex(Name("m_readImage"));
+            EXPECT_EQ(imageInputIndex.GetIndex(), 0);
+
+            imageInputIndex = srgLayout->FindShaderInputImageIndex(Name("m_readWriteImage"));
+            EXPECT_EQ(imageInputIndex.GetIndex(), 1);
+
+            RHI::ShaderInputBufferIndex bufferInputIndex = srgLayout->FindShaderInputBufferIndex(Name("m_constantBuffer"));
+            EXPECT_EQ(bufferInputIndex.GetIndex(), 0);
+
+            bufferInputIndex = srgLayout->FindShaderInputBufferIndex(Name("m_readBuffer"));
+            EXPECT_EQ(bufferInputIndex.GetIndex(), 1);
+
+            bufferInputIndex = srgLayout->FindShaderInputBufferIndex(Name("m_readWriteBuffer"));
+            EXPECT_EQ(bufferInputIndex.GetIndex(), 2);
+
+            RHI::ShaderInputConstantIndex floatValueIndex = srgLayout->FindShaderInputConstantIndex(Name("m_floatValue"));
+            ASSERT_TRUE(floatValueIndex.GetIndex() == 0);
+            RHI::ShaderInputConstantIndex uintValueIndex = srgLayout->FindShaderInputConstantIndex(Name("m_uintValue"));
+            ASSERT_TRUE(uintValueIndex.GetIndex() == 1);
+            RHI::ShaderInputConstantIndex float4ValueIndex = srgLayout->FindShaderInputConstantIndex(Name("m_float4Value"));
+            ASSERT_TRUE(float4ValueIndex.GetIndex() == 2);
+            RHI::ShaderInputConstantIndex nestedDataIndex = srgLayout->FindShaderInputConstantIndex(Name("m_nestedData"));
+            ASSERT_TRUE(nestedDataIndex.GetIndex() == 3);
+            RHI::ShaderInputConstantIndex matrix3x3Index = srgLayout->FindShaderInputConstantIndex(Name("m_matrix3x3"));
+            ASSERT_TRUE(matrix3x3Index.GetIndex() == 4);
+            RHI::ShaderInputConstantIndex matrix4x4Index = srgLayout->FindShaderInputConstantIndex(Name("m_matrix4x4"));
+            ASSERT_TRUE(matrix4x4Index.GetIndex() == 5);
+            RHI::ShaderInputConstantIndex matrix3x4Index = srgLayout->FindShaderInputConstantIndex(Name("m_matrix3x4"));
+            ASSERT_TRUE(matrix3x4Index.GetIndex() == 6);
+
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroupPool> srgPool = aznew AZ::RHI::MultiDeviceShaderResourceGroupPool;
+
+            RHI::ShaderResourceGroupPoolDescriptor descriptor;
+            descriptor.m_budgetInBytes = 16;
+            descriptor.m_layout = srgLayout.get();
+            srgPool->Init(deviceMask, descriptor);
+
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> srg = aznew AZ::RHI::MultiDeviceShaderResourceGroup;
+            srgPool->InitGroup(*srg);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData(*srg);
+
+            float floatValue = 1.234f;
+            srgData.SetConstant(floatValueIndex, floatValue);
+
+            AZStd::array<uint32_t, 3> uintValues = { 5, 6, 7 };
+            srgData.SetConstant(uintValueIndex, uintValues);
+
+            AZStd::array<float, 4> float4Values = { 10.1f, 11.2f, 12.3f, 14.4f };
+            srgData.SetConstant(float4ValueIndex, float4Values);
+
+            NestedData nestedData[16];
+            for (uint32_t i = 0; i < 16; ++i)
+            {
+                nestedData[i].m_x = (float)i * 2;
+                nestedData[i].m_y = (float)i * 3;
+                nestedData[i].m_z = (float)i * 4;
+            }
+
+            // Write the first one as a single element.
+            srgData.SetConstantRaw(nestedDataIndex, &nestedData[0], sizeof(NestedData));
+
+            // Write the second one as an element with an offset.
+            srgData.SetConstantRaw(nestedDataIndex, &nestedData[1], sizeof(NestedData), sizeof(NestedData));
+
+            // Write the next 13 as an array.
+            srgData.SetConstantRaw(nestedDataIndex, nestedData + 2, sizeof(NestedData) * 2, sizeof(NestedData) * 13);
+
+            // Write the last one as a single value with an offset.
+            srgData.SetConstantRaw(nestedDataIndex, &nestedData[15], sizeof(NestedData) * 15, sizeof(NestedData));
+
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                float floatValueResult = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex);
+                EXPECT_EQ(floatValueResult, floatValue);
+            }
+
+            const auto ValidateFloat4Values = [&]()
+            {
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                {
+                    AZStd::span<const float> float4ValueResult =
+                        srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<float>(float4ValueIndex);
+                    EXPECT_EQ(float4ValueResult.size(), 4);
+                    EXPECT_EQ(float4ValueResult[0], float4Values[0]);
+                    EXPECT_EQ(float4ValueResult[1], float4Values[1]);
+                    EXPECT_EQ(float4ValueResult[2], float4Values[2]);
+                    EXPECT_EQ(float4ValueResult[3], float4Values[3]);
+                }
+            };
+
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint32_t> uintValuesResult =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<uint32_t>(uintValueIndex);
+                EXPECT_EQ(uintValuesResult.size(), 3);
+                EXPECT_EQ(uintValuesResult[0], uintValues[0]);
+                EXPECT_EQ(uintValuesResult[1], uintValues[1]);
+                EXPECT_EQ(uintValuesResult[2], uintValues[2]);
+
+                AZStd::span<const NestedData> nestedDataResult =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<NestedData>(nestedDataIndex);
+                EXPECT_EQ(nestedDataResult.size(), 16);
+
+                ValidateFloat4Values();
+
+                for (uint32_t i = 0; i < 16; ++i)
+                {
+                    EXPECT_EQ(nestedDataResult[i].m_x, nestedData[i].m_x);
+                    EXPECT_EQ(nestedDataResult[i].m_y, nestedData[i].m_y);
+                    EXPECT_EQ(nestedDataResult[i].m_z, nestedData[i].m_z);
+                }
+            }
+
+            // SetConstant Matrix tests
+            float matrixValue[16] = {
+                1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f
+            };
+
+            // SetConstant matrix of type Matrix3x3
+            const AZ::Matrix3x3& mat3x3Values = AZ::Matrix3x3::CreateFromRowMajorFloat9(matrixValue);
+            srgData.SetConstant(matrix3x3Index, mat3x3Values);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
+
+            // SetConstant matrix of type Matrix3x4
+            const AZ::Matrix3x4& mat3x4Values = AZ::Matrix3x4::CreateFromRowMajorFloat12(matrixValue);
+            srgData.SetConstant(matrix3x4Index, mat3x4Values);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
+
+            // SetConstant matrix of type Matrix4x4
+            const AZ::Matrix4x4& mat4x4Values = AZ::Matrix4x4::CreateFromRowMajorFloat16(matrixValue);
+            srgData.SetConstant(matrix4x4Index, mat4x4Values);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
+
+            // Reset the constant matrix3x4Index with identity
+            srgData.SetConstant(matrix3x4Index, AZ::Matrix3x4::CreateIdentity());
+
+            // SetConstant matrix rows, sets 3 rows from 4x4 matrix (which becomes 3x4 matrix)
+            srgData.SetConstantMatrixRows(matrix3x4Index, mat4x4Values, 3);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
+
+            // Reset the constant matrix3x3Index with identity
+            srgData.SetConstant(matrix3x3Index, AZ::Matrix3x3::CreateIdentity());
+
+            srgData.SetConstantMatrixRows(matrix3x3Index, mat3x3Values, 3);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
+
+            // Reset the constant matrix4x4Index with identity
+            srgData.SetConstant(matrix4x4Index, AZ::Matrix4x4::CreateIdentity());
+
+            srgData.SetConstantMatrixRows(matrix4x4Index, mat4x4Values, 4);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
+
+            // SetConstant
+            {
+                // Attempt to a larger amount of data than is supported.
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstant(floatValueIndex, AZ::Vector4::CreateOne());
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                    EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
+
+                // Attempt to assign a smaller amount of data than is supported.
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstant(floatValueIndex, uint8_t(0));
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+                    EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
+            }
+
+            // SetConstant (ArrayIndex)
+            {
+                // Assign index that overflows array.
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstant(float4ValueIndex, 5.0f, 5);
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                ValidateFloat4Values();
+
+                // Assign index where alignment doesn't match up.
+                struct Test
+                {
+                    uint16_t m_a = 0;
+                    uint16_t m_b = 1;
+                    uint16_t m_c = 2;
+                };
+
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstant(float4ValueIndex, Test(), 1);
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                ValidateFloat4Values();
+
+                // Finally, assign a valid value and make sure it get assigned.
+                float4Values[1] = 99.0f;
+                srgData.SetConstant(float4ValueIndex, float4Values[1], 1);
+                ValidateFloat4Values();
+            }
+
+            // SetConstantArray
+            {
+                // Attempt to a larger amount of data than is supported.
+                float float6Values[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstantArray<float>(float4ValueIndex, { float6Values, AZ_ARRAY_SIZE(float6Values) });
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                ValidateFloat4Values();
+
+                // Attempt to assign a smaller amount of data than is supported.
+                float float1Value[] = { 5.0f };
+                AZ_TEST_START_ASSERTTEST;
+                srgData.SetConstantArray<float>(float4ValueIndex, { float1Value, AZ_ARRAY_SIZE(float1Value) });
+                AZ_TEST_STOP_ASSERTTEST(deviceCount);
+
+                ValidateFloat4Values();
+            }
+        }
+    };
+
+    namespace MultiDevice
+    {
+
+        RHI::MultiDeviceShaderResourceGroupData PrepareSRGData(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroupPool> srgPool = aznew AZ::RHI::MultiDeviceShaderResourceGroupPool;
+
+            RHI::ShaderResourceGroupPoolDescriptor descriptor;
+            descriptor.m_layout = srgLayout.get();
+            srgPool->Init(deviceMask, descriptor);
+
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> srg = aznew AZ::RHI::MultiDeviceShaderResourceGroup;
+            srgPool->InitGroup(*srg);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData(*srg);
+            return srgData;
+        }
+
+        void TestSetConstantVectorsValidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            const RHI::ShaderInputConstantIndex vector2index = srgLayout->FindShaderInputConstantIndex(Name("m_vector2"));
+            EXPECT_EQ(vector2index.GetIndex(), 7);
+            const RHI::ShaderInputConstantIndex vector3index = srgLayout->FindShaderInputConstantIndex(Name("m_vector3"));
+            EXPECT_EQ(vector3index.GetIndex(), 8);
+            const RHI::ShaderInputConstantIndex vector4index = srgLayout->FindShaderInputConstantIndex(Name("m_vector4"));
+            EXPECT_EQ(vector4index.GetIndex(), 9);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData = PrepareSRGData(srgLayout);
+
+            const float vector2values[2] = { 1.0f, 2.0f };
+            const Vector2 vector2 = Vector2::CreateFromFloat2(vector2values);
+
+            const float vector3values[3] = { 3.0f, 4.0f, 5.0f };
+            const Vector3 vector3 = Vector3::CreateFromFloat3(vector3values);
+
+            const float vector4values[4] = { 6.0f, 7.0f, 8.0f, 9.0f };
+            const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
+
+            EXPECT_TRUE(srgData.SetConstant(vector2index, vector2));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resultVector2 =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
+                const Vector2 vector2result = *reinterpret_cast<const Vector2*>(resultVector2.data());
+                EXPECT_EQ(vector2result, vector2);
+            }
+
+            EXPECT_TRUE(srgData.SetConstant(vector3index, vector3));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resutVector3 =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
+                const Vector3 vector3result = *reinterpret_cast<const Vector3*>(resutVector3.data());
+                EXPECT_EQ(vector3result, vector3);
+            }
+
+            EXPECT_TRUE(srgData.SetConstant(vector4index, vector4));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resutVector4 =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector4index);
+                const Vector4 vector4result = *reinterpret_cast<const Vector4*>(resutVector4.data());
+                EXPECT_EQ(vector4result, vector4);
+            }
+        }
+        void TestSetConstantVectorsInvalidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            const RHI::ShaderInputConstantIndex vector2index = srgLayout->FindShaderInputConstantIndex(Name("m_vector2"));
+            EXPECT_EQ(vector2index.GetIndex(), 7);
+            const RHI::ShaderInputConstantIndex vector3index = srgLayout->FindShaderInputConstantIndex(Name("m_vector3"));
+            EXPECT_EQ(vector3index.GetIndex(), 8);
+            const RHI::ShaderInputConstantIndex vector4index = srgLayout->FindShaderInputConstantIndex(Name("m_vector4"));
+            EXPECT_EQ(vector4index.GetIndex(), 9);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData = PrepareSRGData(srgLayout);
+
+            const float vector2values[2] = { 1.0f, 2.0f };
+            const Vector2 vector2 = Vector2::CreateFromFloat2(vector2values);
+
+            const float vector3values[3] = { 1.0f, 2.0f, 3.0f };
+            const Vector3 vector3 = Vector3::CreateFromFloat3(vector3values);
+
+            const float vector4values[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+            const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
+
+            // Reset constant vector2index to zero
+            EXPECT_TRUE(srgData.SetConstant(vector2index, vector2.CreateZero()));
+
+            AZ_TEST_START_ASSERTTEST;
+            EXPECT_FALSE(srgData.SetConstant(vector2index, vector3));
+            AZ_TEST_STOP_ASSERTTEST(deviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resutV3 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
+                const Vector3 v3result = *reinterpret_cast<const Vector3*>(resutV3.data());
+                EXPECT_NE(v3result, vector3);
+            }
+
+            // Reset constant vector3index to zero
+            EXPECT_TRUE(srgData.SetConstant(vector3index, vector3.CreateZero()));
+
+            AZ_TEST_START_ASSERTTEST;
+            EXPECT_FALSE(srgData.SetConstant(vector3index, vector4));
+            AZ_TEST_STOP_ASSERTTEST(deviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resutV4 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
+                const Vector4 v4result = *reinterpret_cast<const Vector4*>(resutV4.data());
+                EXPECT_NE(v4result, vector4);
+            }
+
+            // Reset constant vector4index to zero
+            EXPECT_TRUE(srgData.SetConstant(vector4index, vector4.CreateZero()));
+
+            AZ_TEST_START_ASSERTTEST;
+            EXPECT_FALSE(srgData.SetConstant(vector4index, vector3));
+            AZ_TEST_STOP_ASSERTTEST(deviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZStd::span<const uint8_t> resutV3FromIndex4 =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector4index);
+                const Vector4 v4resultFromIndex4 = *reinterpret_cast<const Vector4*>(resutV3FromIndex4.data());
+                EXPECT_NE(v4resultFromIndex4, vector4);
+            }
+        }
+
+        void TestGetConstantVectorsValidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            const RHI::ShaderInputConstantIndex vector2index = srgLayout->FindShaderInputConstantIndex(Name("m_vector2"));
+            EXPECT_EQ(vector2index.GetIndex(), 7);
+            const RHI::ShaderInputConstantIndex vector3index = srgLayout->FindShaderInputConstantIndex(Name("m_vector3"));
+            EXPECT_EQ(vector3index.GetIndex(), 8);
+            const RHI::ShaderInputConstantIndex vector4index = srgLayout->FindShaderInputConstantIndex(Name("m_vector4"));
+            EXPECT_EQ(vector4index.GetIndex(), 9);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData = PrepareSRGData(srgLayout);
+
+            const float vector2values[2] = { 1.0f, 2.0f };
+            const Vector2 vector2 = Vector2::CreateFromFloat2(vector2values);
+
+            const float vector3values[3] = { 1.0f, 2.0f, 3.0f };
+            const Vector3 vector3 = Vector3::CreateFromFloat3(vector3values);
+
+            const float vector4values[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+            const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
+
+            EXPECT_TRUE(srgData.SetConstantRaw(vector2index, &vector2, 8));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                const Vector2 vector2result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector2>(vector2index);
+                EXPECT_EQ(vector2result, vector2);
+            }
+
+            EXPECT_TRUE(srgData.SetConstantRaw(vector3index, &vector3, 12));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                const Vector3 vector3result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector3>(vector3index);
+                EXPECT_EQ(vector3result, vector3);
+            }
+
+            EXPECT_TRUE(srgData.SetConstantRaw(vector4index, &vector4, 16));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                const Vector4 vector4result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector4>(vector4index);
+                EXPECT_EQ(vector4result, vector4);
+            }
+        }
+        void TestGetConstantVectorsInvalidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
+        {
+            const RHI::ShaderInputConstantIndex vector2index = srgLayout->FindShaderInputConstantIndex(Name("m_vector2"));
+            EXPECT_EQ(vector2index.GetIndex(), 7);
+            const RHI::ShaderInputConstantIndex vector3index = srgLayout->FindShaderInputConstantIndex(Name("m_vector3"));
+            EXPECT_EQ(vector3index.GetIndex(), 8);
+            const RHI::ShaderInputConstantIndex vector4index = srgLayout->FindShaderInputConstantIndex(Name("m_vector4"));
+            EXPECT_EQ(vector4index.GetIndex(), 9);
+
+            RHI::MultiDeviceShaderResourceGroupData srgData = PrepareSRGData(srgLayout);
+
+            const float vector2values[2] = { 1.0f, 2.0f };
+            const Vector2 vector2 = Vector2::CreateFromFloat2(vector2values);
+
+            const float vector3values[3] = { 1.0f, 2.0f, 3.0f };
+            const Vector3 vector3 = Vector3::CreateFromFloat3(vector3values);
+
+            const float vector4values[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+            const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
+
+            // Invalid cases for GetConstant
+            EXPECT_TRUE(srgData.SetConstantRaw(vector2index, &vector2, 8));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                const Vector3 invalidVector3result =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector3>(vector2index);
+                EXPECT_NE(invalidVector3result, vector3);
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+
+            EXPECT_TRUE(srgData.SetConstantRaw(vector3index, &vector3, 12));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                const Vector4 invalidVector4result =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector4>(vector3index);
+                EXPECT_NE(invalidVector4result, vector4);
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+
+            EXPECT_TRUE(srgData.SetConstantRaw(vector4index, &vector4, 16));
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                const Vector2 invalidVector2result =
+                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector2>(vector4index);
+                EXPECT_NE(invalidVector2result, vector2);
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, TestShaderResourceGroupLayout)
+        {
+            TestShaderResourceGroupLayout();
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, TestShaderResourceGroupLayoutSerialized)
+        {
+            TestShaderResourceGroupLayoutSerialized();
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, TestShaderResourceGroupPools)
+        {
+            TestShaderResourceGroupPools();
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataSetConstant_Vectors_ValidOutput)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            TestSetConstantVectorsValidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataSetConstant_Vectors_InvalidOutput)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            TestSetConstantVectorsInvalidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataGetConstant_Vectors_ValidOutput)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            TestGetConstantVectorsValidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataGetConstant_Vectors_InvalidOutput)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout = CreateLayout();
+
+            TestGetConstantVectorsInvalidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataSetConstant_Vectors_ValidOutput_Serialized)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout;
+            CreateSerializedLayout(srgLayout);
+
+            TestSetConstantVectorsValidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataSetConstant_Vectors_InvalidOutput_Serialized)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout;
+            CreateSerializedLayout(srgLayout);
+
+            TestSetConstantVectorsInvalidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataGetConstant_Vectors_ValidOutput_Serialized)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout;
+            CreateSerializedLayout(srgLayout);
+
+            TestGetConstantVectorsValidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, SRGDataGetConstant_Vectors_InvalidOutput_Serialized)
+        {
+            RHI::ConstPtr<RHI::ShaderResourceGroupLayout> srgLayout;
+            CreateSerializedLayout(srgLayout);
+
+            TestGetConstantVectorsInvalidCase(srgLayout);
+        }
+
+        TEST_F(MultiDeviceShaderResourceGroupTests, TestShaderResourceGroupLayoutHash)
+        {
+            const Name imageName("m_image");
+            const Name bufferName("m_buffer");
+            const Name samplerName("m_sampler");
+            const Name constantBufferName("m_constantBuffer");
+
+            RHI::Ptr<RHI::ShaderResourceGroupLayout> layout = RHI::ShaderResourceGroupLayout::Create();
+            layout->SetBindingSlot(0);
+            layout->AddShaderInput(
+                RHI::ShaderInputImageDescriptor{ imageName, RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, 1, 1,
+                1
+                });
+            layout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                bufferName, RHI::ShaderInputBufferAccess::Constant, RHI::ShaderInputBufferType::Constant, 2, UINT_MAX, 3, 3 });
+            layout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                samplerName, RHI::ShaderInputBufferAccess::Read, RHI::ShaderInputBufferType::Structured, 3, UINT_MAX, 4, 4 });
+            layout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                constantBufferName, RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+            EXPECT_TRUE(layout->Finalize());
+
+            {
+                // Test change name of one shader input
+                RHI::Ptr<RHI::ShaderResourceGroupLayout> otherLayout = RHI::ShaderResourceGroupLayout::Create();
+                otherLayout->SetBindingSlot(0);
+                otherLayout->AddShaderInput(RHI::ShaderInputImageDescriptor{
+                    imageName, RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, 1, 1, 1 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    bufferName, RHI::ShaderInputBufferAccess::Constant, RHI::ShaderInputBufferType::Constant, 2, UINT_MAX, 3, 3 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    samplerName, RHI::ShaderInputBufferAccess::Read, RHI::ShaderInputBufferType::Structured, 3, UINT_MAX, 4, 4 });
+                otherLayout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                    Name{ "m_constantBuffer2" }, RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+                EXPECT_TRUE(otherLayout->Finalize());
+                EXPECT_NE(otherLayout->GetHash(), layout->GetHash());
+            }
+
+            {
+                // Test change of binding slot
+                RHI::Ptr<RHI::ShaderResourceGroupLayout> otherLayout = RHI::ShaderResourceGroupLayout::Create();
+                otherLayout->SetBindingSlot(1);
+                otherLayout->AddShaderInput(RHI::ShaderInputImageDescriptor{
+                    imageName, RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, 1, 1, 1 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    bufferName, RHI::ShaderInputBufferAccess::Constant, RHI::ShaderInputBufferType::Constant, 2, UINT_MAX, 3, 3 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    samplerName, RHI::ShaderInputBufferAccess::Read, RHI::ShaderInputBufferType::Structured, 3, UINT_MAX, 4, 4 });
+                otherLayout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                    constantBufferName, RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+                EXPECT_TRUE(otherLayout->Finalize());
+                EXPECT_NE(otherLayout->GetHash(), layout->GetHash());
+            }
+
+            {
+                // Test adding constants
+                RHI::Ptr<RHI::ShaderResourceGroupLayout> otherLayout = RHI::ShaderResourceGroupLayout::Create();
+                otherLayout->SetBindingSlot(0);
+                otherLayout->AddShaderInput(RHI::ShaderInputImageDescriptor{
+                    imageName, RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, 1, 1, 1 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    bufferName, RHI::ShaderInputBufferAccess::Constant, RHI::ShaderInputBufferType::Constant, 2, UINT_MAX, 3, 3 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    samplerName, RHI::ShaderInputBufferAccess::Read, RHI::ShaderInputBufferType::Structured, 3, UINT_MAX, 4, 4 });
+                otherLayout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                    constantBufferName, RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+                otherLayout->AddShaderInput(RHI::ShaderInputConstantDescriptor{ Name("m_floatValue"), 0, 4, 0, 0 });
+                EXPECT_TRUE(otherLayout->Finalize());
+                EXPECT_NE(otherLayout->GetHash(), layout->GetHash());
+            }
+
+            {
+                // Test adding shader variant key fallback
+                RHI::Ptr<RHI::ShaderResourceGroupLayout> otherLayout = RHI::ShaderResourceGroupLayout::Create();
+                otherLayout->SetBindingSlot(0);
+                otherLayout->AddShaderInput(RHI::ShaderInputImageDescriptor{
+                    imageName, RHI::ShaderInputImageAccess::Read, RHI::ShaderInputImageType::Image2D, 1, 1, 1 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    bufferName, RHI::ShaderInputBufferAccess::Constant, RHI::ShaderInputBufferType::Constant, 2, UINT_MAX, 3, 3 });
+                otherLayout->AddShaderInput(RHI::ShaderInputBufferDescriptor{
+                    samplerName, RHI::ShaderInputBufferAccess::Read, RHI::ShaderInputBufferType::Structured, 3, UINT_MAX, 4, 4 });
+                otherLayout->AddStaticSampler(RHI::ShaderInputStaticSamplerDescriptor{
+                    constantBufferName, RHI::SamplerState::CreateAnisotropic(16, RHI::AddressMode::Wrap), 6, 6 });
+                otherLayout->AddShaderInput(RHI::ShaderInputConstantDescriptor{ Name("m_floatValue"), 0, 4, 0, 0 });
+                otherLayout->SetShaderVariantKeyFallback(Name{ "m_floatValue" }, 1);
+                EXPECT_TRUE(otherLayout->Finalize());
+                EXPECT_NE(otherLayout->GetHash(), layout->GetHash());
+            }
+        }
+    } // namespace MultiDevice
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
+++ b/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
@@ -21,6 +21,8 @@
 #include <AzCore/Component/TickBus.h>
 
 #include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/RHISystem.h>
+#include <Tests/Factory.h>
 
 namespace UnitTest
 {
@@ -56,5 +58,34 @@ namespace UnitTest
             m_reflectionManager->Clear();
             m_reflectionManager.reset();
         }
+    };
+
+    class MultiDeviceRHITestFixture : public RHITestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            RHITestFixture::SetUp();
+
+            m_factory.reset(aznew Factory());
+
+            m_rhiSystem.reset(aznew AZ::RHI::RHISystem);
+
+            m_rhiSystem->InitDevices(true);
+            m_rhiSystem->Init();
+        }
+
+        void TearDown() override
+        {
+            m_rhiSystem->Shutdown();
+            m_rhiSystem.reset();
+            m_factory.reset();
+
+            RHITestFixture::TearDown();
+        }
+
+    private:
+        AZStd::unique_ptr<AZ::RHI::RHISystem> m_rhiSystem;
+        AZStd::unique_ptr<Factory> m_factory;
     };
 }

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -16,31 +16,43 @@ set(FILES
     Source/RHI/LinearAllocator.cpp
     Source/RHI/PoolAllocator.cpp
     Include/Atom/RHI/Buffer.h
+    Include/Atom/RHI/MultiDeviceBuffer.h
     Include/Atom/RHI/BufferView.h
     Include/Atom/RHI/IndexBufferView.h
+    Include/Atom/RHI/MultiDeviceIndexBufferView.h
     Include/Atom/RHI/StreamBufferView.h
+    Include/Atom/RHI/MultiDeviceStreamBufferView.h
     Source/RHI/Buffer.cpp
+    Source/RHI/MultiDeviceBuffer.cpp
     Source/RHI/BufferView.cpp
     Source/RHI/IndexBufferView.cpp
+    Source/RHI/MultiDeviceIndexBufferView.cpp
     Source/RHI/StreamBufferView.cpp
+    Source/RHI/MultiDeviceStreamBufferView.cpp
     Include/Atom/RHI/BufferPool.h
+    Include/Atom/RHI/MultiDeviceBufferPool.h
     Include/Atom/RHI/BufferPoolBase.h
     Source/RHI/BufferPool.cpp
+    Source/RHI/MultiDeviceBufferPool.cpp
     Source/RHI/BufferPoolBase.cpp
     Include/Atom/RHI/CommandList.h
     Include/Atom/RHI/CommandListValidator.h
     Include/Atom/RHI/CommandListStates.h
     Include/Atom/RHI/CopyItem.h
+    Include/Atom/RHI/MultiDeviceCopyItem.h
     Include/Atom/RHI/ConstantsData.h
     Include/Atom/RHI/DispatchItem.h
+    Include/Atom/RHI/MultiDeviceDispatchItem.h
     Include/Atom/RHI/DrawFilterTagRegistry.h
     Include/Atom/RHI/DrawItem.h
+    Include/Atom/RHI/MultiDeviceDrawItem.h
     Include/Atom/RHI/DrawList.h
     Include/Atom/RHI/DrawListTagRegistry.h
     Include/Atom/RHI/DrawListContext.h
     Include/Atom/RHI/DrawPacket.h
     Include/Atom/RHI/DrawPacketBuilder.h
     Include/Atom/RHI/IndirectArguments.h
+    Include/Atom/RHI/MultiDeviceIndirectArguments.h
     Source/RHI/CommandList.cpp
     Source/RHI/CommandListValidator.cpp
     Source/RHI/ConstantsData.cpp
@@ -51,17 +63,21 @@ set(FILES
     Include/Atom/RHI/Device.h
     Include/Atom/RHI/DeviceBusTraits.h
     Include/Atom/RHI/DeviceObject.h
+    Include/Atom/RHI/MultiDeviceObject.h
     Include/Atom/RHI/CommandQueue.h
     Include/Atom/RHI/ValidationLayer.h
     Source/RHI/Device.cpp
     Source/RHI/DeviceObject.cpp
+    Source/RHI/MultiDeviceObject.cpp
     Source/RHI/CommandQueue.cpp
     Source/RHI/ValidationLayer.cpp
     Include/Atom/RHI/Factory.h
     Source/RHI/Factory.cpp
     Include/Atom/RHI/FactoryManagerBus.h
     Include/Atom/RHI/Fence.h
+    Include/Atom/RHI/MultiDeviceFence.h
     Source/RHI/Fence.cpp
+    Source/RHI/MultiDeviceFence.cpp
     Include/Atom/RHI/BufferFrameAttachment.h
     Include/Atom/RHI/FrameAttachment.h
     Include/Atom/RHI/ImageFrameAttachment.h
@@ -93,21 +109,35 @@ set(FILES
     Include/Atom/RHI/FrameScheduler.h
     Source/RHI/FrameScheduler.cpp
     Include/Atom/RHI/Image.h
+    Include/Atom/RHI/MultiDeviceImage.h
     Include/Atom/RHI/ImageView.h
     Source/RHI/Image.cpp
+    Source/RHI/MultiDeviceImage.cpp
     Source/RHI/ImageView.cpp
     Include/Atom/RHI/ImagePool.h
+    Include/Atom/RHI/MultiDeviceImagePool.h
     Include/Atom/RHI/ImagePoolBase.h
+    Include/Atom/RHI/MultiDeviceImagePoolBase.h
     Include/Atom/RHI/StreamingImagePool.h
+    Include/Atom/RHI/MultiDeviceStreamingImagePool.h
     Source/RHI/ImagePool.cpp
+    Source/RHI/MultiDeviceImagePool.cpp
     Source/RHI/ImagePoolBase.cpp
+    Source/RHI/MultiDeviceImagePoolBase.cpp
     Source/RHI/StreamingImagePool.cpp
+    Source/RHI/MultiDeviceStreamingImagePool.cpp
     Include/Atom/RHI/IndirectBufferSignature.h
+    Include/Atom/RHI/MultiDeviceIndirectBufferSignature.h
     Include/Atom/RHI/IndirectBufferView.h
+    Include/Atom/RHI/MultiDeviceIndirectBufferView.h
     Include/Atom/RHI/IndirectBufferWriter.h
+    Include/Atom/RHI/MultiDeviceIndirectBufferWriter.h
     Source/RHI/IndirectBufferSignature.cpp
+    Source/RHI/MultiDeviceIndirectBufferSignature.cpp
     Source/RHI/IndirectBufferView.cpp
+    Source/RHI/MultiDeviceIndirectBufferView.cpp
     Source/RHI/IndirectBufferWriter.cpp
+    Source/RHI/MultiDeviceIndirectBufferWriter.cpp
     Include/Atom/RHI/Object.h
     Include/Atom/RHI/ObjectCache.h
     Include/Atom/RHI/ObjectCollector.h
@@ -119,27 +149,39 @@ set(FILES
     Include/Atom/RHI/PhysicalDevice.h
     Source/RHI/PhysicalDevice.cpp
     Include/Atom/RHI/PipelineLibrary.h
+    Include/Atom/RHI/MultiDevicePipelineLibrary.h
     Include/Atom/RHI/PipelineState.h
+    Include/Atom/RHI/MultiDevicePipelineState.h
     Include/Atom/RHI/PipelineStateCache.h
     Include/Atom/RHI/PipelineStateDescriptor.h
     Source/RHI/PipelineLibrary.cpp
+    Source/RHI/MultiDevicePipelineLibrary.cpp
     Source/RHI/PipelineState.cpp
+    Source/RHI/MultiDevicePipelineState.cpp
     Source/RHI/PipelineStateCache.cpp
     Source/RHI/PipelineStateDescriptor.cpp
     Include/Atom/RHI/Query.h
+    Include/Atom/RHI/MultiDeviceQuery.h
     Source/RHI/Query.cpp
+    Source/RHI/MultiDeviceQuery.cpp
     Include/Atom/RHI/QueryPool.h
+    Include/Atom/RHI/MultiDeviceQueryPool.h
     Include/Atom/RHI/QueryPoolSubAllocator.h
     Source/RHI/QueryPool.cpp
+    Source/RHI/MultiDeviceQueryPool.cpp
     Source/RHI/QueryPoolSubAllocator.cpp
     Include/Atom/RHI/Resource.h
+    Include/Atom/RHI/MultiDeviceResource.h
     Include/Atom/RHI/ResourceInvalidateBus.h
     Include/Atom/RHI/ResourceView.h
     Source/RHI/Resource.cpp
+    Source/RHI/MultiDeviceResource.cpp
     Source/RHI/ResourceView.cpp
     Include/Atom/RHI/ResourcePool.h
+    Include/Atom/RHI/MultiDeviceResourcePool.h
     Include/Atom/RHI/ResourcePoolDatabase.h
     Source/RHI/ResourcePool.cpp
+    Source/RHI/MultiDeviceResourcePool.cpp
     Source/RHI/ResourcePoolDatabase.cpp
     Include/Atom/RHI/MemoryAllocation.h
     Include/Atom/RHI/MemorySubAllocator.h
@@ -159,20 +201,28 @@ set(FILES
     Source/RHI/ResolveScopeAttachment.cpp
     Source/RHI/ScopeAttachment.cpp
     Include/Atom/RHI/ShaderResourceGroup.h    
+    Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
     Include/Atom/RHI/ShaderResourceGroupData.h
+    Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
     Include/Atom/RHI/ShaderResourceGroupDebug.h
     Include/Atom/RHI/ShaderResourceGroupInvalidateRegistry.h
     Include/Atom/RHI/ShaderResourceGroupPool.h
+    Include/Atom/RHI/MultiDeviceShaderResourceGroupPool.h
     Source/RHI/ShaderResourceGroup.cpp
+    Source/RHI/MultiDeviceShaderResourceGroup.cpp
     Source/RHI/ShaderResourceGroupData.cpp
+    Source/RHI/MultiDeviceShaderResourceGroupData.cpp
     Source/RHI/ShaderResourceGroupDebug.cpp
     Source/RHI/ShaderResourceGroupInvalidateRegistry.cpp
     Source/RHI/ShaderResourceGroupPool.cpp
+    Source/RHI/MultiDeviceShaderResourceGroupPool.cpp
     Include/Atom/RHI/MemoryStatisticsBuilder.h
     Include/Atom/RHI/MemoryStatisticsBus.h
     Source/RHI/MemoryStatisticsBuilder.cpp
     Include/Atom/RHI/SwapChain.h
+    Include/Atom/RHI/MultiDeviceSwapChain.h
     Source/RHI/SwapChain.cpp
+    Source/RHI/MultiDeviceSwapChain.cpp
     Include/Atom/RHI/RHISystem.h
     Include/Atom/RHI/RHISystemInterface.h
     Source/RHI/RHISystem.cpp
@@ -187,18 +237,29 @@ set(FILES
     Include/Atom/RHI/TileAllocator.h
     Include/Atom/RHI/TileAllocator.inl
     Include/Atom/RHI/TransientAttachmentPool.h
+    Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
     Source/RHI/TransientAttachmentPool.cpp
+    Source/RHI/MultiDeviceTransientAttachmentPool.cpp
     Include/Atom/RHI/RHIUtils.h
     Source/RHI/RHIUtils.cpp
     Include/Atom/RHI/RayTracingAccelerationStructure.h
+    Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
     Include/Atom/RHI/RayTracingPipelineState.h
+    Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
     Include/Atom/RHI/RayTracingShaderTable.h
+    Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
     Include/Atom/RHI/RayTracingBufferPools.h
+    Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
     Include/Atom/RHI/DispatchRaysItem.h
+    Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
     Source/RHI/RayTracingAccelerationStructure.cpp
+    Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
     Source/RHI/RayTracingPipelineState.cpp
+    Source/RHI/MultiDeviceRayTracingPipelineState.cpp
     Source/RHI/RayTracingShaderTable.cpp
+    Source/RHI/MultiDeviceRayTracingShaderTable.cpp
     Source/RHI/RayTracingBufferPools.cpp
+    Source/RHI/MultiDeviceRayTracingBufferPools.cpp
     Include/Atom/RHI/interval_map.h
     Include/Atom/RHI/ImageProperty.h
     Include/Atom/RHI/BufferProperty.h

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -23,6 +23,7 @@ set(FILES
     Tests/QueryTests.cpp
     Tests/RenderAttachmentLayoutBuilderTests.cpp
     Tests/ShaderResourceGroupTests.cpp
+
     Tests/UtilsTests.cpp
     Tests/Buffer.h
     Tests/Buffer.cpp
@@ -52,6 +53,14 @@ set(FILES
     Tests/ImagePropertyTests.cpp
     Tests/BufferPropertyTests.cpp
     Tests/IntervalMapTests.cpp
+
+    Tests/MultiDeviceBufferTests.cpp
+    Tests/MultiDeviceImageTests.cpp
+    Tests/MultiDeviceQueryTests.cpp
+    Tests/MultiDevicePipelineStateTests.cpp
+
+    Tests/MultiDeviceIndirectBufferTests.cpp
+    Tests/MultiDeviceShaderResourceGroupTests.cpp
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -95,8 +95,8 @@ namespace AZ
                 }
             }
 
-            //Init RHI device
-            m_rhiSystem.InitDevice();
+            // Init RHI device(s)
+            m_rhiSystem.InitDevices(AzFramework::StringFunc::Equal(RHI::GetCommandLineValue("rhi-multiple-devices").c_str(), "enable"));
 
             // Gather asset handlers from sub-systems.
             ImageSystem::GetAssetHandlers(m_assetHandlers);


### PR DESCRIPTION
## What does this PR do?

This PR is part of [RFC #137](https://github.com/o3de/sig-graphics-audio/pull/137) (original proposal including discussion in [RFC Feature #120](https://github.com/o3de/sig-graphics-audio/issues/120), there referred to as `commit 3` in the **Planned git history** sub-section) and introduces multi-device versions of all relevant resource classes on the `RHI` level.

It is important to state that this PR does **not yet** change how the RHI resources are used, but simply introduces multi-device versions, which currently are only called in the respective (newly added) unit tests, but nowhere else in the code base.
[RFC #137](https://github.com/o3de/sig-graphics-audio/pull/137) details which resources/objects received a multi-devie version.

The only actually effective changes have been kept minimial and only facilitate the build or testing of these new multi-device objects, these include:
- Change `RHISystem::InitDevice()` to `RHISystem::InitDevices(bool initializeMultiDevice = false)` to allow for testing of the multi-device objects
	- The command-line flag is now checked in `RPISystem::Initialize` and passed on to the `RHISystem`
- `UnitTest::PhysicalDevice::Enumerate` has been altered to always generate multiple test devices to allow for multi-device testing to take place (`UnitTest::MakeTestDevice` still returns the first device, i.e. this functionality is unchanged)
- `RHI::Device::Init` now does no longer assert when it is called with a device index `>= 0` (to allow for multi-device testing)

## How was this PR tested?

We added new unit tests for all resource classes, which already had `RHI` tests implemented, this includes:
- `MultiDeviceBufferTests`
- `MultiDeviceImageTests`
- `MultiDeviceIndirectBufferTests`
- `MultiDevicePipelineStateTests`
- `MultiDeviceQueryTests`
- `MultiDeviceShaderResourceGroupTests`

These follow the same structures as their single-device counterparts but using the respective multi-device resources. 
