### PR TITLE
Parsing for implicit connections to nodes with multiple data slots

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1877,11 +1877,9 @@ namespace ScriptCanvasEditor
     {
         GeneralRequestBus::Broadcast(&GeneralRequests::PostUndoPoint, GetScriptCanvasId());
 
-#if defined(AZ_PLATFORM_LINUX)
-        // Work-around for a crash on Linux caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
+        // Work-around for a crash caused by the MainWindow::OnSystemTick not being handled before the ReflectedPropertyEditor's DoRefresh.
         // This will force a refresh selection on any post-deletion events so that the DoRefresh will not crash on deleted objects
         UIRequestBus::Broadcast(&UIRequests::RefreshSelection);
-#endif
     }
 
     void EditorGraph::PostCreationEvent()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -3822,7 +3822,7 @@ namespace ScriptCanvas
                     if (connectedNode.second != outSlot)
                     {
                         // If there are no connections to ignore yet, that must mean there are still more slots on this node to parse
-                        if (m_parsedImplicitConnections.size() == 0)
+                        if (m_parsedImplicitConnections.empty())
                         {
                             m_parsedImplicitConnections.push_back(AZStd::make_pair(outSlot, inSlot));
                             return true;
@@ -3830,7 +3830,7 @@ namespace ScriptCanvas
                         else
                         {
                             bool foundConnectionInParsed = false;
-                            for (auto connection : m_parsedImplicitConnections)
+                            for (const auto& connection : m_parsedImplicitConnections)
                             {
                                 if (connection.first == connectedNode.second && connection.second == inSlot)
                                 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.h
@@ -348,6 +348,8 @@ namespace ScriptCanvas
 
             void ParseExecutionMultipleOutSyntaxSugar(ExecutionTreePtr execution, const EndpointsResolved& executionOutNodes, const AZStd::vector<const Slot*>& outSlots);
 
+            bool HasUnparsedImplicitConnections(const Slot* outSlot, const Slot* inSlot);
+
             void ParseExecutionMultipleOutSyntaxSugarOfSequencNode(ExecutionTreePtr sequence);
 
             void ParseExecutionOnce(ExecutionTreePtr execution);
@@ -584,6 +586,8 @@ namespace ScriptCanvas
             VariableUseage m_variableUse;
 
             ParsedRuntimeInputs m_runtimeInputs;
+
+            AZStd::vector<AZStd::pair<const Slot*, const Slot*>> m_parsedImplicitConnections;
 
             AZStd::vector<VariablePtr> FindUserImmediateInput(ExecutionTreePtr call) const;
 


### PR DESCRIPTION
## What does this PR do?

This PR allows for nodes with an execution in slot marked with the m_createsImplicitConnections attribute to be able to parse when it has more than one data in slot. This is accomplished during parsing, where implicit connections connected to nodes with implicit connections that have not been parsed yet will be ignored.
This PR also fixes a crash that happens when nodes that have implicit connections are deleted by refreshing selections before the deletion of nodes. This crash previously only happened on Linux and was fixed here: https://github.com/o3de/o3de/pull/9698.

## How was this PR tested?

Tests for ScriptCanvas and ScriptCanvas Editor were run locally. I also did manual testing by creating, deleting, undoing, and redoing connections. Three simple nodeables were created to test functionality, one that increments a number, one that adds two numbers to each other, and one that adds three numbers to each other:

<img width="659" alt="multoutgraph1" src="https://github.com/o3de/o3de/assets/105814224/29c010e4-75eb-4f47-90e9-38d9ef5bc558">
<br>
<img width="82" alt="multoutout1" src="https://github.com/o3de/o3de/assets/105814224/96ff997d-c2fa-43e0-bd73-7382befc847c">
 <br><br>
<img width="783" alt="multoutgraph2" src="https://github.com/o3de/o3de/assets/105814224/8d750fd6-a3aa-4647-bd76-f77f97a860d4">
<br>
<img width="85" alt="multoutout2" src="https://github.com/o3de/o3de/assets/105814224/c1d6999a-09b4-4159-a73b-00738d1aba87">
<br><br>
<img width="1084" alt="multoutgraph3" src="https://github.com/o3de/o3de/assets/105814224/b41e6acd-0b04-4910-96bf-025372af6b15">
<br>
<img width="78" alt="multoutout3" src="https://github.com/o3de/o3de/assets/105814224/d806cd8d-0653-4393-806d-3d234d3a0956">