### PR TITLE
Fixed pass attachment preview issue with vulkan in Editor when windows dpi is not 100%

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
@@ -125,7 +125,7 @@ namespace AZ
             outputAttachment.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::RenderTarget;
             outputAttachment.SetAttachment(m_passAttachment);
 
-            m_attachmentBindings.push_back(outputAttachment);
+            AddAttachmentBinding(outputAttachment);
 
             ParentPass::BuildInternal();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/RenderToTexturePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/RenderToTexturePass.cpp
@@ -68,7 +68,7 @@ namespace AZ
             outputBinding.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::RenderTarget;
             outputBinding.SetAttachment(m_outputAttachment);
 
-            m_attachmentBindings.push_back(outputBinding);
+            AddAttachmentBinding(outputBinding);
             
             Base::BuildInternal();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -97,7 +97,7 @@ namespace AZ
                 outputBinding.m_slotType = PassSlotType::Output;
                 outputBinding.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::RenderTarget;
                 outputBinding.SetAttachment(m_swapChainAttachment);
-                m_attachmentBindings.push_back(outputBinding);
+                AddAttachmentBinding(outputBinding);
 
                 // create an intermediate attachment which has window render resolution
                 RHI::ImageDescriptor outputImageDesc;
@@ -109,7 +109,8 @@ namespace AZ
                 m_pipelinOutputAttachment->m_descriptor = outputImageDesc;
                 m_pipelinOutputAttachment->m_name = "PipelineOutput";
                 m_pipelinOutputAttachment->ComputePathName(GetPathName());
-                // Note: do not add m_pipelinOutputAttachment to m_ownedAttachments so it won't be imported to frame graph's attachment database
+                // Note: do not add m_pipelinOutputAttachment to m_ownedAttachments so it won't be imported to frame graph's attachment database. 
+                // This is because this attachment is only used for pass reference, but not used for RHI frame graph
 
                 // use the intermediate attachment as pipeline's output
                 pipelineOutput->SetAttachment(m_pipelinOutputAttachment);


### PR DESCRIPTION
## What does this PR do?

This change fixed a crash when preview a pass tree attachment. 
Repro steps:
* Change windows DPI to 150%
* Run Editor with AutomatedTesting project with vulkan backend: add "-rhi=vulkan" to the command line when start Editor. 
* Open a level. For example, Graphics/Sponda
* Open PassTree tool via ImGui menu: press ` key to open the ImGui menu and PassTree tool is under Atom Tools menu.
* Enable show attachment and preview attachment
* Choose an image attachment in MainPipeline's pass tree

## How was this PR tested?

Tested with the repro steps.
ASV screenshot tests
