### PR TITLE
Fix LyShine RTTChildPass depth attachment size issue

### DIFF
--- a/Gems/LyShine/Assets/Passes/RttChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/RttChildPass.pass
@@ -39,12 +39,27 @@
                     }
                 }
             ],
+            "ImageAttachments": [
+                {
+                    "Name": "DepthInputOutputImage",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "RenderTargetOutput"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "Parent",
+                        "Attachment": "DepthInputOutput"
+                    }
+                }
+            ],
             "Connections": [
                 {
                     "LocalSlot": "DepthInputOutput",
                     "AttachmentRef": {
-                        "Pass": "Parent",
-                        "Attachment": "DepthInputOutput"
+                        "Pass": "This",
+                        "Attachment": "DepthInputOutputImage"
                     }
                 }
             ],


### PR DESCRIPTION
## What does this PR do?

Fix "Device Lost" error when creating a UI Canvas with a texture larger than the window size. 
The RTTChildPass was using the depth/stencil attachment from the ForwardPass. If the texture use by the UI Canvas was larger than the depth/stencil attachment of the ForwardPass, an error was generated when running on Vulkan. To fix it, the RTTChildPass now uses a transient attachment that matches the size of the texture used (the depth/stencil texture is cleared, so it wasn't using the depth information from the ForwardPass)

Fixes #13853

## How was this PR tested?
Run Editor with Vulkan and created a UI Canvas of size 1500x1000
