### PR TITLE
Fix saved asset name comparison

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -362,6 +362,7 @@ namespace AzToolsFramework
             if (!m_sourceAssetId.IsValid())
             {
                 SaveAsDialog();
+                return;
             }
 
             if (!m_dirty)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -399,6 +399,7 @@ namespace AzToolsFramework
 
                     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::NormalizePathKeepCase, targetFilePath);
                     m_expectedAddedAssetPath = targetFilePath;
+                    AZStd::to_lower(m_expectedAddedAssetPath.begin(), m_expectedAddedAssetPath.end());
 
                     SourceControlCommandBus::Broadcast(
                         &SourceControlCommandBus::Events::RequestEdit,


### PR DESCRIPTION
## What does this PR do?

This PR resolves #15153. The expected vs saved path comparison was failing due to case differences.
Also fixes #14872.

## How was this PR tested?

Saved several asset types with correct results.
