### PR TITLE
Fixed calculation of `bootstrap.<launcher-type>.<config>.setreg` SubIDs

### DIFF
--- a/Assets/Engine/SeedAssetList.seed
+++ b/Assets/Engine/SeedAssetList.seed
@@ -211,7 +211,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 2872571093
+                "subId": 3428050507
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.client.release.setreg"
@@ -219,7 +219,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 3617796014
+                "subId": 2733667963
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.client.profile.setreg"
@@ -227,7 +227,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 3128343591
+                "subId": 3945067969
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.client.debug.setreg"
@@ -235,7 +235,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 68654025
+                "subId": 3877526290
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.server.release.setreg"
@@ -243,7 +243,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 3046526190
+                "subId": 3451833122
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.server.profile.setreg"
@@ -251,7 +251,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 2583959823
+                "subId": 2263697560
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.server.debug.setreg"
@@ -259,7 +259,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 2402393288
+                "subId": 3208209838
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.unified.release.setreg"
@@ -267,7 +267,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 1383733705
+                "subId": 3520632254
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.unified.profile.setreg"
@@ -275,7 +275,7 @@
         {
             "assetId": {
                 "guid": "{3B28A661-E723-5EBE-AB52-EC5829D88C31}",
-                "subId": 4106752934
+                "subId": 2660526372
             },
             "platformFlags": 255,
             "pathHint": "bootstrap.unified.debug.setreg"

--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -35,7 +35,7 @@ namespace AssetProcessor
         builderDesc.m_busId = m_builderId;
         builderDesc.m_createJobFunction = AZStd::bind(&SettingsRegistryBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDesc.m_processJobFunction = AZStd::bind(&SettingsRegistryBuilder::ProcessJob, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
-        builderDesc.m_version = 2;
+        builderDesc.m_version = 3;
 
         AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBusTraits::RegisterBuilderInformation, builderDesc);
 
@@ -159,6 +159,9 @@ namespace AssetProcessor
             { AZStd::string_view{"unified"}, AZStd::string_view{"debug"} }
         };
 
+        constexpr size_t LauncherTypeIndex = 0;
+        constexpr size_t BuildConfigIndex = 1;
+
         // Add the project specific specializations
         auto projectName = AZ::Utils::GetProjectName();
         if (!projectName.empty())
@@ -259,8 +262,8 @@ namespace AssetProcessor
                 if (auto& operationMessages = mergeResult.GetMessages();
                     !operationMessages.empty())
                 {
-                    AZStd::string_view launcherString = specialization.GetSpecialization(0);
-                    AZStd::string_view buildConfiguration = specialization.GetSpecialization(1);
+                    AZStd::string_view launcherString = specialization.GetSpecialization(LauncherTypeIndex);
+                    AZStd::string_view buildConfiguration = specialization.GetSpecialization(BuildConfigIndex);
                     AZ_Info("Settings Registry Builder", R"(Launcher Type: "%.*s", Build configuration: "%.*s")" "\n"
                         "Merging the Engine, Gem, Project Registry directories resulted in the following messages:\n%s\n",
                         AZ_STRING_ARG(launcherString), AZ_STRING_ARG(buildConfiguration),
@@ -286,9 +289,9 @@ namespace AssetProcessor
                 if (AZ::IO::ByteContainerStream outputStream(&outputBuffer);
                     AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(registry, "", outputStream, dumperSettings))
                 {
-                    AZStd::string_view specializationString(specialization.GetSpecialization(0));
+                    AZStd::string_view specializationString(specialization.GetSpecialization(LauncherTypeIndex));
                     outputPath.Native() += specializationString; // Append launcher type (client, server, or unified)
-                    specializationString = specialization.GetSpecialization(1);
+                    specializationString = specialization.GetSpecialization(BuildConfigIndex);
                     outputPath.Native() += '.';
                     outputPath.Native() += specializationString; // Append configuration
                     outputPath.Native() += ".setreg";
@@ -310,9 +313,9 @@ namespace AssetProcessor
                     // Hash only the launcher type and build config specializations tags
                     size_t hashedSpecialization{};
                     // Get the launcher type specialization tag
-                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(0));
+                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(LauncherTypeIndex));
                     // Get the build config specialization tag
-                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(1));
+                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(BuildConfigIndex));
                     AZ_Assert(hashedSpecialization != 0, "Product ID generation failed for specialization %.*s."
                         " This can result in a product ID collision with other builders for this asset.",
                         AZ_STRING_ARG(specializationString));

--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -307,12 +307,12 @@ namespace AssetProcessor
                     }
                     file.Close();
 
-                    // Hash all specializations tags
+                    // Hash only the launcher type and build config specializations tags
                     size_t hashedSpecialization{};
-                    for (size_t specIndex{}; specIndex < specialization.GetCount(); ++specIndex)
-                    {
-                        AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(specIndex));
-                    }
+                    // Get the launcher type specialization tag
+                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(0));
+                    // Get the build config specialization tag
+                    AZStd::hash_combine(hashedSpecialization, specialization.GetSpecialization(1));
                     AZ_Assert(hashedSpecialization != 0, "Product ID generation failed for specialization %.*s."
                         " This can result in a product ID collision with other builders for this asset.",
                         AZ_STRING_ARG(specializationString));


### PR DESCRIPTION
The SubID calculation was taking into account the project name and project launcher executable name which would cause a different Asset SubID to be generated based on the active project.

That is not needed since each project has it's own Asset Cache and therefore the SubIDs values should be the same across all projects.

## How was this PR tested?

Currently building the AssetProcessor right now to validate that the SubIDs of the `bootstrap.<launcher-type>.<config>.setreg` files are the same when created across two different projects.

Update: Verified that both the AtomSampleViewer and AutomatedTesting project produces the same SubIds for the `bootstrap.<launcher-type>.<config>.setreg` files
