### PR TITLE
Support scripted network spawning

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -38,10 +38,12 @@ namespace AzFramework::Scripts
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     // m_asset
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SpawnableScriptAssetRef::m_asset, "asset", "")
-                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, false)
-                    ->Attribute(AZ::Edit::Attributes::HideProductFilesInAssetPicker, true)
-                    ->Attribute(AZ::Edit::Attributes::AssetPickerTitle, "Spawnable Asset")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SpawnableScriptAssetRef::OnSpawnAssetChanged);
+                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, &SpawnableScriptAssetRef::ShowProductAssetFileName)
+                    ->Attribute(AZ::Edit::Attributes::HideProductFilesInAssetPicker, &SpawnableScriptAssetRef::HideProductAssetFiles)
+                    ->Attribute(AZ::Edit::Attributes::AssetPickerTitle, &SpawnableScriptAssetRef::GetAssetPickerTitle)
+                    ->Attribute(AZ::Edit::Attributes::ChangeValidate, &SpawnableScriptAssetRef::ValidatePotentialSpawnableAsset)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SpawnableScriptAssetRef::OnSpawnAssetChanged)
+                    ;
             }
         }
 
@@ -57,6 +59,33 @@ namespace AzFramework::Scripts
                 ->Method("SetAsset", &SpawnableScriptAssetRef::SetAsset);
         }
     }
+
+    bool SpawnableScriptAssetRef::ShowProductAssetFileName() const
+    {
+        // Show the source file name in the component, not the product file name.
+        return false;
+    }
+
+    bool SpawnableScriptAssetRef::HideProductAssetFiles() const
+    {
+        // Hide all the .spawnable outputs, and only show the source .prefab files.
+        return true;
+    }
+
+    const char* SpawnableScriptAssetRef::GetAssetPickerTitle() const
+    {
+        // Call the dialog box "Pick Spawnable Asset"
+        return "Spawnable Asset";
+    }
+
+    AZ::Outcome<void, AZStd::string> SpawnableScriptAssetRef::ValidatePotentialSpawnableAsset(
+        [[maybe_unused]] void* newValue, [[maybe_unused]] const AZ::Uuid& valueType) const
+    {
+        // By default, any prefab we select should be a valid choice.
+        // Subclasses can choose to get more selective.
+        return AZ::Success();
+    }
+
 
     SpawnableScriptAssetRef::~SpawnableScriptAssetRef()
     {

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
@@ -17,7 +17,7 @@
 namespace AzFramework::Scripts
 {
     //! A wrapper around Spawnable asset that can be used by Script Canvas and Lua
-    class SpawnableScriptAssetRef final
+    class SpawnableScriptAssetRef
         : private AZ::Data::AssetBus::Handler
     {
     public:
@@ -34,6 +34,16 @@ namespace AzFramework::Scripts
 
         void SetAsset(const AZ::Data::Asset<Spawnable>& asset);
         AZ::Data::Asset<Spawnable> GetAsset() const;
+
+    protected:
+        // Prefabs can generate multiple .spawnable products. This class will by default use the first .spawnable generated
+        // from each prefab. If other subsystems (such as networking) generate more types of .spawnables and want to make them
+        // individually selectable, the asset filter controls are exposed here so that subclasses can change how the assets are
+        // displayed and filtered.
+        virtual bool ShowProductAssetFileName() const;
+        virtual bool HideProductAssetFiles() const;
+        virtual const char* GetAssetPickerTitle() const;
+        virtual AZ::Outcome<void, AZStd::string> ValidatePotentialSpawnableAsset(void* newValue, const AZ::Uuid& valueType) const;
 
     private:
         class SerializationEvents : public AZ::SerializeContext::IEventHandler

--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkSpawnableScriptAssetRef.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkSpawnableScriptAssetRef.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h>
+#include <Multiplayer/MultiplayerTypes.h>
+
+namespace Multiplayer
+{
+    //! A wrapper around a Network Spawnable asset that can be used by Script Canvas and Lua.
+    //! This is a subclass of the .spawnable asset reference that only allows .network.spawnable asset references.
+    //! It exists to make scripts very explicit for when they're using the spawnable API with non-networked vs networked spawnables.
+    class NetworkSpawnableScriptAssetRef
+        : public AzFramework::Scripts::SpawnableScriptAssetRef
+    {
+    public:
+        AZ_RTTI(NetworkSpawnableScriptAssetRef, "{2369101C-6C28-4F13-B918-896B37EAD988}", AzFramework::Scripts::SpawnableScriptAssetRef);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        NetworkSpawnableScriptAssetRef() = default;
+        ~NetworkSpawnableScriptAssetRef() override = default;
+
+    protected:
+        // Override the asset selection so that we only can select *.network.spawnable files.
+        bool ShowProductAssetFileName() const override;
+        bool HideProductAssetFiles() const override;
+        const char* GetAssetPickerTitle() const override;
+        AZ::Outcome<void, AZStd::string> ValidatePotentialSpawnableAsset(void* newValue, const AZ::Uuid& valueType) const override;
+
+    private:
+        // Change the GetAsset / SetAsset script functions to specifically use Network spawnables and not just any spawnables.
+        void SetAsset(NetworkSpawnable& asset);
+        NetworkSpawnable GetAsset() const;
+
+    };
+}

--- a/Gems/Multiplayer/Code/Source/Components/SimplePlayerSpawnerComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/SimplePlayerSpawnerComponent.cpp
@@ -152,13 +152,26 @@ namespace Multiplayer
             GetNetworkEntityManager()->CreateEntitiesImmediate(prefabEntityId, NetEntityRole::Authority, transform);
 
         NetworkEntityHandle controlledEntity;
-        if (!entityList.empty())
+        if (entityList.empty())
         {
+            // Failure: The player prefab has no networked entities in it.
+            AZLOG_ERROR("Attempt to spawn prefab %s failed, no entities were spawned. Check that prefab contains a single entity "
+                "that is network enabled with a Network Binding component.", prefabEntityId.m_prefabName.GetCStr());
+        }
+        else if (entityList.size() == 1)
+        {
+            // Success: The player prefab has exactly one networked entity in it.
             controlledEntity = entityList[0];
         }
         else
         {
-            AZLOG_WARN("Attempt to spawn prefab %s failed. Check that prefab is network enabled.", prefabEntityId.m_prefabName.GetCStr());
+            // Failure: The player prefab has too many networked entities in it.
+            AZLOG_ERROR("Attempt to spawn prefab %s failed, it contains too many networked entities. "
+                "A player prefab must only have a single networked entity inside of it.", prefabEntityId.m_prefabName.GetCStr());
+            for (auto& entityHandle : entityList)
+            {
+                AZ::Interface<IMultiplayer>::Get()->GetNetworkEntityManager()->MarkForRemoval(entityHandle);
+            }
         }
 
         return controlledEntity;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -10,6 +10,7 @@
 #include <Multiplayer/Components/MultiplayerComponent.h>
 #include <Multiplayer/Components/NetworkHierarchyRootComponent.h>
 #include <Multiplayer/IMultiplayerSpawner.h>
+#include <Multiplayer/NetworkSpawnableScriptAssetRef.h>
 #include <MultiplayerSystemComponent.h>
 #include <ConnectionData/ClientToServerConnectionData.h>
 #include <ConnectionData/ServerToClientConnectionData.h>
@@ -126,6 +127,8 @@ namespace Multiplayer
     void MultiplayerSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         NetworkSpawnable::Reflect(context);
+        NetworkSpawnableScriptAssetRef::Reflect(context);
+
         if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<MultiplayerSystemComponent, AZ::Component>()

--- a/Gems/Multiplayer/Code/Source/NetworkSpawnableScriptAssetRef.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkSpawnableScriptAssetRef.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Spawnable/SpawnableAssetHandler.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <Multiplayer/NetworkSpawnableScriptAssetRef.h>
+
+namespace Multiplayer
+{
+    void NetworkSpawnableScriptAssetRef::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<NetworkSpawnableScriptAssetRef, AzFramework::Scripts::SpawnableScriptAssetRef>()
+                ->Version(0)
+            ;
+
+            serializeContext->RegisterGenericType<AZStd::vector<NetworkSpawnableScriptAssetRef>>();
+            serializeContext->RegisterGenericType<AZStd::unordered_map<AZStd::string, NetworkSpawnableScriptAssetRef>>();
+            // required to support Map<Number, NetworkSpawnableScriptAssetRef> in Script Canvas
+            serializeContext->RegisterGenericType<AZStd::unordered_map<double, NetworkSpawnableScriptAssetRef>>(); 
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext
+                    ->Class<NetworkSpawnableScriptAssetRef>(
+                        "NetworkSpawnableScriptAssetRef",
+                        "A wrapper around a .network.spawnable asset to be used as a variable in Script Canvas.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ;
+            }
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<NetworkSpawnableScriptAssetRef>("NetworkSpawnableScriptAssetRef")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::EnableAsScriptEventParamType, true)
+                ->Attribute(AZ::Script::Attributes::Category, "Prefab/Spawning")
+                ->Attribute(AZ::Script::Attributes::Module, "prefabs")
+                ->Constructor()
+                ->Method("GetAsset", &NetworkSpawnableScriptAssetRef::GetAsset)
+                ->Method("SetAsset", &NetworkSpawnableScriptAssetRef::SetAsset);
+        }
+    }
+
+    bool NetworkSpawnableScriptAssetRef::ShowProductAssetFileName() const
+    {
+        // Show the product asset name on the component so that it's clear that we chose a networked spawnable.
+        return true;
+    }
+
+    bool NetworkSpawnableScriptAssetRef::HideProductAssetFiles() const
+    {
+        // Show product asset files in the asset picker so that we can pick a .network.spawnable file.
+        return false;
+    }
+
+    const char* NetworkSpawnableScriptAssetRef::GetAssetPickerTitle() const
+    {
+        // Call the dialog "Pick Network Spawnable Asset"
+        return "Network Spawnable Asset";
+    }
+
+    AZ::Outcome<void, AZStd::string> NetworkSpawnableScriptAssetRef::ValidatePotentialSpawnableAsset(
+        void* newValue, const AZ::Uuid& valueType) const
+    {
+        // Only allow .network.spawnable files to get selected.
+        return NetworkSpawnable::ValidatePotentialSpawnableAsset(newValue, valueType);
+    }
+
+    NetworkSpawnable NetworkSpawnableScriptAssetRef::GetAsset() const
+    {
+        return NetworkSpawnable(SpawnableScriptAssetRef::GetAsset());
+    }
+
+    void NetworkSpawnableScriptAssetRef::SetAsset(NetworkSpawnable& asset)
+    {
+        SpawnableScriptAssetRef::SetAsset(asset.m_spawnableAsset);
+    }
+
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/multiplayer_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayer_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     Include/Multiplayer/MultiplayerStats.h
     Include/Multiplayer/MultiplayerTypes.h
     Include/Multiplayer/MultiplayerEditorServerBus.h
+    Include/Multiplayer/NetworkSpawnableScriptAssetRef.h
     Include/Multiplayer/Components/SimplePlayerSpawnerComponent.h
     Include/Multiplayer/Components/ISimplePlayerSpawner.h
     Include/Multiplayer/Components/MultiplayerComponent.h
@@ -76,6 +77,7 @@ set(FILES
     Source/MultiplayerStatSystemComponent.cpp
     Source/MultiplayerStatSystemComponent.h
     Source/MultiplayerStats.cpp
+    Source/NetworkSpawnableScriptAssetRef.cpp
     Source/NetworkEntity/NetworkEntityHandle.cpp
     Source/NetworkEntity/NetworkEntityRpcMessage.cpp
     Source/NetworkEntity/NetworkEntityTracker.cpp


### PR DESCRIPTION
## What does this PR do?

This adds the ability to do scripted network spawning of .network.spawnable files by adding the NetworkSpawnableScriptAssetRef subclass. This subclass can be used with the existing Prefab/Spawn APIs in ScriptCanvas to specifically spawn and despawn *.network.spawnable assets.

For this change to work, SpawnableScriptAssetRef is now a base class that can be inherited from. The overall design of .spawnable assets is to allow for other systems to create more .spawnable subtypes over time for different purposes, which is what networking did with .network.spawnable. By making this a base class, other systems can now create specifically-filtered subtypes that still work with the base spawning APIs, but restrict asset selection to just the subtype of spawnable desired.

This PR also includes additional error messaging to SimplePlayerSpawnerComponent, so that anyone who tries to use it to spawn arbitrary prefabs will get errors letting them know they're using it wrong.

Also, the NetworkSpawnable class has been updated to allow empty assets to be selected. Otherwise, once you fill in an asset reference for SimplePlayerSpawnerComponent or NetworkSpawnableScriptAssetRef, you could never delete it.

After this PR is submitted, there will _likely_ be a few follow-up PRs:
1. Instead of using ChangeValidate to catch bad Spawnable selections, it would be nice to have a new AssetPicker attribute that allows for custom asset filtering so that only valid choices are shown in the first place.
2. The documentation for SimplePlayerSpawnerComponent needs to be updated to explain its use a little better.
3. We'll probably want documentation for NetworkSpawnableScriptAssetRef to explictly show how to use it to spawn networked spawnables.

## How was this PR tested?

Created a test level that spawns a .network.spawnable on the server and replicates it to the client.

![image](https://github.com/o3de/o3de/assets/82224783/aec7ed68-0ba8-4dd6-837a-7c8fa01da3b7)
![image](https://github.com/o3de/o3de/assets/82224783/614028f0-4e4a-4a0d-afa0-b0358796c72e)
