### PR TITLE
Fix PhysX mesh material dependencies

### DIFF
--- a/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
@@ -125,7 +125,7 @@ namespace PhysX
         AZ::Data::AssetHandler::LoadResult MeshAssetHandler::LoadAssetData(
             const AZ::Data::Asset<AZ::Data::AssetData>& asset,
             AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
-            [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB)
+            const AZ::Data::AssetFilterCB& assetLoadFilterCB)
         {
             MeshAsset* meshAsset = asset.GetAs<MeshAsset>();
             if (!meshAsset)
@@ -137,7 +137,8 @@ namespace PhysX
             AZ::SerializeContext* serializeContext = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
 
-            if (!AZ::Utils::LoadObjectFromStreamInPlace(*stream, meshAsset->m_assetData, serializeContext))
+            if (!AZ::Utils::LoadObjectFromStreamInPlace(
+                    *stream, meshAsset->m_assetData, serializeContext, AZ::ObjectStream::FilterDescriptor(assetLoadFilterCB)))
             {
                 return AZ::Data::AssetHandler::LoadResult::Error;
             }


### PR DESCRIPTION
## What does this PR do?

This adds the PhysX material dependencies to the PhysX mesh (pxmesh) assets. Without the dependencies, a rare Editor lockup could occur because when loading a pxmesh asset, the serialized material dependency would become a blocking asset load, which under the right circumstances could cause an unrecoverable deadlock. By adding the dependencies, the Asset Manager uses the dependencies to load all the assets in parallel with non-blocking loads, avoiding the deadlock situation.

The change to the call to LoadAssetStreamInPlace in the MeshAssetHandler is there to pass down the Asset Container filter callback which will assert if a dependent asset load is triggered without a proper dependency set up. This presumably was deliberately (and incorrectly) left off before to avoid the assert since the proper dependencies weren't previously set up.

## How was this PR tested?

1. Ran the Editor several times with Multiplayer Sample to verify the lockup never occurred again. However, I only saw the lockup once, so this doesn't truly prove that it's fixed.
2. Put breakpoints in Asset Serializer to verify that physics mesh loads no longer hit the case where blocking loads are triggered.
3. Looked in the Asset Processor and verified that the physics materials are now showing up as dependencies.

![image](https://github.com/o3de/o3de/assets/82224783/c077c485-c2f2-4c9b-9e5c-dc9d0cb93a51)
