### PR TITLE
More Script Canvas slot subclass support

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -1617,8 +1617,25 @@ namespace ScriptCanvas
         return AZ::Failure(AZStd::string("SlotID not found in Node"));
     }
 
+    Data::Type Node::GetUnderlyingSlotDataType(const SlotId& slotId) const
+    {
+        // Return the slot's base data type, which is used to determine which types of variables or connectors can be hooked to the slot.
+
+        auto slotIter = m_slotIdIteratorCache.find(slotId);
+        if (slotIter != m_slotIdIteratorCache.end() && slotIter->second.HasDatum())
+        {
+            return slotIter->second.GetDatum()->GetType();
+        }
+
+        return Data::Type::Invalid();
+    }
+
+
     Data::Type Node::GetSlotDataType(const SlotId& slotId) const
     {
+        // Return the slot's current data type, which could be a subtype of the slot's defined data type, based on
+        // whatever variable is currently hooked into the slot.
+
         AZ_PROFILE_SCOPE(ScriptCanvas, "ScriptCanvas::Node::GetSlotDataType");
 
         const auto* slot = GetSlot(slotId);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -592,6 +592,8 @@ namespace ScriptCanvas
         AZ::Outcome<void, AZStd::string> SlotAcceptsType(const SlotId&, const Data::Type&) const override;
         Data::Type GetSlotDataType(const SlotId& slotId) const override;
 
+        Data::Type GetUnderlyingSlotDataType(const SlotId& slotId) const;
+
         VariableId GetSlotVariableId(const SlotId& slotId) const override;
         void SetSlotVariableId(const SlotId& slotId, const VariableId& variableId) override;
         void ClearSlotVariableId(const SlotId& slotId) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -867,13 +867,29 @@ namespace ScriptCanvas
         }
 
         // At this point we need to confirm the types are a match.
-        const auto& slotType = GetDataType();
+        // Get the slot definition's data type so that we can verify that the new data type is a compatible type.
+        // We specifcally don't use GetSlotDataType() here, because that will return the data type for any currently-attached
+        // variable, which might have a subtype that's more restrictive that the slot's base type.
+        const auto& slotType = m_node->GetUnderlyingSlotDataType(GetId());
 
-        // As long as the data type is a type of slotType (actual type or subclass), it's a match.
-        if (dataType.IS_A(slotType))
+        if (slotType.IsValid())
         {
-            return AZ::Success();
+            // As long as the data type is a type of slotType (actual type or subclass), it's a match.
+            if (dataType.IS_A(slotType))
+            {
+                return AZ::Success();
+            }
         }
+        else
+        {
+            // If the underlying slot type is invalid, but there's a display type set, then matching the display type is
+            // still a valid match.
+            if (HasDisplayType() && dataType.IS_A(GetDisplayType()))
+            {
+                return AZ::Success();
+            }
+        }
+
 
         return AZ::Failure(AZStd::string::format("%s is not a type match for %s", ScriptCanvas::Data::GetName(GetDataType()).c_str(), ScriptCanvas::Data::GetName(dataType).c_str()));
     }

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -25,6 +25,7 @@
 #include <ScriptCanvas/Core/SlotConfigurationDefaults.h>
 #include <ScriptCanvas/ScriptCanvasGem.h>
 #include <ScriptCanvas/SystemComponent.h>
+#include <ScriptCanvas/Variable/GraphVariableManagerComponent.h>
 
 #include "EntityRefTests.h"
 #include "ScriptCanvasTestApplication.h"
@@ -202,7 +203,12 @@ namespace ScriptCanvasTests
                 CreateGraph();
             }
 
+            ScriptCanvas::ScriptCanvasId scriptCanvasId = m_graph->GetScriptCanvasId();
+            configurableNodeEntity->CreateComponent<ScriptCanvas::GraphVariableManagerComponent>(scriptCanvasId);
+
             configurableNodeEntity->Init();
+
+            m_graph->Activate();
 
             m_graph->AddNode(configurableNodeEntity->GetId());
 

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -104,16 +104,16 @@ namespace ScriptCanvasTests
             auto m_serializeContext = s_application->GetSerializeContext();
             auto m_behaviorContext = s_application->GetBehaviorContext();
 
-            ScriptCanvasTesting::Reflect(m_serializeContext);
-            ScriptCanvasTesting::Reflect(m_behaviorContext);
-
-            ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(m_serializeContext);
-            ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(m_behaviorContext);
-
-            TestNodeableObject::Reflect(m_serializeContext);
-            TestNodeableObject::Reflect(m_behaviorContext);
-            ScriptUnitTestEventHandler::Reflect(m_serializeContext);
-            ScriptUnitTestEventHandler::Reflect(m_behaviorContext);
+            for (AZ::ReflectContext* context :
+                {static_cast<AZ::ReflectContext*>(m_serializeContext), static_cast<AZ::ReflectContext*>(m_behaviorContext)})
+            {
+                ScriptCanvasTesting::Reflect(context);
+                ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(context);
+                TestNodeableObject::Reflect(context);
+                TestBaseClass::Reflect(context);
+                TestSubClass::Reflect(context);
+                ScriptUnitTestEventHandler::Reflect(context);
+            }
         }
 
         static void TearDownTestCase()
@@ -161,6 +161,9 @@ namespace ScriptCanvasTests
             m_stringToNumberMapType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<AZStd::unordered_map<ScriptCanvas::Data::StringType, ScriptCanvas::Data::NumberType>>());
 
             m_dataSlotConfigurationType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<ScriptCanvas::DataSlotConfiguration>());
+
+            m_baseClassType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<TestBaseClass>());
+            m_subClassType = ScriptCanvas::Data::Type::BehaviorContextObject(azrtti_typeid<TestSubClass>());
         }
 
         void TearDown() override
@@ -392,6 +395,9 @@ namespace ScriptCanvasTests
         ScriptCanvas::Data::Type m_stringToNumberMapType;
 
         ScriptCanvas::Data::Type m_dataSlotConfigurationType;
+
+        ScriptCanvas::Data::Type m_baseClassType;
+        ScriptCanvas::Data::Type m_subClassType;
 
         ScriptCanvas::Graph* m_graph = nullptr;
 

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestUtilities.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestUtilities.h
@@ -768,5 +768,62 @@ namespace ScriptCanvasTests
         }
     };
 
+    // Test class that's used to test inheritance with Script Canvas slots
+    class TestBaseClass
+    {
+    public:
+        AZ_RTTI(TestBaseClass, "{C1F80F17-BE3C-49B5-862D-3C41F04208E0}");
 
-} // ScriptCanvasTests
+        TestBaseClass() = default;
+        virtual ~TestBaseClass() = default;
+
+        static void Reflect(AZ::ReflectContext* reflectContext)
+        {
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
+            {
+                serializeContext->Class<TestBaseClass>();
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<TestBaseClass>("TestBaseClass", "");
+                }
+            }
+
+            // reflect API for the node
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflectContext))
+            {
+                behaviorContext->Class<TestBaseClass>("TestBaseClass");
+            }
+        }
+    };
+
+    // Test class that's used to test inheritance with Script Canvas slots
+    class TestSubClass : public TestBaseClass
+    {
+    public:
+        AZ_RTTI(TestSubClass, "{2ED5B680-F097-4044-B1C8-0977A0E3F027}", TestBaseClass);
+
+        TestSubClass() = default;
+        ~TestSubClass() override = default;
+
+        static void Reflect(AZ::ReflectContext* reflectContext)
+        {
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
+            {
+                serializeContext->Class<TestSubClass, TestBaseClass>();
+
+                if (auto editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<TestSubClass>("TestSubClass", "");
+                }
+            }
+
+            // reflect API for the node
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflectContext))
+            {
+                behaviorContext->Class<TestSubClass>("TestSubClass");
+            }
+        }
+    };
+
+} // namespace ScriptCanvasTests

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
@@ -455,6 +455,119 @@ TEST_F(ScriptCanvasTestFixture, SlotConnecting_DataBasic)
     TestConnectionBetween(outputEndpoint, inputEndpoint, validConnection);
 }
 
+TEST_F(ScriptCanvasTestFixture, TypeMatching_SubClassShouldMatchBaseClassSlot)
+{
+    // When a slot is configured to use a base class, the slot should accept subclasses of that base class as well.
+
+    using namespace ScriptCanvas;
+
+    ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
+
+    for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
+    {
+        DataSlotConfiguration dataSlotConfiguration;
+
+        dataSlotConfiguration.m_name = GenerateSlotName();
+        dataSlotConfiguration.SetConnectionType(connectionType);
+
+        // Set the slot to the base class type
+        dataSlotConfiguration.SetType(m_baseClassType);
+
+        Slot* slot = emptyNode->AddTestingSlot(dataSlotConfiguration);
+
+        // When a slot is set to a base class type, it should be able to be hooked up to
+        // either a base class type or a subclass type.
+        EXPECT_TRUE(slot->IsTypeMatchFor(m_baseClassType));
+        EXPECT_TRUE(slot->IsTypeMatchFor(m_subClassType));
+    }
+}
+
+TEST_F(ScriptCanvasTestFixture, TypeMatching_BaseClassShouldNotMatchSubClassSlot)
+{
+    // When a slot is configured to use a subclass, the slot should accept the subclass but not the base class.
+
+    using namespace ScriptCanvas;
+
+    ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
+
+    for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
+    {
+        DataSlotConfiguration dataSlotConfiguration;
+
+        dataSlotConfiguration.m_name = GenerateSlotName();
+        dataSlotConfiguration.SetConnectionType(connectionType);
+
+        // Set the slot to the subclass type
+        dataSlotConfiguration.SetType(m_subClassType);
+
+        Slot* slot = emptyNode->AddTestingSlot(dataSlotConfiguration);
+
+        // When a slot is set to a subclass type, it will only connect to the subclass, not to the base class.
+        EXPECT_FALSE(slot->IsTypeMatchFor(m_baseClassType));
+        EXPECT_TRUE(slot->IsTypeMatchFor(m_subClassType));
+    }
+}
+
+TEST_F(ScriptCanvasTestFixture, DynamicSlotCreation_SubClassShouldMatchBaseClassDisplayType)
+{
+    // When a dynamic slot is created with a base class type, it should match both base classes and subclasses.
+
+    using namespace ScriptCanvas;
+
+    ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
+
+    for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
+    {
+        for (auto dynamicDataType : { DynamicDataType::Any, DynamicDataType::Value })
+        {
+            DynamicDataSlotConfiguration dataSlotConfiguration;
+
+            dataSlotConfiguration.m_name = GenerateSlotName();
+            dataSlotConfiguration.SetConnectionType(connectionType);
+            dataSlotConfiguration.m_dynamicDataType = dynamicDataType;
+
+            // Set the dynamic display type to the base class
+            dataSlotConfiguration.m_displayType = m_baseClassType;
+
+            Slot* slot = emptyNode->AddTestingSlot(dataSlotConfiguration);
+
+            // Both the base class and the subclass should match.
+            EXPECT_TRUE(slot->IsTypeMatchFor(m_baseClassType));
+            EXPECT_TRUE(slot->IsTypeMatchFor(m_subClassType));
+        }
+    }
+}
+
+TEST_F(ScriptCanvasTestFixture, DynamicSlotCreation_BaseClassShouldNotMatchSubClassDisplayType)
+{
+    // When a dynamic slot is created with a subclass type, it should only match the subclass not the base class.
+
+    using namespace ScriptCanvas;
+
+    ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
+
+    for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
+    {
+        for (auto dynamicDataType : { DynamicDataType::Any, DynamicDataType::Value })
+        {
+            DynamicDataSlotConfiguration dataSlotConfiguration;
+
+            dataSlotConfiguration.m_name = GenerateSlotName();
+            dataSlotConfiguration.SetConnectionType(connectionType);
+            dataSlotConfiguration.m_dynamicDataType = dynamicDataType;
+
+            // Set the dynamic display type to the subclass
+            dataSlotConfiguration.m_displayType = m_subClassType;
+
+            Slot* slot = emptyNode->AddTestingSlot(dataSlotConfiguration);
+
+            // Only the subclass should match, not the base class.
+            EXPECT_FALSE(slot->IsTypeMatchFor(m_baseClassType));
+            EXPECT_TRUE(slot->IsTypeMatchFor(m_subClassType));
+        }
+    }
+}
+
 // Exhaustive Data Connection Test(attempts to connect every data type to every other data type, in both input and output)
 
 // 
@@ -900,7 +1013,7 @@ TEST_F(ScriptCanvasTestFixture, DynamicTypingDisplayType_Value)
         DynamicDataSlotConfiguration dataSlotConfiguration;
 
         dataSlotConfiguration.m_name = GenerateSlotName();
-        dataSlotConfiguration.SetConnectionType(ConnectionType::Input);
+        dataSlotConfiguration.SetConnectionType(connectionType);
         dataSlotConfiguration.m_dynamicDataType = DynamicDataType::Value;
 
         Slot* slot = emptyNode->AddTestingSlot(dataSlotConfiguration);
@@ -1924,7 +2037,7 @@ TEST_F(ScriptCanvasTestFixture, SlotGrouping_BasicFunctionalitySanityTest)
 {
     using namespace ScriptCanvas;
 
-    ScriptCanvas::Graph* graph = CreateGraph();
+    [[maybe_unused]] ScriptCanvas::Graph* graph = CreateGraph();
     ConfigurableUnitTestNode* inputNode = CreateConfigurableNode();
 
     Slot* dynamicInputSlot = nullptr;
@@ -2268,7 +2381,7 @@ TEST_F(ScriptCanvasTestFixture, SlotGrouping_SingleGroupDisplayTypeRestriction)
 {
     using namespace ScriptCanvas;
 
-    ScriptCanvas::Graph* graph = CreateGraph();
+    [[maybe_unused]] ScriptCanvas::Graph* graph = CreateGraph();
     ConfigurableUnitTestNode* groupedNode = CreateConfigurableNode();
 
     Slot* restrictedInputSlot = nullptr;
@@ -2332,7 +2445,7 @@ TEST_F(ScriptCanvasTestFixture, SlotGrouping_SingleGroupDisplayTypeRestrictionCo
 {
     using namespace ScriptCanvas;
 
-    ScriptCanvas::Graph* graph = CreateGraph();
+    [[maybe_unused]] ScriptCanvas::Graph* graph = CreateGraph();
     ConfigurableUnitTestNode* groupedNode = CreateConfigurableNode();
 
     Slot* restrictedInputSlot = nullptr;
@@ -2596,4 +2709,4 @@ TEST_F(ScriptCanvasTestFixture, DynamicSlot_DisplayTypeDatum)
         EXPECT_EQ(dataType == randomType, sourceDatum->IS_A(dataType));
     }
 }
-*/
+/**/


### PR DESCRIPTION
## What does this PR do?

This increases the number of situations in which Script Canvas correctly supports hooking subclasses to slots and nodes. Specifically, in the case where a slot defined as a base class is turned into a variable reference, and the selected variable is a subclass, the dropdown of choices for alternative variables will now show anything that matches the base class. Previously, once a variable was assigned, the variable's type would be used, causing only subclasses to match.

There are still other situations that remain unaddressed by this PR, such as assigning a dynamic slot on a Print node to a subclass. That has the workaround of just resetting the slot reference though.

## How was this PR tested?

Added some unit tests to verify at least a few situations in which base class / subclass matching is expected to pass and fail.
