### PR TITLE
Highlight search terms in asset browser views.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -628,18 +628,34 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
 
     if (ed_useNewAssetBrowserListView)
     {
+        auto thumbnailWidget = m_ui->m_thumbnailView->GetThumbnailViewWidget();
+        auto expandedTableWidget = m_ui->m_tableView->GetExpandedTableViewWidget();
+
         if (hasFilter)
         {
-            auto thumbnailWidget = m_ui->m_thumbnailView->GetThumbnailViewWidget();
             if (thumbnailWidget)
             {
                 thumbnailWidget->setRootIndex(thumbnailWidget->model()->index(0, 0, {}));
+                m_ui->m_thumbnailView->SetSearchString(m_ui->m_searchWidget->GetFilterString());
             }
-            auto expandedTableWidget = m_ui->m_tableView->GetExpandedTableViewWidget();
             if (expandedTableWidget)
             {
                 expandedTableWidget->setRootIndex(expandedTableWidget->model()->index(0, 0, {}));
+                m_ui->m_tableView->SetSearchString(m_ui->m_searchWidget->GetFilterString());
             }
+            m_ui->m_assetBrowserTreeViewWidget->SetSearchString(m_ui->m_searchWidget->GetFilterString());
+        }
+        else
+        {
+            if (thumbnailWidget)
+            {
+                m_ui->m_thumbnailView->SetSearchString("");
+            }
+            if (expandedTableWidget)
+            {
+                m_ui->m_tableView->SetSearchString("");
+            }
+            m_ui->m_assetBrowserTreeViewWidget->SetSearchString("");
         }
     }
 }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -21,6 +21,7 @@ AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: 'in
 #include <QScrollBar>
 #include <QSettings>
 #include <QStyledItemDelegate>
+#include <QTextDocument>
 AZ_POP_DISABLE_WARNING
 
 namespace
@@ -200,9 +201,46 @@ namespace AzQtComponents
             const auto textRect = QRect{rect.left(), rect.bottom() - textHeight, rect.width(), textHeight * 2};
 
             painter->setPen(option.palette.color(QPalette::Text));
-            QString text = elidedTextWithExtension(option.fontMetrics, index.data().toString(), textRect.width());
-            (text.contains(QChar::LineFeed) ? painter->drawText(textRect, Qt::AlignTop | Qt::AlignLeft, text)
-                                            : painter->drawText(textRect, Qt::AlignTop | Qt::AlignHCenter, text));
+
+            QString text = index.data().toString();
+
+            QRegularExpression htmlMarkupRegex("<[^>]*>");
+            if (htmlMarkupRegex.match(text).hasMatch())
+            {
+                // Grab the plain text to measure.
+                QTextDocument textDoc;
+                textDoc.setHtml(text);
+                QString plainText = textDoc.toPlainText();
+                textDoc.clear();
+
+                auto textWidth = option.fontMetrics.horizontalAdvance(plainText);
+
+                QString alignment = textWidth > textRect.width() ? "left" : "center";
+
+                QStyleOptionViewItem optionV4{ option };
+                initStyleOption(&optionV4, index);
+                optionV4.state &= ~(QStyle::State_HasFocus | QStyle::State_Selected);
+
+                painter->save();
+                painter->setRenderHint(QPainter::Antialiasing);
+
+                textDoc.setDefaultFont(option.font);
+
+                textDoc.setDefaultStyleSheet("body {color: white}");
+
+                textDoc.setHtml("<body align='" + alignment + "'>" + index.data().toString() + "</span> </body>");
+                painter->translate(textRect.topLeft());
+                textDoc.setTextWidth(textRect.width());
+                textDoc.drawContents(painter, QRectF(0, 0, textRect.width(), textRect.height()));
+                painter->restore();
+            }
+            else
+            {
+                text = elidedTextWithExtension(option.fontMetrics, index.data().toString(), textRect.width());
+
+                (text.contains(QChar::LineFeed) ? painter->drawText(textRect, Qt::AlignTop | Qt::AlignLeft, text)
+                                                : painter->drawText(textRect, Qt::AlignTop | Qt::AlignHCenter, text));
+            }
         }
         else
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
@@ -64,6 +64,8 @@ namespace AzToolsFramework
 
             void SetSortMode(const AssetBrowserSortMode sortMode);
             AssetBrowserSortMode GetSortMode() const;
+
+            void SetSearchString(const QString& searchString);
         Q_SIGNALS:
             void filterChanged();
             //////////////////////////////////////////////////////////////////////////
@@ -91,6 +93,7 @@ namespace AzToolsFramework
             AZ_POP_DISABLE_WARNING
             bool m_invalidateFilter = false;
             AssetBrowserSortMode m_sortMode = AssetBrowserSortMode::Name;
+            AZStd::string m_searchString = "";
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
+#include <AzToolsFramework/Editor/RichTextHighlighter.h>
 
 namespace AzToolsFramework
 {
@@ -40,7 +41,16 @@ namespace AzToolsFramework
                     switch (index.column())
                     {
                     case Name:
-                        return static_cast<const SourceAssetBrowserEntry*>(assetBrowserEntry)->GetName().c_str();
+                        {
+                            QString name = static_cast<const SourceAssetBrowserEntry*>(assetBrowserEntry)->GetName().c_str();
+
+                            if (!m_searchString.empty())
+                            {
+                                // highlight characters in filter
+                                name = AzToolsFramework::RichTextHighlighter::HighlightText(name, m_searchString.c_str());
+                            }
+                            return name;
+                        }
                     case Type:
                         {
                             switch (assetBrowserEntry->GetEntryType())
@@ -273,6 +283,11 @@ namespace AzToolsFramework
                 }
             }
             return QAbstractItemModel::dropMimeData(data, action, row, column, parent);
+        }
+
+        void AssetBrowserTableViewProxyModel::SetSearchString(const QString& searchString)
+        {
+             m_searchString = searchString.toUtf8().data();
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
@@ -48,9 +48,12 @@ namespace AzToolsFramework
             void SetShowSearchResultsMode(bool searchMode);
             const AZStd::string ExtensionToType(AZStd::string_view str) const;
 
+            void SetSearchString(const QString& searchString);
         private:
             QPersistentModelIndex m_rootIndex;
             bool m_searchResultsMode;
+
+            AZStd::string m_searchString = "";
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
@@ -17,7 +17,7 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 
 #include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
-
+#include <AzToolsFramework/Editor/RichTextHighlighter.h>
 
 
 namespace AzToolsFramework
@@ -42,6 +42,17 @@ namespace AzToolsFramework
 
             switch (role)
             {
+            case Qt::DisplayRole:
+                {
+                    QString name = static_cast<const SourceAssetBrowserEntry*>(assetBrowserEntry)->GetName().c_str();
+
+                    if (!m_searchString.empty())
+                    {
+                        // highlight characters in filter
+                        name = AzToolsFramework::RichTextHighlighter::HighlightText(name, m_searchString.c_str());
+                    }
+                    return name;
+                }
             case Qt::DecorationRole:
                 {
                     return AssetBrowserViewUtils::GetThumbnail(assetBrowserEntry);
@@ -114,6 +125,11 @@ namespace AzToolsFramework
                 beginResetModel();
                 endResetModel();
             }
+        }
+
+        void AssetBrowserThumbnailViewProxyModel::SetSearchString(const QString& searchString)
+        {
+            m_searchString = searchString.toUtf8().data();
         }
 
         Qt::DropActions AssetBrowserThumbnailViewProxyModel::supportedDropActions() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
@@ -33,6 +33,8 @@ namespace AzToolsFramework
             bool GetShowSearchResultsMode() const;
             void SetShowSearchResultsMode(bool searchMode);
 
+            void SetSearchString(const QString& searchString);
+
              //////////////////////////////////////////////////////////////////////////
             // QAbstractTableModel
             //////////////////////////////////////////////////////////////////////////
@@ -44,6 +46,7 @@ namespace AzToolsFramework
         private:
             QPersistentModelIndex m_rootIndex;
             bool m_searchResultsMode;
+            AZStd::string m_searchString;
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -19,6 +19,7 @@
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
+#include <AzToolsFramework/Editor/RichTextHighlighter.h>
 #include <AzCore/Utils/Utils.h>
 
 #include <AzQtComponents/Components/Widgets/AssetFolderTableView.h>
@@ -509,6 +510,11 @@ namespace AzToolsFramework
             m_assetFilterModel->SetFilter(FilterConstType(filterCopy));
         }
 
+        void AssetBrowserTableView::SetSearchString(const QString& searchString)
+        {
+            m_expandedTableViewProxyModel->SetSearchString(searchString);
+        }
+
         ExpandedTableViewDelegate::ExpandedTableViewDelegate(QWidget* parent)
             : QStyledItemDelegate(parent)
 
@@ -525,7 +531,6 @@ namespace AzToolsFramework
                 int height = options.rect.height();
                 QRect iconRect(0, options.rect.y() + 5, height - 10, height - 10);
                 QSize iconSize = iconRect.size();
-                QStyle* style = options.widget ? options.widget->style() : qApp->style();
 
                 const auto& qVariant = index.data(Qt::UserRole + 1);
                 if (!qVariant.isNull())
@@ -542,10 +547,15 @@ namespace AzToolsFramework
                         icon.paint(painter, iconRect, Qt::AlignLeft | Qt::AlignVCenter);
                     }
                 }
-                QRect textRect{options.rect};
+                QRect textRect{ options.rect };
                 textRect.setX(textRect.x() + 4);
-                style->drawItemText(
-                    painter, options.rect, Qt::AlignLeft | Qt::AlignVCenter, options.palette, options.state & QStyle::State_Enabled, text.toString());
+
+                QStyleOptionViewItem optionV4{ option };
+                initStyleOption(&optionV4, index);
+                optionV4.state &= ~(QStyle::State_HasFocus | QStyle::State_Selected);
+
+                RichTextHighlighter::PaintHighlightedRichText(text.toString(), painter, optionV4, textRect);
+
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h
@@ -84,6 +84,7 @@ namespace AzToolsFramework
 
             void SelectEntry(QString assetName);
 
+            void SetSearchString(const QString& searchString);
         signals:
             void entryClicked(const AssetBrowserEntry* entry);
             void entryDoubleClicked(const AssetBrowserEntry* entry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -523,5 +523,11 @@ namespace AzToolsFramework
                 }
             }
         }
+
+        void AssetBrowserThumbnailView::SetSearchString(const QString& searchString)
+        {
+            m_thumbnailViewProxyModel->SetSearchString(searchString);
+        }
+
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -73,6 +73,7 @@ namespace AzToolsFramework
             void SetSortMode(const AssetBrowserFilterModel::AssetBrowserSortMode mode);
             AssetBrowserFilterModel::AssetBrowserSortMode GetSortMode() const;
 
+            void SetSearchString(const QString& searchString);
         signals:
             void entryClicked(const AssetBrowserEntry* entry);
             void entryDoubleClicked(const AssetBrowserEntry* entry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -771,6 +771,11 @@ namespace AzToolsFramework
         {
             m_attachedTableView = tableView;
         }
+
+        void AssetBrowserTreeView::SetSearchString(const QString& searchString)
+        {
+            m_delegate->SetSearchString(searchString);
+        }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -121,6 +121,7 @@ namespace AzToolsFramework
 
             void SetApplySnapshot(bool applySnapshot);
 
+            void SetSearchString(const QString& searchString);
         Q_SIGNALS:
             void selectionChangedSignal(const QItemSelection& selected, const QItemSelection& deselected);
             void ClearStringFilter();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -82,7 +82,6 @@ namespace AzToolsFramework
             if (data.canConvert<const AssetBrowserEntry*>())
             {
                 bool isEnabled = (option.state & QStyle::State_Enabled) != 0;
-                bool isSelected = (option.state & QStyle::State_Selected) != 0;
 
                 QStyle* style = option.widget ? option.widget->style() : QApplication::style();
 
@@ -127,10 +126,12 @@ namespace AzToolsFramework
                     ? qvariant_cast<QString>(entry->data(aznumeric_cast<int>(AssetBrowserEntry::Column::DisplayName)))
                     : qvariant_cast<QString>(entry->data(aznumeric_cast<int>(AssetBrowserEntry::Column::Path)));
 
-                style->drawItemText(
-                    painter, remainingRect, option.displayAlignment, actualPalette, isEnabled,
-                    displayString,
-                    isSelected ? QPalette::HighlightedText : QPalette::Text);
+                if (!m_searchString.empty())
+                {
+                    displayString = AzToolsFramework::RichTextHighlighter::HighlightText(displayString, m_searchString.c_str());
+                }
+
+                RichTextHighlighter::PaintHighlightedRichText(displayString, painter, option, remainingRect);
             }
         }
 
@@ -195,6 +196,11 @@ namespace AzToolsFramework
                 }
             }
             return m_iconSize;
+        }
+
+        void EntryDelegate::SetSearchString(QString searchString)
+        {
+            m_searchString = searchString.toUtf8().data();
         }
 
         SearchEntryDelegate::SearchEntryDelegate(QWidget* parent)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.h
@@ -53,7 +53,8 @@ namespace AzToolsFramework
             QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
             //! Set whether to show source control icons, this is still temporary mainly to support existing functionality of material browser
             void SetShowSourceControlIcons(bool showSourceControl);
-        
+            void SetSearchString(QString searchString);
+
         signals:
             void RenameEntry(const QString& value) const;
 
@@ -62,6 +63,7 @@ namespace AzToolsFramework
             bool m_showSourceControl = false;
             //! Draw a thumbnail and return its width
             int DrawThumbnail(QPainter* painter, const QPoint& point, const QSize& size, const AssetBrowserEntry* entry) const;
+            AZStd::string m_searchString;
         };
 
         //! SearchEntryDelegate draws a single item in AssetBrowserListView.


### PR DESCRIPTION
## What does this PR do?

This PR resolves #15966 by highlighting the selected search term in the AssetBrowser Tree, Thumbnail and Table views.

## How was this PR tested?

Manual testing, turned of the disabling of search in the table view to check that for future use.
