### PR TITLE
Linux game mode esc exit hotfix

### DIFF
--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -27,8 +27,10 @@
 #include <AzFramework/Input/Devices/Touch/InputDeviceTouch.h>
 #include <AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h>
 #include <AzFramework/Viewport/ViewportBus.h>
+#include <CrySystem/System.h>
 #include <IConsole.h>
 #include <imgui/imgui_internal.h>
+#include <ISystem.h>
 #include <sstream>
 #include <string>
 
@@ -451,6 +453,21 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
             if (inputChannelId == InputDeviceKeyboard::Key::PunctuationTilde)
             {
                 ToggleThroughImGuiVisibleState();
+            }
+
+            if (inputChannel.GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::Escape)
+            {
+                CSystem *cSys = (CSystem*)GetISystem();
+                if (cSys)
+                {
+                    ISystemUserCallback* pCallback = cSys->GetUserCallback();
+                    {
+                        if (pCallback)
+                        {
+                            pCallback->OnProcessSwitch();
+                        }
+                    }
+                }
             }
         }
 

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -457,7 +457,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
 
             if (inputChannel.GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::Escape)
             {
-                CSystem *cSys = (CSystem*)GetISystem();
+                CSystem* cSys = static_cast<CSystem*>(GetISystem());
                 if (cSys)
                 {
                     ISystemUserCallback* pCallback = cSys->GetUserCallback();


### PR DESCRIPTION
This is a temporary hotfix (may not be the ideal solution) for the current issue of not being able to exit the game mode in Linux after entering. Opening a PR for it to gather feedback.

## What does this PR do?

Allow for exiting from game mode using ESC as intended.

_Please add links to any issues, RFCs or other items that are relevant to this PR._
#15958

## How was this PR tested?

Tested on Fedora 38, by checking to see if exiting game mode was possible by pressing ESC.