### PR TITLE
AWS Util to Extracting Data from an ARN

### DIFF
--- a/Gems/AWSCore/Code/Include/Framework/Util.h
+++ b/Gems/AWSCore/Code/Include/Framework/Util.h
@@ -39,8 +39,12 @@ namespace AWSCore
         //! Be aware that the ARNs for some resources omit the Region, the account ID, or both the Region and the account ID.
         inline AZStd::string ExtractArnData(AZStd::string_view awsArn, ArnFormatDataIndex arnDataIndex)
         {
+            // ARNs that omit region or account id will leave an empty entry.
+            // For example, IAM ARNs will omit the region (notice the 2 colons '::' specifying no region)
+            //     arn:aws:iam::123456789012:<user_data>
+            constexpr bool keepEmptyStrings = true;
             AZStd::vector<AZStd::string> tokenizedGameLiftArn;
-            AZ::StringFunc::Tokenize(awsArn, tokenizedGameLiftArn, ":");
+            AZ::StringFunc::Tokenize(awsArn, tokenizedGameLiftArn, ":", keepEmptyStrings);
             if (tokenizedGameLiftArn.size() >= arnDataIndex)
             {
                 return tokenizedGameLiftArn[arnDataIndex];

--- a/Gems/AWSCore/Code/Include/Framework/Util.h
+++ b/Gems/AWSCore/Code/Include/Framework/Util.h
@@ -9,12 +9,53 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
+#include "AzCore/StringFunc/StringFunc.h"
 #include <aws/core/utils/memory/stl/AWSString.h>
 
 namespace AWSCore
 {
     namespace Util
     {
+        //! An enum representing the available data provided in an AWS ARN (Amazon Resource Name)
+        //! ARN formats:
+        //!     arn:partition:service:region:account-id:resource-id
+        //!     arn:partition:service:region:account-id:resource-type/resource-id
+        //!     arn:partition:service:region:account-id:resource-type:resource-id
+        //! Be aware that the ARNs for some resources omit the Region, the account ID, or both the Region and the account ID.
+        //! Example of GameLift Fleet ARN:
+        //!     "arn:aws:gamelift:us-west-2:<account id>:fleet/fleet-<fleet id>"
+        enum ArnFormatDataIndex
+        {
+            Partition = 1,
+            Service,
+            Region,
+            AccountId
+        };
+
+        //! Extracts information from an AWS ARN (Amazon Resource Name)
+        //! @param awsArn An AWS ARN. ARNs are formatted as arn:partition:service:region:account-id:<resource-type/id>
+        //! @param arnDataIndex The type of ARN data to extract. Possible values are Partition, Service, Region, or AccountId
+        //! @return A string representing extracted ARN data. Empty string is returned if data type isn't found.
+        //! Be aware that the ARNs for some resources omit the Region, the account ID, or both the Region and the account ID.
+        inline AZStd::string ExtractArnData(AZStd::string_view awsArn, ArnFormatDataIndex arnDataIndex)
+        {
+            AZStd::vector<AZStd::string> tokenizedGameLiftArn;
+            AZ::StringFunc::Tokenize(awsArn, tokenizedGameLiftArn, ":");
+            if (tokenizedGameLiftArn.size() >= arnDataIndex)
+            {
+                return tokenizedGameLiftArn[arnDataIndex];
+            }
+            return "";
+        }
+
+        //! Extracts the AWS region from a given ARN (Amazon Resource Name)
+        //! @param awsArn An AWS ARN. ARNs are formatted as arn:partition:service:region:account-id:<resource-type/id>
+        //! @return A string representing the AWS region or an empty string if no region is found.
+        inline AZStd::string ExtractRegion(AZStd::string_view awsArn)
+        {
+            return ExtractArnData(awsArn, ArnFormatDataIndex::Region);
+        }
+
         inline Aws::String ToAwsString(const AZStd::string& s)
         {
             return Aws::String(s.c_str(), s.length());


### PR DESCRIPTION
Adding a new AWS Util for extracting data from an AWS ARN. 
Multiplayer Sample uses this to automatically find the AWS region in order to configure the client.

Helps fix: https://github.com/o3de/o3de-multiplayersample/pull/436