### PR TITLE
Fixed debug font size in Editor when windows has a DPI setting other than 100%

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1638,7 +1638,7 @@ AZ::FFont::DrawParameters AZ::FFont::ExtractDrawParameters(const AzFramework::Te
     internalParams.m_ctx.EnableFrame(false);
     internalParams.m_ctx.SetProportional(!params.m_monospace && params.m_scaleWithWindow);
     internalParams.m_ctx.SetSizeIn800x600(params.m_scaleWithWindow && params.m_virtual800x600ScreenSize);
-    internalParams.m_ctx.SetSize(AZVec2ToLYVec2(AZ::Vector2(params.m_textSizeFactor, params.m_textSizeFactor) * params.m_scale * internalParams.m_viewportContext->GetDpiScalingFactor()));
+    internalParams.m_ctx.SetSize(AZVec2ToLYVec2(AZ::Vector2(params.m_textSizeFactor, params.m_textSizeFactor) * params.m_scale));
     internalParams.m_ctx.SetLineSpacing(params.m_lineSpacing);
 
     if (params.m_hAlign != AzFramework::TextHorizontalAlignment::Left ||


### PR DESCRIPTION
## What does this PR do?
When windows has a dpi setting such as 150%, the debug font in the Editor viewport are rendered with wrong size and layout. See the picture below:
![image (18)](https://github.com/o3de/o3de/assets/55564570/19767cf9-269d-49a1-828a-6a62f8cdd353)
This PR fixes the wrong font size. The screenshot after the change with dpi 200%:
![image](https://github.com/o3de/o3de/assets/55564570/bf2d4701-c32b-4e2d-bfa4-fc81e248bde3)

This issue was brought in after the explicit render resolution change: https://github.com/o3de/o3de/pull/16027

## How was this PR tested?
o3de Editor
