### PR TITLE
DPE: Fixed missing components without data fields and filtering issues when DPE is enabled

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
@@ -24,6 +24,11 @@ namespace AZ::DocumentPropertyEditor
         UpdateMatchDescendants(m_root);
     }
 
+    bool RowFilterAdapter::FilterIsActive() const
+    {
+        return m_filterActive;
+    }
+
     Dom::Path RowFilterAdapter::MapFromSourcePath(const Dom::Path& sourcePath) const
     {
         if (!m_filterActive)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
@@ -20,6 +20,7 @@ namespace AZ::DocumentPropertyEditor
         ~RowFilterAdapter();
 
         void SetIncludeAllMatchDescendants(bool includeAll);
+        bool FilterIsActive() const;
 
         // MetaAdapter overrides
         Dom::Path MapFromSourcePath(const Dom::Path& sourcePath) const override;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
@@ -208,6 +208,11 @@ namespace AzQtComponents
         m_filterRegex = QRegExp(m_filterString, Qt::CaseInsensitive);
     }
 
+    bool ElidingLabel::TextMatchesFilter() const
+    {
+        return m_filterString.isEmpty() || m_text.contains(m_filterRegex);
+    }
+
     void ElidingLabel::paintEvent(QPaintEvent* event)
     {
         if (m_filterString.isEmpty())

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
@@ -65,6 +65,9 @@ namespace AzQtComponents
         //! If the filter string is a substring of the current text, it will appear highlighted
         //! in the label. Used in conjunction with search filters to highlight results.
         void setFilter(const QString& filter);
+        //! Returns if the label text matches the current filter string.
+        //! If no filter string has been set, returns true.
+        bool TextMatchesFilter() const;
 
         //! Sets the description for this label.
         void SetDescription(const QString& description)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -569,7 +569,7 @@ namespace AzToolsFramework
     {
         if (m_dpe)
         {
-            return !m_filterAdapter->IsEmpty();
+            return !m_filterAdapter->FilterIsActive() || !m_filterAdapter->IsEmpty() || GetHeader()->TitleMatchesFilter();
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.cpp
@@ -121,6 +121,11 @@ namespace AzToolsFramework
     {
         m_currentFilterString = str.c_str();
     }
+
+    bool ComponentEditorHeader::TitleMatchesFilter() const
+    {
+        return AzQtComponents::CardHeader::m_titleLabel->TextMatchesFilter();
+    }
 }
 
 #include "UI/PropertyEditor/moc_ComponentEditorHeader.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.hxx
@@ -76,6 +76,7 @@ namespace AzToolsFramework
         void ClearHelpURL();
 
         void SetFilterString(const AZStd::string& str);
+        bool TitleMatchesFilter() const;
     Q_SIGNALS:
         void OnContextMenuClicked(const QPoint& position);
         void OnExpanderChanged(bool expanded);


### PR DESCRIPTION
## What does this PR do?

Fixes #15504 

With the DPE enabled, any components that don't have fields (e.g. Audio Proxy, Network Test Player, etc...) weren't being shown in the Inspector. This is a common use-case for components that are meant to attach code/logic to an Entity but don't need any kind of data fields exposed to the Editor.

The components were being hidden because the RPE would still register at least one visible node (even though it wasn't actually shown) for any component, whereas the DPE queries the adapter which returns empty if there is nothing to display. It also thought it was empty even if a filter hadn't been specified yet.

The final issue uncovered for this scenario is that the RPE was able to match the filter based on the component name (because of the aforementioned invisible root node), whereas the DPE looks specifically at the contents from the adapter, so needed to add an extra check to be able to match based on the name of the component.

BEFORE (NOTE: The Audio Proxy component was on this Entity, but would never be shown. Also under some cases components would be filtered out improperly, as shown here with setting the filter to "Spawner" and seeing the Spawner component be hidden when it should still be visible):

![EntityInspectorFiltering_BEFORE](https://github.com/o3de/o3de/assets/7519264/a132974f-bab2-4f24-be90-bacc57f7e20b)

AFTER:

![EntityInspectorFiltering_AFTER](https://github.com/o3de/o3de/assets/7519264/f34511cf-bff9-48a4-ad9e-8abd616faea7)

## How was this PR tested?

Tested based on the repro steps from the bug as listed, as well as ad-hoc testing with components without data fields. Also tested filtering on various strings (component name, data field labels, partial matches, etc...).