### PR TITLE
Don't Replicate Server Asset Settings to Client

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -42,13 +42,13 @@
 
 namespace AZ::IO
 {
-    AZ_CVAR(int, sys_PakPriority, aznumeric_cast<int>(ArchiveVars{}.m_fileSearchPriority), nullptr, AZ::ConsoleFunctorFlags::Null,
+    AZ_CVAR(int, sys_PakPriority, aznumeric_cast<int>(ArchiveVars{}.m_fileSearchPriority), nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "If set to 0, tells Archive to try to open the file on the file system first othewise check mounted paks.\n"
         "If set to 1, tells Archive to try to open the file in pak first, then go to file system.\n"
         "If set to 2, tells the Archive to only open files from the pak");
-    AZ_CVAR(int, sys_report_files_not_found_in_paks, 0, nullptr, AZ::ConsoleFunctorFlags::Null,
+    AZ_CVAR(int, sys_report_files_not_found_in_paks, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Reports when files are searched for in paks and not found. 1 = log, 2 = warning, 3 = error");
-    AZ_CVAR(int32_t, az_archive_verbosity, 0, nullptr, AZ::ConsoleFunctorFlags::Null,
+    AZ_CVAR(int32_t, az_archive_verbosity, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Sets the verbosity level for logging Archive operations\n"
         ">=1 - Turns on verbose logging of all operations");
 }


### PR DESCRIPTION
Ensure game client pak-file settings aren't affected by the server's settings. 
This was causing MultiplayerSample to change how assets were loaded after connecting to servers.

Fixes https://github.com/o3de/o3de-multiplayersample/issues/396 