### PR TITLE
[Atom Renderer] Explicit render resolution support

### DIFF
--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -153,6 +153,8 @@ namespace UnitTest
             // note: WindowRequests is used internally by ModularViewportCameraController, this ensures it returns the viewport size we want
             ON_CALL(m_mockWindowRequests, GetClientAreaSize())
                 .WillByDefault(Return(AzFramework::WindowSize(WidgetSize.width(), WidgetSize.height())));
+            ON_CALL(m_mockWindowRequests, GetRenderResolution())
+                .WillByDefault(Return(AzFramework::WindowSize(WidgetSize.width(), WidgetSize.height())));
 
             m_mockViewportInteractionRequests.Connect(TestViewportId);
 

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -263,6 +263,8 @@ namespace UnitTest
         // note: WindowRequests is used internally by ViewportManipulatorController
         ON_CALL(mockWindowRequests, GetClientAreaSize())
             .WillByDefault(Return(AzFramework::WindowSize(WidgetSize.width(), WidgetSize.height())));
+        ON_CALL(mockWindowRequests, GetRenderResolution())
+            .WillByDefault(Return(AzFramework::WindowSize(WidgetSize.width(), WidgetSize.height())));
 
         EditorInteractionViewportSelectionFake editorInteractionViewportFake;
         editorInteractionViewportFake.m_internalHandleMouseManipulatorInteraction = [](const MouseInteractionEvent&)

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -76,7 +76,7 @@ namespace SandboxEditor
 
                 AzFramework::WindowSize windowSize;
                 AzFramework::WindowRequestBus::EventResult(
-                    windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                    windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetRenderResolution);
 
                 const auto screenPoint = AzFramework::ScreenPoint(
                     aznumeric_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
@@ -118,6 +118,26 @@ namespace AzFramework
         return m_pimpl->SupportsClientAreaResize();
     }
 
+    void NativeWindow::SetEnableCustomizedResolution(bool enable)
+    {
+        m_pimpl->SetEnableCustomizedResolution(enable);
+    }
+
+    bool NativeWindow::IsCustomizedResolutionEnabled()
+    {
+        return m_pimpl->IsCustomizedResolutionEnabled();
+    }
+
+    WindowSize NativeWindow::GetRenderResolution() const
+    {
+        return m_pimpl->GetRenderResolution();
+    }
+
+    void NativeWindow::SetRenderResolution(WindowSize resolution)
+    {
+        m_pimpl->SetRenderResolution(resolution);
+    }
+
     bool NativeWindow::GetFullScreenState() const
     {
         return m_pimpl->GetFullScreenState();
@@ -243,6 +263,9 @@ namespace AzFramework
         {
             m_activated = true;
             WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnWindowResized, m_width, m_height);
+
+            WindowSize resolution = GetRenderResolution();
+            WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, resolution.m_width, resolution.m_height);
         }
     }
 
@@ -282,6 +305,61 @@ namespace AzFramework
     {
         // Default to client area resize is unsupported, supported platforms will override this function
         return false;
+    }
+
+    void NativeWindow::Implementation::SetEnableCustomizedResolution(bool enable)
+    {
+        if (m_enableCustomizedResolution != enable)
+        {
+            // If disable customized resolution, we need to update render resolution based on client area size
+            WindowSize resolution;
+            if (!enable)
+            {
+                SetRenderResolution(GetClientAreaSize());
+            }
+            m_enableCustomizedResolution = enable;
+            if (enable)
+            {
+                // if enabling customized resolution, send notification if the resolution is different than client area size
+                if (m_customizedRenderResolution != GetClientAreaSize())
+                {
+                    WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, m_customizedRenderResolution.m_width, m_customizedRenderResolution.m_height);
+                }
+            }
+        }
+    }
+
+    bool NativeWindow::Implementation::IsCustomizedResolutionEnabled()
+    {
+        return m_enableCustomizedResolution;
+    }
+
+    WindowSize NativeWindow::Implementation::GetRenderResolution() const
+    {
+        if (m_enableCustomizedResolution)
+        {
+            return m_customizedRenderResolution;
+        }
+        else
+        {
+            return GetClientAreaSize();
+        }
+    }
+
+    void NativeWindow::Implementation::SetRenderResolution(WindowSize resolution)
+    {
+        if (m_enableCustomizedResolution)
+        {
+            if (m_customizedRenderResolution != resolution)
+            {
+                m_customizedRenderResolution = resolution;
+                WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, resolution.m_width, resolution.m_height);
+            } 
+        }
+        else
+        {
+            AZ_Assert(false, "Use SetEnableCustomizedResolution(true) to enable customized render resolution first");
+        }
     }
 
     bool NativeWindow::Implementation::GetFullScreenState() const

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
@@ -123,7 +123,7 @@ namespace AzFramework
         m_pimpl->SetEnableCustomizedResolution(enable);
     }
 
-    bool NativeWindow::IsCustomizedResolutionEnabled()
+    bool NativeWindow::IsCustomizedResolutionEnabled() const
     {
         return m_pimpl->IsCustomizedResolutionEnabled();
     }
@@ -331,7 +331,7 @@ namespace AzFramework
         }
     }
 
-    bool NativeWindow::Implementation::IsCustomizedResolutionEnabled()
+    bool NativeWindow::Implementation::IsCustomizedResolutionEnabled() const
     {
         return m_enableCustomizedResolution;
     }

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
@@ -311,16 +311,18 @@ namespace AzFramework
     {
         if (m_enableCustomizedResolution != enable)
         {
-            // If disable customized resolution, we need to update render resolution based on client area size
-            WindowSize resolution;
+            // If disabling customized resolution, we need to update render resolution based on client area size
+            // Note: this need to be done when m_enableCustomizedResolution is true
             if (!enable)
             {
                 SetRenderResolution(GetClientAreaSize());
             }
+
             m_enableCustomizedResolution = enable;
+
+            // after enabling customized resolution, send notification if the customized resolution is different than client area size
             if (enable)
             {
-                // if enabling customized resolution, send notification if the resolution is different than client area size
                 if (m_customizedRenderResolution != GetClientAreaSize())
                 {
                     WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, m_customizedRenderResolution.m_width, m_customizedRenderResolution.m_height);

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
@@ -128,6 +128,10 @@ namespace AzFramework
         WindowSize GetMaximumClientAreaSize() const override;
         void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options) override;
         bool SupportsClientAreaResize() const override;
+        void SetEnableCustomizedResolution(bool enable) override;
+        bool IsCustomizedResolutionEnabled() override;
+        WindowSize GetRenderResolution() const override;
+        void SetRenderResolution(WindowSize resolution) override;
         bool GetFullScreenState() const override;
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
@@ -179,6 +183,10 @@ namespace AzFramework
             virtual WindowSize GetMaximumClientAreaSize() const;
             virtual void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options);
             virtual bool SupportsClientAreaResize() const;
+            virtual void SetEnableCustomizedResolution(bool enable);
+            virtual bool IsCustomizedResolutionEnabled();
+            virtual WindowSize GetRenderResolution() const;
+            virtual void SetRenderResolution(WindowSize resolution);
             virtual bool GetFullScreenState() const;
             virtual void SetFullScreenState(bool fullScreenState);
             virtual bool CanToggleFullScreenState() const;
@@ -189,6 +197,8 @@ namespace AzFramework
             uint32_t m_width = 0;
             uint32_t m_height = 0;
             bool m_activated = false;
+            WindowSize m_customizedRenderResolution;
+            bool m_enableCustomizedResolution = false;
         };
 
     private:

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
@@ -129,7 +129,7 @@ namespace AzFramework
         void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options) override;
         bool SupportsClientAreaResize() const override;
         void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() override;
+        bool IsCustomizedResolutionEnabled() const override;
         WindowSize GetRenderResolution() const override;
         void SetRenderResolution(WindowSize resolution) override;
         bool GetFullScreenState() const override;
@@ -184,7 +184,7 @@ namespace AzFramework
             virtual void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options);
             virtual bool SupportsClientAreaResize() const;
             virtual void SetEnableCustomizedResolution(bool enable);
-            virtual bool IsCustomizedResolutionEnabled();
+            virtual bool IsCustomizedResolutionEnabled() const;
             virtual WindowSize GetRenderResolution() const;
             virtual void SetRenderResolution(WindowSize resolution);
             virtual bool GetFullScreenState() const;

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -30,6 +30,16 @@ namespace AzFramework
 
         uint32_t m_width = 0;
         uint32_t m_height = 0;
+        
+        bool operator==(const WindowSize& rhs) const
+        {
+            return m_width == rhs.m_width && m_height == rhs.m_height;
+        }
+
+        bool operator!=(const WindowSize& rhs) const
+        {
+            return m_width != rhs.m_width || m_height != rhs.m_height;
+        }
     };
 
     //! Options for resizing and moving the window.
@@ -80,6 +90,21 @@ namespace AzFramework
         //! Generally desktop platforms support resizing, mobile platforms don't.
         virtual bool SupportsClientAreaResize() const = 0;
 
+        //! Enable custom render resolution which is different than client area size.
+        //! If custom render resolution is disabled, the render resolution is same as client area size
+        virtual void SetEnableCustomizedResolution(bool enable) = 0;
+        
+        //! If the custom render resolution is enabled.
+        virtual bool IsCustomizedResolutionEnabled() = 0;
+
+        //! Get the render resolution.
+        //! If customized resolution is not enabled, it would return client area size
+        virtual WindowSize GetRenderResolution() const = 0;
+
+        //! Set render resolution for the window.
+        //! It should only be called when customized resolution is enabled. 
+        virtual void SetRenderResolution(WindowSize resolution) = 0;
+
         //! Get the full screen state of the window.
         //! \return True if the window is currently in full screen, false otherwise.
         virtual bool GetFullScreenState() const = 0;
@@ -127,6 +152,9 @@ namespace AzFramework
 
         //! This is called once when the window is Activated and also called if the user resizes the window.
         virtual void OnWindowResized(uint32_t width, uint32_t height) { AZ_UNUSED(width); AZ_UNUSED(height); };
+        
+        //! This is called when the window's desired render resolution is changed.
+        virtual void OnResolutionChanged(uint32_t width, uint32_t height) { AZ_UNUSED(width); AZ_UNUSED(height); };
 
         //! This is called if the window's underyling DPI scaling factor changes.
         virtual void OnDpiScaleFactorChanged(float dpiScaleFactor) { AZ_UNUSED(dpiScaleFactor); }

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -95,7 +95,7 @@ namespace AzFramework
         virtual void SetEnableCustomizedResolution(bool enable) = 0;
         
         //! If the custom render resolution is enabled.
-        virtual bool IsCustomizedResolutionEnabled() = 0;
+        virtual bool IsCustomizedResolutionEnabled() const = 0;
 
         //! Get the render resolution.
         //! If customized resolution is not enabled, it would return client area size

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -432,6 +432,10 @@ namespace AzFramework
             {
                 WindowNotificationBus::Event(
                     reinterpret_cast<NativeWindowHandle>(m_xcbWindow), &WindowNotificationBus::Events::OnWindowResized, width, height);
+                if (!m_enableCustomizedResolution)
+                {
+                    WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, width, height);
+                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -325,37 +325,37 @@ namespace AzFramework
             //const bool windowIsNowInactive = (LOWORD(wParam) == WA_INACTIVE);
             //const bool windowFullScreenState = nativeWindowImpl->GetFullScreenState();
 
-            //if (windowIsNowInactive)
-            //{
-            //    if (windowFullScreenState)
-            //    {
-            //        nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = true;
-            //        nativeWindowImpl->SetFullScreenState(false);
-            //    }
+            if (windowIsNowInactive)
+            {
+                if (windowFullScreenState)
+                {
+                    nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = true;
+                    nativeWindowImpl->SetFullScreenState(false);
+                }
 
-            //    // When becoming inactive, transition from TOPMOST to NOTOPMOST.
-            //    SetWindowPos(nativeWindowImpl->m_win32Handle,
-            //        HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
-            //}
-            //else
-            //{
-            //    // When running in Windowed mode, we might want either NOTOPMOST or TOPMOST, depending on whether or not a debugger is attached.
-            //    HWND windowPriority = GetWindowedPriority();
+                // When becoming inactive, transition from TOPMOST to NOTOPMOST.
+                SetWindowPos(nativeWindowImpl->m_win32Handle,
+                    HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+            }
+            else
+            {
+                // When running in Windowed mode, we might want either NOTOPMOST or TOPMOST, depending on whether or not a debugger is attached.
+                HWND windowPriority = GetWindowedPriority();
 
-            //    if (!windowFullScreenState && nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate)
-            //    {
-            //        nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = false;
-            //        nativeWindowImpl->SetFullScreenState(true);
+                if (!windowFullScreenState && nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate)
+                {
+                    nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = false;
+                    nativeWindowImpl->SetFullScreenState(true);
 
-            //        // If we're going to fullscreen, then we presumably want to be TOPMOST whether or not a debugger is attached.
-            //        windowPriority = HWND_TOPMOST;
-            //    }
+                    // If we're going to fullscreen, then we presumably want to be TOPMOST whether or not a debugger is attached.
+                    windowPriority = HWND_TOPMOST;
+                }
 
-            //    // When becoming active again, transition from NOTOPMOST to TOPMOST. (Or stay NOTOPMOST if a debugger is attached)
-            //    SetWindowPos(
-            //        nativeWindowImpl->m_win32Handle,
-            //        windowPriority, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
-            //}
+                // When becoming active again, transition from NOTOPMOST to TOPMOST. (Or stay NOTOPMOST if a debugger is attached)
+                SetWindowPos(
+                    nativeWindowImpl->m_win32Handle,
+                    windowPriority, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+            }
             break;
         }
         case WM_SYSKEYDOWN:

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -322,8 +322,8 @@ namespace AzFramework
             // Alt-tabbing out of the app while it is in a full screen state does not
             // work unless we explicitly exit the full screen state upon deactivation,
             // in which case we want to enter full screen state again upon activation.
-            //const bool windowIsNowInactive = (LOWORD(wParam) == WA_INACTIVE);
-            //const bool windowFullScreenState = nativeWindowImpl->GetFullScreenState();
+            const bool windowIsNowInactive = (LOWORD(wParam) == WA_INACTIVE);
+            const bool windowFullScreenState = nativeWindowImpl->GetFullScreenState();
 
             if (windowIsNowInactive)
             {

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -322,40 +322,40 @@ namespace AzFramework
             // Alt-tabbing out of the app while it is in a full screen state does not
             // work unless we explicitly exit the full screen state upon deactivation,
             // in which case we want to enter full screen state again upon activation.
-            const bool windowIsNowInactive = (LOWORD(wParam) == WA_INACTIVE);
-            const bool windowFullScreenState = nativeWindowImpl->GetFullScreenState();
+            //const bool windowIsNowInactive = (LOWORD(wParam) == WA_INACTIVE);
+            //const bool windowFullScreenState = nativeWindowImpl->GetFullScreenState();
 
-            if (windowIsNowInactive)
-            {
-                if (windowFullScreenState)
-                {
-                    nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = true;
-                    nativeWindowImpl->SetFullScreenState(false);
-                }
+            //if (windowIsNowInactive)
+            //{
+            //    if (windowFullScreenState)
+            //    {
+            //        nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = true;
+            //        nativeWindowImpl->SetFullScreenState(false);
+            //    }
 
-                // When becoming inactive, transition from TOPMOST to NOTOPMOST.
-                SetWindowPos(nativeWindowImpl->m_win32Handle,
-                    HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
-            }
-            else
-            {
-                // When running in Windowed mode, we might want either NOTOPMOST or TOPMOST, depending on whether or not a debugger is attached.
-                HWND windowPriority = GetWindowedPriority();
+            //    // When becoming inactive, transition from TOPMOST to NOTOPMOST.
+            //    SetWindowPos(nativeWindowImpl->m_win32Handle,
+            //        HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+            //}
+            //else
+            //{
+            //    // When running in Windowed mode, we might want either NOTOPMOST or TOPMOST, depending on whether or not a debugger is attached.
+            //    HWND windowPriority = GetWindowedPriority();
 
-                if (!windowFullScreenState && nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate)
-                {
-                    nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = false;
-                    nativeWindowImpl->SetFullScreenState(true);
+            //    if (!windowFullScreenState && nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate)
+            //    {
+            //        nativeWindowImpl->m_shouldEnterFullScreenStateOnActivate = false;
+            //        nativeWindowImpl->SetFullScreenState(true);
 
-                    // If we're going to fullscreen, then we presumably want to be TOPMOST whether or not a debugger is attached.
-                    windowPriority = HWND_TOPMOST;
-                }
+            //        // If we're going to fullscreen, then we presumably want to be TOPMOST whether or not a debugger is attached.
+            //        windowPriority = HWND_TOPMOST;
+            //    }
 
-                // When becoming active again, transition from NOTOPMOST to TOPMOST. (Or stay NOTOPMOST if a debugger is attached)
-                SetWindowPos(
-                    nativeWindowImpl->m_win32Handle,
-                    windowPriority, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
-            }
+            //    // When becoming active again, transition from NOTOPMOST to TOPMOST. (Or stay NOTOPMOST if a debugger is attached)
+            //    SetWindowPos(
+            //        nativeWindowImpl->m_win32Handle,
+            //        windowPriority, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+            //}
             break;
         }
         case WM_SYSKEYDOWN:
@@ -426,6 +426,10 @@ namespace AzFramework
             if (m_activated)
             {
                 WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnWindowResized, width, height);
+                if (!m_enableCustomizedResolution)
+                {
+                    WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnResolutionChanged, width, height);
+                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Tests/Mocks/MockWindowRequests.h
+++ b/Code/Framework/AzFramework/Tests/Mocks/MockWindowRequests.h
@@ -32,6 +32,10 @@ namespace UnitTest
         MOCK_CONST_METHOD0(GetMaximumClientAreaSize, AzFramework::WindowSize());
         MOCK_METHOD2(ResizeClientArea, void(AzFramework::WindowSize clientAreaSize, const AzFramework::WindowPosOptions& options));
         MOCK_CONST_METHOD0(SupportsClientAreaResize, bool());
+        MOCK_METHOD1(SetRenderResolution, void(AzFramework::WindowSize resolution));
+        MOCK_CONST_METHOD0(GetRenderResolution, AzFramework::WindowSize());
+        MOCK_CONST_METHOD0(IsCustomizedResolutionEnabled, bool());
+        MOCK_METHOD1(SetEnableCustomizedResolution, void(bool));
         MOCK_CONST_METHOD0(GetFullScreenState, bool());
         MOCK_METHOD1(SetFullScreenState, void(bool));
         MOCK_CONST_METHOD0(CanToggleFullScreenState, bool());

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -53,6 +53,7 @@ AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRig
 AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
 AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
 AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
+AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render solution same as window client area size, 1: render solution use a specified resolution");
 
 namespace AZ
 {
@@ -178,6 +179,24 @@ namespace AZ
                     }
                 }
 
+                const AZStd::string resolutionModeCvarName("r_resolutionMode");
+                if (pCmdLine->HasSwitch(resolutionModeCvarName))
+                {
+                    auto numValues = pCmdLine->GetNumSwitchValues(resolutionModeCvarName);
+                    if (numValues > 0)
+                    {
+                        auto valueStr = pCmdLine->GetSwitchValue(resolutionModeCvarName);
+                        if (AZ::StringFunc::LooksLikeInt(valueStr.c_str()))
+                        {
+                            auto resolutionMode = AZ::StringFunc::ToInt(valueStr.c_str());
+                            if (resolutionMode >= 0)
+                            {
+                                r_resolutionMode = resolutionMode;
+                            }
+                        }
+                    }
+                }
+
             }
 
             void BootstrapSystemComponent::Activate()
@@ -230,6 +249,15 @@ namespace AZ
                         if (m_nativeWindow)
                         {
                             // wait until swapchain has been created before setting fullscreen state
+                            if ((uint32_t)r_resolutionMode > 0)
+                            {
+                                m_nativeWindow->SetEnableCustomizedResolution(true);
+                                m_nativeWindow->SetRenderResolution(AzFramework::WindowSize(r_width, r_height));
+                            }
+                            else
+                            {
+                                m_nativeWindow->SetEnableCustomizedResolution(false);
+                            }
                             m_nativeWindow->SetFullScreenState(r_fullscreen);
                         }
                     });

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -53,7 +53,7 @@ AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRig
 AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
 AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
 AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
-AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render solution same as window client area size, 1: render solution use a specified resolution");
+AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
 
 namespace AZ
 {

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -249,7 +249,7 @@ namespace AZ
                         if (m_nativeWindow)
                         {
                             // wait until swapchain has been created before setting fullscreen state
-                            if ((uint32_t)r_resolutionMode > 0)
+                            if (r_resolutionMode > 0u)
                             {
                                 m_nativeWindow->SetEnableCustomizedResolution(true);
                                 m_nativeWindow->SetRenderResolution(AzFramework::WindowSize(r_width, r_height));

--- a/Gems/Atom/Component/DebugCamera/Code/Source/ArcBallControllerComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/ArcBallControllerComponent.cpp
@@ -88,7 +88,7 @@ namespace AZ
             AzFramework::WindowRequestBus::EventResult(
                 windowSize,
                 windowHandle,
-                &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                &AzFramework::WindowRequestBus::Events::GetRenderResolution);
 
             m_windowWidth = windowSize.m_width;
             m_windowHeight = windowSize.m_height;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
@@ -56,14 +56,13 @@ namespace AZ
          */
         class DisplayMapperPass
             : public RPI::ParentPass
-            , public AzFramework::WindowNotificationBus::Handler
         {
             AZ_RPI_PASS(DisplayMapperPass);
 
         public:
             AZ_RTTI(DisplayMapperPass, "{B022D9D6-BDFA-4435-B27C-466DC4C91D18}", RPI::ParentPass);
             AZ_CLASS_ALLOCATOR(DisplayMapperPass, SystemAllocator);
-            virtual ~DisplayMapperPass();
+            virtual ~DisplayMapperPass() = default;
 
             //! Creates a DisplayMapperPass
             static RPI::Ptr<DisplayMapperPass> Create(const RPI::PassDescriptor& descriptor);
@@ -77,9 +76,6 @@ namespace AZ
             void FrameBeginInternal(FramePrepareParams params) final;
             void FrameEndInternal() final;
             void CreateChildPassesInternal() final;
-
-            // WindowNotificationBus::Handler overrides ...
-            void OnResolutionChanged(uint32_t width, uint32_t height) override;
 
         private:
             void ConfigureDisplayParameters();

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperPass.h
@@ -79,7 +79,7 @@ namespace AZ
             void CreateChildPassesInternal() final;
 
             // WindowNotificationBus::Handler overrides ...
-            void OnWindowResized(uint32_t width, uint32_t height) override;
+            void OnResolutionChanged(uint32_t width, uint32_t height) override;
 
         private:
             void ConfigureDisplayParameters();

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -63,7 +63,7 @@ namespace AZ
             AzFramework::WindowNotificationBus::Handler::BusDisconnect();
         }
 
-        void DisplayMapperPass::OnWindowResized([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
+        void DisplayMapperPass::OnResolutionChanged([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
         {
             // Need to invalidate the CopyToSwapChain pass so that it updates the pipeline state in the event that 
             // the swapchain format changed (for example, moving from LDR to HDR display)

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -43,12 +43,6 @@ namespace AZ
         DisplayMapperPass::DisplayMapperPass(const RPI::PassDescriptor& descriptor)
             : RPI::ParentPass(descriptor)
         {
-            AzFramework::NativeWindowHandle windowHandle = nullptr;
-            AzFramework::WindowSystemRequestBus::BroadcastResult(
-                windowHandle,
-                &AzFramework::WindowSystemRequestBus::Events::GetDefaultWindowHandle);
-            AzFramework::WindowNotificationBus::Handler::BusConnect(windowHandle);
-
             GetDisplayMapperConfiguration();
 
             const DisplayMapperPassData* passData = RPI::PassUtils::GetPassData<DisplayMapperPassData>(descriptor);
@@ -56,26 +50,6 @@ namespace AZ
             {
                 m_displayMapperConfigurationDescriptor = passData->m_config;
             }
-        }
-
-        DisplayMapperPass::~DisplayMapperPass()
-        {
-            AzFramework::WindowNotificationBus::Handler::BusDisconnect();
-        }
-
-        void DisplayMapperPass::OnResolutionChanged([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
-        {
-            // Need to invalidate the CopyToSwapChain pass so that it updates the pipeline state in the event that 
-            // the swapchain format changed (for example, moving from LDR to HDR display)
-            const Name copyToSwapChainPassName("CopyToSwapChain");
-            RPI::PassFilter passFilter = RPI::PassFilter::CreateWithPassName(copyToSwapChainPassName, GetRenderPipeline());
-            RPI::PassSystemInterface::Get()->ForEachPass(passFilter, [](RPI::Pass* pass) -> RPI::PassFilterExecutionFlow
-                {
-                    pass->QueueForInitialization();
-                    return RPI::PassFilterExecutionFlow::StopVisitingPasses;
-                });
-
-            ConfigureDisplayParameters();
         }
 
         void DisplayMapperPass::ConfigureDisplayParameters()

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
@@ -130,7 +130,23 @@ namespace AZ
             DepthThenKey,
             ReverseDepthThenKey
         };
+        
+        enum class Scaling : uint32_t
+        {
+            None = 0,               // No scaling
+            Stretch,                // Scale the source to fit the target
+            AspectRatioStretch,     // Scale the source to fit the target while preserving the aspect ratio of the source
+        };
 
+        //! Flags for specifying supported Scaling modes
+        enum class ScalingFlags : uint32_t
+        {
+            None = 0,
+            Stretch = AZ_BIT(static_cast<uint32_t>(Scaling ::Stretch)),
+            AspectRatioStretch = AZ_BIT(static_cast<uint32_t>(Scaling ::AspectRatioStretch)),
+            All = Stretch | AspectRatioStretch
+        };
+        AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ScalingFlags);
     }
 
     AZ_TYPE_INFO_SPECIALIZE(RHI::DrawListSortType, "{D43AF0B7-7314-4B57-AA98-6209235B91BB}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
@@ -94,6 +94,9 @@ namespace AZ
             
             //! Whether the adapter supports wave/subgroup operation
             bool m_waveOperation = false;
+                        
+            //! Whether swapchain scaling support is available.
+            RHI::ScalingFlags m_swapchainScalingFlags = RHI::ScalingFlags::None;
 
             /// Additional features here.
         };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
@@ -64,6 +64,11 @@ namespace AZ
             // Return the index of a XR swapchain
             // as you can have multiple XR swapchains (one per view).
             uint32_t m_xrSwapChainIndex = 0;
+
+            // The scaling mode when presents the swapchain's back buffer to the target
+            // Note: not all platforms support stretch or stretch with aspect ratio.
+            // Use DeviceFeature::m_swapChainScalingFlags to find out supported stretch modes
+            Scaling m_scalingMode = RHI::Scaling::None;
         };
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
@@ -65,7 +65,7 @@ namespace AZ
             // as you can have multiple XR swapchains (one per view).
             uint32_t m_xrSwapChainIndex = 0;
 
-            // The scaling mode when presents the swapchain's back buffer to the target
+            // The scaling mode to use when presenting the swapchain's back buffer to the target
             // Note: not all platforms support stretch or stretch with aspect ratio.
             // Use DeviceFeature::m_swapChainScalingFlags to find out supported stretch modes
             Scaling m_scalingMode = RHI::Scaling::None;

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
@@ -50,7 +50,7 @@ namespace AZ
             swapChainDesc.Width = descriptor.m_dimensions.m_imageWidth;
             swapChainDesc.Height = descriptor.m_dimensions.m_imageHeight;
             swapChainDesc.Format = ConvertFormat(descriptor.m_dimensions.m_imageFormat);
-            swapChainDesc.Scaling = DXGI_SCALING_NONE;
+            swapChainDesc.Scaling = DXGI_SCALING_STRETCH; // Note: Creating SwapChain with DXGI_SCALING_ASPECT_RATIO_STRETCH scaling always fail. Some source said it can't be used for swapchain created for HWnd
             swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
             swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
             if (m_isTearingSupported)

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
@@ -50,7 +50,7 @@ namespace AZ
             swapChainDesc.Width = descriptor.m_dimensions.m_imageWidth;
             swapChainDesc.Height = descriptor.m_dimensions.m_imageHeight;
             swapChainDesc.Format = ConvertFormat(descriptor.m_dimensions.m_imageFormat);
-            swapChainDesc.Scaling = DXGI_SCALING_STRETCH; // Note: Creating SwapChain with DXGI_SCALING_ASPECT_RATIO_STRETCH scaling always fail. Some source said it can't be used for swapchain created for HWnd
+            swapChainDesc.Scaling = ConvertScaling(descriptor.m_scalingMode);
             swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
             swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
             if (m_isTearingSupported)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
@@ -1455,5 +1455,20 @@ namespace AZ
                     return RHI::ResultCode::Fail;
             }
         }
-   }
+
+        DXGI_SCALING ConvertScaling(RHI::Scaling scaling)
+        {
+            switch(scaling)
+            {
+                case RHI::Scaling::None:
+                    return DXGI_SCALING_NONE;
+                case RHI::Scaling::Stretch:
+                    return DXGI_SCALING_STRETCH;
+                case RHI::Scaling::AspectRatioStretch:
+                    return DXGI_SCALING_ASPECT_RATIO_STRETCH;
+                default:
+                    return DXGI_SCALING_STRETCH;
+            }
+        }
+    }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.h
@@ -170,5 +170,7 @@ namespace AZ
         D3D12_SHADING_RATE_COMBINER ConvertShadingRateCombiner(RHI::ShadingRateCombinerOp op);
 
         RHI::ResultCode ConvertResult(HRESULT result);
+
+        DXGI_SCALING ConvertScaling(RHI::Scaling scaling);
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -231,6 +231,12 @@ namespace AZ
             m_features.m_indirectDrawCountBufferSupported = true;
             m_features.m_indirectDispatchCountBufferSupported = true;
             m_features.m_indirectDrawStartInstanceLocationSupported = true;
+
+            // DXGI_SCALING_ASPECT_RATIO_STRETCH is only compatible with CreateSwapChainForCoreWindow or CreateSwapChainForComposition,
+            // not Win32 window handles and associated methods (cannot find an MSDN source for that)
+            // Source: https://stackoverflow.com/questions/58586223/d3d11-createswapchainforhwnd-fails-with-either-dxgi-error-invalid-call-or-e-inva
+            // Create swapchain would fail if uses DXGI_SCALING_ASPECT_RATIO_STRETCH
+            m_features.m_swapchainScalingFlags = RHI::ScalingFlags::Stretch;
                         
             D3D12_FEATURE_DATA_D3D12_OPTIONS options;
             GetDevice()->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
@@ -28,6 +28,7 @@
     RHIMetalView* metalView = reinterpret_cast<RHIMetalView*>([notification.object contentView]);
     CGSize drawableSize = metalView.metalLayer.drawableSize;
     AzFramework::WindowNotificationBus::Event(notification.object, &AzFramework::WindowNotificationBus::Events::OnWindowResized, drawableSize.width, drawableSize.height);
+    AzFramework::WindowNotificationBus::Event(notification.object, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, drawableSize.width, drawableSize.height);
 }
 @end
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SwapChainPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SwapChainPass.h
@@ -55,7 +55,7 @@ namespace AZ
             void FrameBeginInternal(FramePrepareParams params) override final;
             
             // WindowNotificationBus::Handler overrides ...
-            void OnWindowResized(uint32_t width, uint32_t height) override;
+            void OnResolutionChanged(uint32_t width, uint32_t height) override;
 
         private:
             // Sets up a swap chain PassAttachment using the swap chain id from the window context 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -237,6 +237,9 @@ namespace AZ
             //! Return the view type associated with this pipeline.
             ViewType GetViewType() const;
 
+            //! Update viewport and scissor based on pass tree's output
+            void UpdateViewportScissor();
+
         private:
             RenderPipeline() = default;
 
@@ -297,8 +300,6 @@ namespace AZ
             // End of functions accessed by Scene class
             //////////////////////////////////////////////////
 
-            // update viewport and scissor based on pass tree's output
-            void UpdateViewportScissor();
 
             RenderMode m_renderMode = RenderMode::RenderEveryTick;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -94,9 +94,7 @@ namespace AZ
             void OnEndPrepareRender() override;
 
             // WindowNotificationBus interface overrides...
-            //! Used to fire a notification when our window resizes.
-            void OnWindowResized(uint32_t width, uint32_t height) override;
-            //! Used to fire a notification when our window DPI changes.
+            void OnResolutionChanged(uint32_t width, uint32_t height) override;
             void OnDpiScaleFactorChanged(float dpiScaleFactor) override;
 
             using SizeChangedEvent = AZ::Event<AzFramework::WindowSize>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
@@ -70,9 +70,14 @@ namespace AZ
 
             //! Get the number of active swapchains
             uint32_t GetSwapChainsSize() const;
+
+            //! Get swapchain scaling mode
+            RHI::Scaling GetSwapChainScalingMode() const;
+
         private:
 
             // WindowNotificationBus::Handler overrides ...
+            void OnWindowResized(uint32_t width, uint32_t height) override;
             void OnResolutionChanged(uint32_t width, uint32_t height) override;
             void OnWindowClosed() override;
             void OnVsyncIntervalChanged(uint32_t interval) override;
@@ -84,6 +89,14 @@ namespace AZ
 
             // Creates the underlying RHI level SwapChain for the given Window plus XR swapchains.
             void CreateSwapChains(RHI::Device& device);
+
+            // Figure out swapchain's size based on window's client area size, render resolution and
+            // device's swapchain scaling support
+            AzFramework::WindowSize ResolveSwapchainSize();
+
+            // Resize the swapchain if it's needed when window size or render resolution changed.
+            // Return true if swapchain is resized. 
+            bool CheckResizeSwapChain();
 
             // Destroys the underlying default SwapChain
             void DestroyDefaultSwapChain();
@@ -116,6 +129,8 @@ namespace AZ
             };
             // Data structure to hold SwapChain for Default and XR SwapChains.
             AZStd::vector<SwapChainData> m_swapChainsData;
+
+            RHI::Scaling m_swapChainScalingMode; 
 
             // Non-owning reference to associated ViewportContexts (if any)
             AZStd::vector<AZStd::weak_ptr<ViewportContext>> m_viewportContexts;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
@@ -73,7 +73,7 @@ namespace AZ
         private:
 
             // WindowNotificationBus::Handler overrides ...
-            void OnWindowResized(uint32_t width, uint32_t height) override;
+            void OnResolutionChanged(uint32_t width, uint32_t height) override;
             void OnWindowClosed() override;
             void OnVsyncIntervalChanged(uint32_t interval) override;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
@@ -130,6 +130,8 @@ namespace AZ
             // Data structure to hold SwapChain for Default and XR SwapChains.
             AZStd::vector<SwapChainData> m_swapChainsData;
 
+            // The scaling mode used by the device swapchain.
+            // If it supports stretch, the SwapChainPass in the render pipeline shouldn't need to do extra scaling
             RHI::Scaling m_swapChainScalingMode; 
 
             // Non-owning reference to associated ViewportContexts (if any)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -217,16 +217,11 @@ namespace AZ
 
             RHI::Size targetImageSize = outputAttachment->m_descriptor.m_image.m_size;
 
-            
-            m_viewportState.m_maxX = static_cast<float>(AZStd::min(static_cast<uint32_t>(params.m_viewportState.m_maxX), targetImageSize.m_width));
-            m_viewportState.m_maxY = static_cast<float>(AZStd::min(static_cast<uint32_t>(params.m_viewportState.m_maxY), targetImageSize.m_height));
-            m_viewportState.m_minX = static_cast<float>(AZStd::min(params.m_viewportState.m_minX, m_viewportState.m_maxX));
-            m_viewportState.m_minY = static_cast<float>(AZStd::min(params.m_viewportState.m_minY, m_viewportState.m_maxY));
+            m_viewportState.m_maxX = static_cast<float>(targetImageSize.m_width);
+            m_viewportState.m_maxY = static_cast<float>(targetImageSize.m_height);
 
-            m_scissorState.m_maxX = AZStd::min(static_cast<uint32_t>(params.m_scissorState.m_maxX), targetImageSize.m_width);
-            m_scissorState.m_maxY = AZStd::min(static_cast<uint32_t>(params.m_scissorState.m_maxY), targetImageSize.m_height);
-            m_scissorState.m_minX = AZStd::min(params.m_scissorState.m_minX, m_scissorState.m_maxX);
-            m_scissorState.m_minY = AZStd::min(params.m_scissorState.m_minY, m_scissorState.m_maxY);
+            m_scissorState.m_maxX = static_cast<int32_t>(targetImageSize.m_width);
+            m_scissorState.m_maxY = static_cast<int32_t>(targetImageSize.m_height);
 
             RenderPass::FrameBeginInternal(params);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -27,7 +27,7 @@ namespace AZ
             
             // Need an intermediate output and a copy pass if the render resolution is different than swapchain's size
             // Ideally, this should be set based on the size of window's render resolution and swapchain's size
-            // The pass system has problem to update the pass tree properly when the m_needCopyOutput state changes
+            // The pass system has problem updating the pass tree properly when the m_needCopyOutput state changes
             // Now we set it to true if the window context doesn't have swapchain scaling
             m_needCopyOutput = windowContext->GetSwapChainScalingMode() == RHI::Scaling::None;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -159,6 +159,11 @@ namespace AZ
             SetupSwapChainAttachment();
 
             ParentPass::BuildInternal();
+
+            if (m_pipeline)
+            {
+                m_pipeline->UpdateViewportScissor();
+            }
         }
 
         void SwapChainPass::CreateChildPassesInternal()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -140,7 +140,7 @@ namespace AZ
             ParentPass::FrameBeginInternal(params);
         }
         
-        void SwapChainPass::OnWindowResized([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
+        void SwapChainPass::OnResolutionChanged([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
         {
             QueueForBuildAndInitialization();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -28,7 +28,7 @@ namespace AZ
             AzFramework::WindowRequestBus::EventResult(
                 m_viewportSize,
                 nativeWindow,
-                &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                &AzFramework::WindowRequestBus::Events::GetRenderResolution);
             AzFramework::WindowRequestBus::EventResult(
                 m_viewportDpiScaleFactor,
                 nativeWindow,
@@ -404,7 +404,7 @@ namespace AZ
             }
         }
 
-        void ViewportContext::OnWindowResized(uint32_t width, uint32_t height)
+        void ViewportContext::OnResolutionChanged(uint32_t width, uint32_t height)
         {
             if (m_viewportSize.m_width != width || m_viewportSize.m_height != height)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
 
 #include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
 
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Math/MathUtils.h>
@@ -24,6 +25,19 @@ namespace AZ
         void WindowContext::Initialize(RHI::Device& device, AzFramework::NativeWindowHandle windowHandle)
         {
             m_windowHandle = windowHandle;
+
+            if (RHI::CheckBitsAll(device.GetFeatures().m_swapchainScalingFlags, RHI::ScalingFlags::AspectRatioStretch))
+            {
+                m_swapChainScalingMode = RHI::Scaling::AspectRatioStretch;
+            }
+            else if (RHI::CheckBitsAll(device.GetFeatures().m_swapchainScalingFlags, RHI::ScalingFlags::Stretch))
+            {
+                m_swapChainScalingMode = RHI::Scaling::Stretch;
+            }
+            else
+            {
+                m_swapChainScalingMode = RHI::Scaling::None;
+            }
 
             CreateSwapChains(device);
 
@@ -77,6 +91,11 @@ namespace AZ
             return aznumeric_cast<uint32_t>(m_swapChainsData.size());
         }
 
+        RHI::Scaling WindowContext::GetSwapChainScalingMode() const
+        {
+            return m_swapChainScalingMode;
+        }
+
         const RHI::Viewport& WindowContext::GetViewport(ViewType viewType) const
         {
             uint32_t swapChainIndex = static_cast<uint32_t>(viewType);
@@ -90,25 +109,38 @@ namespace AZ
             AZ_Assert(swapChainIndex < GetSwapChainsSize(), "Swapchain does not exist");
             return m_swapChainsData[swapChainIndex].m_scissor;  
         }
+        
+        void WindowContext::OnWindowResized([[maybe_unused]]uint32_t width, [[maybe_unused]]uint32_t height)
+        {
+            CheckResizeSwapChain();
+        }
 
-        void WindowContext::OnResolutionChanged(uint32_t width, uint32_t height)
+        void WindowContext::OnResolutionChanged([[maybe_unused]]uint32_t width, [[maybe_unused]]uint32_t height)
+        {
+            CheckResizeSwapChain();
+        }
+
+        bool WindowContext::CheckResizeSwapChain()
         {
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             const AZ::RHI::SwapChainDimensions& currentDimensions = defaultSwapChain->GetDescriptor().m_dimensions;
-            if (width != currentDimensions.m_imageWidth || height != currentDimensions.m_imageHeight)
+            AzFramework::WindowSize renderSize = ResolveSwapchainSize();
+            if (renderSize.m_width != currentDimensions.m_imageWidth || renderSize.m_height != currentDimensions.m_imageHeight)
             {
                 // Get current dimension and only overwrite the sizes.
                 RHI::SwapChainDimensions dimensions = defaultSwapChain->GetDescriptor().m_dimensions;
-                dimensions.m_imageWidth = AZStd::max(width, 1u);
-                dimensions.m_imageHeight = AZStd::max(height, 1u);
+                dimensions.m_imageWidth = renderSize.m_width;
+                dimensions.m_imageHeight = renderSize.m_height;
                 dimensions.m_imageFormat = GetSwapChainFormat(defaultSwapChain->GetDevice());
 
                 FillWindowState(dimensions.m_imageWidth, dimensions.m_imageHeight);
 
                 defaultSwapChain->Resize(dimensions);
 
-                WindowContextNotificationBus::Event(m_windowHandle, &WindowContextNotifications::OnViewportResized, width, height);
+                WindowContextNotificationBus::Event(m_windowHandle, &WindowContextNotifications::OnViewportResized, dimensions.m_imageWidth, dimensions.m_imageHeight);
+                return true;
             }
+            return false;
         }
 
         void WindowContext::OnWindowClosed()
@@ -148,32 +180,51 @@ namespace AZ
             return defaultSwapChain->SetExclusiveFullScreenState(fullScreenState);
         }
 
+        AzFramework::WindowSize WindowContext::ResolveSwapchainSize()
+        {
+            AzFramework::WindowSize windowSize;
+            AzFramework::WindowSize renderSize;
+            AzFramework::WindowRequestBus::EventResult(
+                windowSize,
+                m_windowHandle,
+                &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+            AzFramework::WindowRequestBus::EventResult(
+                renderSize,
+                m_windowHandle,
+                &AzFramework::WindowRequestBus::Events::GetRenderResolution);
+
+            if (windowSize != renderSize && m_swapChainScalingMode == RHI::Scaling::None)
+            {
+                // no stretch support. we need to use the window size for render size
+                renderSize = windowSize;
+            }
+
+            renderSize.m_width = AZStd::max(renderSize.m_width, 1u);
+            renderSize.m_height = AZStd::max(renderSize.m_height, 1u);
+            return renderSize;
+        }
+
         void WindowContext::CreateSwapChains(RHI::Device& device)
         {
             RHI::Ptr<RHI::SwapChain> swapChain = RHI::Factory::Get().CreateSwapChain();
 
-            AzFramework::WindowSize windowSize;
-            AzFramework::WindowRequestBus::EventResult(
-                windowSize,
-                m_windowHandle,
-                &AzFramework::WindowRequestBus::Events::GetRenderResolution);
+            RHI::SwapChainDescriptor descriptor;
 
-            uint32_t width = AZStd::max(windowSize.m_width, 1u);
-            uint32_t height = AZStd::max(windowSize.m_height, 1u);
-
+            AzFramework::WindowSize renderSize = ResolveSwapchainSize();
+           
             const RHI::WindowHandle windowHandle = RHI::WindowHandle(reinterpret_cast<uintptr_t>(m_windowHandle));
 
             uint32_t syncInterval = 1;
             AzFramework::WindowRequestBus::EventResult(
                 syncInterval, m_windowHandle, &AzFramework::WindowRequestBus::Events::GetSyncInterval);
 
-            RHI::SwapChainDescriptor descriptor;
             descriptor.m_window = windowHandle;
             descriptor.m_verticalSyncInterval = syncInterval;
-            descriptor.m_dimensions.m_imageWidth = width;
-            descriptor.m_dimensions.m_imageHeight = height;
+            descriptor.m_dimensions.m_imageWidth = renderSize.m_height;
+            descriptor.m_dimensions.m_imageHeight = renderSize.m_width;
             descriptor.m_dimensions.m_imageCount = AZStd::max(RHI::Limits::Device::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
             descriptor.m_dimensions.m_imageFormat = GetSwapChainFormat(device);
+            descriptor.m_scalingMode = m_swapChainScalingMode;
 
             AZStd::string attachmentName = AZStd::string::format("WindowContextAttachment_%p", m_windowHandle);
             descriptor.m_attachmentId = RHI::AttachmentId{ attachmentName.c_str() };
@@ -217,6 +268,7 @@ namespace AZ
                     xrDescriptor.m_isXrSwapChain = true;
                     xrDescriptor.m_xrSwapChainIndex = i;
                     xrDescriptor.m_dimensions.m_imageFormat = xrSystem->GetSwapChainFormat(i);
+                    xrDescriptor.m_scalingMode = m_swapChainScalingMode;
 
                     const AZStd::string xrAttachmentName = AZStd::string::format("XRSwapChain_View_%i", i);
                     xrDescriptor.m_attachmentId = RHI::AttachmentId{ xrAttachmentName.c_str() };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -220,8 +220,8 @@ namespace AZ
 
             descriptor.m_window = windowHandle;
             descriptor.m_verticalSyncInterval = syncInterval;
-            descriptor.m_dimensions.m_imageWidth = renderSize.m_height;
-            descriptor.m_dimensions.m_imageHeight = renderSize.m_width;
+            descriptor.m_dimensions.m_imageWidth = renderSize.m_width;
+            descriptor.m_dimensions.m_imageHeight = renderSize.m_height;
             descriptor.m_dimensions.m_imageCount = AZStd::max(RHI::Limits::Device::MinSwapChainImages, RHI::Limits::Device::FrameCountMax);
             descriptor.m_dimensions.m_imageFormat = GetSwapChainFormat(device);
             descriptor.m_scalingMode = m_swapChainScalingMode;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -93,7 +93,6 @@ namespace AZ
 
         void WindowContext::OnResolutionChanged(uint32_t width, uint32_t height)
         {
-            AZ_TracePrintf("OnResolutionChanged", "Width: %d, Height: %d'\n", width, height);
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             const AZ::RHI::SwapChainDimensions& currentDimensions = defaultSwapChain->GetDescriptor().m_dimensions;
             if (width != currentDimensions.m_imageWidth || height != currentDimensions.m_imageHeight)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -91,8 +91,9 @@ namespace AZ
             return m_swapChainsData[swapChainIndex].m_scissor;  
         }
 
-        void WindowContext::OnWindowResized(uint32_t width, uint32_t height)
+        void WindowContext::OnResolutionChanged(uint32_t width, uint32_t height)
         {
+            AZ_TracePrintf("OnResolutionChanged", "Width: %d, Height: %d'\n", width, height);
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             const AZ::RHI::SwapChainDimensions& currentDimensions = defaultSwapChain->GetDescriptor().m_dimensions;
             if (width != currentDimensions.m_imageWidth || height != currentDimensions.m_imageHeight)
@@ -156,7 +157,7 @@ namespace AZ
             AzFramework::WindowRequestBus::EventResult(
                 windowSize,
                 m_windowHandle,
-                &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                &AzFramework::WindowRequestBus::Events::GetRenderResolution);
 
             uint32_t width = AZStd::max(windowSize.m_width, 1u);
             uint32_t height = AZStd::max(windowSize.m_height, 1u);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -118,7 +118,7 @@ namespace AtomToolsFramework
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
         void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() override;
+        bool IsCustomizedResolutionEnabled() const override;
         AzFramework::WindowSize GetRenderResolution() const override;
         void SetRenderResolution(AzFramework::WindowSize resolution) override;
         float GetDpiScaleFactor() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -117,6 +117,10 @@ namespace AtomToolsFramework
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
+        void SetEnableCustomizedResolution(bool enable) override;
+        bool IsCustomizedResolutionEnabled() override;
+        AzFramework::WindowSize GetRenderResolution() const override;
+        void SetRenderResolution(AzFramework::WindowSize resolution) override;
         float GetDpiScaleFactor() const override;
         uint32_t GetSyncInterval() const override;
         bool SetSyncInterval(uint32_t newSyncInterval) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -225,7 +225,7 @@ namespace AtomToolsFramework
         {
             AzFramework::WindowSize windowSize;
             AzFramework::WindowRequestBus::EventResult(
-                windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetRenderResolution);
 
             return m_cameraSystem.HandleEvents(AzFramework::BuildInputEvent(event.m_inputChannel, findModifierStatesFn(), windowSize));
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -290,7 +290,7 @@ namespace AtomToolsFramework
         AzFramework::WindowNotificationBus::Event(
             windowId, &AzFramework::WindowNotifications::OnWindowResized, windowSize.width(), windowSize.height());
         AzFramework::WindowNotificationBus::Event(
-            windowId, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, windowSize.width(), windowSize.height());
+            windowId, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, uiWindowSize.width(), uiWindowSize.height());
     }
 
     void RenderViewportWidget::SendWindowCloseEvent()
@@ -413,7 +413,8 @@ namespace AtomToolsFramework
 
     AzFramework::WindowSize RenderViewportWidget::GetClientAreaSize() const
     {
-        return AzFramework::WindowSize{aznumeric_cast<uint32_t>(width()), aznumeric_cast<uint32_t>(height())};
+        const auto pixelRatio = devicePixelRatioF();
+        return AzFramework::WindowSize{aznumeric_cast<uint32_t>(width()*pixelRatio), aznumeric_cast<uint32_t>(height()*pixelRatio)};
     }
 
     void RenderViewportWidget::ResizeClientArea(AzFramework::WindowSize clientAreaSize, [[maybe_unused]] const AzFramework::WindowPosOptions& options)
@@ -461,7 +462,7 @@ namespace AtomToolsFramework
 
     AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
     {
-        return GetClientAreaSize();
+        return AzFramework::WindowSize{aznumeric_cast<uint32_t>(width()), aznumeric_cast<uint32_t>(height())};
     }
 
     void RenderViewportWidget::SetRenderResolution([[maybe_unused]]AzFramework::WindowSize resolution)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -447,6 +447,26 @@ namespace AtomToolsFramework
         // The RenderViewportWidget does not currently support full screen.
     }
 
+    void RenderViewportWidget::SetEnableCustomizedResolution([[maybe_unused]]bool enable)
+    {
+        // The RenderViewportWidget does not currently support customized render resolution.
+    }
+
+    bool RenderViewportWidget::IsCustomizedResolutionEnabled()
+    {
+        return false;
+    }
+
+    AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
+    {
+        return GetClientAreaSize();
+    }
+
+    void RenderViewportWidget::SetRenderResolution([[maybe_unused]]AzFramework::WindowSize resolution)
+    {
+        // The RenderViewportWidget does not currently support customized render resolution.
+    }
+
     float RenderViewportWidget::GetDpiScaleFactor() const
     {
         return aznumeric_cast<float>(devicePixelRatioF());

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -455,7 +455,7 @@ namespace AtomToolsFramework
         // The RenderViewportWidget does not currently support customized render resolution.
     }
 
-    bool RenderViewportWidget::IsCustomizedResolutionEnabled()
+    bool RenderViewportWidget::IsCustomizedResolutionEnabled() const
     {
         return false;
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -289,6 +289,8 @@ namespace AtomToolsFramework
         const AzFramework::NativeWindowHandle windowId = reinterpret_cast<AzFramework::NativeWindowHandle>(winId());
         AzFramework::WindowNotificationBus::Event(
             windowId, &AzFramework::WindowNotifications::OnWindowResized, windowSize.width(), windowSize.height());
+        AzFramework::WindowNotificationBus::Event(
+            windowId, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, windowSize.width(), windowSize.height());
     }
 
     void RenderViewportWidget::SendWindowCloseEvent()

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportInputController.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportInputController.cpp
@@ -42,7 +42,7 @@ namespace EMStudio
 
             AzFramework::WindowSize windowSize;
             AzFramework::WindowRequestBus::EventResult(
-                windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+                windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetRenderResolution);
 
             const auto screenPoint = AzFramework::ScreenPoint(
                 aznumeric_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -725,7 +725,7 @@ void ImGuiManager::ToggleThroughImGuiVisibleState()
     m_setEnabledEvent.Signal(m_clientMenuBarState == DisplayState::Hidden);
 }
 
-void ImGuiManager::OnWindowResized(uint32_t width, uint32_t height)
+void ImGuiManager::OnResolutionChanged(uint32_t width, uint32_t height)
 {
     m_windowSize.m_width = width;
     m_windowSize.m_height = height;
@@ -742,7 +742,7 @@ void ImGuiManager::InitWindowSize()
 
         if (windowHandle)
         {
-            AzFramework::WindowRequestBus::EventResult(m_windowSize, windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+            AzFramework::WindowRequestBus::EventResult(m_windowSize, windowHandle, &AzFramework::WindowRequestBus::Events::GetRenderResolution);
             AzFramework::WindowNotificationBus::Handler::BusConnect(windowHandle);
         }
     }

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -81,7 +81,7 @@ namespace ImGui
         // -- AzFramework::InputChannelEventListener and AzFramework::InputTextEventListener Interface ------------
 
         // AzFramework::WindowNotificationBus::Handler overrides...
-        void OnWindowResized(uint32_t width, uint32_t height) override;
+        void OnResolutionChanged(uint32_t width, uint32_t height) override;
 
         // Sets up initial window size and listens for changes
         void InitWindowSize();


### PR DESCRIPTION
## What does this PR do?
This PR added implicit render resolution support for render pipeline which renders to a swapchain. 
The render resolution can be different than the swapchain's size.
It also added support for swapchain scaling if the backend device supports it. 
A cvar is added for setting up implicit render resolution:
r_resolutionMode: "0: render solution same as window client area size, 1: render solution use a specified resolution"

Fullscreen on 4x monitor with swapchain scaling, dx12
<img width="960" alt="dx12_swapchain" src="https://github.com/o3de/o3de/assets/55564570/2af422f0-a389-4bc4-a76f-9f76267d951c">
Fullscreen on 4x monitor by utilize CopyToSwapChain pass to do scaling , Vulkan
![image](https://github.com/o3de/o3de/assets/55564570/3180a60e-79a4-4060-ad77-a522491ed01c)


## How was this PR tested?
MPS setting menu in game launcher 
O3DE Editor. 
Material Editor.
ASV full test suites. 
All applications were tested with both DX12 and Vulkan backend on windows with 150% DPI
