### PR TITLE
[Linux] Fix crash when enabling Bloom component.

### DIFF
--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
@@ -13,6 +13,8 @@
 #include <AzFramework/XcbConnectionManager.h>
 #include <qpa/qplatformnativeinterface.h>
 #include <AzFramework/XcbEventHandler.h>
+#include <AzFramework/Input/Channels/InputChannel.h>
+#include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #endif
 
 namespace Editor
@@ -36,6 +38,7 @@ namespace Editor
         }
         return reinterpret_cast<xcb_connection_t*>(native->nativeResourceForIntegration(QByteArray("connection")));
     }
+
 
     void EditorQtApplicationXcb::OnStartPlayInEditor()
     {
@@ -76,4 +79,18 @@ namespace Editor
         }
         return false;
     }
+
+	void EditorQtApplicationXcb::OnInputChannelEvent(const AzFramework::InputChannel& inputChannel, bool& hasBeenConsumed)
+	{
+		if(GetIEditor()->IsInGameMode())
+		{
+			if(inputChannel.GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::Escape)
+			{
+				hasBeenConsumed = true;
+				GetIEditor()->SetInGameMode(false);
+			}
+		}
+
+		InputChannelNotifications::OnInputChannelEvent(inputChannel, hasBeenConsumed);
+	}
 } // namespace Editor

--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
@@ -9,6 +9,7 @@
 #if !defined(Q_MOC_RUN)
 #include <Editor/Core/QtEditorApplication.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzFramework/Input/Buses/Notifications/InputChannelNotificationBus.h>
 #endif
 
 using xcb_connection_t = struct xcb_connection_t;
@@ -18,6 +19,7 @@ namespace Editor
     class EditorQtApplicationXcb
         : public EditorQtApplication
         , public AzToolsFramework::EditorEntityContextNotificationBus::Handler
+		, public AzFramework::InputChannelNotificationBus::Handler
     {
         Q_OBJECT
     public:
@@ -26,6 +28,7 @@ namespace Editor
         {
             // Connect bus to listen for OnStart/StopPlayInEditor events
             AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
+			AzFramework::InputChannelNotificationBus::Handler::BusConnect();
         }
 
         xcb_connection_t* GetXcbConnectionFromQt();
@@ -37,5 +40,6 @@ namespace Editor
 
         // QAbstractNativeEventFilter:
         bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;
+		void OnInputChannelEvent(const AzFramework::InputChannel& inputChannel, bool& hasBeenConsumed) override;
     };
 } // namespace Editor

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BaseStyleSheet.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/BaseStyleSheet.qss
@@ -26,7 +26,7 @@ QTreeView
 {
     /* give a background color to views without parent (completer popups)
        it is reset to transparent in the next setting for views with a parent */
-    background-color: #444444;
+    background-color: #212121;
 }
 
 QWidget > QTableView,
@@ -34,7 +34,7 @@ QWidget > QListView,
 QWidget > QTreeView
 {
     /* reset the background-color of views with parents to transparent */
-    background-color: transparent;
+    background-color: #212121;
 }
 
 /* Fix frame HLine and VLine drawing. Affects QFrame but not subclasses */
@@ -62,7 +62,7 @@ QDialog,
 QDockWidget
 {
     color: #cccccc;
-    background-color: #444444;
+    background-color: #212121;
 }
 
 QTextEdit,
@@ -76,11 +76,11 @@ QComboBox
     background-color: #CCCCCC;
     color: black;
     font-family: "Open Sans";
-    border-radius: 2px;
     border-width: 0px;
     border-color: #e9e9e9;
     font-size: 12px;
     line-height: 16px;
+    border-radius: 0px;
 }
 
 QTextEdit,

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Card.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Card.qss
@@ -40,7 +40,7 @@ AzQtComponents--Card[selected="true"] > #contentContainer
 
 AzQtComponents--Card #contentContainer
 {
-    background-color: #555555;
+    background-color: #3b3b3b;
 }
 
 AzQtComponents--Card[hideFrame=true]
@@ -152,14 +152,14 @@ AzQtComponents--CardHeader[class~="SectionCardHeader"]
 
 .primaryCardHeader
 {
-    background-color: #333333;
+    background-color: #2f2f2f;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 }
 
 .secondaryCardHeader
 {
-    background-color: #555555;
+    background-color: #444444;
     padding: 0px;
 }
 
@@ -258,7 +258,7 @@ AzQtComponents--CardHeader #Help
 
 .separator
 {
-    color: #999999;
+    color: #212121;
     margin: 0px;
     padding: 0px;
 }
@@ -271,7 +271,7 @@ AzQtComponents--Card #SeparatorContainer
 
 AzQtComponents--Card QLabel:disabled
 {
-    color: #999999;
+
 }
 
 /* Show expander arrow in card header at full opacity even when card is disabled */

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.qss
@@ -24,7 +24,7 @@ QComboBox:hover
     margin: 0px;
     border-width: 1px;
     border-style: solid;
-    border-radius: 3px;
+    border-radius: 0px;
     border-color: rgba(0, 0, 0, 50);
 }
 
@@ -35,7 +35,7 @@ QComboBox[HasPopupOpen=true][HasPopupOpen=true]
     margin: 0px;
     border-width: 1px;
     border-style: solid;
-    border-radius: 3px;
+    border-radius: 0px;
     border-color: #94D2FF;
 
     background-color: #FFFFFF;
@@ -46,7 +46,7 @@ QComboBox[HasError=true]
     margin: 0px;
     border-width: 2px;
     border-style: solid;
-    border-radius: 4px;
+    border-radius: 0px;
     border-color: #E25243;
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/PushButtonConfig.ini
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/PushButtonConfig.ini
@@ -1,11 +1,11 @@
 [DefaultFrame]
 Height=24
-Radius=4
+Radius=0
 Margin=8
 
 [SmallIcon]
 Frame\Height=24
-Frame\Radius=4
+Frame\Radius=0
 Frame\Margin=8
 EnabledArrowColor=#FFFFFF
 DisabledArrowColor=#BBBBBB

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Splitter.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Splitter.qss
@@ -7,7 +7,7 @@
  */
 
 QSplitter::handle {
-    background-color: #222222;
+    background-color: #131313;
 }
 
 QSplitter::handle:horizontal {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.qss
@@ -10,7 +10,7 @@
 QTabWidget,
 QTabBar
 {
-    background-color: #444444;
+    background-color: #ff0000;
 }
 
 QTabBar::tab
@@ -25,7 +25,7 @@ AzQtComponents--TabWidget
 
 AzQtComponents--TabWidget > QWidget
 {
-    background-color: #444444;
+    background-color: #212121;
 }
 
 AzQtComponents--TabWidget:pane
@@ -49,7 +49,7 @@ AzQtComponents--TabBar
 AzQtComponents--TabBar:tab
 {
     border: 1px solid #111111;
-    background-color: #333333;
+    background-color: #2f2f2f;
 
     text-align: left;
     padding: 6px -2px 6px 9px; /* top, right, bottom, left */
@@ -63,13 +63,14 @@ AzQtComponents--TabBar::tab:text
 
 AzQtComponents--TabBar::tab:selected
 {
-    border-bottom: 1px solid #444444;
+    /* The line belows the tab. */
+    border-bottom: 1px solid #333333;
 }
 
 AzQtComponents--TabBar::tab:selected,
 AzQtComponents--TabBar::tab:hover
 {
-    background-color: #444444;
+    background-color: #212121;
 }
 
 AzQtComponents--TabBar:focus

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
@@ -18,7 +18,7 @@ QTreeView
 {
     /* Use opaque colours because the ::branch subcontrol background is painted slightly differently
        to the rest of the row */
-    alternate-background-color: rgb(77, 77, 77);
+    alternate-background-color: #272727;
 
     selection-background-color: rgb(101, 101, 101);
     selection-color: #ffffff;
@@ -96,9 +96,9 @@ QTreeView::branch:open:has-children:has-siblings  {
     padding: 10px 4px;
 }
 
-QTreeView::item:disabled 
-{ 
-    color: #777777; 
+QTreeView::item:disabled
+{
+    color: #777777;
 }
 
 AzQtComponents--TableView::branch:open:has-children,

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ToolBar.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ToolBar.qss
@@ -17,7 +17,6 @@ QToolBar
     /* QToolBar required a background colour to ensure it has a background when
      * displaying an overflow menu, or when floating
      */
-    background-color: #444444;
     qproperty-iconSize: 16px 16px;
     border: 0 none;
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.qss
@@ -9,8 +9,6 @@
 AzQtComponents--VectorElement QLabel
 {
     margin: 2px;
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
     text-align: center;
 }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -82,6 +82,17 @@ namespace LUAEditor
         auto settingsRegistry = AZ::SettingsRegistry::Get();
         AZ::IO::FixedMaxPath engineRootPath;
         settingsRegistry->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+		GameEngineFolder = engineRootPath.String();
+
+		AZ::IO::Path projectPath;
+		settingsRegistry->Get(projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath);
+		GameAssetFolder = projectPath.String();
+
+		if(m_lastOpenFilePath.empty())
+		{
+			m_lastOpenFilePath = GameAssetFolder;
+		}
+
         AzQtComponents::StyleManager* m_styleSheet = new AzQtComponents::StyleManager(this);
         m_styleSheet->initialize(qApp, engineRootPath);
 
@@ -821,7 +832,18 @@ namespace LUAEditor
         rootDir.setPath(rootDirString);
         rootDir.cdUp();
 
-        QString name = QFileDialog::getOpenFileName(this, "Open lua file", m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(), "Lua files (*.lua)");
+		QFileDialog dialog;
+
+		const QList<QUrl> bookmarks =
+		{
+			QUrl::fromLocalFile(GameAssetFolder.c_str()),
+			QUrl::fromLocalFile(GameEngineFolder.c_str())
+		};
+		dialog.setSidebarUrls(bookmarks);
+		QString name = dialog.getOpenFileName(this,
+											  tr("Open Lua File"),
+											  m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(),
+											  QString("Lua files (*.lua)"));
         if (name.isEmpty())
         {
             return;
@@ -1281,7 +1303,7 @@ namespace LUAEditor
             return;
         }
 
-        LUAEditorGoToLineDialog dlg(this);
+        LUAEditorGoToLineDialog dlg(nullptr);
 
         int lineNumber = 0, cursorColumn = 0;
         currentView->GetCursorPosition(lineNumber, cursorColumn);
@@ -1769,7 +1791,18 @@ namespace LUAEditor
         rootDir.setPath(rootDirString);
         rootDir.cdUp();
 
-        QString name = QFileDialog::getSaveFileName(this, QString(AZStd::string::format("Save File {%s}", assetName.c_str()).c_str()), m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(), QString("*.lua"));
+		QFileDialog dialog;
+
+		const QList<QUrl> bookmarks =
+		{
+			QUrl::fromLocalFile(GameAssetFolder.c_str()),
+			QUrl::fromLocalFile(GameEngineFolder.c_str())
+		};
+		dialog.setSidebarUrls(bookmarks);
+		QString name = dialog.getSaveFileName(this,
+											  QString(AZStd::string::format("Save File {%s}",assetName.c_str()).c_str()),
+											  m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(),
+											  QString("*.lua"));
         if (name.isEmpty())
         {
             return false;
@@ -1790,7 +1823,18 @@ namespace LUAEditor
         rootDir.setPath(rootDirString);
         rootDir.cdUp();
 
-        QString name = QFileDialog::getSaveFileName(this, QString(AZStd::string::format("Save File As {%s}", assetName.c_str()).c_str()), rootDir.absolutePath(), QString("*.lua"));
+		QFileDialog dialog;
+
+		const QList<QUrl> bookmarks =
+		{
+			QUrl::fromLocalFile(GameAssetFolder.c_str()),
+			QUrl::fromLocalFile(GameEngineFolder.c_str())
+		};
+		dialog.setSidebarUrls(bookmarks);
+		QString name = dialog.getSaveFileName(this,
+											  QString(AZStd::string::format("Save File {%s}",assetName.c_str()).c_str()),
+											  m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(),
+											  QString("*.lua"));
         if (name.isEmpty())
         {
             return false;

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
@@ -213,6 +213,9 @@ namespace LUAEditor
 
         void OnOptionsMenuRequested();
 
+		AZStd::string GameAssetFolder;
+		AZStd::string GameEngineFolder;
+
     public:
 
         void SetupLuaFilesPanel();

--- a/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
@@ -44,8 +44,8 @@
                             "Attachment": "Input"
                         },
                         "Multipliers":{
-                            "WidthMultiplier" : "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier" : 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                      "FormatSource": {
@@ -65,8 +65,8 @@
                             "Attachment": "Input"
                         },
                         "Multipliers":{
-                            "WidthMultiplier" : "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier" : 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                      "FormatSource": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpace.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpace.pass
@@ -78,8 +78,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -95,8 +95,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
@@ -132,8 +132,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -152,8 +152,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -172,8 +172,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {


### PR DESCRIPTION
## What does this PR do?

## What does this PR do?

This PR is fixing the crash on Linux when enabling the Bloom component. With this fix, the Bloom component works.
The issue is, as you can see, that some pass templates did use strings for the WidthMultiplier,  HeightMultiplier. This was causing in 

RHI::Size PassAttachmentSizeMultipliers::ApplyModifiers(const RHI::Size& size) const

zero sizes of images.

Might be also related to this:

https://github.com/o3de/o3de/issues/4812
https://github.com/o3de/o3de/issues/7400


I also changed two other pass templates using the string version of passing a float value.

## How was this PR tested?

Running on Linux inside the O3DE Editor.
