### PR TITLE
Fix occasional shutdown crash

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -176,7 +176,7 @@ namespace AZ
 
         bool ImGuiPass::OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel)
         {
-            if (!IsEnabled() || GetRenderPipeline()->GetScene() == nullptr)
+            if (!IsEnabled() || GetRenderPipeline() == nullptr || GetRenderPipeline()->GetScene() == nullptr)
             {
                 return false;
             }


### PR DESCRIPTION
## What does this PR do?

Sometimes, on shutdown, during the level unload if there are any queued input events IMGUI will try to process them. However, IMGUI's pipeline might be null at this point, causing a crash. This fixes the crash.

## How was this PR tested?

Ran MPS ServerLauncher and shut it down multiple times without a crash.
