### PR TITLE
Fix error when trying to import a second asset.

### DIFF
--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterDragAndDropHandler.cpp
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterDragAndDropHandler.cpp
@@ -33,6 +33,7 @@ AssetImporterDragAndDropHandler::AssetImporterDragAndDropHandler(QObject* parent
     // They are used to prevent opening the Asset Importer by dragging and dropping files and folders to the Main Window when it is already running
     connect(m_assetImporterManager, &AssetImporterManager::StartAssetImporter, this, &AssetImporterDragAndDropHandler::OnStartAssetImporter);
     connect(m_assetImporterManager, &AssetImporterManager::StopAssetImporter, this, &AssetImporterDragAndDropHandler::OnStopAssetImporter);
+    connect(m_assetImporterManager, &AssetImporterManager::AssetImportingComplete, this, &AssetImporterDragAndDropHandler::OnAssetImportingComplete);
 }
 
 AssetImporterDragAndDropHandler::~AssetImporterDragAndDropHandler()
@@ -197,6 +198,10 @@ void AssetImporterDragAndDropHandler::OnStopAssetImporter()
     m_isAssetImporterRunning = false;
 }
 
+void AssetImporterDragAndDropHandler::OnAssetImportingComplete()
+{
+    m_isAssetImporterRunning = false;
+}
 
 bool AssetImporterDragAndDropHandler::ContainCrateFiles(QString path)
 {

--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterDragAndDropHandler.h
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterDragAndDropHandler.h
@@ -56,6 +56,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void OnStartAssetImporter();
     void OnStopAssetImporter();
+    void OnAssetImportingComplete();
 
 private:
     bool m_isAssetImporterRunning = false;

--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
@@ -171,6 +171,15 @@ void AssetImporterManager::reject()
     Q_EMIT StopAssetImporter();
 }
 
+void AssetImporterManager::CompleteAssetImporting()
+{
+    // Clear the pathMap to prevent trying to reimport assets later.
+    m_pathMap.clear();
+    m_destinationRootDirectory = "";
+    // Inform listeners that we have completed the copy/move operation.
+    Q_EMIT AssetImportingComplete();
+}
+
 void AssetImporterManager::OnDragAndDropFiles(const QStringList* fileList)
 {
     for (int i = 0; i < fileList->size(); ++i)
@@ -465,6 +474,10 @@ void AssetImporterManager::ProcessCopyFiles()
     {
         reject();
     }
+    else
+    {
+        CompleteAssetImporting();
+    }
 }
 
 void AssetImporterManager::ProcessMoveFiles()
@@ -515,6 +528,10 @@ void AssetImporterManager::ProcessMoveFiles()
     if (numberOfProcessedFiles == 0)
     {
         reject();
+    }
+    else
+    {
+        CompleteAssetImporting();
     }
 }
 

--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
@@ -166,18 +166,23 @@ void AssetImporterManager::Exec(const QStringList& dragAndDropFileList, const QS
 // used to cancel actions and close the dialog
 void AssetImporterManager::reject()
 {
-    m_pathMap.clear();
-    m_destinationRootDirectory = "";
-    Q_EMIT StopAssetImporter();
+    CompleteAssetImporting(false);
 }
 
-void AssetImporterManager::CompleteAssetImporting()
+void AssetImporterManager::CompleteAssetImporting(bool wasSuccessful)
 {
     // Clear the pathMap to prevent trying to reimport assets later.
     m_pathMap.clear();
     m_destinationRootDirectory = "";
     // Inform listeners that we have completed the copy/move operation.
-    Q_EMIT AssetImportingComplete();
+    if (wasSuccessful)
+    {
+        Q_EMIT AssetImportingComplete();
+    }
+    else
+    {
+        Q_EMIT StopAssetImporter();
+    }
 }
 
 void AssetImporterManager::OnDragAndDropFiles(const QStringList* fileList)

--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.h
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.h
@@ -56,7 +56,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void reject();
-    void CompleteAssetImporting();
+    void CompleteAssetImporting(bool wasSuccessful = true);
     void OnDragAndDropFiles(const QStringList* fileList);
     void OnBrowseDestinationFilePath(QLineEdit* destinationLineEdit);
     void OnCopyFiles();

--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.h
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.h
@@ -52,9 +52,11 @@ public:
 Q_SIGNALS:
     void StartAssetImporter();
     void StopAssetImporter();
+    void AssetImportingComplete();
 
 private Q_SLOTS:
     void reject();
+    void CompleteAssetImporting();
     void OnDragAndDropFiles(const QStringList* fileList);
     void OnBrowseDestinationFilePath(QLineEdit* destinationLineEdit);
     void OnCopyFiles();


### PR DESCRIPTION
## What does this PR do?

This PR resolves #14434. Formerly, a successful file copy/move operation would not clear up after itself, leading the drag/drop handler to assume the operation was still in progress, and trying to re-import the previously imported asset if the import menu option was subsequently used. 

## How was this PR tested?

Dragged multiple assets into the editor from explorer successfully.
