### PR TITLE
Add missing getters to PhysX/ArticulationJointBus.

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/ArticulationJointBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/ArticulationJointBus.h
@@ -99,6 +99,14 @@ namespace PhysX
 
         //! Get the maximum joint velocity for all the degrees of freedom of this joint.
         virtual float GetMaxJointVelocity() const = 0;
+
+        //! Get the current joint position.
+        virtual float GetJointPosition(ArticulationJointAxis jointAxis) const = 0;
+
+        //! Get the current joint position.
+        virtual float GetJointVelocity(ArticulationJointAxis jointAxis) const = 0;
+
+
     };
 
     using ArticulationJointRequestBus = AZ::EBus<ArticulationJointRequests>;

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -714,6 +714,24 @@ namespace PhysX
         return 0.0f;
     }
 
+    float ArticulationLinkComponent::GetJointPosition(ArticulationJointAxis jointAxis) const
+    {
+        if (auto* joint = GetDriveJoint())
+        {
+            return joint->getJointPosition(GetPxArticulationAxis(jointAxis));
+        }
+        return 0.0f;
+    }
+
+    float ArticulationLinkComponent::GetJointVelocity(ArticulationJointAxis jointAxis) const
+    {
+        if (auto* joint = GetDriveJoint())
+        {
+            return joint->getJointVelocity(GetPxArticulationAxis(jointAxis));
+        }
+        return 0.0f;
+    }
+
     void ArticulationLinkComponent::SetFrictionCoefficient(float frictionCoefficient)
     {
         if (auto* joint = GetDriveJoint())

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -75,7 +75,8 @@ namespace PhysX
         float GetFrictionCoefficient() const override;
         void SetMaxJointVelocity(float maxJointVelocity) override;
         float GetMaxJointVelocity() const override;
-
+        float GetJointPosition(ArticulationJointAxis jointAxis) const override;
+        float GetJointVelocity(ArticulationJointAxis jointAxis) const override;
         // ArticulationSensorRequestBus overrides ...
         AZ::Transform GetSensorTransform(AZ::u32 sensorIndex) const override;
         void SetSensorTransform(AZ::u32 sensorIndex, const AZ::Transform& sensorTransform) override;


### PR DESCRIPTION
Modify `ArticulationLinkComponent` to implement extend ArticulationJointBus.

## What does this PR do?

This PR is adding missing getters to `ArticulationJointBus`:
 - `GetJointPosition`
 - `GetJointVelocity`

## How was this PR tested?

Manual testing implementing, new features in ROS2 Gem.