### PR TITLE
Add edit-repo-properties CLI function and unit test

### DIFF
--- a/scripts/o3de.py
+++ b/scripts/o3de.py
@@ -35,7 +35,7 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     from o3de import engine_properties, engine_template, gem_properties, \
         global_project, register, print_registration, get_registration, \
         enable_gem, disable_gem, project_properties, sha256, download, \
-        export_project, repo
+        export_project, repo, repo_properties
     # Remove the temporarily added path
     sys.path = sys.path[1:]
 
@@ -81,6 +81,8 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     # repo
     repo.add_args(subparsers)
 
+    # modify remote repo
+    repo_properties.add_args(subparsers)
 
 if __name__ == "__main__":
     # parse the command line args

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -94,7 +94,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
     zip_path = releases_path / archive_filename
     # check if a object.zip folder already exist in the path - ask user if they want to overwrite the current zip
     if not force and zip_path.exists():
-        logger.error(f'{zip_path} already exists.  Use the --force to overwrite the existing zip or '
+        logger.error(f'{zip_path} already exists.  Use --force command to overwrite the existing zip or '
                      'provide a new location to save your archive.')
         return 1
     else:

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -257,7 +257,6 @@ def _edit_objects(object_typename:str,
                             del repo_objects_data[index]              
 
     repo_json[f'{object_typename}s_data'] = repo_objects_data
-     #if older version is removed, merged the items thats changed in the newer version if newer version exist and update version
 
 def edit_repo_props(repo_path: pathlib.Path = None,
                        repo_name: str = None,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -348,7 +348,7 @@ def add_parser_args(parser):
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--repo-path', '-rp', type=pathlib.Path, required=False,
                        help='The local path to the remote repository.')
-    group = parser.add_argument_group('properties', 'arguments for modifying individual project properties.')
+    group = parser.add_argument_group('properties', 'arguments for modifying individual remote repo properties.')
     group.add_argument('--repo-name','-rn',  type=str, required=False,
                        help='The name of the remote repository.')
     group = parser.add_mutually_exclusive_group(required=False)

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -1,0 +1,386 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+"""
+This file contains all the code that has to do with editing the remote repo template
+"""
+import argparse
+import pathlib
+import sys
+import json
+import logging
+import hashlib
+import shutil
+
+from o3de import manifest, utils, validation
+
+logger = logging.getLogger('o3de.repo_properties')
+logging.basicConfig(format=utils.LOG_FORMAT)
+
+
+def merge_json_data(json_path: pathlib.Path, json_data: dict) -> dict:
+    """
+    Merges the json data with the existing json data if it exists.
+    If the json data does not exist, it is created.
+    The json data is saved to the json path.
+    Returns the merged json data.
+    
+    Args:
+        json_path (pathlib.Path): The path to the json file.
+        json_data (dict): The json data to merge with the existing json data.
+    
+    Returns:
+        dict: The merged json data.
+    
+    Raises:
+        FileNotFoundError: If the json path does not exist.
+        ValueError: If the json data is not a dict.
+    """
+    merged_json_data = {}
+    if json_path.exists():
+        existing_json_data = {}
+        with open(json_path, 'r') as f:
+            existing_json_data = json.load(f)
+
+        merged_json_data = existing_json_data | json_data
+
+        if not 'version' in merged_json_data:
+            merged_json_data['version'] = '1.0.0'
+
+        with open(json_path, 'w') as f:
+            f.write(json.dumps(merged_json_data, indent=4) + '\n')
+
+    return merged_json_data
+
+def create_release(src_data_path: pathlib.Path, 
+                   json_data_path: pathlib.Path, 
+                   archive_filename: pathlib.PurePath, 
+                   releases_path: pathlib.Path, 
+                   repo_uri:str,
+                   download_prefix:str) -> dict:
+    """
+    Creates a release for the given src_data_path.
+    The release is saved to the releases_path.
+    Returns the json data.
+    
+    Args:
+        src_data_path (pathlib.Path): The path to the src root folder.
+        json_data_path (pathlib.Path): The path to the json data.
+        name (str): The object name.
+        releases_path (pathlib.Path): The path where the release archive should be output.
+        repo_uri (str): The uri of the repo.
+        download_prefix (str): The prefix of the download uri.
+    
+    Returns:
+        dict: The json data.
+    
+    Raises:
+        FileNotFoundError: If the src_data_path does not exist.
+        FileNotFoundError: If the json_data_path does not exist.
+        ValueError: If the json_data_path is not a dict.
+    """
+    #basename = f'{object_name}_release_1.0.0'
+    #zip_filename = f'{archive_filename}.zip'
+    basename = archive_filename.stem
+    zip_filename = archive_filename
+
+    json_data = merge_json_data(json_data_path, {
+        'repo_uri':repo_uri,
+        'download_source_uri':f'{download_prefix}/{zip_filename}',
+    })
+
+    logging.info(f"Creating '{releases_path / zip_filename}'")
+
+    # create the release zip file
+    shutil.make_archive(releases_path / basename, 'zip', src_data_path)
+
+    zip_path = releases_path / zip_filename
+
+    with zip_path.open('rb') as f:
+        json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
+
+    return json_data
+
+# retrieves json data of the repository from a file path
+def get_repo_props(path: pathlib.Path) -> dict:
+    repo_json = manifest.get_json_data_file(path, "Repo", validation.valid_o3de_repo_json)
+    if not isinstance(repo_json, dict):
+        logger.error(f'Could not retrieve repo.json file for {path}')
+        return None
+    return repo_json
+
+
+def _find_index(data:list, key:str, value:str) -> int:
+    for index, item in enumerate(data):
+        if item.get(key) == value:
+            return index
+    return -1
+
+def _changed(original:dict, new:dict) -> dict:
+    changed = {}
+    for key, value in new.items():
+        if key not in original:
+            changed[key] = value
+        elif original[key] != value:
+            changed[key] = value
+
+    return changed
+
+def _edit_objects(object_typename:str,
+                  validator:callable,
+                  repo_json: dict,
+                  add_objects: pathlib.Path or list = None,
+                  delete_objects: str or list = None,
+                  replace_objects: pathlib.Path or list = None,
+                  release_archive_path: pathlib.Path = None,
+                  download_prefix: str = None):
+    # The beginning remote repo json template
+    repo_objects_data = repo_json.get(f'{object_typename}s_data',[])
+
+    if add_objects:
+        # path to the gem you are adding to repo.json remote repo 
+        paths = add_objects.split() if isinstance(add_objects, str) else add_objects
+
+        for object_path in paths:
+            # gem data of the gem you want to add
+            json_data = manifest.get_json_data(object_typename, object_path, validator)
+            if json_data:
+                if release_archive_path:
+                    version = json_data.get('version','0.0.0')
+                    archive_filename = pathlib.PurePath(f"{json_data[f'{object_typename}_name']}-{version}-{object_typename}.zip".lower())
+                    json_data = create_release(object_path, 
+                                   object_path / f'{object_typename}.json', 
+                                   archive_filename, 
+                                   release_archive_path, 
+                                   repo_json['repo_uri'], 
+                                   download_prefix)
+                index = _find_index(repo_objects_data, f'{object_typename}_name', json_data[f'{object_typename}_name'])
+                # if the added gem is same with partial changes
+                if index != -1:
+                    # we want changes only
+                    version_data = _changed(repo_objects_data[index], json_data)
+                    if not version_data:
+                        # there is no difference between the gem being added and 
+                        # what already exists in gems_data
+                        continue
+
+                    # versions data must always include the version
+                    version_data['version'] = json_data['version']
+
+                    # versions data must always include one of the download/source uris
+                    if 'download_source_uri' in json_data:
+                        version_data['download_source_uri'] = json_data['download_source_uri']
+                    if 'source_control_uri' in json_data:
+                        version_data['source_control_uri'] = json_data['source_control_uri']
+                    if 'source_control_ref' in json_data:
+                        version_data['source_control_ref'] = json_data['source_control_ref']
+
+                    version_index = _find_index(repo_objects_data[index].get('versions_data',[]), 'version', json_data['version'])
+                    if version_index != -1:
+                        # update the existing version
+                        if version_data:
+                            repo_objects_data[index]['versions_data'][version_index] = version_data
+                    else:
+                        # add the new version
+                        if 'versions_data' not in repo_objects_data[index]:
+                            repo_objects_data[index]['versions_data'] = [version_data] 
+                        else:
+                            repo_objects_data[index]['versions_data'].append(version_data) 
+                else:
+                    repo_objects_data.append(json_data)
+
+    # Remove duplicates from list 
+    if delete_objects:      
+        # Convert delete_objects to individual string if multiple items received
+        removal_list = delete_objects.split() if isinstance(delete_objects, str) else delete_objects
+        # find name field of object you want to delete
+        object_key = str(f'{object_typename}_name')
+        # Iterate over removal_lists received
+        for removal_object in removal_list:
+            # Remove the JSON object(s) with the specified object_name value
+            repo_objects_data = [object_typename for object_typename in repo_objects_data if object_typename.get(object_key) != removal_object]
+
+    
+    # Replace 
+    if replace_objects:
+        paths = replace_objects.split() if isinstance(replace_objects, str) else replace_objects
+        for object_path in paths:
+            # clear suggect object field
+            repo_objects_data = []
+            # add gems back to cleared object field
+            json_data = manifest.get_json_data(object_typename, object_path, validator)
+
+            if json_data:
+                if release_archive_path:
+                    version = json_data.get('version','0.0.0')
+                    archive_filename = pathlib.PurePath(f"{json_data[f'{object_typename}_name']}-{version}-{object_typename}.zip".lower())
+                    json_data = create_release(object_path, 
+                                   object_path / f'{object_typename}.json', 
+                                   archive_filename, 
+                                   release_archive_path, 
+                                   repo_json['repo_uri'], 
+                                   download_prefix)
+                index = _find_index(repo_objects_data, f'{object_typename}_name', json_data[f'{object_typename}_name'])
+                # if the added gem is same with partial changes
+                if index != -1:
+                    # we want changes only
+                    version_data = _changed(repo_objects_data[index], json_data)
+                    if not version_data:
+                        # there is no difference between the gem being added and 
+                        # what already exists in gems_data
+                        continue
+
+                    # versions data must always include the version
+                    version_data['version'] = json_data['version']
+
+                    # versions data must always include one of the download/source uris
+                    if 'download_source_uri' in json_data:
+                        version_data['download_source_uri'] = json_data['download_source_uri']
+                    if 'source_control_uri' in json_data:
+                        version_data['source_control_uri'] = json_data['source_control_uri']
+                    if 'source_control_ref' in json_data:
+                        version_data['source_control_ref'] = json_data['source_control_ref']
+
+                    version_index = _find_index(repo_objects_data[index].get('versions_data',[]), 'version', json_data['version'])
+                    if version_index != -1:
+                        # update the existing version
+                        if version_data:
+                            repo_objects_data[index]['versions_data'][version_index] = version_data
+                    else:
+                        # add the new version
+                        if 'versions_data' not in repo_objects_data[index]:
+                            repo_objects_data[index]['versions_data'] = [version_data] 
+                        else:
+                            repo_objects_data[index]['versions_data'].append(version_data) 
+                else:
+                    repo_objects_data.append(json_data)
+
+    repo_json[f'{object_typename}s_data'] = repo_objects_data
+
+def edit_repo_props(repo_path: pathlib.Path = None,
+                       repo_name: str = None,
+                       add_gems: pathlib.Path or list = None,
+                       delete_gems: str or list = None,
+                       replace_gems: pathlib.Path or list = None,
+                       add_projects: pathlib.Path or list = None,
+                       delete_projects: str or list = None,
+                       replace_projects: pathlib.Path or list = None,
+                       add_templates: pathlib.Path or list = None,
+                       delete_templates: str or list = None,
+                       replace_templates: pathlib.Path or list = None,
+                       release_archive_path: pathlib.Path = None,
+                       download_prefix: str = None
+                       ) -> int:
+    """
+    Edits and modifies the project properties for the project located at 'proj_path' or with the name 'proj_name'.
+    :param repo_path: The path to the project folder
+    :param repo_name: The new name for the project
+    :param add_gems: New tags to add to 'user_tags'
+    :param delete_gems: Tags to remove from 'user_tags'
+    :param replace_gems: Tags to replace 'user_tags' with
+    """
+    repo_json = get_repo_props(repo_path)
+
+    if not repo_json:
+        return 1
+
+    if isinstance(repo_name, str):
+        if not utils.validate_identifier(repo_name):
+            logger.error(f'Repo name must be fewer than 64 characters, contain only alphanumeric, "_" or "-"'
+                         f' characters, and start with a letter.  {repo_name}')
+            return 1
+        repo_json['repo_name'] = repo_name
+
+    if add_gems or delete_gems or replace_gems:
+        #_edit_gems(repo_json, add_gems, delete_gems, replace_gems, release_archive_path, download_prefix)
+        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, download_prefix)
+
+    if add_projects or delete_projects or replace_projects:
+        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, download_prefix)
+
+    if add_templates or delete_templates or replace_templates:
+        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, download_prefix)
+
+    return 0 if manifest.save_o3de_manifest(repo_json, repo_path) else 1
+
+
+def _edit_repo_props(args: argparse) -> int:
+    return edit_repo_props(repo_path=args.repo_path,
+                              repo_name=args.repo_name,
+
+                              add_gems=args.add_gems,
+                              delete_gems=args.delete_gems,
+                              replace_gems=args.replace_gems,
+
+                              add_projects=args.add_projects,
+                              delete_projects=args.delete_projects,
+                              replace_projects=args.replace_projects,
+
+                              add_templates=args.add_templates,
+                              delete_templates=args.delete_templates,
+                              replace_templates=args.replace_templates,
+
+                              release_archive_path=args.release_archive_path,
+                              download_prefix=args.download_prefix
+                              )
+
+
+def add_parser_args(parser):
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--repo-path', '-rp', type=pathlib.Path, required=False,
+                       help='The local path to the remote repository.')
+    group = parser.add_argument_group('properties', 'arguments for modifying individual project properties.')
+    group.add_argument('--repo-name','-rn',  type=str, required=False,
+                       help='The name of the remote repository.')
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('--add-gems', '-ag', type=pathlib.Path, nargs='*', required=False,
+                       help="Adds gem(s) to the 'gems_data' property. Space delimited list (ex. -ag c:/gem1 c:/gem2)")
+    group.add_argument('--delete-gems', '-dg', type=str, nargs='*', required=False,
+                       help='Removes gems(s) from the gems_data property. Space delimited list (ex. -db A B C')
+    group.add_argument('--replace-gems', '-rg', type=pathlib.Path, nargs='*', required=False,
+                       help='Replace entirety of gems_data property with the provided gems')
+
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('--add-templates', '-at', type=pathlib.Path, nargs='*', required=False,
+                       help="Adds template(s) to the 'templates_data' property. Space delimited list (ex. -at c:/template1 c:/template2)")
+    group.add_argument('--delete-templates', '-dt', type=str, nargs='*', required=False,
+                       help='Removes templates(s) from the templates_data property. Space delimited list (ex. -dt A B C')
+    group.add_argument('--replace-templates', '-rt', type=pathlib.Path, nargs='*', required=False,
+                       help='Replace entirety of templates_data property with the provided templates')
+
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('--add-projects', '-apr', type=pathlib.Path, nargs='*', required=False,
+                       help="Adds projects(s) to the 'projects_data' property. Space delimited list (ex. -at c:/project1 c:/project2)") 
+    group.add_argument('--delete-projects', '-dpr', type=str, nargs='*', required=False,
+                       help='Removes projects(s) from the projects_data property. Space delimited list (ex. -dp A B C')
+    group.add_argument('--replace-projects', '-rpr', type=pathlib.Path, nargs='*', required=False,
+                       help='Replace entirety of projects_data property with the provided projects')
+
+    modify_gems_group = parser.add_argument_group(title='modify gems',
+                                                  description='path arguments to use with the --add-gems or --replace-gems option')
+    modify_gems_group.add_argument('--release-archive-path','-rap',  type=pathlib.Path, required=False,
+                            help='Create a release archive at the specified local path and update the download_source_uri and sha256 fields.')
+    modify_gems_group.add_argument('--download-prefix','-dp',  type=str, required=False,
+                            help='Download prefix for the release archive.')
+    parser.set_defaults(func=_edit_repo_props)
+
+
+def add_args(subparsers) -> None:
+    enable_repo_props_subparser = subparsers.add_parser('edit-repo-properties')
+    add_parser_args(enable_repo_props_subparser)
+
+
+def main():
+    the_parser = argparse.ArgumentParser()
+    add_parser_args(the_parser)
+    the_args = the_parser.parse_args()
+    ret = the_args.func(the_args) if hasattr(the_args, 'func') else 1
+    sys.exit(ret)
+    
+
+if __name__ == "__main__":
+    main()

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -83,8 +83,8 @@ def create_release(src_data_path: pathlib.Path,
         FileNotFoundError: If the json_data_path does not exist.
         ValueError: If the json_data_path is not a dict.
     """
-    #basename = f'{object_name}_release_1.0.0'
-    #zip_filename = f'{archive_filename}.zip'
+    # basename = f'{object_name}_release_1.0.0'
+    # zip_filename = f'{archive_filename}.zip'
     basename = archive_filename.stem
     zip_filename = archive_filename
 
@@ -152,9 +152,7 @@ def _edit_objects(object_typename:str,
     repo_objects_data = repo_json.get(f'{object_typename}s_data',[])
 
     if add_objects:
-        # path to the gem you are adding to repo.json remote repo 
         paths = add_objects.split() if isinstance(add_objects, str) else add_objects
-
         for object_path in paths:
             # gem data of the gem you want to add
             json_data = manifest.get_json_data(object_typename, object_path, validator)

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -138,6 +138,16 @@ def _edit_objects(object_typename:str,
                   replace_objects: pathlib.Path or list = None,
                   release_archive_path: pathlib.Path = None,
                   download_prefix: str = None):
+    """
+    Edits and modifies the 'gem_data/projects_data/template_data' in the repo_json parameter
+    :param object_typename: The type object field you want to change
+    :param validator: validates the object you want to edit
+    :param add_objects: Any object paths you want to add to your repo_json object field
+    :param delete_objects: Any object_names to be removed from your repo_json object field
+    :param replace_objects: A list of object paths that will completely replace the current object_list
+    :param release_archive_path: Path where you want your release to be located
+    :param download_prefix: The prefix of the download uri
+    """
     # The beginning remote repo json template
     repo_objects_data = repo_json.get(f'{object_typename}s_data',[])
 
@@ -195,11 +205,9 @@ def _edit_objects(object_typename:str,
 
     # Remove duplicates from list 
     if delete_objects:      
-        # Convert delete_objects to individual string if multiple items received
         removal_list = delete_objects.split() if isinstance(delete_objects, str) else delete_objects
         # find name field of object you want to delete
         object_key = str(f'{object_typename}_name')
-        # Iterate over removal_lists received
         for removal_object in removal_list:
             # Remove the JSON object(s) with the specified object_name value
             repo_objects_data = [object_typename for object_typename in repo_objects_data if object_typename.get(object_key) != removal_object]
@@ -276,12 +284,20 @@ def edit_repo_props(repo_path: pathlib.Path = None,
                        download_prefix: str = None
                        ) -> int:
     """
-    Edits and modifies the project properties for the project located at 'proj_path' or with the name 'proj_name'.
-    :param repo_path: The path to the project folder
-    :param repo_name: The new name for the project
-    :param add_gems: New tags to add to 'user_tags'
-    :param delete_gems: Tags to remove from 'user_tags'
-    :param replace_gems: Tags to replace 'user_tags' with
+    Edits and modifies the remote repo properties for the repo.json located at 'repo_path'.
+    :param repo_path: The path to the repo.json file
+    :param repo_name: The new name for the remote repo
+    :param add_gems: Any gem paths to be added to the list
+    :param delete_gems: Any gem names to be removed from the list
+    :param replace_gems: A list of gem paths that will completely replace the current list of path
+    :add_projects: Any project paths to be added to the list
+    :delete_projects:  Any project names to be removed from the list
+    :replace_projects: A list of project paths that will completely replace the current list of path
+    :add_templates: Any template paths to be added to the list
+    :delete_templates: Any template names to be removed from the list
+    :replace_templates: A list of template paths that will completely replace the current list of path
+    :release_archive_path: Path where you want your release to be located
+    :download_prefix: The string prefix of the download uri
     """
     repo_json = get_repo_props(repo_path)
 
@@ -296,7 +312,6 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         repo_json['repo_name'] = repo_name
 
     if add_gems or delete_gems or replace_gems:
-        #_edit_gems(repo_json, add_gems, delete_gems, replace_gems, release_archive_path, download_prefix)
         _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, download_prefix)
 
     if add_projects or delete_projects or replace_projects:
@@ -380,7 +395,7 @@ def main():
     the_args = the_parser.parse_args()
     ret = the_args.func(the_args) if hasattr(the_args, 'func') else 1
     sys.exit(ret)
-    
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -264,9 +264,6 @@ class TestEditRepoProperties:
                          None, None, None, None,
                          None, None, None, None,
                          0),
-
-            # Adding a gem without a version, then adding a gem with the same name but with a version and then removing the unversioned 
-            # gem by using the delete_gems = ['gemA==0.0.0'] or delete_gems = ['gemA<1.0.0']
             ]
     ) 
     # Where actual test starts

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -16,7 +16,7 @@ from o3de import repo_properties
 TEST_TEMPLATE_REPO_JSON = '''
 {
     "repo_name": "repotest",
-    "repo_uri": "https://test",
+    "repo_uri": "https://test.com",
     "$schemaVersion": "1.0.0",
     "origin": "o3de",
     "origin_url": "${OriginURL}",
@@ -28,6 +28,59 @@ TEST_TEMPLATE_REPO_JSON = '''
     "templates_data": []
 }
 '''
+
+GEM_VERSION_ONE_JSON={
+    "gem_name": "TestGem",
+    "version": "1.0.0",
+}
+
+GEM_VERSION_TWO_JSON={
+    "gem_name": "TestGem",
+    "version": "2.0.0"
+}
+
+GEM_VERSION_THREE_JSON={
+    "gem_name": "TestGem",
+    "version": "3.0.0"
+}
+
+GEM_VERSION_ONE_TOBE_UPDATED={
+    "gem_name": "TestGemUpdate",
+    "version": "1.0.0",
+    "display_name": "testGem"
+}
+
+GEM_VERSION_ONE_WITH_UPDATED_FIELD={
+    "gem_name": "TestGemUpdate",
+    "version": "1.0.0",
+    "display_name": "hiWorld"
+}
+
+GEM_VERSION_TWO_TOBE_UPDATED={
+    "gem_name": "TestGem",
+    "version": "2.0.0",
+    "display_name": "wastwo"
+}
+
+GEM_VERSION_TWO_WITH_UPDATED_FIELD={
+    "gem_name": "TestGem",
+    "version": "2.0.0",
+    "display_name": "hiWorld"
+}
+
+GEM_WITH_NO_VERSION={
+    "gem_name": "TestGem"
+}
+
+JSON_DICT={'gem_version1_json_key': GEM_VERSION_ONE_JSON,
+           'gem_version2_json_key': GEM_VERSION_TWO_JSON,
+           'gem_version3_json_key': GEM_VERSION_THREE_JSON,
+           'gem_version1_tobe_updated_key': GEM_VERSION_ONE_TOBE_UPDATED,
+           'gem_version1_with_updated_field_key': GEM_VERSION_ONE_WITH_UPDATED_FIELD,
+           'gem_version2_tobe_updated_key': GEM_VERSION_TWO_TOBE_UPDATED,
+           'gem_version2_updated_key': GEM_VERSION_TWO_WITH_UPDATED_FIELD,
+           'gem_with_no_version_key': GEM_WITH_NO_VERSION}
+
 # class returns a dictionary of the template repo json
 @pytest.fixture(scope='function')
 def init_repo_json_data(request):
@@ -39,6 +92,7 @@ def init_repo_json_data(request):
 
 # use the TEST_TEMPLATE_REPO_JSON created above as the repo json template
 @pytest.mark.usefixtures('init_repo_json_data')
+
 class TestEditRepoProperties:
 
     @staticmethod
@@ -51,106 +105,193 @@ class TestEditRepoProperties:
                               add_templates, delete_templates, replace_templates, expected_templates, \
                               expected_result", [
             # test add gems
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1',
                          'gem1 gem3', None, None, [{'gem_name':'gem1'}, {'gem_name':'gem3'}],
                          None, None, None, None,
                          None, None, None, None,
                          0),
             # test remove a gem
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('D:/repotest'),'Repotest2',
                          'gem1 gem2', 'gem2', None, [{'gem_name':'gem1'}],
                          None, None, None, None,
                          None, None, None, None,
                          0),
             # test replace with multiple gems
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest/AFH'),'Repotest3',
                          'gem1 gem2', None, 'gem3 gem4', [{'gem_name':'gem3'}, {'gem_name':'gem4'}],
                          None, None, None, None,
                          None, None, None, None,
                          0),
             # test replace a gem with an empty parameter
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'Repo',
                          'gem1 gem2', None, '', [{'gem_name':'gem1'}, {'gem_name':'gem2'}],
                          None, None, None, None,
                          None, None, None, None,
                          0),
             # test add projects
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'test',
                          None, None, None, None,
                          'project1 project2', None, None, [{'project_name':'project1'}, {'project_name':'project2'}],
                          None, None, None, None,
                          0),
             # test remove a project
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'random',
                          None, None, None, None,
                          'project1 project2 project3', 'project2', None, [{'project_name':'project1'}, {'project_name':'project3'}],
                          None, None, None, None,
                          0),
             # test replace a project
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'RepoReplace',
                          None, None, None, None,
                          'project1 project2', None, 'project3', [{'project_name':'project3'}],
                          None, None, None, None,
                          0),
             # test remove project with a empty parameter
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'RepoRemove', 
                          None, None, None, None,
                          'project1 project2', '', None, [{'project_name':'project1'}, {'project_name':'project2'}],
                          None, None, None, None,
                          0),
             # test add template
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'RepoAdd',
                          None, None, None, None,
                          None, None, None, None,
                          'template1 template2 template3', None, None, [{'template_name':'template1'}, {'template_name':'template2'}, 
                                                                        {'template_name':'template3'}],
                          0),
             # test remove multiple templates
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'removeTemplate',
                          None, None, None, None,
                          None, None, None, None,
                          'template1 template2 template3', 'template1 template2', None, [{'template_name':'template3'}],
                          0),
             # test replace a temlpate
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'replaceTemp',
                          None, None, None, None,
                          None, None, None, None,
                          'template1 template2 template3', None, "template48", [{'template_name':'template48'}],
                          0),
             # test add all objects
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'addAll',
                          'gem1', None, None, [{'gem_name':'gem1'}],
                          'project1', None, None, [{'project_name':'project1'}],
                          'template1 template2', None, None, [{'template_name':'template1'}, {'template_name':'template2'}],
                          0),
             # test remove all object types
-            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+            pytest.param(pathlib.Path('F:/repotest'),'removeAll',
                          'gem1 gem2', 'gem1', None, [{'gem_name':'gem2'}],
                          'project1', 'project1', None, [],
                          'template1 template2 template3', 'template1 template3', None, [{'template_name':'template2'}],
-                         0)
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddVersion',
+                         'gem_version1_json_key gem_version2_json_key', None, None, [{"gem_name": "TestGem",
+                                                                                      "version": "1.0.0",
+                                                                                      "versions_data": [{"version": "2.0.0"}]
+                                                                                    }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 2.0.0             
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveVersion',
+                         'gem_version1_json_key gem_version2_json_key', 'TestGem==2.0.0', None, [{"gem_name": "TestGem",
+                                                                                                  "version": "1.0.0",
+                                                                                                  'versions_data': []
+                                                                                                }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 1.0.0
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveBaseVersion',
+                         'gem_version1_json_key gem_version2_json_key', 'TestGem==1.0.0', None, [{"gem_name": "TestGem",
+                                                                                                  "version": "2.0.0",
+                                                                                                  'versions_data': []
+                                                                                                }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 1.0.0 and 2.0.0
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveAllVersion',
+                         'gem_version1_json_key gem_version2_json_key', 'TestGem==1.0.0 TestGem==2.0.0', None, [],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with the same version but other updated gem.json fields
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
+                         'gem_version1_tobe_updated_key gem_version1_with_updated_field_key', None, None, [{'gem_name': 'TestGemUpdate',
+                                                                                                            'version': '1.0.0',
+                                                                                                            'display_name': 'hiWorld'
+                                                                                                            }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then adding version 2.0.0 with updated gem.json fields
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
+                         'gem_version1_json_key gem_version2_tobe_updated_key gem_version2_updated_key', None, None, [{'gem_name': 'TestGem',
+                                                                                                                       'version': '1.0.0',
+                                                                                                                       'versions_data': [{
+                                                                                                                           'version': '2.0.0',
+                                                                                                                           'display_name': 'hiWorld'
+                                                                                                                           }]
+                                                                                                                        }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem with multiple versions and then replacing all gems with another set of gems             
+            pytest.param(pathlib.Path('F:/repotest'),'ReplaceGem',
+                         'gem_version1_json_key gem_version2_json_key', None, 'gem_version3_json_key', [{'gem_name': 'TestGem',
+                                                                                                         'version': '3.0.0'}],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Deleting a gem with version>2.0.0
+            pytest.param(pathlib.Path('F:/repotest'),'DeletingGemVersion',
+                         'gem_version1_json_key gem_version2_json_key gem_version3_json_key', 'TestGem>2.0.0', None, [{'gem_name': 'TestGem',
+                                                                                                                       'version': '1.0.0',
+                                                                                                                       'versions_data': [{
+                                                                                                                           'version': '2.0.0'
+                                                                                                                           }]
+                                                                                                                        }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # Adding a gem without a version, then adding a gem with the same name but with a version
+            pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
+                         'gem_with_no_version_key gem_version1_json_key', None, None, [{'gem_name': 'TestGem',
+                                                                                        'versions_data': [{
+                                                                                            'version': '1.0.0'}]
+                                                                                        }],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+
+            # Adding a gem without a version, then adding a gem with the same name but with a version and then removing the unversioned 
+            # gem by using the delete_gems = ['gemA==0.0.0'] or delete_gems = ['gemA<1.0.0']
             ]
     ) 
     # Where actual test starts
-    def test_edit_repo_properties(self, repo_path, repo_name, add_gems, delete_gems, replace_gems, expected_gems,
+    def test_edit_repo_obj_version(self, repo_path, repo_name, add_gems, delete_gems, replace_gems, expected_gems,
                                      add_projects, delete_projects, replace_projects, expected_projects, 
                                      add_templates, delete_templates, replace_templates, expected_templates, 
                                      expected_result):
         
-        def get_repo_props(repo_path: pathlib.Path) -> dict or None:
+        def get_repo_props(repo_path: str or pathlib.Path = None) -> dict or None:
             if not repo_path:
                 self.repo_json.data = None
                 return None
             return self.repo_json.data
-        
+
         def save_o3de_manifest(json_data: dict, manifest_path: pathlib.Path = None) -> bool:
             self.repo_json.data = json_data
             return True
 
         def get_json_data(object_typename: str,
-                  object_path: str or pathlib.Path,
-                  object_validator: callable) -> dict or None: 
-            
+                    object_path: str or pathlib.Path,
+                    object_validator: callable) -> dict or None: 
+            # object_path = gem
+            if object_path in JSON_DICT:
+                return JSON_DICT[object_path].copy()
+            # if object json template doesn't exist 
             if object_typename == "gem":
                 return {'gem_name': object_path}
             if object_typename == "project":
@@ -167,7 +308,7 @@ class TestEditRepoProperties:
             assert result == expected_result
             if result == 0:
                 assert self.repo_json.data.get('repo_name') == repo_name
-                assert self.repo_json.data.get('repo_uri') == 'https://test'
+                assert self.repo_json.data.get('repo_uri') == 'https://test.com'
                 assert self.repo_json.data.get('$schemaVersion') == '1.0.0'
                 assert self.repo_json.data.get('origin') == 'o3de'
 
@@ -177,4 +318,3 @@ class TestEditRepoProperties:
                     assert project in expected_projects
                 for template in self.repo_json.data.get('templates_data', []):
                     assert template in expected_templates
-              

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -28,7 +28,7 @@ TEST_TEMPLATE_REPO_JSON = '''
     "templates_data": []
 }
 '''
-# cls returns a dictionary of the template repo json
+# class returns a dictionary of the template repo json
 @pytest.fixture(scope='function')
 def init_repo_json_data(request):
     class RepoJsonData:
@@ -123,7 +123,7 @@ class TestEditRepoProperties:
                          'project1', None, None, [{'project_name':'project1'}],
                          'template1 template2', None, None, [{'template_name':'template1'}, {'template_name':'template2'}],
                          0),
-            # test remove all objects
+            # test remove all object types
             pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
                          'gem1 gem2', 'gem1', None, [{'gem_name':'gem2'}],
                          'project1', 'project1', None, [],
@@ -166,7 +166,7 @@ class TestEditRepoProperties:
                                                      add_templates, delete_templates, replace_templates)
             assert result == expected_result
             if result == 0:
-                assert self.repo_json.data.get('repo_name') == 'Repotest1'
+                assert self.repo_json.data.get('repo_name') == repo_name
                 assert self.repo_json.data.get('repo_uri') == 'https://test'
                 assert self.repo_json.data.get('$schemaVersion') == '1.0.0'
                 assert self.repo_json.data.get('origin') == 'o3de'

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -1,0 +1,180 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+import json
+import pytest
+import pathlib
+from unittest.mock import patch
+
+from o3de import repo_properties
+
+TEST_TEMPLATE_REPO_JSON = '''
+{
+    "repo_name": "repotest",
+    "repo_uri": "https://test",
+    "$schemaVersion": "1.0.0",
+    "origin": "o3de",
+    "origin_url": "${OriginURL}",
+    "summary": "${Summary}",
+    "additional_info": "${AdditionalInfo}",
+    "last_updated": "",
+    "gems_data": [],
+    "projects_data": [],
+    "templates_data": []
+}
+'''
+# cls returns a dictionary of the template repo json
+@pytest.fixture(scope='function')
+def init_repo_json_data(request):
+    class RepoJsonData:
+        def __init__(self):
+            self.data = json.loads(TEST_TEMPLATE_REPO_JSON)
+            self.path = None
+    request.cls.repo_json = RepoJsonData()
+
+# use the TEST_TEMPLATE_REPO_JSON created above as the repo json template
+@pytest.mark.usefixtures('init_repo_json_data')
+class TestEditRepoProperties:
+
+    @staticmethod
+    def resolve(self):
+        return self
+
+    @pytest.mark.parametrize("repo_path, repo_name, \
+                              add_gems, delete_gems, replace_gems, expected_gems, \
+                              add_projects, delete_projects, replace_projects, expected_projects, \
+                              add_templates, delete_templates, replace_templates, expected_templates, \
+                              expected_result", [
+            # test add gems
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1 gem3', None, None, [{'gem_name':'gem1'}, {'gem_name':'gem3'}],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # test remove a gem
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1 gem2', 'gem2', None, [{'gem_name':'gem1'}],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # test replace with multiple gems
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1 gem2', None, 'gem3 gem4', [{'gem_name':'gem3'}, {'gem_name':'gem4'}],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # test replace a gem with an empty parameter
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1 gem2', None, '', [{'gem_name':'gem1'}, {'gem_name':'gem2'}],
+                         None, None, None, None,
+                         None, None, None, None,
+                         0),
+            # test add projects
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         'project1 project2', None, None, [{'project_name':'project1'}, {'project_name':'project2'}],
+                         None, None, None, None,
+                         0),
+            # test remove a project
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         'project1 project2 project3', 'project2', None, [{'project_name':'project1'}, {'project_name':'project3'}],
+                         None, None, None, None,
+                         0),
+            # test replace a project
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         'project1 project2', None, 'project3', [{'project_name':'project3'}],
+                         None, None, None, None,
+                         0),
+            # test remove project with a empty parameter
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         'project1 project2', '', None, [{'project_name':'project1'}, {'project_name':'project2'}],
+                         None, None, None, None,
+                         0),
+            # test add template
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         None, None, None, None,
+                         'template1 template2 template3', None, None, [{'template_name':'template1'}, {'template_name':'template2'}, 
+                                                                       {'template_name':'template3'}],
+                         0),
+            # test remove multiple templates
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         None, None, None, None,
+                         'template1 template2 template3', 'template1 template2', None, [{'template_name':'template3'}],
+                         0),
+            # test replace a temlpate
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         None, None, None, None,
+                         None, None, None, None,
+                         'template1 template2 template3', None, "template48", [{'template_name':'template48'}],
+                         0),
+            # test add all objects
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1', None, None, [{'gem_name':'gem1'}],
+                         'project1', None, None, [{'project_name':'project1'}],
+                         'template1 template2', None, None, [{'template_name':'template1'}, {'template_name':'template2'}],
+                         0),
+            # test remove all objects
+            pytest.param(pathlib.Path('F:/repotest'),'Repotest1', 
+                         'gem1 gem2', 'gem1', None, [{'gem_name':'gem2'}],
+                         'project1', 'project1', None, [],
+                         'template1 template2 template3', 'template1 template3', None, [{'template_name':'template2'}],
+                         0)
+            ]
+    ) 
+    # Where actual test starts
+    def test_edit_repo_properties(self, repo_path, repo_name, add_gems, delete_gems, replace_gems, expected_gems,
+                                     add_projects, delete_projects, replace_projects, expected_projects, 
+                                     add_templates, delete_templates, replace_templates, expected_templates, 
+                                     expected_result):
+        
+        def get_repo_props(repo_path: pathlib.Path) -> dict or None:
+            if not repo_path:
+                self.repo_json.data = None
+                return None
+            return self.repo_json.data
+        
+        def save_o3de_manifest(json_data: dict, manifest_path: pathlib.Path = None) -> bool:
+            self.repo_json.data = json_data
+            return True
+
+        def get_json_data(object_typename: str,
+                  object_path: str or pathlib.Path,
+                  object_validator: callable) -> dict or None: 
+            
+            if object_typename == "gem":
+                return {'gem_name': object_path}
+            if object_typename == "project":
+                return {'project_name': object_path}
+            if object_typename == "template":
+                return {'template_name': object_path}
+
+        with patch('o3de.repo_properties.get_repo_props', side_effect=get_repo_props) as get_repo_props_patch, \
+                patch('o3de.manifest.save_o3de_manifest', side_effect=save_o3de_manifest) as save_o3de_manifest_patch, \
+                patch('o3de.manifest.get_json_data', side_effect=get_json_data) as get_json_data_patch:
+            result = repo_properties.edit_repo_props(repo_path, repo_name, add_gems, delete_gems, replace_gems,
+                                                     add_projects, delete_projects, replace_projects, 
+                                                     add_templates, delete_templates, replace_templates)
+            assert result == expected_result
+            if result == 0:
+                assert self.repo_json.data.get('repo_name') == 'Repotest1'
+                assert self.repo_json.data.get('repo_uri') == 'https://test'
+                assert self.repo_json.data.get('$schemaVersion') == '1.0.0'
+                assert self.repo_json.data.get('origin') == 'o3de'
+
+                for gem in self.repo_json.data.get('gems_data', []):
+                    assert gem in expected_gems
+                for project in self.repo_json.data.get('projects_data', []):
+                    assert project in expected_projects
+                for template in self.repo_json.data.get('templates_data', []):
+                    assert template in expected_templates
+              


### PR DESCRIPTION
## What does this PR do?

Added a edit-repo-CLI function that edits the repo.json fields -> 
gems_data: add gems / remove gems / replace gems
template_data: add template / remove template / replace template
project_data: add project / remove project / replace project

the command to add a gem is: './o3de.bat edit-repo-properties -rp "C:\o3de_Projects\test1\repo.json" -ag "C:\o3de_Projects\o3de\Gems\Archive"'

## How was this PR tested?
I wrote unit test test_repo_properties.py file and tested through the command line argument to add, delete, and replace different objects. 
