### PR TITLE
MeshFeatureProcessor: Consider emissive intensity unit for raytracing materials

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
@@ -63,7 +63,7 @@ namespace AZ
             }
         }
 
-        float ConvertEmissiveUnitFunctor::GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex)
+        float ConvertEmissiveUnitFunctor::GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex) const
         {
             PhotometricUnit sourceType;
             if (lightUnitIndex == m_ev100Index)

--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.cpp
@@ -38,23 +38,7 @@ namespace AZ
             // Convert unit on runtime
             float sourceValue = context.GetMaterialPropertyValue<float>(m_intensityPropertyIndex);
             uint32_t lightUnit = context.GetMaterialPropertyValue<uint32_t>(m_lightUnitPropertyIndex);
-
-            PhotometricUnit sourceType;
-            if (lightUnit == m_ev100Index)
-            {
-                sourceType = PhotometricUnit::Ev100Luminance;
-            }
-            else if (lightUnit == m_nitIndex)
-            {
-                sourceType = PhotometricUnit::Nit;
-            }
-            else
-            {
-                sourceType = PhotometricUnit::Unknown;
-                AZ_Assert(false, "ConvertEmissiveUnitFunctor doesn't recognize light unit.")
-            }
-
-            float targetValue = PhotometricValue::ConvertIntensityBetweenUnits(sourceType, PhotometricUnit::Nit, sourceValue);
+            float targetValue = GetProcessedValue(sourceValue, lightUnit);
             context.GetShaderResourceGroup()->SetConstant(m_shaderInputIndex, targetValue);
         }
 
@@ -77,6 +61,26 @@ namespace AZ
             {
                 AZ_Assert(false, "ConvertEmissiveUnitFunctor doesn't recognize light unit.")
             }
+        }
+
+        float ConvertEmissiveUnitFunctor::GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex)
+        {
+            PhotometricUnit sourceType;
+            if (lightUnitIndex == m_ev100Index)
+            {
+                sourceType = PhotometricUnit::Ev100Luminance;
+            }
+            else if (lightUnitIndex == m_nitIndex)
+            {
+                sourceType = PhotometricUnit::Nit;
+            }
+            else
+            {
+                sourceType = PhotometricUnit::Unknown;
+                AZ_Assert(false, "ConvertEmissiveUnitFunctor doesn't recognize light unit.")
+            }
+
+            return PhotometricValue::ConvertIntensityBetweenUnits(sourceType, PhotometricUnit::Nit, originalEmissiveIntensity);
         }
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
@@ -31,7 +31,7 @@ namespace AZ
             using RPI::MaterialFunctor::Process;
             void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
             void Process(RPI::MaterialFunctorAPI::EditorContext& context) override;
-            float GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex);
+            float GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex) const;
 
         private:
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/ConvertEmissiveUnitFunctor.h
@@ -31,6 +31,8 @@ namespace AZ
             using RPI::MaterialFunctor::Process;
             void Process(RPI::MaterialFunctorAPI::RuntimeContext& context) override;
             void Process(RPI::MaterialFunctorAPI::EditorContext& context) override;
+            float GetProcessedValue(float originalEmissiveIntensity, uint32_t lightUnitIndex);
+
         private:
 
             AZ::RPI::MaterialPropertyIndex m_intensityPropertyIndex;


### PR DESCRIPTION
## What does this PR do?

The light intensity in the StandardPBR material is defined in Ev100 in the Editor. However the shader expects Nits.
For the non-raytracing materials the intensity is converted using a Functor that is registered in the material (in `EmissivePropertyGroup.json`). This Functor is never called for the raytracing material.

My solution is to search for the specific Functor when creating the raytracing material, and convert the unit using this functor.

The solution is kind of dirty, but I can't think of another way, to convert the unit, with the current material system. The raytracing support, for materials, is quite limited currently.

## How was this PR tested?

Vulkan and Windows
