### PR TITLE
Add ShadingRate 4x1 and 1x4 enums

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VariableRateShadingEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VariableRateShadingEnums.h
@@ -45,6 +45,8 @@ namespace AZ
             Rate2x2,    // Specifies that the shading rate should reduce the resolution of both axes 2x.
             Rate2x4,    // Specifies that the shading rate should reduce horizontal resolution 2x, and reduce vertical resolution 4x.
             Rate4x2,    // Specifies that the shading rate should reduce horizontal resolution 4x, and reduce vertical resolution 2x.
+            Rate4x1,    // Specifies that the shading rate should reduce horizontal resolution 4x, and reduce vertical resolution 1x.
+            Rate1x4,    // Specifies that the shading rate should reduce horizontal resolution 1x, and reduce vertical resolution 4x.
             Rate4x4,    // Specifies that the shading rate should reduce the resolution of both axes 4x.
             Count
         };
@@ -59,6 +61,8 @@ namespace AZ
             Rate2x2 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate2x2)),
             Rate2x4 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate2x4)),
             Rate4x2 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate4x2)),
+            Rate4x1 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate4x1)),
+            Rate1x4 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate1x4)),
             Rate4x4 = AZ_BIT(static_cast<uint32_t>(ShadingRate ::Rate4x4))
         };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -710,6 +710,14 @@ namespace AZ
                 fragmentSize.width = 4;
                 fragmentSize.height = 2;
                 break;
+            case RHI::ShadingRate::Rate4x1:
+                fragmentSize.width = 4;
+                fragmentSize.height = 1;
+                break;
+            case RHI::ShadingRate::Rate1x4:
+                fragmentSize.width = 1;
+                fragmentSize.height = 4;
+                break;
             case RHI::ShadingRate::Rate4x4:
                 fragmentSize.width = fragmentSize.height = 4;
                 break;
@@ -731,6 +739,7 @@ namespace AZ
                 {
                 case 1: return RHI::ShadingRate::Rate1x1;
                 case 2: return RHI::ShadingRate::Rate1x2;
+                case 4: return RHI::ShadingRate::Rate1x4;
                 default:
                     break;
                 }
@@ -746,6 +755,7 @@ namespace AZ
             case 4:
                 switch (rate.height)
                 {
+                case 1: return RHI::ShadingRate::Rate4x1;
                 case 2: return RHI::ShadingRate::Rate4x2;
                 case 4: return RHI::ShadingRate::Rate4x4;
                 default:

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -905,6 +905,14 @@ namespace AZ
                     encoded_rate_w = 2;
                     encoded_rate_h = 1;
                     break;
+                case RHI::ShadingRate::Rate4x1:
+                    encoded_rate_w = 2;
+                    encoded_rate_h = 0;
+                    break;
+                case RHI::ShadingRate::Rate1x4:
+                    encoded_rate_w = 0;
+                    encoded_rate_h = 2;
+                    break;
                 case RHI::ShadingRate::Rate4x4:
                     encoded_rate_w = encoded_rate_h = 2;
                     break;
@@ -944,6 +952,14 @@ namespace AZ
                 case RHI::ShadingRate::Rate4x2:
                     encoded_rate_w = 2;
                     encoded_rate_h = 1;
+                    break;
+                case RHI::ShadingRate::Rate1x4:
+                    encoded_rate_w = 0;
+                    encoded_rate_h = 2;
+                    break;
+                case RHI::ShadingRate::Rate4x1:
+                    encoded_rate_w = 2;
+                    encoded_rate_h = 0;
                     break;
                 case RHI::ShadingRate::Rate4x4:
                     encoded_rate_w = encoded_rate_h = 2;


### PR DESCRIPTION
## What does this PR do?

Add missing enums of 4x1 and 1x4 for Variable Shade Rating values.

## How was this PR tested?

Run Variable Shade Rating sample on ASV
