### PR TITLE
Add useCompactStyle attribute to AutoGen function nodes

### DIFF
--- a/Code/Framework/AzCore/AzCore/ScriptCanvas/ScriptCanvasAttributes.h
+++ b/Code/Framework/AzCore/AzCore/ScriptCanvas/ScriptCanvasAttributes.h
@@ -68,6 +68,8 @@ namespace AZ
 
         static const AZ::Crc32 BranchOnResult = AZ_CRC("BranchOnResult", 0x7a741f05);
 
+        static const AZ::Crc32 UseCompactStyle = AZ_CRC_CE("UseCompactStyle");
+
         ///< \see enum class Script::Attributes::OperatorType
         static const AZ::Crc32 OperatorOverride = AZ_CRC("OperatorOverride", 0x6b0e3ffb);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
@@ -85,6 +85,12 @@
                                             <xs:documentation>Options: True/False. Default is False.</xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
+                                    <xs:attribute name="UseCompactStyle" type="NonEmptyString" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>The tag to indicate whether the generated node should use a compact style.</xs:documentation>
+                                            <xs:documentation>Options: True/False. Default is False.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunctionRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunctionRegistry_Source.jinja
@@ -124,6 +124,10 @@ namespace ScriptCanvas
 {% if hasbranch|booleanTrue == true %}
                     ->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
 {% endif %}
+{% set useCompactStyle = macros.CleanName(function.attrib['UseCompactStyle']) %}
+{% if useCompactStyle is defined and useCompactStyle.lower() == "true" %}
+                    ->Attribute(AZ::ScriptCanvasAttributes::UseCompactStyle, true)
+{% endif %}
                 ;
             }
 {% endfor -%}


### PR DESCRIPTION
## What does this PR do?

This adds an attribute to the ScriptCanvasFunction.xsd schema file to allow for users to specify a node created through AzAutoGen to have a compact style. Changes the ScriptCanvasFunctionRegistry_Source.jinja template file to add this data as an attribute to the behavior context. No visible changes happen yet when this attribute is enabled for a particular function node. I am currently working on implementing these changes, where adding the attribute will shrink down the size of the node and make it into a more compact style.

## How was this PR tested?

I preformed manual testing by adding the attribute to different function nodes created with AzAutoGen.
