### PR TITLE
Fixed signature of Red-Black Tree node_handle_insert

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/rbtree.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/rbtree.h
@@ -796,14 +796,14 @@ namespace AZStd
         template <class InsertReturnType, class NodeHandle>
         InsertReturnType node_handle_insert_unique(NodeHandle&& nodeHandle);
         template <class NodeHandle>
-        auto node_handle_insert_unique(const iterator hint, NodeHandle&& nodeHandle) -> iterator;
+        auto node_handle_insert_unique(const_iterator hint, NodeHandle&& nodeHandle) -> iterator;
 
         //! Returns an iterator pointing to the inserted element.
         //! If the nodeHandle is empty the end() iterator is returned
         template <class NodeHandle>
         auto node_handle_insert_equal(NodeHandle&& nodeHandle) -> iterator;
         template <class NodeHandle>
-        auto node_handle_insert_equal(const iterator hint, NodeHandle&& nodeHandle) -> iterator;
+        auto node_handle_insert_equal(const_iterator hint, NodeHandle&& nodeHandle) -> iterator;
 
         //! Searches for an element which matches the value of key and extracts it from the hash_table
         //! @return A NodeHandle which can be used to insert the an element between unique and non-unique containers of the same type
@@ -2036,7 +2036,7 @@ namespace AZStd
 
     template <class Traits>
     template <class NodeHandle>
-    inline auto rbtree<Traits>::node_handle_insert_unique(const iterator hint, NodeHandle&& nodeHandle) -> iterator
+    inline auto rbtree<Traits>::node_handle_insert_unique(const_iterator hint, NodeHandle&& nodeHandle) -> iterator
     {
         if (nodeHandle.empty())
         {
@@ -2067,7 +2067,7 @@ namespace AZStd
     }
     template <class Traits>
     template <class NodeHandle>
-    inline auto rbtree<Traits>::node_handle_insert_equal(const iterator hint, NodeHandle&& nodeHandle) -> iterator
+    inline auto rbtree<Traits>::node_handle_insert_equal(const_iterator hint, NodeHandle&& nodeHandle) -> iterator
     {
         if (nodeHandle.empty())
         {

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -641,7 +641,7 @@ namespace AZStd
         template <class InsertReturnType, class NodeHandle>
         InsertReturnType node_handle_insert(NodeHandle&& nodeHandle);
         template <class NodeHandle>
-        auto node_handle_insert(const iterator hint, NodeHandle&& nodeHandle) -> iterator;
+        auto node_handle_insert(const_iterator hint, NodeHandle&& nodeHandle) -> iterator;
 
         //! Searches for an element which matches the value of key and extracts it from the hash_table
         //! @return A NodeHandle which can be used to insert the an element between unique and non-unique containers of the same type
@@ -1199,7 +1199,7 @@ namespace AZStd
 
     template <class Traits>
     template <class NodeHandle>
-    inline auto hash_table<Traits>::node_handle_insert(const iterator, NodeHandle&& nodeHandle) -> iterator
+    inline auto hash_table<Traits>::node_handle_insert(const_iterator, NodeHandle&& nodeHandle) -> iterator
     {
         return node_handle_insert<insert_return_type<iterator, NodeHandle>>(AZStd::move(nodeHandle)).position;
     }

--- a/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
@@ -947,6 +947,23 @@ namespace UnitTest
         EXPECT_EQ(-73, static_cast<int32_t>(extractedNode.value()));
     }
 
+    TYPED_TEST(TreeSetContainers, ExtractAndReinsertNodeHandleByIteratorSucceeds)
+    {
+        using SetType = typename TypeParam::SetType;
+        using node_type = typename SetType::node_type;
+
+        SetType testContainer = TypeParam::Create();
+        auto foundIter = testContainer.find(-73);
+        auto nextIter = AZStd::next(foundIter);
+        node_type extractedNode = testContainer.extract(foundIter);
+        extractedNode.value() = static_cast<int32_t>(extractedNode.value()) + 1;
+        testContainer.insert(nextIter, AZStd::move(extractedNode));
+
+        // Lookup reinserted node
+        foundIter = testContainer.find(-72);
+        ASSERT_NE(testContainer.end(), foundIter);
+    }
+
     TYPED_TEST(TreeSetContainers, InsertNodeHandleSucceeds)
     {
         using SetType = AZStd::set<int32_t>;
@@ -1268,6 +1285,22 @@ namespace UnitTest
         EXPECT_FALSE(extractedNode.empty());
         EXPECT_EQ(73, static_cast<int32_t>(extractedNode.key()));
         EXPECT_EQ(0xfee1badd, extractedNode.mapped());
+    }
+
+    TYPED_TEST(TreeMapContainers, ExtractAndReinsertNodeHandleByIteratorSucceeds)
+    {
+        using MapType = typename TypeParam::MapType;
+        using node_type = typename MapType::node_type;
+
+        MapType testContainer = TypeParam::Create();
+        auto foundIter = testContainer.find(73);
+        auto nextIter = AZStd::next(foundIter);
+        node_type extractedNode = testContainer.extract(foundIter);
+        extractedNode.key() = static_cast<int32_t>(extractedNode.key()) + 1;
+        testContainer.insert(nextIter, AZStd::move(extractedNode));
+
+        foundIter = testContainer.find(74);
+        ASSERT_NE(testContainer.end(), foundIter);
     }
 
     TYPED_TEST(TreeMapContainers, InsertNodeHandleSucceeds)


### PR DESCRIPTION
The `node_handle_insert_unique` and `node_handle_insert_equal` functions are expected to work with a `const_iterator` which is iterator to a constant view of the pair data and not just a `const iterator` which is a constant iterator to a non-constant view of the pair data.


## How was this PR tested?

Added unitest to validate that node extraction and re-insertion with an iterator compiles successfully.