### PR TITLE
Misc Atom Improvements.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
+
+#if ENABLE_SHADOWS
 #include <Atom/Features/Shadow/DirectionalLightShadow.azsli>
+#endif
 
 void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, float4 screenUv)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
+
+#if ENABLE_SHADOWS
 #include <Atom/Features/Shadow/ProjectedShadow.azsli>
+#endif
 
 #if ENABLE_DISK_LIGHTS
 enum DiskLightFlag

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -9,9 +9,15 @@
 #pragma once
 
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
+
+#if ENABLE_SHADOWS
 #include <Atom/Features/Shadow/ProjectedShadow.azsli>
+#endif
 
 #if ENABLE_SPHERE_LIGHTS
+
+#if ENABLE_SHADOWS
+
 int GetPointLightShadowCubemapFace(const float3 targetPos, const float3 lightPos)
 {
     const float3 toPoint = targetPos - lightPos;    
@@ -64,6 +70,8 @@ uint ComputeShadowIndex(const ViewSrg::PointLight light, const Surface surface)
     const int shadowCubemapFace = GetPointLightShadowCubemapFace(biasedPosition, light.m_position);
     return UnpackPointLightShadowIndex(light, shadowCubemapFace);
 }
+
+#endif // ENABLE_SHADOWS
 
 void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -8,6 +8,12 @@
 
 #pragma once
 
+#ifndef ENABLE_SHADOWS
+#define ENABLE_SHADOWS              1
+#endif
+
+#if ENABLE_SHADOWS
+
 #include <scenesrg.srgi>
 #include <viewsrg.srgi>
 #include <Atom/RPI/Math.azsli>
@@ -159,3 +165,4 @@ float3 DirectionalLightShadow::AddDebugColoring(float3 color, uint lightIndex, f
     return color;
 }
 
+#endif // ENABLE_SHADOWS

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
@@ -8,6 +8,12 @@
 
 #pragma once
 
+#ifndef ENABLE_SHADOWS
+#define ENABLE_SHADOWS              1
+#endif
+
+#if ENABLE_SHADOWS
+
 #include <scenesrg.srgi>
 #include <viewsrg.srgi>
 #include <Atom/Features/Shadow/ShadowmapAtlasLib.azsli>
@@ -338,3 +344,5 @@ float3 ProjectedShadow::GetAtlasPosition(float2 texturePosition)
 
     return float3(coordInTexture, slice);
 }
+
+#endif // ENABLE_SHADOWS

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -55,7 +55,7 @@ namespace AZ
 
                 if (descriptor.m_renderStates.m_depthStencilState.m_depth.m_enable || descriptor.m_renderStates.m_depthStencilState.m_stencil.m_enable)
                 {
-                if (renderTargetConfiguration.GetDepthStencilFormat() == RHI::Format::Unknown)
+                    if (renderTargetConfiguration.GetDepthStencilFormat() == RHI::Format::Unknown)
                     {
                         AZ_Error("PipelineState", false, "Depth-stencil format is not set.");
                         error = true;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RasterPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RasterPass.h
@@ -77,6 +77,10 @@ namespace AZ
             // we need to creates a combined draw list which combines all the draw lists to one and cache it until they are submitted. 
             RHI::DrawList m_combinedDrawList;
             
+            // Forces viewport and scissor to match width/height of output image at specified index.
+            // Does nothing if index is negative.
+            s32 m_viewportAndScissorTargetOutputIndex = -1;
+
             RHI::Scissor m_scissorState;
             RHI::Viewport m_viewportState;
             bool m_overrideScissorSate = false;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RasterPassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RasterPassData.h
@@ -39,6 +39,10 @@ namespace AZ
             RHI::Scissor m_overrideScissor = RHI::Scissor::CreateNull();
 
             RHI::DrawListSortType m_drawListSortType = RHI::DrawListSortType::KeyThenDepth;
+
+            // Forces viewport and scissor to match width/height of output image at specified index.
+            // Does nothing if index is negative.
+            s32 m_viewportAndScissorTargetOutputIndex = -1;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -85,6 +85,7 @@ namespace AZ
                 m_viewportState = rasterData->m_overrideViewport;
                 m_overrideViewportState = true;
             }
+            m_viewportAndScissorTargetOutputIndex = rasterData->m_viewportAndScissorTargetOutputIndex;
         }
 
         RasterPass::~RasterPass()
@@ -130,15 +131,25 @@ namespace AZ
 
         void RasterPass::FrameBeginInternal(FramePrepareParams params)
         {
-            if (!m_overrideScissorSate)
+            if (m_viewportAndScissorTargetOutputIndex >= 0)
             {
-                m_scissorState = params.m_scissorState;
+                PassAttachmentBinding& target = GetOutputBinding(m_viewportAndScissorTargetOutputIndex);
+                u32 targetWidth = target.GetAttachment()->m_descriptor.m_image.m_size.m_width;
+                u32 targetHeight = target.GetAttachment()->m_descriptor.m_image.m_size.m_height;
+                m_scissorState = RHI::Scissor(0, 0, targetWidth, targetHeight);
+                m_viewportState = RHI::Viewport(0, (float)targetWidth, 0, (float)targetHeight);
             }
-            if (!m_overrideViewportState)
+            else
             {
-                m_viewportState = params.m_viewportState;
+                if (!m_overrideScissorSate)
+                {
+                    m_scissorState = params.m_scissorState;
+                }
+                if (!m_overrideViewportState)
+                {
+                    m_viewportState = params.m_viewportState;
+                }
             }
-
             UpdateDrawList();
 
             RenderPass::FrameBeginInternal(params);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -137,7 +137,7 @@ namespace AZ
                 u32 targetWidth = target.GetAttachment()->m_descriptor.m_image.m_size.m_width;
                 u32 targetHeight = target.GetAttachment()->m_descriptor.m_image.m_size.m_height;
                 m_scissorState = RHI::Scissor(0, 0, targetWidth, targetHeight);
-                m_viewportState = RHI::Viewport(0, (float)targetWidth, 0, (float)targetHeight);
+                m_viewportState = RHI::Viewport(0, static_cast<float>(targetWidth), 0, static_cast<float>(targetHeight));
             }
             else
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -62,12 +62,13 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<RasterPassData, RenderPassData>()
-                    ->Version(3) // ATOM-15472
+                    ->Version(4) // antonmic: added m_viewportAndScissorOutputTargetIndex
                     ->Field("DrawListTag", &RasterPassData::m_drawListTag)
                     ->Field("PassSrgShaderAsset", &RasterPassData::m_passSrgShaderReference)
                     ->Field("Viewport", &RasterPassData::m_overrideViewport)
                     ->Field("Scissor", &RasterPassData::m_overrideScissor)
                     ->Field("DrawListSortType", &RasterPassData::m_drawListSortType)
+                    ->Field("ViewportScissorTargetOutputIndex", &RasterPassData::m_viewportAndScissorTargetOutputIndex)
                     ;
             }
         }

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
@@ -11,6 +11,7 @@
 #include <Atom/RHI.Reflect/MultisampleState.h>
 
 #include <Atom/RPI.Public/Pass/ParentPass.h>
+#include <Atom/RPI.Public/Pass/RasterPass.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -275,6 +276,13 @@ namespace AZ::Render
                     | ((m_selectedPassPath == pass->GetPathName()) ? ImGuiTreeNodeFlags_Selected : 0);
 
                 bool nodeOpen = Scriptable_ImGui::TreeNodeEx(pass->GetName().GetCStr(), flags);
+
+
+                AZ::RPI::RasterPass* asRasterPass = azrtti_cast<AZ::RPI::RasterPass*>(pass);
+                if (asRasterPass)
+                {
+                    ImGui::Text("Raster pass with %d draw items", asRasterPass->GetDrawItemCount());
+                }
 
                 if (ImGui::IsItemClicked())
                 {


### PR DESCRIPTION
Added ifdefs to disable shadow code when included in files that define ENABLE_SHADOWS to be 0, allowing such shaders to compile. Added option for RasterPass to set its viewport/scissor based on its output. Added RasterPass draw item count to ImGuiPassTree visualization to help debug how many draw items each RasterPass is receiving.