### PR TITLE
Fix event stream related API deprecation

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Mac/native/FileWatcher/FileWatcher_mac.h
+++ b/Code/Tools/AssetProcessor/Platform/Mac/native/FileWatcher/FileWatcher_mac.h
@@ -33,5 +33,6 @@ public:
     void ConsumeEvents(size_t numEvents, const char **filePaths, const FSEventStreamEventFlags eventFlags[], const FSEventStreamEventId eventIds[]);
     
     FileWatcher* m_watcher = nullptr;
+    dispatch_queue_t m_dispatchQueue;
 };
 

--- a/Code/Tools/AssetProcessor/Platform/Mac/native/FileWatcher/FileWatcher_macos.cpp
+++ b/Code/Tools/AssetProcessor/Platform/Mac/native/FileWatcher/FileWatcher_macos.cpp
@@ -60,6 +60,8 @@ bool FileWatcher::PlatformStart()
 
     AZ_Error("FileWatcher", (m_platformImpl->m_stream != nullptr), "FSEventStreamCreate returned a nullptr. No file events will be reported.");
 
+    m_platformImpl->m_dispatchQueue = dispatch_queue_create("EventStreamQueue", DISPATCH_QUEUE_CONCURRENT);
+    
     const CFIndex pathCount = CFArrayGetCount(pathsToWatch);
     for(CFIndex i = 0; i < pathCount; ++i)
     {
@@ -93,7 +95,7 @@ void FileWatcher::WatchFolderLoop()
     static const CFTimeInterval secondsToProcess = 0.5;
 
     m_platformImpl->m_runLoop = CFRunLoopGetCurrent();
-    FSEventStreamScheduleWithRunLoop(m_platformImpl->m_stream, m_platformImpl->m_runLoop, kCFRunLoopDefaultMode);
+    FSEventStreamSetDispatchQueue(m_platformImpl->m_stream, m_platformImpl->m_dispatchQueue);
     FSEventStreamStart(m_platformImpl->m_stream);
 
     const bool returnAfterFirstEventHandled = false;


### PR DESCRIPTION
## What does this PR do?

Adds an async dispatch_queue_t to be used for the updated FSEventStreamSetDispatchQueue api as FSEventStreamScheduleWithRunLoop is deprecated

## How was this PR tested?

- Ran AP within ASV
- Ran AztestRunner with CL params **libAssetProcessor.Tests.dylib AzRunUnitTests --gtest_filter=FileWatcherUnitTest***

cwd = /Users/moudgils/GitHub/o3de-atom-sampleviewer/build/MacBuild/bin/profile
LIB: libAssetProcessor.Tests.dylib
Loading: libAssetProcessor.Tests.dylib
OKAY Library loaded: libAssetProcessor.Tests.dylib
OKAY Symbol found: AzRunUnitTests
Note: Google Test filter = FileWatcherUnitTest*
[==========] Running 17 tests from 3 test cases.
[----------] Global test environment set-up.
[----------] 13 tests from FileWatcherUnitTest
[ RUN      ] FileWatcherUnitTest.WatchFileCreation_CreateSingleFile_FileChangeFound
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileCreation_CreateSingleFile_FileChangeFound (30 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileDeletion_RemoveTestAsset_FileChangeFound
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileDeletion_RemoveTestAsset_FileChangeFound (25 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileCreateModifyDeletion_AllFileChangesFound
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileCreateModifyDeletion_AllFileChangesFound (47 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileCreation_MultipleFiles_FileChangesFound_ChangesAreInOrder_SUITE_periodic
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileCreation_MultipleFiles_FileChangesFound_ChangesAreInOrder_SUITE_periodic (222 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileCreation_MultipleFiles_IgnoresAreIgnored_SUITE_periodic
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileCreation_MultipleFiles_IgnoresAreIgnored_SUITE_periodic (227 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryAdditions_ShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryAdditions_ShowUp (24 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryAdditions_IgnoredFilesDoNotShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryAdditions_IgnoredFilesDoNotShowUp (24 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryAdditions_NonIgnoredFiles_InIgnoredDirectories_DoNotShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryAdditions_NonIgnoredFiles_InIgnoredDirectories_DoNotShowUp (25 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryAdditions_NonIgnoredDirectories_InIgnoredDirectories_DoNotShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryAdditions_NonIgnoredDirectories_InIgnoredDirectories_DoNotShowUp (25 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryRemoves_ShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryRemoves_ShowUp (49 ms)
[ RUN      ] FileWatcherUnitTest.DirectoryRemoves_IgnoredDoNotShowUp
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.DirectoryRemoves_IgnoredDoNotShowUp (50 ms)
[ RUN      ] FileWatcherUnitTest.WatchFileRelocation_RenameTestAsset_FileChangeFound
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFileRelocation_RenameTestAsset_FileChangeFound (126 ms)
[ RUN      ] FileWatcherUnitTest.WatchFolder_ValidFoldersWatched
AssetProcessor: File Change Monitoring started.
[       OK ] FileWatcherUnitTest.WatchFolder_ValidFoldersWatched (3 ms)
[----------] 13 tests from FileWatcherUnitTest (877 ms total)

[----------] 2 tests from FileWatcherUnitTest/FileWatcherUnitTest_FloodTests
[ RUN      ] FileWatcherUnitTest/FileWatcherUnitTest_FloodTests.FileAddedAfterDirectoryAdded_IsNotMissed_SUITE_periodic/0
AssetProcessor: File Change Monitoring started.
