### PR TITLE
Add additional attribute options to Nodeables

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
@@ -15,12 +15,16 @@
 												<xs:attribute name="Type" type="xs:string" use="required" />
 												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
 												<xs:attribute name="Description" type="xs:string" use="required" />
+												<xs:attribute name="HideInputField" type="xs:boolean" use="optional" />
+												<xs:attribute name="HideName" type="xs:boolean" use="optional"/>
+												<xs:attribute name="DisplayGroup" type="xs:string" use="optional"/>
 											</xs:complexType>
 										</xs:element>
 									</xs:sequence>
 									<xs:attribute name="Name" type="xs:string" use="required" />
 									<xs:attribute name="Description" type="xs:string" use="required" />
 									<xs:attribute name="OutputName" type="xs:string" use="optional" />
+									<xs:attribute name="DisplayGroup" type="xs:string" use="optional" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="Output" minOccurs="0" maxOccurs="unbounded" >
@@ -32,11 +36,14 @@
 												<xs:attribute name="Type" type="xs:string" use="required" />
 												<xs:attribute name="Description" type="xs:string" use="required" />
 												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
+												<xs:attribute name="HideName" type="xs:boolean" use="optional"/>
+												<xs:attribute name="DisplayGroup" type="xs:string" use="optional"/>
 											</xs:complexType>
 										</xs:element>
 									</xs:sequence>
 									<xs:attribute name="Name" type="xs:string" use="required" />
 									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="DisplayGroup" type="xs:string" use="optional" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element maxOccurs="unbounded" minOccurs="0" name="PropertyInterface">
@@ -56,6 +63,7 @@
 						<xs:attribute name="Namespace" type="xs:string" use="required" />
 						<xs:attribute name="Description" type="xs:string" use="required" />
 						<xs:attribute name="Base" type="xs:string" use="optional" />
+						<xs:attribute name="Style" type="xs:string" use="optional" />
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
@@ -108,6 +108,9 @@ public: \
               /* no slot configuration extension, Use Class attribute 'ExtendConfigureSlots' to extend them */
 
 {% endif %}
+{% if Class.attrib['Style'] is defined %}
+              void OnInit() override;
+{% endif %}
               void ConfigureVisualExtensions() override;
 
               size_t GenerateFingerprint() const override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
@@ -108,9 +108,7 @@ public: \
               /* no slot configuration extension, Use Class attribute 'ExtendConfigureSlots' to extend them */
 
 {% endif %}
-{% if Class.attrib['Style'] is defined %}
               void OnInit() override;
-{% endif %}
               void ConfigureVisualExtensions() override;
 
               size_t GenerateFingerprint() const override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -44,6 +44,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%- set attribute_VersionConverter = Class.attrib['VersionConverter'] %}
 {%- set attribute_EventHandler = Class.attrib['EventHandler'] %}
 {%- set attribute_Deprecated = Class.attrib['Deprecated'] %}
+{%- set attribute_Style = Class.attrib['Style'] %}
 
 {%- set attribute_Base = "ScriptCanvas::Nodeable" %}
 {% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
@@ -341,6 +342,14 @@ void Nodes::{{ nodeableNodeName }}::ConfigureVisualExtensions()
     OnConfigureVisualExtensions();
 }
 
+{# OnInit #}
+{% if attribute_Style is defined %}
+void Nodes::{{ nodeableNodeName }}::OnInit()
+{
+    SetNodeStyle("{{attribute_Style}}");
+}
+{% endif %}
+
 {# ConfigureSlots #}
 // Configure Slots and Build the Nodeable Execution Maps
 void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
@@ -361,7 +370,7 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
         in.slotId = slotId{{ macros.CleanName(itemName) }}Input;
 
 {% for paraItem in item.findall('Parameter') %}
-        {{ nodemacro.AddDataSlot("true", "in.inputs", undefined, paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name']) }}
+        {{ nodemacro.AddDataSlot("true", "in.inputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
 {% endfor %}
         { // execution outs begin    
 {%      if item.findall("Branch")|length == 0 %}
@@ -383,7 +392,9 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
             AZ_Assert(outSlotId.IsValid(), "ExecutionOutput slot is not created successfully.");
             out.slotId = outSlotId;
 {%          for return in item.findall('Return') %}
-                {{ nodemacro.AddDataSlot("false", "out.outputs", itemDisplayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], item.attrib['Name']) }}
+                {# Default to the input's display group if no group for this tag is defined #}
+                {% set displayGroup = return.attrib['DisplayGroup'] if return.attrib['DisplayGroup'] is defined else itemDisplayGroup %}
+                {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], item.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName']) }}
 {%          endfor %}
             in.outs.push_back(out);
 {%      else %}
@@ -403,7 +414,9 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
                 AZ_Assert(outSlotId.IsValid(), "ExecutionOutput slot is not created successfully.");
                 out.slotId = outSlotId;
 {%              for return in branchItem.findall('Return') %}
-                    {{ nodemacro.AddDataSlot("false", "out.outputs", branchDisplayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], branchItem.attrib['Name']) }}
+                    {# Default to the branch's display group if no group for this tag is defined #}
+                    {% set displayGroup = return.attrib['DisplayGroup'] if return.attrib['DisplayGroup'] is defined else branchDisplayGroup %}
+                    {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], branchItem.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName']) }}
 {%              endfor %}
                 in.outs.push_back(out);
             }
@@ -423,10 +436,10 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
         out.slotId = slotId{{ nodemacro.SlotName(itemName) }}Output;
         out.name = "{{itemName}}";
 {%      for paraItem in item.findall('Parameter') %}
-{{     nodemacro.AddDataSlot("false", "out.outputs", undefined, paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name']) }}
+{{     nodemacro.AddDataSlot("false", "out.outputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
 {%      endfor %}
 {%      for paraItem in item.findall('Return') %}
-{{     nodemacro.AddDataSlot("true", "out.returnValues.values", undefined, paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name']) }}
+{{     nodemacro.AddDataSlot("true", "out.returnValues.values", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
 {%      endfor %}
         outs.push_back(out);
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -343,12 +343,12 @@ void Nodes::{{ nodeableNodeName }}::ConfigureVisualExtensions()
 }
 
 {# OnInit #}
-{% if attribute_Style is defined %}
 void Nodes::{{ nodeableNodeName }}::OnInit()
 {
+{% if attribute_Style is defined %}
     SetNodeStyle("{{attribute_Style}}");
-}
 {% endif %}
+}
 
 {# ConfigureSlots #}
 // Configure Slots and Build the Nodeable Execution Maps

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -131,7 +131,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 {# ------- #}
 
-{% macro AddDataSlot(isInput, executionName, displayGroup, slotName, slotDescription, slotDefaultValue, valueType, parentName) %}
+{% macro AddDataSlot(isInput, executionName, displayGroup, slotName, slotDescription, slotDefaultValue, valueType, parentName, hideInputField, hideName) %}
 
         // Data Slot: {{slotName}} ({% if isInput == "true" %}Input{% else %}Output{% endif %})
         {
@@ -140,8 +140,15 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
             static_assert(false, "DataSlot type is undefined for slot: {{ slotName }}");
 {% endif %}
             ScriptCanvas::DataSlotConfiguration dataSlotConfiguration;
+{% if hideName %}
+            dataSlotConfiguration.m_name = " ";
+{% else %}
             dataSlotConfiguration.m_name = "{{ slotName }}";
+{% endif %}
             dataSlotConfiguration.m_toolTip = "{{ slotDescription }}";
+{% if hideInputField %}
+            dataSlotConfiguration.m_canHaveInputField = false;
+{% endif %}
 {% if displayGroup is defined %}
             dataSlotConfiguration.m_displayGroup = "{{ displayGroup }}";
 {% elif parentName is defined%}


### PR DESCRIPTION
## What does this PR do?

This PR adds additional styling options to Nodeables that users can take advantage of in a Nodeable's xml file. The following attributes were added:
HideName, which hides the name label of a data slot.
HideInputField, which hides the input field of a data slot.
Style, which sets the nodeable's style to the specified GraphCanvas substyle.
DisplayGroup, which sets the display group of a data or execution slot. Previously this only worked for execution slots.

Future PRs will utilize these new options for compact style small operator nodes.

## How was this PR tested?

Manual testing was preformed to test the effects of enabling these attributes. I created a new Nodeable node with these options:

![Screenshot 2023-06-06 095531](https://github.com/o3de/o3de/assets/105814224/0512b46d-bfe9-44a3-acc0-29b59cff573e)

To create this node:

![Screenshot 2023-06-05 164736](https://github.com/o3de/o3de/assets/105814224/6c6d201f-afa7-437a-a784-03b9a36bf20e)

I also created a simple script to test that the node worked as intended with these options enabled:

![Screenshot 2023-06-05 165713](https://github.com/o3de/o3de/assets/105814224/c455a76a-c8f5-46c2-bd47-1d9d1523645b)

![Screenshot 2023-06-05 165643](https://github.com/o3de/o3de/assets/105814224/9c69aa73-b57b-416e-95cc-8ef81524534b)

Because I made changes to the Nodeable template, I also checked other Nodeables to make sure they were not altered by this change:

![Screenshot 2023-06-06 123616](https://github.com/o3de/o3de/assets/105814224/b3a5f405-e272-46ce-ad2c-fd1459de1b6c)


