### PR TITLE
Remove references to old Gamelift 3.4.2 3P Package in favor of the new 5.0.0 version

### DIFF
--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
@@ -18,7 +18,6 @@ ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform               
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-linux-aarch64                             TARGETS expat                       PACKAGE_HASH 934a535c1492d11906789d7ddf105b1a530cf8d8fb126063ffde16c5caeb0179)
 ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-linux-aarch64                            TARGETS assimplib                   PACKAGE_HASH 0e497e129f9868088c81891e87b778894c12486b039a5b7bd8a47267275b640f)
-ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.9.50-rev3-linux-aarch64                     TARGETS AWSNativeSDK                PACKAGE_HASH d03fc208ff2fc08b18568f3b6f072cb0de7605ab1dd314118b175f3f67aa04b3)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-rev1-linux-aarch64                            TARGETS cityhash                    PACKAGE_HASH c4fafa13add81c6ca03338462af78eabbdea917de68c599f11c4a36b0982cec2)
 ly_associate_package(PACKAGE_NAME tiff-4.2.0.15-rev3-linux-aarch64                           TARGETS TIFF                        PACKAGE_HASH 429461014b21a530dcad597c2d91072ae39d937a04b7bbbf5c34491c41767f7f)
 ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-linux-aarch64                         TARGETS Freetype                    PACKAGE_HASH b4e3069acdcdae2f977108679d0986fb57371b9a7d4a3a496ab16909feabcba6)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
@@ -19,7 +19,6 @@ ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                    
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-linux                            TARGETS expat                       PACKAGE_HASH 755369a919e744b9b3f835d1acc684f02e43987832ad4a1c0b6bbf884e6cd45b)
 ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-linux                           TARGETS assimplib                   PACKAGE_HASH 67bd3625078b63b40ae397ef7a3e589a6f77e95d3318c97dd7075e3e22a638cd)
-ly_associate_package(PACKAGE_NAME AWSGameLiftServerSDK-3.4.2-rev1-linux             TARGETS AWSGameLiftServerSDK        PACKAGE_HASH 875a8ee45ab5948b10eedfd9057b14db7f01c4b31820f8f998eb6dee1c05a176)
 ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.9.50-rev3-linux                    TARGETS AWSNativeSDK                PACKAGE_HASH 5ae5dc681e166156dad59c9b43917b449a9031dac5b1c05d5607285c8c7f3850)
 ly_associate_package(PACKAGE_NAME tiff-4.2.0.15-rev3-linux                          TARGETS TIFF                        PACKAGE_HASH 2377f48b2ebc2d1628d9f65186c881544c92891312abe478a20d10b85877409a)
 ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-linux                        TARGETS Freetype                    PACKAGE_HASH 28bbb850590507eff85154604787881ead6780e6eeee9e71ed09cd1d48d85983)


### PR DESCRIPTION
## What does this PR do?

This removes the outdated references to the older linux versions gamelift (3.4.2) 3P packages in favor of the newer 5.0.0 packages that were merged in as part of https://github.com/o3de/o3de/pull/15980 

## How was this PR tested?

1 Cleared .o3de/packages ffolder
2. Created new project with Gamelift enabled
3. Validated that the new 5.0.0 version is in .o3de/packages
4. Validated that the old 3.4.2 is NOT in .o3de/packages
5. Project builds successfully

