### PR TITLE
Fixed Vegetation Layer Debugger component not showing cube size field

### DIFF
--- a/Gems/Vegetation/Code/Source/Debugger/AreaDebugComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Debugger/AreaDebugComponent.cpp
@@ -48,7 +48,7 @@ namespace Vegetation
                     "Vegetation Layer Debugger Config", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->DataElement(AZ::Edit::UIHandlers::Color, &AreaDebugConfig::m_debugColor, "Debug Visualization Color", "")
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &AreaDebugConfig::m_debugCubeSize, "Debug Visualization Cube Size", "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AreaDebugConfig::m_debugCubeSize, "Debug Visualization Cube Size", "")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, std::numeric_limits<float>::max())
                     ->DataElement(AZ::Edit::UIHandlers::CheckBox, &AreaDebugConfig::m_hideDebug, "Hide created instance in the Debug Visualization", "")


### PR DESCRIPTION
## What does this PR do?

The cube size field in the `Vegetation Layer Debugger` component is a float field, but was trying to register to use a color handler to display it, which is why no widget showed up. This was seemingly working by accident with the RPE (because it ended up showing a float widget somehow), but with the DPE we just didn't show a widget because the handler type mismatched.

Fixing the registration allows the field to be shown as expected.

BEFORE:
![LayerDebugger_BEFORE](https://github.com/o3de/o3de/assets/7519264/aa98d949-20ea-499b-a9eb-61d0a5c87dfb)

AFTER:
![LayerDebugger_AFTER](https://github.com/o3de/o3de/assets/7519264/34159cfb-af5a-4838-ae2f-aba76ee0ad0a)

## How was this PR tested?

Tested adding a `Vegetation Layer Component` to an entity and verified the cube size field now appears and is usable as expected.