### PR TITLE
Fixed crash in Cloth component

### DIFF
--- a/Gems/NvCloth/Code/Source/Components/ClothConfiguration.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothConfiguration.cpp
@@ -74,31 +74,4 @@ namespace NvCloth
                 ;
         }
     }
-
-    MeshNodeList ClothConfiguration::PopulateMeshNodeList()
-    {
-        if (m_populateMeshNodeListCallback)
-        {
-            return m_populateMeshNodeListCallback();
-        }
-        return {};
-    }
-
-    bool ClothConfiguration::HasBackstopData()
-    {
-        if (m_hasBackstopDataCallback)
-        {
-            return m_hasBackstopDataCallback();
-        }
-        return false;
-    }
-
-    AZ::EntityId ClothConfiguration::GetEntityId()
-    {
-        if (m_getEntityIdCallback)
-        {
-            return m_getEntityIdCallback();
-        }
-        return AZ::EntityId();
-    }
 } // namespace NvCloth

--- a/Gems/NvCloth/Code/Source/Components/ClothConfiguration.h
+++ b/Gems/NvCloth/Code/Source/Components/ClothConfiguration.h
@@ -11,7 +11,6 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
-#include <AzCore/std/function/function_template.h>
 
 #include <Utils/AssetHelper.h>
 
@@ -117,14 +116,9 @@ namespace NvCloth
         // it's unnecessary for the clients using ClothConfiguration.
         friend class EditorClothComponent;
 
-        // Callback functions set by the EditorClothComponent.
-        AZStd::function<MeshNodeList()> m_populateMeshNodeListCallback;
-        AZStd::function<bool()> m_hasBackstopDataCallback;
-        AZStd::function<AZ::EntityId()> m_getEntityIdCallback;
-
         // Used by data elements in EditorClothComponent edit context.
-        MeshNodeList PopulateMeshNodeList();
-        bool HasBackstopData();
-        AZ::EntityId GetEntityId();
+        MeshNodeList m_meshNodeList;
+        bool m_hasBackstopData = false;
+        AZ::EntityId m_entityId;
     };
 } // namespace NvCloth

--- a/Gems/NvCloth/Code/Source/Components/EditorClothComponent.h
+++ b/Gems/NvCloth/Code/Source/Components/EditorClothComponent.h
@@ -59,6 +59,8 @@ namespace NvCloth
 
         bool ContainsBackstopData(AssetHelper* assetHelper, const AZStd::string& meshNode) const;
 
+        void UpdateConfigMeshNodeData();
+
         ClothConfiguration m_config;
 
         AZStd::unique_ptr<ClothComponentMesh> m_clothComponentMesh;


### PR DESCRIPTION
## What does this PR do?

Fixes #16086 

This resolves a crash noticed when enabling the DPE and trying to inspect an Entity that has a Cloth component. The `ClothConfiguration` is owned by the `EditorClothComponent`, but is given callbacks that reference back to the `EditorClothComponent` because there are fields in the reflected data that are driven by querying a `Mesh` component that may or may not be on the same Entity. Instead of re-working the EditContext reflection for this, I opted to instead push pure data down to the `ClothConfiguration` instead of a callback for a safer flow of ownership.

## How was this PR tested?

Tested adding a Cloth component and verified the mesh node related fields are populated as expected when adding a Mesh component and assigning it a mesh with cloth capabilities.