### PR TITLE
Workaround for a presumed VS2019 compiler bug causing compile errors

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
@@ -38,3 +38,7 @@ set(FILES
     Source/TestImpactPythonRuntime.cpp
     Source/TestImpactPythonRuntimeConfigurationFactory.cpp
 )
+
+# Remove this file from unity builds because with VS2019, the include of AzCore/std/string/regex.h can sometimes
+# trigger an invalid warning about a mismatched #pragma warning(push) in xlocinfo.h.
+list(APPEND SKIP_UNITY_BUILD_INCLUSION_FILES Source/TestImpactPythonRuntime.cpp)


### PR DESCRIPTION
## What does this PR do?

With VS 2019, some of us were seeing occasional compile errors when compiling the TestImpact.Runtime.Python.Static project that looked like this:
```
62>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\xlocinfo.h(18,17): error C5032: detected #pragma warning(push) with no corresponding #pragma warning(pop)
62>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\xlocinfo.h(18,17): error C5032: #pragma warning(push, _STL_WARNING_LEVEL)
62>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\xlocinfo.h(18,17): error C5032:                 ^
62>Done building project "TestImpact.Runtime.Python.Static.vcxproj" -- FAILED.
```

Further investigation suggested that it was somehow related to the include of AzCore/std/string/regex.h in TestImpactPythonRuntime.cpp. Various potential workarounds included adding another include of regex.h earlier in the include chain all the way to simply removing the unused operator== definitions from TestImpact::JobInfo. These are inexplicable fixes that seem pretty fragile because they are likely affecting how the code aligns to various size boundaries in the unity build.

So instead, this PR uses a much more straightforward workaround suggested by @lumberyard-employee-dm (thanks!) to just remove TestImpactPythonRuntime.cpp from the unity build. These keeps the size predictable and consistent and seems to workaround the issue successfully.

## How was this PR tested?

Built TestImpact.Runtime.Python.Static.lib successfully multiple times on a system / VS 2019 environment that was exhibiting the problem.
