### PR TITLE
Multi-device base resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Device.h>
+
+namespace AZ::RHI
+{
+    //! A variant of Object associated with a DeviceMask. It provides a simple accessor API.
+    class MultiDeviceObject : public Object
+    {
+    public:
+        AZ_RTTI(MultiDeviceObject, "{17D34F71-944C-4AF5-9823-627474C4C0A6}", Object);
+        virtual ~MultiDeviceObject() = default;
+
+        //! Returns whether the device object is initialized.
+        bool IsInitialized() const;
+
+        //! Returns the device this object is associated with. It is only permitted to call
+        //! this method when the object is initialized.
+        MultiDevice::DeviceMask GetDeviceMask() const;
+
+    protected:
+        MultiDeviceObject() = default;
+
+        //! The derived class should call this method to assign the device.
+        void Init(MultiDevice::DeviceMask deviceMask);
+
+        //! Clears the current bound device to null.
+        void Shutdown() override;
+
+        //! Helper method that will iterate over all selected devices and call the provided callback
+        template<typename T>
+        void IterateDevices(T callback)
+        {
+            AZ_Error(
+                "RPI::MultiDeviceObject", AZStd::to_underlying(m_deviceMask) != 0u, "Device mask is not initialized with a valid value.");
+
+            int deviceCount = GetDeviceCount();
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    if (!callback(deviceIndex))
+                        break;
+                }
+            }
+        }
+
+    private:
+        //! Returns the number of initialized devices
+        int GetDeviceCount() const;
+
+        //! A bitmask denoting on which devices an object is present/valid/allocated
+        MultiDevice::DeviceMask m_deviceMask{ 0u };
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceResourcePool;
+    class FrameAttachment;
+    class MemoryStatisticsBuilder;
+    class ResourceView;
+    class ImageView;
+    class BufferView;
+    struct ImageViewDescriptor;
+    struct BufferViewDescriptor;
+
+    //! MultiDeviceResource is a base class for pooled, multi-device RHI resources (MultiDeviceImage / MultiDeviceBuffer /
+    //! MultiDeviceShaderResourceGroup, etc). It provides some common lifecycle management semantics. MultiDeviceResource creation is
+    //! separate from initialization. Resources are created separate from any pool, but its backing platform data is associated at
+    //! initialization time on a specific pool.
+    class MultiDeviceResource : public MultiDeviceObject
+    {
+        friend class FrameAttachment;
+        friend class MultiDeviceResourcePool;
+
+    public:
+        AZ_RTTI(MultiDeviceResource, "{613AED98-48FD-4453-98F8-6956D2133489}", MultiDeviceObject);
+        virtual ~MultiDeviceResource();
+
+        //! Returns whether the resource is currently an attachment on a frame graph.
+        bool IsAttachment() const;
+
+        //! Shuts down the resource by detaching it from its parent pool.
+        virtual void Shutdown() override = 0;
+
+        //! Returns the parent pool this resource is registered on. Since resource creation is
+        //! separate from initialization, this will be null until the resource is registered on a pool.
+        const MultiDeviceResourcePool* GetPool() const;
+        MultiDeviceResourcePool* GetPool();
+
+        //! Returns the version number. This number is monotonically increased anytime
+        //! new platform memory is assigned to the resource. Any dependent resource is
+        //! valid so long as the version numbers match.
+        uint32_t GetVersion() const;
+
+        //! Returns the frame attachment associated with this image (if it exists).
+        const FrameAttachment* GetFrameAttachment() const;
+
+        //! Invalidates all views referencing this resource. Invalidation is handled implicitly
+        //! on a Shutdown / Init cycle from the pool. For example, it is safe to create a resource,
+        //! create a view to that resource, and then Shutdown / Re-Init the resource. InvalidateViews is
+        //! called to synchronize views (and shader resource groups which hold them) to the new data.
+        //!
+        //! Platform back-ends which invalidate GPU-specific data on the resource without an explicit
+        //! shutdown / re-initialization will need to call this method explicitly.
+        virtual void InvalidateViews() = 0;
+
+        //! Returns true if the ResourceView is in the cache
+        bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
+        bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
+
+        //! Removes the provided ResourceView from the cache
+        void EraseResourceView(ResourceView* resourceView) const;
+
+    protected:
+        MultiDeviceResource() = default;
+
+    private:
+        //! Returns whether this resource has been initialized before.
+        bool IsFirstVersion() const;
+
+        //! Called by the parent pool at initialization time.
+        void SetPool(MultiDeviceResourcePool* pool);
+
+        //! Called by the frame attachment at frame building time.
+        void SetFrameAttachment(FrameAttachment* frameAttachment);
+
+        //! The parent pool this resource is registered with.
+        MultiDeviceResourcePool* m_mdPool = nullptr;
+
+        //! The current frame attachment registered on this resource.
+        FrameAttachment* m_frameAttachment = nullptr;
+
+        //! The version is monotonically incremented any time the backing resource is changed.
+        uint32_t m_version = 0;
+
+        //! Tracks whether an invalidation request is currently queued on this resource.
+        bool m_isInvalidationQueued = false;
+
+        //! Cache the resourceViews in order to avoid re-creation
+        //! Since ResourceView has a dependency to MultiDeviceResource this cache holds raw pointers here in order to ensure there
+        //! is no circular dependency between the resource and it's resourceview.
+        mutable AZStd::unordered_map<size_t, ResourceView*> m_resourceViewCache;
+        //! This should help provide thread safe access to resourceView cache
+        mutable AZStd::mutex m_cacheMutex;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResourcePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResourcePool.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ResourcePoolDescriptor.h>
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/MemoryStatisticsBus.h>
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/std/parallel/shared_mutex.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+namespace AZ::RHI
+{
+    class CommandList;
+    class MultiDeviceResource;
+    class MemoryStatisticsBuilder;
+
+    //! A base class for multi-device resource pools. This class facilitates registration of multi-device resources
+    //! into the pool, and allows iterating child resource instances.
+    class MultiDeviceResourcePool : public MultiDeviceObject
+    {
+        friend class MultiDeviceResource;
+
+    public:
+        AZ_RTTI(MultiDeviceResourcePool, "{BAE5442C-A312-4133-AE80-1200753A7C3E}", MultiDeviceObject);
+        virtual ~MultiDeviceResourcePool();
+
+        //! Shuts down the pool. This method will shutdown all resources associated with the pool.
+        virtual void Shutdown() override = 0;
+
+        //! Loops through every resource matching the provided resource type (RTTI casting is used) and
+        //! calls the provided callback method. Both methods are thread-safe with respect to
+        //! other Init calls. A shared_mutex is used to guard the internal registry. This means
+        //! that multiple iterations can be done without blocking each other, but a resource Init / Shutdown
+        //! will serialize with this method.
+        template<typename ResourceType>
+        void ForEach(AZStd::function<void(ResourceType&)> callback);
+
+        template<typename ResourceType>
+        void ForEach(AZStd::function<void(const ResourceType&)> callback) const;
+
+        //! Returns the number of resources in the pool.
+        uint32_t GetResourceCount() const;
+
+        //! Returns the resource pool descriptor.
+        virtual const ResourcePoolDescriptor& GetDescriptor() const = 0;
+
+    protected:
+        MultiDeviceResourcePool() = default;
+
+        //!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//!//
+        // Middle Layer API - Used by specific RHI pools.
+
+        //! A simple functor that returns a result code.
+        using PlatformMethod = AZStd::function<RHI::ResultCode()>;
+
+        //! Validates the pool for initialization, calls the provided init method (which wraps the platform-specific
+        //! resource init call). If the platform init fails, the resource pool is shutdown and an error code is returned.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const PlatformMethod& initMethod);
+
+        //! Validates the state of resource, calls the provided init method, and registers the resource
+        //! with the pool. If validation or the internal platform init method fail, the resource is not
+        //! registered and an error code is returned.
+        ResultCode InitResource(MultiDeviceResource* resource, const PlatformMethod& initResourceMethod);
+
+        //! Validates the resource is registered / unregistered with the pool,
+        //! and that it not null. In non-release builds this will issue a warning.
+        //! Non-release builds will branch and fail the call if validation fails,
+        //! but this should be treated as a bug, because release will disable
+        //! validation.
+        bool ValidateIsRegistered(const MultiDeviceResource* resource) const;
+        bool ValidateIsUnregistered(const MultiDeviceResource* resource) const;
+
+        //! Validates that the resource pool is initialized and ready to service requests.
+        bool ValidateIsInitialized() const;
+
+    private:
+        //! Shuts down an resource by releasing all backing resources. This happens implicitly
+        //! if the resource is released. The resource is still valid after this call, and can be
+        //! re-initialized safely on another pool.
+        void ShutdownResource(MultiDeviceResource* resource);
+
+        //! Registers an resource instance with the pool (explicit pool derivations will do this).
+        void Register(MultiDeviceResource& resource);
+
+        //! Unregisters an resource instance with the pool.
+        void Unregister(MultiDeviceResource& resource);
+
+        //! The registry of resources initialized on the pool, guarded by a shared_mutex.
+        mutable AZStd::shared_mutex m_registryMutex;
+        AZStd::unordered_set<MultiDeviceResource*> m_mdRegistry;
+    };
+
+    template<typename ResourceType>
+    void MultiDeviceResourcePool::ForEach(AZStd::function<void(ResourceType&)> callback)
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+        for (MultiDeviceResource* resourceBase : m_mdRegistry)
+        {
+            ResourceType* resourceType = azrtti_cast<ResourceType*>(resourceBase);
+            if (resourceType)
+            {
+                callback(*resourceType);
+            }
+        }
+    }
+
+    template<typename ResourceType>
+    void MultiDeviceResourcePool::ForEach(AZStd::function<void(const ResourceType&)> callback) const
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+        for (const MultiDeviceResource* resourceBase : m_mdRegistry)
+        {
+            const ResourceType* resourceType = azrtti_cast<const ResourceType*>(resourceBase);
+            if (resourceType)
+            {
+                callback(*resourceType);
+            }
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceObject.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    bool MultiDeviceObject::IsInitialized() const
+    {
+        return AZStd::to_underlying(m_deviceMask) != 0u;
+    }
+
+    MultiDevice::DeviceMask MultiDeviceObject::GetDeviceMask() const
+    {
+        return m_deviceMask;
+    }
+
+    void MultiDeviceObject::Init(MultiDevice::DeviceMask deviceMask)
+    {
+        m_deviceMask = deviceMask;
+    }
+
+    void MultiDeviceObject::Shutdown()
+    {
+        m_deviceMask = static_cast<MultiDevice::DeviceMask>(0u);
+    }
+
+    int MultiDeviceObject::GetDeviceCount() const
+    {
+        return RHI::RHISystemInterface::Get()->GetDeviceCount();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI.Reflect/BufferViewDescriptor.h>
+#include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ResourceView.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/hash.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceResource::~MultiDeviceResource()
+    {
+        AZ_Assert(
+            GetPool() == nullptr,
+            "MultiDeviceResource '%s' is still registered on pool. %s",
+            GetName().GetCStr(),
+            GetPool()->GetName().GetCStr());
+    }
+
+    bool MultiDeviceResource::IsAttachment() const
+    {
+        return m_frameAttachment != nullptr;
+    }
+
+    uint32_t MultiDeviceResource::GetVersion() const
+    {
+        return m_version;
+    }
+
+    bool MultiDeviceResource::IsFirstVersion() const
+    {
+        return m_version == 0;
+    }
+
+    void MultiDeviceResource::SetPool(MultiDeviceResourcePool* bufferPool)
+    {
+        m_mdPool = bufferPool;
+
+        const bool isValidPool = bufferPool != nullptr;
+        if (isValidPool)
+        {
+            // Only invalidate the resource if it has dependent views. It
+            // can't have any if this is the first initialization.
+            if (!IsFirstVersion())
+            {
+                InvalidateViews();
+            }
+        }
+
+        ++m_version;
+    }
+
+    const MultiDeviceResourcePool* MultiDeviceResource::GetPool() const
+    {
+        return m_mdPool;
+    }
+
+    MultiDeviceResourcePool* MultiDeviceResource::GetPool()
+    {
+        return m_mdPool;
+    }
+
+    void MultiDeviceResource::SetFrameAttachment(FrameAttachment* frameAttachment)
+    {
+        if (Validation::IsEnabled())
+        {
+            // The frame attachment has tight control over lifecycle here.
+            [[maybe_unused]] const bool isAttach = (!m_frameAttachment && frameAttachment);
+            [[maybe_unused]] const bool isDetach = (m_frameAttachment && !frameAttachment);
+            AZ_Assert(isAttach || isDetach, "The frame attachment for resource '%s' was not assigned properly.", GetName().GetCStr());
+        }
+
+        m_frameAttachment = frameAttachment;
+    }
+
+    const FrameAttachment* MultiDeviceResource::GetFrameAttachment() const
+    {
+        return m_frameAttachment;
+    }
+
+    void MultiDeviceResource::Shutdown()
+    {
+        // Shutdown is delegated to the parent pool if this resource is registered on one.
+        if (m_mdPool)
+        {
+            AZ_Error(
+                "MultiDeviceResource",
+                m_frameAttachment == nullptr,
+                "The resource is currently attached on a frame graph. It is not valid "
+                "to shutdown a resource while it is being used as an Attachment. The "
+                "behavior is undefined.");
+
+            m_mdPool->ShutdownResource(this);
+        }
+        MultiDeviceObject::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResourcePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResourcePool.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ResourcePoolDatabase.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceResourcePool::~MultiDeviceResourcePool()
+    {
+        AZ_Assert(m_mdRegistry.empty(), "ResourceType pool was not properly shutdown.");
+    }
+
+    uint32_t MultiDeviceResourcePool::GetResourceCount() const
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
+        return static_cast<uint32_t>(m_mdRegistry.size());
+    }
+
+    bool MultiDeviceResourcePool::ValidateIsRegistered(const MultiDeviceResource* resource) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!resource || resource->GetPool() != this)
+            {
+                AZ_Error(
+                    "MultiDeviceResourcePool", false, "'%s': MultiDeviceResource is not registered on this pool.", GetName().GetCStr());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool MultiDeviceResourcePool::ValidateIsUnregistered(const MultiDeviceResource* resource) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!resource || resource->GetPool() != nullptr)
+            {
+                AZ_Error(
+                    "MultiDeviceResourcePool",
+                    false,
+                    "'%s': MultiDeviceResource is null or registered on another pool.",
+                    GetName().GetCStr());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool MultiDeviceResourcePool::ValidateIsInitialized() const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (IsInitialized() == false)
+            {
+                AZ_Error("MultiDeviceResourcePool", false, "MultiDeviceResource pool is not initialized.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    void MultiDeviceResourcePool::Register(MultiDeviceResource& resource)
+    {
+        resource.SetPool(this);
+
+        AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
+        m_mdRegistry.emplace(&resource);
+    }
+
+    void MultiDeviceResourcePool::Unregister(MultiDeviceResource& resource)
+    {
+        resource.SetPool(nullptr);
+
+        AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
+        m_mdRegistry.erase(&resource);
+    }
+
+    ResultCode MultiDeviceResourcePool::Init(MultiDevice::DeviceMask deviceMask, const PlatformMethod& platformInitMethod)
+    {
+        if (Validation::IsEnabled())
+        {
+            if (IsInitialized())
+            {
+                AZ_Error("MultiDeviceResourcePool", false, "MultiDeviceResourcePool '%s' is already initialized.", GetName().GetCStr());
+                return ResultCode::InvalidOperation;
+            }
+        }
+
+        MultiDeviceObject::Init(deviceMask);
+
+        ResultCode resultCode = platformInitMethod();
+
+        return resultCode;
+    }
+
+    void MultiDeviceResourcePool::Shutdown()
+    {
+        // Multiple shutdown is allowed for pools.
+        if (IsInitialized())
+        {
+            for (MultiDeviceResource* resource : m_mdRegistry)
+            {
+                resource->SetPool(nullptr);
+                resource->Shutdown();
+            }
+            m_mdRegistry.clear();
+            MultiDeviceObject::Shutdown();
+        }
+    }
+
+    ResultCode MultiDeviceResourcePool::InitResource(MultiDeviceResource* resource, const PlatformMethod& platformInitResourceMethod)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsUnregistered(resource))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        const ResultCode resultCode = platformInitResourceMethod();
+        if (resultCode == ResultCode::Success)
+        {
+            resource->Init(GetDeviceMask());
+            Register(*resource);
+        }
+        return resultCode;
+    }
+
+    void MultiDeviceResourcePool::ShutdownResource(MultiDeviceResource* resource)
+    {
+        if (ValidateIsInitialized() && ValidateIsRegistered(resource))
+        {
+            Unregister(*resource);
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -51,10 +51,12 @@ set(FILES
     Include/Atom/RHI/Device.h
     Include/Atom/RHI/DeviceBusTraits.h
     Include/Atom/RHI/DeviceObject.h
+    Include/Atom/RHI/MultiDeviceObject.h
     Include/Atom/RHI/CommandQueue.h
     Include/Atom/RHI/ValidationLayer.h
     Source/RHI/Device.cpp
     Source/RHI/DeviceObject.cpp
+    Source/RHI/MultiDeviceObject.cpp
     Source/RHI/CommandQueue.cpp
     Source/RHI/ValidationLayer.cpp
     Include/Atom/RHI/Factory.h
@@ -133,13 +135,17 @@ set(FILES
     Source/RHI/QueryPool.cpp
     Source/RHI/QueryPoolSubAllocator.cpp
     Include/Atom/RHI/Resource.h
+    Include/Atom/RHI/MultiDeviceResource.h
     Include/Atom/RHI/ResourceInvalidateBus.h
     Include/Atom/RHI/ResourceView.h
     Source/RHI/Resource.cpp
+    Source/RHI/MultiDeviceResource.cpp
     Source/RHI/ResourceView.cpp
     Include/Atom/RHI/ResourcePool.h
+    Include/Atom/RHI/MultiDeviceResourcePool.h
     Include/Atom/RHI/ResourcePoolDatabase.h
     Source/RHI/ResourcePool.cpp
+    Source/RHI/MultiDeviceResourcePool.cpp
     Source/RHI/ResourcePoolDatabase.cpp
     Include/Atom/RHI/MemoryAllocation.h
     Include/Atom/RHI/MemorySubAllocator.h


### PR DESCRIPTION
## What does this PR do?
This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces the base resource classes from which most multi-device classes inherit, which includes
- `MultiDeviceObject`
- `MultiDeviceResource`
- `MultiDeviceResourcePool`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the `RHI` or `RPI` level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

- Preparation [PR16138](https://github.com/o3de/o3de/pull/16138)
- Base Resources <------ this commit
- Buffers & Images
- Pipelines
- Independent Resources
- Indirect*
- *Items
- SRGs
- RayTracing Resources
