### PR TITLE
Fixed PlaceholderText support in DPE

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -91,6 +91,7 @@ namespace AZ
             const static AZ::Crc32 PostChangeNotify = AZ_CRC("PostChangeNotify", 0x456e84c8);
 
             const static AZ::Crc32 ValueText = AZ_CRC_CE("ValueText");
+            const static AZ::Crc32 PlaceholderText = AZ_CRC_CE("PlaceholderText");
 
             const static AZ::Crc32 TrueText = AZ_CRC("TrueText", 0x263d9d95);
             const static AZ::Crc32 FalseText = AZ_CRC("FalseText", 0x5f8c95bd);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -102,8 +102,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterPropertyEditor<RadioButton>();
         system->RegisterPropertyEditor<EntityId>();
         system->RegisterPropertyEditor<LayoutPadding>();
+
         system->RegisterPropertyEditor<LineEdit>();
+        system->RegisterNodeAttribute<LineEdit>(LineEdit::PlaceholderText);
+
         system->RegisterPropertyEditor<MultiLineEdit>();
+        system->RegisterNodeAttribute<MultiLineEdit>(MultiLineEdit::PlaceholderText);
+
         system->RegisterPropertyEditor<Quaternion>();
         system->RegisterPropertyEditor<Crc>();
         system->RegisterPropertyEditor<Vector2>();

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -252,11 +252,13 @@ namespace AZ::DocumentPropertyEditor::Nodes
     struct LineEdit : PropertyEditorDefinition
     {
         static constexpr AZStd::string_view Name = "LineEdit";
+        static constexpr auto PlaceholderText = AttributeDefinition<AZStd::string_view>("PlaceholderText");
     };
 
     struct MultiLineEdit : PropertyEditorDefinition
     {
         static constexpr AZStd::string_view Name = "MultiLineEdit";
+        static constexpr auto PlaceholderText = AttributeDefinition<AZStd::string_view>("PlaceholderText");
     };
 
     struct Quaternion : PropertyEditorDefinition

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
@@ -41,7 +41,7 @@ namespace AzToolsFramework
     {
         AZ_TraceContext("Attribute name", debugName);
 
-        if (attrib == AZ_CRC("PlaceholderText", 0xa23ec278))
+        if (attrib == AZ::Edit::Attributes::PlaceholderText)
         {
             AZStd::string placeholderText;
             if (attrValue->Read<AZStd::string>(placeholderText))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -130,6 +130,19 @@ namespace AzToolsFramework
                 AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'MaxLength' attribute from property '%s' into text field", debugName);
             }
         }
+        else if (attrib == AZ::Edit::Attributes::PlaceholderText)
+        {
+            AZStd::string placeholderText;
+            if (attrValue->Read<AZStd::string>(placeholderText))
+            {
+                GUI->GetLineEdit()->setPlaceholderText(placeholderText.c_str());
+            }
+            else
+            {
+                AZ_WarningOnce("AzToolsFramework", false,
+                    "Failed to read 'PlaceholderText' attribute from property '%s' into string text field.", debugName);
+            }
+        }
         GUI->blockSignals(false);
     }
 

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/Editor/AssetCollectionAsyncLoaderTestComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/Editor/AssetCollectionAsyncLoaderTestComponent.cpp
@@ -49,7 +49,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZStd::vector<AZ::Crc32>({ AZ_CRC("Level", 0x9aeacc13), AZ_CRC("Game", 0x232b318c), AZ_CRC("Layer", 0xe4db211a) }))
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::LineEdit, &AssetCollectionAsyncLoaderTestComponent::m_pathToAssetListJson, "", "Path To Asset List")
-                            ->Attribute(AZ_CRC("PlaceholderText", 0xa23ec278), "Path to a JSON file")
+                            ->Attribute(AZ::Edit::Attributes::PlaceholderText, "Path to a JSON file")
                         ->UIElement(AZ::Edit::UIHandlers::Button, "", "Starts/Stop the test")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AssetCollectionAsyncLoaderTestComponent::OnStartCancelButtonClicked)
                             ->Attribute(AZ::Edit::Attributes::ButtonText, &AssetCollectionAsyncLoaderTestComponent::GetStartCancelButtonText);

--- a/Gems/LmbrCentral/Code/Source/Editor/EditorCommentComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Editor/EditorCommentComponent.cpp
@@ -35,7 +35,7 @@ namespace LmbrCentral
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/editor/comment/")
                     ->DataElement(AZ::Edit::UIHandlers::MultiLineEdit, &EditorCommentComponent::m_comment,"", "Comment")
-                        ->Attribute(AZ_CRC("PlaceholderText", 0xa23ec278), "Add comment text here");
+                        ->Attribute(AZ::Edit::Attributes::PlaceholderText, "Add comment text here");
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #16065 

This fixes support for the `PlaceholderText` attribute in the DPE. Made several changes:
* Consolidated all usages of the attribute to a single constant instead of duplicating the crc throughout the code-base
* Registered the attribute with both the string line edit and multiline edit widgets
* Updated the string line edit handler to consume the attribute (This attribute was being passed in the `AssetCollectionAsyncLoaderTest` component for the json path field, but the handler for the string line edit never actually had support for this attribute, so it didn't work in the RPE either for this field)

BEFORE:
![PlaceholderText_BEFORE](https://github.com/o3de/o3de/assets/7519264/ed336d3a-c048-4196-acc1-94f682250c63)

AFTER:
![PlaceholderText_AFTER](https://github.com/o3de/o3de/assets/7519264/f839bace-26f9-4cb2-88dd-45e7c84d9637)

## How was this PR tested?

Tested both the `Comment` and `AssetCollectionAsyncLoaderTest` components that make use of this attribute on fields and verified they work as expected now.