### PR TITLE
Add support to the ByteContainerStream for an `Open` function

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/ByteContainerStream.h
+++ b/Code/Framework/AzCore/AzCore/IO/ByteContainerStream.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZCORE_IO_BYTECONTAINERSTREAM_H
-#define AZCORE_IO_BYTECONTAINERSTREAM_H
+#pragma once
 
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Math/MathUtils.h>
@@ -14,239 +13,303 @@
 #include <AzCore/std/typetraits/has_member_function.h>
 #include <AzCore/Casting/numeric_cast.h>
 
-namespace AZ
+namespace AZ::IO
 {
-    namespace IO
+    /*
+    * ByteContainerStream
+    * A stream that wraps around a sequence container
+    * Currently only AZStd::vector and AZStd::fixed_vector are supported as
+    * we use direct memcpy, so underlying storage has to be guaranteed continuous.
+    * It can be generalized if necessary, but for now this should do.
+    */
+    template<bool V>
+    struct WritableStreamType  {};
+    template<>
+    struct WritableStreamType<true>
     {
-        /*
-         * ByteContainerStream
-         * A stream that wraps around a sequence container
-         * Currently only AZStd::vector and AZStd::fixed_vector are supported as
-         * we use direct memcpy, so underlying storage has to be guaranteed continuous.
-         * It can be generalized if necessary, but for now this should do.
-         */
-        template<bool V>
-        struct WritableStreamType  {};
-        template<>
-        struct WritableStreamType<true>
+        typedef int type;
+    };
+
+    template<typename ContainerType>
+    class ByteContainerStream
+        : public GenericStream
+    {
+    public:
+        ByteContainerStream() = default;
+        ByteContainerStream(ContainerType* buffer, size_t maxGrowSize = 5 * 1024 * 1024);
+        ~ByteContainerStream() override {}
+
+        bool Open(ContainerType& buffer, size_t maxGrowSize = 5 * 1024 * 1024);
+        bool        IsOpen() const override                              { return m_opened; }
+        bool        CanSeek() const override                             { return true; }
+        bool        CanRead() const override                    { return true; }
+        bool        CanWrite() const override                   { return true; }
+        SizeType GetCurPos() const override
         {
-            typedef int type;
-        };
-
-        template<typename ContainerType>
-        class ByteContainerStream
-            : public GenericStream
-        {
-        public:
-            ByteContainerStream(ContainerType* buffer, size_t maxGrowSize = 5 * 1024 * 1024);
-            ~ByteContainerStream() override {}
-
-            bool        IsOpen() const override                              { return m_opened; }
-            bool        CanSeek() const override                             { return true; }
-            bool        CanRead() const override                    { return true; }
-            bool        CanWrite() const override                   { return true; }
-            SizeType    GetCurPos() const override                           { return m_pos; }
-            SizeType    GetLength() const override                           { return m_buffer->size(); }
-            void        Seek(OffsetType bytes, SeekMode mode) override;
-            SizeType    Read(SizeType bytes, void* oBuffer) override;
-            SizeType    Write(SizeType bytes, const void* iBuffer) override;
-            SizeType    WriteFromStream(SizeType bytes, GenericStream* inputStream) override;
-            template<typename T>
-            inline SizeType Write(const T* iBuffer)
+            if (!IsOpen())
             {
-                return Write(sizeof(T), iBuffer);
+                AZ_Error("ByteContainerStream", false, "Stream is closed, cannot query current position");
+                return 0;
             }
-
-            // Truncate the stream to the current position.
-            void                Truncate();
-
-            ContainerType*      GetData() const                             { return m_buffer; }
-
-            bool ReOpen() override
-            {
-                m_opened = true;
-                return m_opened;
-            }
-            void Close() override
-            {
-                m_opened = false;
-            }
-
-        protected:
-            SizeType PrepareToWrite(SizeType bytes);
-            template<typename T>
-            SizeType Write(SizeType bytes, const void* iBuffer, typename T::type);
-            template<typename T>
-            SizeType WriteFromStream(SizeType bytes, GenericStream* inputStream, typename T::type);
-            template<typename T>
-            SizeType Write(SizeType, const void*, unsigned int);
-            template<typename T>
-            SizeType WriteFromStream(SizeType, GenericStream*, unsigned int);
-
-            ContainerType*  m_buffer;
-            size_t          m_pos;
-            size_t          m_maxGrowSize; //< Maximum grow size to avoid the buffer growing too fast when it's working on big files
-            //! Used to track if the ByteContainerStream has received a Close() call
-            //! By default the ByteContainerStream is open
-            bool            m_opened{ true };
-        };
-
-        namespace Internal
-        {
-            AZ_HAS_MEMBER(ResizeNoConstruct, resize_no_construct, void, (size_t));
-
-            // As we are about to write bytes to a container, use the fast resize (without constructing elements) if available.
-            template<class ContainerType>
-            inline void ResizeContainerBuffer(ContainerType* buffer, size_t newLength, const AZStd::true_type& /* HasResizeNoConstruct<ContainerType> */)
-            {
-                buffer->resize_no_construct(newLength);
-            }
-
-            // If resize_no_construct if not supported by the container, just call resize.
-            template<class ContainerType>
-            inline void ResizeContainerBuffer(ContainerType* buffer, size_t newLength, const AZStd::false_type& /* HasResizeNoConstruct<ContainerType> */)
-            {
-                buffer->resize(newLength);
-            }
-
-            // Set the container capacity to manage better number of allocations (especially when doing small allocation)
-            AZ_HAS_MEMBER(SetCapacity, set_capacity, void, (size_t));
-
-            template<class ContainerType>
-            inline void AdjustContainerBufferCapacity(ContainerType* buffer, size_t requiredSize, size_t maxCapacityGrowSize, const AZStd::true_type& /* HasSetCapacity<ContainerType> */)
-            {
-                if (requiredSize > buffer->capacity())
-                {
-                    // grow by 50%, if we can.
-                    size_t newCapacityGrowSize = AZ::GetClamp<size_t>(requiredSize / 2, 4, maxCapacityGrowSize);
-                    size_t newCapacity = requiredSize + newCapacityGrowSize;
-                    buffer->set_capacity(newCapacity);
-                }
-            }
-
-            template<class ContainerType>
-            inline void AdjustContainerBufferCapacity(ContainerType* buffer, size_t requiredSize, size_t maxCapacityGrowSize, const AZStd::false_type& /* HasSetCapacityt<ContainerType> */)
-            {
-                (void)buffer; (void)requiredSize; (void)maxCapacityGrowSize;
-                // no set capacity support we will need to rely on resize alone
-            }
+            return m_pos;
         }
-
-        template<typename ContainerType>
-        ByteContainerStream<ContainerType>::ByteContainerStream(ContainerType* buffer, size_t maxGrowSize)
-            : m_buffer(buffer)
-            , m_pos(0)
-            , m_maxGrowSize(maxGrowSize)
+        SizeType GetLength() const override
         {
-            static_assert(sizeof(typename ContainerType::value_type) == 1, "The buffer is not a container of bytes!");
-            AZ_Assert(m_buffer, "You cannot make a ByteContainerStream with buffer = null!");
-        }
-
-        template<typename ContainerType>
-        void ByteContainerStream<ContainerType>::Seek(OffsetType bytes, SeekMode mode)
-        {
-            m_pos = static_cast<size_t>(ComputeSeekPosition(bytes, mode));
-        }
-
-        template<typename ContainerType>
-        SizeType ByteContainerStream<ContainerType>::Read(SizeType bytes, void* oBuffer)
-        {
-            size_t len = m_buffer->size();
-            size_t bytesToRead = 0;
-            if (m_pos + static_cast<size_t>(bytes) < len)
+            if (!IsOpen())
             {
-                bytesToRead = static_cast<size_t>(bytes);
+                AZ_Error("ByteContainerStream", false, "Cannot query Length on a close stream");
+                return 0;
             }
-            else if (len > m_pos)
-            {
-                bytesToRead = len - m_pos;
-            }
-            if (bytesToRead > 0)
-            {
-                AZ_Assert(oBuffer, "Output buffer can't be null!");
-                memcpy(oBuffer, m_buffer->data() + m_pos, bytesToRead);
-                m_pos += bytesToRead;
-            }
-            return bytesToRead;
+            return m_buffer->size();
         }
-
-        template<typename ContainerType>
-        SizeType ByteContainerStream<ContainerType>::Write(SizeType bytes, const void* iBuffer)
-        {
-            return Write<WritableStreamType<!AZStd::is_const<ContainerType>::value> >(bytes, iBuffer, 0);
-        }
-
-        template<typename ContainerType>
-        SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType bytes, GenericStream* inputStream)
-        {
-            return WriteFromStream<WritableStreamType<!AZStd::is_const<ContainerType>::value> >(bytes, inputStream, 0);
-        }
-
-        template<typename ContainerType>
-        SizeType ByteContainerStream<ContainerType>::PrepareToWrite(SizeType bytes)
-        {
-            size_t len = m_buffer->size();
-            size_t requiredLen = static_cast<size_t>(m_pos + bytes);
-
-            if (requiredLen > len)
-            {
-                // Make sure we grow the write buffer in a reasonable manner to avoid too many allocations
-                Internal::AdjustContainerBufferCapacity(m_buffer, requiredLen, m_maxGrowSize, typename Internal::HasSetCapacity<ContainerType>::type());
-
-                Internal::ResizeContainerBuffer(m_buffer, requiredLen, typename Internal::HasResizeNoConstruct<ContainerType>::type());
-            }
-
-            // For now, just return back the value that was handed in.  This could also be used to return 0 if error checking gets added
-            // to the buffer adjustments above.
-            return bytes;
-        }
-
-        template<typename ContainerType>
+        void        Seek(OffsetType bytes, SeekMode mode) override;
+        SizeType    Read(SizeType bytes, void* oBuffer) override;
+        SizeType    Write(SizeType bytes, const void* iBuffer) override;
+        SizeType    WriteFromStream(SizeType bytes, GenericStream* inputStream) override;
         template<typename T>
-        SizeType ByteContainerStream<ContainerType>::Write(SizeType bytes, const void* iBuffer, typename T::type)
+        inline SizeType Write(const T* iBuffer)
         {
-            size_t bytesToCopy = aznumeric_cast<size_t>(PrepareToWrite(bytes));
-            memcpy(m_buffer->data() + m_pos, iBuffer, bytesToCopy);
-            m_pos += bytesToCopy;
-            return bytes;
+            return Write(sizeof(T), iBuffer);
         }
 
-        template<typename ContainerType>
-        template<typename T>
-        SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType bytes, GenericStream* inputStream, typename T::type)
+        // Truncate the stream to the current position.
+        void                Truncate();
+
+        ContainerType* GetData() const
         {
-            AZ_Assert(inputStream, "Input stream is null!");
-            AZ_Assert(inputStream != this, "Can't write and read from the same stream.");
-            size_t bytesToCopy = aznumeric_cast<size_t>(PrepareToWrite(bytes));
-            bytesToCopy = inputStream->Read(bytesToCopy, m_buffer->data() + m_pos);
-            m_pos += bytesToCopy;
-            return bytesToCopy;
+            return IsOpen() ? m_buffer : nullptr;
         }
 
-        template<typename ContainerType>
-        template<typename T>
-        SizeType ByteContainerStream<ContainerType>::Write(SizeType, const void*, unsigned int)
+        bool ReOpen() override
         {
-            AZ_Assert(false, "This stream is read-only!");
+            AZ_Warning("ByteContainerStream", IsOpen(), "The stream is already open."
+                " This operaion will reset the seek offset");
+            m_pos = 0;
+            m_opened = m_buffer != nullptr;
+            return m_opened;
+        }
+        void Close() override
+        {
+            m_opened = false;
+            m_pos = 0;
+        }
+
+    protected:
+        SizeType PrepareToWrite(SizeType bytes);
+        template<typename T>
+        SizeType Write(SizeType bytes, const void* iBuffer, typename T::type);
+        template<typename T>
+        SizeType WriteFromStream(SizeType bytes, GenericStream* inputStream, typename T::type);
+        template<typename T>
+        SizeType Write(SizeType, const void*, unsigned int);
+        template<typename T>
+        SizeType WriteFromStream(SizeType, GenericStream*, unsigned int);
+
+        ContainerType*  m_buffer{};
+        size_t          m_pos{};
+        size_t          m_maxGrowSize{}; //< Maximum grow size to avoid the buffer growing too fast when it's working on big files
+        //! Used to track if the ByteContainerStream has received a Close() call
+        bool            m_opened{ false };
+    };
+
+    namespace Internal
+    {
+        AZ_HAS_MEMBER(ResizeNoConstruct, resize_no_construct, void, (size_t));
+
+        // As we are about to write bytes to a container, use the fast resize (without constructing elements) if available.
+        template<class ContainerType>
+        inline void ResizeContainerBuffer(ContainerType* buffer, size_t newLength, const AZStd::true_type& /* HasResizeNoConstruct<ContainerType> */)
+        {
+            buffer->resize_no_construct(newLength);
+        }
+
+        // If resize_no_construct if not supported by the container, just call resize.
+        template<class ContainerType>
+        inline void ResizeContainerBuffer(ContainerType* buffer, size_t newLength, const AZStd::false_type& /* HasResizeNoConstruct<ContainerType> */)
+        {
+            buffer->resize(newLength);
+        }
+
+        // Set the container capacity to manage better number of allocations (especially when doing small allocation)
+        AZ_HAS_MEMBER(SetCapacity, set_capacity, void, (size_t));
+
+        template<class ContainerType>
+        inline void AdjustContainerBufferCapacity(ContainerType* buffer, size_t requiredSize, size_t maxCapacityGrowSize, const AZStd::true_type& /* HasSetCapacity<ContainerType> */)
+        {
+            if (requiredSize > buffer->capacity())
+            {
+                // grow by 50%, if we can.
+                size_t newCapacityGrowSize = AZ::GetClamp<size_t>(requiredSize / 2, 4, maxCapacityGrowSize);
+                size_t newCapacity = requiredSize + newCapacityGrowSize;
+                buffer->set_capacity(newCapacity);
+            }
+        }
+
+        template<class ContainerType>
+        inline void AdjustContainerBufferCapacity(ContainerType* buffer, size_t requiredSize, size_t maxCapacityGrowSize, const AZStd::false_type& /* HasSetCapacityt<ContainerType> */)
+        {
+            (void)buffer; (void)requiredSize; (void)maxCapacityGrowSize;
+            // no set capacity support we will need to rely on resize alone
+        }
+    }
+
+    template<typename ContainerType>
+    ByteContainerStream<ContainerType>::ByteContainerStream(ContainerType* buffer, size_t maxGrowSize)
+        : m_buffer(buffer)
+        , m_pos(0)
+        , m_maxGrowSize(maxGrowSize)
+        , m_opened(m_buffer != nullptr)
+    {
+        static_assert(sizeof(typename ContainerType::value_type) == 1, "The buffer is not a container of bytes!");
+        AZ_Assert(m_buffer, "You cannot make a ByteContainerStream with buffer = null!");
+    }
+
+    template<typename ContainerType>
+    bool ByteContainerStream<ContainerType>::Open(ContainerType& buffer, size_t maxGrowSize)
+    {
+        if (IsOpen())
+        {
+            AZ_Error("ByteContainerStream", false, "Attempting to open new Byte Container stream"
+                " while an existing stream is open. Please invoke Close(), before calling Open()");
+            return false;
+        }
+
+        m_buffer = &buffer;
+        m_maxGrowSize = maxGrowSize;
+        m_pos = 0;
+        m_opened = true;
+        return m_opened;
+    }
+
+    template<typename ContainerType>
+    void ByteContainerStream<ContainerType>::Seek(OffsetType bytes, SeekMode mode)
+    {
+        if (!IsOpen())
+        {
+            AZ_Error("ByteContainerStream", false, "The stream is closed, cannot seek");
+            return;
+        }
+        m_pos = static_cast<size_t>(ComputeSeekPosition(bytes, mode));
+    }
+
+    template<typename ContainerType>
+    SizeType ByteContainerStream<ContainerType>::Read(SizeType bytes, void* oBuffer)
+    {
+        if (!IsOpen())
+        {
+            AZ_Error("ByteContainerStream", false, "The stream is closed, the read call will return 0 bytes");
             return 0;
         }
 
-        template<typename ContainerType>
-        template<typename T>
-        SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType, GenericStream*, unsigned int)
+        size_t len = m_buffer->size();
+        size_t bytesToRead = 0;
+        if (m_pos + static_cast<size_t>(bytes) < len)
         {
-            AZ_Assert(false, "This stream is read-only!");
+            bytesToRead = static_cast<size_t>(bytes);
+        }
+        else if (len > m_pos)
+        {
+            bytesToRead = len - m_pos;
+        }
+        if (bytesToRead > 0)
+        {
+            AZ_Assert(oBuffer, "Output buffer can't be null!");
+            memcpy(oBuffer, m_buffer->data() + m_pos, bytesToRead);
+            m_pos += bytesToRead;
+        }
+        return bytesToRead;
+    }
+
+    template<typename ContainerType>
+    SizeType ByteContainerStream<ContainerType>::Write(SizeType bytes, const void* iBuffer)
+    {
+        if (!IsOpen())
+        {
+            AZ_Error("ByteContainerStream", false, "The stream is closed, write operattion will not occur");
             return 0;
         }
 
+        return Write<WritableStreamType<!AZStd::is_const<ContainerType>::value> >(bytes, iBuffer, 0);
+    }
 
-        template<typename ContainerType>
-        void ByteContainerStream<ContainerType>::Truncate()
+    template<typename ContainerType>
+    SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType bytes, GenericStream* inputStream)
+    {
+        if (!IsOpen())
         {
-            Internal::ResizeContainerBuffer(m_buffer, m_pos, typename Internal::HasResizeNoConstruct<ContainerType>::type());
+            AZ_Error("ByteContainerStream", false, "The stream is closed, copy operation from other stream will not occur");
+            return 0;
         }
-    }   // IO
-}   // namespace AZ
 
-#endif  // AZCORE_IO_BYTECONTAINERSTREAM_H
-#pragma once
+        return WriteFromStream<WritableStreamType<!AZStd::is_const<ContainerType>::value> >(bytes, inputStream, 0);
+    }
+
+    template<typename ContainerType>
+    SizeType ByteContainerStream<ContainerType>::PrepareToWrite(SizeType bytes)
+    {
+        size_t len = m_buffer->size();
+        size_t requiredLen = static_cast<size_t>(m_pos + bytes);
+
+        if (requiredLen > len)
+        {
+            // Make sure we grow the write buffer in a reasonable manner to avoid too many allocations
+            Internal::AdjustContainerBufferCapacity(m_buffer, requiredLen, m_maxGrowSize, typename Internal::HasSetCapacity<ContainerType>::type());
+
+            Internal::ResizeContainerBuffer(m_buffer, requiredLen, typename Internal::HasResizeNoConstruct<ContainerType>::type());
+        }
+
+        // For now, just return back the value that was handed in.  This could also be used to return 0 if error checking gets added
+        // to the buffer adjustments above.
+        return bytes;
+    }
+
+    template<typename ContainerType>
+    template<typename T>
+    SizeType ByteContainerStream<ContainerType>::Write(SizeType bytes, const void* iBuffer, typename T::type)
+    {
+        size_t bytesToCopy = aznumeric_cast<size_t>(PrepareToWrite(bytes));
+        memcpy(m_buffer->data() + m_pos, iBuffer, bytesToCopy);
+        m_pos += bytesToCopy;
+        return bytes;
+    }
+
+    template<typename ContainerType>
+    template<typename T>
+    SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType bytes, GenericStream* inputStream, typename T::type)
+    {
+        AZ_Assert(inputStream, "Input stream is null!");
+        AZ_Assert(inputStream != this, "Can't write and read from the same stream.");
+        size_t bytesToCopy = aznumeric_cast<size_t>(PrepareToWrite(bytes));
+        bytesToCopy = inputStream->Read(bytesToCopy, m_buffer->data() + m_pos);
+        m_pos += bytesToCopy;
+        return bytesToCopy;
+    }
+
+    template<typename ContainerType>
+    template<typename T>
+    SizeType ByteContainerStream<ContainerType>::Write(SizeType, const void*, unsigned int)
+    {
+        AZ_Assert(false, "This stream is read-only!");
+        return 0;
+    }
+
+    template<typename ContainerType>
+    template<typename T>
+    SizeType ByteContainerStream<ContainerType>::WriteFromStream(SizeType, GenericStream*, unsigned int)
+    {
+        AZ_Assert(false, "This stream is read-only!");
+        return 0;
+    }
+
+
+    template<typename ContainerType>
+    void ByteContainerStream<ContainerType>::Truncate()
+    {
+        if (!IsOpen())
+        {
+            AZ_Error("ByteContainerStream", false, "The stream is closed, cannot truncate buffer");
+            return;
+        }
+        Internal::ResizeContainerBuffer(m_buffer, m_pos, typename Internal::HasResizeNoConstruct<ContainerType>::type());
+    }
+}   // namespace AZ::IO

--- a/Code/Framework/AzCore/AzCore/IO/OpenMode.h
+++ b/Code/Framework/AzCore/AzCore/IO/OpenMode.h
@@ -17,18 +17,18 @@ namespace AZ::IO
         Invalid = 0,
         //! Open the file in read mode ("r")
         //! if ModeRead is specified without ModeWrite, the file is open in file share write mode
-        //! when on platforms that uses WinAPI
+        //! when on platforms that use WinAPI
         ModeRead = (1 << 0),
         //! Open the file in write mode ("w")
         //! If the ModeAppend option is not specified, the file is truncated
         ModeWrite = (1 << 1),
         //! Opens the file in append mode ("a")
-        //! The file is opened and and set the write offset to the end of the file
+        //! The file is opened and sets the write offset to the end of the file
         ModeAppend = (1 << 2),
         //! Opens the file with the binary option("b") set
         ModeBinary = (1 << 3),
         //! Opens the file with the text option("t") set
-        //! This may affect how newlines are handled on Windows platforms
+        //! This affects may affect how newlines are handled on different platforms ("\n" vs "\r\n")
         ModeText = (1 << 4),
         //! Open the file in update mode with the ("+") symbol
         //! If ModeRead is also set and the file doe NOT exist, it will not be created

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -765,7 +765,7 @@ namespace AZ
 }
 
 //! Use this macro to simplify safe printing of a PathView or BasicPath* which may not be null-terminated.
-//! Example: AZStd::fixed_string<1024>::format("Safely formatted: %.*s", AZ_PATH_ARG(myString));
+//! Example: AZStd::fixed_string<1024>::format("Safely formatted: %.*s", AZ_PATH_ARG(myPathView));
 #define AZ_PATH_ARG(path) static_cast<int>(path.Native().size()), path.Native().data()
 
 #include <AzCore/IO/Path/Path.inl>

--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
@@ -414,7 +414,6 @@ namespace AZ
 
     void TaskExecutor::Submit(Internal::CompiledTaskGraph& graph, TaskGraphEvent* event)
     {
-        ++m_graphsRemaining;
 
         if (event)
         {
@@ -427,11 +426,18 @@ namespace AZ
         // to be signaled to release the semaphore so that the TaskGraphEvent::Wait
         // function does not deadlock
         auto& compiledTasks = graph.Tasks();
-        if (compiledTasks.empty() && event)
+        if (compiledTasks.empty())
         {
-            event->Signal();
+            if (event != nullptr)
+            {
+                event->Signal();
+            }
             return;
         }
+
+        // Since there is at least one compiled task, it is safe
+        // to increment the graphs remaining member
+        ++m_graphsRemaining;
 
         // Submit all tasks that have no inbound edges
         for (Internal::Task& task : compiledTasks)

--- a/Code/Framework/AzCore/Tests/GenericStreamTests.cpp
+++ b/Code/Framework/AzCore/Tests/GenericStreamTests.cpp
@@ -133,3 +133,125 @@ TEST_F(GenericStreamTest, MemoryStreamWriteFromStream_MoreBytesThanTempBuffer_Co
     // just to help catch any possible errors.
     TestMemoryStreamWriteFromStream(aznumeric_cast<size_t>(AZ::IO::GenericStream::StreamToStreamCopyBufferSize * 2.6f));
 }
+
+namespace AZ::IO::Test
+{
+    class ByteContainerStreamTest
+        : public UnitTest::LeakDetectionFixture
+    {
+    };
+
+    TEST_F(ByteContainerStreamTest, IsDefaultConstructible)
+    {
+        using ContainerType = AZStd::vector<AZStd::byte>;
+        AZ::IO::ByteContainerStream<ContainerType> byteContainerStream;
+        EXPECT_FALSE(byteContainerStream.IsOpen());
+    }
+
+    TEST_F(ByteContainerStreamTest, CanBeOpened_PostConstruction)
+    {
+        using ContainerType = AZStd::vector<AZStd::byte>;
+        AZ::IO::ByteContainerStream<ContainerType> byteContainerStream;
+        EXPECT_FALSE(byteContainerStream.IsOpen());
+
+        ContainerType byteBuffer;
+        EXPECT_TRUE(byteContainerStream.Open(byteBuffer));
+        ASSERT_TRUE(byteContainerStream.IsOpen());
+        EXPECT_EQ(0, byteContainerStream.GetCurPos());
+    }
+
+    TEST_F(ByteContainerStreamTest, Open_OnAlreadyOpenStream_Fails)
+    {
+        using ContainerType = AZStd::vector<AZStd::byte>;
+        ContainerType byteBuffer;
+        AZ::IO::ByteContainerStream byteContainerStream(&byteBuffer);
+        ASSERT_TRUE(byteContainerStream.IsOpen());
+
+        ContainerType secondBuffer;
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        EXPECT_FALSE(byteContainerStream.Open(secondBuffer));
+        AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
+    }
+
+    TEST_F(ByteContainerStreamTest, Cannot_PerformStreamModificationOperations_OnClosedStream)
+    {
+        using ContainerType = AZStd::vector<AZStd::byte>;
+        ContainerType byteBuffer;
+        AZ::IO::ByteContainerStream byteContainerStream(&byteBuffer);
+        EXPECT_TRUE(byteContainerStream.IsOpen());
+
+        constexpr AZStd::string_view testString("Hello World");
+        EXPECT_EQ(testString.size(), byteContainerStream.Write(testString.size(), testString.data()));
+        EXPECT_EQ(testString.size(), byteContainerStream.GetCurPos());
+        EXPECT_EQ(testString.size(), byteContainerStream.GetLength());
+
+        // Seek back to the beginning of the stream
+        byteContainerStream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+
+        AZStd::string outputString;
+        auto ReadByteContainerStream = [expectedSize = testString.size(),
+            &byteContainerStream](char* buffer, size_t size)
+        {
+            AZ::IO::SizeType readSize = byteContainerStream.Read(size, buffer);
+            EXPECT_EQ(expectedSize, readSize);
+            return readSize;
+        };
+        outputString.resize_and_overwrite(testString.size(), ReadByteContainerStream);
+
+        // Close the stream and retry the above operations
+        byteContainerStream.Close();
+        ASSERT_FALSE(byteContainerStream.IsOpen());
+
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        EXPECT_EQ(0, byteContainerStream.Write(testString.size(), testString.data()));
+        EXPECT_EQ(0, byteContainerStream.GetCurPos());
+        EXPECT_EQ(0, byteContainerStream.GetLength());
+        AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
+
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        // This seek should do nothing, but output an AZ_Error
+        byteContainerStream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        auto ReadByteContainerStreamOnClosed = [&byteContainerStream](char* buffer, size_t size)
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            AZ::IO::SizeType readSize = byteContainerStream.Read(size, buffer);
+            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
+            EXPECT_EQ(0, readSize);
+            return readSize;
+        };
+        outputString.clear();
+        outputString.resize_and_overwrite(testString.size(), ReadByteContainerStreamOnClosed);
+
+        // Now re-open the stream and validate that seeking/reading and writing works again
+        EXPECT_TRUE(byteContainerStream.ReOpen());
+        ASSERT_TRUE(byteContainerStream.IsOpen());
+
+        AZ::IO::SizeType seekPos = byteContainerStream.GetLength();
+        EXPECT_EQ(seekPos, byteContainerStream.GetLength());
+        // Seek to the end of the stream
+        byteContainerStream.Seek(seekPos, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+        EXPECT_EQ(seekPos, byteContainerStream.GetCurPos());
+
+        // Yes, "byte" was on purpose
+        constexpr AZStd::string_view secondString("Goodbyte World");
+        EXPECT_EQ(secondString.size(), byteContainerStream.Write(secondString.size(), secondString.data()));
+        EXPECT_EQ(testString.size() + secondString.size(), byteContainerStream.GetCurPos());
+        EXPECT_EQ(testString.size() + secondString.size(), byteContainerStream.GetLength());
+
+        // Seek to beginning of the second string
+        byteContainerStream.Seek(testString.size(), AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+
+        auto ReadByteContainerStreamOnReopened = [expectedSize = secondString.size(),
+            &byteContainerStream](char* buffer, size_t size)
+        {
+            AZ::IO::SizeType readSize = byteContainerStream.Read(size, buffer);
+            EXPECT_EQ(expectedSize, readSize);
+            return readSize;
+        };
+
+        outputString.clear();
+        outputString.resize_and_overwrite(secondString.size(), ReadByteContainerStreamOnReopened);
+    }
+}

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.h
@@ -49,7 +49,7 @@ namespace Archive
 
     //! Updates the ArchiveHeader structure with compression algorithm ID if
     //! there is space in the ArchiveHeader compression algorithm ID array
-    //! @param compresionAlgorithmId compression algorithm ID to add to the archive header
+    //! @param compressionAlgorithmId compression algorithm ID to add to the archive header
     //! @param archiveHeader modifiable archive header reference to update
     //! with compression algorithm ID if a slot is available
     //! @return true if the specified compression algorithm ID was added

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.inl
@@ -23,7 +23,7 @@ namespace Archive
             return false;
         }
 
-        // Check the compression algorithm id is already registered with the compression algorithm id array
+        // Check if the compression algorithm id is already registered with the compression algorithm id array
         // If not, then register the compression algorithm at the first unused slot index
         size_t firstUnusedIndex = InvalidAlgorithmIndex;
         for (size_t compressionAlgorithmIndex{}; compressionAlgorithmIndex < archiveHeader.m_compressionAlgorithmsIds.size();

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
@@ -104,7 +104,7 @@ namespace Archive
         {
             result.m_errorCode = ArchiveHeaderErrorCode::InvalidMagicBytes;
             result.m_errorMessage = ArchiveHeaderValidationResult::ErrorString::format(
-                "Archive header has invalid magic byte sequence %u",
+                "Archive header has invalid magic byte sequence %x",
                 archiveHeader.m_magicBytes);
         }
         return result;

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
@@ -48,7 +48,11 @@ namespace Archive
         ArchiveWriterErrorString m_errorMessage;
     };
 
-    //! Stores settings to configure how Archive Writer Settings
+    //! Stores settings to configure how Archive Writer perform specific operations
+    //! This can be used to change if the Archive TOC should be compressed on Commit
+    //! It also supports configuring an optional error callback to invoke if an
+    //! error occurs in a function that can't return a outcome value such as a constructor/destructor
+    //! The number of compression task that can run in parallel is also configurable
     struct ArchiveWriterSettings
     {
         ArchiveWriterSettings();
@@ -248,12 +252,12 @@ namespace Archive
         //! NOTE: The entry in the table of contents is not actually removed
         //! The index where the file is located using the filePathToken
         //! is just added to the removed file indices set
-        //! //! @return ArchiveRemoveResult with metadata about how the deleted file was
+        //! @return ArchiveRemoveResult with metadata about how the deleted file was
         //! stored in the Archive
         virtual ArchiveRemoveFileResult RemoveFileFromArchive(ArchiveFileToken filePathToken) = 0;
         //! Removes the file from the archive using a relative path name
         //! @param relativePath Relative path within archive to search for
-        //! //! @return ArchiveRemoveResult with metadata about how the deleted file was
+        //! @return ArchiveRemoveResult with metadata about how the deleted file was
         //! stored in the Archive
         virtual ArchiveRemoveFileResult RemoveFileFromArchive(AZ::IO::PathView relativePath) = 0;
 

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOC.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOC.h
@@ -43,6 +43,8 @@ namespace Archive
 
         //! Wrapper path structure to ensure the Table of Contents only contain paths that
         //! uses the Posix Path Separator '/'
+        //! This is used to normalize how the paths within the Table of Cotnents
+        //! are stored across platforms(Linux/MacOS vs Windows)
         struct Path
         {
             Path() = default;
@@ -56,7 +58,7 @@ namespace Archive
             Path& operator=(const Path&) = default;
             Path& operator=(Path&&) = default;
             //! Add support for storing an AZ::IO::Path into the table of contents
-            //! as a path with a
+            //! as a path with only Posix Path Separators of '/'
             Path& operator=(AZ::IO::Path filePath);
             Path& operator=(AZ::IO::PathView filePath);
 
@@ -80,7 +82,7 @@ namespace Archive
         };
 
         //! vector storing a copy of each file path in memory
-//! It's length matches the value of m_fileCount
+        //! It's length matches the value of m_fileCount
         using ArchiveFilePathTable = AZStd::vector<Path>;
         ArchiveFilePathTable m_filePaths;
 

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
@@ -102,7 +102,7 @@ namespace Archive
             ArchiveTocValidationResult tocValidationResult;
             tocValidationResult.m_errorCode = ArchiveTocErrorCode::InvalidMagicBytes;
             tocValidationResult.m_errorMessage = ArchiveTocValidationResult::ErrorString::format(
-                "The Archive TOC has an invalid magic byte sequence of %llu", tocView.m_magicBytes);
+                "The Archive TOC has an invalid magic byte sequence of %llx", tocView.m_magicBytes);
             return tocValidationResult;
         }
 


### PR DESCRIPTION
### ByteContainerStream changes
The ByteContainerStream now supports an Open member, that can be used to associate a different container buffer with the ByteContainerStream instance.

The ByteContainerStream member functions that mutate the underlying container buffer (`Seek`, `Read`, `Write`, etc...), now check if the buffer is in an "open" state before performing any of those operations.
`AZ_Error` messages gets logged in that case.

### Task System changes
Updated the `TaskExecutor::Submit` function to not increment the `m_graphsRemaining` member until it has been validated there is at least one compiled task to run.

### Archive Writer PR feedback adressing.

The feedback from the ArchiveWriter PR post commit has been addressed: https://github.com/o3de/o3de/pull/16052

## How was this PR tested?

Added UnitTest to validate the ByteContainerStream functionality.
