### PR TITLE
Add Check To Require Download-prefix To Be Provided With Usage Suggestion

### DIFF
--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -91,7 +91,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         ValueError: If the json_data_path is not a dict.
     """
     if download_prefix is None:
-        logger.error('The -download-prefix must be provided. A url prefix for a file attached to a Github release might look like this:'
+        logger.error('The --download-prefix argument must be provided. A url prefix for a file attached to a Github release might look like this:'
                      '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
         return {}
     zip_path = releases_path / archive_filename

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -93,6 +93,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
     if download_prefix is None:
         logger.error('The -download-prefix must be provided. A url prefix for a file attached to a Github release might look like this:'
                      '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
+        return {}
     zip_path = releases_path / archive_filename
     # check if a object.zip folder already exist in the path - ask user if they want to overwrite the current zip
     if not force and zip_path.exists():

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -90,7 +90,9 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         FileNotFoundError: If the json_data_path does not exist.
         ValueError: If the json_data_path is not a dict.
     """
-
+    if download_prefix is None:
+        logger.error('The -download-prefix must be provided. A url prefix for a file attached to a Github release might look like this:'
+                     '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
     zip_path = releases_path / archive_filename
     # check if a object.zip folder already exist in the path - ask user if they want to overwrite the current zip
     if not force and zip_path.exists():


### PR DESCRIPTION
## What does this PR do?

If user use the --release-archive-path command without --download-prefix and error message would require user to pass in a --download-prefix along with an example of a github url

fix https://github.com/o3de/o3de/issues/16181

## How was this PR tested?
I used this command: ./o3de.bat edit-repo-properties -rp "C:\o3de_Projects\o3deRemoteRepo\repo.json" -ag "C:\o3de_Projects\o3deRemoteRepo\Gems\TestGem\" --release-archive-path "C:\o3de_Projects"
an error message would be: [ERROR] o3de.repo_properties: The -download-prefix must be provided. A url prefix for a file attached to a Github release might look like this: -dp https://github.com/o3de/o3de-extras/releases/download/2305.0
