### PR TITLE
bugfix: ignore SNAP_BUILD if not defined

### DIFF
--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.INFO)
 def get_this_engine_path() -> pathlib.Path:
     # When running from SNAP, __file__ was returning an incorrect (temporary) folder so
     # we manually build the correct path from env variables here when running from snap
-    if "SNAP" in os.environ:
+    if "SNAP" in os.environ and "SNAP_BUILD" in os.environ:
         return pathlib.Path(os.environ.get('SNAP')) / os.environ.get('SNAP_BUILD')
     else:
         return pathlib.Path(os.path.realpath(__file__)).parents[3].resolve()


### PR DESCRIPTION
## What does this PR do?

I'm running this in a neovim running from snap, I think a similar situation can be reproduced in vscode from snap. this is my terminal env SNAP_BUILD is not defined so o3de will fail to start. 

![image](https://github.com/o3de/o3de/assets/854359/0b4d3408-0b0b-4239-9988-c3677bf14b3b)
