### PR TITLE
Style fixup for upcoming compact nodes

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
@@ -157,6 +157,12 @@ namespace GraphCanvas
             {
                 slotLayout->insertItem(1, m_title);
                 slotLayout->setContentsMargins(0, 0, 0, 0);
+
+                // Center the title and slots vertically
+                for (int i = 0; i < slotLayout->count(); i++)
+                {
+                    slotLayout->setAlignment(slotLayout->itemAt(i), Qt::AlignVCenter);
+                }
             }
         }
         

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
@@ -400,14 +400,7 @@ namespace GraphCanvas
 
     void DataSlotLayout::OnNameChanged(const AZStd::string& name)
     {
-        if (m_isNameHidden)
-        {
-            m_slotText->SetLabel("");
-        }
-        else
-        {
-            m_slotText->SetLabel(name);
-        }
+        m_slotText->SetLabel(m_isNameHidden ? "" : name);
     }
 
     void DataSlotLayout::OnTooltipChanged(const AZStd::string& tooltip)

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
@@ -277,6 +277,14 @@ namespace GraphCanvas
         m_nodePropertyDisplay = aznew NodePropertyDisplayWidget();
         m_slotConnectionPin = aznew DataSlotConnectionPin(owner.GetEntityId());
         m_slotText = aznew GraphCanvasLabel();
+
+        if (const AZ::Entity* ownerEntity = owner.GetEntity())
+        {
+            if (const SlotComponent* slotComponent = ownerEntity->FindComponent<DataSlotComponent>())
+            {
+                m_isNameHidden = slotComponent->IsNameHidden();
+            }
+        }
     }
 
     DataSlotLayout::~DataSlotLayout()
@@ -337,7 +345,7 @@ namespace GraphCanvas
         {
             m_connectionType = slotRequests->GetConnectionType();
 
-            m_slotText->SetLabel(slotRequests->GetName());
+            OnNameChanged(slotRequests->GetName());
 
             OnTooltipChanged(slotRequests->GetTooltip());
 
@@ -392,7 +400,14 @@ namespace GraphCanvas
 
     void DataSlotLayout::OnNameChanged(const AZStd::string& name)
     {
-        m_slotText->SetLabel(name);
+        if (m_isNameHidden)
+        {
+            m_slotText->SetLabel("");
+        }
+        else
+        {
+            m_slotText->SetLabel(name);
+        }
     }
 
     void DataSlotLayout::OnTooltipChanged(const AZStd::string& tooltip)

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.h
@@ -195,6 +195,8 @@ namespace GraphCanvas
 
         GraphCanvasLabel* m_textDecoration = nullptr;
 
+        bool m_isNameHidden = false;
+
         // track the last seen values of some members to prevent UpdateLayout doing unnecessary work
         struct
         {

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.cpp
@@ -8,11 +8,10 @@
 
 #include <QCoreApplication>
 
+#include <Components/Slots/Execution/ExecutionSlotComponent.h>
+#include <Components/Slots/Execution/ExecutionSlotConnectionPin.h>
 #include <Components/Slots/Execution/ExecutionSlotLayoutComponent.h>
 
-#include <Components/Slots/Execution/ExecutionSlotConnectionPin.h>
-
-#include <Components/Slots/Execution/ExecutionSlotComponent.h>
 
 namespace GraphCanvas
 {
@@ -95,14 +94,7 @@ namespace GraphCanvas
 
     void ExecutionSlotLayout::OnNameChanged(const AZStd::string& name)
     {
-        if (m_isNameHidden)
-        {
-            m_slotText->SetLabel("");
-        }
-        else
-        {
-            m_slotText->SetLabel(name);
-        }
+        m_slotText->SetLabel(m_isNameHidden ? "" : name);
     }
 
     void ExecutionSlotLayout::OnTooltipChanged(const AZStd::string& tooltip)

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.cpp
@@ -12,6 +12,8 @@
 
 #include <Components/Slots/Execution/ExecutionSlotConnectionPin.h>
 
+#include <Components/Slots/Execution/ExecutionSlotComponent.h>
+
 namespace GraphCanvas
 {
     ////////////////////////
@@ -28,6 +30,14 @@ namespace GraphCanvas
 
         m_slotConnectionPin = aznew ExecutionSlotConnectionPin(owner.GetEntityId());
         m_slotText = aznew GraphCanvasLabel();
+
+        if (const AZ::Entity* ownerEntity = owner.GetEntity())
+        {
+            if (const SlotComponent* slotComponent = ownerEntity->FindComponent<ExecutionSlotComponent>())
+            {
+                m_isNameHidden = slotComponent->IsNameHidden();
+            }
+        }
     }
 
     ExecutionSlotLayout::~ExecutionSlotLayout()
@@ -58,7 +68,7 @@ namespace GraphCanvas
         {
             m_connectionType = slotRequests->GetConnectionType();
 
-            m_slotText->SetLabel(slotRequests->GetName());
+            OnNameChanged(slotRequests->GetName());
             OnTooltipChanged(slotRequests->GetTooltip());
 
             const SlotConfiguration& configuration = slotRequests->GetSlotConfiguration();
@@ -85,7 +95,14 @@ namespace GraphCanvas
 
     void ExecutionSlotLayout::OnNameChanged(const AZStd::string& name)
     {
-        m_slotText->SetLabel(name);
+        if (m_isNameHidden)
+        {
+            m_slotText->SetLabel("");
+        }
+        else
+        {
+            m_slotText->SetLabel(name);
+        }
     }
 
     void ExecutionSlotLayout::OnTooltipChanged(const AZStd::string& tooltip)

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Execution/ExecutionSlotLayoutComponent.h
@@ -75,6 +75,8 @@ namespace GraphCanvas
         GraphCanvasLabel*           m_slotText;
 
         GraphCanvasLabel*           m_textDecoration;
+
+        bool m_isNameHidden = false;
     };
 
     //! Lays out the parts of a basic Node

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/SlotComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/SlotComponent.cpp
@@ -398,6 +398,10 @@ namespace GraphCanvas
         return AZ::EntityId();
     }
 
+    bool SlotComponent::IsNameHidden() const
+    {
+        return m_slotConfiguration.m_isNameHidden;
+    }
 
     AZStd::vector<AZ::EntityId> SlotComponent::GetConnections() const
     {

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/SlotComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/SlotComponent.h
@@ -114,6 +114,8 @@ namespace GraphCanvas
 
         bool HasConnections() const override;
 
+        bool IsNameHidden() const;
+
         AZ::EntityId GetLastConnection() const override;
         AZStd::vector<AZ::EntityId> GetConnections() const override;
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
@@ -91,6 +91,8 @@ namespace GraphCanvas
         AZStd::string m_tooltip;
         AZStd::string m_name;
 
+        bool m_isNameHidden = false;
+
         SlotGroup m_slotGroup = SlotGroups::Invalid;
 
         AZStd::string m_textDecoration;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/definitions.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/definitions.h
@@ -62,10 +62,12 @@ namespace GraphCanvas
 
             const char* const CommentText = ".commentText";
 
+            // The compact sub-style makes a node appear more compact by reducing margins and placing the node title between
+            // slots instead of above them.
+            const char* const Compact = ".compact";
+
             // Custom Widgets
             const char* const CheckBox = "checkBox";
-
-            const char* const Small = ".small";
 
         } // namespace Elements
 

--- a/Gems/ScriptCanvas/Assets/ScriptCanvas/StyleSheet/graphcanvas_style.json
+++ b/Gems/ScriptCanvas/Assets/ScriptCanvas/StyleSheet/graphcanvas_style.json
@@ -99,7 +99,7 @@
     "opacity": "40%"
   },
   {
-    "selectors": [ "node.small" ],
+    "selectors": [ "node.compact" ],
 
     "border-width": 0,
     "spacing": 0,
@@ -144,7 +144,7 @@
     "margin": 5
   },
   {
-    "selectors": [ "node.small > title" ],
+    "selectors": [ "node.compact > title" ],
 
     "background-color": "transparent",
 
@@ -172,7 +172,7 @@
     "margin": 0
   },
   {
-    "selectors": [ "node.small > .maintitle" ],
+    "selectors": [ "node.compact > .maintitle" ],
 
     "text-alignment": "center",
 
@@ -193,7 +193,7 @@
     "background-color": "#6441A4"
   },
   {
-    "selectors": [ "node.small:disabled > .maintitle" ],
+    "selectors": [ "node.compact:disabled > .maintitle" ],
     "font-style": "italic",
     "color": "#ffffff"
   },
@@ -674,7 +674,7 @@
     "padding": 0
   },
   {
-    "selectors": [ "generalSlotLayout.small" ],
+    "selectors": [ "generalSlotLayout.compact" ],
 
     "spacing": 0
   },
@@ -912,7 +912,7 @@
     "border-color": "#E25243"
   },
   {
-    "selectors": [ "dataSlot.small" ],
+    "selectors": [ "dataSlot.compact" ],
 
     "spacing": 0,
     "padding": 0
@@ -951,11 +951,6 @@
     "min-height": 25
   },
   {
-    "selectors": [ "dataSlot.small > .slotName" ],
-
-    "min-height": 0
-  },
-  {
     "selectors": [ "dataSlot > .inputSlotName" ],
 
     "font-family": "Open Sans",
@@ -976,9 +971,11 @@
     "min-height": 25
   },
   {
-    "selectors": [ "dataSlot.small > .inputSlotName" ],
+    "selectors": [ "dataSlot.compact > .inputSlotName" ],
 
-    "min-height": 0
+    "min-height": 0,
+    "min-width": 20,
+    "font-size": "80%"
   },
   {
     "selectors": [ "dataSlot > .inputSlotName:validDrop" ],
@@ -1011,9 +1008,11 @@
     "min-height": 25
   },
   {
-    "selectors": [ "dataSlot.small > .outputSlotName" ],
+    "selectors": [ "dataSlot.compact > .outputSlotName" ],
 
-    "min-height": 0
+    "min-height": 0,
+    "min-width": 20,
+    "font-size": "80%"
   },
   {
     "selectors": [ "dataSlot > .outputSlotName:validDrop" ],

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -1245,6 +1245,8 @@ namespace ScriptCanvasEditor::Nodes
             executionConfiguration.m_tooltip = slot.GetToolTip();
             executionConfiguration.m_slotGroup = slotGroup;
 
+            executionConfiguration.m_isNameHidden = slot.IsNameHidden();
+
             if (slot.IsLatent())
             {
                 executionConfiguration.m_textDecoration = u8"\U0001f552";
@@ -1269,6 +1271,8 @@ namespace ScriptCanvasEditor::Nodes
             dataSlotConfiguration.m_name = slot.GetName();
             dataSlotConfiguration.m_tooltip = slot.GetToolTip();
             dataSlotConfiguration.m_slotGroup = slotGroup;
+
+            dataSlotConfiguration.m_isNameHidden = slot.IsNameHidden();
 
             if (slot.IsLatent())
             {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -796,7 +796,7 @@ namespace
             incrementNodeData.m_title = "++";
             incrementNodeData.m_toolTip = "Increments the input number by 1";
             incrementNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            incrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            incrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* incrementPaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();             // This data is in charge of the node palette item
             incrementPaletteData->m_nodeData = incrementNodeData;
@@ -810,7 +810,7 @@ namespace
             decrementNodeData.m_title = "--";
             decrementNodeData.m_toolTip = "Decrements the input number by 1";
             decrementNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            decrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            decrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* decrementPaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             decrementPaletteData->m_nodeData = decrementNodeData;
@@ -824,7 +824,7 @@ namespace
             doubleNodeData.m_title = "*2";
             doubleNodeData.m_toolTip = "Doubles input number";
             doubleNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            doubleNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            doubleNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* doublePaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             doublePaletteData->m_nodeData = doubleNodeData;
@@ -838,7 +838,7 @@ namespace
             negativeNodeData.m_title = "*-1";
             negativeNodeData.m_toolTip = "Multiplies input number by -1";
             negativeNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            negativeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            negativeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* negativePaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             negativePaletteData->m_nodeData = negativeNodeData;
@@ -852,7 +852,7 @@ namespace
             squareNodeData.m_title = "^2";
             squareNodeData.m_toolTip = "Squares input number";
             squareNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            squareNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            squareNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* squarePaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             squarePaletteData->m_nodeData = squareNodeData;
@@ -866,7 +866,7 @@ namespace
             cubeNodeData.m_title = "^3";
             cubeNodeData.m_toolTip = "Cubes input number";
             cubeNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            cubeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            cubeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* cubePaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             cubePaletteData->m_nodeData = cubeNodeData;
@@ -880,7 +880,7 @@ namespace
             squareRootNodeData.m_title = "sqrt";
             squareRootNodeData.m_toolTip = "Gets the square root of input number";
             squareRootNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            squareRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            squareRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* squareRootPaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             squareRootPaletteData->m_nodeData = squareRootNodeData;
@@ -894,7 +894,7 @@ namespace
             cubeRootNodeData.m_title = "cbrt";
             cubeRootNodeData.m_toolTip = "Gets the cube root of input number";
             cubeRootNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            cubeRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            cubeRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* cubeRootPaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             cubeRootPaletteData->m_nodeData = cubeRootNodeData;
@@ -908,7 +908,7 @@ namespace
             invertVector2NodeData.m_title = "inv";
             invertVector2NodeData.m_toolTip = "Inverts the input vector 2";
             invertVector2NodeData.m_dataType = ScriptCanvas::Data::Type::Vector2();
-            invertVector2NodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            invertVector2NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector2PaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             invertVector2PaletteData->m_nodeData = invertVector2NodeData;
@@ -922,7 +922,7 @@ namespace
             invertVector3NodeData.m_title = "inv";
             invertVector3NodeData.m_toolTip = "Inverts the input vector 3";
             invertVector3NodeData.m_dataType = ScriptCanvas::Data::Type::Vector3();
-            invertVector3NodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            invertVector3NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector3PaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             invertVector3PaletteData->m_nodeData = invertVector3NodeData;
@@ -936,7 +936,7 @@ namespace
             invertVector4NodeData.m_title = "inv";
             invertVector4NodeData.m_toolTip = "Inverts the input vector";
             invertVector4NodeData.m_dataType = ScriptCanvas::Data::Type::Vector4();
-            invertVector4NodeData.m_subStyle = GraphCanvas::Styling::Elements::Small;
+            invertVector4NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
             ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector4PaletteData =
                 aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
             invertVector4PaletteData->m_nodeData = invertVector4NodeData;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -384,6 +384,9 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
             outSlotConfiguration.m_name = "On {{itemName}}";
 {%          endif %}
             outSlotConfiguration.m_toolTip = "{{item.attrib['Description']}}";
+{% if item.attrib['HideName'] %}
+            outSlotConfiguration.m_isNameHidden = true;
+{% endif %}
             outSlotConfiguration.m_displayGroup = "{{ itemDisplayGroup }}";
             outSlotConfiguration.SetConnectionType(ScriptCanvas::ConnectionType::Output);
 {%          if item.attrib['Hidden'] %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -140,14 +140,13 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
             static_assert(false, "DataSlot type is undefined for slot: {{ slotName }}");
 {% endif %}
             ScriptCanvas::DataSlotConfiguration dataSlotConfiguration;
-{% if hideName %}
-            dataSlotConfiguration.m_name = " ";
-{% else %}
             dataSlotConfiguration.m_name = "{{ slotName }}";
-{% endif %}
             dataSlotConfiguration.m_toolTip = "{{ slotDescription }}";
 {% if hideInputField %}
             dataSlotConfiguration.m_canHaveInputField = false;
+{% endif %}
+{% if hideName %}
+            dataSlotConfiguration.m_isNameHidden = true;
 {% endif %}
 {% if displayGroup is defined %}
             dataSlotConfiguration.m_displayGroup = "{{ displayGroup }}";
@@ -220,6 +219,9 @@ false
         ScriptCanvas::ExecutionSlotConfiguration slotConfiguration{{executionDirection}}; 
         slotConfiguration{{executionDirection}}.m_name = "{{ slotName }}";
         slotConfiguration{{executionDirection}}.m_toolTip = "{{ slotDescription }}";
+{% if tag.attrib['HideName'] %}
+        slotConfiguration{{executionDirection}}.m_isNameHidden = true;
+{% endif %}
         slotConfiguration{{executionDirection}}.SetConnectionType(ScriptCanvas::ConnectionType::{{ executionDirection }});
 {% if tag.attrib['DisplayGroup'] is defined %}
         slotConfiguration{{executionDirection}}.m_displayGroup = "{{ tag.attrib['DisplayGroup'] }}";

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -212,6 +212,7 @@ namespace ScriptCanvas
                 ->Field("IsUserAdded", &Slot::m_isUserAdded)
                 ->Field("CanHaveInputField", &Slot::m_canHaveInputField)
                 ->Field("CreatesImplicitConnections", &Slot::m_createsImplicitConnections)
+                ->Field("IsNameHidden", &Slot::m_isNameHidden)
                 ;
         }
 
@@ -228,6 +229,7 @@ namespace ScriptCanvas
         , m_isVisible(slotConfiguration.m_isVisible)
         , m_canHaveInputField(slotConfiguration.m_canHaveInputField)
         , m_createsImplicitConnections(slotConfiguration.m_createsImplicitConnections)
+        , m_isNameHidden(slotConfiguration.m_isNameHidden)
     {
         if (!slotConfiguration.m_displayGroup.empty())
         {
@@ -444,6 +446,11 @@ namespace ScriptCanvas
     bool Slot::CreatesImplicitConnections() const
     {
         return m_createsImplicitConnections;
+    }
+
+    bool Slot::IsNameHidden() const
+    {
+        return m_isNameHidden;
     }
 
     bool Slot::CanConvertToValue() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -154,6 +154,8 @@ namespace ScriptCanvas
 
         bool CreatesImplicitConnections() const;
 
+        bool IsNameHidden() const;
+
         bool CanConvertTypes() const;
 
         bool CanConvertToValue() const;
@@ -241,6 +243,8 @@ namespace ScriptCanvas
         AZ::Crc32 m_dynamicGroup;
 
         bool m_canHaveInputField = true;
+
+        bool m_isNameHidden = false;
 
         bool               m_isLatentSlot  = false;
         SlotDescriptor     m_descriptor;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
@@ -229,6 +229,7 @@ namespace ScriptCanvas
         bool m_isLatent = false;
         bool m_isUserAdded = false;
         bool m_canHaveInputField = true;
+        bool m_isNameHidden = false;
 
         // Enabling this attribute on an execution slot will cause it to automatically make a "behind the scenes"
         // connection to nodes connected by other slots of the same connection type as this slot


### PR DESCRIPTION
## What does this PR do?

This PR adds some styling fixes for upcoming small operators:

- The compact substyle that small operators use has been more apropriately renamed from "small" to "compact". The unfinished small operators hidden behind the cvar "ed_showSmallOperators" also had their style updated to this name, and will be removed in a future PR
- Slots can now make use of a new "m_isNameHidden" attribute, which prevents the name of a slot from appearing in the graph. This was added because slots often use their name to identify themselves, so slots couldn't just be given an empty string for a name. Several small operators will take advantage of this attribute
- The Autogen HideName attribute now enables the m_isNameHidden attribute in the slot's SlotConfiguration
- Compact nodes' slots' names that are displayed are now 80% of their original size. These names also no longer off-center the title
- Input and output slots and titles of compact nodes are now vertically centered

## How was this PR tested?

This PR was tested manually by testing out several different graphs involving the small operators. I also ran tests locally often to make sure I wasn't breaking anything else. Small operators now look like this:

<img width="242" alt="nodes" src="https://github.com/o3de/o3de/assets/105814224/31ca9932-56d7-4cf2-a86d-4c027c9c1371">
