### PR TITLE
Added functionality for implicit execution connections

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1145,6 +1145,11 @@ namespace ScriptCanvasEditor
         const ScriptCanvas::Node* sourceNode = FindNode(sourceEndpoint.GetNodeId());
         const ScriptCanvas::Node* targetNode = FindNode(targetEndpoint.GetNodeId());
 
+        if (!sourceNode || !targetNode)
+        {
+            return;
+        }
+
         // Retrieve the source node's execution out and target node's execution in
         const ScriptCanvas::Slot* sourceNodeExecutionSlot;
         const ScriptCanvas::Slot* targetNodeExecutionSlot;

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1074,7 +1074,7 @@ namespace ScriptCanvasEditor
             ? *AZStd::any_cast<AZ::EntityId>(connectionUserData)
             : AZ::EntityId();
 
-        if (ScriptCanvas::Connection* connectionComponent = AZ::EntityUtils::FindFirstDerivedComponent<ScriptCanvas::Connection>(scConnectionId))
+        if (auto connectionComponent = AZ::EntityUtils::FindFirstDerivedComponent<ScriptCanvas::Connection>(scConnectionId))
         {
             ScriptCanvas::Endpoint sourceEndpoint = connectionComponent->GetSourceEndpoint();
             ScriptCanvas::Endpoint targetEndpoint = connectionComponent->GetTargetEndpoint();

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1187,7 +1187,7 @@ namespace ScriptCanvasEditor
                 // Count the number of data connections between the nodes of the two endpoints
                 for (const ScriptCanvas::Slot* dataSlot : sourceNodeDataSlots)
                 {
-                    for (ScriptCanvas::EndpointResolved connectedNode : sourceNode->GetConnectedNodes(*dataSlot))
+                    for (const ScriptCanvas::EndpointResolved& connectedNode : sourceNode->GetConnectedNodes(*dataSlot))
                     {
                         if (connectedNode.first == targetNode)
                         {

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1146,8 +1146,22 @@ namespace ScriptCanvasEditor
         const ScriptCanvas::Node* targetNode = FindNode(targetEndpoint.GetNodeId());
 
         // Retrieve the source node's execution out and target node's execution in
-        const ScriptCanvas::Slot* sourceNodeExecutionSlot = sourceNode->GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionOut(), false)[0];
-        const ScriptCanvas::Slot* targetNodeExecutionSlot = targetNode->GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionIn(), false)[0];
+        const ScriptCanvas::Slot* sourceNodeExecutionSlot;
+        const ScriptCanvas::Slot* targetNodeExecutionSlot;
+
+        AZStd::vector< const ScriptCanvas::Slot* > sourceNodeExecutionSlots = sourceNode->GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionOut(), false);
+        AZStd::vector< const ScriptCanvas::Slot* > targetNodeExecutionSlots = targetNode->GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionIn(), false);
+
+        // Ensure there is exactly 1 non-latent execution source and target slot
+        if (sourceNodeExecutionSlots.size() == 1 && targetNodeExecutionSlots.size() == 1)
+        {
+            sourceNodeExecutionSlot = sourceNodeExecutionSlots[0];
+            targetNodeExecutionSlot = targetNodeExecutionSlots[0];
+        }
+        else
+        {
+            return;
+        }
 
         // If either the source or target slot execution slots on these nodes are implicit, then check if the implicit connection should be updated
         if (sourceNodeExecutionSlot->CreatesImplicitConnections() || targetNodeExecutionSlot->CreatesImplicitConnections())

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
@@ -169,6 +169,9 @@ namespace ScriptCanvasEditor
         void DisconnectConnection(const GraphCanvas::ConnectionId& connectionId) override;
         bool CreateConnection(const GraphCanvas::ConnectionId& connectionId, const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) override;
 
+        // Adds or removes an implicit execution connection between the nodes these endpoints are connected if necessary
+        void UpdateCorrospondingImplicitConnection(const ScriptCanvas::Endpoint& sourceEndpoint, const ScriptCanvas::Endpoint& targetEndpoint);
+
         bool IsValidConnection(const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) const override;
 
         AZStd::string GetDataTypeString(const AZ::Uuid& typeId) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
@@ -25,6 +25,8 @@
 									<xs:attribute name="Description" type="xs:string" use="required" />
 									<xs:attribute name="OutputName" type="xs:string" use="optional" />
 									<xs:attribute name="DisplayGroup" type="xs:string" use="optional" />
+									<xs:attribute name="Implicit" type="xs:boolean" use="optional"/>
+									<xs:attribute name="Hidden" type="xs:boolean" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="Output" minOccurs="0" maxOccurs="unbounded" >

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -386,6 +386,9 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
             outSlotConfiguration.m_toolTip = "{{item.attrib['Description']}}";
             outSlotConfiguration.m_displayGroup = "{{ itemDisplayGroup }}";
             outSlotConfiguration.SetConnectionType(ScriptCanvas::ConnectionType::Output);
+{%          if item.attrib['Hidden'] %}
+            outSlotConfiguration{{executionDirection}}.m_isVisible = false;
+{%          endif %}
             outSlotConfiguration.m_isLatent = false;
             out.name = outSlotConfiguration.m_name;
             SlotId outSlotId = AddSlot(outSlotConfiguration);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -226,6 +226,12 @@ false
 {% else %}
         slotConfiguration{{executionDirection}}.m_displayGroup = "{{ slotName }}";
 {% endif %}
+{% if tag.attrib['Implicit'] %}
+        slotConfiguration{{executionDirection}}.m_createsImplicitConnections = true;
+{% endif %}
+{% if tag.attrib['Hidden'] %}
+        slotConfiguration{{executionDirection}}.m_isVisible = false;
+{% endif %}
 {% if isLatent is defined or executionDirection == "Output" %}
         slotConfiguration{{executionDirection}}.m_isLatent = true;
 {% endif %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -211,6 +211,7 @@ namespace ScriptCanvas
                 ->Field("VariableReference", &Slot::m_variableReference)
                 ->Field("IsUserAdded", &Slot::m_isUserAdded)
                 ->Field("CanHaveInputField", &Slot::m_canHaveInputField)
+                ->Field("CreatesImplicitConnections", &Slot::m_createsImplicitConnections)
                 ;
         }
 
@@ -226,6 +227,7 @@ namespace ScriptCanvas
         , m_id(slotConfiguration.m_slotId)
         , m_isVisible(slotConfiguration.m_isVisible)
         , m_canHaveInputField(slotConfiguration.m_canHaveInputField)
+        , m_createsImplicitConnections(slotConfiguration.m_createsImplicitConnections)
     {
         if (!slotConfiguration.m_displayGroup.empty())
         {
@@ -437,6 +439,11 @@ namespace ScriptCanvas
     bool Slot::CanHaveInputField() const
     {
         return m_canHaveInputField;
+    }
+
+    bool Slot::CreatesImplicitConnections() const
+    {
+        return m_createsImplicitConnections;
     }
 
     bool Slot::CanConvertToValue() const
@@ -933,7 +940,6 @@ namespace ScriptCanvas
     {
         ScriptCanvas::ModifiableDatumView datumView;
         GetNode()->ModifyUnderlyingSlotDatum(GetId(), datumView);
-
         bool isVisible = !IsConnected() && datumView.GetDataType().IsValid();
 
         datumView.SetVisibility(isVisible ? AZ::Edit::PropertyVisibility::ShowChildrenOnly : AZ::Edit::PropertyVisibility::Hide);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -940,6 +940,7 @@ namespace ScriptCanvas
     {
         ScriptCanvas::ModifiableDatumView datumView;
         GetNode()->ModifyUnderlyingSlotDatum(GetId(), datumView);
+
         bool isVisible = !IsConnected() && datumView.GetDataType().IsValid();
 
         datumView.SetVisibility(isVisible ? AZ::Edit::PropertyVisibility::ShowChildrenOnly : AZ::Edit::PropertyVisibility::Hide);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -152,6 +152,8 @@ namespace ScriptCanvas
 
         bool CanHaveInputField() const;
 
+        bool CreatesImplicitConnections() const;
+
         bool CanConvertTypes() const;
 
         bool CanConvertToValue() const;
@@ -229,6 +231,7 @@ namespace ScriptCanvas
         bool m_isOverload = false;
         bool m_isVisible = true;
         bool m_isUserAdded = false;
+        bool m_createsImplicitConnections = false;
 
         void SetDynamicGroup(const AZ::Crc32& dynamicGroup);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
@@ -230,6 +230,10 @@ namespace ScriptCanvas
         bool m_isUserAdded = false;
         bool m_canHaveInputField = true;
 
+        // Enabling this attribute on an execution slot will cause it to automatically make a "behind the scenes"
+        // connection to nodes connected by other slots of the same connection type as this slot
+        bool m_createsImplicitConnections = false;
+
         AZStd::vector<ContractDescriptor> m_contractDescs;
         bool m_addUniqueSlotByNameAndType = true; // Only adds a new slot if a slot with the supplied name and CombinedSlotType does not exist on the node
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -3769,9 +3769,23 @@ namespace ScriptCanvas
                 execution->AddChild({ outSlots[childIndex], {}, nullptr });
             }
 
+            // Sort the out node connections to ensure that implicit execution connections are always parsed first
+            EndpointsResolved sortedExecutionOutNodes;
+            for (EndpointResolved endpoint : executionOutNodes)
+            {
+                if (endpoint.second->CreatesImplicitConnections())
+                {
+                    sortedExecutionOutNodes.insert(sortedExecutionOutNodes.begin(), endpoint);
+                }
+                else
+                {
+                    sortedExecutionOutNodes.emplace_back(endpoint);
+                }
+            }
+
             for (size_t childIndex = 0; childIndex < executionOutNodes.size(); ++childIndex)
             {
-                ParseExecutionFunctionRecurse(execution, execution->ModChild(childIndex), *outSlots[childIndex], executionOutNodes[childIndex]);
+                ParseExecutionFunctionRecurse(execution, execution->ModChild(childIndex), *outSlots[childIndex], sortedExecutionOutNodes[childIndex]);
 
                 if (!IsErrorFree())
                 {


### PR DESCRIPTION
## What does this PR do?

This PR allows execution slots to be given the attribute m_createsImplicitConnections. This makes it so the slot automatically connects itself to other nodes' execution slots behind the scenes when their data slots are connected. I do this by having implicit connections only create their entity in the Script Canvas gem without creating a corresponding visual connection entity in the Graph Canvas gem.
I also added a few more attributes to nodeables to allow for nodeable input execution slots to be given the m_createsImplicitConnections attribute, and for nodeble execution slots to be hidden.
Finally, I made a few changes in the AbstractCodeModel to ensure that execution out slots with multiple connections will always parse nodes with implicit connections first. I did this so people can make nodes without execution slots that preform a certain calculation first so that nodes can always pull the data from it later on in execution (examples below).

## How was this PR tested?

Script canvas tests were run locally to ensure I wasn't breaking anything else. I also did manual testing by connecting, disconnecting, moving, undoing, redoing, and deleting the data connections of nodes with an implicit connection caused by that data connection to ensure that the implicit connection remained/was removed as expected. Saving and loading graphs was also tested extensively.
Functionality of the implicit connections was tested by making a simple increment nodeable node and giving it an execution input that creates implicit connections:

<img width="1242" alt="Screenshot 2023-06-15 165713" src="https://github.com/o3de/o3de/assets/105814224/6ee6e3d8-5a73-4702-8e61-72bc0fa2faa9">
<img width="85" alt="Screenshot 2023-06-15 165742" src="https://github.com/o3de/o3de/assets/105814224/ff6565a8-f228-490f-8aa5-433c5a618efb">

Increment nodeables can also be chained together:

<img width="937" alt="Screenshot 2023-06-15 165856" src="https://github.com/o3de/o3de/assets/105814224/7299b3f1-6781-436f-8fcd-68931c0284b1">
<img width="77" alt="Screenshot 2023-06-15 165919" src="https://github.com/o3de/o3de/assets/105814224/1f4fffb6-907a-4be4-bd99-1b153ada30b2">
