### PR TITLE
Fix thread handling in Editor startup dialog

### DIFF
--- a/Code/Editor/StartupLogoDialog.cpp
+++ b/Code/Editor/StartupLogoDialog.cpp
@@ -96,14 +96,12 @@ void CStartupLogoDialog::SetText(const char* text)
 
 void CStartupLogoDialog::SetInfoText(const char* text)
 {
-    m_ui->m_TransparentText->setText(text);
-
-    if (QThread::currentThread() == thread())
-    {
-        m_ui->m_TransparentText->repaint();
-    }
-
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents); // if you don't process events, repaint does not function correctly.
+    QMetaObject::invokeMethod(
+        this,
+        [this, text = QString(text)]()
+        {
+            m_ui->m_TransparentText->setText(text);
+        });
 }
 
 void CStartupLogoDialog::paintEvent(QPaintEvent*)


### PR DESCRIPTION
## What does this PR do?

The Editor startup dialog sometimes crashes, for me, when an information text is set.
This is because the text is, sometimes, set from a thread that is not the thread that the `QWidgets` are supposed to be updated from.
In Qt its not allowed to call the `setText` of the text widget in a thread that's not the Widget thread.

To solve this, the text is set through the `QMetaObject::invokeMethod` function (https://doc.qt.io/qt-6/qmetaobject.html#invokeMethod-8).
If the calling thread is not the widget thread, this function enqueues the function call. It is called when the `QEventLoop` of the widgets thread processes its events.+
If it is called from the widget thread, the passed function is called immediately ([Qt::AutoConnection](https://doc.qt.io/qt-6/qt.html#ConnectionType-enum))

## How was this PR tested?

This was tested on Windows. I started the Editor a few times and checked if the info texts appear, and the Editor does not crash.
