### PR TITLE
User can switch render pipeline at runtime for Editor's main viewport and GameLauncher's viewport

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Periodic_GPU.py
@@ -97,7 +97,7 @@ def run_test(workspace, rhi, test_name, screenshot_name, test_script, level_path
         game_launcher.args.extend([ f'--rhi={rhi} ',
                                     f'--run-automation-suite={test_script} ',
                                     '--exit-on-automation-end ',
-                                    f'--r_default_pipeline_name={render_pipeline}',
+                                    f'--r_renderPipelinePath={render_pipeline}',
                                     f'--regset-file={setreg_file.name}'])
         game_launcher.start()
         waiter.wait_for(lambda: process_utils.process_exists(launcher_name, ignore_extensions=True))

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Smoke_GPU.py
@@ -38,7 +38,7 @@ class TestAutomation_RHIValidation_Vulkan_LowEndPipeline(EditorTestSuite):
         "-autotest_mode",
         "-rhi=vulkan",
         "-rhi-device-validation=enable",
-        "--r_default_pipeline_name=passes/LowEndRenderPipeline.azasset"
+        "--r_renderPipelinePath=passes/LowEndRenderPipeline.azasset"
         ]  # Default is ["-BatchMode", "-autotest_mode"]
     use_null_renderer = False  # Default is True
 

--- a/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
+++ b/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
@@ -11,6 +11,7 @@
 
 #include <AzFramework/Scene/SceneSystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Reflect/System/RenderPipelineDescriptor.h>
 
 namespace AZ::Render::Bootstrap
 {
@@ -23,6 +24,7 @@ namespace AZ::Render::Bootstrap
 
         virtual AZ::RPI::ScenePtr GetOrCreateAtomSceneFromAzScene(AzFramework::Scene* scene) = 0;
         virtual bool EnsureDefaultRenderPipelineInstalledForScene(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext) = 0;
+        virtual void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) = 0;
 
     protected:
         ~Request() = default;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -46,7 +46,35 @@
 #include <AzCore/Console/IConsole.h>
 #include <BootstrapSystemComponent_Traits_Platform.h>
 
-AZ_CVAR(AZ::CVarFixedString, r_default_pipeline_name, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default render pipeline name");
+void cvar_default_pipeline_name_Changed(const AZ::CVarFixedString& newPipelinePath)
+{
+    auto viewportContextManager = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+    if (!viewportContextManager)
+    {
+        return;
+    }
+    auto viewportContext = viewportContextManager->GetDefaultViewportContext();
+    if (!viewportContext)
+    {
+        return;
+    }
+
+    AZ::Data::Asset<AZ::RPI::AnyAsset> pipelineAsset =
+        AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::AnyAsset>(newPipelinePath.data(), AZ::RPI::AssetUtils::TraceLevel::Error);
+    if (pipelineAsset)
+    {
+        AZ::RPI::RenderPipelineDescriptor renderPipelineDescriptor =
+            *AZ::RPI::GetDataFromAnyAsset<AZ::RPI::RenderPipelineDescriptor>(pipelineAsset); // Copy descriptor from asset
+
+        AZ::Render::Bootstrap::RequestBus::Broadcast(&AZ::Render::Bootstrap::RequestBus::Events::SwitchRenderPipeline, renderPipelineDescriptor, viewportContext);
+    }
+    else
+    {
+        AZ_Warning("SetDefaultPipeline", false, "Failed to switch default render pipeline to %s: can't load the asset", newPipelinePath.data());
+    }
+}
+
+AZ_CVAR(AZ::CVarFixedString, r_default_pipeline_name, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_default_pipeline_name_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
@@ -196,7 +224,6 @@ namespace AZ
                         }
                     }
                 }
-
             }
 
             void BootstrapSystemComponent::Activate()
@@ -512,6 +539,38 @@ namespace AZ
                 }
 
                 return true;
+            }
+
+            void BootstrapSystemComponent::SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext)
+            {
+                AZ::RPI::RenderPipelineDescriptor pipelineDescriptor = newRenderPipelineDesc;
+                pipelineDescriptor.m_name =
+                    AZStd::string::format("%s_%i", pipelineDescriptor.m_name.c_str(), viewportContext->GetId());
+
+                if (pipelineDescriptor.m_renderSettings.m_multisampleState.m_customPositionsCount &&
+                    !RHI::RHISystemInterface::Get()->GetDevice()->GetFeatures().m_customSamplePositions)
+                {
+                    // Disable custom sample positions because they are not supported
+                    AZ_Warning(
+                        "BootstrapSystemComponent",
+                        false,
+                        "Disabling custom sample positions for pipeline %s because they are not supported on this device",
+                        pipelineDescriptor.m_name.c_str());
+                    pipelineDescriptor.m_renderSettings.m_multisampleState.m_customPositions = {};
+                    pipelineDescriptor.m_renderSettings.m_multisampleState.m_customPositionsCount = 0;
+                }
+
+                // Create new render pipeline
+                auto oldRenderPipeline = viewportContext->GetRenderScene()->GetDefaultRenderPipeline();
+                RPI::RenderPipelinePtr newRenderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(
+                        pipelineDescriptor, *viewportContext->GetWindowContext().get(), AZ::RPI::ViewType::Default);
+
+                // Switch render pipeline
+                viewportContext->GetRenderScene()->RemoveRenderPipeline(oldRenderPipeline->GetId());
+                viewportContext->GetRenderScene()->AddRenderPipeline(newRenderPipeline);
+                newRenderPipeline->SetDefaultView(oldRenderPipeline->GetDefaultView());
+
+                AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(newRenderPipeline->GetRenderSettings().m_multisampleState);
             }
 
             RPI::RenderPipelinePtr BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -46,7 +46,7 @@
 #include <AzCore/Console/IConsole.h>
 #include <BootstrapSystemComponent_Traits_Platform.h>
 
-void cvar_default_pipeline_name_Changed(const AZ::CVarFixedString& newPipelinePath)
+void cvar_r_renderPipelinePath_Changed(const AZ::CVarFixedString& newPipelinePath)
 {
     auto viewportContextManager = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
     if (!viewportContextManager)
@@ -74,7 +74,7 @@ void cvar_default_pipeline_name_Changed(const AZ::CVarFixedString& newPipelinePa
     }
 }
 
-AZ_CVAR(AZ::CVarFixedString, r_default_pipeline_name, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_default_pipeline_name_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
+AZ_CVAR(AZ::CVarFixedString, r_renderPipelinePath, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_r_renderPipelinePath_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
 AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
@@ -455,7 +455,7 @@ namespace AZ
                 // Load the main default pipeline if applicable
                 if (loadDefaultRenderPipeline)
                 {
-                    AZ::CVarFixedString pipelineName = static_cast<AZ::CVarFixedString>(r_default_pipeline_name);
+                    AZ::CVarFixedString pipelineName = static_cast<AZ::CVarFixedString>(r_renderPipelinePath);
                     if (xrSystem)
                     {
                         // When running launcher on PC having an XR system present then the default render pipeline is suppose to reflect

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -67,6 +67,7 @@ namespace AZ
                 // Render::Bootstrap::RequestBus::Handler overrides ...
                 AZ::RPI::ScenePtr GetOrCreateAtomSceneFromAzScene(AzFramework::Scene* scene) override;
                 bool EnsureDefaultRenderPipelineInstalledForScene(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext) override;
+                void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) override;
 
             protected:
                 // Component overrides ...

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -254,7 +254,6 @@ namespace AZ::Render
             return;
         }
         auto rootPass = viewportContext->GetCurrentPipeline()->GetRootPass();
-        const RPI::PipelineStatisticsResult stats = rootPass->GetLatestPipelineStatisticsResult();
 
         RPI::PassSystemFrameStatistics passSystemFrameStatistics = AZ::RPI::PassSystemInterface::Get()->GetFrameStatistics();
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -220,6 +220,8 @@ namespace AZ::Render
             viewportContext->GetViewportSize().m_height,
             multisampleState.m_samples > 1 ? AZStd::string::format("MSAA %dx", multisampleState.m_samples).c_str() : "NoMSAA"
         ));
+                
+        DrawLine(AZStd::string::format("Render pipeline: %s", viewportContext->GetCurrentPipeline()->GetId().GetCStr()));
     }
 
     void AtomViewportDisplayInfoSystemComponent::DrawCameraInfo()
@@ -257,10 +259,8 @@ namespace AZ::Render
         RPI::PassSystemFrameStatistics passSystemFrameStatistics = AZ::RPI::PassSystemInterface::Get()->GetFrameStatistics();
 
         DrawLine(AZStd::string::format(
-            "RenderPasses: %d Vertex Count: %lld Primitive Count: %lld",
-            passSystemFrameStatistics.m_numRenderPassesExecuted,
-            aznumeric_cast<long long>(stats.m_vertexCount),
-            aznumeric_cast<long long>(stats.m_primitiveCount)
+            "RenderPasses: %d",
+            passSystemFrameStatistics.m_numRenderPassesExecuted
         ));
         DrawLine(AZStd::string::format(
             "Total Draw Item Count: %d  Max Draw Items in a Pass: %d",
@@ -357,7 +357,7 @@ namespace AZ::Render
         }
 
         DrawLine(
-            AZStd::string::format("StreamingImagePool %s (used/allocated/budget): %.2f / %.2f/%.2f MiB", supportTiledImage?"Tiled":"", imagePoolUsedAllocatedMB, imagePoolTotalAllocatedMB, imagePoolBudgetMB),
+            AZStd::string::format("Texture %s (used/allocated/budget): %.2f / %.2f/%.2f MiB", supportTiledImage?"Tiled":"", imagePoolUsedAllocatedMB, imagePoolTotalAllocatedMB, imagePoolBudgetMB),
             fontColor
         );
     }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorStatePassSystem.cpp
@@ -58,6 +58,14 @@ namespace AZ::Render
             return;
         }
 
+        // check if the reference pass of insert position exist
+        Name postProcessPassName = Name("PostProcessPass");
+        if (renderPipeline->FindFirstPass(postProcessPassName) == nullptr)
+        {
+            AZ_Warning("EditorModeFeedback", false, "Can't find %s in the render pipeline. Editor mode feedback is disabled", postProcessPassName.GetCStr());
+            return;
+        }
+
         auto mainParentPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(templateName);
         if (!mainParentPassTemplate)
         {
@@ -165,7 +173,7 @@ namespace AZ::Render
         passRequest.m_passName = Name(MainPassParentPassName);
         passRequest.m_templateName = mainParentPassTemplate->m_name;
         passRequest.AddInputConnection(
-            RPI::PassConnection{ Name("ColorInputOutput"), RPI::PassAttachmentRef{ Name("PostProcessPass"), Name("Output") } });
+            RPI::PassConnection{ Name("ColorInputOutput"), RPI::PassAttachmentRef{ postProcessPassName, Name("Output") } });
         passRequest.AddInputConnection(
             RPI::PassConnection{ Name("InputDepth"), RPI::PassAttachmentRef{ Name("DepthPrePass"), Name("Depth") } });
 
@@ -177,7 +185,7 @@ namespace AZ::Render
         }
 
         // Inject the parent pass after the PostProcess pass
-        if (!renderPipeline->AddPassAfter(parentPass, Name("PostProcessPass")))
+        if (!renderPipeline->AddPassAfter(parentPass, postProcessPassName))
         {
             AZ_Error(
                 "EditorStatePassSystem", false, "Add editor mode feedback parent pass to render pipeline [%s] failed", renderPipeline->GetId().GetCStr());

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -329,6 +329,14 @@ namespace AZ
                     CreatePerPassResources();
                     return true;
                 }
+                // check if the reference pass of insert position exist
+                Name opaquePassName = Name("OpaquePass");
+                if (renderPipeline->FindFirstPass(opaquePassName) == nullptr)
+                {
+                    AZ_Warning("HairFeatureProcessor", false, "Can't find %s in the render pipeline. Atom TressFX won't be rendered", opaquePassName.GetCStr());
+                    return;
+                }
+
                 const char* passRequestAssetFilePath = "Passes/AtomTressFX_PassRequest.azasset";
                 m_hairPassRequestAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::AnyAsset>(
                     passRequestAssetFilePath, AZ::RPI::AssetUtils::TraceLevel::Warning);

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -334,7 +334,7 @@ namespace AZ
                 if (renderPipeline->FindFirstPass(opaquePassName) == nullptr)
                 {
                     AZ_Warning("HairFeatureProcessor", false, "Can't find %s in the render pipeline. Atom TressFX won't be rendered", opaquePassName.GetCStr());
-                    return;
+                    return false;
                 }
 
                 const char* passRequestAssetFilePath = "Passes/AtomTressFX_PassRequest.azasset";

--- a/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
+++ b/Gems/ScriptAutomation/Code/Source/ScriptAutomationScriptBindings.cpp
@@ -376,8 +376,8 @@ namespace AZ::ScriptAutomation
         {
             AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
             AZStd::string renderPipelinePath;
-            console->GetCvarValue("r_default_pipeline_name", renderPipelinePath);
-            AZ_Assert(renderPipelinePath.size() > 0, "Invalid render pipeline path obtained from r_default_pipeline_name CVAR");
+            console->GetCvarValue("r_renderPipelinePath", renderPipelinePath);
+            AZ_Assert(renderPipelinePath.size() > 0, "Invalid render pipeline path obtained from r_renderPipelinePath CVAR");
             return AZ::IO::PathView(renderPipelinePath).Stem().String();
         }
 


### PR DESCRIPTION
## What does this PR do?

User can set the pipeline's azasset file file to r_default_pipeline_name cvar at runtime to switch the render pipeline for Editor's 3d viewport or game launcher

The viewport debug info now has information of current render pipeline's name. Resolve the pass injections errors form hair FP and editorModeFeedback FP when switched to low end pipeline. Output warnings.

## How was this PR tested?

Tested with graphics/Stanza level and Graphics/PbrMaterialSheet level of AutomatedTesting project in Editor (dx12, Vulkan) and GameLauncher. 
Multiplayer Sample Project: works fine with dx12; got a device lost crash with vulkan when switch render pipeline.
