### PR TITLE
Hardended the NativeShardedTestRunJobInfoGeneratorBase sharding configuration checks

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
@@ -204,12 +204,24 @@ namespace TestImpact
         const TestTargetAndEnumeration& testTargetAndEnumeration, typename TestJobRunner::JobInfo::Id startingId)
     {
         // If the target can shard and has more than one test, and the max concurrency is greater than 1, we will shard
-        if (const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
-            testTarget->CanShard()
+        const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
+        const bool testTargetCanShard = testEnumeration.has_value() &&
+            ((testTarget->GetShardingConfiguration() == ShardingConfiguration::TestInterleaved
+                && testEnumeration->GetNumEnabledTests() > 1) ||
+                (testTarget->GetShardingConfiguration() == ShardingConfiguration::FixtureInterleaved
+                    && testEnumeration->GetNumEnabledTestSuites() > 1));
+
+        if (testTarget->CanShard()
             && m_maxConcurrency > 1
-            && testEnumeration.has_value()
-            && testEnumeration->GetNumEnabledTests() > 1)
+            && testTargetCanShard)
         {
+            std::printf(R"(Splitting test run into shards with sharding configuration "%s", enabled test count = "%zu")"
+                R"(, enabled test suite/fixture count = "%zu" for target "%s")" "\n",
+                testTarget->GetShardingConfiguration() == ShardingConfiguration::TestInterleaved
+                ? "Test Interleaved" : "Fixture Interleaved",
+                testEnumeration->GetNumEnabledTests(),
+                testEnumeration->GetNumEnabledTestSuites(),
+                testTarget->GetName().c_str());
             return GenerateJobInfoImpl(testTargetAndEnumeration, startingId);
         }
         else


### PR DESCRIPTION
The checks only check if the number of enabled test were greater than 1, but did not account for the number of enabled test fixtures being greater than 1 when the sharding configuration was for fixtures.

## How was this PR tested?

Successfully the TestImpact Analysis Frameworks targets successfully locally.
