### PR TITLE
Add create-repo CLI and unit test for this function

### DIFF
--- a/Templates/RemoteRepo/Template/repo.json
+++ b/Templates/RemoteRepo/Template/repo.json
@@ -1,9 +1,9 @@
 {
-    "repo_name":"${Name}",
+    "repo_name": "${Name}",
     "repo_uri": "${RepoURI}",
     "$schemaVersion": "1.0.0",
-    "origin":"${Origin}",
-    "origin_url":"${OriginURL}",
+    "origin": "${Origin}",
+    "origin_url": "${OriginURL}",
     "summary": "${Summary}",
     "additional_info": "${AdditionalInfo}",
     "last_updated": "",

--- a/Templates/RemoteRepo/Template/repo.json
+++ b/Templates/RemoteRepo/Template/repo.json
@@ -9,5 +9,6 @@
     "last_updated": "",
     "gems_data": [],
     "projects_data": [],
-    "templates_data":[]
+    "templates_data":[],
+    "repos":[]
 }

--- a/Templates/RemoteRepo/Template/repo.json
+++ b/Templates/RemoteRepo/Template/repo.json
@@ -9,6 +9,6 @@
     "last_updated": "",
     "gems_data": [],
     "projects_data": [],
-    "templates_data":[],
-    "repos":[]
+    "templates_data": [],
+    "repos": []
 }

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2911,7 +2911,7 @@ def add_args(subparsers) -> None:
     create_repo_subparser.add_argument('-s', '--summary', type=str, required=False,
                                        help='A short description of this Repo')
     create_repo_subparser.add_argument('-ai', '--additional-info', type=str, required=False,
-                                       help='Any additional info you want to add to this Remote repo')
+                                       help='Any additional info you want to add to this Remote repo that is not necessary to know')
     create_repo_subparser.add_argument('-f','--force', action='store_true', default=False,
                                       help='Copies over instantiated RemoteRepo directory even if it exist.')
     create_repo_subparser.add_argument('-r', '--replace', type=str, required=False,

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2465,7 +2465,8 @@ def _run_create_repo(args: argparse) -> int:
                        args.summary,
                        args.additional_info,
                        args.force,
-                       args.replace
+                       args.replace,
+                       args.no_register
                        )
 
 def add_args(subparsers) -> None:
@@ -2923,7 +2924,9 @@ def add_args(subparsers) -> None:
                                            ' Ex. --replace ${DATE} 1/1/2020 ${id} 1723905'
                                            ' Note: <RepoName> is the last component of repo_path'
                                            ' Note: ${Name} is automatically <Name>')
-    
+    create_repo_subparser.add_argument('--no-register', action='store_true', default=False,
+                                      help='If the remote repo template is instantiated successfully, it will not register the'
+                                           ' remote repo with the global, project or engine manifest file.')                                       
     create_repo_subparser.set_defaults(func=_run_create_repo)
 
 if __name__ == "__main__":

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -257,8 +257,7 @@ def _execute_template_json(json_data: dict,
     for copy_file in json_data['copyFiles']:
         # construct the input file name
         in_file = template_path / 'Template' / copy_file['file']
-        
-        # construct the output file name        
+        # construct the output file name
         out_file = destination_path / copy_file['file']
 
         # transform the output file name

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2308,8 +2308,7 @@ def create_repo(repo_path: pathlib.Path,
                 additional_info: str = None,
                 force: bool = False,
                 replace: list = None,
-                no_register: bool = False
-                ) -> int:
+                no_register: bool = False) -> int:
 
     template_name = 'RemoteRepo'
 
@@ -2466,8 +2465,7 @@ def _run_create_repo(args: argparse) -> int:
                        args.additional_info,
                        args.force,
                        args.replace,
-                       args.no_register
-                       )
+                       args.no_register)
 
 def add_args(subparsers) -> None:
     """

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2925,8 +2925,8 @@ def add_args(subparsers) -> None:
                                            ' Note: <RepoName> is the last component of repo_path'
                                            ' Note: ${Name} is automatically <Name>')
     create_repo_subparser.add_argument('--no-register', action='store_true', default=False,
-                                      help='If the remote repo template is instantiated successfully, it will not register the'
-                                           ' remote repo with the global, project or engine manifest file.')                                       
+                                      help='If the repo template is instantiated successfully, it will not register the'
+                                               ' repo with the global manifest file.')                                       
     create_repo_subparser.set_defaults(func=_run_create_repo)
 
 if __name__ == "__main__":

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -132,7 +132,7 @@ def _remove_license_text_markers(source_data: str):
         next_line = source_data.find('\n', license_block_start_index + len(begin_marker))
         if next_line != -1:
             # Skip past {BEGIN_LICENSE} line +1 for the newline character
-            license_block_start_index = next_line + 1;
+            license_block_start_index = next_line + 1
         else:
             # Otherwise Skip pass the {BEGIN_LICENSE} text as the file contains no more newlines
             license_block_start_index = license_block_start_index + len(begin_marker)
@@ -257,8 +257,8 @@ def _execute_template_json(json_data: dict,
     for copy_file in json_data['copyFiles']:
         # construct the input file name
         in_file = template_path / 'Template' / copy_file['file']
-
-        # construct the output file name
+        
+        # construct the output file name        
         out_file = destination_path / copy_file['file']
 
         # transform the output file name
@@ -2300,6 +2300,75 @@ def create_gem(gem_path: pathlib.Path,
     # Register the gem with the either o3de_manifest.json, engine.json or project.json based on the gem path
     return register.register(gem_path=gem_path) if not no_register else 0
 
+def create_repo(repo_path: pathlib.Path,
+                repo_uri: str,
+                repo_name: str = None,
+                origin: str = None,
+                origin_url: str = None,
+                summary: str = None,
+                additional_info: str = None,
+                force: bool = False,
+                replace: list = None
+                ) -> int:
+
+    template_name = 'RemoteRepo'
+
+    template_path = manifest.get_registered(template_name=template_name)
+
+    template_json = template_path / 'template.json'
+  
+    # read in the template.json
+    with open(template_json) as s:
+        try:
+            template_json_data = json.load(s)
+        except KeyError as e:
+            logger.error(f'Could not read template json {template_json}: {str(e)}.')
+            return 1
+
+    if not repo_path:
+        logger.error('Destination path on local machine cannot be empty.')
+        return 1
+    if not repo_uri:
+        logger.error('Destination path on online version control uri cannot be empty.')
+        return 1
+    if not repo_path and repo_uri:
+        logger.error('Please provide repository destination path on local machine and online uri.')
+        return 1
+    
+    if not force and os.path.isdir(repo_path):
+        logger.error(f'Destination path {repo_path} already exists.')
+        return 1
+    else:
+        os.makedirs(repo_path, exist_ok=force)
+
+    if not repo_name:
+        # destination name is now the last component of the destination_path
+        repo_name = repo_path.name
+
+    # any user supplied replacements
+    replacements = list()
+    while replace:
+        replace_this = replace.pop(0)
+        with_this = replace.pop(0)
+        replacements.append((replace_this, with_this))
+
+    replacements.append(("${Name}", repo_name))
+    replacements.append(("${RepoURI}", repo_uri))
+    replacements.append(("${Origin}",  origin if origin else "${Origin}"))
+    replacements.append(("${OriginURL}",  origin_url if origin_url else "${OriginURL}"))
+    replacements.append(("${Summary}", summary if summary else "${Summary}"))
+    replacements.append(("${AdditionalInfo}", additional_info if additional_info else "${AdditionalInfo}"))
+
+    # create repo.json file
+    if _execute_template_json(template_json_data,
+                              repo_path,
+                              template_path,
+                              replacements):    
+        logger.error(f'Instantiation of the remote repository has failed.')
+        return 1
+    logger.warning('Remote Repo is successfully initiated!')
+    json_data=manifest.load_o3de_manifest()
+    return register.register_remote_repo(json_data=json_data,repo_uri=repo_uri) 
 
 def _run_create_template(args: argparse) -> int:
     return create_template(args.source_path,
@@ -2392,6 +2461,17 @@ def _run_create_gem(args: argparse) -> int:
                       args.module_id,
                       args.version)
 
+def _run_create_repo(args: argparse) -> int:
+    return create_repo(args.repo_path,
+                       args.repo_uri,
+                       args.repo_name,
+                       args.origin,
+                       args.origin_url,
+                       args.summary,
+                       args.additional_info,
+                       args.force,
+                       args.replace
+                       )
 
 def add_args(subparsers) -> None:
     """
@@ -2815,6 +2895,45 @@ def add_args(subparsers) -> None:
                        help='An optional version. Defaults to 1.0.0')
     create_gem_subparser.set_defaults(func=_run_create_gem)
 
+
+    create_repo_subparser = subparsers.add_parser('create-repo')
+    create_repo_subparser.add_argument('-rp','--repo-path', type=pathlib.Path, required=True,
+                                       help = 'The location of the remote repo you wish to create from the RemoteRepo template,'
+                                       'can be an absolute path or relative to the current working directory'
+                                       'Ex. C:/o3de/TestRemoteRepo'
+                                       'TestRemoteRepo = <RemoteRepo_name> if --project_name not provided')
+    create_repo_subparser.add_argument('-ru', '--repo-uri', type=str, required=True,
+                                       help = 'The online remote repository uri')
+    create_repo_subparser.add_argument('-rn', '--repo-name', type=str, required=False,
+                                       help = 'The name to use when substituting the ${Name} placeholder for the remote repo,'
+                                           ' must be alphanumeric, '
+                                           ' and can contain _ and - characters.'
+                                           ' If no name is provided, will use last component of the repo-path provided by user.'
+                                           ' Ex. Remote_repo1')
+    create_repo_subparser.add_argument('-o', '--origin', type=str, required=False,
+                                       default='o3de',
+                                       help = 'The name of the originator or creator i.e. o3de.')
+    create_repo_subparser.add_argument('-ou', '--origin-url', type=str, required=False,
+                                       default='https://github.com/o3de/o3de',
+                                       help='The origin website for your remote repository. i.e. http://www.mydomain.com')
+    create_repo_subparser.add_argument('-s', '--summary', type=str, required=False,
+                                       default='This is a remote repository for my o3de project',
+                                       help='A short description of this Repo')
+    create_repo_subparser.add_argument('-ai', '--additional-info', type=str, required=False,
+                                       help='Any additional info you want to add to this Remote repo')
+    create_repo_subparser.add_argument('-f','--force', action='store_true', default=False,
+                                      help='Copies over instantiated RemoteRepo directory even if it exist.')
+    create_repo_subparser.add_argument('-r', '--replace', type=str, required=False,
+                                      nargs='*',
+                                      help='String that specifies ADDITIONAL A->B replacement pairs. ${Name} and'
+                                           ' all other standard gem replacements will be automatically inferred'
+                                           ' from the repo name. These replacements will superseded all inferred'
+                                           ' replacement pairs.'
+                                           ' Ex. --replace ${DATE} 1/1/2020 ${id} 1723905'
+                                           ' Note: <RepoName> is the last component of repo_path'
+                                           ' Note: ${Name} is automatically <Name>')
+    
+    create_repo_subparser.set_defaults(func=_run_create_repo)
 
 if __name__ == "__main__":
     # parse the command line args

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2307,7 +2307,8 @@ def create_repo(repo_path: pathlib.Path,
                 summary: str = None,
                 additional_info: str = None,
                 force: bool = False,
-                replace: list = None
+                replace: list = None,
+                no_register: bool = False
                 ) -> int:
 
     template_name = 'RemoteRepo'
@@ -2343,7 +2344,7 @@ def create_repo(repo_path: pathlib.Path,
         os.makedirs(repo_path, exist_ok=force)
 
     if not repo_name:
-        #  repo name default is the last component of repo_path
+        # repo name default is the last component of repo_path
         repo_name = repo_path.name
 
     # any user supplied replacements
@@ -2355,15 +2356,14 @@ def create_repo(repo_path: pathlib.Path,
 
     replacements.append(("${Name}", repo_name))
     replacements.append(("${RepoURI}", repo_uri))
-    replacements.append(("${Origin}",  origin if origin else "${Origin}"))
-    replacements.append(("${OriginURL}",  origin_url if origin_url else "${OriginURL}"))
+    replacements.append(("${Origin}", origin if origin else "${Origin}"))
+    replacements.append(("${OriginURL}", origin_url if origin_url else "${OriginURL}"))
     replacements.append(("${Summary}", summary if summary else "${Summary}"))
     replacements.append(("${AdditionalInfo}", additional_info if additional_info else "${AdditionalInfo}"))
 
     # create repo.json file
     _execute_template_json(template_json_data, repo_path, template_path, replacements)
-    json_data=manifest.load_o3de_manifest()
-    return register.register_remote_repo(json_data=json_data,repo_uri=repo_uri) 
+    return register.register(repo_uri=repo_path.as_posix(), force_register_with_o3de_manifest=True) if not no_register else 0
 
 def _run_create_template(args: argparse) -> int:
     return create_template(args.source_path,
@@ -2907,7 +2907,6 @@ def add_args(subparsers) -> None:
                                        default='o3de',
                                        help = 'The name of the originator or creator i.e. o3de.')
     create_repo_subparser.add_argument('-ou', '--origin-url', type=str, required=False,
-                                       default='https://github.com/o3de/o3de',
                                        help='The origin website for your remote repository. i.e. http://www.mydomain.com')
     create_repo_subparser.add_argument('-s', '--summary', type=str, required=False,
                                        help='A short description of this Repo')

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -615,7 +615,7 @@ def register_repo(json_data: dict,
     return 1
 
 def register_remote_repo(json_data: dict,
-                  repo_uri: str,) -> int:
+                  repo_uri: str) -> int:
     # get the o3de_manifest.json file and insert new remote repo in the repos field
     json_data.setdefault('repos', []).insert(0, repo_uri)
     # save updated o3de_manifest.json file

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -593,6 +593,7 @@ def register_repo(json_data: dict,
         while repo_uri in json_data.get('repos', []):
             json_data['repos'].remove(repo_uri)
     else:
+        # this will fail if repo_uri is a file://uri
         repo_uri = pathlib.Path(repo_uri).resolve().as_posix()
         while repo_uri in json_data.get('repos', []):
             json_data['repos'].remove(repo_uri)
@@ -611,16 +612,9 @@ def register_repo(json_data: dict,
             json_data.setdefault('repos', []).insert(0, repo_uri)
 
         return result
-
+    else:
+        logger.error(f'Failed to download repo_manifest {manifest_uri}.')
     return 1
-
-def register_remote_repo(json_data: dict,
-                  repo_uri: str) -> int:
-    # get the o3de_manifest.json file and insert new remote repo in the repos field
-    json_data.setdefault('repos', []).insert(0, repo_uri)
-    # save updated o3de_manifest.json file
-    manifest.save_o3de_manifest(json_data)
-    return 0
 
 def register_default_o3de_object_folder(json_data: dict,
                                         default_o3de_object_folder: pathlib.Path,

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -614,6 +614,13 @@ def register_repo(json_data: dict,
 
     return 1
 
+def register_remote_repo(json_data: dict,
+                  repo_uri: str,) -> int:
+    # get the o3de_manifest.json file and insert new remote repo in the repos field
+    json_data.setdefault('repos', []).insert(0, repo_uri)
+    # save updated o3de_manifest.json file
+    manifest.save_o3de_manifest(json_data)
+    return 0
 
 def register_default_o3de_object_folder(json_data: dict,
                                         default_o3de_object_folder: pathlib.Path,

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -80,11 +80,11 @@ TEST_CONCRETE_TESTGEM_TEMPLATE_CONTENT_WITH_LICENSE = string.Template(
 
 TEST_TEMPLATE_REPO_JSON = """\
 {
-    "repo_name":"${Name}",
+    "repo_name": "${Name}",
     "repo_uri": "${RepoURI}",
     "$schemaVersion": "1.0.0",
-    "origin":"${Origin}",
-    "origin_url":"${OriginURL}",
+    "origin": "${Origin}",
+    "origin_url": "${OriginURL}",
     "summary": "${Summary}",
     "additional_info": "${AdditionalInfo}",
     "last_updated": "",
@@ -379,11 +379,15 @@ class TestCreateTemplate:
         template_dest_path = engine_root / instantiated_name
        
         # Skip registration in test
-        with patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
-                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
-            result = engine_template.create_repo(template_dest_path, repo_name="TestRepo", repo_uri = "http://test.com", summary="summary", origin='o3de',
-                                              origin_url='https://github.com/o3de/o3de', force=force)
-
+        def download_repo_manifest(manifest_uri: str, force_overwrite: bool = True) -> pathlib.Path or None:
+            # return the path to the .json file
+            return manifest_uri
+        with patch('o3de.repo.download_repo_manifest', side_effect=download_repo_manifest) as download_repo_manifest_patch, \
+                    patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
+                    patch('o3de.repo.process_add_o3de_repo', return_value=0) as process_o3de_manifest_patch, \
+                    patch('o3de.manifest.get_registered', return_value=template_default_folder) as get_registered_patch, \
+                    patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
+                result = engine_template.create_repo(template_dest_path, repo_name="TestRepo", repo_uri = "http://test.com", summary="summary", origin='o3de', origin_url='https://github.com/o3de/o3de')
         assert expect_results == result 
         if expect_results == 0:
             test_folder = template_dest_path

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -78,6 +78,25 @@ TEST_CONCRETE_TESTGEM_TEMPLATE_CONTENT_WITHOUT_LICENSE = string.Template(
 TEST_CONCRETE_TESTGEM_TEMPLATE_CONTENT_WITH_LICENSE = string.Template(
     TEST_TEMPLATED_CONTENT_WITH_LICENSE).safe_substitute({'SanitizedCppName': "TestGem"})
 
+TEST_TEMPLATE_REPO_JSON = """\
+{
+    "repo_name":"${Name}",
+    "repo_uri": "${RepoURI}",
+    "$schemaVersion": "1.0.0",
+    "origin":"${Origin}",
+    "origin_url":"${OriginURL}",
+    "summary": "${Summary}",
+    "additional_info": "${AdditionalInfo}",
+    "last_updated": "",
+    "gems_data": [],
+    "projects_data": [],
+    "templates_data":[]
+}
+"""
+
+TEST_REPO_JSON = string.Template(TEST_TEMPLATE_REPO_JSON).safe_substitute({'Name': 'TestRepo', 'RepoURI' : "http://test", 'Summary': 'summary',
+                                                                           'Origin': 'o3de', 'OriginURL': "https://github.com/o3de/o3de"})
+
 TEST_TEMPLATE_JSON_CONTENTS = """\
 {
     "template_name": "Templates",
@@ -120,6 +139,32 @@ TEST_TEMPLATE_JSON_CONTENTS = """\
 }
 """
 
+TEST_TEMPLATE_REMOTEREPO_JSON_CONTENTS = """\
+{
+    "template_name": "RemoteRepo",
+    "origin": "Open 3D Engine - o3de.org",
+    "origin_url": "https://github.com/o3de/o3de",
+    "license": "Apache-2.0 or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "display_name": "Remote Repository",
+    "summary": "This is an O3DE remote repository template.",
+    "canonical_tags": [
+        "Template",
+        "Repo"
+    ],
+    "user_tags": [
+        "RemoteRepo"
+    ],
+    "icon_path": "preview.png",
+    "copyFiles": [
+        {
+            "file": "repo.json",
+            "isTemplated": true
+        }
+    ],
+    "createDirectories": []
+}
+"""
 
 TEST_CONCRETE_TEMPLATE_JSON_CONTENTS = string.Template(
     TEST_TEMPLATE_JSON_CONTENTS).safe_substitute({'Name': 'TestTemplate'})
@@ -297,6 +342,70 @@ class TestCreateTemplate:
 
             return test_folder
 
+    #test create Remote repo
+    @pytest.mark.parametrize(
+        "force, expect_results",
+         [
+            pytest.param(True, 0),
+            pytest.param(False, 0)
+        ]
+    )
+    def test_create_repo(self, tmpdir, force, expect_results):
+        concrete_contents = TEST_REPO_JSON
+        templated_contents = TEST_TEMPLATE_REPO_JSON 
+        template_json_contents = TEST_TEMPLATE_REMOTEREPO_JSON_CONTENTS
+
+        # Append the project.json to the list of files to copy from the template
+        template_json_dict = json.loads(template_json_contents)
+        template_json_dict.setdefault('copyFiles', []).append(
+        {
+            "file": "repo.json",
+            "isTemplated": True
+        })
+
+        # Convert the python dictionary back into a json string
+        template_json_contents = json.dumps(template_json_dict, indent=4)
+
+        instantiated_name = 'TestRepo'
+        #  Use a SHA-1 Hash of the destination_name for every Random_Uuid for determinism in the test
+        concrete_contents = string.Template(concrete_contents).safe_substitute(
+            {
+                'Random_Uuid': str(uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)).upper()
+            })
+
+        engine_root = (pathlib.Path(tmpdir) / 'engine-root').resolve()
+        engine_root.mkdir(parents=True, exist_ok=True)
+
+        template_default_folder = engine_root / 'Templates'
+        template_default_folder.mkdir(parents=True, exist_ok=True)
+
+        template_json = template_default_folder / 'template.json'
+        with template_json.open('w') as s:
+            s.write(template_json_contents)
+        
+        file_template_path = template_default_folder / 'Template' / "repo.json"
+        file_template_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_template_path.open('w') as file_template_handle:
+            file_template_handle.write(templated_contents)
+
+        template_dest_path = engine_root / instantiated_name
+       
+        # Skip registration in test
+        with patch('uuid.uuid4', return_value=uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)) as uuid4_mock, \
+                patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
+                patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
+            result = engine_template.create_repo(template_dest_path, repo_name="TestRepo", repo_uri = "http://test", summary="summary", origin='o3de',
+                                              origin_url='https://github.com/o3de/o3de', force=force)
+
+        assert expect_results == result 
+        if expect_results == 0:
+            test_folder = template_dest_path
+            assert test_folder.is_dir()
+            test_repo_file = test_folder / 'repo.json'
+            assert test_repo_file.is_file()
+            with test_repo_file.open('r') as s:
+                s_data = s.read()
+            assert s_data == concrete_contents
 
     # Use a SHA-1 Hash of the destination_name for every Random_Uuid for determinism in the test
     @pytest.mark.parametrize(

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -90,7 +90,8 @@ TEST_TEMPLATE_REPO_JSON = """\
     "last_updated": "",
     "gems_data": [],
     "projects_data": [],
-    "templates_data":[]
+    "templates_data":[],
+    "repos":[]
 }
 """
 

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -90,8 +90,8 @@ TEST_TEMPLATE_REPO_JSON = """\
     "last_updated": "",
     "gems_data": [],
     "projects_data": [],
-    "templates_data":[],
-    "repos":[]
+    "templates_data": [],
+    "repos": []
 }
 """
 

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -95,7 +95,7 @@ TEST_TEMPLATE_REPO_JSON = """\
 """
 
 TEST_REPO_JSON = string.Template(TEST_TEMPLATE_REPO_JSON).safe_substitute({'Name': 'TestRepo', 
-                                                                           'RepoURI' : "http://test", 
+                                                                           'RepoURI' : "http://test.com", 
                                                                            'Summary': 'summary',
                                                                            'Origin': 'o3de', 
                                                                            'OriginURL': "https://github.com/o3de/o3de"})

--- a/scripts/o3de/tests/test_engine_template.py
+++ b/scripts/o3de/tests/test_engine_template.py
@@ -94,8 +94,11 @@ TEST_TEMPLATE_REPO_JSON = """\
 }
 """
 
-TEST_REPO_JSON = string.Template(TEST_TEMPLATE_REPO_JSON).safe_substitute({'Name': 'TestRepo', 'RepoURI' : "http://test", 'Summary': 'summary',
-                                                                           'Origin': 'o3de', 'OriginURL': "https://github.com/o3de/o3de"})
+TEST_REPO_JSON = string.Template(TEST_TEMPLATE_REPO_JSON).safe_substitute({'Name': 'TestRepo', 
+                                                                           'RepoURI' : "http://test", 
+                                                                           'Summary': 'summary',
+                                                                           'Origin': 'o3de', 
+                                                                           'OriginURL': "https://github.com/o3de/o3de"})
 
 TEST_TEMPLATE_JSON_CONTENTS = """\
 {
@@ -355,23 +358,7 @@ class TestCreateTemplate:
         templated_contents = TEST_TEMPLATE_REPO_JSON 
         template_json_contents = TEST_TEMPLATE_REMOTEREPO_JSON_CONTENTS
 
-        # Append the project.json to the list of files to copy from the template
-        template_json_dict = json.loads(template_json_contents)
-        template_json_dict.setdefault('copyFiles', []).append(
-        {
-            "file": "repo.json",
-            "isTemplated": True
-        })
-
-        # Convert the python dictionary back into a json string
-        template_json_contents = json.dumps(template_json_dict, indent=4)
-
         instantiated_name = 'TestRepo'
-        #  Use a SHA-1 Hash of the destination_name for every Random_Uuid for determinism in the test
-        concrete_contents = string.Template(concrete_contents).safe_substitute(
-            {
-                'Random_Uuid': str(uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)).upper()
-            })
 
         engine_root = (pathlib.Path(tmpdir) / 'engine-root').resolve()
         engine_root.mkdir(parents=True, exist_ok=True)
@@ -391,10 +378,9 @@ class TestCreateTemplate:
         template_dest_path = engine_root / instantiated_name
        
         # Skip registration in test
-        with patch('uuid.uuid4', return_value=uuid.uuid5(uuid.NAMESPACE_DNS, instantiated_name)) as uuid4_mock, \
-                patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
+        with patch('o3de.manifest.load_o3de_manifest', return_value={}) as load_o3de_manifest_patch, \
                 patch('o3de.manifest.save_o3de_manifest', return_value=True) as save_o3de_manifest_patch:
-            result = engine_template.create_repo(template_dest_path, repo_name="TestRepo", repo_uri = "http://test", summary="summary", origin='o3de',
+            result = engine_template.create_repo(template_dest_path, repo_name="TestRepo", repo_uri = "http://test.com", summary="summary", origin='o3de',
                                               origin_url='https://github.com/o3de/o3de', force=force)
 
         assert expect_results == result 


### PR DESCRIPTION
## What does this PR do?

This PR adds a new create-repo CLI function to engine_template.py, which supports creation of a remote repository that generates a repo.json template and registers it with the engine. This supports user to share their personal projects/Gems online.

## How was this PR tested?

I run the create-repo function from CLI and added the relevant variables and made sure the correct information was produced in the generated repo.json file and checks if the user provided repo_uri has been registered with the engine.

command used: ./o3de.bat create-repo -rp "C:\o3de_Projects\test1" -ru "https://github.com/VeryKaylin-player1/o3deRemoteRepo.git"

I also added a unit test name test_create_repo in test_engine_template.py and make sure the correct information was generated.