### PR TITLE
DPE | Fix PhysX Dynamic Rigid Body type property labeling

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/ReflectContext.h
@@ -269,7 +269,7 @@ namespace AZ
             return {};
         }
 
-        /// Gets a marshaleld Dom::Value representation of this attribute bound to a given instance.
+        /// Gets a marshalled Dom::Value representation of this attribute bound to a given instance.
         /// By default this is just abbreviated to a marshalled version of the data stored in the attribute,
         /// but for invokable attributes, override this method to serializes a pointer to the instance and this attribute
         virtual AZ::Dom::Value GetAsDomValue([[maybe_unused]] void* instance)

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -1300,7 +1300,7 @@ namespace AZ
         // Call beginElemCB for this element if there is one. If the callback
         // returns false, stop enumeration of this branch
         // pass the original ptr to the user instead of objectPtr because
-        // he may want to replace the actual object.
+        // they may want to replace the actual object.
         if (!callContext->m_beginElemCB || callContext->m_beginElemCB(ptr, dataClassInfo, classElement))
         {
             if (dataClassInfo->m_container)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -42,6 +42,8 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::Visibility);
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::ReadOnly);
         system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::NameLabelOverride);
+        system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::SetTrueLabel);
+        system->RegisterNodeAttribute<NodeWithVisiblityControl>(NodeWithVisiblityControl::SetFalseLabel);
 
         system->RegisterNode<Adapter, NodeWithVisiblityControl>();
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -38,6 +38,8 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto Visibility = AttributeDefinition<PropertyVisibility>("Visibility");
         static constexpr auto ReadOnly = AttributeDefinition<bool>("ReadOnly");
         static constexpr auto NameLabelOverride = AttributeDefinition<AZStd::string_view>("NameLabelOverride");
+        static constexpr auto SetTrueLabel = AttributeDefinition<AZStd::string_view>("SetTrueLabel");
+        static constexpr auto SetFalseLabel = AttributeDefinition<AZStd::string_view>("SetFalseLabel");
 
         static constexpr auto Disabled = AttributeDefinition<bool>("Disabled");
         //! In some cases, a node may need to know that it is descended from a disabled ancestor. For example, disabled

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -21,7 +21,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
     //! Be sure to update this if you change this file.
     void Reflect(PropertyEditorSystemInterface* system);
 
-    //! PropertyVisibility: Provided for compatability with the RPE, determines whether an entry
+    //! PropertyVisibility: Provided for compatibility with the RPE, determines whether an entry
     //! and/or its children should be visible.
     enum class PropertyVisibility : AZ::u32
     {


### PR DESCRIPTION
- Defines `SetTrueLabel` and `SetFalseLabel` attributes so that the `Type` property of the `PhysX Dynamic Rigid Body
` component is populated correctly.
- Also fixes minor issues in comments.

BEFORE:
![image](https://github.com/o3de/o3de/assets/82231674/e65ade1d-4efa-45e4-a50b-ce4fd5c621e9)

AFTER:
![image](https://github.com/o3de/o3de/assets/82231674/dab19556-644e-475f-b776-bcf0ae79f21f)
