### PR TITLE
[LINUX] Fix "white" background of textfield

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
@@ -498,7 +498,6 @@ namespace O3DE::ProjectManager
         hLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding));
 
         m_filterLineEdit = new AzQtComponents::SearchLineEdit();
-        m_filterLineEdit->setStyleSheet("background-color: #DDDDDD;");
         connect(m_filterLineEdit, &QLineEdit::textChanged, this, [=](const QString& text)
             {
                 filterProxyModel->SetSearchString(text);


### PR DESCRIPTION
## What does this PR do?

In the current version, there is an issue where the background color and font background color appear to be identical, making the font unreadable in the GemCatalog. This problem is particularly noticeable on my system. Additionally, the StyleSheet is already set globally for the Editor, so there is no need to set it manually in this specific instance.


## How was this PR tested?

To test this pull request, the following steps were taken:

1. Started the Editor with the project on Linux.
2. Opened the Project Settings and accessed the Gems configuration.
3. Observed that the font was not visible in the search field and with this PR the font gets the correct color.

