### PR TITLE
Add CMake var for debug symbols in release builds, make Gem Assets inside Project folders higher priority

### DIFF
--- a/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/DefaultProject/Template/Registry/assetprocessor_settings.setreg
@@ -16,7 +16,8 @@
                     "watch": "@PROJECTROOT@/Registry",
                     "recursive": 1,
                     "order": 3
-                }
+                },
+                "ProjectRelativeGemsScanFolderPriority":"higher"
             }
         }
     }

--- a/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
+++ b/Templates/MinimalProject/Template/Registry/assetprocessor_settings.setreg
@@ -16,7 +16,8 @@
                     "watch": "@PROJECTROOT@/Registry",
                     "recursive": 1,
                     "order": 3
-                }
+                },
+                "ProjectRelativeGemsScanFolderPriority":"higher"
             }
         }
     }

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -139,6 +139,17 @@ else()
     )
 endif()
 
+set(O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE FALSE CACHE BOOL "Add debug symbols when building in release configuration. (default = FALSE)")
+if(O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE)
+    ly_append_configurations_options(
+        COMPILATION_RELEASE
+            /Od             # Enable debug symbols
+            /Zi             # Generate debugging information (no Edit/Continue)
+        LINK_NON_STATIC_RELEASE
+            /DEBUG          # Generate pdbs
+    )
+endif()
+
 # Configure system includes
 ly_set(LY_CXX_SYSTEM_INCLUDE_CONFIGURATION_FLAG
     /experimental:external # Turns on "external" headers feature for MSVC compilers, required for MSVC < 16.10


### PR DESCRIPTION
## What does this PR do?

- Add `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` to output .pdb symbol files for release builds
- Set the default asset processor priority for Gems inside Project folders to be higher than the Project, so that if you place a Gem inside your Project, the Gem's asset paths in the cache are not relative to the Project root, but relative to the Gem `Assets` folder like they are when the Gem is outside the Project folder.

## How was this PR tested?

- Placed PopcornFX gem inside a project's folder and verified the paths were relative to the Popcorn `Assets` folder by looking at the source and product output in the Asset Processor.
- Verified when the `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` is enabled .pdb symbol files are generated in release mode
