### PR TITLE
Repo Path Folder Exist Error Fix

### DIFF
--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2331,20 +2331,16 @@ def create_repo(repo_path: pathlib.Path,
         logger.error('Remote repository URI cannot be empty.')
         return 1
     
-    # check if path is empty and
-    if not force and repo_path.is_dir():
-        logger.error(f'{repo_path} already exists. Use the --force command to overwrite the existing directory.')
-        return 1
     repo_json_path = repo_path / 'repo.json'
     # if a repo.json file already exist in directory - can only have one repo.json file per project
-    if repo_json_path.is_file():
+    if not force and repo_json_path.is_file():
         logger.error(f'{repo_json_path} already exists. If you want to edit the repo.json properties, use edit-repo-properties command.'
-                     'If you want to create a new remote repo template, create a new directory.')
+                     'Use --force if you want to override the current repo.json file')
         return 1
     elif repo_path.is_file():
         logger.error(f'{repo_path} already exists and is a file instead of a directory.')
         return 1
-    else:
+    elif not repo_path.is_dir():
         os.makedirs(repo_path, exist_ok=force)
 
     if not repo_name:

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2341,7 +2341,7 @@ def create_repo(repo_path: pathlib.Path,
         logger.error(f'{repo_path} already exists and is a file instead of a directory.')
         return 1
     elif not repo_path.is_dir():
-        os.makedirs(repo_path, exist_ok=force)
+        os.makedirs(repo_path, exist_ok=True)
 
     if not repo_name:
         # repo name default is the last component of repo_path

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -2306,7 +2306,7 @@ def create_repo(repo_path: pathlib.Path,
                 origin_url: str = None,
                 summary: str = None,
                 additional_info: str = None,
-                force: bool = False,
+                force: bool = None,
                 replace: list = None,
                 no_register: bool = False) -> int:
 
@@ -2331,10 +2331,15 @@ def create_repo(repo_path: pathlib.Path,
         logger.error('Remote repository URI cannot be empty.')
         return 1
     
-    # check if a repo.json file already exist in directory - can only have one repo.json file per project
+    # check if path is empty and
+    if not force and repo_path.is_dir():
+        logger.error(f'{repo_path} already exists. Use the --force command to overwrite the existing directory.')
+        return 1
     repo_json_path = repo_path / 'repo.json'
-    if not force and repo_json_path.is_file():
-        logger.error(f'{repo_json_path} already exists.  Use the --force to overwrite the existing file.')
+    # if a repo.json file already exist in directory - can only have one repo.json file per project
+    if repo_json_path.is_file():
+        logger.error(f'{repo_json_path} already exists. If you want to edit the repo.json properties, use edit-repo-properties command.'
+                     'If you want to create a new remote repo template, create a new directory.')
         return 1
     elif repo_path.is_file():
         logger.error(f'{repo_path} already exists and is a file instead of a directory.')


### PR DESCRIPTION
## What does this PR do?
1. Checks if a folder already exists at the user provided path when user calls the create-repo cli command. Provides an error message telling user to use --force if they would want to override the current directory. 
2. If there is already a repo.json file in the directory, provided error message saying that a repo.json already exist and ask user if they want to edit the repo.json properties instead, if so, they should be using edit-repo-properties function.
3. fixes https://github.com/o3de/o3de/issues/16172 

## How was this PR tested?
I called create-repo function and pass in a path that already has a folder, and I now see an error message instead of a crash.  I choose --force to override that folder when prompted.

Here is the command I used when there was a already a folder existed at the path I provided: ./o3de.bat create-repo -rp "C:\o3de_Projects\bugtest"  -ru https://github.com/AMZN-Gene/Open3dRepoTest -s "An awesome repo", there would be a error message "o3de.engine_template: C:\o3de_Projects\bugtest already exists. Use the --force command to overwrite the existing directory." 
Then, calling the same function again  ./o3de.bat create-repo -rp "C:\o3de_Projects\bugtest"  -ru https://github.com/AMZN-Gene/Open3dRepoTest -s "An awesome repo" -f will override the current directory and create the repo.json file.
