### PR TITLE
Add modulo by zero checks to the TIAF SharedTest JobInfo Generator

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
@@ -251,6 +251,11 @@ namespace TestImpact
         const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
         const auto numTests = testEnumeration->GetNumEnabledTests();
         const auto numShards = std::min(m_maxConcurrency, numTests);
+        if (numShards == 0)
+        {
+            // If there are no shards, there is no work to be done
+            return {};
+        }
         ShardedTestsList shardTestList(numShards);
 
         size_t testIndex = 0;
@@ -283,6 +288,11 @@ namespace TestImpact
         const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
         const auto numFixtures = testEnumeration->GetNumEnabledTestSuites();
         const auto numShards = std::min(m_maxConcurrency, numFixtures);
+        if (numShards == 0)
+        {
+            // If there are no shards, there is no work to be done
+            return {};
+        }
         ShardedTestsList shardTestList(numShards);
 
         size_t fixtureIndex = 0;


### PR DESCRIPTION
There is a scenario where the TestImpactNativeShardedTestJobInfoGenerator.h could attempt to perform a divide by zero operation where the number of test shards is 0.

## How was this PR tested?

Using Jenkins to run the TIAF job.
