### PR TITLE
Add README.md Files And Generate Repo.json.bak File When Change Is Made

### DIFF
--- a/Templates/RemoteRepo/Template/Gems/README.md
+++ b/Templates/RemoteRepo/Template/Gems/README.md
@@ -1,0 +1,1 @@
+This folder is where you should place all your gems

--- a/Templates/RemoteRepo/Template/Projects/README.md
+++ b/Templates/RemoteRepo/Template/Projects/README.md
@@ -1,0 +1,1 @@
+This folder is where you should place all your projects

--- a/Templates/RemoteRepo/Template/Templates/README.md
+++ b/Templates/RemoteRepo/Template/Templates/README.md
@@ -1,0 +1,1 @@
+This folder is where you should place all your templates

--- a/Templates/RemoteRepo/template.json
+++ b/Templates/RemoteRepo/template.json
@@ -18,7 +18,29 @@
         {
             "file": "repo.json",
             "isTemplated": true
+        },
+        {
+            "file": "Gems/README.md",
+            "isTemplated": false
+        },
+        {
+            "file": "Templates/README.md",
+            "isTemplated": false
+        },
+        {
+            "file": "Projects/README.md",
+            "isTemplated": false
         }
     ],
-    "createDirectories": []
+    "createDirectories": [
+        {
+            "dir": "Gems"
+        },
+        {
+            "dir": "Templates"
+        },
+        {
+            "dir": "Projects"
+        }
+    ]
 }

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -306,12 +306,15 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         repo_json['repo_name'] = repo_name
 
     if add_gems or delete_gems or replace_gems:
+        utils.backup_file(repo_path)
         _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix)
 
     if add_projects or delete_projects or replace_projects:
+        utils.backup_file(repo_path)
         _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix)
 
     if add_templates or delete_templates or replace_templates:
+        utils.backup_file(repo_path)
         _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix)
 
     return 0 if manifest.save_o3de_manifest(repo_json, repo_path) else 1

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -9,6 +9,7 @@
 This file contains all the code that has to do with editing the remote repo template
 """
 import argparse
+import copy
 import pathlib
 import sys
 import json
@@ -298,6 +299,8 @@ def edit_repo_props(repo_path: pathlib.Path = None,
     if not repo_json:
         return 1
 
+    repo_json_original = copy.deepcopy(repo_json)
+
     if isinstance(repo_name, str):
         if not utils.validate_identifier(repo_name):
             logger.error(f'Repo name must be fewer than 64 characters, contain only alphanumeric, "_" or "-"'
@@ -306,16 +309,16 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         repo_json['repo_name'] = repo_name
 
     if add_gems or delete_gems or replace_gems:
-        utils.backup_file(repo_path)
         _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix)
 
     if add_projects or delete_projects or replace_projects:
-        utils.backup_file(repo_path)
         _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix)
 
     if add_templates or delete_templates or replace_templates:
-        utils.backup_file(repo_path)
         _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix)
+
+    if repo_json_original != repo_json:
+        utils.backup_file(repo_path)
 
     return 0 if manifest.save_o3de_manifest(repo_json, repo_path) else 1
 

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -121,6 +121,7 @@ def init_repo_json_data(request):
         def __init__(self):
             self.data = json.loads(TEST_TEMPLATE_REPO_JSON)
             self.path = None
+            self.backup_file_name = None
     request.cls.repo_json = RepoJsonData()
 
 @pytest.fixture(scope="session")
@@ -351,7 +352,7 @@ class TestEditRepoProperties:
                                      release_archive_path, force, download_prefix,  
                                      expected_result):
         def backup_file(file_name: str or pathlib.Path) -> None:
-            file_name = None
+            self.backup_file_name = file_name
 
         def get_repo_props(repo_path: str or pathlib.Path = None) -> dict or None:
             if not repo_path:

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -13,7 +13,7 @@ import pytest
 import pathlib
 from unittest.mock import patch
 
-from o3de import download, repo_properties
+from o3de import download, repo_properties, utils
 
 TEST_TEMPLATE_REPO_JSON = '''{
     "repo_name": "repotest",
@@ -350,7 +350,9 @@ class TestEditRepoProperties:
                                      add_templates, delete_templates, replace_templates, expected_templates,
                                      release_archive_path, force, download_prefix,  
                                      expected_result):
-        
+        def backup_file(file_name: str or pathlib.Path) -> None:
+            file_name = None
+
         def get_repo_props(repo_path: str or pathlib.Path = None) -> dict or None:
             if not repo_path:
                 self.repo_json.data = None
@@ -379,6 +381,7 @@ class TestEditRepoProperties:
 
         with patch('o3de.repo_properties.get_repo_props', side_effect=get_repo_props) as get_repo_props_patch, \
                 patch('o3de.manifest.save_o3de_manifest', side_effect=save_o3de_manifest) as save_o3de_manifest_patch, \
+                patch('o3de.utils.backup_file', side_effect=backup_file) as backup_file_patch, \
                 patch('o3de.manifest.get_json_data', side_effect=get_json_data) as get_json_data_patch:
             if release_archive_path:
                 add_gems = [temp_folder / 'gem']

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -397,6 +397,7 @@ class TestEditRepoProperties:
                 assert self.repo_json.data.get('repo_uri') == 'https://test.com'
                 assert self.repo_json.data.get('$schemaVersion') == '1.0.0'
                 assert self.repo_json.data.get('origin') == 'o3de'
+                assert self.backup_file_name == repo_path
 
                 for gem in self.repo_json.data.get('gems_data', []):
                     if release_archive_path:


### PR DESCRIPTION
## What does this PR do?

1. Auto Creates Gems/Projects/Templates folder when create-repo command is called, each with README.md inside of them that clarifies what should be placed in those folders. 
2. Allow repo.json to generate a backup file called repo.json.bak every time user made a change to their repo.json file

## How was this PR tested?
1. Auto generation of folders is tested by calling this command to create a remote repo:
> ./o3de.bat create-repo -rp "C:\o3de_Projects\RemoteRepoCheck\repo.json" -ru "https://github.com/VeryKaylin-player1/RemoteRepoCheck"
 Result: Three folders would show up with appropriate README.md files inside them with appropriate message

- Rerun all unit test in test_repo_properties.py file to make sure adding this function won't affect the previous functions


2. To test repo.json.bak file call add command on edit-repo-properties: 
> ./o3de.bat edit-repo-properties -rp "C:\o3de_Projects\RemoteRepoCheck\repo.json" --add-gem "C:\o3de_Projects\RemoteRepoCheck\Gems\MyGem"
Result: This will create a backup of the current repo.json file before adding the new gem called repo.json.bak0


