### PR TITLE
Use lld linker by default for Linux clang build if it is installed

### DIFF
--- a/cmake/Platform/Common/Configurations_common.cmake
+++ b/cmake/Platform/Common/Configurations_common.cmake
@@ -75,3 +75,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 include(CheckPIESupported)
 check_pie_supported()
+
+# Determine if lld is installed to use as a default linker by supported platforms/configurations
+find_program(LLD_LINKER_INSTALLED lld)

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -10,8 +10,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
     include(cmake/Platform/Common/Clang/Configurations_clang.cmake)
 
-    if (NOT ${LLD_LINKER_INSTALLED} STREQUAL "LLD_LINKER_INSTALLED-NOTFOUND")
-        set(ALTERNATIVE_LINKER_FLAG "-fuse-ld=lld")
+    if(DEFINED LY_LINKER)
+        set(SPECIFY_LINKER_FLAG "-fuse-ld=${LY_LINKER}")
+    elseif(NOT ${LLD_LINKER_INSTALLED} STREQUAL "LLD_LINKER_INSTALLED-NOTFOUND")
+        set(SPECIFY_LINKER_FLAG "-fuse-ld=lld")
     endif()
     
     if ($ENV{O3DE_SNAP})
@@ -23,7 +25,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             COMPILATION
                 -msse4.1
             LINK_NON_STATIC
-                ${ALTERNATIVE_LINKER_FLAG}
+                ${SPECIFY_LINKER_FLAG}
                 -Wl,--no-undefined
                 -fpie
                 -Wl,-z,relro,-z,now
@@ -31,7 +33,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
             LINK_EXE
-                ${ALTERNATIVE_LINKER_FLAG}
+                ${SPECIFY_LINKER_FLAG}
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
@@ -47,13 +49,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             COMPILATION
                 -msse4.1
             LINK_NON_STATIC
-                ${ALTERNATIVE_LINKER_FLAG}
+                ${SPECIFY_LINKER_FLAG}
                 -Wl,--no-undefined
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
             LINK_EXE
-                ${ALTERNATIVE_LINKER_FLAG}
+                ${SPECIFY_LINKER_FLAG}
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -10,6 +10,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
     include(cmake/Platform/Common/Clang/Configurations_clang.cmake)
 
+    if (NOT ${LLD_LINKER_INSTALLED} STREQUAL "LLD_LINKER_INSTALLED-NOTFOUND")
+        set(ALTERNATIVE_LINKER_FLAG "-fuse-ld=lld")
+    endif()
+    
     if ($ENV{O3DE_SNAP})
         ly_append_configurations_options(
             DEFINES
@@ -19,6 +23,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             COMPILATION
                 -msse4.1
             LINK_NON_STATIC
+                ${ALTERNATIVE_LINKER_FLAG}
                 -Wl,--no-undefined
                 -fpie
                 -Wl,-z,relro,-z,now
@@ -26,6 +31,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 -L$ENV{SNAP}/lib/x86_64-linux-gnu
                 -L$ENV{SNAP}/usr/lib/x86_64-linux-gnu
             LINK_EXE
+                ${ALTERNATIVE_LINKER_FLAG}
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
@@ -41,11 +47,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             COMPILATION
                 -msse4.1
             LINK_NON_STATIC
+                ${ALTERNATIVE_LINKER_FLAG}
                 -Wl,--no-undefined
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack
             LINK_EXE
+                ${ALTERNATIVE_LINKER_FLAG}
                 -fpie
                 -Wl,-z,relro,-z,now
                 -Wl,-z,noexecstack

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -3,6 +3,7 @@
 # Build Tools Packages
 cmake/3.22.1-0kitware1ubuntu18.04.1     # For cmake
 clang-12                                # For the compiler and its dependencies
+lld                                     # For the llvm linker
 ninja-build                             # For Ninja Build System
 java-11-amazon-corretto-jdk             # For Jenkins and Android
 

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -3,6 +3,7 @@
 # Build Tools Packages
 cmake/3.22.1-0kitware1ubuntu20.04.1     # For cmake
 clang-12                                # For the compiler and its dependencies
+lld                                     # For the llvm linker
 ninja-build                             # For Ninja Build System
 java-11-amazon-corretto-jdk             # For Jenkins and Android
 

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
@@ -2,6 +2,7 @@
 
 # Build Tools Packages
 clang                                   # For the compiler and its dependencies
+lld                                     # For the llvm linker
 ninja-build                             # For Ninja Build System
 java-11-amazon-corretto-jdk             # For Jenkins and Android
 


### PR DESCRIPTION
## What does this PR do?

These changes add a check to see if lld is installed on the system as part of the cmake configuration, and if so adds a flag for the Linux+clang build to make use of it. This is to speed up build times by using lld which is a faster and more memory efficient linker than ld.

_Please add links to any issues, RFCs or other items that are relevant to this PR._
https://github.com/o3de/o3de/issues/7635

## How was this PR tested?

Configured and built engine with changes on Fedora 38 with the lld package installed and uninstalled to make sure both worked. One consideration is that if the engine is built with lld uninstalled, lld is installed, then a project is created and build files generated for it, the build files will specify to use lld instead of ld as the engine does. This doesn't seem to cause any problems but may be undesirable behavior.
