### PR TITLE
DPE: Reworked finding generic property handlers

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h>
@@ -41,31 +42,59 @@ namespace AzToolsFramework
             return InvalidHandlerId;
         }
 
-        // If the Type is empty or unspecified, check the default handler list
+        auto typeIdAttribute = node.FindMember(PropertyEditor::ValueType.GetName());
+        AZ::TypeId typeId = AZ::TypeId::CreateNull();
+        if (typeIdAttribute != node.MemberEnd())
+        {
+            typeId = AZ::Dom::Utils::DomValueToTypeId(typeIdAttribute->second);
+        }
+        else
+        {
+            AZ::Dom::Value value = PropertyEditor::Value.ExtractFromDomNode(node).value_or(AZ::Dom::Value());
+            typeId = AZ::Dom::Utils::GetValueTypeId(value);
+        }
+
         AZStd::string_view typeName = PropertyEditor::Type.ExtractFromDomNode(node).value_or("");
-        if (typeName.empty())
+        return GetPropertyHandlerForType(typeName, typeId);
+    }
+
+    PropertyEditorToolsSystem::PropertyHandlerId PropertyEditorToolsSystem::GetPropertyHandlerForType(AZStd::string_view handlerName, const AZ::TypeId& typeId)
+    {
+        // If the Type is empty or unspecified, check the default handler list
+        if (handlerName.empty())
         {
             for (PropertyHandlerId handler : m_defaultHandlers)
             {
-                if (handler->m_shouldHandleNode(node))
+                if (handler->m_shouldHandleType(typeId))
                 {
                     return handler;
                 }
             }
-            return InvalidHandlerId;
         }
-
-        auto handlerBucketIt = m_registeredHandlers.find(AZ::Name(typeName));
-        if (handlerBucketIt == m_registeredHandlers.end())
+        // Otherwise search all registered handlers by name
+        else if (auto handlerBucketIt = m_registeredHandlers.find(AZ::Name(handlerName)); handlerBucketIt != m_registeredHandlers.end())
         {
-            return InvalidHandlerId;
-        }
-
-        for (auto handlerIt = handlerBucketIt->second.begin(); handlerIt != handlerBucketIt->second.end(); ++handlerIt)
-        {
-            if (handlerIt->m_shouldHandleNode(node))
+            for (auto handlerIt = handlerBucketIt->second.begin(); handlerIt != handlerBucketIt->second.end(); ++handlerIt)
             {
-                return &(*handlerIt);
+                if (handlerIt->m_shouldHandleType(typeId))
+                {
+                    return &(*handlerIt);
+                }
+            }
+        }
+
+        // If we still couldn't find the handler, check if there is any generic class info for this type.
+        // This might happen if there is a single generic handler for multiple derived types, such is the
+        // case for asset property handlers that have a generic handler for AZ::Data::Asset<AZ::Data::AssetData>,
+        // where the asset type is a derived class of AZ::Data::AssetData.
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+        if (const auto* genericInfo = serializeContext->FindGenericClassInfo(typeId))
+        {
+            if (genericInfo->GetGenericTypeId() != typeId)
+            {
+                auto genericTypeId = genericInfo->GetGenericTypeId();
+                return GetPropertyHandlerForType(handlerName, genericTypeId);
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.h
@@ -35,5 +35,7 @@ namespace AzToolsFramework
         AZStd::vector<PropertyHandlerId> m_defaultHandlers;
         // PropertyEditorSystem contains all non-UI system logic for the DPE, like the DOM schema
         AZ::DocumentPropertyEditor::PropertyEditorSystem m_lowLevelSystem;
+
+        PropertyHandlerId GetPropertyHandlerForType(AZStd::string_view handlerName, const AZ::TypeId& typeId);
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystemInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystemInterface.h
@@ -32,13 +32,13 @@ namespace AzToolsFramework
             AZStd::string_view m_name;
             //! A factory functor that constructs an instance of this handler.
             PropertyHandlerInstanceFactory m_factory;
-            //! A functor that returns true if this handler should be created for a given node.
+            //! A functor that returns true if this handler should be created for a given type.
             //! The first registered handler that returns true for this will be provided when calling
             //! GetPropertyHandlerForNode.
-            AZStd::function<bool(const AZ::Dom::Value&)> m_shouldHandleNode;
+            AZStd::function<bool(const AZ::TypeId&)> m_shouldHandleType;
             //! Determines whether this handler should be in the "default" pool and match against editors
             //! with no "Type" attribute explicitly specified. The first default handler that returns true
-            //! from m_shouldHandleNode will be selected (if any).
+            //! from m_shouldHandleType will be selected (if any).
             //! Care should be taken to not provide overly general handlers as default handlers.
             bool m_isDefaultHandler;
         };
@@ -65,15 +65,15 @@ namespace AzToolsFramework
 
         //! Registers a factory for a given type of PropertyHandlerWidgetInterface.
         //! This type must implement `static const AZStd::string_view GetHandlerName()`
-        //! and may implement `static bool ShouldHandleNode(const AZ::Dom::Value& node)`
+        //! and may implement `static bool ShouldHandleType(const AZ::TypeId& typeId)`
         template<typename HandlerType>
         void RegisterHandler()
         {
             HandlerData handlerData;
             handlerData.m_name = HandlerType::GetHandlerName();
-            handlerData.m_shouldHandleNode = [](const AZ::Dom::Value& node) -> bool
+            handlerData.m_shouldHandleType = [](const AZ::TypeId& typeId) -> bool
             {
-                return HandlerType::ShouldHandleNode(node);
+                return HandlerType::ShouldHandleType(typeId);
             };
             handlerData.m_factory = []
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
@@ -44,10 +44,10 @@ namespace AzToolsFramework
         //! By default, this returns GetWidget, a single widget tab order.
         virtual QWidget* GetLastInTabOrder();
 
-        //! Returns true if this handler should be used for this node (assuming its type already matches GetHandlerName())
+        //! Returns true if this handler should be used for this type (assuming its type already matches GetHandlerName())
         //! This may be reimplemented in subclasses to allow handler specialization, for example a handler that handles
         //! integral types and a separate handler for handling floating point types.
-        static bool ShouldHandleNode([[maybe_unused]] const AZ::Dom::Value& node)
+        static bool ShouldHandleType([[maybe_unused]] const AZ::TypeId& typeId)
         {
             return true;
         }
@@ -60,7 +60,7 @@ namespace AzToolsFramework
         }
 
         //! If overridden, this can be used to indicate that this handler should be added to the "default" pool of
-        //! property handlers. Default property handlers will have ShouldHandleNode queried for PropertyEditor nodes
+        //! property handlers. Default property handlers will have ShouldHandleType queried for PropertyEditor nodes
         //! that don't have an explicit Type set.
         //! For example, a numeric spin box might be registered as a default handler, in which case a node like:
         //! <PropertyEditor Value=5 ValueType="int" />

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
@@ -191,9 +191,9 @@ namespace AzToolsFramework
             using HandlerType = RpePropertyHandlerWrapper<void*>;
             PropertyEditorToolsSystemInterface::HandlerData registrationInfo;
             registrationInfo.m_name = HandlerType::GetHandlerName(*this);
-            registrationInfo.m_shouldHandleNode = [this](const AZ::Dom::Value& node)
+            registrationInfo.m_shouldHandleType = [this](const AZ::TypeId& typeId)
             {
-                return HandlerType::ShouldHandleNode(*this, node);
+                return HandlerType::ShouldHandleType(*this, typeId);
             };
             registrationInfo.m_factory = [this]()
             {


### PR DESCRIPTION
## What does this PR do?

Fixes #16057 

The initial fix to get asset property handlers to show (#15954) introduced a crash on certain enum/combo boxes. The first commit was to back out just the logic from that PR in `PropertyEditorAPI_Internals.h`. The new approach is similar in that we need to account for generic class info when searching for property handlers by type, but with two major differences:

1. No longer modify the `m_proxyClassData.m_typeId`, which led to crashes in other widgets (enum/combo boxes)
2. Instead of checking generic info in each handler every check, now we only fallback to looking at the generic info if the initial searches in the default and registered handlers fail to find a handler, which matches the logic flow for the RPE `PropertyManagerComponent::ResolvePropertyHandler`. 

## How was this PR tested?

Verified the `DPEDebugViewStandalone` no longer crashes and the `Editor` no longer crashes when adding a `Display Mapper` component. Tested `Mesh` component and other components with asset properties and verified the asset property widgets still show up.