### PR TITLE
Disable DPE support in the Asset Editor

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -159,7 +159,8 @@ namespace AzToolsFramework
             setObjectName("AssetEditorTab");
 
             QWidget* propertyEditor = nullptr;
-            m_useDPE = DocumentPropertyEditor::ShouldReplaceRPE();
+            // TODO: Re-enable the DPE in the Asset Editor
+            //m_useDPE = DocumentPropertyEditor::ShouldReplaceRPE();
             if (!m_useDPE)
             {
                 m_propertyEditor = new ReflectedPropertyEditor(this);


### PR DESCRIPTION
## What does this PR do?

Temporarily disable support for the DPE in the Asset Editor so that we can focus on the Entity Inspector for now. This will later be revisited to tackle the following issues that were found:
https://github.com/o3de/o3de/issues/16229
https://github.com/o3de/o3de/issues/16230

## How was this PR tested?

Tested the Asset Editor with the DPE enabled and verified the above issues no longer occur.