### PR TITLE
Adding Archive Reader implementation

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Crc.h
+++ b/Code/Framework/AzCore/AzCore/Math/Crc.h
@@ -80,13 +80,16 @@ namespace AZ
          * Calculates the value from a block of raw data.
          */
         Crc32(const void* data, size_t size, bool forceLowerCase = false);
-        constexpr Crc32(const uint8_t* data, size_t size, bool forceLowerCase = false);
-        constexpr Crc32(const char* data, size_t size, bool forceLowerCase = false);
+        template<class ByteType, class = AZStd::enable_if_t<sizeof(ByteType) == 1>>
+        constexpr Crc32(const ByteType* data, size_t size, bool forceLowerCase = false);
+        constexpr Crc32(AZStd::span<const AZStd::byte> inputSpan);
 
         constexpr void Add(AZStd::string_view view);
         void Add(const void* data, size_t size, bool forceLowerCase = false);
-        constexpr void Add(const uint8_t* data, size_t size, bool forceLowerCase = false);
-        constexpr void Add(const char* data, size_t size, bool forceLowerCase = false);
+        template<class ByteType>
+        constexpr auto Add(const ByteType* data, size_t size, bool forceLowerCase = false)
+            -> AZStd::enable_if_t<sizeof(ByteType) == 1>;
+        constexpr void Add(AZStd::span<const AZStd::byte> inputSpan);
 
         constexpr operator u32() const               { return m_value; }
 
@@ -101,8 +104,9 @@ namespace AZ
         // A constant expression cannot contain a conversion from const-volatile void to any pointer to object type
         // nor can it contain a reinterpret_cast, therefore overloads for const char* and uint8_t are added
         void Set(const void* data, size_t size, bool forceLowerCase = false);
-        constexpr void Set(const uint8_t* data, size_t size, bool forceLowerCase = false);
-        constexpr void Set(const char* data, size_t size, bool forceLowerCase = false);
+        template<class ByteType>
+        constexpr auto Set(const ByteType* data, size_t size, bool forceLowerCase = false)
+            -> AZStd::enable_if_t<sizeof(ByteType) == 1>;
         constexpr void Combine(u32 crc, size_t len);
 
         u32 m_value;

--- a/Code/Framework/AzCore/AzCore/Math/Crc.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Crc.inl
@@ -72,37 +72,6 @@ namespace AZ
 
     //=========================================================================
     //
-    // Crc32 constructor
-    //
-    //=========================================================================
-    constexpr Crc32::Crc32(AZStd::string_view view)
-        : m_value{ 0 }
-    {
-        if (!view.empty())
-        {
-            Set(view.data(), view.size(), true);
-        }
-    }
-
-    //=========================================================================
-    //
-    // Crc32 constructor
-    //
-    //=========================================================================
-    template<class ByteType, class>
-    constexpr Crc32::Crc32(const ByteType* data, size_t size, bool forceLowerCase)
-        : m_value{ 0 }
-    {
-        Set(data, size, forceLowerCase);
-    }
-    constexpr Crc32::Crc32(AZStd::span<const AZStd::byte> inputSpan)
-        : m_value{ 0 }
-    {
-        Set(inputSpan.data(), inputSpan.size(), false);
-    }
-
-    //=========================================================================
-    //
     // Crc32 - Set
     //
     //=========================================================================
@@ -162,6 +131,37 @@ namespace AZ
         -> AZStd::enable_if_t<sizeof(ByteType) == 1>
     {
         Internal::Crc32Set(data, size, forceLowerCase, m_value);
+    }
+
+    //=========================================================================
+    //
+    // Crc32 constructor
+    //
+    //=========================================================================
+    constexpr Crc32::Crc32(AZStd::string_view view)
+        : m_value{ 0 }
+    {
+        if (!view.empty())
+        {
+            Set(view.data(), view.size(), true);
+        }
+    }
+
+    //=========================================================================
+    //
+    // Crc32 constructor
+    //
+    //=========================================================================
+    template<class ByteType, class>
+    constexpr Crc32::Crc32(const ByteType* data, size_t size, bool forceLowerCase)
+        : m_value{ 0 }
+    {
+        Set(data, size, forceLowerCase);
+    }
+    constexpr Crc32::Crc32(AZStd::span<const AZStd::byte> inputSpan)
+        : m_value{ 0 }
+    {
+        Set(inputSpan.data(), inputSpan.size(), false);
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/Math/Crc.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Crc.inl
@@ -89,15 +89,16 @@ namespace AZ
     // Crc32 constructor
     //
     //=========================================================================
-    constexpr Crc32::Crc32(const uint8_t* data, size_t size, bool forceLowerCase)
+    template<class ByteType, class>
+    constexpr Crc32::Crc32(const ByteType* data, size_t size, bool forceLowerCase)
         : m_value{ 0 }
     {
         Set(data, size, forceLowerCase);
     }
-    constexpr Crc32::Crc32(const char* data, size_t size, bool forceLowerCase)
+    constexpr Crc32::Crc32(AZStd::span<const AZStd::byte> inputSpan)
         : m_value{ 0 }
     {
-        Set(data, size, forceLowerCase);
+        Set(inputSpan.data(), inputSpan.size(), false);
     }
 
     //=========================================================================
@@ -156,12 +157,9 @@ namespace AZ
         }
     }
 
-    constexpr void Crc32::Set(const uint8_t* data, size_t size, bool forceLowerCase)
-    {
-        Internal::Crc32Set(data, size, forceLowerCase, m_value);
-    }
-
-    constexpr void Crc32::Set(const char* data, size_t size, bool forceLowerCase)
+    template <class ByteType>
+    constexpr auto Crc32::Set(const ByteType* data, size_t size, bool forceLowerCase)
+        -> AZStd::enable_if_t<sizeof(ByteType) == 1>
     {
         Internal::Crc32Set(data, size, forceLowerCase, m_value);
     }
@@ -182,14 +180,16 @@ namespace AZ
     //=========================================================================
     // Crc32 - Add
     //=========================================================================
-    constexpr void Crc32::Add(const uint8_t* data, size_t size, bool forceLowerCase)
+    template <class ByteType>
+    constexpr auto Crc32::Add(const ByteType* data, size_t size, bool forceLowerCase)
+        -> AZStd::enable_if_t<sizeof(ByteType) == 1>
     {
         Combine(Crc32{ data, size, forceLowerCase }, size);
     }
 
-    constexpr void Crc32::Add(const char* data, size_t size, bool forceLowerCase)
+    constexpr void Crc32::Add(AZStd::span<const AZStd::byte> inputSpan)
     {
-        Combine(Crc32{ data, size, forceLowerCase }, size);
+        Combine(Crc32{ inputSpan }, inputSpan.size());
     }
 
     constexpr u32 MatrixTimes(u32* mat, u32 vec)

--- a/Code/Framework/AzCore/AzCore/PlatformDef.h
+++ b/Code/Framework/AzCore/AzCore/PlatformDef.h
@@ -281,35 +281,45 @@
 
 // define builtin functions used by char_traits class for efficient compile time and runtime
 // operations
+// The list of builtins can be found on the clang and GCC documentation pages at
+// https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
+// https://clang.llvm.org/docs/LanguageExtensions.html#builtin-functions
+
+// NOTE: __builtin_memcpy and __builtin_memmove for GCC is not usable in a compile time context currently
+// The following is a permalink to godbolt that checks which builtin intrinsics
+// are available for GCC 10.1+ and clang 12.0.0+
+// The non-short link is being used here to not rely on a URL shortener service
+// https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxBIAHKQADqgKhE4MHt6%2BekkpjgJBIeEsUTFc8XaYDmlCBEzEBBk%2Bfly2mPZ5DDV1BAVhkdFxtrX1jVktCsM9wX3FA2UAlLaoXsTI7BzmAMzByN5YANQmm24TxMHAAPoAbniYAO5H2CYaAILPLwD0H/sAatF4NEwCn2ES8dEcDH2wQIZwYKWQwIICCYBH2dUw%2By8CiYEXoUMhTH2aBYCToGMcbCJskwqgI7zQcIINISxHxqKZEwuoPBwQUEHmhwA7FZXvsxVTGczWRN0CAQKdztdbnd9gplqsMUcACKHMxmAASbVoqH2AHUSLR0OYzEcRS9xRKJlLVQRZSA7gqjEr7vs7ngsEJ1WtDpsdQFrYbaMazRarXrbe93g7kMjWVgJiYAKwWTY2zNakzCwsFzZ2h13FN1C6ov1YLVAunZ3NZgtFwUlu1J8VffZsFjIBIATxBYNoEIUibM2yo%2BwuF2RCi5o4hEDn3LHwQufYHg/mXbFa%2BXm%2B3Q4g6YIpFVQcwADp0CimPzL2qVmsbykAF6Yfl70uTzauAC/4ArO85MIu64roePIMBcdwnru%2B6gZBm7wZg/anrWmD1hMl5YYGr63vetRPr6/qYARGrvngX4/gmrxbIBVCJgxordt8fYsKgVwYihcLATOc4LkuMGriJG6wZx3GYHubEHuJEJbuhXE8WeDbPted4PqRL5UZ%2B37zL%2BnZTkxAmgcJfFiXxcFSTxsn2uK0ESTZynSRAWE4ReZEBppxGPos3kUZp%2Bl0X%2BDEmQw%2BDMaxDlij2pz0JCfETuF07meBCnBFZR6wQljD2Q6TmKXlDAQLpb5%2BaFxkAZFQGpSBQkZZZRWoQiiUFY5mWwRWCiJe55GURV2mGfRbwRVFLGxfsPbbggrLJWZjUQTl2UwUp/ZzR18nWbNxBlb5w2XhoGmEdRtEjWFY01RN9WCWBy2iS13W7VtyE5S5G17fhB0kQFx2BYNt4hRd1WmTFDozehyAkiOMEpVdDX3V1q3OQhr1Pet0MJPtp2VQFEZGia5rEJa1onXpNEGUZ/5gwjd0WStGNof2JLo11H1Y/1Pm44d%2BzhnqkbRsTpN6nhA3BZTVU07V0VvHJ%2BzEJgBArJCGijcWk3Qr2TBZfZhZluKDJOqoLJsgrQJeGOIY6hyBBdXy1Pg%2BKivK8QkKKwolt0pdxYcIstCcJmvB%2BBwWikKgnBuNY1hXoRuqbDwpAEJofuLAA1iAmybDeWe53n%2BcAGz6JwkjByn4ecLwCggMdyeh37pBwLAMCICgqAkmSZAUBAxKkvQMTAFwCekFgNxrD8yoAPIJIwnCJzQY7RNXEAROXETBHUg5z7w6/MMQg6TxE2iVHXifEmwgiTwwtBb/XI%2BYKCwBuGItDV9wvBYCwhjAOId/4IrVQeJvzDjSSoXgmTb3IIINo5daB4AiMQTeHgsDlxhHgFg29FhUAMMABQE97jT1nu/GQggRBiHYFIEh8glBqHLroFoBgjAoGjpYfQ8Dq6QEWKgBIHQ34AFoZTalMJYawXBBS8GksQM46Z4CLAqFUZwEBXCjGaKQQI0wiglGyMkVIAgVHaNyGkXomi5itHaNUSY%2BjxhtBPhY7oxj%2BilCGN0Kxzj6gONmKUOR14JD%2B0DmXO%2BEcOD7FULEAufCC6SH2MAZAyB9hDxvFwfYEBcCEBIPHLg8xeB1y0IZUgGdMzHQDhwUupAMGFNICHMOQSq41yTinRYTdW7LAIAkcB5BKC907qEVg6xQnhMidE2J8Ts6J0wPgIg0i9D8FIaIcQlCZnUJUOoO%2B9DSB3EQQkTBxcOBB0qeXIJk9wFtNRKgGc/SIlRJiXEhJSSIAeA7v3DJWT6n1zyQgTATAsAxCfMU0p5TjpVIkZXWwdScmp3yZnbO%2BcYW5yLsUzYATqkgvBY0luTSIBIC6f3DpPd259wGLsb%2BXAzAaGOqPPA48p4zxDvPcES9KCrzvrvTekCWX70PsfBwkDz6MAIFfG%2B5csCP2flGN%2BidP7f1/mHf%2BtigHl1AcgcB6xE7QhgXfOBCCkEYHWGHNBGD35YJwXg6lRD56yDIfM6QizFDLLoSAMw%2Bhv7MJEawzVHCnzcN4ZwARrohEsIsGIiRPEpHkQ9XImxCi/BKMiq49RhRHEGN0ekTwTQk0dA8Vo6x5iBBdBGKmsYZjbG5smJm0xEwXEFtURW9xGjE2ZKWIRXxOy9lAorsEi5gyiVGHiWYG8Gh%2B3JNSZM552SGnpyhTnWFMKdn/JABUttNTQW1waY3dFSAWknNxdi6IPS2CcE7VE7twBe39v7bwcZaSpktEWZaih1rZC2toash16zNnbOKa2g5nAjmtPAfsM5ISwmXKJIwk9JKz0aGSQ8glrIthmBeaixYHyvkDF%2BSXXgAL9mBJBdXFdbyJ1ZyndOvOOzEXYeRRwMdBGdlmCRcCqjrzcmLBDSkZwkggA%3D%3D%3D
+
 #if defined(__has_builtin)
-    #if __has_builtin(__builtin_memcpy) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)
+    #if __has_builtin(__builtin_memcpy) && (!defined(AZ_COMPILER_GCC))
         #define az_has_builtin_memcpy true
     #endif
-    #if __has_builtin(__builtin_wmemcpy) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)
+    #if __has_builtin(__builtin_wmemcpy)
         #define az_has_builtin_wmemcpy true
     #endif
-    #if __has_builtin(__builtin_memmove) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)
+    #if __has_builtin(__builtin_memmove) && (!defined(AZ_COMPILER_GCC))
         #define az_has_builtin_memmove true
     #endif
-    #if __has_builtin(__builtin_wmemmove) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)
+    #if __has_builtin(__builtin_wmemmove)
         #define az_has_builtin_wmemmove true
     #endif
-    #if (__has_builtin(__builtin_strlen) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_strlen)) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_strlen true
     #endif
-    #if (__has_builtin(__builtin_wcslen) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_wcslen)) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_wcslen true
     #endif
-    #if (__has_builtin(__builtin_char_memchr) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_char_memchr)) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_char_memchr true
     #endif
-    #if (__has_builtin(__builtin_wmemchr) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_wmemchr)) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_wmemchr true
     #endif
-    #if (__has_builtin(__builtin_memcmp) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_memcmp) && (!defined(AZ_COMPILER_GCC))) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_memcmp true
     #endif
-    #if (__has_builtin(__builtin_wmemcmp) && (!defined(AZ_COMPILER_GCC) || AZ_COMPILER_GCC >= 130000)) || defined(AZ_COMPILER_MSVC)
+    #if (__has_builtin(__builtin_wmemcmp)) || defined(AZ_COMPILER_MSVC)
         #define az_has_builtin_wmemcmp true
     #endif
 #elif defined(AZ_COMPILER_MSVC)

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -263,7 +263,7 @@ namespace AZ
         extern template struct AggregateTypes<Crc32>;
 
         template<typename T>
-        constexpr const char* GetTypeName()
+        constexpr AZStd::string_view GetTypeName()
         {
             return AZ::AzTypeInfo<T>::Name();
         }
@@ -300,9 +300,9 @@ namespace AZ
 
         // Supports any non-type template argument which supports conversion to a size_t
         template<auto N>
-        constexpr const char* GetTypeName()
+        constexpr AZStd::string_view GetTypeName()
         {
-            return IntTypeName<static_cast<AZStd::size_t>(N)>.c_str();
+            return IntTypeName<static_cast<AZStd::size_t>(N)>;
         }
 
         template<typename T>

--- a/Code/Framework/AzCore/AzCore/std/utility/expected.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/expected.h
@@ -43,7 +43,8 @@ namespace AZStd
         template<class E2>
         friend constexpr bool operator==(const unexpected&, const unexpected<E2>&);
 
-        friend constexpr void swap(unexpected& x, unexpected& y) noexcept(noexcept(x.swap(y)));
+        template<class E2>
+        friend constexpr void swap(unexpected<E2>& x, unexpected<E2>& y) noexcept(noexcept(x.swap(y)));
 
     private:
         E m_unexpected;

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -663,7 +663,9 @@
       <DisplayString Condition="!has_value()">Error = {error()}</DisplayString>
       <Expand>
           <Item Name="has_value">has_value()</Item>
-          <Item Name="value" Condition="has_value()">Success</Item>
+          <Synthetic Name="value" Condition="has_value()">
+              <DisplayString>Success</DisplayString>
+          </Synthetic>
           <Item Name="error" Condition="!has_value()">error()</Item>
       </Expand>
   </Type>
@@ -688,7 +690,9 @@
         <DisplayString Condition="!has_value()">{{Error = {error()}}}</DisplayString>
         <Expand>
             <Item Name="IsSuccess">has_value()</Item>
-            <Item Name="Value" Condition="has_value()">Success</Item>
+            <Synthetic Name="Value" Condition="has_value()">
+                <DisplayString>Success</DisplayString>
+            </Synthetic>
             <Item Name="Error" Condition="!has_value()">error()</Item>
         </Expand>
     </Type>

--- a/Code/Framework/AzCore/Tests/Math/CrcTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/CrcTests.cpp
@@ -84,6 +84,8 @@ namespace UnitTest
 
         constexpr uint8_t binaryData[] = { 'B', 'i', 'n', 0x3 };
         static_assert(AZ::Crc32(binaryData, 4, false) == AZ::Crc32(0x3528a896), R"(Crc32 should match the calculation on the binary blob "Bin\x03")");
+        constexpr AZStd::byte byteData[]{ AZStd::byte('B'), AZStd::byte('i'), AZStd::byte('n'), AZStd::byte(0x3) };
+        static_assert(AZ::Crc32(AZStd::span(byteData)) == AZ::Crc32(0x3528a896));
     }
 
     TEST_F(Crc32Fixture, OperatorUint32t_IsConstexpr)

--- a/Code/Framework/AzCore/Tests/Rtti.cpp
+++ b/Code/Framework/AzCore/Tests/Rtti.cpp
@@ -73,8 +73,14 @@ static_assert(AZStd::is_same_v<AZ::AzGenericTypeInfo::Internal::TemplateIdentity
 // any instantiation of the template to void
 // Similarly `template<class T> unique_ptr = std::unique_ptr<T>`, is not an alias for the `std::unique_ptr`
 // template, the result of it's instantiation results in a class type of `std::unique_ptr<T>`
-static_assert(!AZStd::is_same_v<AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTest::AliasTest>,
-    AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTestAlias::AliasTest>>);
+#if !defined(AZ_COMPILER_GCC)
+    static_assert(!AZStd::is_same_v<AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTest::AliasTest>,
+        AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTestAlias::AliasTest>>);
+#else
+    // On GCC the Alias template  matches actual template identifier
+    static_assert(AZStd::is_same_v<AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTest::AliasTest>,
+        AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<UnitTestAlias::AliasTest>>);
+#endif
 
 namespace UnitTest
 {

--- a/Code/Framework/AzCore/Tests/SystemFileTest.cpp
+++ b/Code/Framework/AzCore/Tests/SystemFileTest.cpp
@@ -339,7 +339,7 @@ namespace UnitTest
         // Read 0 bytes to validate that the stdin handle is open
         // as well to avoid needing stdin to have data within it
         // This call should block.
-        EXPECT_EQ(0, stdinHandle.Read(static_cast<size_t>(0), buffer));
+        EXPECT_EQ(0, stdinHandle.Read(static_cast<AZ::IO::SizeType>(0), buffer));
     }
 
 }   // namespace UnitTest

--- a/Gems/Archive/Code/CMakeLists.txt
+++ b/Gems/Archive/Code/CMakeLists.txt
@@ -157,6 +157,13 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
     ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
 
+
+    ### AssetBundler additions ###
+    # Add the Clients.API and Tools.API as a build dependency of the AssetBundler if this gem is available
+    # as part of the current project
+    # This allows the Asset Bundler to have access to the gems API includes which it can use
+    # to create O3AR archive format files
+    target_link_libraries(AssetBundlerBatch.Static PUBLIC ${gem_name}.Clients ${gem_name}.Tools)
 endif()
 
 ################################################################################

--- a/Gems/Archive/Code/CMakeLists.txt
+++ b/Gems/Archive/Code/CMakeLists.txt
@@ -163,7 +163,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     # as part of the current project
     # This allows the Asset Bundler to have access to the gems API includes which it can use
     # to create O3AR archive format files
-    target_link_libraries(AssetBundlerBatch.Static PUBLIC ${gem_name}.Clients ${gem_name}.Tools)
+    target_link_libraries(AssetBundlerBatch.Static PUBLIC ${gem_name}.API ${gem_name}.Editor.API)
 endif()
 
 ################################################################################

--- a/Gems/Archive/Code/Include/Archive/ArchiveTypeIds.h
+++ b/Gems/Archive/Code/Include/Archive/ArchiveTypeIds.h
@@ -31,4 +31,10 @@ namespace Archive
     // Archive Reader TypeIds
     inline constexpr const char* IArchiveReaderTypeId = "{FF23A098-E900-4361-94DC-34CC56E0C67E}";
     inline constexpr const char* ArchiveReaderTypeId = "{03CF9E2D-D063-4912-9789-56275DCD4DFD}";
+
+    // Archive Factory TypeIds
+    inline constexpr const char* IArchiveWriterFactoryTypeId = "{D96EB527-D174-4BF5-8521-EB2658821ED7}";
+    inline constexpr const char* ArchiveWriterFactoryTypeId = "{1B4F8F63-5D36-4BF4-B88E-003A0B8F667B}";
+    inline constexpr const char* IArchiveReaderFactoryTypeId = "{6E33EEA8-2059-47EE-B614-90BA1D9F03A7}";
+    inline constexpr const char* ArchiveReaderFactoryTypeId = "{9B27ABB6-A3C1-4548-BA80-42BECDD0510F}";
 } // namespace Archive

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveBaseAPI.inl
@@ -68,8 +68,8 @@ namespace Archive
         // If the compression algorithm id is uncompressed
         // return a value of 7 which is the highest 3-bit value(0b111)
         // The compression algorithm Id array contains 7 elements for registering compression algorithms.
-        // The index of 7 is used to represent the file is uncompressed the purposes of storing
-        // that information the archive table of contents for an uncompressed file
+        // The index of 7 is used to represent that the file is uncompressed for th  purpose of storing
+        // that information the archive TOC for an uncompressed file
         if (compressionAlgorithmId == Compression::Uncompressed)
         {
             return UncompressedAlgorithmIndex;

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
@@ -378,7 +378,7 @@ namespace Archive
         if (blockIndex >= blockCount)
         {
             result.m_errorMessage = "Block index is out of range of the number of block count."
-                " A block line index cannot be returned";
+                " A block line index cannot be returned.";
             return result;
         }
 
@@ -386,9 +386,7 @@ namespace Archive
         {
             auto GetFinalIndexForFinalBlockLineSetOf3 = [](AZ::u64 blockCount) constexpr
             {
-                return blockCount <= MaxBlocksNoJumpEntry
-                    ? MaxBlocksNoJumpEntry
-                    : AZ_SIZE_ALIGN_UP(blockCount - MaxBlocksNoJumpEntry, BlocksToSkipWithJumpEntry) + MaxBlocksNoJumpEntry;
+                return AZ_SIZE_ALIGN_UP(blockCount - MaxBlocksNoJumpEntry, BlocksToSkipWithJumpEntry) + MaxBlocksNoJumpEntry;
             };
 
             return blockCount <= MaxBlocksNoJumpEntry ? 0 : GetFinalIndexForFinalBlockLineSetOf3(blockCount) - MaxBlocksNoJumpEntry;

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
@@ -49,11 +49,49 @@ namespace Archive
         return m_value;
     }
 
-    // ArchiveHeader constructor implementation
+    // ArchiveHeader constructor implementations
     inline ArchiveHeader::ArchiveHeader()
         : m_tocCompressedSize{}
         , m_tocCompressionAlgoIndex{ UncompressedAlgorithmIndex }
     {}
+
+    inline ArchiveHeader::ArchiveHeader(const ArchiveHeader& other)
+        : m_minorVersion(other.m_minorVersion)
+        , m_majorVersion(other.m_majorVersion)
+        , m_revision(other.m_revision)
+        , m_layout(other.m_layout)
+        , m_fileCount(other.m_fileCount)
+        , m_tocOffset(other.m_tocOffset)
+        , m_tocCompressedSize(other.m_tocCompressedSize)
+        , m_tocCompressionAlgoIndex(other.m_tocCompressionAlgoIndex)
+        , m_tocFileMetadataTableUncompressedSize(other.m_tocFileMetadataTableUncompressedSize)
+        , m_tocPathIndexTableUncompressedSize(other.m_tocPathIndexTableUncompressedSize)
+        , m_tocPathBlobUncompressedSize(other.m_tocPathBlobUncompressedSize)
+        , m_tocBlockOffsetTableUncompressedSize(other.m_tocBlockOffsetTableUncompressedSize)
+        , m_compressionThreshold(other.m_compressionThreshold)
+        , m_compressionAlgorithmsIds(other.m_compressionAlgorithmsIds)
+        , m_firstDeletedBlockOffset(other.m_firstDeletedBlockOffset)
+    {}
+    inline ArchiveHeader& ArchiveHeader::operator=(const ArchiveHeader& other)
+    {
+        m_minorVersion = other.m_minorVersion;
+        m_majorVersion = other.m_majorVersion;
+        m_revision = other.m_revision;
+        m_layout = other.m_layout;
+        m_fileCount = other.m_fileCount;
+        m_tocOffset = other.m_tocOffset;
+        m_tocCompressedSize = other.m_tocCompressedSize;
+        m_tocCompressionAlgoIndex = other.m_tocCompressionAlgoIndex;
+        m_tocFileMetadataTableUncompressedSize = other.m_tocFileMetadataTableUncompressedSize;
+        m_tocPathIndexTableUncompressedSize = other.m_tocPathIndexTableUncompressedSize;
+        m_tocPathBlobUncompressedSize = other.m_tocPathBlobUncompressedSize;
+        m_tocBlockOffsetTableUncompressedSize = other.m_tocBlockOffsetTableUncompressedSize;
+        m_compressionThreshold = other.m_compressionThreshold;
+        m_compressionAlgorithmsIds = other.m_compressionAlgorithmsIds;
+        m_firstDeletedBlockOffset = other.m_firstDeletedBlockOffset;
+
+        return *this;
+    }
 
     // Get the total uncompressed size of the Table of Contents
     inline AZ::u64 ArchiveHeader::GetUncompressedTocSize() const
@@ -131,17 +169,17 @@ namespace Archive
     // The ArchiveBlockLine constructor zero initializes each block line
     // Block lines are made up of 3 blocks at a time
     inline ArchiveBlockLine::ArchiveBlockLine()
-        : m_block1{}
+        : m_block0{}
+        , m_block1{}
         , m_block2{}
-        , m_block3{}
         , m_blockUsed{ 1 }
     {}
 
     // ArchiveBlockLineJump constructor
     inline ArchiveBlockLineJump::ArchiveBlockLineJump()
         : m_blockJump{}
+        , m_block0{}
         , m_block1{}
-        , m_block2{}
         , m_blockUsed{ 1 }
     {}
 
@@ -283,5 +321,197 @@ namespace Archive
         "28 MiB + 1 byte file if compressed should have its compressed sizes fit in 6 block lines");
     static_assert(GetBlockLineCountIfCompressed(MaxFileSizeForMinBlockLinesWithJumpEntry + (2 * MaxBlockLineSize)) == 6,
         "34 MiB file if compressed should have its compressed sizes fit in 6 block lines");
+
+
+    //! The blockLineIndexForOffset and blockLineSentinelForBytesToRead values
+    //! form a range of offsets blocks to read from the archive
+    //! The mathematical range is [blockLineIndexForOffset, blockLineSentinelForBytesToRead)
+    //!
+    //! For example given a start offset to read from a file that is = 4 MiB - 1
+    //! and the read amount is = 4 MiB + 2
+    //! The first block to read would be at index 1 which is calculated as follows
+    //! AlignedDownTo2MiB(4 MiB - 1) = 2 MiB
+    //! Next divide the value that was aligned down by 2 MiB = 1
+    //! This makes sure the block containing the start offset is read
+    //!
+    //! The last block to read would would be at index 4 using the following calculations
+    //! AlignedUpTo2MiB(4 MiB - 1 + 4 MiB + 2) == AlignedUpTo2MiB(8 MiB + 1) = 10 MiB
+    //! Next that aligned up value is divided by 2 MiB = 5
+    //! This makes sure the last block containing the the bytes to read is included before
+    //! the sentinel value
+    //!
+    //! This forms a range of [1, 5), therefore the blocks of 1, 2, 3, 4 are read
+    //! The final byte from block index 1 is read (running count = 1)
+    //! All bytes from block index 2 and 3 are read (running count = 1 + 2 MiB * 2 = 4 MiB + 1)
+    //! The first byte from block index 4 is read (final count = 4 MiB + 2)
+    //! As 4 MiB + 2 is the amount of bytes requested to be read from the user it is returned.
+    constexpr AZStd::pair<AZ::u64, AZ::u64> GetBlockRangeToRead(AZ::u64 uncompressedOffset, AZ::u64 bytesToRead)
+    {
+        // Index value that contains the first block to read for the file
+        AZ::u64 blockLineIndexForOffset = AZ_SIZE_ALIGN_DOWN(uncompressedOffset, ArchiveBlockSizeForCompression)
+            / ArchiveBlockSizeForCompression;
+
+        // Sentinel index value that is one above the last compressed block to read
+        AZ::u64 blockLineSentinelForBytesToRead = AZ_SIZE_ALIGN_UP(uncompressedOffset + bytesToRead, ArchiveBlockSizeForCompression)
+            / ArchiveBlockSizeForCompression;
+
+        return { blockLineIndexForOffset, blockLineSentinelForBytesToRead };
+    }
+
+    // Use an immediate invoked lambda expression to test the GetBlockRangeToRead
+    // condition at compile time
+    static_assert([]() {
+        auto blockRange = GetBlockRangeToRead(4_mib - 1, 4_mib + 2);
+        return blockRange.first == 1 && blockRange.second == 5;
+    }(), "A start offset of 4 MiB - 1 and a read size of 4 MiB + 2, should result in a block range of [1, 5)");
+
+
+    // Implementation of the GetBlockLineFromBlockIndex function
+    constexpr GetBlockLineIndexResult::operator bool() const
+    {
+        return m_errorMessage.empty();
+    }
+
+    constexpr GetBlockLineIndexResult GetBlockLineIndexFromBlockIndex(AZ::u64 blockCount, AZ::u64 blockIndex)
+    {
+        GetBlockLineIndexResult result;
+        if (blockIndex >= blockCount)
+        {
+            result.m_errorMessage = "Block index is out of range of the number of block count."
+                " A block line index cannot be returned";
+            return result;
+        }
+
+        auto GetFirstIndexForFinalBlockLineSetOf3 = [](AZ::u64 blockCount) constexpr
+        {
+            auto GetFinalIndexForFinalBlockLineSetOf3 = [](AZ::u64 blockCount) constexpr
+            {
+                return blockCount <= MaxBlocksNoJumpEntry
+                    ? MaxBlocksNoJumpEntry
+                    : AZ_SIZE_ALIGN_UP(blockCount - MaxBlocksNoJumpEntry, BlocksToSkipWithJumpEntry) + MaxBlocksNoJumpEntry;
+            };
+
+            return blockCount <= MaxBlocksNoJumpEntry ? 0 : GetFinalIndexForFinalBlockLineSetOf3(blockCount) - MaxBlocksNoJumpEntry;
+        };
+
+        // To calculate the block line index for a block index that is before the final set of 3 block lines which do not
+        // include a jump entry, the formula is
+        // BlocksToSkipWithJump = 8
+        // BlockLinesToSkipWithJump = 3
+        // f(x) = (blockIndex / BlocksToSkipWithJump) % BlockLinesToSkipWithJump
+        //
+        // When the block index is within the final set of 3 block lines, there is no jump entry involved
+        // and the formula is split into two parts
+        // A calculation using the above formula using the value of the "first index in the final block line set"
+        // plus the difference between the blockIndex and the value of the "first index in the final block line set"
+        // followed by divided by the number of blocks per line
+        // As the final 3 block lines have no jump entries, there is exactly 3 block per block line, so that part of the equation is simple
+        //
+        // BlocksPerBlockLine = 3
+        // blockLineIndexBeforeFinalSet = GetFirstIndexForFinalBlockLineSetOf3(blockCount)
+        // f(x) = (blockLineIndexBeforeFinalSet % BlocksToSkipWithJump) %BlockLinesToSkipWithJump
+        // g(x) = (blockIndex - blockLineIndexBeforeFinalSet) / BlocksPerLine
+        // h(x) = f(x) + g(x)
+
+        if (const AZ::u64 firstIndexForFinalBlockLineSetOf3 = GetFirstIndexForFinalBlockLineSetOf3(blockCount);
+            blockIndex < firstIndexForFinalBlockLineSetOf3)
+        {
+            // Convert the blocks to skip with a jump entry -> block lines to skip with a jump entry
+            const AZ::u64 skippedBlockLines = blockIndex / BlocksToSkipWithJumpEntry * BlockLinesToSkipWithJumpEntry;
+            result.m_blockLineIndex = skippedBlockLines +
+                ((blockIndex % BlocksToSkipWithJumpEntry) + 1) / BlockLinesToSkipWithJumpEntry;
+            // For block lines sets of 3 that include a jump entries, the blocks per line area layout is
+            // 2 -> 3 -> 3
+            // block line 0 -> block line 1 -> block line 2
+            // A phase shift is used here to pivot the relative block index to 0 and then modulo arithmetic with
+            // the blocks per block line (which is 3) is used to determine the offset within a block
+            // If the block index < 2 then its value is used directly
+            const AZ::u64 relativeBlockIndex = blockIndex % BlocksToSkipWithJumpEntry;
+
+            result.m_offsetInBlockLine = relativeBlockIndex < BlocksPerBlockLineWithJump
+                ? relativeBlockIndex
+                : (relativeBlockIndex - BlocksPerBlockLineWithJump) % BlocksPerBlockLine;
+        }
+        else
+        {
+            const AZ::u64 skippedBlockLines = firstIndexForFinalBlockLineSetOf3
+                / BlocksToSkipWithJumpEntry * BlockLinesToSkipWithJumpEntry;
+            const AZ::u64 blockLineIndexRelativeToFinalSetOf3 = (blockIndex - firstIndexForFinalBlockLineSetOf3) / BlocksPerBlockLine;
+            result.m_blockLineIndex = skippedBlockLines + blockLineIndexRelativeToFinalSetOf3;
+            // The operation of blockIndex - firstIndexForFinalBlockLineSetOf3 will returns a value in the range of [0, 9)
+            // By taking that value modulo 3, the offset within the block line is returned
+            const AZ::u64 offsetInBlockLineRelativeToFinalSetOf3 = (blockIndex - firstIndexForFinalBlockLineSetOf3)
+                % BlocksPerBlockLine;
+            result.m_offsetInBlockLine = offsetInBlockLineRelativeToFinalSetOf3;
+        }
+
+        return result;
+    }
+
+    // Verify a small set of known block line indices and offsets within those block liens
+    static_assert(!GetBlockLineIndexFromBlockIndex(0, 0),
+        "The block index is out of range of the block count, so an error should be returned");
+
+    // Used to validate GetBlockLineIndexResult structure
+    constexpr bool ValidateBlockLineAndBlockOffset(AZ::u64 blockCount, AZ::u64 blockIndex,
+        AZ::u64 expectedBlockCount, AZ::u64 expectedOffsetInBlockLine)
+    {
+        auto blockLineIndexResult = GetBlockLineIndexFromBlockIndex(blockCount, blockIndex);
+        return blockLineIndexResult.m_blockLineIndex == expectedBlockCount
+            && blockLineIndexResult.m_offsetInBlockLine == expectedOffsetInBlockLine;
+    };
+    static_assert(ValidateBlockLineAndBlockOffset(1, 0, 0, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 0, 0, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 1, 0, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 2, 0, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 3, 1, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 4, 1, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 5, 1, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 6, 2, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 7, 2, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(9, 8, 2, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 0, 0, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 1, 0, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 2, 1, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 3, 1, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 4, 1, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 5, 2, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 6, 2, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 7, 2, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 8, 3, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(10, 9, 3, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(11, 10, 3, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(17, 8, 3, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(17, 9, 3, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(17, 10, 3, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(17, 16, 5, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(18, 16, 6, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(18, 17, 6, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(19, 18, 6, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 0, 0, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 1, 0, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 2, 1, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 3, 1, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 4, 1, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 5, 2, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 6, 2, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 7, 2, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 8, 3, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 9, 3, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 10, 4, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 11, 4, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 12, 4, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 13, 5, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 14, 5, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 15, 5, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 16, 6, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 17, 6, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 18, 6, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 19, 7, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 20, 7, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 21, 7, 2));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 22, 8, 0));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 23, 8, 1));
+    static_assert(ValidateBlockLineAndBlockOffset(25, 24, 8, 2));
 } // namespace Archive
 

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
@@ -127,10 +127,13 @@ namespace Archive
         //! this value is at least 512,
         //! NOTE: The TocOffsetU64 structure is used to enforce that the value is >= 512
         ArchiveHeader::TocOffsetU64 m_offset{};
+        //! CRC32 checksum of the uncompressed file data
+        AZ::Crc32 m_crc32{};
         //! Span which view of the extracted file data
         //! If the ArchiveReaderFileSettings specifies decompression should occur,
         //! Then the extracted file content will be the raw content
         AZStd::span<AZStd::byte> m_fileSpan;
+
         //! Stores any error messages related to extraction of the file from the archive
         ResultOutcome m_resultOutcome;
     };
@@ -161,6 +164,9 @@ namespace Archive
         //! this value is at least 512,
         //! NOTE: The TocOffsetU64 structure is used to enforce that the value is >= 512
         ArchiveHeader::TocOffsetU64 m_offset{};
+        //! CRC32 checksum of the uncompressed file data
+        AZ::Crc32 m_crc32{};
+
         //! Stores error and information messages with listing the contents of the file
         ResultOutcome m_resultOutcome;
     };
@@ -259,10 +265,10 @@ namespace Archive
         //! @return result structure that is convertible to a boolean value indicating if enumeration was successful
         virtual EnumerateArchiveResult EnumerateFilesInArchive(ListFileCallback listFileCallback) const = 0;
 
-        //! Writes metadata for the archive to the supplied generic stream
+        //! Dump metadata for the archive to the supplied generic stream
         //! @param metadataStream with human readable data about files within the archive will be written to the stream
         //! @return true if metadata was successfully written
-        virtual bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+        virtual bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const = 0;
     };
 

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
@@ -235,6 +235,16 @@ namespace Archive
         //! The outputSpan should be a pre-allocated buffer that is large enough
         //! to fit either the uncompressed size of the file if the `m_decompressFile` setting is true
         //! or the compressed size of the file if the `m_decompressFile` setting is false
+        //!
+        //! @param outputSpan pre-allocated buffer that should be large enough to store the extracted
+        //! file
+        //! @param fileSettings settings which can configure whether the file should be decompressed,
+        //! the start offset where to start reading content within the file, how many bytes
+        //! to read from the file, etc...
+        //! @return ArchiveExtractFileResult structure which on success contains
+        //! a span of the actual data extracted from the Archive.
+        //! NOTE: The extracted data can be smaller than the outputSpan.size()
+        //! On failure, the result outcome member contains the error that occurred
         virtual ArchiveExtractFileResult ExtractFileFromArchive(AZStd::span<AZStd::byte> outputSpan,
             const ArchiveReaderFileSettings& fileSettings) = 0;
 
@@ -243,9 +253,8 @@ namespace Archive
         //! metadata about the file
         //! @return ArchiveListResult with metadata for the file if found
         virtual ArchiveListFileResult ListFileInArchive(ArchiveFileToken filePathToken) const = 0;
-        //! List the file metadata from the archive using the ArchiveFileToken
-        //! @param filePathToken identifier token that can be used to quickly lookup
-        //! metadata about the file
+        //! List the file metadata from the archive using the relative FilePath
+        //! @param relativePath File path to lookup within the archive
         //! @return ArchiveListResult with metadata for the file if found
         virtual ArchiveListFileResult ListFileInArchive(AZ::IO::PathView relativePath) const = 0;
 
@@ -273,7 +282,8 @@ namespace Archive
 
         //! Dump metadata for the archive to the supplied generic stream
         //! @param metadataStream with human readable data about files within the archive will be written to the stream
-        //! @return true if metadata was successfully written
+        //! @param metadataStream archive file metadata will be written to the stream
+        //! @param metadataSettings settings using which control the file metadata to write to the stream
         virtual bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const = 0;
     };

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/base.h>
+
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/std/parallel/thread.h>
+
+#include <Archive/Clients/ArchiveBaseAPI.h>
+#include <Archive/Clients/ArchiveInterfaceStructs.h>
+
+#include <Compression/CompressionInterfaceStructs.h>
+
+namespace AZ::IO
+{
+    class GenericStream;
+}
+
+namespace AZStd
+{
+    using std::unique_ptr;
+}
+
+namespace Compression
+{
+    struct DecompressionOptions;
+}
+
+namespace Archive
+{
+    //! ErrorCode structure which is used to indicate errors
+    //! when reading from an archive
+    //! The value of 0 is reserved to indicate no error
+    enum class ArchiveReaderErrorCode
+    {
+        ErrorOpeningArchive = 1,
+        ErrorReadingHeader,
+        ErrorReadingTableOfContents,
+    };
+    using ArchiveReaderErrorString = AZStd::fixed_string<512>;
+
+    //! Wraps an error code enum and a string containing an error message
+    //! when performing archive reading operations
+    struct ArchiveReaderError
+    {
+        explicit operator bool() const;
+
+        ArchiveReaderErrorCode m_errorCode{};
+        ArchiveReaderErrorString m_errorMessage;
+    };
+
+    //! Stores settings to configure how Archive Reader Settings
+    struct ArchiveReaderSettings
+    {
+        //! Callback which is invoked by the ArchiveReader to inform users of errors that occurs
+        //! This is used in by functions that can't return an error outcome such as constructors
+        using ErrorCallback = AZStd::function<void(const ArchiveReaderError&)>;
+        ErrorCallback m_errorCallback = [](const ArchiveReaderError&) {};
+
+        //! Configures the maximum number of decompression task that can run in parallel
+        //! If the value is 0, then a single decompression task that will be run
+        //! at a given moment
+        AZ::u32 m_maxDecompressTasks{ AZStd::thread::hardware_concurrency() };
+
+        //! Configures the maximum number of read task that can run in parallel
+        //! For a value of 0 maps to a single read task
+        AZ::u32 m_maxReadTasks{ 1 };
+    };
+
+    //! Settings for controlling how an individual file is extracted from an archive.
+    //! It supports specifying custom decompression options that is forwarded
+    //! to the registered IDecompressionInterface used to decompress
+    //! the file if it is compressed
+    struct ArchiveReaderFileSettings
+    {
+        //! Variant which stores either a path view or an ArchiveFileToken
+        //! It is used to supply the identifier that can be used
+        //! to query the file contents
+        AZStd::variant<AZ::IO::PathView, ArchiveFileToken> m_filePathIdentifier;
+        //! Decompress the file content if compressed
+        //! By default, a compressed content will be decompressed
+        //! after being read from the Archive file
+        bool m_decompressFile{ true };
+        //! Pointer to a decompression options derived struct
+        //! This can be used to supply custom decompression options
+        const Compression::DecompressionOptions* m_decompressionOptions{};
+        //! Offset within the file being extracted to start reading
+        AZ::u64 m_startOffset{};
+        //! The amount of bytes to read from the extracted file
+        //! Defaults to AZStd::numeric_limits<AZ::u64>::max()
+        //! which is used as sentinel value to indicate the entire
+        //! file should be read
+        AZ::u64 m_bytesToRead{ AZStd::numeric_limits<AZ::u64>::max() };
+    };
+
+    //! Returns result data around operation of adding a stream of content data
+    //! to an archive file
+    struct ArchiveExtractFileResult
+    {
+        //! returns if adding a stream of data to a file within the archive has succeeded
+        //! it does by checking that the ArchiveFileToken != InvalidArchiveFileToken
+        explicit operator bool() const;
+
+        //! The file path of the extracted file
+        AZ::IO::Path m_relativeFilePath;
+        //! Identifier token that allows for quicker lookup of the file in the mounted
+        //! archive TOC for the ArchiveReader instance the file was extracted from
+        ArchiveFileToken m_filePathToken{ InvalidArchiveFileToken };
+        //! The compression algorithm ID representing the compression algorithm used to store the file
+        Compression::CompressionAlgorithmId m_compressionAlgorithm{ Compression::Uncompressed };
+        //! The uncompressed size of the removed file
+        AZ::u64 m_uncompressedSize{};
+        //! the compressed size of the extracted file
+        AZ::u64 m_compressedSize{};
+        //! The raw offset of the file in the archive
+        //! As the ArchiveHeader is 512-byte aligned to the beginning of the file
+        //! this value is at least 512,
+        //! NOTE: The TocOffsetU64 structure is used to enforce that the value is >= 512
+        ArchiveHeader::TocOffsetU64 m_offset{};
+        //! Span which view of the extracted file data
+        //! If the ArchiveReaderFileSettings specifies decompression should occur,
+        //! Then the extracted file content will be the raw content
+        AZStd::span<AZStd::byte> m_fileSpan;
+        //! Stores any error messages related to extraction of the file from the archive
+        ResultOutcome m_resultOutcome;
+    };
+
+    //! Returns a result structure that indicates if removal of a content file from the
+    //! archive was successful
+    //! Metadata about the file is returned, such as its file path, compressed algorithm ID
+    //! offset from the beginning of the raw file data blocks, uncompressed size and compressed size
+    struct ArchiveListFileResult
+    {
+        //! returns if adding a stream of data to a file within the archive has succeeded
+        //! it does by checking that the ArchiveFileToken != InvalidArchiveFileToken
+        explicit operator bool() const;
+
+        //! The file path of the file being queried
+        AZ::IO::Path m_relativeFilePath;
+        //! Identifier token that allows for quicker lookup of the file in the archive TOC
+        ArchiveFileToken m_filePathToken{ InvalidArchiveFileToken };
+        //! The compression algorithm ID representing the compression algorithm used to store the file
+        Compression::CompressionAlgorithmId m_compressionAlgorithm{ Compression::Uncompressed };
+        //! The uncompressed size of the removed file
+        AZ::u64 m_uncompressedSize{};
+        //! the compressed size of the removed file
+        //! INFO: This value will be a multiple of 512
+        AZ::u64 m_compressedSize{};
+        //! The raw offset of the file in the archive
+        //! As the ArchiveHeader is 512-byte aligned to the beginning of the file
+        //! this value is at least 512,
+        //! NOTE: The TocOffsetU64 structure is used to enforce that the value is >= 512
+        ArchiveHeader::TocOffsetU64 m_offset{};
+        //! Stores error and information messages with listing the contents of the file
+        ResultOutcome m_resultOutcome;
+    };
+
+    //! Encapsulates the result of enumerating files with the archive
+    //! If an error occurs the ResultOutcome unexpected value is set
+    struct EnumerateArchiveResult
+    {
+        //! returns true if the ResultOutcome has a non-error value
+        explicit constexpr operator bool() const;
+        //! Stores error info about enumerating all files within the archive
+        ResultOutcome m_resultOutcome;
+    };
+
+
+    //! Interface for the ArchiveReader of O3DE Archive format
+    //! An ArchiveReaderSettings object can be used to customize how
+    //! an archive is read.
+    //! Such as the ability to specify the number of read and decompression task that
+    //! can run in parallel
+
+    //! The user can supply their own stream of archive data via the AZ::IO::GenericStream interface
+    //! In that case the archive needs to be opened with at least OpenMode::Read
+    //! The recommend OpenMode value for opening the archive are as follows
+    //! constexpr OpenMode mode = OpenMode::Read | OpenMode::Binary
+    class IArchiveReader
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(IArchiveReader);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        //! Unique pointer which wraps a stream of archive data
+        //! The stream can be owned by the ArchiveReader depending
+        //! on the m_delete value
+        struct ArchiveStreamDeleter
+        {
+            ArchiveStreamDeleter();
+            ArchiveStreamDeleter(bool shouldDelete);
+            void operator()(AZ::IO::GenericStream* ptr) const;
+            bool m_delete{ true };
+        };
+        using ArchiveStreamPtr = AZStd::unique_ptr<AZ::IO::GenericStream, ArchiveStreamDeleter>;
+
+        virtual ~IArchiveReader();
+
+        //! Opens the archive path and returns true if successful
+        //! Will unmount any previously mounted archive
+        virtual bool MountArchive(AZ::IO::PathView archivePath) = 0;
+        virtual bool MountArchive(ArchiveStreamPtr archiveStream) = 0;
+
+        //! Closes the handle to the mounted archive stream
+        virtual void UnmountArchive() = 0;
+
+        //! Returns if an open archive that is mounted
+        virtual bool IsMounted() const = 0;
+
+        //! Reads the content of the file specified in the ArchiveReadeFileSettings
+        //! The file path identifier in the settings is used to locate the file to extract from the archive
+        //! The outputSpan should be a pre-allocated buffer that is large enough
+        //! to fit either the uncompressed size of the file if the `m_decompressFile` setting is true
+        //! or the compressed size of the file if the `m_decompressFile` setting is false
+        virtual ArchiveExtractFileResult ExtractFileFromArchive(AZStd::span<AZStd::byte> outputSpan,
+            const ArchiveReaderFileSettings& fileSettings) = 0;
+
+        //! List the file metadata from the archive using the ArchiveFileToken
+        //! @param filePathToken identifier token that can be used to quickly lookup
+        //! metadata about the file
+        //! @return ArchiveListResult with metadata for the file if found
+        virtual ArchiveListFileResult ListFileInArchive(ArchiveFileToken filePathToken) const = 0;
+        //! List the file metadata from the archive using the ArchiveFileToken
+        //! @param filePathToken identifier token that can be used to quickly lookup
+        //! metadata about the file
+        //! @return ArchiveListResult with metadata for the file if found
+        virtual ArchiveListFileResult ListFileInArchive(AZ::IO::PathView relativePath) const = 0;
+
+        //! Returns if the archive contains a relative path
+        //! @param relativePath Relative path within archive to search for
+        //! @returns true if the relative path is contained with the Archive
+        //! equivalent to `return FindFile(relativePath) != InvalidArchiveFileToken;`
+        virtual bool ContainsFile(AZ::IO::PathView relativePath) const = 0;
+
+        //! Callback structure which is invoked with the metadata for each file in the archive
+        //! table of contents section
+        //! This can be used to perform filtering on files within the archive
+        //! @return a value of `true` can be returned to continue enumeration of the archive
+        using ListFileCallback = AZStd::function<bool(ArchiveListFileResult)>;
+
+        //! Enumerates all files within the archive table of contents and invokes a callback
+        //! function with the listing information about the file
+        //! This function can be used to build filter files in the Archive based on any value
+        //! supplied in the ArchiveListFileResult structure
+        //! For example filtering can be done based on file path(such as globbing for all *.txt files)
+        //! or filtering based on uncompressed size(such as locating all files > 2MiB, etc...)
+        //! @param listFileCallback Callback which is invoked for each file in the archive
+        //! @return result structure that is convertible to a boolean value indicating if enumeration was successful
+        virtual EnumerateArchiveResult EnumerateFilesInArchive(ListFileCallback listFileCallback) const = 0;
+
+        //! Writes metadata for the archive to the supplied generic stream
+        //! @param metadataStream with human readable data about files within the archive will be written to the stream
+        //! @return true if metadata was successfully written
+        virtual bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+            const ArchiveMetadataSettings& metadataSettings = {}) const = 0;
+    };
+
+    //! Creates an instance of the Concrete ArchiveReader class
+    //! The parameters are forwarded to the ArchiveReader constructor and used to initialize the instance
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader();
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(const ArchiveReaderSettings& readerSettings);
+
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(AZ::IO::PathView archivePath,
+        const ArchiveReaderSettings& readerSettings = {});
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(IArchiveReader::ArchiveStreamPtr archiveStream,
+        const ArchiveReaderSettings& readerSettings = {});
+
+} // namespace Archive
+
+// Implementation for any struct functions
+#include "ArchiveReaderAPI.inl"

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.inl
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+
+#include <Archive/ArchiveTypeIds.h>
+
+namespace Archive
+{
+    inline ArchiveReaderError::operator bool() const
+    {
+        return m_errorCode != ArchiveReaderErrorCode{};
+    }
+
+    // A file path token that isn't Invalid indicates
+    // that the file exist in the archive
+    inline ArchiveExtractFileResult::operator bool() const
+    {
+        return m_filePathToken != InvalidArchiveFileToken
+            && m_resultOutcome.has_value();
+    }
+
+    // As for the case with ther ArchiveExtractFileResult
+    // a valid file path token is used to indicate success of the result
+    inline ArchiveListFileResult::operator bool() const
+    {
+        return m_filePathToken != InvalidArchiveFileToken
+            && m_resultOutcome.has_value();
+    }
+
+    inline constexpr EnumerateArchiveResult::operator bool() const
+    {
+        return m_resultOutcome.has_value();
+    }
+
+    // Archive Writer interface TypeInfo, rtti and allocator macros
+    AZ_TYPE_INFO_WITH_NAME_IMPL_INLINE(IArchiveReader, "IArchiveReader", IArchiveReaderTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL_INLINE(IArchiveReader);
+    AZ_CLASS_ALLOCATOR_IMPL_INLINE(IArchiveReader, AZ::SystemAllocator);
+
+    // ArchiveStreamDeleter for the GenericStream unique_ptr
+    inline IArchiveReader::ArchiveStreamDeleter::ArchiveStreamDeleter() = default;
+    inline IArchiveReader::ArchiveStreamDeleter::ArchiveStreamDeleter(bool shouldDelete)
+        : m_delete(shouldDelete)
+    {}
+
+    inline void IArchiveReader::ArchiveStreamDeleter::operator()(AZ::IO::GenericStream* ptr) const
+    {
+        if (m_delete && ptr)
+        {
+            delete ptr;
+        }
+    }
+
+    // IArchiveReader impl
+    inline IArchiveReader::~IArchiveReader() = default;
+} // namespace Archive
+

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveReaderAPI.inl
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTIMacros.h>
@@ -42,7 +43,7 @@ namespace Archive
         return m_resultOutcome.has_value();
     }
 
-    // Archive Writer interface TypeInfo, rtti and allocator macros
+    // Archive Reader interface TypeInfo, rtti and allocator macros
     AZ_TYPE_INFO_WITH_NAME_IMPL_INLINE(IArchiveReader, "IArchiveReader", IArchiveReaderTypeId);
     AZ_RTTI_NO_TYPE_INFO_IMPL_INLINE(IArchiveReader);
     AZ_CLASS_ALLOCATOR_IMPL_INLINE(IArchiveReader, AZ::SystemAllocator);
@@ -63,5 +64,60 @@ namespace Archive
 
     // IArchiveReader impl
     inline IArchiveReader::~IArchiveReader() = default;
+
+    // ArchiveReaderFactory functions
+    AZ_TYPE_INFO_WITH_NAME_IMPL_INLINE(IArchiveReaderFactory, "IArchiveReaderFactory", IArchiveReaderFactoryTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL_INLINE(IArchiveReaderFactory);
+    AZ_CLASS_ALLOCATOR_IMPL_INLINE(IArchiveReaderFactory, AZ::SystemAllocator);
+
+    inline IArchiveReaderFactory::~IArchiveReaderFactory() = default;
+
+    inline CreateArchiveReaderResult CreateArchiveReader()
+    {
+        auto archiveReaderFactory = AZ::Interface<IArchiveReaderFactory>::Get();
+        if (archiveReaderFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveReaderFactory is not registered with an"
+                " AZ::Interface<IArchiveReaderFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveReaderFactory->Create();
+    }
+    inline CreateArchiveReaderResult CreateArchiveReader(const ArchiveReaderSettings& readerSettings)
+    {
+        auto archiveReaderFactory = AZ::Interface<IArchiveReaderFactory>::Get();
+        if (archiveReaderFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveReaderFactory is not registered with an"
+                " AZ::Interface<IArchiveReaderFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveReaderFactory->Create(readerSettings);
+    }
+
+    inline CreateArchiveReaderResult CreateArchiveReader(AZ::IO::PathView archivePath,
+        const ArchiveReaderSettings& readerSettings)
+    {
+        auto archiveReaderFactory = AZ::Interface<IArchiveReaderFactory>::Get();
+        if (archiveReaderFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveReaderFactory is not registered with an"
+                " AZ::Interface<IArchiveReaderFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveReaderFactory->Create(archivePath, readerSettings);
+    }
+    inline CreateArchiveReaderResult CreateArchiveReader(IArchiveReader::ArchiveStreamPtr archiveStream,
+        const ArchiveReaderSettings& readerSettings)
+    {
+        auto archiveReaderFactory = AZ::Interface<IArchiveReaderFactory>::Get();
+        if (archiveReaderFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveReaderFactory is not registered with an"
+                " AZ::Interface<IArchiveReaderFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveReaderFactory->Create(AZStd::move(archiveStream), readerSettings);
+    }
 } // namespace Archive
 

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
@@ -262,10 +262,10 @@ namespace Archive
         //! stored in the Archive
         virtual ArchiveRemoveFileResult RemoveFileFromArchive(AZ::IO::PathView relativePath) = 0;
 
-        //! Writes metadata for the archive to the supplied generic stream
+        //! Dump metadata for the archive to the supplied generic stream
         //! @param metadataStream with human readable data about files within the archive will be written to the stream
         //! @return true if metadata was successfully written
-        virtual bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+        virtual bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const = 0;
     };
 

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
@@ -235,11 +235,30 @@ namespace Archive
         [[nodiscard]] virtual CommitResult Commit() = 0;
 
         //! Adds the content from the stream to the relative path
-        //! based on the ArchiveWriterFileSettings
+        //! @param inputStream stream class where data for the file is source from
+        //! The entire stream is read into the memory and written into archive
+        //! @param fileSettings settings used to configure the relative path to
+        //! write to the archive for the given file data.
+        //! It also allows users to configure the compression algorithm to use,
+        //! and whether the AddFileToArchive logic fails if an existing file is being added
+        //! @return ArchiveAddFileResult containing the actual compression file path
+        //! as saved to the Archive TOC, the compression algorithm used
+        //! and an Archive File Token which can be used to remove the file if need be
+        //! On failure, the result outcome contains any errors that have occurred
         virtual ArchiveAddFileResult AddFileToArchive(AZ::IO::GenericStream& inputStream,
             const ArchiveWriterFileSettings& fileSettings) = 0;
 
-        //! The span contents is used to supply file data for the file to the archive
+        //! Use the span contents to add the file to the archive
+        //! @param inputSpan view of data which will be written to the archive
+        //! at the relative path supplied in the @fileSettings parameter
+        //! @param fileSettings settings used to configure the relative path to
+        //! write to the archive for the given file data.
+        //! It also allows users to configure the compression algorithm to use,
+        //! and whether the AddFileToArchive logic fails if an existing file is being added
+        //! @return ArchiveAddFileResult containing the actual compression file path
+        //! as saved to the Archive TOC, the compression algorithm used
+        //! and an Archive File Token which can be used to remove the file if need be
+        //! On failure, the result outcome contains any errors that have occurred
         virtual ArchiveAddFileResult AddFileToArchive(AZStd::span<const AZStd::byte> inputSpan,
             const ArchiveWriterFileSettings& fileSettings) = 0;
 
@@ -269,7 +288,8 @@ namespace Archive
         virtual ArchiveRemoveFileResult RemoveFileFromArchive(AZ::IO::PathView relativePath) = 0;
 
         //! Dump metadata for the archive to the supplied generic stream
-        //! @param metadataStream with human readable data about files within the archive will be written to the stream
+        //! @param metadataStream archive file metadata will be written to the stream
+        //! @param metadataSettings settings using which control the file metadata to write to the stream
         //! @return true if metadata was successfully written
         virtual bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const = 0;

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
@@ -230,11 +230,11 @@ namespace Archive
         //! Adds the content from the stream to the relative path
         //! based on the ArchiveWriterFileSettings
         virtual ArchiveAddFileResult AddFileToArchive(AZ::IO::GenericStream& inputStream,
-            const ArchiveWriterFileSettings& fileSettings = {}) = 0;
+            const ArchiveWriterFileSettings& fileSettings) = 0;
 
         //! The span contents is used to supply file data for the file to the archive
         virtual ArchiveAddFileResult AddFileToArchive(AZStd::span<const AZStd::byte> inputSpan,
-            const ArchiveWriterFileSettings& fileSettings = {}) = 0;
+            const ArchiveWriterFileSettings& fileSettings) = 0;
 
         //! Searches for a relative path within the archive
         //! @param relativePath Relative path within archive to search for

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.h
@@ -137,6 +137,7 @@ namespace Archive
         //! is not available.
         //! In that case, the file will be stored uncompressed
         Compression::CompressionAlgorithmId m_compressionAlgorithm{ Compression::Uncompressed };
+
         //! Stores any error messages that occur when adding the file from the archive
         ResultOutcome m_resultOutcome;
     };
@@ -158,13 +159,13 @@ namespace Archive
         //! The uncompressed size of the removed file
         AZ::u64 m_uncompressedSize{};
         //! the compressed size of the removed file
-        //! INFO: This value will be a multiple of 512
         AZ::u64 m_compressedSize{};
         //! The raw offset of the file in the ArchiveFile from the beginning of the raw file data block
         //! As the ArchiveHeader is 512-byte aligned to the beginning of the file
         //! this value is at least 512,
         //! NOTE: The TocOffsetU64 structure is used to enforce that the value is >= 512
         ArchiveHeader::TocOffsetU64 m_offset{};
+
         //! Stores any error messages that occur when removing the file from the archive
         ResultOutcome m_resultOutcome;
     };

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.inl
@@ -27,7 +27,8 @@ namespace Archive
     // if the file path token isn't invalid
     inline ArchiveAddFileResult::operator bool() const
     {
-        return m_filePathToken != InvalidArchiveFileToken;
+        return m_filePathToken != InvalidArchiveFileToken
+            && m_resultOutcome.has_value();
     }
 
     // If the archive file was successfully removed

--- a/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.inl
+++ b/Gems/Archive/Code/Include/Archive/Tools/ArchiveWriterAPI.inl
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTIMacros.h>
@@ -59,5 +60,60 @@ namespace Archive
 
     // IArchiveWriter impl
     inline IArchiveWriter::~IArchiveWriter() = default;
+
+    // ArchiveWriterFactory functions
+    AZ_TYPE_INFO_WITH_NAME_IMPL_INLINE(IArchiveWriterFactory, "IArchiveWriterFactory", IArchiveWriterFactoryTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL_INLINE(IArchiveWriterFactory);
+    AZ_CLASS_ALLOCATOR_IMPL_INLINE(IArchiveWriterFactory, AZ::SystemAllocator);
+
+    inline IArchiveWriterFactory::~IArchiveWriterFactory() = default;
+
+    inline CreateArchiveWriterResult CreateArchiveWriter()
+    {
+        auto archiveWriterFactory = AZ::Interface<IArchiveWriterFactory>::Get();
+        if (archiveWriterFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveWriterFactory is not registered with an"
+                " AZ::Interface<IArchiveWriterFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveWriterFactory->Create();
+    }
+    inline CreateArchiveWriterResult CreateArchiveWriter(const ArchiveWriterSettings& writerSettings)
+    {
+        auto archiveWriterFactory = AZ::Interface<IArchiveWriterFactory>::Get();
+        if (archiveWriterFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveWriterFactory is not registered with an"
+                " AZ::Interface<IArchiveWriterFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveWriterFactory->Create(writerSettings);
+    }
+
+    inline CreateArchiveWriterResult CreateArchiveWriter(AZ::IO::PathView archivePath,
+        const ArchiveWriterSettings& writerSettings)
+    {
+        auto archiveWriterFactory = AZ::Interface<IArchiveWriterFactory>::Get();
+        if (archiveWriterFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveWriterFactory is not registered with an"
+                " AZ::Interface<IArchiveWriterFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveWriterFactory->Create(archivePath, writerSettings);
+    }
+    inline CreateArchiveWriterResult CreateArchiveWriter(IArchiveWriter::ArchiveStreamPtr archiveStream,
+        const ArchiveWriterSettings& writerSettings)
+    {
+        auto archiveWriterFactory = AZ::Interface<IArchiveWriterFactory>::Get();
+        if (archiveWriterFactory == nullptr)
+        {
+            return AZStd::unexpected(ResultString("ArchiveWriterFactory is not registered with an"
+                " AZ::Interface<IArchiveWriterFactory>. Has the Archive Gem been set as active?"));
+        }
+
+        return archiveWriterFactory->Create(AZStd::move(archiveStream), writerSettings);
+    }
 } // namespace Archive
 

--- a/Gems/Archive/Code/Source/ArchiveModuleInterface.cpp
+++ b/Gems/Archive/Code/Source/ArchiveModuleInterface.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Memory/Memory.h>
 
 #include <Archive/ArchiveTypeIds.h>
+#include <Clients/ArchiveReaderFactory.h>
 #include <Clients/ArchiveSystemComponent.h>
 
 namespace Archive
@@ -28,6 +29,14 @@ namespace Archive
         m_descriptors.insert(m_descriptors.end(), {
             ArchiveSystemComponent::CreateDescriptor(),
             });
+
+        m_archiveReaderFactory = AZStd::make_unique<ArchiveReaderFactory>();
+        ArchiveReaderFactoryInterface::Register(m_archiveReaderFactory.get());
+    }
+
+    ArchiveModuleInterface::~ArchiveModuleInterface()
+    {
+        ArchiveReaderFactoryInterface::Unregister(m_archiveReaderFactory.get());
     }
 
     AZ::ComponentTypeList ArchiveModuleInterface::GetRequiredSystemComponents() const

--- a/Gems/Archive/Code/Source/ArchiveModuleInterface.h
+++ b/Gems/Archive/Code/Source/ArchiveModuleInterface.h
@@ -13,6 +13,8 @@
 
 namespace Archive
 {
+    class IArchiveReaderFactory;
+
     class ArchiveModuleInterface
         : public AZ::Module
     {
@@ -22,10 +24,16 @@ namespace Archive
         AZ_CLASS_ALLOCATOR_DECL
 
         ArchiveModuleInterface();
+        ~ArchiveModuleInterface();
 
         /**
          * Add required SystemComponents to the SystemEntity.
          */
         AZ::ComponentTypeList GetRequiredSystemComponents() const override;
+    private:
+        // Archive Reader factory registered with the ArchiveReaderFactoryInterface
+        // This allows external gem modules to create ArchiveReader instances
+        // via the CreateArchiveReader functions in the ArchiveReaderAPI.h
+        AZStd::unique_ptr<IArchiveReaderFactory> m_archiveReaderFactory;
     };
 }// namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -25,29 +25,6 @@ namespace Archive
     AZ_RTTI_NO_TYPE_INFO_IMPL(ArchiveReader, IArchiveReader);
     AZ_CLASS_ALLOCATOR_IMPL(ArchiveReader, AZ::SystemAllocator);
 
-    // ArchiveReader forwarding functions
-    // This is used to create an ArchiveReader instance that is pointed
-    // to from an IArchiveReader* to allow use of the ArchiveReader in modules outside of the Archive Gem
-    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader()
-    {
-        return AZStd::make_unique<ArchiveReader>();
-    }
-    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(const ArchiveReaderSettings& readerSettings)
-    {
-        return AZStd::make_unique<ArchiveReader>(readerSettings);
-    }
-
-    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(AZ::IO::PathView archivePath,
-        const ArchiveReaderSettings& readerSettings)
-    {
-        return AZStd::make_unique<ArchiveReader>(archivePath, readerSettings);
-    }
-    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(IArchiveReader::ArchiveStreamPtr archiveStream,
-        const ArchiveReaderSettings& readerSettings)
-    {
-        return AZStd::make_unique<ArchiveReader>(AZStd::move(archiveStream), readerSettings);
-    }
-
     ArchiveReader::ArchiveReader() = default;
 
     ArchiveReader::~ArchiveReader()

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -254,6 +254,8 @@ namespace Archive
         // then unmount the archive and return false
         if (!ReadArchiveHeaderAndToc())
         {
+            // UnmountArchive is invoked to reset
+            // the Archive Header, TOC and the path map structures
             UnmountArchive();
             return false;
         }
@@ -274,6 +276,8 @@ namespace Archive
 
         if (!ReadArchiveHeaderAndToc())
         {
+            // UnmountArchive is invoked to reset
+            // the Archive Header, TOC and the path map structures
             UnmountArchive();
             return false;
         }

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -586,7 +586,7 @@ namespace Archive
         {
             const AZ::u64 blockCompressedSize = GetCompressedSizeForBlock(fileBlockLineSpan, blockCount, blockIndex);
             // Get the next 2 MiB block (or less if in the final block) of memory to store the compressed block data
-            const size_t availableBytesInCompressedBlock = AZStd::min(compressedBlockRemainingSpan.size(),
+            const auto availableBytesInCompressedBlock = AZStd::min<size_t>(compressedBlockRemainingSpan.size(),
                 ArchiveBlockSizeForCompression);
             const AZStd::span<AZStd::byte> compressedBlockToReadInto = compressedBlockRemainingSpan.first(
                 availableBytesInCompressedBlock);
@@ -642,7 +642,7 @@ namespace Archive
             {
                 const AZ::u64 blockCompressedSize = GetCompressedSizeForBlock(fileBlockLineSpan, blockCount, blockIndex);
                 // Downsize the 2 MiB span that was used to read the compressed data to the exact compressed size
-                const size_t availableBytesInCompressedBlock = AZStd::min(compressedBlockRemainingSpan.size(),
+                const auto availableBytesInCompressedBlock = AZStd::min<size_t>(compressedBlockRemainingSpan.size(),
                     ArchiveBlockSizeForCompression);
                 AZStd::span<const AZStd::byte> compressedDataForBlock = compressedBlockRemainingSpan
                     .first(availableBytesInCompressedBlock)
@@ -653,7 +653,7 @@ namespace Archive
                 // Get the block span for storing the decompressed block
                 // As the uncompressed size is 2 MiB for all blocks except the last
                 // the entire contiguous file sequence will be available in the decompressedResultSpan after the loop
-                const size_t remainingBytesInBlockSpan = AZStd::min(decompressionRemainingSpan.size(),
+                const auto remainingBytesInBlockSpan = AZStd::min<size_t>(decompressionRemainingSpan.size(),
                     ArchiveBlockSizeForCompression);
                 AZStd::span<AZStd::byte> decompressionBlockSpan = decompressionRemainingSpan
                     .first(remainingBytesInBlockSpan);
@@ -695,7 +695,7 @@ namespace Archive
         // with the ArchiveBlockSizeForCompression (2 MiB).
         // The start offset will always be in the first read block
         size_t startOffset = fileSettings.m_startOffset % ArchiveBlockSizeForCompression;
-        size_t endOffset = AZStd::min(decompressionResultSpan.size() - startOffset, maxBytesToReadForFile);
+        size_t endOffset = AZStd::min<size_t>(decompressionResultSpan.size() - startOffset, maxBytesToReadForFile);
         return decompressionResultSpan.subspan(startOffset, endOffset);
     }
 

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -1,0 +1,945 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ArchiveReader.h"
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/IO/GenericStreams.h>
+#include <AzCore/IO/OpenMode.h>
+#include <AzCore/std/parallel/scoped_lock.h>
+#include <AzCore/Task/TaskGraph.h>
+
+#include <Archive/ArchiveTypeIds.h>
+
+#include <Compression/DecompressionInterfaceAPI.h>
+
+namespace Archive
+{
+    // Implement TypeInfo, Rtti and Allocator support
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ArchiveReader, "ArchiveReader", ArchiveReaderTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ArchiveReader, IArchiveReader);
+    AZ_CLASS_ALLOCATOR_IMPL(ArchiveReader, AZ::SystemAllocator);
+
+    // ArchiveReader forwarding functions
+    // This is used to create an ArchiveReader instance that is pointed
+    // to from an IArchiveReader* to allow use of the ArchiveReader in modules outside of the Archive Gem
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader()
+    {
+        return AZStd::make_unique<ArchiveReader>();
+    }
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(const ArchiveReaderSettings& readerSettings)
+    {
+        return AZStd::make_unique<ArchiveReader>(readerSettings);
+    }
+
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(AZ::IO::PathView archivePath,
+        const ArchiveReaderSettings& readerSettings)
+    {
+        return AZStd::make_unique<ArchiveReader>(archivePath, readerSettings);
+    }
+    AZStd::unique_ptr<IArchiveReader> CreateArchiveReader(IArchiveReader::ArchiveStreamPtr archiveStream,
+        const ArchiveReaderSettings& readerSettings)
+    {
+        return AZStd::make_unique<ArchiveReader>(AZStd::move(archiveStream), readerSettings);
+    }
+
+    ArchiveReader::ArchiveReader() = default;
+
+    ArchiveReader::~ArchiveReader()
+    {
+        UnmountArchive();
+    }
+
+    ArchiveReader::ArchiveReader(const ArchiveReaderSettings& writerSettings)
+        : m_settings(writerSettings)
+    {}
+
+    ArchiveReader::ArchiveReader(AZ::IO::PathView archivePath, const ArchiveReaderSettings& writerSettings)
+        : m_settings(writerSettings)
+    {
+        MountArchive(archivePath);
+    }
+
+    ArchiveReader::ArchiveReader(ArchiveStreamPtr archiveStream, const ArchiveReaderSettings& writerSettings)
+        : m_settings(writerSettings)
+    {
+        MountArchive(AZStd::move(archiveStream));
+    }
+
+    bool ArchiveReader::ReadArchiveHeader(ArchiveHeader& archiveHeader, AZ::IO::GenericStream& archiveStream)
+    {
+        // Read the Archive header into memory
+        AZStd::scoped_lock archiveLock(m_archiveStreamMutex);
+        archiveStream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+        AZ::IO::SizeType bytesRead = archiveStream.Read(sizeof(archiveHeader), &archiveHeader);
+        archiveStream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+        if (bytesRead != sizeof(archiveHeader))
+        {
+            m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingHeader, ArchiveReaderErrorString::format(
+                "Archive header should have size %zu, but only %llu bytes were read from the beginning of the archive",
+                sizeof(archiveHeader), bytesRead) });
+        }
+
+        return true;
+    }
+
+    // Define the Archive TableOfContentReader constructors
+    ArchiveReader::ArchiveTableOfContentsReader::ArchiveTableOfContentsReader() = default;
+
+    // Takes ownership of the buffer containing the Table of Contents raw data
+    // and an ArchiveTableOfContentsView instance
+    ArchiveReader::ArchiveTableOfContentsReader::ArchiveTableOfContentsReader(AZStd::vector<AZStd::byte> tocBuffer,
+        ArchiveTableOfContentsView tocView)
+        : m_tocBuffer(AZStd::move(tocBuffer))
+        , m_tocView(AZStd::move(tocView))
+    {}
+
+    bool ArchiveReader::ReadArchiveTOC(ArchiveTableOfContentsReader& archiveToc, AZ::IO::GenericStream& archiveStream,
+        const ArchiveHeader& archiveHeader)
+    {
+        // RAII structure which resets the archive stream to offset 0
+        // when it goes out of scope
+        struct SeekStreamToBeginRAII
+        {
+            ~SeekStreamToBeginRAII()
+            {
+                m_stream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+            }
+            AZ::IO::GenericStream& m_stream;
+        };
+
+        if (archiveHeader.m_tocOffset > archiveStream.GetLength())
+        {
+            // The TOC offset is invalid since it is after the end of the stream
+            m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents,
+                    ArchiveReaderErrorString::format("TOC offset is invalid. It is pass the end of the stream."
+                        " Offset value %llu, archive stream size %llu",
+                        static_cast<AZ::u64>(archiveHeader.m_tocOffset), archiveStream.GetLength()) });
+            return false;
+        }
+
+        // Buffer which stores the raw table of contents data from the archive file
+        AZStd::vector<AZStd::byte> tocBuffer;
+
+        // Seek to the location of the Table of Contents
+        {
+            AZStd::scoped_lock archiveLock(m_archiveStreamMutex);
+            // Make sure the archive offset is reset to 0 on return
+            SeekStreamToBeginRAII seekToBeginScope{ archiveStream };
+            archiveStream.Seek(archiveHeader.m_tocOffset, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+
+            tocBuffer.resize_no_construct(archiveHeader.GetTocStoredSize());
+            AZ::IO::SizeType bytesRead = archiveStream.Read(tocBuffer.size(), tocBuffer.data());
+            if (bytesRead != tocBuffer.size())
+            {
+                m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents,
+                    ArchiveReaderErrorString::format("Unable to read all TOC bytes from the archive."
+                        " The TOC size is %zu, but only %llu bytes were read",
+                        tocBuffer.size(), bytesRead) });
+                return false;
+            }
+        }
+
+        // Check if the archive table of contents is compressed
+        if (archiveHeader.m_tocCompressionAlgoIndex < UncompressedAlgorithmIndex)
+        {
+            auto decompressionRegistrar = Compression::DecompressionRegistrar::Get();
+            if (decompressionRegistrar == nullptr)
+            {
+                // The decompression registrar does not exist
+                m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents,
+                    ArchiveReaderErrorString("The Decompression Registry is not available"
+                        " Is the Compression gem active?") });
+                return false;
+            }
+
+            Compression::CompressionAlgorithmId tocCompressionAlgorithmId =
+                archiveHeader.m_compressionAlgorithmsIds[archiveHeader.m_tocCompressionAlgoIndex];
+
+            Compression::IDecompressionInterface* decompressionInterface =
+                decompressionRegistrar->FindDecompressionInterface(tocCompressionAlgorithmId);
+            if (decompressionInterface == nullptr)
+            {
+                // Compression algorithm isn't registered with the decompression registrar
+                m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents,
+                    ArchiveReaderErrorString::format("Compression Algorithm %u used by TOC"
+                        " isn't registered with decompression registrar",
+                        AZStd::to_underlying(tocCompressionAlgorithmId)) });
+                return false;
+            }
+
+            // Resize the uncompressed TOC buffer to be the size of the uncompressed Table of Contents
+            AZStd::vector<AZStd::byte> uncompressedTocBuffer;
+            uncompressedTocBuffer.resize_no_construct(archiveHeader.GetUncompressedTocSize());
+
+            // Run the compressed toc data through the decompressor
+            if (Compression::DecompressionResultData decompressionResultData =
+                decompressionInterface->DecompressBlock(uncompressedTocBuffer, tocBuffer, Compression::DecompressionOptions{});
+                decompressionResultData)
+            {
+
+                // If decompression succeed, move the uncompressed buffer to the tocBuffer variable
+                tocBuffer = AZStd::move(uncompressedTocBuffer);
+                if (decompressionResultData.GetUncompressedByteCount() != tocBuffer.size())
+                {
+                    // The size of uncompressed size of the data does not match the total uncompressed
+                    // TOC size read from the ArchiveHeader::GetUncompressedTocSize() function
+                    m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents,
+                    ArchiveReaderErrorString::format("The uncompressed TOC size %llu does not match the total uncompressed size %zu"
+                        " read from the archive header",
+                        decompressionResultData.GetUncompressedByteCount(), tocBuffer.size()) });
+                    return false;
+                }
+            }
+        }
+
+        // Wrap the table of contents in an reader structure that encapsulates the raw tocBuffer data on disk
+        // and a view into the Table of Contents memory
+        if (auto tocView = ArchiveTableOfContentsView::CreateFromArchiveHeaderAndBuffer(archiveHeader, tocBuffer);
+            tocView)
+        {
+            archiveToc = ArchiveTableOfContentsReader{ AZStd::move(tocBuffer), AZStd::move(tocView).value() };
+        }
+        else
+        {
+            // Invoke the error callback indicating an error reading the table of contents
+            m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorReadingTableOfContents, tocView.error().m_errorMessage });
+            return false;
+        }
+
+        return true;
+    }
+
+    bool ArchiveReader::BuildFilePathMap(const ArchiveTableOfContentsView& tocView)
+    {
+        m_pathMap.clear();
+
+        // Build a map of file path view to within the FilePathIndex array of the TOC View
+        auto BuildViewOfFilePaths = [this, filePathBlobTable = &tocView.m_filePathBlob, filePathIndex = 0]
+        (AZ::u32 filePathBlobOffset, AZ::u16 filePathSize) mutable
+        {
+            AZ::IO::PathView contentPathView(filePathBlobTable->substr(filePathBlobOffset, filePathSize));
+            m_pathMap.emplace(contentPathView, filePathIndex++);
+        };
+        EnumerateFilePathIndexOffsets(BuildViewOfFilePaths, tocView);
+
+        return true;
+    }
+
+    bool ArchiveReader::MountArchive(AZ::IO::PathView archivePath)
+    {
+        UnmountArchive();
+        AZ::IO::FixedMaxPath mountPath{ archivePath };
+        constexpr AZ::IO::OpenMode openMode =
+            AZ::IO::OpenMode::ModeRead
+            | AZ::IO::OpenMode::ModeBinary;
+
+        m_archiveStream.reset(aznew AZ::IO::SystemFileStream(mountPath.c_str(), openMode));
+
+        // Early return if the archive is not open
+        if (!m_archiveStream->IsOpen())
+        {
+            m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorOpeningArchive, ArchiveReaderErrorString::format(
+                "Archive with filename %s could not be open",
+                mountPath.c_str()) });
+            return false;
+        }
+
+        // If the Archive header and TOC could not be read
+        // then unmount the archive and return false
+        if (!ReadArchiveHeaderAndToc())
+        {
+            UnmountArchive();
+            return false;
+        }
+        return true;
+    }
+
+    bool ArchiveReader::MountArchive(ArchiveStreamPtr archiveStream)
+    {
+        UnmountArchive();
+        m_archiveStream = AZStd::move(archiveStream);
+
+        if (m_archiveStream == nullptr || !m_archiveStream->IsOpen())
+        {
+            m_settings.m_errorCallback({ ArchiveReaderErrorCode::ErrorOpeningArchive,
+                ArchiveReaderErrorString("Archive stream pointer is nullptr or not open") });
+            return false;
+        }
+
+        if (!ReadArchiveHeaderAndToc())
+        {
+            UnmountArchive();
+            return false;
+        }
+        return true;
+    }
+
+    bool ArchiveReader::ReadArchiveHeaderAndToc()
+    {
+        if (m_archiveStream == nullptr)
+        {
+            return false;
+        }
+
+        const bool mountResult = ReadArchiveHeader(m_archiveHeader, *m_archiveStream)
+            && ReadArchiveTOC(m_archiveToc, *m_archiveStream, m_archiveHeader)
+            && BuildFilePathMap(m_archiveToc.m_tocView);
+
+        return mountResult;
+    }
+
+    void ArchiveReader::UnmountArchive()
+    {
+        if (m_archiveStream != nullptr && m_archiveStream->IsOpen())
+        {
+            // Clear the path mount on unmount as it has pointers
+            // into the table of contents reader
+            m_pathMap.clear();
+            // Now clear the table of contents reader
+            m_archiveToc = {};
+            // Finally clear the archive header
+            m_archiveHeader = {};
+        }
+
+        m_archiveStream.reset();
+    }
+
+    bool ArchiveReader::IsMounted() const
+    {
+        return m_archiveStream != nullptr && m_archiveStream->IsOpen();
+    }
+
+    ArchiveExtractFileResult ArchiveReader::ExtractFileFromArchive(AZStd::span<AZStd::byte> outputSpan,
+        const ArchiveReaderFileSettings& fileSettings)
+    {
+        ArchiveListFileResult listResult;
+        if (auto filePathString = AZStd::get_if<AZ::IO::PathView>(&fileSettings.m_filePathIdentifier);
+            filePathString != nullptr)
+        {
+            listResult = ListFileInArchive(*filePathString);
+        }
+        else
+        {
+            // The only remaining alternative is the ArchiveFileToken
+            // so use AZStd::get is used on a reference to the variant
+            // Make sure the filePathToken points to file within the TOC
+            const ArchiveFileToken archiveFileToken = AZStd::get<ArchiveFileToken>(fileSettings.m_filePathIdentifier);
+            listResult = ListFileInArchive(archiveFileToken);
+        }
+
+        // Copy the result of listing the file in the archive to the extract result structure
+        ArchiveExtractFileResult extractResult;
+        extractResult.m_relativeFilePath = listResult.m_relativeFilePath;
+        extractResult.m_filePathToken = listResult.m_filePathToken;
+        extractResult.m_compressionAlgorithm = listResult.m_compressionAlgorithm;
+        extractResult.m_uncompressedSize = listResult.m_uncompressedSize;
+        extractResult.m_compressedSize = listResult.m_compressedSize;
+        extractResult.m_offset = listResult.m_offset;
+        extractResult.m_resultOutcome = listResult.m_resultOutcome;
+
+        // If querying of the file within the archive failed,
+        // then return the extract file result which copied the error
+        // state from the list file result
+        if (!extractResult)
+        {
+            return extractResult;
+        }
+
+        // Determine if the file is compressed
+        const bool isFileCompressed = extractResult.m_compressionAlgorithm != Compression::Uncompressed
+            && extractResult.m_compressionAlgorithm != Compression::Invalid;
+        // Check if the file should be decompressed
+        const bool shouldDecompressFile = fileSettings.m_decompressFile
+            && isFileCompressed;
+
+        // if the should be decompressed, decompress it
+        if (shouldDecompressFile)
+        {
+            // If the decompressFile option is true, then decompress the file into the output buffer
+            if (fileSettings.m_decompressFile)
+            {
+                // Decompress the data into the output span
+                if (ReadCompressedFileOutcome readFileOutcome = ReadCompressedFileIntoBuffer(outputSpan,
+                    fileSettings, extractResult);
+                    readFileOutcome)
+                {
+                    // On success populate a span with the exact size of the file data read
+                    // from the archive
+                    extractResult.m_fileSpan = readFileOutcome.value();
+                }
+                else
+                {
+                    extractResult.m_resultOutcome = AZStd::unexpected(AZStd::move(readFileOutcome.error()));
+                }
+
+            }
+        }
+        else
+        {
+            // When performing a raw read, use the knowledge of the file being compressed
+            // to decide the file size to read
+            AZ::u64 fileSize = isFileCompressed ? extractResult.m_compressedSize : extractResult.m_uncompressedSize;
+
+            // Read the raw file data directly into the output span if possible
+            if (ReadRawFileOutcome readFileOutcome = ReadRawFileIntoBuffer(outputSpan, extractResult.m_offset,
+                fileSize, fileSettings);
+                readFileOutcome)
+            {
+                // On success populate a span with the exact size of the file data read
+                // from the archive
+                extractResult.m_fileSpan = readFileOutcome.value();
+            }
+            else
+            {
+                extractResult.m_resultOutcome = AZStd::unexpected(AZStd::move(readFileOutcome.error()));
+            }
+        }
+
+        return extractResult;
+    }
+
+    auto ArchiveReader::ReadRawFileIntoBuffer(AZStd::span<AZStd::byte> fileBuffer, AZ::u64 offset,
+        AZ::u64 fileSize,
+        const ArchiveReaderFileSettings& fileSettings)
+        -> ReadRawFileOutcome
+    {
+        // Calculate the start offset where to read the file content from
+        // It must be within the the range of [offset, offset + size)
+        AZ::IO::OffsetType readOffset = AZStd::clamp(offset, offset + fileSettings.m_startOffset, offset + fileSize);
+        // Next clamp the bytesToRead to be not read pass the end of the file
+        AZ::IO::SizeType bytesAvailableForRead = (offset + fileSize) - readOffset;
+
+        // Set the amount of bytes to read to be the minimum of the file size and the amount of bytes to read
+        AZ::IO::SizeType bytesToRead = AZStd::min(bytesAvailableForRead, fileSettings.m_bytesToRead);
+        if (fileBuffer.size() < bytesToRead)
+        {
+            return AZStd::unexpected(ResultString::format("Buffer size is not large enough to read the raw file data at"
+                " archive file offset %lld."
+                " Buffer size is %zu, while %llu is required.", readOffset, fileBuffer.size(), bytesToRead));
+        }
+
+        AZStd::scoped_lock archiveReadLock(m_archiveStreamMutex);
+        if (AZ::IO::SizeType bytesRead = m_archiveStream->ReadAtOffset(bytesToRead, fileBuffer.data(), readOffset);
+            bytesRead < bytesToRead)
+        {
+            return AZStd::unexpected(ResultString::format("Attempted to read %llu bytes from the archive at offset %lld."
+                " But only %llu bytes were able to be read", bytesToRead, readOffset, bytesRead));
+        }
+
+        // Make a span with the exact amount of data read
+        return fileBuffer.first(bytesToRead);
+    }
+
+    auto ArchiveReader::ReadCompressedFileIntoBuffer(AZStd::span<AZStd::byte> decompressionResultSpan,
+        const ArchiveReaderFileSettings& fileSettings,
+        const ArchiveExtractFileResult& extractFileResult) -> ReadCompressedFileOutcome
+    {
+        // If the file is empty, there is nothing to decompress
+        if (extractFileResult.m_uncompressedSize == 0)
+        {
+            // Return a successful expectation with an empty span
+            return {};
+        }
+
+        auto decompressionRegistrar = Compression::DecompressionRegistrar::Get();
+        if (decompressionRegistrar == nullptr)
+        {
+            return AZStd::unexpected(ResultString("Decompression Registrar is not available. File cannot be decompressed"));
+        }
+
+        Compression::IDecompressionInterface* decompressionInterface =
+            decompressionRegistrar->FindDecompressionInterface(extractFileResult.m_compressionAlgorithm);
+        if (decompressionInterface == nullptr)
+        {
+            return AZStd::unexpected(ResultString::format("Compression Algorithm with ID %x is not registered"
+                " with the decompression registrar.",
+                extractFileResult.m_compressionAlgorithm));
+        }
+
+        // Retrieve a subspan of the block lines for the file being extracted
+        // The file path token doubles as the index into the table of contents FileMetadataTable and FilePathIndexTable vector
+        auto fileMetadataTableIndex = static_cast<AZ::u64>(extractFileResult.m_filePathToken);
+        auto blockLineSpanOutcome = GetBlockLineSpanForFile(m_archiveToc.m_tocView, fileMetadataTableIndex);
+        if (!blockLineSpanOutcome)
+        {
+            // Return the error for retrieving the block line for the file
+            return AZStd::unexpected(AZStd::move(blockLineSpanOutcome.error()));
+        }
+
+        AZStd::span<const ArchiveBlockLineUnion> fileBlockLineSpan = blockLineSpanOutcome.value();
+
+        // Determine the range of compressed blocks within the file to read
+        // The cap is uncompressed size of the file
+        if (fileSettings.m_startOffset > extractFileResult.m_uncompressedSize)
+        {
+            return AZStd::unexpected(ResultString::format("Start offset %llu to read file data from is larger."
+                " than the size of the file %llu for file %s", fileSettings.m_startOffset,
+                extractFileResult.m_compressedSize,
+                extractFileResult.m_relativeFilePath.c_str()));
+        }
+
+        // Clamp the the bytes that can read for the file to be at
+        // most the difference in uncompressed size and the start offset
+        AZ::u64 maxBytesToReadForFile = AZStd::min(fileSettings.m_bytesToRead,
+            extractFileResult.m_uncompressedSize - fileSettings.m_startOffset);
+
+        // Set the amount of bytes to read to be the minimum of the file size and the amount of bytes to read
+        auto blockRange = GetBlockRangeToRead(fileSettings.m_startOffset, maxBytesToReadForFile);
+
+        // Get the number of 2-MiB blocks for the file
+        AZ::u32 blockCount = GetBlockCountIfCompressed(extractFileResult.m_uncompressedSize);
+
+        // First calculate if the first block line is a jump entry
+        // If there are more than 3 blocks lines, then the file contains at least a jump from
+        // block line[0] -> block line[3] and the file contains at least 10 blocks of data
+        // If the file only contains 3 block lines, then there would not be a jump entry
+        // and the file would contain at most 9 blocks
+        // See the ArchiveInterfaceStructs.h header for more information
+
+        // The aligned seek offset where to read to start reading the compressed
+        // data will calculated by adding up the 512-byte aligned sizes of each compressed block
+        AZ::IO::SizeType alignedFirstSeekOffset{};
+
+        for (AZ::u64 blockIndex{}; blockIndex < blockRange.first;)
+        {
+            // The internal archive code will never trigger the error case of (blockIndex >= blockCount),
+            // so checking it will be skipped
+            size_t blockLineIndex = GetBlockLineIndexFromBlockIndex(blockCount, blockIndex).m_blockLineIndex;
+            // Block line indices which are multiples of 3 all have jump entries unless they are part of the final 3 block
+            // lines of a file
+            const bool blockLineContainsJump = (blockLineIndex % BlockLinesToSkipWithJumpEntry == 0)
+                && (fileBlockLineSpan.size() - blockLineIndex) > BlockLinesToSkipWithJumpEntry;
+            if (blockLineContainsJump)
+            {
+                const ArchiveBlockLineJump& blockLineWithJump = fileBlockLineSpan[blockLineIndex].m_blockLineWithJump;
+                // there is a jump entry for the file, so the logic gets a bit more trickier
+                // First check if the blockIndex + BlocksToSkipWithJumpEntry is less than blockRange.first
+                if (blockIndex + BlocksToSkipWithJumpEntry < blockRange.first)
+                {
+                    // In this case the jump entry can be used to skip the next 8 blocks(3 block lines)
+                    // The jump entry contains the number of 512-byte sectors the next 8 blocks
+                    // take in the raw file section of the archive
+                    // The value is multiplied by ArchiveDefaultBlockAlignment to get the correct value
+                    alignedFirstSeekOffset += blockLineWithJump.m_blockJump * ArchiveDefaultBlockAlignment;
+
+                    // Increment the block index by 8, as it was the number of blocks that were skipped
+                    blockIndex += BlocksToSkipWithJumpEntry;
+                }
+                else
+                {
+                    // Otherwise process up to the remaining two block entries in this block line if possible
+                    alignedFirstSeekOffset += AZ_SIZE_ALIGN_UP(blockLineWithJump.m_block0, ArchiveDefaultBlockAlignment);
+                    ++blockIndex;
+
+                    // If the blockIndex is still less than the beginning of the block range to read
+                    // then grab the second and final block from the block line
+                    if ((blockIndex + 1) < blockRange.first)
+                    {
+                        alignedFirstSeekOffset += AZ_SIZE_ALIGN_UP(blockLineWithJump.m_block1, ArchiveDefaultBlockAlignment);
+                        ++blockIndex;
+                    }
+                }
+            }
+            else
+            {
+                // There aren't anymore jump entry for the file so accumulate the aligned compressed block offsets
+                const ArchiveBlockLine& blockLine = fileBlockLineSpan[blockLineIndex].m_blockLine;
+                // Try to process up to 3 block lines per for loop iteration
+                // This allows skipping the blockIndex / BlocksPerBlockLine division twice
+                // If the blockIndex is within 3 of the blockRange.first value then up to that amount of blocks are processed
+                const AZ::u64 blocksToProcess = AZStd::min(BlocksPerBlockLine, blockRange.first - blockIndex);
+
+                // Align all the compressed sizes up to 512-byte alignment to get the correct
+                // seek offset for the file
+                // blocksToProcess is >=1 due to the for loop condition
+                alignedFirstSeekOffset += AZ_SIZE_ALIGN_UP(blockLine.m_block0, ArchiveDefaultBlockAlignment);
+                alignedFirstSeekOffset += blocksToProcess >= BlocksPerBlockLine - 1
+                    ? AZ_SIZE_ALIGN_UP(blockLine.m_block1, ArchiveDefaultBlockAlignment)
+                    : 0;
+                alignedFirstSeekOffset += blocksToProcess >= BlocksPerBlockLine
+                    ? AZ_SIZE_ALIGN_UP(blockLine.m_block2, ArchiveDefaultBlockAlignment)
+                    : 0;
+
+                // Increment the block index by the blocks that were processed
+                blockIndex += blocksToProcess;
+            }
+        }
+
+        // Stores the list of compressed blocks to decompress
+        AZStd::vector<AZStd::byte> compressedBlocks;
+        compressedBlocks.resize_no_construct((blockRange.second - blockRange.first) * ArchiveBlockSizeForCompression);
+        AZStd::span<AZStd::byte> compressedBlockRemainingSpan = compressedBlocks;
+
+        AZ::IO::SizeType fileRelativeSeekOffset = alignedFirstSeekOffset;
+        for (AZ::u64 blockIndex = blockRange.first; blockIndex != blockRange.second; ++blockIndex)
+        {
+            const AZ::u64 blockCompressedSize = GetCompressedSizeForBlock(fileBlockLineSpan, blockCount, blockIndex);
+            // Get the next 2 MiB block (or less if in the final block) of memory to store the compressed block data
+            const size_t availableBytesInCompressedBlock = AZStd::min(compressedBlockRemainingSpan.size(),
+                ArchiveBlockSizeForCompression);
+            const AZStd::span<AZStd::byte> compressedBlockToReadInto = compressedBlockRemainingSpan.first(
+                availableBytesInCompressedBlock);
+            // Slide the compressed block remaining span view ahead by the 2 MiB that is being used for the read span
+            compressedBlockRemainingSpan = compressedBlockRemainingSpan.subspan(availableBytesInCompressedBlock);
+            const AZ::u64 absoluteSeekOffset = extractFileResult.m_offset + fileRelativeSeekOffset;
+            if (AZ::IO::SizeType bytesRead = m_archiveStream->ReadAtOffset(blockCompressedSize,
+                compressedBlockToReadInto.data(), absoluteSeekOffset);
+                bytesRead != blockCompressedSize)
+            {
+                return AZStd::unexpected(ResultString::format("Cannot read all of compressed block for"
+                    " block %llu. The compressed block size is %llu, but only %llu was able to be read",
+                    blockIndex, blockCompressedSize, bytesRead));
+            }
+
+            // As the read was successful add the aligned compressed size to the the fileRelativeSeekOffset
+            // The value is the read offset where the next block data starts
+            fileRelativeSeekOffset += AZ_SIZE_ALIGN_UP(blockCompressedSize, ArchiveDefaultBlockAlignment);
+        }
+
+        // Reset the compressed block remaining to the start of the compressedBlocks vector
+        compressedBlockRemainingSpan = compressedBlocks;
+        // The span below is used to slide a 2 MiB window for storing decompressed file contents
+        AZStd::span<AZStd::byte> decompressionRemainingSpan = decompressionResultSpan;
+
+        // Get a reference to the the caller supplied decompression options if available
+        const auto& decompressionOptions = fileSettings.m_decompressionOptions != nullptr
+            ? *fileSettings.m_decompressionOptions
+            : Compression::DecompressionOptions{};
+
+        // m_maxDecompressTasks has a minimum value of 1
+        // This makes sure there is never a scenario where the there are blocks to decompress
+        // but the decompress task count is 0
+        const AZ::u32 maxDecompressTasks = AZStd::min(
+            AZStd::max(1U, m_settings.m_maxDecompressTasks),
+            static_cast<AZ::u32>(blockRange.second - blockRange.first));
+        AZStd::vector<Compression::DecompressionResultData> decompressedBlockResults(maxDecompressTasks);
+
+        for (AZ::u64 blockIndex = blockRange.first; blockIndex < blockRange.second;)
+        {
+            // Determine the number of decompression task that can be run in parallel
+            const AZ::u32 decompressTaskCount = AZStd::min(static_cast<AZ::u32>(blockRange.second - blockIndex),
+                maxDecompressTasks);
+
+            // Task graph event used to block decompressing blocks in parallel
+            auto taskDecompressGraphEvent = AZStd::make_unique<AZ::TaskGraphEvent>("Content File Decompress Sync");
+            AZ::TaskGraph taskGraph{ "Archive Decompress Tasks" };
+            AZ::TaskDescriptor decompressTaskDescriptor{ "Decompress Block", "Archive Content File Decompression" };
+
+            // Increment the block index as part of the inner loop that creates the decompression task
+            for (AZ::u32 decompressTaskSlot = 0; decompressTaskSlot < decompressTaskCount; ++decompressTaskSlot,
+                ++blockIndex)
+            {
+                const AZ::u64 blockCompressedSize = GetCompressedSizeForBlock(fileBlockLineSpan, blockCount, blockIndex);
+                // Downsize the 2 MiB span that was used to read the compressed data to the exact compressed size
+                const size_t availableBytesInCompressedBlock = AZStd::min(compressedBlockRemainingSpan.size(),
+                    ArchiveBlockSizeForCompression);
+                AZStd::span<const AZStd::byte> compressedDataForBlock = compressedBlockRemainingSpan
+                    .first(availableBytesInCompressedBlock)
+                    .first(blockCompressedSize);
+                // Slide the compressed block remaining span by 2 MiB
+                compressedBlockRemainingSpan = compressedBlockRemainingSpan.subspan(availableBytesInCompressedBlock);
+
+                // Get the block span for storing the decompressed block
+                // As the uncompressed size is 2 MiB for all blocks except the last
+                // the entire contiguous file sequence will be available in the decompressedResultSpan after the loop
+                const size_t remainingBytesInBlockSpan = AZStd::min(decompressionRemainingSpan.size(),
+                    ArchiveBlockSizeForCompression);
+                AZStd::span<AZStd::byte> decompressionBlockSpan = decompressionRemainingSpan
+                    .first(remainingBytesInBlockSpan);
+                // Slide the remaining decompressed span by 2 MiB as well
+                decompressionRemainingSpan = decompressionRemainingSpan.subspan(remainingBytesInBlockSpan);
+
+                //! Decompress Task to execute in task executor
+                auto decompressTask = [decompressionInterface, &decompressionOptions, decompressionBlockSpan, compressedDataForBlock,
+                    &decompressedBlockResult = decompressedBlockResults[decompressTaskSlot]]()
+                {
+                    // Decompressed the compressed block
+                    decompressedBlockResult = decompressionInterface->DecompressBlock(
+                        decompressionBlockSpan, compressedDataForBlock, decompressionOptions);
+                };
+
+                taskGraph.AddTask(decompressTaskDescriptor, AZStd::move(decompressTask));
+            }
+
+            taskGraph.SubmitOnExecutor(m_taskExecutor, taskDecompressGraphEvent.get());
+            // Sync on the task completion
+            taskDecompressGraphEvent->Wait();
+
+            // Validate the decompression for all blocks
+            for (AZ::u32 decompressTaskSlot = 0; decompressTaskSlot < decompressTaskCount; ++decompressTaskSlot)
+            {
+                const auto& decompressedBlockResult = decompressedBlockResults[decompressTaskSlot];
+                if (!decompressedBlockResult)
+                {
+                    // If one of the decompression task fails, early return with the error message
+                    return AZStd::unexpected(AZStd::move(decompressedBlockResult.m_decompressionOutcome.m_resultString));
+                }
+            }
+        }
+
+        // Return a subspan that accounts for the start offset within the compressed file to start
+        // reading from, up to the bytes read amount
+        // Due to the logic in the function only reading the set of 2 MiB blocks that are needed
+        // the start offset for reading is calculated  a modulo operation
+        // with with the ArchiveBlockSizeForCompression (2 MiB).
+        // The start offset will always be in the first read block
+        size_t startOffset = fileSettings.m_startOffset % ArchiveBlockSizeForCompression;
+        size_t endOffset = AZStd::min(decompressionResultSpan.size() - startOffset, maxBytesToReadForFile);
+        return decompressionResultSpan.subspan(startOffset, endOffset);
+    }
+
+    ArchiveListFileResult ArchiveReader::ListFileInArchive(ArchiveFileToken archiveFileToken) const
+    {
+        if (static_cast<AZ::u64>(archiveFileToken) > m_archiveToc.m_tocView.m_filePathIndexTable.size())
+        {
+            ArchiveListFileResult errorResult;
+            errorResult.m_filePathToken = archiveFileToken;
+            errorResult.m_resultOutcome = AZStd::unexpected(
+                ResultString::format(R"(A file token "%llu" is being used to extract the file and that token does not point)"
+                    " to a file within the archive TOC.", static_cast<AZ::u64>(archiveFileToken)));
+            return errorResult;
+        }
+
+        // Populate the path view from the Table of Contents View
+        ArchiveTocFilePathIndex filePathOffsetSize = m_archiveToc.m_tocView.m_filePathIndexTable[
+            static_cast<AZ::u64>(archiveFileToken)];
+
+        if (filePathOffsetSize.m_size == 0)
+        {
+            ArchiveListFileResult errorResult;
+            errorResult.m_filePathToken = archiveFileToken;
+            errorResult.m_resultOutcome = AZStd::unexpected(
+                ResultString::format(R"(A file token "%llu" is being used to extract the file,)"
+                    " but the file path stored in the TOC is empty."
+                    "This indicates that the token is referring to a deleted file",
+                    static_cast<AZ::u64>(archiveFileToken)));
+            return errorResult;
+        }
+
+        // The file has been found and has a non-empty path
+        // Populate the ArchiveListFileResult structure
+        ArchiveListFileResult listResult;
+        // Now the extract the path has stored in the file path blob into the extract result
+        listResult.m_relativeFilePath = AZ::IO::PathView(
+            m_archiveToc.m_tocView.m_filePathBlob.substr(filePathOffsetSize.m_offset, filePathOffsetSize.m_size));
+        listResult.m_filePathToken = archiveFileToken;
+
+        // Gather the file metadata
+        const ArchiveTocFileMetadata& fileMetadata = m_archiveToc.m_tocView.m_fileMetadataTable[
+            static_cast<AZ::u64>(archiveFileToken)];
+
+        // Use the compression algorithm index to lookup the compression algorithm ID
+        // if the file the value is less than the size of the compression AlgorithmIds array
+        if (fileMetadata.m_compressionAlgoIndex < m_archiveHeader.m_compressionAlgorithmsIds.size())
+        {
+            listResult.m_compressionAlgorithm = m_archiveHeader.m_compressionAlgorithmsIds[
+                fileMetadata.m_compressionAlgoIndex];
+        }
+
+        listResult.m_uncompressedSize = fileMetadata.m_uncompressedSize;
+        if (auto rawFileSizeResult = GetRawFileSize(fileMetadata, m_archiveToc.m_tocView.m_blockOffsetTable);
+            !rawFileSizeResult)
+        {
+            ArchiveListFileResult errorResult;
+            errorResult.m_filePathToken = archiveFileToken;
+            // Take the error from GetRawFileSize call and return that
+            errorResult.m_resultOutcome = AZStd::unexpected(AZStd::move(rawFileSizeResult.error()));
+            return errorResult;
+        }
+        else
+        {
+            listResult.m_compressedSize = rawFileSizeResult.value();
+        }
+        listResult.m_offset = fileMetadata.m_offset;
+
+        return listResult;
+    }
+
+    ArchiveListFileResult ArchiveReader::ListFileInArchive(AZ::IO::PathView relativePath) const
+    {
+        if (relativePath.empty())
+        {
+            ArchiveListFileResult errorResult;
+            errorResult.m_resultOutcome = AZStd::unexpected(
+                ResultString(R"(An empty file path has been supplied."
+                " An empty path cannot be found in the archive.)"));
+            return errorResult;
+        }
+        auto foundIt = m_pathMap.find(relativePath);
+        if (foundIt == m_pathMap.end())
+        {
+            ArchiveListFileResult errorResult;
+            errorResult.m_relativeFilePath = AZStd::move(relativePath);
+            errorResult.m_resultOutcome = AZStd::unexpected(
+                ResultString::format(R"(The file path "%.*s")"
+                    " does not exist in the archive.", AZ_PATH_ARG(errorResult.m_relativeFilePath)));
+            return errorResult;
+        }
+
+        // Now that the file has been found, pass in the ArchiveFileToken to the
+        // the other overload
+        return ListFileInArchive(static_cast<ArchiveFileToken>(foundIt->second));
+    }
+
+    bool ArchiveReader::ContainsFile(AZ::IO::PathView relativePath) const
+    {
+        return static_cast<bool>(ListFileInArchive(relativePath));
+    }
+
+    EnumerateArchiveResult ArchiveReader::EnumerateFilesInArchive(ListFileCallback listFileCallback) const
+    {
+        ResultOutcome fileResultOutcome;
+        // Lambda is marked mutable to allow the filePathIndex variable to be incremented each call
+        auto EnumerateAllFiles = [&listFileCallback, &fileResultOutcome, this, filePathIndex = 0]
+        (AZ::u32 filePathBlobOffset, AZ::u16 filePathSize) mutable
+            {
+                // Invoke callback on each file with a non-empty path
+                if (AZ::IO::PathView contentPathView(m_archiveToc.m_tocView.m_filePathBlob.substr(filePathBlobOffset, filePathSize));
+                    !contentPathView.empty())
+                {
+                    ArchiveListFileResult listResult;
+                    listResult.m_relativeFilePath = contentPathView;
+                    listResult.m_filePathToken = static_cast<ArchiveFileToken>(filePathIndex);
+
+                    // Gather the file metadata
+                    const ArchiveTocFileMetadata& fileMetadata = m_archiveToc.m_tocView.m_fileMetadataTable[filePathIndex];
+
+                    // Use the compression algorithm index to lookup the compression algorithm ID
+                    // if the file the value is less than the size of the compression AlgorithmIds array
+                    if (fileMetadata.m_compressionAlgoIndex < m_archiveHeader.m_compressionAlgorithmsIds.size())
+                    {
+                        listResult.m_compressionAlgorithm = m_archiveHeader.m_compressionAlgorithmsIds[
+                            fileMetadata.m_compressionAlgoIndex];
+                    }
+
+                    listResult.m_uncompressedSize = fileMetadata.m_uncompressedSize;
+                    if (auto rawFileSizeResult = GetRawFileSize(fileMetadata, m_archiveToc.m_tocView.m_blockOffsetTable);
+                        !rawFileSizeResult)
+                    {
+                        fileResultOutcome = AZStd::unexpected(AZStd::move(rawFileSizeResult.error()));
+                        return;
+                    }
+                    else
+                    {
+                        listResult.m_compressedSize = rawFileSizeResult.value();
+                    }
+                    listResult.m_offset = fileMetadata.m_offset;
+
+                    listFileCallback(AZStd::move(listResult));
+                }
+                ++filePathIndex;
+            };
+        EnumerateFilePathIndexOffsets(EnumerateAllFiles, m_archiveToc.m_tocView);
+
+        // There are currently no error messages that enumerate file path sets
+        // So a default constructed instance which converts to boolean true is returned
+        return {};
+    }
+
+    bool ArchiveReader::WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+        const ArchiveMetadataSettings& metadataSettings) const
+    {
+        using MetadataString = AZStd::fixed_string<256>;
+        if (metadataSettings.m_writeFileCount)
+        {
+            auto fileCountString = MetadataString::format("Total File Count: %u\n", m_archiveHeader.m_fileCount);
+            metadataStream.Write(fileCountString.size(), fileCountString.data());
+        }
+
+        if (metadataSettings.m_writeFilePaths)
+        {
+            // Validate the file path and file metadata tables are in sync
+            if (m_archiveToc.m_tocView.m_filePathIndexTable.size() != m_archiveToc.m_tocView.m_fileMetadataTable.size())
+            {
+                auto errorString = MetadataString::format("Error: The Archive TOC of contents has a mismatched size between"
+                    " the file path index vector (size=%zu) and the file metadata vector (size=%zu).\n"
+                    "This indicates a code error in the ArchiveReader in keeping both vectors in sync and should never occur",
+                    m_archiveToc.m_tocView.m_filePathIndexTable.size(), m_archiveToc.m_tocView.m_fileMetadataTable.size());
+                metadataStream.Write(errorString.size(), errorString.data());
+                return false;
+            }
+
+            // Trackes the index of the file being output
+            size_t activeFileOffset{};
+
+            for (size_t filePathIndexTableIndex{}; filePathIndexTableIndex < m_archiveToc.m_tocView.m_filePathIndexTable.size();
+                ++filePathIndexTableIndex)
+            {
+                // Use the FilePathIndex entry to lookup the offset and size of the file path within the FilePath blob
+                const auto& contentFilePathIndex = m_archiveToc.m_tocView.m_filePathIndexTable[filePathIndexTableIndex];
+                AZ::IO::PathView contentFilePath(m_archiveToc.m_tocView.m_filePathBlob.substr(contentFilePathIndex.m_offset,
+                    contentFilePathIndex.m_size));
+                // An empty file path is used to track removed files from the archive,
+                // therefore only non-empty paths are iterated
+                if (!contentFilePath.empty())
+                {
+                    const ArchiveTocFileMetadata& contentFileMetadata = m_archiveToc.m_tocView.m_fileMetadataTable[filePathIndexTableIndex];
+                    auto fileMetadataString = MetadataString::format(R"(File %zu: path="%.*s")", activeFileOffset, AZ_PATH_ARG(contentFilePath));
+                    if (metadataSettings.m_writeFileOffsets)
+                    {
+                        fileMetadataString += MetadataString::format(R"(, offset=%llu)", contentFileMetadata.m_offset);
+                    }
+                    if (metadataSettings.m_writeFileSizesAndCompression)
+                    {
+                        fileMetadataString += MetadataString::format(R"(, uncompressed_size=%llu)", contentFileMetadata.m_uncompressedSize);
+                        // Only output compressed size if an compression that compresses data is being used
+                        if (contentFileMetadata.m_compressionAlgoIndex < UncompressedAlgorithmIndex)
+                        {
+                            if (auto rawFileSizeResult = GetRawFileSize(contentFileMetadata, m_archiveToc.m_tocView.m_blockOffsetTable);
+                                rawFileSizeResult)
+                            {
+                                AZ::u64 compressedSize = rawFileSizeResult.value();
+                                fileMetadataString += MetadataString::format(R"(, compressed_size=%llu)",
+                                    compressedSize);
+                            }
+                            fileMetadataString += MetadataString::format(R"(, compression_algorithm_id=%u)",
+                                AZStd::to_underlying(m_archiveHeader.m_compressionAlgorithmsIds[contentFileMetadata.m_compressionAlgoIndex]));
+                        }
+                    }
+
+                    // Append a newline before writing to the stream
+                    fileMetadataString.push_back('\n');
+                    metadataStream.Write(fileMetadataString.size(), fileMetadataString.data());
+
+                    // Increment the active file offset for non-removed files
+                    ++activeFileOffset;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    size_t ArchiveReader::FindCompressionAlgorithmId(Compression::CompressionAlgorithmId compressionAlgorithmId)
+    {
+        // If the compression algorithm id is invalid return the invalid algorithm index
+        if (compressionAlgorithmId == Compression::Invalid)
+        {
+            return InvalidAlgorithmIndex;
+        }
+
+        // If the compression algorithm id is uncompressed
+        // return a value of 7 which is the highest 3-bit value(0b111)
+        // The compression algorithm Id array contains 7 elements for registering compression algorithms.
+        // The index of 7 is used to represent the file is uncompressed the purposes of storing
+        // that information the archive table of contents for an uncompressed file
+        if (compressionAlgorithmId == Compression::Uncompressed)
+        {
+            return UncompressedAlgorithmIndex;
+        }
+
+        // Locate the compression algorithm Id in the compression algorithm id array
+        auto foundIt = AZStd::find(m_archiveHeader.m_compressionAlgorithmsIds.begin(), m_archiveHeader.m_compressionAlgorithmsIds.end(),
+            compressionAlgorithmId);
+        return foundIt != m_archiveHeader.m_compressionAlgorithmsIds.end()
+            ? AZStd::distance(m_archiveHeader.m_compressionAlgorithmsIds.begin(), foundIt)
+            : InvalidAlgorithmIndex;
+    }
+
+} // namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -841,7 +841,7 @@ namespace Archive
             {
                 auto errorString = MetadataString::format("Error: The Archive TOC of contents has a mismatched size between"
                     " the file path index vector (size=%zu) and the file metadata vector (size=%zu).\n"
-                    "This indicates a code error in the ArchiveReader",
+                    "This indicates a code error in the ArchiveReader.",
                     m_archiveToc.m_tocView.m_filePathIndexTable.size(), m_archiveToc.m_tocView.m_fileMetadataTable.size());
                 metadataStream.Write(errorString.size(), errorString.data());
                 return false;

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.h
@@ -199,7 +199,7 @@ namespace Archive
         //! Stores mapping of FilePath to index within the file path table in the Archive TOC
         //! The index is used to as the ArchiveFileToken
         //! IMPORTANT: The PathView is a view into the m_archiveToc TOC buffer
-        //! and therefore this map should be clear before re-reading another archive TOC
+        //! and therefore this map should be cleared before reading another archive TOC
         using FilePathTable = AZStd::unordered_map<AZ::IO::PathView, size_t>;
         FilePathTable m_pathMap;
 

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.h
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Archive/Clients/ArchiveBaseAPI.h>
+#include <Archive/Clients/ArchiveReaderAPI.h>
+
+#include <Clients/ArchiveTOCView.h>
+
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/utility/to_underlying.h>
+#include <AzCore/Task/TaskExecutor.h>
+
+namespace AZ
+{
+    class TaskGraphEvent;
+}
+
+namespace AZ::IO
+{
+    class GenericStream;
+}
+
+namespace Archive
+{
+    //! Implements the Archive Reader Interface
+    //! This can be used to read and extract files from an archive
+    class ArchiveReader
+        : public IArchiveReader
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(ArchiveReader);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        ArchiveReader();
+        //! Create an archive reader using the specified reader settings
+        explicit ArchiveReader(const ArchiveReaderSettings& readerSettings);
+        //! Open an file at the specified file path and takes sole ownership of it
+        //! The ArchiveReader will close the file on Unmount
+        explicit ArchiveReader(AZ::IO::PathView archivePath, const ArchiveReaderSettings& readerSettings = {});
+        //! Takes ownership of the open stream and will optionally delete it based on the ArchiveFileDeleter
+        explicit ArchiveReader(ArchiveStreamPtr archiveStream, const ArchiveReaderSettings& readerSettings = {});
+        ~ArchiveReader();
+
+        //! Opens the archive path and returns true if successful
+        //! Will unmount any previously mounted archive
+        bool MountArchive(AZ::IO::PathView archivePath) override;
+        bool MountArchive(ArchiveStreamPtr archiveStream) override;
+
+        //! Closes the handle to the mounted archive stream
+        void UnmountArchive() override;
+
+        //! Returns if an open archive that is mounted
+        bool IsMounted() const override;
+
+        //! Reads the content of the file specified in the ArchiveReadeFileSettings
+        //! The file path identifier in the settings is used to locate the file to extract from the archive
+        //! The outputSpan should be a pre-allocated buffer that is large enough
+        //! to fit either the uncompressed size of the file if the `m_decompressFile` setting is true
+        //! or the compressed size of the file if the `m_decompressFile` setting is false
+        ArchiveExtractFileResult ExtractFileFromArchive(AZStd::span<AZStd::byte> outputSpan,
+            const ArchiveReaderFileSettings& fileSettings) override;
+
+        //! List the file metadata from the archive using the ArchiveFileToken
+        //! @param filePathToken identifier token that can be used to quickly lookup
+        //! metadata about the file
+        //! @return ArchiveListResult with metadata for the file if found
+        ArchiveListFileResult ListFileInArchive(ArchiveFileToken filePathToken) const override;
+        //! List the file metadata from the archive using the ArchiveFileToken
+        //! @param filePathToken identifier token that can be used to quickly lookup
+        //! metadata about the file
+        //! @return ArchiveListResult with metadata for the file if found
+        ArchiveListFileResult ListFileInArchive(AZ::IO::PathView relativePath) const override;
+
+        //! Returns if the archive contains a relative path
+        //! @param relativePath Relative path within archive to search for
+        //! @returns true if the relative path is contained with the Archive
+        //! equivalent to `return FindFile(relativePath) != InvalidArchiveFileToken;`
+        bool ContainsFile(AZ::IO::PathView relativePath) const override;
+
+        //! Enumerates all files within the archive table of contents and invokes a callback
+        //! function with the listing information about the file
+        //! This function can be used to build filter files in the Archive based on any value
+        //! supplied in the ArchiveListFileResult structure
+        //! For example filtering can be done based on file path(such as globbing for all *.txt files)
+        //! or filtering based on uncompressed size(such as locating all files > 2MiB, etc...)
+        //! Alternatively this function can be used to list all of the files within the archive by
+        //! binding a lambda that populates a vector
+        //!
+        //! @param listFileCallback Callback which is invoked for each file in the archive
+        //! @return result structure that is convertible to a boolean value indicating if enumeration was successful
+        EnumerateArchiveResult EnumerateFilesInArchive(ListFileCallback listFileCallback) const override;
+
+        //! Writes metadata for the archive to the supplied generic stream
+        //! @param metadataStream with human readable data about files within the archive will be written to the stream
+        //! @return true if metadata was successfully written
+        bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+            const ArchiveMetadataSettings& metadataSettings = {}) const override;
+
+    private:
+        //! Queries the archive header for the index matching the specified compression
+        //! algorithm id
+        //! @param compressionAlgorithmId Id to query for the index in the archive header
+        //! for the compression algorithm Id array
+        //! @return the index of the registered compression algorithm Id
+        //! Special Case: If the input ID is `Compression::Uncompressed`, then
+        //! the value of `Compression::UncompressedAlgorithmIndex` is return instead
+        //! If the algorithm Id is not registered then the value of `InvalidAlgorithmIndex`
+        //! is returned
+        size_t FindCompressionAlgorithmId(Compression::CompressionAlgorithmId);
+
+        //! Reads the Archive Header into memory.
+        //! Afterwards the Archive Header is used to read the TOC into memory
+        //! and build any structures for acceleration of lookups
+        bool ReadArchiveHeaderAndToc();
+        //! Reads the archive header from the generic stream
+        bool ReadArchiveHeader(ArchiveHeader& archiveHeader, AZ::IO::GenericStream& archiveStream);
+        //! Reads the archive table of contents from the generic stream by using the archive header
+        //! to determine the offset and size of the table of contents
+        struct ArchiveTableOfContentsReader;
+        bool ReadArchiveTOC(ArchiveTableOfContentsReader& archiveToc, AZ::IO::GenericStream& archiveStream,
+            const ArchiveHeader& archiveHeader);
+
+        //! Creates a mapping of views to the file paths within the archive to the ArchiveFileToken
+        //! The ArchiveFileToken currently corresponds to the index within the table of contents
+        //! ArchiveTocFilePathIndex, ArchiveTocFileMetadata and ArchiveFilePath vector structures
+        bool BuildFilePathMap(const ArchiveTableOfContentsView& archiveToc);
+
+        //! Read data from offset within archive directly to span
+        //! @param fileBuffer pre-allocated span to populate buffer with data
+        //! @param offset absolute file within mounted archive to start reading data from
+        //! @param fileSize the amount of data to read at the specified offset
+        //! @return result outcome which contains an error messages related to reading the file
+        //! if it fails
+        using ReadRawFileOutcome = AZStd::expected<AZStd::span<AZStd::byte>, ResultString>;
+        ReadRawFileOutcome ReadRawFileIntoBuffer(AZStd::span<AZStd::byte> fileBuffer, AZ::u64 offset,
+            AZ::u64 fileSize,
+            const ArchiveReaderFileSettings& fileSettings);
+
+        //! Decompressed the content from the input buffer
+        //! @param decompressionResultSpan span to populated with decompressed results
+        //! @param compressedInputSpan compressed data span to decompress
+        //! @param fileSettings settings which indicate the max number of decompression task
+        //! to use for decompressing the file content.
+        //! This parameter also contains settings for selecting an offset within the decompressed
+        //! file to start reading, as well as a cap on the number of bytes to read from that start offset
+        //! @param blockOffsetIndex start index into the block line table vector which contains
+        //! the compressed sizes of each 2 MiB block of the file
+        //! @param extractFileResult Contains the compressed size, raw offset within the archive and uncompressed
+        //! size of the file needed for extracting
+        //! @return result outcome with a span containing a view of the decompressed file data
+        //! within the offset range specified by
+        //! [ArchiveReaderFileSettings::m_startOffset,ArchiveReaderFileSettings::m_startOffset + ArchiveReaderFileSettings::m_bytesToRead)
+        //! Otherwise an error message string providing reasons why decompression failed
+        using ReadCompressedFileOutcome = AZStd::expected<AZStd::span<AZStd::byte>, ResultString>;
+        ReadCompressedFileOutcome ReadCompressedFileIntoBuffer(AZStd::span<AZStd::byte> decompressionResultSpan,
+            const ArchiveReaderFileSettings& fileSettings,
+            const ArchiveExtractFileResult& extractFileResult);
+
+
+        // Private Member variables section
+
+        //! Archive Reader specific settings
+        //! Controls the number of tasks to use for reading and decompression of content
+        //! from the archive
+        //! Also contains an error callback that is invoked when error occurs in the constructor
+        ArchiveReaderSettings m_settings;
+        //! Archive header as read from the first sizeof(ArchiveHeader) blocks of the archive stream
+        //! The header is not modified by the reader
+        ArchiveHeader m_archiveHeader;
+        //! View of the Archive TOC within the supplied archive stream
+        //! Since the ArchiveReader doesn't mutate the archive, a Table of Contents View is used
+        //! and paired with a raw buffer of the Table of Contents
+        struct ArchiveTableOfContentsReader
+        {
+            // Default a table of contents reader that has an empty vector
+            // and default constructed view
+            ArchiveTableOfContentsReader();
+            // Takes ownership of the buffer containing the Table of Contents raw data
+            // and an ArchiveTableOfContentsView instance
+            ArchiveTableOfContentsReader(AZStd::vector<AZStd::byte> tocBuffer, ArchiveTableOfContentsView tocView);
+
+            ArchiveTableOfContentsView m_tocView;
+        private:
+            AZStd::vector<AZStd::byte> m_tocBuffer;
+        };
+        ArchiveTableOfContentsReader m_archiveToc;
+
+        //! Stores mapping of FilePath to index within the file path table in the Archive TOC
+        //! The index is used to as the ArchiveFileToken
+        //! IMPORTANT: The PathView is a view into the m_archiveToc TOC buffer
+        //! and therefore this map should be clear before re-reading another archive TOC
+        using FilePathTable = AZStd::unordered_map<AZ::IO::PathView, size_t>;
+        FilePathTable m_pathMap;
+
+        //! GenericStream pointer which stores the open archive
+        ArchiveStreamPtr m_archiveStream;
+
+        //! Protects reads within the archive stream
+        //! NOTE: This does restrict read jobs to be done on one thread at a time
+        //! if done using the AZ::IO::GenericStream API as it maintains a single seek position
+        AZStd::mutex m_archiveStreamMutex;
+
+        //! Task Executor used to decompress blocks of a file in parallel
+        AZ::TaskExecutor m_taskExecutor;
+    };
+} // namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.h
@@ -186,8 +186,8 @@ namespace Archive
             // Default a table of contents reader that has an empty vector
             // and default constructed view
             ArchiveTableOfContentsReader();
-            // Takes ownership of the buffer containing the Table of Contents raw data
-            // and an ArchiveTableOfContentsView instance
+            // Stores the buffer containing the Table of Contents raw data
+            // and an ArchiveTableOfContentsView instance which is a read-only view into that raw data
             ArchiveTableOfContentsReader(AZStd::vector<AZStd::byte> tocBuffer, ArchiveTableOfContentsView tocView);
 
             ArchiveTableOfContentsView m_tocView;

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.h
@@ -101,10 +101,10 @@ namespace Archive
         //! @return result structure that is convertible to a boolean value indicating if enumeration was successful
         EnumerateArchiveResult EnumerateFilesInArchive(ListFileCallback listFileCallback) const override;
 
-        //! Writes metadata for the archive to the supplied generic stream
+        //! Dump metadata for the archive to the supplied generic stream
         //! @param metadataStream with human readable data about files within the archive will be written to the stream
         //! @return true if metadata was successfully written
-        bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+        bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const override;
 
     private:

--- a/Gems/Archive/Code/Source/Clients/ArchiveReaderFactory.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReaderFactory.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ArchiveReaderFactory.h"
+#include <Clients/ArchiveReader.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <Archive/ArchiveTypeIds.h>
+
+
+namespace Archive
+{
+    // Implement TypeInfo, Rtti and Allocator support
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ArchiveReaderFactory, "ArchiveReaderFactory", ArchiveReaderFactoryTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ArchiveReaderFactory, IArchiveReaderFactory);
+    AZ_CLASS_ALLOCATOR_IMPL(ArchiveReaderFactory, AZ::SystemAllocator);
+
+    // ArchiveReader forwarding functions
+    // This is used to create an ArchiveReader instance that is pointed
+    // to from an IArchiveReader* to allow use of the ArchiveReader in modules outside of the Archive Gem
+    AZStd::unique_ptr<IArchiveReader> ArchiveReaderFactory::Create() const
+    {
+        return AZStd::make_unique<ArchiveReader>();
+    }
+
+    AZStd::unique_ptr<IArchiveReader> ArchiveReaderFactory::Create(const ArchiveReaderSettings& readerSettings) const
+    {
+        return AZStd::make_unique<ArchiveReader>(readerSettings);
+    }
+
+    AZStd::unique_ptr<IArchiveReader> ArchiveReaderFactory::Create(AZ::IO::PathView archivePath,
+        const ArchiveReaderSettings& readerSettings) const
+    {
+        return AZStd::make_unique<ArchiveReader>(archivePath, readerSettings);
+    }
+
+    AZStd::unique_ptr<IArchiveReader> ArchiveReaderFactory::Create(IArchiveReader::ArchiveStreamPtr archiveStream,
+        const ArchiveReaderSettings& readerSettings) const
+    {
+        return AZStd::make_unique<ArchiveReader>(AZStd::move(archiveStream), readerSettings);
+    }
+} // namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveReaderFactory.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReaderFactory.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Archive/Clients/ArchiveReaderAPI.h>
+
+namespace Archive
+{
+    // Implements a factory that is registered with an
+    // AZ::Interface<IArchiveReaderFactory> in the Archive.Clients
+    // gem module ArchiveModule class
+    // This allows users of the Archive.Clients.API to create an ArchiveReader
+    class ArchiveReaderFactory
+        : public IArchiveReaderFactory
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(ArchiveReaderFactory);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        AZStd::unique_ptr<IArchiveReader> Create() const override;
+        AZStd::unique_ptr<IArchiveReader> Create(const ArchiveReaderSettings& readerSettings) const override;
+        AZStd::unique_ptr<IArchiveReader> Create(AZ::IO::PathView archivePath,
+            const ArchiveReaderSettings& readerSettings) const override;
+        AZStd::unique_ptr<IArchiveReader> Create(IArchiveReader::ArchiveStreamPtr archiveStream,
+            const ArchiveReaderSettings& readerSettings) const override;
+   };
+} // namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOC.inl
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOC.inl
@@ -12,7 +12,7 @@
 
 namespace Archive
 {
-    ArchiveTableOfContents::ArchiveTableOfContents() = default;
+    inline ArchiveTableOfContents::ArchiveTableOfContents() = default;
 
     // Archive Table of Contents file path wrapper
     inline ArchiveTableOfContents::Path::Path(AZ::IO::Path filePath)

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOC.inl
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOC.inl
@@ -15,84 +15,84 @@ namespace Archive
     ArchiveTableOfContents::ArchiveTableOfContents() = default;
 
     // Archive Table of Contents file path wrapper
-    ArchiveTableOfContents::Path::Path(AZ::IO::Path filePath)
+    inline ArchiveTableOfContents::Path::Path(AZ::IO::Path filePath)
         : m_posixPath{ AZStd::move(filePath.Native()), AZ::IO::PosixPathSeparator }
     {
         // Convert the path to use Posix path separators
         m_posixPath.MakePreferred();
     }
 
-    ArchiveTableOfContents::Path::Path(AZ::IO::PathView filePath)
+    inline ArchiveTableOfContents::Path::Path(AZ::IO::PathView filePath)
         : m_posixPath{ filePath.Native(), AZ::IO::PosixPathSeparator }
     {
         // Convert the path to use Posix path separators
         m_posixPath.MakePreferred();
     }
 
-    auto ArchiveTableOfContents::Path::operator=(AZ::IO::Path filePath) -> Path&
+    inline auto ArchiveTableOfContents::Path::operator=(AZ::IO::Path filePath) -> Path&
     {
         m_posixPath = AZ::IO::Path(AZStd::move(filePath.Native()), AZ::IO::PosixPathSeparator).MakePreferred();
         return *this;
     }
 
-    auto ArchiveTableOfContents::Path::operator=(AZ::IO::PathView filePath) -> Path&
+    inline auto ArchiveTableOfContents::Path::operator=(AZ::IO::PathView filePath) -> Path&
     {
         m_posixPath = AZ::IO::Path(filePath.Native(), AZ::IO::PosixPathSeparator).MakePreferred();
         return *this;
     }
 
-    ArchiveTableOfContents::Path::operator AZ::IO::Path&() &
+    inline ArchiveTableOfContents::Path::operator AZ::IO::Path&() &
     {
         return m_posixPath;
     }
 
-    ArchiveTableOfContents::Path::operator const AZ::IO::Path&() const&
+    inline ArchiveTableOfContents::Path::operator const AZ::IO::Path&() const&
     {
         return m_posixPath;
     }
 
-    ArchiveTableOfContents::Path::operator AZ::IO::Path&&() &&
+    inline ArchiveTableOfContents::Path::operator AZ::IO::Path&&() &&
     {
         return AZStd::move(m_posixPath);
     }
 
-    ArchiveTableOfContents::Path::operator const AZ::IO::Path&&() const&&
+    inline ArchiveTableOfContents::Path::operator const AZ::IO::Path&&() const&&
     {
         return AZStd::move(m_posixPath);
     }
 
-    bool ArchiveTableOfContents::Path::empty() const
+    inline bool ArchiveTableOfContents::Path::empty() const
     {
         return m_posixPath.empty();
     }
-    void ArchiveTableOfContents::Path::clear()
+    inline void ArchiveTableOfContents::Path::clear()
     {
         m_posixPath.clear();
     }
 
-    const typename AZ::IO::Path::string_type& ArchiveTableOfContents::Path::Native() const& noexcept
+    inline const typename AZ::IO::Path::string_type& ArchiveTableOfContents::Path::Native() const& noexcept
     {
         return m_posixPath.Native();
     }
 
-    const typename AZ::IO::Path::string_type&& ArchiveTableOfContents::Path::Native() const&& noexcept
+    inline const typename AZ::IO::Path::string_type&& ArchiveTableOfContents::Path::Native() const&& noexcept
     {
         return AZStd::move(m_posixPath.Native());
     }
-    typename AZ::IO::Path::string_type& ArchiveTableOfContents::Path::Native() & noexcept
+    inline typename AZ::IO::Path::string_type& ArchiveTableOfContents::Path::Native() & noexcept
     {
         return m_posixPath.Native();
     }
-    typename AZ::IO::Path::string_type&& ArchiveTableOfContents::Path::Native() && noexcept
+    inline typename AZ::IO::Path::string_type&& ArchiveTableOfContents::Path::Native() && noexcept
     {
         return AZStd::move(m_posixPath.Native());
     }
-    const typename AZ::IO::Path::value_type* ArchiveTableOfContents::Path::c_str() const noexcept
+    inline const typename AZ::IO::Path::value_type* ArchiveTableOfContents::Path::c_str() const noexcept
     {
         return m_posixPath.c_str();
     }
 
-    auto ArchiveTableOfContents::CreateFromTocView(
+    inline auto ArchiveTableOfContents::CreateFromTocView(
         const ArchiveTableOfContentsView& tocView) -> CreateFromTocViewOutcome
     {
         ArchiveTableOfContents tableOfContents;

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOCView.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOCView.h
@@ -32,7 +32,7 @@ namespace Archive
     //! to validate the archive table of contents against its header
     struct ArchiveTocValidationResult
     {
-        explicit operator bool() const;
+        explicit constexpr operator bool() const;
         ArchiveTocErrorCode m_errorCode{};
         using ErrorString = AZStd::basic_fixed_string<char, 512, AZStd::char_traits<char>>;
         ErrorString m_errorMessage;
@@ -104,6 +104,49 @@ namespace Archive
     size_t EnumerateFilePathIndexOffsets(FilePathIndexEntryVisitor callback,
         const ArchiveTableOfContentsView& tocView);
 } // namespace Archive
+
+// Separate namespace block to create visual spacing around utility functions
+// for querying the the Table of Contents View
+namespace Archive
+{
+   //! Retrieves a subspan from the Table of Contents Archive BlockLine Offset Table
+   //! that contains the block lines associated with a specific file
+   //! @param fileMetadataTableIndex index into the file metadata table
+   //!        This is used to lookup the uncompressed size and the first block line offset entry
+   //!        for a file
+   //! @return On success return a span over a view of each block line associated with the file
+   //!         at the provided file metadata table index.
+   //!         On failure returns an error message providing the reason the span could not be created
+    using FileBlockLineOutcome = AZStd::expected<AZStd::span<const ArchiveBlockLineUnion>, ResultString>;
+    FileBlockLineOutcome GetBlockLineSpanForFile(const ArchiveTableOfContentsView& tocView,
+        size_t fileMetadataTableIndex);
+
+    //! Queries the compressed size at the block index in the block line span for the compressed file
+    //! @param fileBlockLineSpan span of the block lines associated with a single file
+    //!       The entire TOC block line span should NOT be passed to this function
+    //!       The span that is passed in should be from a call of GetBlockLineSpanForFile()
+    //! @param blockCount The number of 2-MiB blocks for the file
+    //! @param blockIndex index of block entry in the block line span to read the compressed size
+    //! @return the compressed size value for the block if block index corresponds to a block in the file
+    //!         otherwise 0 is returned
+    AZ::u64 GetCompressedSizeForBlock(AZStd::span<const ArchiveBlockLineUnion> fileBlockLineSpan,
+        AZ::u64 blockCount, AZ::u64 blockIndex);
+
+   //! Gets the raw size for the file in the archive
+   //! If the file is uncompressed then the uncompressed size is returned from the file metadata
+   //! If the file is compressed, then this returns the size needed to read the contiguous
+   //! sequence of compressed blocks exact
+   //!
+   //! @param fileMetadata reference to the TOC file metadata entry which contains the start offset into
+   //!        the block offset table for the file.
+   //!        The TOC file metadata structure m_uncompressedSize member is used to determine
+   //! @param tocBlockOffsetTable span for the entire TOC block line offset table
+   //! @return On success return the exact size for the file as stored in the archive
+   //!         On failure returns an error message with the failure reason
+    using GetRawFileSizeOutcome = AZStd::expected<AZ::u64, ResultString>;
+    GetRawFileSizeOutcome GetRawFileSize(const ArchiveTocFileMetadata& fileMetadata,
+        AZStd::span<const ArchiveBlockLineUnion> tocBlockOffsetTable);
+}
 
 // Implementation for any struct functions
 #include "ArchiveTOCView.inl"

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOCView.h
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOCView.h
@@ -109,8 +109,10 @@ namespace Archive
 // for querying the the Table of Contents View
 namespace Archive
 {
-   //! Retrieves a subspan from the Table of Contents Archive BlockLine Offset Table
+   //! Retrieves a subspan from the archive TOC BlockLine Offset Table
    //! that contains the block lines associated with a specific file
+   //! @param tocView readonly view into the Archive TOC
+   //!        The file metadata table and block offset table is accessed using the TOC view
    //! @param fileMetadataTableIndex index into the file metadata table
    //!        This is used to lookup the uncompressed size and the first block line offset entry
    //!        for a file

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
@@ -13,9 +13,9 @@
 namespace Archive
 {
     //! ArchiveTableOfContentsView member implementation
-    ArchiveTableOfContentsView::ArchiveTableOfContentsView() = default;
+    inline ArchiveTableOfContentsView::ArchiveTableOfContentsView() = default;
 
-    auto ArchiveTableOfContentsView::CreateFromArchiveHeaderAndBuffer(const ArchiveHeader& archiveHeader,
+    inline auto ArchiveTableOfContentsView::CreateFromArchiveHeaderAndBuffer(const ArchiveHeader& archiveHeader,
         AZStd::span<AZStd::byte> tocBuffer) -> CreateTOCViewOutcome
     {
         // A valid table of contents must have at least 8 bytes to store the Magic Bytes
@@ -88,12 +88,12 @@ namespace Archive
         return validationResult ? CreateTOCViewOutcome{ tocView } : CreateTOCViewOutcome{ AZStd::unexpected(AZStd::move(validationResult)) };
     }
 
-    ArchiveTocValidationResult::operator bool() const
+    constexpr ArchiveTocValidationResult::operator bool() const
     {
         return m_errorCode == ArchiveTocErrorCode{};
     }
 
-    ArchiveTocValidationResult ValidateTableOfContents(const ArchiveTableOfContentsView& tocView,
+    inline ArchiveTocValidationResult ValidateTableOfContents(const ArchiveTableOfContentsView& tocView,
         const ArchiveHeader& archiveHeader,
         const ArchiveTocValidationOptions& validationOptions)
     {
@@ -167,7 +167,7 @@ namespace Archive
         return {};
     }
 
-    size_t EnumerateFilePathIndexOffsets(FilePathIndexEntryVisitor callback,
+    inline size_t EnumerateFilePathIndexOffsets(FilePathIndexEntryVisitor callback,
         const ArchiveTableOfContentsView& tocView)
     {
         size_t filePathsVisited{};
@@ -182,6 +182,167 @@ namespace Archive
         }
 
         return filePathsVisited;
+    }
+
+    // Implementation of function which returns a span that encompass the block lines
+    // for a content file provided that the first block line index for that file is supplied
+    // along with that file uncompressed size
+    inline FileBlockLineOutcome GetBlockLineSpanForFile(const ArchiveTableOfContentsView& tocView,
+        size_t indexInFileMetadataTable)
+    {
+        if (indexInFileMetadataTable >= tocView.m_fileMetadataTable.size())
+        {
+            return AZStd::unexpected(ResultString::format("The index %zu into the Table of Contents file metadata table"
+                " is is out of range", indexInFileMetadataTable));
+        }
+
+        // Query the uncompressed size and block line start index for the file from the TOC
+        const AZ::u64 uncompressedSize = tocView.m_fileMetadataTable[indexInFileMetadataTable].m_uncompressedSize;
+        const AZ::u64 blockLineFirstIndex = tocView.m_fileMetadataTable[indexInFileMetadataTable].m_blockLineTableFirstIndex;
+
+        // Determine the number of blocks lines a file uses based on the uncompressed size
+        const AZ::u64 fileBlockLineCount = GetBlockLineCountIfCompressed(uncompressedSize);
+        if (blockLineFirstIndex >= tocView.m_blockOffsetTable.size()
+            && (blockLineFirstIndex + fileBlockLineCount) >= tocView.m_blockOffsetTable.size())
+        {
+            return AZStd::unexpected(ResultString::format("Either the first block index for the file with value %llu"
+                "is incorrect or the uncompressed size (%llu) for the file is incorrect", blockLineFirstIndex,
+                uncompressedSize));
+        }
+
+        // returns a subspan that starts at the first block line for the file
+        // and continues for the count of the block lines based on the uncompressed size
+        return tocView.m_blockOffsetTable.subspan(blockLineFirstIndex, fileBlockLineCount);
+    }
+
+    // Retrieves the compressed size for the given block
+    inline AZ::u64 GetCompressedSizeForBlock(AZStd::span<const ArchiveBlockLineUnion> fileBlockLineSpan,
+        AZ::u64 blockCount, AZ::u64 blockIndex)
+    {
+        // Get the index of the block line corresponding to the index of the block
+        auto blockLineResult = GetBlockLineIndexFromBlockIndex(blockCount, blockIndex);
+        if (!blockLineResult)
+        {
+            return 0;
+        }
+
+        // Block line indices which are multiples of 3 all have jump entries unless they are part of the final 3 block
+        // lines of a file
+        const bool blockLineContainsJump = (blockLineResult.m_blockLineIndex % BlockLinesToSkipWithJumpEntry == 0)
+            && (fileBlockLineSpan.size() - blockLineResult.m_blockLineIndex) > BlockLinesToSkipWithJumpEntry;
+        if (blockLineContainsJump)
+        {
+            const ArchiveBlockLineJump& blockLineWithJump = fileBlockLineSpan[
+                blockLineResult.m_blockLineIndex].m_blockLineWithJump;
+            switch (blockLineResult.m_offsetInBlockLine)
+            {
+            case 0:
+                return blockLineWithJump.m_block0;
+            case 1:
+                return blockLineWithJump.m_block1;
+            default:
+                return 0;
+            }
+        }
+        else
+        {
+            const ArchiveBlockLine& blockLine = fileBlockLineSpan[
+                blockLineResult.m_blockLineIndex].m_blockLine;
+            switch (blockLineResult.m_offsetInBlockLine)
+            {
+            case 0:
+                return blockLine.m_block0;
+            case 1:
+                return blockLine.m_block1;
+            case 2:
+                return blockLine.m_block2;
+            default:
+                return 0;
+            }
+        }
+    }
+
+    // Returns the summation of the compressed sizes of each block of the file
+    inline GetRawFileSizeOutcome GetRawFileSize(const ArchiveTocFileMetadata& fileMetadata,
+        AZStd::span<const ArchiveBlockLineUnion> tocBlockOffsetTable)
+    {
+        // Query the uncompressed size TOC
+        const AZ::u64 uncompressedSize = fileMetadata.m_uncompressedSize;
+
+        // If the uncompressed, then return the uncompressed size as the raw file size
+        if (fileMetadata.m_compressionAlgoIndex >= UncompressedAlgorithmIndex)
+        {
+            return uncompressedSize;
+        }
+
+        // Determine the number of blocks lines a file uses based on the uncompressed size
+        const AZ::u64 blockLineFirstIndex = fileMetadata.m_blockLineTableFirstIndex;
+        const AZ::u64 fileBlockLineCount = GetBlockLineCountIfCompressed(uncompressedSize);
+        if (blockLineFirstIndex >= tocBlockOffsetTable.size()
+            && (blockLineFirstIndex + fileBlockLineCount) >= tocBlockOffsetTable.size())
+        {
+            return AZStd::unexpected(ResultString::format("The first block offset entry for the file with value %llu"
+                "is incorrect or the uncompressed size (%llu) is incorrect", blockLineFirstIndex,
+                uncompressedSize));
+        }
+
+        // Get a subspan of only the blocks associated with the file
+        AZStd::span<const ArchiveBlockLineUnion> fileBlockLineSpan = tocBlockOffsetTable.subspan(blockLineFirstIndex, fileBlockLineCount);
+
+        AZ::u64 compressedSize{};
+        size_t blockCount = GetBlockCountIfCompressed(uncompressedSize);
+        for (size_t blockLineIndex{}, blockIndex{}; blockLineIndex < fileBlockLineSpan.size();)
+        {
+            // Determine if the block line contains a jump entry
+            // This can be used to determine the compressed block sizes for the next 8 blocks (3 block lines)
+            const bool blockLineContainsJump = (blockLineIndex % BlockLinesToSkipWithJumpEntry == 0)
+                && (fileBlockLineSpan.size() - blockLineIndex) > BlockLinesToSkipWithJumpEntry;
+            if (blockLineContainsJump)
+            {
+                const ArchiveBlockLineJump& blockLineWithJump = fileBlockLineSpan[blockLineIndex].m_blockLineWithJump;
+                // A jump entry contains the aligned compressed size for the next 8 blocks
+                compressedSize = blockLineWithJump.m_blockJump * ArchiveDefaultBlockAlignment;
+                blockLineIndex += BlockLinesToSkipWithJumpEntry;
+                blockIndex += BlocksToSkipWithJumpEntry;
+            }
+            else
+            {
+                // When this logic is reached, there are no more blocks with jump entries in the file
+                // therefore add the aligned size of compressed block EXCEPT the last block
+                // where it's actual size is used.
+                const ArchiveBlockLine& blockLine = fileBlockLineSpan[blockLineIndex].m_blockLine;
+
+                // Check if the current blockIndex corresponds to the last block of the compressed
+                // file section
+                if (bool isLastBlock = ++blockIndex == blockCount;
+                    isLastBlock)
+                {
+                    compressedSize += blockLine.m_block0;
+                    break;
+                }
+                compressedSize += AZ_SIZE_ALIGN_UP(blockLine.m_block0, ArchiveDefaultBlockAlignment);
+
+                if (bool isLastBlock = ++blockIndex == blockCount;
+                    isLastBlock)
+                {
+                    compressedSize += blockLine.m_block1;
+                    break;
+                }
+                compressedSize += AZ_SIZE_ALIGN_UP(blockLine.m_block2, ArchiveDefaultBlockAlignment);
+                if (bool isLastBlock = ++blockIndex == blockCount;
+                    isLastBlock)
+                {
+                    compressedSize += blockLine.m_block2;
+                    break;
+                }
+                compressedSize += AZ_SIZE_ALIGN_UP(blockLine.m_block2, ArchiveDefaultBlockAlignment);
+
+                // Increment the block line index by 1 to move to the next block
+                ++blockLineIndex;
+            }
+        }
+
+        return compressedSize;
     }
 
 } // namespace Archive

--- a/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
+++ b/Gems/Archive/Code/Source/Clients/ArchiveTOCView.inl
@@ -34,26 +34,26 @@ namespace Archive
         // magic bytes offset
         constexpr size_t MagicBytesOffset = 0;
 
-        // Round up the File metadata offset as it is 16-byte aligned
+        // Round up the File metadata offset as it is 32-byte aligned
         constexpr size_t FileMetadataTableOffset = AZ_SIZE_ALIGN_UP(
             MagicBytesOffset + sizeof(ArchiveTocMagicBytes),
-            16);
+            sizeof(ArchiveTocFileMetadata));
 
-        // The file path metadata entries is 16 bytes aligned
-        // so round up to the nearest 16th byte before reading the file path index entries
+        // The file path metadata entries is 32 bytes aligned
+        // so round up to the nearest multiple of alignment before reading the file path index entries
         const size_t FilePathIndexTableOffset = AZ_SIZE_ALIGN_UP(
             FileMetadataTableOffset + archiveHeader.m_tocFileMetadataTableUncompressedSize,
-            16);
+            sizeof(ArchiveTocFileMetadata));
         // The file path index entries are 8 bytes aligned
-        // so round up to the nearest 8th byte before reading the file path blob
+        // so round up to the nearest multiple of alignment before reading the file path blob
         const size_t FilePathBlobOffset = AZ_SIZE_ALIGN_UP(
             FilePathIndexTableOffset + archiveHeader.m_tocPathIndexTableUncompressedSize,
-            8);
+            sizeof(ArchiveTocFilePathIndex));
 
         // The block offset table starts on an address aligned at a multiple of 8 bytes
         const size_t BlockOffsetTableOffset = AZ_SIZE_ALIGN_UP(
             FilePathBlobOffset + archiveHeader.m_tocPathBlobUncompressedSize,
-            8);
+            sizeof(ArchiveBlockLineUnion));
 
         // Cast the first 8 of the TOC buffer
         tocView.m_magicBytes = *reinterpret_cast<decltype(tocView.m_magicBytes)*>(tocBuffer.data() + MagicBytesOffset);

--- a/Gems/Archive/Code/Source/Tools/ArchiveEditorModule.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveEditorModule.cpp
@@ -9,6 +9,7 @@
 #include <Archive/ArchiveTypeIds.h>
 #include <ArchiveModuleInterface.h>
 #include "ArchiveEditorSystemComponent.h"
+#include "ArchiveWriterFactory.h"
 
 namespace Archive
 {
@@ -27,7 +28,15 @@ namespace Archive
             // This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(m_descriptors.end(), {
                 ArchiveEditorSystemComponent::CreateDescriptor(),
-            });
+                });
+
+            m_archiveWriterFactory = AZStd::make_unique<ArchiveWriterFactory>();
+            ArchiveWriterFactoryInterface::Register(m_archiveWriterFactory.get());
+        }
+
+        ~ArchiveEditorModule()
+        {
+            ArchiveWriterFactoryInterface::Unregister(m_archiveWriterFactory.get());
         }
 
         /**
@@ -40,6 +49,11 @@ namespace Archive
                 azrtti_typeid<ArchiveEditorSystemComponent>(),
             };
         }
+
+    private:
+        // ArchiveWriterFactory instance for the Tools module that allows
+        // external gem modules to create ArchiveWriter instances
+        AZStd::unique_ptr<IArchiveWriterFactory> m_archiveWriterFactory;
     };
 }// namespace Archive
 

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
@@ -413,6 +413,10 @@ namespace Archive
 
         if (!ReadArchiveHeaderAndToc())
         {
+            // UnmountArchive is invoked to reset
+            // the Archive Header, TOC,
+            // file path -> file index map and entries
+            // and the deleted block offset table
             UnmountArchive();
             return false;
         }
@@ -433,6 +437,10 @@ namespace Archive
 
         if (!ReadArchiveHeaderAndToc())
         {
+            // UnmountArchive is invoked to reset
+            // the Archive Header, TOC,
+            // file path -> file index map and entries
+            // and the deleted block offset table
             UnmountArchive();
             return false;
         }
@@ -1506,7 +1514,7 @@ namespace Archive
             : ArchiveRemoveFileResult{};
     }
 
-    bool ArchiveWriter::WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+    bool ArchiveWriter::DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
         const ArchiveMetadataSettings& metadataSettings) const
     {
         using MetadataString = AZStd::fixed_string<256>;

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
@@ -1508,7 +1508,7 @@ namespace Archive
             {
                 auto errorString = MetadataString::format("Error: The Archive TOC of contents has a mismatched size between"
                     " the file path vector (size=%zu) and the file metadata vector (size=%zu).\n"
-                    "This indicates a code error in the ArchiveWriter",
+                    "This indicates a code error in the ArchiveWriter.",
                     m_archiveToc.m_filePaths.size(), m_archiveToc.m_fileMetadataTable.size());
                 metadataStream.Write(errorString.size(), errorString.data());
                 return false;

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
@@ -29,29 +29,6 @@ namespace Archive
     AZ_RTTI_NO_TYPE_INFO_IMPL(ArchiveWriter, IArchiveWriter);
     AZ_CLASS_ALLOCATOR_IMPL(ArchiveWriter, AZ::SystemAllocator);
 
-    // ArchiveWriter forwarding functions
-    // This is used to create an ArchiveWriter instance that is pointed
-    // to from an IArchiveWriter* to allow use of the ArchiveWriter in modules outside of the Archive Gem
-    AZStd::unique_ptr<IArchiveWriter> CreateArchiveWriter()
-    {
-        return AZStd::make_unique<ArchiveWriter>();
-    }
-    AZStd::unique_ptr<IArchiveWriter> CreateArchiveWriter(const ArchiveWriterSettings& writerSettings)
-    {
-        return AZStd::make_unique<ArchiveWriter>(writerSettings);
-    }
-
-    AZStd::unique_ptr<IArchiveWriter> CreateArchiveWriter(AZ::IO::PathView archivePath,
-        const ArchiveWriterSettings& writerSettings)
-    {
-        return AZStd::make_unique<ArchiveWriter>(archivePath, writerSettings);
-    }
-    AZStd::unique_ptr<IArchiveWriter> CreateArchiveWriter(IArchiveWriter::ArchiveStreamPtr archiveStream,
-        const ArchiveWriterSettings& writerSettings)
-    {
-        return AZStd::make_unique<ArchiveWriter>(AZStd::move(archiveStream), writerSettings);
-    }
-
     ArchiveWriter::ArchiveWriter() = default;
 
     ArchiveWriter::~ArchiveWriter()

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.cpp
@@ -1508,7 +1508,7 @@ namespace Archive
             {
                 auto errorString = MetadataString::format("Error: The Archive TOC of contents has a mismatched size between"
                     " the file path vector (size=%zu) and the file metadata vector (size=%zu).\n"
-                    "This indicates a code error in the ArchiveWriter in keeping both vectors in sync and should never occur",
+                    "This indicates a code error in the ArchiveWriter",
                     m_archiveToc.m_filePaths.size(), m_archiveToc.m_fileMetadataTable.size());
                 metadataStream.Write(errorString.size(), errorString.data());
                 return false;

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
@@ -178,11 +178,13 @@ namespace Archive
             //! This path has been posted processed to to account for any changes
             //! to file case due to the `ArchiveWriterFileSettings::m_fileCase` member
             AZ::IO::PathView m_relativeFilePath;
-            //! Size of the input span as supplied to @AddFileToArchive
-            AZ::u64 m_uncompressedSize;
             //! stores block data about the file contents to write to block section of archive
-            //! The block data contains offsets into the buffer to wrtie
+            //! The block data contains offsets into the buffer to write
             ContentFileBlocks m_contentFileBlocks;
+            //! Reference to the file contents span that was supplied to @AddFileToArchive
+            //! This is used to retrieve the uncompressed size of the file contents
+            //! and to perform a CRC32 over the uncompressed data
+            AZStd::span<const AZStd::byte> m_uncompressedSpan;
         };
         //! Update the archive header with the new file count and the location
         //! of the file in the archive

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
@@ -120,10 +120,10 @@ namespace Archive
         //! stored in the Archive
         ArchiveRemoveFileResult RemoveFileFromArchive(AZ::IO::PathView relativePath) override;
 
-        //! Writes metadata for the archive to the supplied generic stream
+        //! Dump metadata for the archive to the supplied generic stream
         //! @param metadataStream with human readable data about files within the archive will be written to the stream
         //! @return true if metadata was successfully written
-        bool WriteArchiveMetadata(AZ::IO::GenericStream& metadataStream,
+        bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const override;
 
     private:

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
@@ -50,7 +50,7 @@ namespace Archive
     {
     public:
         AZ_TYPE_INFO_WITH_NAME_DECL(ArchiveWriter);
-        AZ_RTTI_NO_TYPE_INFO_DECL()
+        AZ_RTTI_NO_TYPE_INFO_DECL();
         AZ_CLASS_ALLOCATOR_DECL;
 
         ArchiveWriter();
@@ -89,11 +89,11 @@ namespace Archive
         //! Adds the content from the stream to the relative path
         //! based on the ArchiveWriterFileSettings
         ArchiveAddFileResult AddFileToArchive(AZ::IO::GenericStream& inputStream,
-            const ArchiveWriterFileSettings& fileSettings = {}) override;
+            const ArchiveWriterFileSettings& fileSettings) override;
 
         //! Used the span contents to add the file to the archive
         ArchiveAddFileResult AddFileToArchive(AZStd::span<const AZStd::byte> inputSpan,
-            const ArchiveWriterFileSettings& fileSettings = {}) override;
+            const ArchiveWriterFileSettings& fileSettings) override;
 
         //! Searches for a relative path within the archive
         //! @param relativePath Relative path within archive to search for

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriter.h
@@ -87,11 +87,30 @@ namespace Archive
         [[nodiscard]] CommitResult Commit() override;
 
         //! Adds the content from the stream to the relative path
-        //! based on the ArchiveWriterFileSettings
+        //! @param inputStream stream class where data for the file is source from
+        //! The entire stream is read into the memory and written into archive
+        //! @param fileSettings settings used to configure the relative path to
+        //! write to the archive for the given file data.
+        //! It also allows users to configure the compression algorithm to use,
+        //! and whether the AddFileToArchive logic fails if an existing file is being added
+        //! @return ArchiveAddFileResult containing the actual compression file path
+        //! as saved to the Archive TOC, the compression algorithm used
+        //! and an Archive File Token which can be used to remove the file if need be
+        //! On failure, the result outcome contains any errors that have occurred
         ArchiveAddFileResult AddFileToArchive(AZ::IO::GenericStream& inputStream,
             const ArchiveWriterFileSettings& fileSettings) override;
 
-        //! Used the span contents to add the file to the archive
+        //! Use the span contents to add the file to the archive
+        //! @param inputSpan view of data which will be written to the archive
+        //! at the relative path supplied in the @fileSettings parameter
+        //! @param fileSettings settings used to configure the relative path to
+        //! write to the archive for the given file data.
+        //! It also allows users to configure the compression algorithm to use,
+        //! and whether the AddFileToArchive logic fails if an existing file is being added
+        //! @return ArchiveAddFileResult containing the actual compression file path
+        //! as saved to the Archive TOC, the compression algorithm used
+        //! and an Archive File Token which can be used to remove the file if need be
+        //! On failure, the result outcome contains any errors that have occurred
         ArchiveAddFileResult AddFileToArchive(AZStd::span<const AZStd::byte> inputSpan,
             const ArchiveWriterFileSettings& fileSettings) override;
 
@@ -121,7 +140,8 @@ namespace Archive
         ArchiveRemoveFileResult RemoveFileFromArchive(AZ::IO::PathView relativePath) override;
 
         //! Dump metadata for the archive to the supplied generic stream
-        //! @param metadataStream with human readable data about files within the archive will be written to the stream
+        //! @param metadataStream archive file metadata will be written to the stream
+        //! @param metadataSettings settings using which control the file metadata to write to the stream
         //! @return true if metadata was successfully written
         bool DumpArchiveMetadata(AZ::IO::GenericStream& metadataStream,
             const ArchiveMetadataSettings& metadataSettings = {}) const override;

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriterFactory.cpp
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriterFactory.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ArchiveWriterFactory.h"
+#include <Tools/ArchiveWriter.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <Archive/ArchiveTypeIds.h>
+
+
+namespace Archive
+{
+    // Implement TypeInfo, Rtti and Allocator support
+    AZ_TYPE_INFO_WITH_NAME_IMPL(ArchiveWriterFactory, "ArchiveWriterFactory", ArchiveWriterFactoryTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL(ArchiveWriterFactory, IArchiveWriterFactory);
+    AZ_CLASS_ALLOCATOR_IMPL(ArchiveWriterFactory, AZ::SystemAllocator);
+
+    // ArchiveWriter forwarding functions
+    // This is used to create an ArchiveWriter instance that is pointed
+    // to from an IArchiveWriter* to allow use of the ArchiveWriter in modules outside of the Archive Gem
+    AZStd::unique_ptr<IArchiveWriter> ArchiveWriterFactory::Create() const
+    {
+        return AZStd::make_unique<ArchiveWriter>();
+    }
+
+    AZStd::unique_ptr<IArchiveWriter> ArchiveWriterFactory::Create(const ArchiveWriterSettings& writerSettings) const
+    {
+        return AZStd::make_unique<ArchiveWriter>(writerSettings);
+    }
+
+    AZStd::unique_ptr<IArchiveWriter> ArchiveWriterFactory::Create(AZ::IO::PathView archivePath,
+        const ArchiveWriterSettings& writerSettings) const
+    {
+        return AZStd::make_unique<ArchiveWriter>(archivePath, writerSettings);
+    }
+
+    AZStd::unique_ptr<IArchiveWriter> ArchiveWriterFactory::Create(IArchiveWriter::ArchiveStreamPtr archiveStream,
+        const ArchiveWriterSettings& writerSettings) const
+    {
+        return AZStd::make_unique<ArchiveWriter>(AZStd::move(archiveStream), writerSettings);
+    }
+} // namespace Archive

--- a/Gems/Archive/Code/Source/Tools/ArchiveWriterFactory.h
+++ b/Gems/Archive/Code/Source/Tools/ArchiveWriterFactory.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Archive/Tools/ArchiveWriterAPI.h>
+
+namespace Archive
+{
+    // Implements a factory that is registered with an
+    // AZ::Interface<IArchiveWriterFactory> in the Archive.Tools
+    // gem module ArchiveEditorModule class
+    // This allows users of the Archive.Tools.API to create an ArchiveWriter
+    class ArchiveWriterFactory
+        : public IArchiveWriterFactory
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(ArchiveWriterFactory);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        AZStd::unique_ptr<IArchiveWriter> Create() const override;
+        AZStd::unique_ptr<IArchiveWriter> Create(const ArchiveWriterSettings& writerSettings) const override;
+        AZStd::unique_ptr<IArchiveWriter> Create(AZ::IO::PathView archivePath,
+            const ArchiveWriterSettings& writerSettings) const override;
+        AZStd::unique_ptr<IArchiveWriter> Create(IArchiveWriter::ArchiveStreamPtr archiveStream,
+            const ArchiveWriterSettings& writerSettings) const override;
+   };
+} // namespace Archive

--- a/Gems/Archive/Code/Tests/Tools/ArchiveReaderTest.cpp
+++ b/Gems/Archive/Code/Tests/Tools/ArchiveReaderTest.cpp
@@ -21,7 +21,7 @@ namespace Archive::Test
     // Note the ArchiveReader unit test are placed in the Archive.Editor.Tests
     // Tools module to have to the ArchiveWriter which is used to create
     // test archives to be read
-    // In theory if the all archives were written to a file on disk
+    // In theory if all archives were written to a file on disk
     // the test could be placed in the Archive.Tests client module
 
     // The ArchiveEditorTestEnvironment is tracking memory
@@ -103,8 +103,8 @@ namespace Archive::Test
         EXPECT_TRUE(mountErrorOccurred);
         EXPECT_FALSE(archiveReader->IsMounted());
 
-            // reset the mountErrorOccurred boolean
-            mountErrorOccurred = false;
+        // reset the mountErrorOccurred boolean
+        mountErrorOccurred = false;
 
         // now try explicitly mounting an archive using the MountArchive method
         archiveStreamPtr.reset(&archiveStream);
@@ -631,6 +631,13 @@ namespace Archive::Test
             AZStd::string_view textFileSpan(reinterpret_cast<const char*>(archiveExtractFileResult.m_fileSpan.data()),
                 archiveExtractFileResult.m_fileSpan.size());
             EXPECT_THAT(textFileSpan, ::testing::ContainerEq(fooFileData));
+
+            // Validate the CRC32 of the entire file contents
+            // NOTE: This only works on when extracting the entire uncompressed file
+            // If the file was extracted with the ArchiveReader::m_decompressFile option set to false
+            // and the file was compressed, then the CRC does not apply
+            // Also if a partial read of the file was done, the Crc32 also does not apply
+            EXPECT_EQ(archiveExtractFileResult.m_crc32, AZ::Crc32(archiveExtractFileResult.m_fileSpan));
         }
 
         {
@@ -674,6 +681,13 @@ namespace Archive::Test
             AZStd::string_view textFileSpan(reinterpret_cast<const char*>(archiveExtractFileResult.m_fileSpan.data()),
                 archiveExtractFileResult.m_fileSpan.size());
             EXPECT_THAT(textFileSpan, ::testing::ContainerEq(levelPrefabFileData));
+
+            // Validate the CRC32 of the entire file contents
+            // NOTE: This only works on when extracting the entire uncompressed file
+            // If the file was extracted with the ArchiveReader::m_decompressFile option set to false
+            // and the file was compressed, then the CRC does not apply
+            // Also if a partial read of the file was done, the Crc32 also does not apply
+            EXPECT_EQ(archiveExtractFileResult.m_crc32, AZ::Crc32(archiveExtractFileResult.m_fileSpan));
         }
     }
 

--- a/Gems/Archive/Code/Tests/Tools/ArchiveReaderTest.cpp
+++ b/Gems/Archive/Code/Tests/Tools/ArchiveReaderTest.cpp
@@ -1,0 +1,898 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
+
+#include <Archive/Clients/ArchiveReaderAPI.h>
+#include <Archive/Tools/ArchiveWriterAPI.h>
+
+#include <Compression/CompressionLZ4API.h>
+
+namespace Archive::Test
+{
+    // Note the ArchiveReader unit test are placed in the Archive.Editor.Tests
+    // Tools module to have to the ArchiveWriter which is used to create
+    // test archives to be read
+    // In theory if the all archives were written to a file on disk
+    // the test could be placed in the Archive.Tests client module
+
+    // The ArchiveEditorTestEnvironment is tracking memory
+    // via the GemTestEnvironment::SetupEnvironment function
+    // so the LeakDetectionFixture should not be used
+    class ArchiveReaderFixture
+        : public ::testing::Test
+    {
+    public:
+        ArchiveReaderFixture() = default;
+        ~ArchiveReaderFixture() = default;
+
+    protected:
+    };
+
+
+    TEST_F(ArchiveReaderFixture, CreateArchiveReader_Succeeds)
+    {
+        {
+            auto archiveReader = CreateArchiveReader();
+            ASSERT_NE(nullptr, archiveReader);
+        }
+
+        {
+            auto archiveReader = CreateArchiveReader(ArchiveReaderSettings{});
+            ASSERT_NE(nullptr, archiveReader);
+        }
+    }
+
+    TEST_F(ArchiveReaderFixture, MountingEmptyFile_Fails)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
+        ArchiveReaderSettings readerSettings;
+        bool mountErrorOccurred{};
+        readerSettings.m_errorCallback = [&mountErrorOccurred](const ArchiveReaderError&)
+        {
+            mountErrorOccurred = true;
+        };
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveStreamPtr),
+            readerSettings);
+
+        EXPECT_TRUE(mountErrorOccurred);
+        EXPECT_FALSE(archiveReader->IsMounted());
+
+        // reset the mountErrorOccurred boolean
+        mountErrorOccurred = false;
+
+        // now try explicitly mounting an archive using the MountArchive method
+        archiveStreamPtr.reset(&archiveStream);
+        EXPECT_FALSE(archiveReader->MountArchive(AZStd::move(archiveStreamPtr)));
+        EXPECT_TRUE(mountErrorOccurred);
+        EXPECT_FALSE(archiveReader->IsMounted());
+    }
+
+    TEST_F(ArchiveReaderFixture, MountingFailsForInvalidArchive)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+        // Write random data to the archiveStream
+        constexpr AZStd::string_view testData = "The slow gray fox hid under the hyperactive cat";
+        archiveStream.Write(testData.size(), testData.data());
+        archiveStream.Seek(0, AZ::IO::GenericStream::SeekMode::ST_SEEK_BEGIN);
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
+        ArchiveReaderSettings readerSettings;
+        bool mountErrorOccurred{};
+        readerSettings.m_errorCallback = [&mountErrorOccurred](const ArchiveReaderError&)
+        {
+            mountErrorOccurred = true;
+        };
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveStreamPtr),
+            readerSettings);
+
+        EXPECT_TRUE(mountErrorOccurred);
+        EXPECT_FALSE(archiveReader->IsMounted());
+
+            // reset the mountErrorOccurred boolean
+            mountErrorOccurred = false;
+
+        // now try explicitly mounting an archive using the MountArchive method
+        archiveStreamPtr.reset(&archiveStream);
+        EXPECT_FALSE(archiveReader->MountArchive(AZStd::move(archiveStreamPtr)));
+        EXPECT_TRUE(mountErrorOccurred);
+        EXPECT_FALSE(archiveReader->IsMounted());
+    }
+
+    TEST_F(ArchiveReaderFixture, DefaultArchive_CreatedFromWriter_CanBeMounted)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        {
+            // Create an empty archive with no files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        ArchiveReaderSettings readerSettings;
+        bool mountErrorOccurred{};
+        readerSettings.m_errorCallback = [&mountErrorOccurred](const ArchiveReaderError&)
+        {
+            mountErrorOccurred = true;
+        };
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr),
+            readerSettings);
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_FALSE(mountErrorOccurred);
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        // Unmount the archive
+        archiveReader->UnmountArchive();
+        EXPECT_FALSE(archiveReader->IsMounted());
+
+        // reset the mountErrorOccurred boolean
+        mountErrorOccurred = false;
+
+        // now try explicitly mounting an archive using the MountArchive method
+        archiveReaderStreamPtr.reset(&archiveStream);
+        EXPECT_TRUE(archiveReader->MountArchive(AZStd::move(archiveReaderStreamPtr)));
+        EXPECT_FALSE(mountErrorOccurred);
+        EXPECT_TRUE(archiveReader->IsMounted());
+    }
+
+    TEST_F(ArchiveReaderFixture, ListFileInArchive_ForExistingFile_Succeeds)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view fooFileData;
+        AZStd::string_view levelPrefabFileData;
+
+        {
+            // Create an archive with a several files in it
+            // At least one of the files are compressed
+            // and at one is not compressed
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write an uncompressed file with the contents of hello world
+            AZStd::string_view fileData = "Hello World";
+            fooFileData = fileData;
+            fileSettings.m_relativeFilePath = "foo.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a compressed file this time
+            fileData = "My Prefab Data in an Archive";
+            levelPrefabFileData = fileData;
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "subdirectory/Level.prefab";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        // The fooFileToken ArchiveFileToken instance will be used to validate
+        // the overload of ListFileInArchive which accepts an ArchiveFileToken
+        ArchiveFileToken fooFileToken = InvalidArchiveFileToken;
+        {
+            // Lookup the foo.txt file
+            constexpr AZStd::string_view fooPath = "foo.txt";
+
+            ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(fooPath);
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            // Store of the file token for later lookup
+            fooFileToken = archiveListFileResult.m_filePathToken;
+
+            EXPECT_EQ(fooPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(fooFileData.size(), archiveListFileResult.m_uncompressedSize);
+            // As the file is not compressed, the ArchiveListFileResult compressed member is not check
+
+            // The file is expected to have been written at offset 512-byte and aligned up to the next multiple of 512
+            // which is 1024 since the file is <= 512 bytes in size
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+
+        }
+
+        {
+            // Lookup the subdirectory/level.prefab file
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::Path prefabPathLower = "subdirectory/Level.prefab";
+            AZStd::to_lower(prefabPathLower.Native());
+            ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(prefabPathLower);
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(prefabPathLower, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(CompressionLZ4::GetLZ4CompressionAlgorithmId(), archiveListFileResult.m_compressionAlgorithm);
+            // The file should have been compressed
+            // Just validate that its size > 0
+            EXPECT_GT(archiveListFileResult.m_compressedSize, 0);
+            EXPECT_EQ(levelPrefabFileData.size(), archiveListFileResult.m_uncompressedSize);
+
+            // Since this is the second file written to the archive
+            // the start offset should be at the next 512-byte offset a
+            // which is 1024, as foo.txt was written at offset 512
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment * 2;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+
+        {
+            // This time lookup the foo.txt file using the ArchiveFileToken
+            constexpr AZStd::string_view fooPath = "foo.txt";
+
+            ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(fooFileToken);
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(fooPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(fooFileData.size(), archiveListFileResult.m_uncompressedSize);
+            // As the file is not compressed, the ArchiveListFileResult compressed member is not check
+
+            // The file is expected to have been written at offset 512-byte and aligned up to the next multiple of 512
+            // which is 1024 since the file is <= 512 bytes in size
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+
+        // Finally validate the ContainsFile function succeeds
+        EXPECT_TRUE(archiveReader->ContainsFile("foo.txt"));
+    }
+
+    TEST_F(ArchiveReaderFixture, ListFileInArchive_ForFileNotInArchive_Fails)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view fooFileData;
+
+        {
+            // Create an archive with files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write an uncompressed file with the contents of hello world
+            AZStd::string_view fileData = "Hello World";
+            fooFileData = fileData;
+            fileSettings.m_relativeFilePath = "foo.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        {
+            // Lookup the non-existent/foo.txt
+            constexpr AZStd::string_view nonExistentPath = "non-existent/foo.txt";
+
+            ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(nonExistentPath);
+            EXPECT_FALSE(archiveListFileResult);
+            EXPECT_FALSE(archiveListFileResult.m_resultOutcome.has_value());
+
+            // Also the ContainsFile function should fail as well
+            EXPECT_FALSE(archiveReader->ContainsFile(nonExistentPath));
+        }
+    }
+
+    TEST_F(ArchiveReaderFixture, EnumerateFilesInArchive_Visits_EachFileInTheArchive)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view fooFileData;
+        AZStd::string_view levelPrefabFileData;
+        AZStd::string_view barFileData;
+
+        {
+            // Create an archive with a several files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write an uncompressed file with the contents of hello world
+            AZStd::string_view fileData = "Hello World";
+            fooFileData = fileData;
+            fileSettings.m_relativeFilePath = "foo.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a compressed file this time
+            fileData = "My Prefab Data in an Archive";
+            levelPrefabFileData = fileData;
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "subdirectory/Level.prefab";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a second text file
+            fileData = "Box Box, Box Box";
+            barFileData = fileData;
+            // Don't compress the file this time
+            fileSettings.m_compressionAlgorithm = Compression::Uncompressed;
+            fileSettings.m_relativeFilePath = "subdirectory/bar.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        AZStd::vector<ArchiveListFileResult> filesInArchive;
+        auto GetListResultsForFiles = [&filesInArchive](ArchiveListFileResult listFileResult) -> bool
+        {
+            filesInArchive.emplace_back(AZStd::move(listFileResult));
+            // A return of true causes enumeration to continue
+            return true;
+        };
+        EXPECT_TRUE(archiveReader->EnumerateFilesInArchive(GetListResultsForFiles));
+
+        // The vector should have 3 entries in it
+        ASSERT_EQ(3, filesInArchive.size());
+        size_t fileIndex{};
+        {
+            // Validate the first entry in the vector
+            // Lookup the foo.txt file
+            constexpr AZStd::string_view fooPath = "foo.txt";
+
+            const ArchiveListFileResult archiveListFileResult = filesInArchive[fileIndex++];
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(fooPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(fooFileData.size(), archiveListFileResult.m_uncompressedSize);
+            // As the file is not compressed, the ArchiveListFileResult compressed member is not check
+
+            // The file is expected to have been written at offset 512-byte and aligned up to the next multiple of 512
+            // which is 1024 since the file is <= 512 bytes in size
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+
+        {
+            // Validate the second entry in the vector
+            // Lookup the subdirectory/level.prefab file
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::Path prefabPathLower = "subdirectory/Level.prefab";
+            AZStd::to_lower(prefabPathLower.Native());
+
+            const ArchiveListFileResult archiveListFileResult = filesInArchive[fileIndex++];
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(prefabPathLower, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(CompressionLZ4::GetLZ4CompressionAlgorithmId(), archiveListFileResult.m_compressionAlgorithm);
+            // The file should have been compressed
+            // Just validate that its size > 0
+            EXPECT_GT(archiveListFileResult.m_compressedSize, 0);
+            EXPECT_EQ(levelPrefabFileData.size(), archiveListFileResult.m_uncompressedSize);
+
+            // Since this is the second file written to the archive
+            // the start offset should be at the next 512-byte offset a
+            // which is 1024, as foo.txt was written at offset 512
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment * 2;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+
+        {
+            // Validate the third entry in the vector
+            // Lookup the subdirectory/bar.txt file
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::PathView barPath = "subdirectory/bar.txt";
+
+            const ArchiveListFileResult archiveListFileResult = filesInArchive[fileIndex++];
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(barPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(barFileData.size(), archiveListFileResult.m_uncompressedSize);
+
+            // Since this is the third file written to the archive
+            // and the first two files should have had an uncompressed size
+            // and compressed size that is < 512-bytes
+            // the start offset for bar.txt should be at 512 * 3 = 1536
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment * 3;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+    }
+
+    TEST_F(ArchiveReaderFixture, EnumerateFilesInArchive_CanFilterFiles_Succeeds)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view fooFileData;
+        AZStd::string_view levelPrefabFileData;
+        AZStd::string_view barFileData;
+
+        {
+            // Create an archive with a several files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write an uncompressed file with the contents of hello world
+            AZStd::string_view fileData = "Hello World";
+            fooFileData = fileData;
+            fileSettings.m_relativeFilePath = "foo.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a compressed file this time
+            fileData = "My Prefab Data in an Archive";
+            levelPrefabFileData = fileData;
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "subdirectory/Level.prefab";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a second text file
+            fileData = "Box Box, Box Box";
+            barFileData = fileData;
+            // Don't compress the file this time
+            fileSettings.m_compressionAlgorithm = Compression::Uncompressed;
+            fileSettings.m_relativeFilePath = "subdirectory/bar.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        AZStd::vector<ArchiveListFileResult> filesInArchive;
+        //!!! This time only add .txt files to the list file vector
+        auto FilterListResultsForFiles = [&filesInArchive](ArchiveListFileResult listFileResult) -> bool
+        {
+            if (listFileResult.m_relativeFilePath.Match("*.txt"))
+            {
+                filesInArchive.emplace_back(AZStd::move(listFileResult));
+            }
+            return true;
+        };
+        EXPECT_TRUE(archiveReader->EnumerateFilesInArchive(FilterListResultsForFiles));
+
+        // The vector should have 2 entries in it
+        // as there are only two txt files in it
+        ASSERT_EQ(2, filesInArchive.size());
+        size_t fileIndex{};
+        {
+            // Validate the first entry in the vector
+            // Lookup the foo.txt file
+            constexpr AZStd::string_view fooPath = "foo.txt";
+
+            const ArchiveListFileResult archiveListFileResult = filesInArchive[fileIndex++];
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(fooPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(fooFileData.size(), archiveListFileResult.m_uncompressedSize);
+            // As the file is not compressed, the ArchiveListFileResult compressed member is not check
+
+            // The file is expected to have been written at offset 512-byte and aligned up to the next multiple of 512
+            // which is 1024 since the file is <= 512 bytes in size
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+
+        {
+            // Validate the next entry in the vector
+            // Lookup the subdirectory/bar.txt file
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::PathView barPath = "subdirectory/bar.txt";
+
+            const ArchiveListFileResult archiveListFileResult = filesInArchive[fileIndex++];
+            EXPECT_TRUE(archiveListFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveListFileResult.m_filePathToken);
+            EXPECT_EQ(barPath, archiveListFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveListFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(barFileData.size(), archiveListFileResult.m_uncompressedSize);
+
+            // Since this is the third file written to the archive
+            // and the first two files should have had an uncompressed size
+            // and compressed size that is < 512-bytes
+            // the start offset for bar.txt should be at 512 * 3 = 1536
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment * 3;
+            EXPECT_EQ(expectedFileOffset, archiveListFileResult.m_offset);
+        }
+    }
+
+    TEST_F(ArchiveReaderFixture, ExtractFileFromArchive_ForExistingFile_Succeeds)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view fooFileData;
+        AZStd::string_view levelPrefabFileData;
+        AZStd::string_view barFileData;
+
+        {
+            // Create an archive with a several files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write an uncompressed file with the contents of hello world
+            AZStd::string_view fileData = "Hello World";
+            fooFileData = fileData;
+            fileSettings.m_relativeFilePath = "foo.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a compressed file this time
+            fileData = "My Prefab Data in an Archive";
+            levelPrefabFileData = fileData;
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "subdirectory/Level.prefab";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            // Write a second text file
+            fileData = "Box Box, Box Box";
+            barFileData = fileData;
+            // Don't compress the file this time
+            fileSettings.m_compressionAlgorithm = Compression::Uncompressed;
+            fileSettings.m_relativeFilePath = "subdirectory/bar.txt";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(fileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        {
+            // Extract foo.txt
+            constexpr AZStd::string_view fooPath = "foo.txt";
+
+            // Use ArchiveListFileResult to lookup the file metadata to determine
+            // its uncompressed size
+            const ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(fooPath);
+            ASSERT_TRUE(archiveListFileResult);
+
+            AZStd::vector<AZStd::byte> fileBuffer;
+            // Resize the buffer to exact size needed
+            fileBuffer.resize_no_construct(archiveListFileResult.m_uncompressedSize);
+            // Populate settings structure needed to extract the file
+            ArchiveReaderFileSettings fileSettings;
+            fileSettings.m_filePathIdentifier = fooPath;
+            const ArchiveExtractFileResult archiveExtractFileResult = archiveReader->ExtractFileFromArchive(
+                fileBuffer, fileSettings);
+            ASSERT_TRUE(archiveExtractFileResult);
+
+            EXPECT_NE(InvalidArchiveFileToken, archiveExtractFileResult.m_filePathToken);
+            EXPECT_EQ(fooPath, archiveExtractFileResult.m_relativeFilePath);
+            EXPECT_EQ(Compression::Uncompressed, archiveExtractFileResult.m_compressionAlgorithm);
+            EXPECT_EQ(fooFileData.size(), archiveExtractFileResult.m_uncompressedSize);
+            // As the file is not compressed, the ArchiveListFileResult compressed member is not check
+
+            // The file is expected to have been written at offset 512-byte and aligned up to the next multiple of 512
+            // which is 1024 since the file is <= 512 bytes in size
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveExtractFileResult.m_offset);
+
+            // Now check the file span from the archiveExtractFileResult to get the exact foo data
+            // Reinterpret the byte data in file span as text
+            AZStd::string_view textFileSpan(reinterpret_cast<const char*>(archiveExtractFileResult.m_fileSpan.data()),
+                archiveExtractFileResult.m_fileSpan.size());
+            EXPECT_THAT(textFileSpan, ::testing::ContainerEq(fooFileData));
+        }
+
+        {
+            // Extract subdirectory/Level.prefab
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::Path prefabPathLower = "subdirectory/Level.prefab";
+            AZStd::to_lower(prefabPathLower.Native());
+
+            // Use ArchiveListFileResult to lookup the file metadata to uncompressed size
+            const ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(prefabPathLower);
+            ASSERT_TRUE(archiveListFileResult);
+
+            AZStd::vector<AZStd::byte> fileBuffer;
+            // Resize the buffer to exact size needed
+            fileBuffer.resize_no_construct(archiveListFileResult.m_uncompressedSize);
+            // Populate settings structure needed to extract the file
+            ArchiveReaderFileSettings fileSettings;
+            // Use the file path token this time to extract the file
+            fileSettings.m_filePathIdentifier = archiveListFileResult.m_filePathToken;
+            const ArchiveExtractFileResult archiveExtractFileResult = archiveReader->ExtractFileFromArchive(
+                fileBuffer, fileSettings);
+            ASSERT_TRUE(archiveExtractFileResult);
+
+            EXPECT_NE(InvalidArchiveFileToken, archiveExtractFileResult.m_filePathToken);
+            EXPECT_EQ(prefabPathLower, archiveExtractFileResult.m_relativeFilePath);
+            EXPECT_EQ(CompressionLZ4::GetLZ4CompressionAlgorithmId(), archiveExtractFileResult.m_compressionAlgorithm);
+            // The file should have been compressed
+            // Just validate that its size > 0
+            EXPECT_GT(archiveExtractFileResult.m_compressedSize, 0);
+            EXPECT_EQ(levelPrefabFileData.size(), archiveExtractFileResult.m_uncompressedSize);
+
+            // The subdirectory/level.prefab is the second file within the archive
+            // So it its start offset should be at 1024 since the foo.txt start offset was at 512
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment * 2;
+            EXPECT_EQ(expectedFileOffset, archiveExtractFileResult.m_offset);
+
+            // Now check the file span from the archiveExtractFileResult to get the exact
+            // view of the file data for the level.prefab after running it through decompression
+            AZStd::string_view textFileSpan(reinterpret_cast<const char*>(archiveExtractFileResult.m_fileSpan.data()),
+                archiveExtractFileResult.m_fileSpan.size());
+            EXPECT_THAT(textFileSpan, ::testing::ContainerEq(levelPrefabFileData));
+        }
+    }
+
+    //! This test validates the setting the ArchiveReaderFileSettings::m_decompressFile option to `false`
+    //! will extract the compressed file WITHOUT decompressing it.
+    TEST_F(ArchiveReaderFixture, ExtractFileFromArchive_ExtractionOfFile_ThatSkipsDecompressed_Succeeds)
+    {
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        AZStd::string_view levelPrefabFileData = "My Prefab Data in an Archive";
+        AZStd::vector<AZStd::byte> expectedCompressedFileData;
+        auto compressionRegistrar = Compression::CompressionRegistrar::Get();
+        ASSERT_NE(nullptr, compressionRegistrar);
+        auto lz4Compressor = compressionRegistrar->FindCompressionInterface(CompressionLZ4::GetLZ4CompressionAlgorithmId());
+        ASSERT_NE(nullptr, lz4Compressor);
+
+        // Resize the output buffer to be large enough to contain the compressed data
+        expectedCompressedFileData.resize_no_construct(lz4Compressor->CompressBound(levelPrefabFileData.size()));
+        // Compress the test data into the byte buffer
+        Compression::CompressionResultData compressionResult = lz4Compressor->CompressBlock(expectedCompressedFileData,
+            AZStd::as_bytes(AZStd::span(levelPrefabFileData)));
+        ASSERT_TRUE(compressionResult);
+
+        AZStd::span<AZStd::byte> actualCompressedDataSpan = compressionResult.m_compressedBuffer;
+        {
+            // Create an archive with a several files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Write a compressed file this time
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "subdirectory/Level.prefab";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(AZStd::as_bytes(AZStd::span(levelPrefabFileData)), fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        {
+            // Extract subdirectory/Level.prefab
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::Path prefabPathLower = "subdirectory/Level.prefab";
+            AZStd::to_lower(prefabPathLower.Native());
+
+            // Use ArchiveListFileResult to lookup the file metadata
+            const ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(prefabPathLower);
+            ASSERT_TRUE(archiveListFileResult);
+
+            AZStd::vector<AZStd::byte> fileBuffer;
+            // As the buffer is pointing to compressed data this time
+            // It is resized to be large enough to store the compressed data
+            fileBuffer.resize_no_construct(archiveListFileResult.m_compressedSize);
+            // Populate settings structure needed to extract the file
+            ArchiveReaderFileSettings fileSettings;
+            // Use the file path token this time to extract the file
+            fileSettings.m_filePathIdentifier = archiveListFileResult.m_filePathToken;
+            // Skip Decompression of the file content
+            fileSettings.m_decompressFile = false;
+            const ArchiveExtractFileResult archiveExtractFileResult = archiveReader->ExtractFileFromArchive(
+                fileBuffer, fileSettings);
+            ASSERT_TRUE(archiveExtractFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveExtractFileResult.m_filePathToken);
+            EXPECT_EQ(prefabPathLower, archiveExtractFileResult.m_relativeFilePath);
+            EXPECT_EQ(CompressionLZ4::GetLZ4CompressionAlgorithmId(), archiveExtractFileResult.m_compressionAlgorithm);
+            // The file should have been compressed
+            // Just validate that its size > 0
+            EXPECT_GT(archiveExtractFileResult.m_compressedSize, 0);
+            EXPECT_EQ(levelPrefabFileData.size(), archiveExtractFileResult.m_uncompressedSize);
+
+            // The subdirectory/level.prefab is the only file within the archive
+            // So it its start offset should be at 512
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveExtractFileResult.m_offset);
+
+            // The file span should still be compressed at this point
+            AZStd::span<AZStd::byte> compressedFileSpan = archiveExtractFileResult.m_fileSpan;
+            EXPECT_TRUE(AZStd::ranges::equal(compressedFileSpan, actualCompressedDataSpan));
+        }
+    }
+
+    TEST_F(ArchiveReaderFixture, ExtractFileFromArchive_PartialReadOfCompressedFile_Across3Blocks_Succeeds)
+    {
+        // Verify that the ArchiveReaderFileSettings can read content from a compressed file
+        // where the data is are in different 2 MiB blocks of the file when uncompressed
+        // The format of the data will be as follows
+        // First 2-MiB Block to be compressed:
+        //   (2-MiB - 1) bytes of '\0'
+        //   1 byte of 'H'
+        // Second 2-MiB Block to be compressed:
+        //   10 bytes that are 'e', 'l', 'l' 'o', ' ', 'W', 'o', 'r', 'l', 'd'
+        //   (2-MiB - 10) byte of '\0'
+        // Final 2-MiB Block to be compressed (partial:
+        //   1 byte 'A'
+        //   7 bytes of "rchive"
+        //
+        // The test will attempt to start reading at offset (2MiB -1)
+        // and will attempt to read (2 MiB + 2) bytes
+        // This should result internally in 3 compressed blocks being read
+        // and decompressed
+        // What should be returned is the value of
+        // "Hello World" + (2-MiB - 10) of '\0' + 'A'
+        //
+
+        // This will store to the expected uncompressed that is being tested
+        constexpr AZStd::string_view firstBlockEnd = "H";
+        constexpr AZStd::string_view secondBlockBegin = "ello World";
+        constexpr AZStd::string_view finalBlockBegin = "Archive";
+        AZStd::vector<AZStd::byte> expectedResultData;
+        // The total size should be (2 MiB + 2)
+        constexpr size_t PartialReadSize = firstBlockEnd.size() + ArchiveBlockSizeForCompression + 1;
+        static_assert(PartialReadSize == 2_mib + 2);
+
+        expectedResultData.reserve(PartialReadSize);
+
+        auto expectedDataBackInserter = AZStd::back_inserter(expectedResultData);
+        AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(firstBlockEnd)), expectedDataBackInserter);
+        AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(secondBlockBegin)), expectedDataBackInserter);
+        AZStd::fill_n(expectedDataBackInserter, ArchiveBlockSizeForCompression - secondBlockBegin.size(), AZStd::byte{});
+        // Only copy the first character from the final block
+        AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(finalBlockBegin)).first(1), expectedDataBackInserter);
+        ASSERT_EQ(PartialReadSize, expectedResultData.size());
+
+        AZStd::vector<AZStd::byte> archiveBuffer;
+        AZ::IO::ByteContainerStream archiveStream(&archiveBuffer);
+
+        {
+            // Create an archive with a several files in it
+            IArchiveWriter::ArchiveStreamPtr archiveWriterStreamPtr(&archiveStream, { false });
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveWriterStreamPtr));
+
+            ArchiveWriterFileSettings fileSettings;
+
+            // Generate the data for the file to compressed
+            AZStd::vector<AZStd::byte> fileBuffer;
+            // The file should be 4-MiB + the the size of the string "Archive"
+            constexpr size_t FileSize = ArchiveBlockSizeForCompression * 2 + finalBlockBegin.size();
+            fileBuffer.reserve(FileSize);
+            auto fileBufferBackInserter = AZStd::back_inserter(fileBuffer);
+
+            // Generate the data for the first block
+            AZStd::fill_n(fileBufferBackInserter, ArchiveBlockSizeForCompression - firstBlockEnd.size(), AZStd::byte{});
+            AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(firstBlockEnd)), fileBufferBackInserter);
+            // Generate the data for the second block
+            AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(secondBlockBegin)), fileBufferBackInserter);
+            AZStd::fill_n(fileBufferBackInserter, ArchiveBlockSizeForCompression - secondBlockBegin.size(), AZStd::byte{});
+            // Generate the data for the final block
+            AZStd::ranges::copy(AZStd::as_bytes(AZStd::span(finalBlockBegin)), fileBufferBackInserter);
+            ASSERT_EQ(FileSize, fileBuffer.size());
+
+            fileSettings.m_compressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
+            fileSettings.m_relativeFilePath = "MultiblockCompressed.bin";
+            EXPECT_TRUE(archiveWriter->AddFileToArchive(fileBuffer, fileSettings));
+
+            IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
+            ASSERT_TRUE(commitResult);
+        }
+
+        // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
+        IArchiveReader::ArchiveStreamPtr archiveReaderStreamPtr(&archiveStream, { false });
+        AZStd::unique_ptr<IArchiveReader> archiveReader = CreateArchiveReader(AZStd::move(archiveReaderStreamPtr));
+
+        // No error should occur and the archive should have been successfully mounted
+        EXPECT_TRUE(archiveReader->IsMounted());
+
+        {
+            // Extract subdirectory/Level.prefab
+
+            // The default ArchiveWriterFileSettings used in this test lowercases the files paths that were added
+            // So before looking up the Level.prefab in the "subdirectory" directory, lowercase the path
+            AZ::IO::Path filePathLower = "MultiblockCompressed.bin";
+            AZStd::to_lower(filePathLower.Native());
+
+            // Use ArchiveListFileResult to lookup the file metadata
+            const ArchiveListFileResult archiveListFileResult = archiveReader->ListFileInArchive(filePathLower);
+            ASSERT_TRUE(archiveListFileResult);
+
+            AZStd::vector<AZStd::byte> fileBuffer;
+            fileBuffer.resize_no_construct(archiveListFileResult.m_uncompressedSize);
+            // Populate settings structure needed to extract the file
+            ArchiveReaderFileSettings fileSettings;
+            // Use the file path token this time to extract the file
+            fileSettings.m_filePathIdentifier = archiveListFileResult.m_filePathToken;
+            // Set the start offset to start reading from the byte of the first block
+            fileSettings.m_startOffset = ArchiveBlockSizeForCompression - 1;
+            // Read 2-Mib + 2 to read the final byte of the first block, the entire second block
+            // and the first byte from the final block
+            fileSettings.m_bytesToRead = ArchiveBlockSizeForCompression + 2;
+
+            const ArchiveExtractFileResult archiveExtractFileResult = archiveReader->ExtractFileFromArchive(
+                fileBuffer, fileSettings);
+            ASSERT_TRUE(archiveExtractFileResult);
+            EXPECT_NE(InvalidArchiveFileToken, archiveExtractFileResult.m_filePathToken);
+            EXPECT_EQ(filePathLower, archiveExtractFileResult.m_relativeFilePath);
+            EXPECT_EQ(CompressionLZ4::GetLZ4CompressionAlgorithmId(), archiveExtractFileResult.m_compressionAlgorithm);
+            // The file should have been compressed
+            // Just validate that its size > 0
+            EXPECT_GT(archiveExtractFileResult.m_compressedSize, 0);
+            EXPECT_EQ(fileBuffer.size(), archiveExtractFileResult.m_uncompressedSize);
+
+            // Since this is the only file within the achive it should start at offset 512
+            AZ::u64 expectedFileOffset = ArchiveDefaultBlockAlignment;
+            EXPECT_EQ(expectedFileOffset, archiveExtractFileResult.m_offset);
+
+            // The file span should only view the 2-MiB + 2 sequence within the uncompressed file
+            // that buffer
+            AZStd::span<AZStd::byte> requestedFileData = archiveExtractFileResult.m_fileSpan;
+            EXPECT_TRUE(AZStd::ranges::equal(requestedFileData, expectedResultData));
+        }
+    }
+}

--- a/Gems/Archive/Code/Tests/Tools/ArchiveWriterTest.cpp
+++ b/Gems/Archive/Code/Tests/Tools/ArchiveWriterTest.cpp
@@ -15,6 +15,9 @@
 
 #include <Compression/CompressionLZ4API.h>
 
+// Archive Gem private implementation includes
+#include <Tools/ArchiveWriterFactory.h>
+
 namespace Archive::Test
 {
     // The ArchiveEditorTestEnvironment is tracking memory
@@ -24,10 +27,20 @@ namespace Archive::Test
         : public ::testing::Test
     {
     public:
-        ArchiveWriterFixture() = default;
-        ~ArchiveWriterFixture() = default;
+        ArchiveWriterFixture()
+        {
+            m_archiveWriterFactory = AZStd::make_unique<ArchiveWriterFactory>();
+            AZ::Interface<IArchiveWriterFactory>::Register(m_archiveWriterFactory.get());
+        }
+        ~ArchiveWriterFixture()
+        {
+            AZ::Interface<IArchiveWriterFactory>::Unregister(m_archiveWriterFactory.get());
+        }
 
     protected:
+        // Create and register Archive Writer factory
+        // to allow IArchiveWriter instances to be created
+        AZStd::unique_ptr<IArchiveWriterFactory> m_archiveWriterFactory;
     };
 
     // Helper function for converting a string view to a byte span
@@ -41,12 +54,16 @@ namespace Archive::Test
     TEST_F(ArchiveWriterFixture, CreateArchiveWriter_Succeeds)
     {
         {
-            auto archiveWriter = CreateArchiveWriter();
+            auto createArchiveWriterResult = CreateArchiveWriter();
+            ASSERT_TRUE(createArchiveWriterResult);
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
             ASSERT_NE(nullptr, archiveWriter);
         }
 
         {
-            auto archiveWriter = CreateArchiveWriter(ArchiveWriterSettings{});
+            auto createArchiveWriterResult = CreateArchiveWriter(ArchiveWriterSettings{});
+            ASSERT_TRUE(createArchiveWriterResult);
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
             ASSERT_NE(nullptr, archiveWriter);
         }
     }
@@ -58,7 +75,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
         ASSERT_TRUE(commitResult);
@@ -79,7 +98,9 @@ namespace Archive::Test
         {
             // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
             IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+            auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+            ASSERT_TRUE(createArchiveWriterResult);
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
             IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
             ASSERT_TRUE(commitResult);
@@ -98,7 +119,9 @@ namespace Archive::Test
         {
             // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
             IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-            AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+            auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+            ASSERT_TRUE(createArchiveWriterResult);
+            AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
             // Recommit the existing archive with no changes
             IArchiveWriter::CommitResult commitResult = archiveWriter->Commit();
@@ -120,7 +143,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Add an uncompressed file to the Archive
         AZStd::string_view fileContent = "Hello World";
@@ -174,7 +199,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Add an uncompressed file to the Archive
         AZStd::string_view fileContent = "Hello World";
@@ -235,7 +262,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         AZStd::array<ArchiveAddFileResult, 2> addedFileResults;
 
@@ -324,7 +353,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         EXPECT_TRUE(archiveWriter->IsMounted());
 
@@ -434,7 +465,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         AZStd::array<ArchiveAddFileResult, 2> addedFileResults;
 
@@ -676,7 +709,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Add an compressed file to archive
         AZStd::string_view fileContent = "Hello World";
@@ -767,7 +802,9 @@ namespace Archive::Test
 
         // Set the ArchiveStreamDeleter to not delete the stack ByteContainerStream
         IArchiveWriter::ArchiveStreamPtr archiveStreamPtr(&archiveStream, { false });
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Add a compressed file to archive
         ArchiveWriterFileSettings fileSettings;
@@ -816,8 +853,10 @@ namespace Archive::Test
 
         ArchiveWriterSettings writerSettings;
         writerSettings.m_tocCompressionAlgorithm = CompressionLZ4::GetLZ4CompressionAlgorithmId();
-        AZStd::unique_ptr<IArchiveWriter> archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr),
+        auto createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr),
             writerSettings);
+        ASSERT_TRUE(createArchiveWriterResult);
+        AZStd::unique_ptr<IArchiveWriter> archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Add an compressed file to archive
         AZStd::string_view fileContent = "Hello World";
@@ -865,7 +904,9 @@ namespace Archive::Test
         archiveWriter.reset();
 
         archiveStreamPtr.reset(&archiveStream);
-        archiveWriter = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        createArchiveWriterResult = CreateArchiveWriter(AZStd::move(archiveStreamPtr));
+        ASSERT_TRUE(createArchiveWriterResult);
+        archiveWriter = AZStd::move(createArchiveWriterResult.value());
 
         // Validate the Table of Contents by updating an existing file
         fileSettings.m_fileMode = ArchiveWriterFileMode::AddNewOrUpdateExisting;

--- a/Gems/Archive/Code/archive_api_files.cmake
+++ b/Gems/Archive/Code/archive_api_files.cmake
@@ -10,4 +10,6 @@ set(FILES
     Include/Archive/Clients/ArchiveBaseAPI.h
     Include/Archive/Clients/ArchiveInterfaceStructs.h
     Include/Archive/Clients/ArchiveInterfaceStructs.inl
+    Include/Archive/Clients/ArchiveReaderAPI.h
+    Include/Archive/Clients/ArchiveReaderAPI.inl
 )

--- a/Gems/Archive/Code/archive_editor_private_files.cmake
+++ b/Gems/Archive/Code/archive_editor_private_files.cmake
@@ -9,4 +9,6 @@ set(FILES
     Source/Tools/ArchiveEditorSystemComponent.h
     Source/Tools/ArchiveWriter.cpp
     Source/Tools/ArchiveWriter.h
+    Source/Tools/ArchiveWriterFactory.cpp
+    Source/Tools/ArchiveWriterFactory.h
 )

--- a/Gems/Archive/Code/archive_editor_tests_files.cmake
+++ b/Gems/Archive/Code/archive_editor_tests_files.cmake
@@ -6,5 +6,6 @@
 
 set(FILES
     Tests/Tools/ArchiveEditorTest.cpp
+    Tests/Tools/ArchiveReaderTest.cpp
     Tests/Tools/ArchiveWriterTest.cpp
 )

--- a/Gems/Archive/Code/archive_private_files.cmake
+++ b/Gems/Archive/Code/archive_private_files.cmake
@@ -9,6 +9,8 @@ set(FILES
     Source/ArchiveModuleInterface.h
     Source/Clients/ArchiveReader.cpp
     Source/Clients/ArchiveReader.h
+    Source/Clients/ArchiveReaderFactory.cpp
+    Source/Clients/ArchiveReaderFactory.h
     Source/Clients/ArchiveSystemComponent.cpp
     Source/Clients/ArchiveSystemComponent.h
     Source/Clients/ArchiveTOC.h

--- a/Gems/Archive/Code/archive_private_files.cmake
+++ b/Gems/Archive/Code/archive_private_files.cmake
@@ -7,6 +7,8 @@
 set(FILES
     Source/ArchiveModuleInterface.cpp
     Source/ArchiveModuleInterface.h
+    Source/Clients/ArchiveReader.cpp
+    Source/Clients/ArchiveReader.h
     Source/Clients/ArchiveSystemComponent.cpp
     Source/Clients/ArchiveSystemComponent.h
     Source/Clients/ArchiveTOC.h

--- a/Gems/Compression/Code/Include/Compression/CompressionInterfaceAPI.h
+++ b/Gems/Compression/Code/Include/Compression/CompressionInterfaceAPI.h
@@ -75,6 +75,9 @@ namespace Compression
 
         //! Retrieves the 32-bit compression algorithm ID associated with this interface
         virtual CompressionAlgorithmId GetCompressionAlgorithmId() const = 0;
+        //! Human readable name associated with the compression algorithm
+        virtual AZStd::string_view GetCompressionAlgorithmName() const = 0;
+
         //! Compresses the uncompressed data into the compressed buffer
         //! @param compressedBuffer destination buffer where compressed output will be stored to
         //! @param uncompressedData source buffer containing uncompressed content
@@ -134,6 +137,14 @@ namespace Compression
         //! @param compressionAlgorithmId unique Id of compression interface to query
         //! @return pointer to the compression interface or nullptr if not found
         [[nodiscard]] virtual ICompressionInterface* FindCompressionInterface(CompressionAlgorithmId compressionAlgorithmId) const = 0;
+        //! Queries the compression interface using the name of the compression algorithm
+        //! This is slower than the using the compression algorithm ID.
+        //! Furthermore the algorithm name doesn't have to be unique,
+        //! so this will return the first compression interface associated with the algorithm name
+        //! @param algorithmName Name of the compression algorithm.
+        //! NOTE: The compression algorithm name is not checked for uniqueness, unlike the algorithm id
+        //! @return pointer to the compression interface or nullptr if not found
+        [[nodiscard]] virtual ICompressionInterface* FindCompressionInterface(AZStd::string_view algorithmName) const = 0;
 
 
         //! Return true if there is an compression interface registered with the specified id

--- a/Gems/Compression/Code/Include/Compression/CompressionLZ4API.h
+++ b/Gems/Compression/Code/Include/Compression/CompressionLZ4API.h
@@ -22,9 +22,15 @@ namespace CompressionLZ4
     //! @return LZ4 Compression AlgorithmId
     constexpr Compression::CompressionAlgorithmId GetLZ4CompressionAlgorithmId();
 
+    //! Human readable name associated with the compression algorithm
+    constexpr AZStd::string_view GetLZ4CompressionAlgorithmName()
+    {
+        return "LZ4";
+    }
+
     constexpr Compression::CompressionAlgorithmId GetLZ4CompressionAlgorithmId()
     {
-        constexpr Compression::CompressionAlgorithmId AlgorithmId{ AZ::u32(AZStd::hash<AZStd::string_view>{}("LZ4")) };
+        constexpr Compression::CompressionAlgorithmId AlgorithmId{ AZ::u32(AZStd::hash<AZStd::string_view>{}(GetLZ4CompressionAlgorithmName())) };
         return AlgorithmId;
     }
 } // namespace CompressionLZ4

--- a/Gems/Compression/Code/Include/Compression/DecompressionInterfaceAPI.h
+++ b/Gems/Compression/Code/Include/Compression/DecompressionInterfaceAPI.h
@@ -76,6 +76,8 @@ namespace Compression
 
         //! Retrieves the 32-bit compression algorithm ID associated with this interface
         virtual CompressionAlgorithmId GetCompressionAlgorithmId() const = 0;
+        //! Human readable name associated with the compression algorithm
+        virtual AZStd::string_view GetCompressionAlgorithmName() const = 0;
 
         //! Decompresses the input compressed data into the uncompressed buffer
         //! Both parameters are specified as spans which encapsulates the contiguous buffer and it's size.
@@ -132,6 +134,14 @@ namespace Compression
         //! @param compressionAlgorithmId unique Id of decompression interface to query
         //! @return pointer to the decompression interface or nullptr if not found
         [[nodiscard]] virtual IDecompressionInterface* FindDecompressionInterface(CompressionAlgorithmId compressionAlgorithmId) const = 0;
+        //! Queries the decompression interface using the name of the compression algorithm
+        //! This is slower than the using the compression algorithm ID.
+        //! Furthermore the algorithm name doesn't have to be unique,
+        //! so this will return the first compression interface associated with the algorithm name
+        //! @param algorithmName Name of the compression algorithm.
+        //! NOTE: The compression algorithm name is not checked for uniqueness, unlike the algorithm id
+        //! @return pointer to the decompression interface or nullptr if not found
+        [[nodiscard]] virtual IDecompressionInterface* FindDecompressionInterface(AZStd::string_view algorithmName) const = 0;
 
 
         //! Return true if there is an decompression interface registered with the specified id

--- a/Gems/Compression/Code/Source/Clients/DecompressionRegistrarImpl.h
+++ b/Gems/Compression/Code/Source/Clients/DecompressionRegistrarImpl.h
@@ -38,6 +38,7 @@ namespace Compression
         bool UnregisterDecompressionInterface(CompressionAlgorithmId algorithmId) override;
 
         [[nodiscard]] IDecompressionInterface* FindDecompressionInterface(CompressionAlgorithmId algorithmId) const override;
+        [[nodiscard]] IDecompressionInterface* FindDecompressionInterface(AZStd::string_view algorithmName) const override;
 
         [[nodiscard]] bool IsRegistered(CompressionAlgorithmId algorithmId) const override;
 

--- a/Gems/Compression/Code/Source/Clients/DecompressorLZ4Impl.cpp
+++ b/Gems/Compression/Code/Source/Clients/DecompressorLZ4Impl.cpp
@@ -22,6 +22,11 @@ namespace CompressionLZ4
         return GetLZ4CompressionAlgorithmId();
     }
 
+    AZStd::string_view DecompressorLZ4::GetCompressionAlgorithmName() const
+    {
+        return GetLZ4CompressionAlgorithmName();
+    }
+
     Compression::DecompressionResultData DecompressorLZ4::DecompressBlock(
         AZStd::span<AZStd::byte> decompressionBuffer, const AZStd::span<const AZStd::byte>& compressedData,
         [[maybe_unused]] const Compression::DecompressionOptions& decompressionOptions) const
@@ -47,7 +52,7 @@ namespace CompressionLZ4
         {
             // LZ4_compress_HC returns a zero value for corrupt data and insufficient buffer
             resultData.m_decompressionOutcome.m_resultString += Compression::DecompressionResultString::format(
-                "LZ4_decompress_safe call has failed. Either the decompression buffer cannot fit all decompressed content"
+                "LZ4_decompress_safe call has failed. Either the decompression buffer cannot fit all decompressed content "
                 "or the source stream is malformed. Dest buffer capacity: %zu, source stream size: %zu",
                 decompressionBuffer.size(), compressedData.size());
             resultData.m_decompressionOutcome.m_result = Compression::DecompressionResult::Failed;

--- a/Gems/Compression/Code/Source/Clients/DecompressorLZ4Impl.h
+++ b/Gems/Compression/Code/Source/Clients/DecompressorLZ4Impl.h
@@ -20,6 +20,8 @@ namespace CompressionLZ4
         DecompressorLZ4();
         //! Retrieves the 32-bit compression algorithm ID associated with this interface
         Compression::CompressionAlgorithmId GetCompressionAlgorithmId() const override;
+        //! Retrieves the human readable associated with the LZ4 compressor
+        AZStd::string_view GetCompressionAlgorithmName() const override;
         //! Compresses the uncompressed data into the compressed buffer
         //! @return a CompressionResultData instance to indicate if compression operation has succeeded
         [[nodiscard]] Compression::DecompressionResultData DecompressBlock(

--- a/Gems/Compression/Code/Source/Tools/CompressionRegistrarImpl.h
+++ b/Gems/Compression/Code/Source/Tools/CompressionRegistrarImpl.h
@@ -38,6 +38,7 @@ namespace Compression
         bool UnregisterCompressionInterface(CompressionAlgorithmId algorithmId) override;
 
         [[nodiscard]] ICompressionInterface* FindCompressionInterface(CompressionAlgorithmId algorithmId) const override;
+        [[nodiscard]] ICompressionInterface* FindCompressionInterface(AZStd::string_view algorithmName) const override;
 
         [[nodiscard]] bool IsRegistered(CompressionAlgorithmId algorithmId) const override;
 

--- a/Gems/Compression/Code/Source/Tools/CompressorLZ4Impl.cpp
+++ b/Gems/Compression/Code/Source/Tools/CompressorLZ4Impl.cpp
@@ -22,6 +22,11 @@ namespace CompressionLZ4
         return GetLZ4CompressionAlgorithmId();
     }
 
+    AZStd::string_view CompressorLZ4::GetCompressionAlgorithmName() const
+    {
+        return GetLZ4CompressionAlgorithmName();
+    }
+
     [[nodiscard]] size_t CompressorLZ4::CompressBound([[maybe_unused]] size_t uncompressedBufferSize) const
     {
         return LZ4_compressBound(static_cast<int>(uncompressedBufferSize));

--- a/Gems/Compression/Code/Source/Tools/CompressorLZ4Impl.h
+++ b/Gems/Compression/Code/Source/Tools/CompressorLZ4Impl.h
@@ -20,6 +20,8 @@ namespace CompressionLZ4
         CompressorLZ4();
         //! Retrieves the 32-bit compression algorithm ID associated with this interface
         Compression::CompressionAlgorithmId GetCompressionAlgorithmId() const override;
+        //! Retrieves the human readable associated with the LZ4 compressor
+        AZStd::string_view GetCompressionAlgorithmName() const override;
         //! Compresses the uncompressed data into the compressed buffer
         //! @return a CompressionResultData instance to indicate if compression operation has succeeded
         [[nodiscard]] Compression::CompressionResultData CompressBlock(

--- a/Gems/Compression/Code/Tests/Clients/CompressionTest.cpp
+++ b/Gems/Compression/Code/Tests/Clients/CompressionTest.cpp
@@ -33,6 +33,12 @@ namespace CompressionTest
         {
             return GetTestCompressionAlgorithmId();
         }
+
+        AZStd::string_view GetCompressionAlgorithmName() const override
+        {
+            return "TestCompressor";
+        }
+
         //! Compresses the uncompressed data into the compressed buffer
         //! @return a CompressionResultData instance to indicate if compression operation has succeeded
         [[nodiscard]] Compression::DecompressionResultData DecompressBlock(

--- a/Gems/Compression/Code/Tests/Tools/CompressionEditorTest.cpp
+++ b/Gems/Compression/Code/Tests/Tools/CompressionEditorTest.cpp
@@ -33,6 +33,12 @@ namespace CompressionTest
         {
             return GetTestCompressionAlgorithmId();
         }
+
+        AZStd::string_view GetCompressionAlgorithmName() const override
+        {
+            return "TestCompressor";
+        }
+
         //! Compresses the uncompressed data into the compressed buffer
         //! @return a CompressionResultData instance to indicate if compression operation has succeeded
         [[nodiscard]] Compression::CompressionResultData CompressBlock(


### PR DESCRIPTION
### Archive Gem changes
Adding complete implementation of the new Archive ArchiveReader API

This pairs with the implementation of the ArchiveWriter API and
therefore can be used to write and O3AR archive files.

The Archive Reader supports the following operations

1. `ListFileInArchive` - This function can query a file within an
   archive by file path or file token which was queried previously from
   a ListFileInArchive call
1. `ExtractFileFromArchive` - This function can extract file from the
   archive using either the relative file path of the contained file or
   the file token queried from a call to `ListFileInArchive`
   The file is extracted to a user provided allocated buffer via an
   `AZStd::span<AZStd::byte>` paramter
1. `EnumerateFilesInArchive` - This functions enumerates all non-deleted files within the archive and invokes a user provided callback with the ArchiveListFileResult structure for each file. The `ArchiveListFileResult` structure is the same type returned by `ListFileInArchive`

#### Archive Factory addition

Added an Archive Reader and Writer Factory implementation

The Archive Reader Factory allows IArchiveReader instances to be created
by external Client gem modules by depending on the Archive.Clients.API target

The Archive Writer Factory allows IArchiveWriter instances to be created
by external Tool gem modules by depending on the Archive.Tools.API
target.

This other Gems such as the AssetValidation or some other library such as the AssetBundler to create Archive class instances needed to interact with the API

### Compression Gem changes
Adding a new interface function of `GetCompressionAlgorithmName` to the ICompressionInterface/IDecompressionInterface interfaces.
Overriding this function can used to provide a human readable name associated with the Compression algorithm

The plan for this change is to make it easier for a future CLI to allow uses to specify the compression algorithm to use when adding files to an archive.

## How was this PR tested?

Added UnitTest for the ArchiveReader functionality to the Archive.Editor.Tests module
Validated the existing ArchiveWriter test still passes.