### PR TITLE
Snap package fixes for Ubuntu 20.04

### DIFF
--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -23,17 +23,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
-                -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
-                -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
             LINK_EXE
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
-                -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
-                -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
         )
     else()

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -24,11 +24,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
-<<<<<<< Updated upstream
-                -L/snap/core20/current/lib/x86_64-linux-gnu
-                -L/snap/core20/current/usr/lib/x86_64-linux-gnu
-=======
->>>>>>> Stashed changes
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -37,11 +32,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
-<<<<<<< Updated upstream
-                -L/snap/core20/current/lib/x86_64-linux-gnu
-                -L/snap/core20/current/usr/lib/x86_64-linux-gnu
-=======
->>>>>>> Stashed changes
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -98,13 +88,4 @@ endif()
 
 ly_set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 ly_set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-<<<<<<< Updated upstream
-
-if ($ENV{O3DE_SNAP})
-    ly_set(CMAKE_INSTALL_RPATH "$ORIGIN:/snap/core20/current/lib/x86_64-linux-gnu:/snap/core20/current/usr/lib/x86_64-linux-gnu")
-else()
-    ly_set(CMAKE_INSTALL_RPATH "$ORIGIN")
-endif()
-=======
 ly_set(CMAKE_INSTALL_RPATH "$ORIGIN")
->>>>>>> Stashed changes

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -24,8 +24,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
+<<<<<<< Updated upstream
                 -L/snap/core20/current/lib/x86_64-linux-gnu
                 -L/snap/core20/current/usr/lib/x86_64-linux-gnu
+=======
+>>>>>>> Stashed changes
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -34,8 +37,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
+<<<<<<< Updated upstream
                 -L/snap/core20/current/lib/x86_64-linux-gnu
                 -L/snap/core20/current/usr/lib/x86_64-linux-gnu
+=======
+>>>>>>> Stashed changes
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -92,9 +98,13 @@ endif()
 
 ly_set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 ly_set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+<<<<<<< Updated upstream
 
 if ($ENV{O3DE_SNAP})
     ly_set(CMAKE_INSTALL_RPATH "$ORIGIN:/snap/core20/current/lib/x86_64-linux-gnu:/snap/core20/current/usr/lib/x86_64-linux-gnu")
 else()
     ly_set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif()
+=======
+ly_set(CMAKE_INSTALL_RPATH "$ORIGIN")
+>>>>>>> Stashed changes

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -24,8 +24,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
-                -L/snap/core22/current/lib/x86_64-linux-gnu
-                -L/snap/core22/current/usr/lib/x86_64-linux-gnu
+                -L/snap/core20/current/lib/x86_64-linux-gnu
+                -L/snap/core20/current/usr/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -34,8 +34,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
                 -L$ENV{SNAP}/usr/lib/gcc/x86_64-linux-gnu/12/
-                -L/snap/core22/current/lib/x86_64-linux-gnu
-                -L/snap/core22/current/usr/lib/x86_64-linux-gnu
+                -L/snap/core20/current/lib/x86_64-linux-gnu
+                -L/snap/core20/current/usr/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/lib32/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
@@ -94,7 +94,7 @@ ly_set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 ly_set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 if ($ENV{O3DE_SNAP})
-    ly_set(CMAKE_INSTALL_RPATH "$ORIGIN:/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu")
+    ly_set(CMAKE_INSTALL_RPATH "$ORIGIN:/snap/core20/current/lib/x86_64-linux-gnu:/snap/core20/current/usr/lib/x86_64-linux-gnu")
 else()
     ly_set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif()

--- a/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
+++ b/cmake/Platform/Linux/Packaging/snapcraft.yaml.in
@@ -5,7 +5,7 @@ description: |
   Open 3D Engine (O3DE) is an Apache 2.0-licensed multi-platform 3D engine that enables developers and content creators to build AAA games, cinema-quality 3D worlds, and high-fidelity simulations without any fees or commercial obligations. 
 license: Apache-2.0
 confinement: classic
-base: core22
+base: core20
 
 parts:
   o3de:
@@ -13,53 +13,43 @@ parts:
     source: ./${CPACK_PACKAGE_NAME}
     source-type: local
     build-attributes:
-     - enable-patchelf
+      - enable-patchelf
     stage-packages:
-     - cmake
-     - clang-14
-     - ninja-build
-     - libglu1-mesa-dev
-     - libxcb-xinerama0
-     - libxcb-xinput0
-     - libxcb-xinput-dev
-     - libxcb-xfixes0-dev
-     - libxcb-xkb-dev
-     - libxkbcommon-dev
-     - libxkbcommon-x11-dev
-     - libfontconfig1-dev
-     - libcurl4-openssl-dev
-     - libsdl2-dev
-     - zlib1g-dev
-     - mesa-common-dev
-     - libssl-dev
-     - libffi8
-     - libxcb-icccm4
-     - libxcb-image0
-     - libxcb-keysyms1
-     - libxcb-randr0
-     - libxcb-render-util0
-     - libunwind-dev
-     - pkg-config
-     - libc-dev
-     - libstdc++-12-dev
-     - libpng16-16
-     - libsm6
-     - libdbus-1-3
-     - libzstd-dev
-
-  patch-o3de:
-    plugin: nil
-    after: [o3de]
-    build-packages: [patchelf]
-    override-stage: |
-      snapcraftctl stage
-      find $SNAPCRAFT_STAGE/usr/bin/ -type f -executable -exec patchelf --set-interpreter /snap/core22/current/lib64/ld-linux-x86-64.so.2 {} \;
-      find $SNAPCRAFT_STAGE/usr/lib/ -type f -executable -exec patchelf --set-interpreter /snap/core22/current/lib64/ld-linux-x86-64.so.2 {} \;
-      find $SNAPCRAFT_STAGE/usr/bin/ -type f -executable -exec patchelf --force-rpath --set-rpath $(patchelf --print-rpath {})':/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu' {} \;
-      find $SNAPCRAFT_STAGE/usr/lib/ -type f -exec patchelf --force-rpath --set-rpath $(patchelf --print-rpath {})':/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu' {} \;
-      find $SNAPCRAFT_STAGE/lib/ -type f -exec patchelf --force-rpath --set-rpath $(patchelf --print-rpath {} )':/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu' {} \;
-      find $SNAPCRAFT_STAGE/lib32/ -type f -exec patchelf --force-rpath --set-rpath $(patchelf --print-rpath {} )':/snap/core22/current/lib/x86_64-linux-gnu:/snap/core22/current/usr/lib/x86_64-linux-gnu' {} \;
-      echo -e "/* GNU ld script\n   Use the shared library, but some functions are only in\n   the static library, so try that secondarily.  */\nOUTPUT_FORMAT(elf64-x86-64)\nGROUP ( /snap/core22/current/lib/x86_64-linux-gnu/libc.so.6 /snap/o3de/current/usr/lib/x86_64-linux-gnu/libc.a /usr/lib/x86_64-linux-gnu/libc_nonshared.a  AS_NEEDED ( /snap/core22/current/usr/lib64/ld-linux-x86-64.so.2 ) )\n" > $SNAPCRAFT_STAGE/usr/lib/x86_64-linux-gnu/libc.so
+      - clang-12
+      - cmake
+      - libc-dev
+      - libclang-cpp12-dev
+      - libcurl4-openssl-dev
+      - libdbus-1-3
+      - libffi7
+      - libfontconfig1-dev
+      - libglu1-mesa-dev
+      - libpng16-16
+      - libsdl2-dev
+      - libsm6
+      - libssl-dev
+      - libstdc++-9-dev
+      - libtcl8.6
+      - libtk8.6
+      - libunwind-dev
+      - libxcb-icccm4
+      - libxcb-image0
+      - libxcb-keysyms1
+      - libxcb-randr0
+      - libxcb-render-util0
+      - libxcb-xfixes0-dev
+      - libxcb-xinerama0
+      - libxcb-xinput-dev
+      - libxcb-xinput0
+      - libxcb-xkb-dev
+      - libxkbcommon-dev
+      - libxkbcommon-x11-dev
+      - libzstd-dev
+      - llvm-12-dev
+      - mesa-common-dev
+      - ninja-build
+      - pkg-config
+      - zlib1g-dev
 
 apps:
   o3de:

--- a/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
+++ b/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
@@ -12,7 +12,9 @@ include(${CPACK_CODESIGN_SCRIPT})
 
 if("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "SNAP")
     set(snap_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_NAME}_amd64.snap")
-    set(assertion_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}_amd64.snap.assert")
+    set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_NAME}_amd64.snap.sha384")
+    file(SHA384 ${snap_file} file_checksum) # Snap asserts use SHA284
+    file(WRITE ${hash_file} "${file_checksum}  ${CPACK_PACKAGE_NAME}_amd64.snap")
 elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
     set(deb_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb")
     set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb.sha256")
@@ -42,8 +44,8 @@ if(CPACK_UPLOAD_URL)
     file(GLOB _artifacts 
         "${CPACK_TOPLEVEL_DIRECTORY}/*.deb" 
         "${CPACK_TOPLEVEL_DIRECTORY}/*.sha256"
+        "${CPACK_TOPLEVEL_DIRECTORY}/*.sha384"
         "${CPACK_TOPLEVEL_DIRECTORY}/*.snap"
-        "${CPACK_TOPLEVEL_DIRECTORY}/*.assert"
         "${LY_ROOT_FOLDER}/scripts/signer/Platform/Linux/*.gpg"
         "${CPACK_3P_LICENSE_FILE}"
         "${CPACK_3P_MANIFEST_FILE}"
@@ -56,7 +58,7 @@ if(CPACK_UPLOAD_URL)
     ly_upload_to_url(
         ${CPACK_UPLOAD_URL}
         ${CPACK_UPLOAD_DIRECTORY}
-        ".*(.deb|.gpg|.sha256|.snap|.assert|.txt|.json)$"
+        ".*(.deb|.gpg|.sha256|.sha384|.snap|.assert|.txt|.json)$"
     )
 
     # for auto tagged builds, we will also upload a second copy of the package
@@ -70,13 +72,10 @@ if(CPACK_UPLOAD_URL)
             )
             ly_upload_to_latest(${CPACK_UPLOAD_URL} "${latest_snap_package}")
 
-            # Generate a assert file for latest and upload it
-            set(latest_assertion_file ${CPACK_UPLOAD_DIRECTORY}/${CPACK_PACKAGE_NAME}_latest_amd64.snap.assert)
-            file(COPY_FILE
-                ${assertion_file}
-                ${latest_assertion_file}
-            )
-            ly_upload_to_latest(${CPACK_UPLOAD_URL} "${latest_assertion_file}")
+            # Generate a checksum file for latest and upload it
+            set(latest_hash_file "${CPACK_UPLOAD_DIRECTORY}/${CPACK_PACKAGE_NAME}_latest.deb.sha384")
+            file(WRITE "${latest_hash_file}" "${file_checksum}  ${latest_snap_package}")
+            ly_upload_to_latest(${CPACK_UPLOAD_URL} "${latest_hash_file}")
         elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
             set(latest_deb_package "${CPACK_UPLOAD_DIRECTORY}/${CPACK_PACKAGE_NAME}_latest.deb")
             file(COPY_FILE

--- a/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
+++ b/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
@@ -11,10 +11,10 @@ include(${LY_ROOT_FOLDER}/cmake/Platform/Common/PackagingPostBuild_common.cmake)
 include(${CPACK_CODESIGN_SCRIPT})
 
 if("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "SNAP")
-    set(snap_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_NAME}_amd64.snap")
-    set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_NAME}_amd64.snap.sha384")
+    set(snap_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}_amd64.snap")
+    set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}_amd64.snap.sha384")
     file(SHA384 ${snap_file} file_checksum) # Snap asserts use SHA284
-    file(WRITE ${hash_file} "${file_checksum}  ${CPACK_PACKAGE_NAME}_amd64.snap")
+    file(WRITE ${hash_file} "${file_checksum}  ${CPACK_PACKAGE_FILE_NAME}_amd64.snap")
 elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
     set(deb_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb")
     set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb.sha256")
@@ -73,7 +73,7 @@ if(CPACK_UPLOAD_URL)
             ly_upload_to_latest(${CPACK_UPLOAD_URL} "${latest_snap_package}")
 
             # Generate a checksum file for latest and upload it
-            set(latest_hash_file "${CPACK_UPLOAD_DIRECTORY}/${CPACK_PACKAGE_NAME}_latest.deb.sha384")
+            set(latest_hash_file "${CPACK_UPLOAD_DIRECTORY}/${CPACK_PACKAGE_NAME}_latest.snap.sha384")
             file(WRITE "${latest_hash_file}" "${file_checksum}  ${latest_snap_package}")
             ly_upload_to_latest(${CPACK_UPLOAD_URL} "${latest_hash_file}")
         elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")

--- a/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
+++ b/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
@@ -58,7 +58,7 @@ if(CPACK_UPLOAD_URL)
     ly_upload_to_url(
         ${CPACK_UPLOAD_URL}
         ${CPACK_UPLOAD_DIRECTORY}
-        ".*(.deb|.gpg|.sha256|.sha384|.snap|.assert|.txt|.json)$"
+        ".*(.deb|.gpg|.sha256|.sha384|.snap|.txt|.json)$"
     )
 
     # for auto tagged builds, we will also upload a second copy of the package

--- a/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
+++ b/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
@@ -13,7 +13,7 @@ include(${CPACK_CODESIGN_SCRIPT})
 if("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "SNAP")
     set(snap_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}_amd64.snap")
     set(hash_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}_amd64.snap.sha384")
-    file(SHA384 ${snap_file} file_checksum) # Snap asserts use SHA284
+    file(SHA384 ${snap_file} file_checksum) # Snap asserts use SHA384
     file(WRITE ${hash_file} "${file_checksum}  ${CPACK_PACKAGE_FILE_NAME}_amd64.snap")
 elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
     set(deb_file "${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb")

--- a/cmake/Platform/Linux/Packaging_Snapcraft.cmake
+++ b/cmake/Platform/Linux/Packaging_Snapcraft.cmake
@@ -30,19 +30,10 @@ execute_process (COMMAND snapcraft --verbose
 )
 
 set(snap_file "${CPACK_TEMPORARY_DIRECTORY}/o3de_${CPACK_PACKAGE_VERSION}_amd64.snap")
-set(assertion_file "${CPACK_TEMPORARY_DIRECTORY}/o3de_${CPACK_PACKAGE_VERSION}_amd64.snap.assert")
-execute_process(
-    COMMAND snapcraft sign-build ${snap_file}
-    OUTPUT_FILE ${assertion_file}
-)
 
 # Manually copy the files, the CPACK_EXTERNAL_BUILT_PACKAGES process runs after our packaging post build script
 # which is too late to be uploaded.
 file(COPY_FILE
                 ${snap_file}
                 "${CPACK_TOPLEVEL_DIRECTORY}/o3de_${CPACK_PACKAGE_VERSION}_amd64.snap"
-            )
-file(COPY_FILE
-                ${assertion_file}
-                "${CPACK_TOPLEVEL_DIRECTORY}/o3de_${CPACK_PACKAGE_VERSION}_amd64.snap.assert"
             )

--- a/cmake/install/Findo3de.cmake.in
+++ b/cmake/install/Findo3de.cmake.in
@@ -42,11 +42,7 @@ if (disable_test_modules)
 endif()
 
 if ($ENV{O3DE_SNAP})
-<<<<<<< Updated upstream
-    list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu;/snap/core20/current/usr/include;/snap/core20/current/usr/include/x86_64-linux-gnu")
-=======
     list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu")
->>>>>>> Stashed changes
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "Wl,-L$ENV{SNAP}/usr/lib/x86_64-linux-gnu")
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "-print-target-triple")
 endif()

--- a/cmake/install/Findo3de.cmake.in
+++ b/cmake/install/Findo3de.cmake.in
@@ -42,7 +42,7 @@ if (disable_test_modules)
 endif()
 
 if ($ENV{O3DE_SNAP})
-    list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu;/snap/core22/current/usr/include;/snap/core22/current/usr/include/x86_64-linux-gnu")
+    list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu;/snap/core20/current/usr/include;/snap/core20/current/usr/include/x86_64-linux-gnu")
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "Wl,-L$ENV{SNAP}/usr/lib/x86_64-linux-gnu")
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "-print-target-triple")
 endif()

--- a/cmake/install/Findo3de.cmake.in
+++ b/cmake/install/Findo3de.cmake.in
@@ -42,7 +42,11 @@ if (disable_test_modules)
 endif()
 
 if ($ENV{O3DE_SNAP})
+<<<<<<< Updated upstream
     list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu;/snap/core20/current/usr/include;/snap/core20/current/usr/include/x86_64-linux-gnu")
+=======
+    list(APPEND CMAKE_REQUIRED_INCLUDES "$ENV{SNAP}/usr/include;$ENV{SNAP}/usr/include/x86_64-linux-gnu")
+>>>>>>> Stashed changes
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "Wl,-L$ENV{SNAP}/usr/lib/x86_64-linux-gnu")
     list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "-print-target-triple")
 endif()


### PR DESCRIPTION
## What does this PR do?

Rolls back some of the fixes for make snap packages work on Ubuntu 22.04, including:
- Removing paths to core22 in the Linux compiler and configurations in the CMake scripts
- Remove custom patchelf fixes and relying on the autopatch provided by Snapcraft 7.3

Re-sets the snap package dependencies for Ubuntu 20.04:
- Sets the base image to core20 (Ubuntu 20.04 container)
- Adds packages needed for Ubuntu 20.04 

## How was this PR tested?

Tested on a snap package built in a sandbox in Ubuntu 20.04 and 22.04

Signed-off-by: Mike Chang <changml@amazon.com>
