### PR TITLE
Fix subclass support on ScriptCanvas nodes.

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -867,9 +867,10 @@ namespace ScriptCanvas
         }
 
         // At this point we need to confirm the types are a match.
-        const auto& thisType = GetDataType();
+        const auto& slotType = GetDataType();
 
-        if (thisType.IS_A(dataType))
+        // As long as the data type is a type of slotType (actual type or subclass), it's a match.
+        if (dataType.IS_A(slotType))
         {
             return AZ::Success();
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariableManagerComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariableManagerComponent.cpp
@@ -327,7 +327,7 @@ namespace ScriptCanvas
     {
         for (auto& variablePair : m_variableData.GetVariables())
         {
-            if (variablePair.second.GetDataType() == dataType)
+            if (variablePair.second.GetDataType().IS_A(dataType))
             {
                 if (excludedVariableIds.count(variablePair.first) == 0)
                 {


### PR DESCRIPTION
## What does this PR do?

Script Canvas nodes are _intended_ to support subclasses when hooking variables to input slots, but the subclass support was broken in a couple of spots:
1. The code was checking for "if slotType.is_a(variableType)" instead of "if variableType.is_a(slotType)", so the backwards check only worked if the slot type was a subclass of the variable. Instead, it should work if the variable is a subclass of the slot type.
2. When filling in the default variable choice after converting a slot to a reference, the code was only look for exact slot type matches from the list of variables. It now looks for subclasses as well.

## How was this PR tested?

Tested with an upcoming change that relies on using subclasses with the Spawning API in ScriptCanvas. Before the change, the dropdown only listed the "Spawnable" (type SpawnableScriptAssetRef). After the change, it lists both SpawnableScriptAssetRef and NetworkSpawnableScriptAssetRef types.

![image](https://github.com/o3de/o3de/assets/82224783/34a79d4c-14a2-4aea-b45c-e55c77e63072)
