### PR TITLE
Check that AssetBrowser is focused before auto renaming.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -331,9 +331,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         {
             // If multiple AssetBrowsers are open, only the focused browser should perform the rename.
             QWidget* focusWidget = QApplication::focusWidget();
-
-            auto children = this->findChildren<QWidget*>();
-            if (!children.contains(focusWidget))
+            if (!isAncestorOf(focusWidget))
             {
                 return;
             }

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -329,6 +329,15 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         this,
         [this](const QModelIndex& index)
         {
+            // If multiple AssetBrowsers are open, only the focused browser should perform the rename.
+            QWidget* focusWidget = QApplication::focusWidget();
+
+            auto children = this->findChildren<QWidget*>();
+            if (!children.contains(focusWidget))
+            {
+                return;
+            }
+
             if (m_ui->m_thumbnailView->GetThumbnailActiveView())
             {
                 m_ui->m_thumbnailView->OpenItemForEditing(index);


### PR DESCRIPTION
## What does this PR do?

This PR resolves #13990. Each AssetBrowser checks whether the focused widget is a descendant before entering the renaming functionality.

## How was this PR tested?

Manual testing.
