### PR TITLE
Added support for handling the NameLabelOverride attribute in the DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -41,6 +41,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNode<NodeWithVisiblityControl>();
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::Visibility);
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::ReadOnly);
+        system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::NameLabelOverride);
 
         system->RegisterNode<Adapter, NodeWithVisiblityControl>();
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -37,6 +37,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr AZStd::string_view Name = "NodeWithVisiblityControl";
         static constexpr auto Visibility = AttributeDefinition<PropertyVisibility>("Visibility");
         static constexpr auto ReadOnly = AttributeDefinition<bool>("ReadOnly");
+        static constexpr auto NameLabelOverride = AttributeDefinition<AZStd::string_view>("NameLabelOverride");
 
         static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -573,11 +573,18 @@ namespace AZ::Reflection
                 return m_stack.back().m_instance;
             }
 
-            AZStd::string_view GetNodeDisplayLabel(const StackEntry& nodeData, AZStd::fixed_string<128>& labelAttributeBuffer)
+            AZStd::string_view GetNodeDisplayLabel(StackEntry& nodeData, AZStd::fixed_string<128>& labelAttributeBuffer)
             {
+                using DocumentPropertyEditor::Nodes::PropertyEditor;
+
                 // First check for overrides or for presence of parent container
                 if (!nodeData.m_labelOverride.empty())
                 {
+                    return nodeData.m_labelOverride;
+                }
+                else if (auto nameLabelOverrideAttribute = Find(PropertyEditor::NameLabelOverride.GetName()); nameLabelOverrideAttribute)
+                {
+                    nodeData.m_labelOverride = PropertyEditor::NameLabelOverride.DomToValue(*nameLabelOverrideAttribute).value_or("");
                     return nodeData.m_labelOverride;
                 }
                 else if (!nodeData.m_group.empty())


### PR DESCRIPTION
## What does this PR do?

Fixes #16075 and #16083

Added support for handling the `NameLabelOverride` attribute in the DPE. This was added to the `GetNodeDisplayLabel` that will continue to be extended in future PRs to handle additional name label overrides (e.g. child indexes).

BEFORE:
![NameLabelOverride_BEFORE](https://github.com/o3de/o3de/assets/7519264/d2b84e72-4203-4680-948d-e64ba685fedf)

AFTER:
![NameLabelOverride_AFTER](https://github.com/o3de/o3de/assets/7519264/afb4c11c-1928-4aa4-9028-11ccc19543f9)

## How was this PR tested?

Tested the components mentioned in both issues and verified the expected labels now appear.