### PR TITLE
[LINUX] Fix crash when enabling bloom component.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
@@ -44,8 +44,8 @@
                             "Attachment": "Input"
                         },
                         "Multipliers":{
-                            "WidthMultiplier" : "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier" : 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                      "FormatSource": {
@@ -65,8 +65,8 @@
                             "Attachment": "Input"
                         },
                         "Multipliers":{
-                            "WidthMultiplier" : "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier" : 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                      "FormatSource": {


### PR DESCRIPTION
# What does this PR do?

This PR addresses a crash issue on Linux that occurs when the Bloom component is enabled. The fix resolves the problem, allowing the Bloom component to function properly.

The root cause of the crash was identified as the usage of strings for the WidthMultiplier and HeightMultiplier parameters in some pass templates. This resulted in zero-sized images being generated in the RHI::Size PassAttachmentSizeMultipliers::ApplyModifiers(const RHI::Size& size) const function.

It is worth noting that this issue may also be related to the following tickets:

#4812
#7400

Additionally, there are other template passes that utilize the same approach and may require similar fixes.
# How was this PR tested?

The changes in this PR were tested on Linux within the O3DE Editor environment to ensure its functionality and verify the resolution of the crash issue.