### PR TITLE
Fixed read-only handling in DPE to get applied to UIElements as well

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -40,6 +40,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         system->RegisterNode<NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::Visibility);
+        system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::ReadOnly);
 
         system->RegisterNode<Adapter, NodeWithVisiblityControl>();
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -36,6 +36,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         static constexpr AZStd::string_view Name = "NodeWithVisiblityControl";
         static constexpr auto Visibility = AttributeDefinition<PropertyVisibility>("Visibility");
+        static constexpr auto ReadOnly = AttributeDefinition<bool>("ReadOnly");
 
         static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled


### PR DESCRIPTION
## What does this PR do?

Fixes #16067 

Fixed an issue with the DPE handling of read-only attributes that was preventing them being handled for UIElements (e.g. buttons, groups). I moved the check to the generic `checkAttribute` location in the `LegacyReflectionBridge` so it gets all the same benefits of that method, but kept the special-case to ignore it if we'd already detected the ancestor node is disabled.

Here is a simple use-case in the `Transform` component where the `Add non-uniform scale` button should get disabled based on whether or not the  `Non-uniform Scale component` is present for this Entity. Before this change, the button is just always enabled.

BEFORE:
![ReadOnly_BEFORE](https://github.com/o3de/o3de/assets/7519264/4b23934b-fcbd-4b55-ba9f-70ca364d68be)

AFTER:
![ReadOnly_AFTER](https://github.com/o3de/o3de/assets/7519264/eec3d8e5-a8a0-4ec8-8277-c3f418fd7ef8)

## How was this PR tested?

Tested according to repro steps listed in bug and above. Tested various other read-only usages on normal data elements (e.g. Mesh Stats in Mesh component) and verified they still work as expected.