### PR TITLE
Moved Bake Texture button out of group

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -154,13 +154,12 @@ namespace AZ
                                 ->EnumAttribute(DiffuseProbeGridMode::RealTime, "Real Time (Ray-Traced)")
                                 ->EnumAttribute(DiffuseProbeGridMode::Baked, "Baked")
                                 ->EnumAttribute(DiffuseProbeGridMode::AutoSelect, "Auto Select")
-                        ->ClassElement(AZ::Edit::ClassElements::Group, "Bake Textures")
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                            ->UIElement(AZ::Edit::UIHandlers::Button, "Bake Textures", "Bake the Diffuse Probe Grid textures to static assets that will be used when the mode is set to Baked")
-                                ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
-                                ->Attribute(AZ::Edit::Attributes::ButtonText, "Bake Textures")
-                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorDiffuseProbeGridComponent::BakeDiffuseProbeGrid)
-                                ->Attribute(AZ::Edit::Attributes::Visibility, &EditorDiffuseProbeGridComponent::GetBakeDiffuseProbeGridVisibilitySetting)
+                        ->EndGroup()
+                        ->UIElement(AZ::Edit::UIHandlers::Button, "Bake Textures", "Bake the Diffuse Probe Grid textures to static assets that will be used when the mode is set to Baked")
+                            ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                            ->Attribute(AZ::Edit::Attributes::ButtonText, "Bake Textures")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorDiffuseProbeGridComponent::BakeDiffuseProbeGrid)
+                            ->Attribute(AZ::Edit::Attributes::Visibility, &EditorDiffuseProbeGridComponent::GetBakeDiffuseProbeGridVisibilitySetting)
                         ;
 
                     editContext->Class<DiffuseProbeGridComponentController>(


### PR DESCRIPTION
## What does this PR do?

Fixes #16077 

This fix actually isn't a DPE bug, but rather was an unnecessary placement of the "Bake Textures" button on the "Diffuse Probe Grid" component underneath a group with the same name. It appears the author wasn't aware of the ability to end the scope of a group (which is why I later added the `EndGroup` helper API), so this "Bake Textures" button was put underneath a group so that it wouldn't be grouped under the "Grid mode" group.

I came across this during DPE testing and it caught my eye as a potential DPE bug, but actually turned out to just be how it was reflected as it appeared the same in the RPE, but I went ahead and fixed it so that it wouldn't appear to others as a DPE bug.

BEFORE:
![BakeTextures_BEFORE](https://github.com/o3de/o3de/assets/7519264/9e99d81e-cd60-4a78-9a87-7767f616ea44)

AFTER:
![BakeTextures_AFTER](https://github.com/o3de/o3de/assets/7519264/7741b751-fedd-486b-b350-c61f2882395f)

## How was this PR tested?

Tested on the "Diffuse Probe Grid" component and verified the "Bake Textures" now lives on its own at the root instead of underneath a sub-group.