### PR TITLE
Preparation for multi-device resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -90,7 +90,14 @@ namespace AZ
 
         namespace MultiDevice
         {
-            constexpr int DefaultDeviceIndex = 0;
+            //! "Strong typedef" such that device mask and index cannot be used interchangeably
+            enum class DeviceMask : uint32_t
+            {
+            };
+            constexpr DeviceMask AllDevices{ static_cast<DeviceMask>(AZStd::numeric_limits<uint32_t>::max()) };
+            constexpr DeviceMask DefaultDevice{ 1u };
+
+            constexpr uint32_t DefaultDeviceIndex { 0 };
         }
 
         constexpr uint32_t InvalidIndex = AZStd::numeric_limits<uint32_t>::max();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -24,6 +24,14 @@ namespace AZ
     {
         class Scene;
 
+        //! Initialization flags passed to RHISystem::InitDevices to signal if all available devices should be initialized 
+        //! or just one (potentially preferred) adapter
+        enum class InitDevicesFlags : uint32_t
+        {
+            SingleDevice = 0,
+            MultiDevice
+        };
+
         class RHISystem final
             : public RHISystemInterface
             , public RHIMemoryStatisticsInterface
@@ -31,7 +39,7 @@ namespace AZ
         public:
             //! This function just initializes the native device and RHI::Device as a result.
             //! We can use this device to then query for device capabilities.
-            ResultCode InitDevice();
+            ResultCode InitDevices(InitDevicesFlags initializationVariant = InitDevicesFlags::SingleDevice);
 
             //! This function initializes the rest of the RHI/RHI backend.
             //! bindlessSrgLayout in this case is layout associated with the bindless srg (Bindless.azsli).
@@ -83,8 +91,8 @@ namespace AZ
 
         private:
 
-            //Enumerates the Physical devices and picks one to be used to initialize the RHI::Device with
-            ResultCode InitInternalDevices();
+            //! Enumerates the Physical devices and picks one (or multiple) to be used to initialize the RHI::Device(s) with
+            ResultCode InitInternalDevices(InitDevicesFlags initializationVariant);
 
             AZStd::vector<RHI::Ptr<RHI::Device>> m_devices;
             RHI::FrameScheduler m_frameScheduler;

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -78,8 +78,6 @@ namespace AZ
             m_physicalDevice = &physicalDevice;
             m_deviceIndex = deviceIndex;
 
-            AZ_Assert(deviceIndex == 0, "Multi-device support is not implemented yet.");
-
             RHI::ResultCode resultCode = InitInternal(physicalDevice);
 
             if (resultCode == ResultCode::Success)

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -37,11 +37,11 @@ namespace AZ
             return Interface<RHIMemoryStatisticsInterface>::Get();
         }
 
-        ResultCode RHISystem::InitDevice()
+        ResultCode RHISystem::InitDevices(InitDevicesFlags initializationVariant)
         {
             Interface<RHISystemInterface>::Register(this);
             Interface<RHIMemoryStatisticsInterface>::Register(this);
-            return InitInternalDevices();
+            return InitInternalDevices(initializationVariant);
         }
     
         void RHISystem::Init(RHI::Ptr<RHI::ShaderResourceGroupLayout> bindlessSrgLayout)
@@ -100,7 +100,7 @@ namespace AZ
             m_frameScheduler.Init(*m_devices[MultiDevice::DefaultDeviceIndex], frameSchedulerDescriptor);
         }
 
-        ResultCode RHISystem::InitInternalDevices()
+        ResultCode RHISystem::InitInternalDevices(InitDevicesFlags initializationVariant)
         {
             RHI::PhysicalDeviceList physicalDevices = RHI::Factory::Get().EnumeratePhysicalDevices();
 
@@ -112,12 +112,9 @@ namespace AZ
                 return ResultCode::Fail;
             }
 
-            static const char* MultiGPUCommandLineOption = "rhi-multiple-devices";
-            AZStd::string multipleDevicesValue = RHI::GetCommandLineValue(MultiGPUCommandLineOption);
-
             RHI::PhysicalDeviceList usePhysicalDevices;
 
-            if (AzFramework::StringFunc::Equal(multipleDevicesValue.c_str(), "enable"))
+            if (initializationVariant == InitDevicesFlags::MultiDevice)
             {
                 AZ_Printf("RHISystem", "\tUsing multiple devices\n");
 

--- a/Gems/Atom/RHI/Code/Tests/Device.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Device.cpp
@@ -24,13 +24,18 @@ namespace UnitTest
 
     RHI::PhysicalDeviceList PhysicalDevice::Enumerate()
     {
-        return RHI::PhysicalDeviceList{aznew PhysicalDevice};
+        RHI::PhysicalDeviceList devices;
+        for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            devices.emplace_back(aznew PhysicalDevice);
+        }
+        return devices;
     }
 
     RHI::Ptr<RHI::Device> MakeTestDevice()
     {
         RHI::PhysicalDeviceList physicalDevices = RHI::Factory::Get().EnumeratePhysicalDevices();
-        EXPECT_EQ(physicalDevices.size(), 1);
+        EXPECT_EQ(physicalDevices.size(), DeviceCount);
 
         RHI::Ptr<RHI::Device> device = RHI::Factory::Get().CreateDevice();
         device->Init(RHI::MultiDevice::DefaultDeviceIndex, *physicalDevices[0]);

--- a/Gems/Atom/RHI/Code/Tests/Device.h
+++ b/Gems/Atom/RHI/Code/Tests/Device.h
@@ -10,9 +10,13 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <Atom/RHI/Device.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <Atom/RHI.Reflect/Limits.h>
 
 namespace UnitTest
 {
+    static constexpr auto DeviceCount{8};
+    static constexpr AZ::RHI::MultiDevice::DeviceMask DeviceMask{AZ::RHI::MultiDevice::AllDevices};
+
     class PhysicalDevice
         : public AZ::RHI::PhysicalDevice
     {

--- a/Gems/Atom/RHI/Code/Tests/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Factory.cpp
@@ -163,12 +163,12 @@ namespace UnitTest
 
     AZ::RHI::Ptr<AZ::RHI::IndirectBufferSignature> Factory::CreateIndirectBufferSignature()
     {
-        return aznew IndirectBufferSignature;
+        return aznew NiceIndirectBufferSignature;
     }
 
     AZ::RHI::Ptr<AZ::RHI::IndirectBufferWriter> Factory::CreateIndirectBufferWriter()
     {
-        return aznew IndirectBufferWriter;
+        return aznew NiceIndirectBufferWriter;
     }
 
     AZ::RHI::Ptr<AZ::RHI::RayTracingBufferPools> Factory::CreateRayTracingBufferPools()

--- a/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
+++ b/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
@@ -21,6 +21,8 @@
 #include <AzCore/Component/TickBus.h>
 
 #include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/RHISystem.h>
+#include <Tests/Factory.h>
 
 namespace UnitTest
 {
@@ -56,5 +58,34 @@ namespace UnitTest
             m_reflectionManager->Clear();
             m_reflectionManager.reset();
         }
+    };
+
+    class MultiDeviceRHITestFixture : public RHITestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            RHITestFixture::SetUp();
+
+            m_factory.reset(aznew Factory());
+
+            m_rhiSystem.reset(aznew AZ::RHI::RHISystem);
+
+            m_rhiSystem->InitDevices(AZ::RHI::InitDevicesFlags::MultiDevice);
+            m_rhiSystem->Init();
+        }
+
+        void TearDown() override
+        {
+            m_rhiSystem->Shutdown();
+            m_rhiSystem.reset();
+            m_factory.reset();
+
+            RHITestFixture::TearDown();
+        }
+
+    private:
+        AZStd::unique_ptr<AZ::RHI::RHISystem> m_rhiSystem;
+        AZStd::unique_ptr<Factory> m_factory;
     };
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -95,8 +95,8 @@ namespace AZ
                 }
             }
 
-            //Init RHI device
-            m_rhiSystem.InitDevice();
+            // Init RHI device(s)
+            m_rhiSystem.InitDevices(AzFramework::StringFunc::Equal(RHI::GetCommandLineValue("enableMultipleDevices").c_str(), "enable") ? RHI::InitDevicesFlags::MultiDevice : RHI::InitDevicesFlags::SingleDevice);
 
             // Gather asset handlers from sub-systems.
             ImageSystem::GetAssetHandlers(m_assetHandlers);


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and lays the foundations for introducing multi-device versions of all relevant resource classes on the `RHI` level.

This MR holds all minor changes that affect the current code setup and is necessary as a first step for introducing multi-device resources as well as the ability to write tests that can utilize multiple devices.

The changes include:
- Moving multi-device command line parameter query to the `RPISystem`, which is more coherent and allows the test suite to instantiate the `RHISystem` in a multi-device fashion.
- Define `DeviceMask` as a parameter as well as default parameters for `DeviceMask` and device index
- Allow tests to enumerate multiple devices and fixes to the test factory as well as a new base class for multi-device tests

### Planned PRs
This commit is one in a series of PRs to come:
1. Preparation  <------ this commit
2. Base Resources
3. Buffers & Images
4. Pipelines
5. Independent Resources
6. Indirect*
7. *Items
8. SRGs
9. RayTracing Resources
