### PR TITLE
DX12: Fixed indirect indexed draw

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -501,7 +501,14 @@ namespace AZ
 
             case RHI::DrawType::Indirect:
             {
-                ExecuteIndirect(drawItem.m_arguments.m_indirect);
+                const auto& indirect = drawItem.m_arguments.m_indirect;
+                const RHI::IndirectBufferLayout& layout = indirect.m_indirectBufferView->GetSignature()->GetDescriptor().m_layout;
+                if (layout.GetType() == RHI::IndirectBufferLayoutType::IndexedDraw)
+                {
+                    AZ_Assert(drawItem.m_indexBufferView, "Index buffer view is null!");
+                    SetIndexBuffer(*drawItem.m_indexBufferView);
+                }
+                ExecuteIndirect(indirect);
                 break;
             }
             default:


### PR DESCRIPTION
## What does this PR do?

Indirect indexed draw did not work for the DX12 RHI, because the Index Buffer was never set.
The Index buffer is now set the same way as in the direct indexed draw case.

## How was this PR tested?

Windows and DX12, with a custom pass, that performs an indexed indirect draw.
