### PR TITLE
Adds VectorN, MatrixMxN, some code cleanup, and unit tests

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
@@ -219,10 +219,10 @@ namespace AZ
         viewFrustumAttributes.m_worldTransform = Transform::CreateFromMatrix3x3AndTranslation(orientation, origin);
 
         const float originDotForward = origin.Dot(forward);
-        const float nearClip = -Vec4::SelectFourth(m_planes[PlaneId::Near]) - originDotForward;
+        const float nearClip = -Vec4::SelectIndex3(m_planes[PlaneId::Near]) - originDotForward;
 
         viewFrustumAttributes.m_nearClip = nearClip;
-        viewFrustumAttributes.m_farClip = Vec4::SelectFourth(m_planes[PlaneId::Far]) - originDotForward;
+        viewFrustumAttributes.m_farClip = Vec4::SelectIndex3(m_planes[PlaneId::Far]) - originDotForward;
 
         const float leftNormalDotForward = left.GetNormal().Dot(forward);
         const float frustumNearHeight =

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.inl
@@ -48,7 +48,7 @@ namespace AZ
 
         for (PlaneId i = PlaneId::Near; i < PlaneId::MAX; ++i)
         {
-            const float distance = Simd::Vec1::SelectFirst(Simd::Vec4::PlaneDistance(m_planes[i], center.GetSimdValue()));
+            const float distance = Simd::Vec1::SelectIndex0(Simd::Vec4::PlaneDistance(m_planes[i], center.GetSimdValue()));
 
             if (distance < -radius)
             {
@@ -79,7 +79,7 @@ namespace AZ
         for (PlaneId i = PlaneId::Near; i < PlaneId::MAX; ++i)
         {
             const Vector3 disjointSupport = aabb.GetSupport(-Vector3(Simd::Vec4::ToVec3(m_planes[i])));
-            const float   disjointDistance = Simd::Vec1::SelectFirst(Simd::Vec4::PlaneDistance(m_planes[i], disjointSupport.GetSimdValue()));
+            const float   disjointDistance = Simd::Vec1::SelectIndex0(Simd::Vec4::PlaneDistance(m_planes[i], disjointSupport.GetSimdValue()));
 
             if (disjointDistance < 0.0f)
             {
@@ -89,7 +89,7 @@ namespace AZ
             // We now know the interior point we just checked passes the plane check..
             // Check an exterior support point to determine whether or not the whole AABB is contained or if this is an intersection
             const Vector3 intersectSupport = aabb.GetSupport(Vector3(Simd::Vec4::ToVec3(m_planes[i])));
-            const float   intersectDistance = Simd::Vec1::SelectFirst(Simd::Vec4::PlaneDistance(m_planes[i], intersectSupport.GetSimdValue()));
+            const float   intersectDistance = Simd::Vec1::SelectIndex0(Simd::Vec4::PlaneDistance(m_planes[i], intersectSupport.GetSimdValue()));
 
             if (intersectDistance >= 0.0f)
             {

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_neonDouble.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_neonDouble.inl
@@ -70,12 +70,12 @@ namespace AZ
                 vst1_s32(addr, value);
             }
 
-            AZ_MATH_INLINE float SelectFirst(float32x2_t value)
+            AZ_MATH_INLINE float SelectIndex0(float32x2_t value)
             {
                 return vget_lane_f32(value, 0);
             }
 
-            AZ_MATH_INLINE float SelectSecond(float32x2_t value)
+            AZ_MATH_INLINE float SelectIndex1(float32x2_t value)
             {
                 return vget_lane_f32(value, 1);
             }
@@ -90,34 +90,34 @@ namespace AZ
                 return vdup_n_s32(value);
             }
 
-            AZ_MATH_INLINE float32x2_t SplatFirst(float32x2_t value)
+            AZ_MATH_INLINE float32x2_t SplatIndex0(float32x2_t value)
             {
                 return vdup_lane_f32(value, 0);
             }
 
-            AZ_MATH_INLINE float32x2_t SplatSecond(float32x2_t value)
+            AZ_MATH_INLINE float32x2_t SplatIndex1(float32x2_t value)
             {
                 return vdup_lane_f32(value, 1);
             }
 
-            AZ_MATH_INLINE float32x2_t ReplaceFirst(float32x2_t a, float b)
+            AZ_MATH_INLINE float32x2_t ReplaceIndex0(float32x2_t a, float b)
             {
                 return vset_lane_f32(b, a, 0);
             }
 
-            AZ_MATH_INLINE float32x2_t ReplaceFirst(float32x2_t a, float32x2_t b)
+            AZ_MATH_INLINE float32x2_t ReplaceIndex0(float32x2_t a, float32x2_t b)
             {
-                return ReplaceFirst(a, SelectFirst(b));
+                return ReplaceIndex0(a, SelectIndex0(b));
             }
 
-            AZ_MATH_INLINE float32x2_t ReplaceSecond(float32x2_t a, float b)
+            AZ_MATH_INLINE float32x2_t ReplaceIndex1(float32x2_t a, float b)
             {
                 return vset_lane_f32(b, a, 1);
             }
 
-            AZ_MATH_INLINE float32x2_t ReplaceSecond(float32x2_t a, float32x2_t b)
+            AZ_MATH_INLINE float32x2_t ReplaceIndex1(float32x2_t a, float32x2_t b)
             {
-                return ReplaceSecond(a, SelectSecond(b));
+                return ReplaceIndex1(a, SelectIndex1(b));
             }
 
             AZ_MATH_INLINE float32x2_t LoadImmediate(float x, float y)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_neonQuad.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_neonQuad.inl
@@ -26,7 +26,7 @@ namespace AZ
 
             AZ_MATH_INLINE float32x4_t FromVec1(float32x2_t value)
             {
-                value = NeonDouble::SplatFirst(value);
+                value = NeonDouble::SplatIndex0(value);
                 return vcombine_f32(value, value); // {value.x, value.x, value.x, value.x}
             }
 
@@ -91,22 +91,22 @@ namespace AZ
                 vst1q_s32(addr, value);
             }
 
-            AZ_MATH_INLINE float SelectFirst(float32x4_t value)
+            AZ_MATH_INLINE float SelectIndex0(float32x4_t value)
             {
                 return vgetq_lane_f32(value, 0);
             }
 
-            AZ_MATH_INLINE float SelectSecond(float32x4_t value)
+            AZ_MATH_INLINE float SelectIndex1(float32x4_t value)
             {
                 return vgetq_lane_f32(value, 1);
             }
 
-            AZ_MATH_INLINE float SelectThird(float32x4_t value)
+            AZ_MATH_INLINE float SelectIndex2(float32x4_t value)
             {
                 return vgetq_lane_f32(value, 2);
             }
 
-            AZ_MATH_INLINE float SelectFourth(float32x4_t value)
+            AZ_MATH_INLINE float SelectIndex3(float32x4_t value)
             {
                 return vgetq_lane_f32(value, 3);
             }
@@ -121,64 +121,64 @@ namespace AZ
                 return vdupq_n_s32(value);
             }
 
-            AZ_MATH_INLINE float32x4_t SplatFirst(float32x4_t value)
+            AZ_MATH_INLINE float32x4_t SplatIndex0(float32x4_t value)
             {
                 return vdupq_laneq_f32(value, 0);
             }
 
-            AZ_MATH_INLINE float32x4_t SplatSecond(float32x4_t value)
+            AZ_MATH_INLINE float32x4_t SplatIndex1(float32x4_t value)
             {
                 return vdupq_laneq_f32(value, 1);
             }
 
-            AZ_MATH_INLINE float32x4_t SplatThird(float32x4_t value)
+            AZ_MATH_INLINE float32x4_t SplatIndex2(float32x4_t value)
             {
                 return vdupq_laneq_f32(value, 2);
             }
 
-            AZ_MATH_INLINE float32x4_t SplatFourth(float32x4_t value)
+            AZ_MATH_INLINE float32x4_t SplatIndex3(float32x4_t value)
             {
                 return vdupq_laneq_f32(value, 3);
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceFirst(float32x4_t a, float b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex0(float32x4_t a, float b)
             {
                 return vsetq_lane_f32(b, a, 0);
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceFirst(float32x4_t a, float32x4_t b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex0(float32x4_t a, float32x4_t b)
             {
-                return ReplaceFirst(a, SelectFirst(b));
+                return ReplaceIndex0(a, SelectIndex0(b));
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceSecond(float32x4_t a, float b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex1(float32x4_t a, float b)
             {
                 return vsetq_lane_f32(b, a, 1);
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceSecond(float32x4_t a, float32x4_t b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex1(float32x4_t a, float32x4_t b)
             {
-                return ReplaceSecond(a, SelectSecond(b));
+                return ReplaceIndex1(a, SelectIndex1(b));
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceThird(float32x4_t a, float b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex2(float32x4_t a, float b)
             {
                 return vsetq_lane_f32(b, a, 2);
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceThird(float32x4_t a, float32x4_t b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex2(float32x4_t a, float32x4_t b)
             {
-                return ReplaceThird(a, SelectThird(b));
+                return ReplaceIndex2(a, SelectIndex2(b));
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceFourth(float32x4_t a, float b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex3(float32x4_t a, float b)
             {
                 return vsetq_lane_f32(b, a, 3);
             }
 
-            AZ_MATH_INLINE float32x4_t ReplaceFourth(float32x4_t a, float32x4_t b)
+            AZ_MATH_INLINE float32x4_t ReplaceIndex3(float32x4_t a, float32x4_t b)
             {
-                return ReplaceFourth(a, SelectFourth(b));
+                return ReplaceIndex3(a, SelectIndex3(b));
             }
 
             AZ_MATH_INLINE float32x4_t LoadImmediate(float x, float y, float z, float w)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
@@ -538,6 +538,16 @@ namespace AZ
 
 
             template <typename VecType>
+            AZ_MATH_INLINE void Mat4x4MultiplyAdd(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
+            {
+                out[0] = VecType::Madd(VecType::SplatFourth(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[0]), rowsB[0], out[0]))));
+                out[1] = VecType::Madd(VecType::SplatFourth(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[1]), rowsB[0], out[1]))));
+                out[2] = VecType::Madd(VecType::SplatFourth(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[2]), rowsB[0], out[2]))));
+                out[3] = VecType::Madd(VecType::SplatFourth(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[3]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[3]), rowsB[0], out[3]))));
+            }
+
+
+            template <typename VecType>
             AZ_MATH_INLINE void Mat4x4TransposeMultiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
                 out[0] = VecType::Madd(VecType::SplatFirst (rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatFirst (rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatFirst (rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatFirst (rowsA[3]), rowsB[3]))));

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
@@ -538,12 +538,12 @@ namespace AZ
 
 
             template <typename VecType>
-            AZ_MATH_INLINE void Mat4x4MultiplyAdd(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
+            AZ_MATH_INLINE void Mat4x4MultiplyAdd(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, const typename VecType::FloatType* __restrict add, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[0]), rowsB[0], out[0]))));
-                out[1] = VecType::Madd(VecType::SplatIndex3(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[1]), rowsB[0], out[1]))));
-                out[2] = VecType::Madd(VecType::SplatIndex3(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[2]), rowsB[0], out[2]))));
-                out[3] = VecType::Madd(VecType::SplatIndex3(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[3]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[3]), rowsB[0], out[3]))));
+                out[0] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[0]), rowsB[0], add[0]))));
+                out[1] = VecType::Madd(VecType::SplatIndex3(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[1]), rowsB[0], add[1]))));
+                out[2] = VecType::Madd(VecType::SplatIndex3(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[2]), rowsB[0], add[2]))));
+                out[3] = VecType::Madd(VecType::SplatIndex3(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[3]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[3]), rowsB[0], add[3]))));
             }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
@@ -391,7 +391,7 @@ namespace AZ
             template <typename VecType>
             AZ_MATH_INLINE typename VecType::FloatType Normalize(typename VecType::FloatArgType value)
             {
-                const typename VecType::FloatType lengthSquared = VecType::SplatFirst(VecType::FromVec1(VecType::Dot(value, value)));
+                const typename VecType::FloatType lengthSquared = VecType::SplatIndex0(VecType::FromVec1(VecType::Dot(value, value)));
                 const typename VecType::FloatType length = VecType::Sqrt(lengthSquared);
                 return VecType::Div(value, length);
             }
@@ -400,7 +400,7 @@ namespace AZ
             template <typename VecType>
             AZ_MATH_INLINE typename VecType::FloatType NormalizeEstimate(typename VecType::FloatArgType value)
             {
-                const typename VecType::FloatType lengthSquared = VecType::SplatFirst(VecType::FromVec1(VecType::Dot(value, value)));
+                const typename VecType::FloatType lengthSquared = VecType::SplatIndex0(VecType::FromVec1(VecType::Dot(value, value)));
                 const typename VecType::FloatType invLength = VecType::SqrtInvEstimate(lengthSquared);
                 return VecType::Mul(invLength, value);
             }
@@ -410,7 +410,7 @@ namespace AZ
             AZ_MATH_INLINE typename VecType::FloatType NormalizeSafe(typename VecType::FloatArgType value, float tolerance)
             {
                 const typename VecType::FloatType floatEpsilon = VecType::Splat(tolerance * tolerance);
-                const typename VecType::FloatType lengthSquared = VecType::SplatFirst(VecType::FromVec1(VecType::Dot(value, value)));
+                const typename VecType::FloatType lengthSquared = VecType::SplatIndex0(VecType::FromVec1(VecType::Dot(value, value)));
                 if (VecType::CmpAllLt(lengthSquared, floatEpsilon))
                 {
                     return VecType::ZeroFloat();
@@ -423,7 +423,7 @@ namespace AZ
             AZ_MATH_INLINE typename VecType::FloatType NormalizeSafeEstimate(typename VecType::FloatArgType value, float tolerance)
             {
                 const typename VecType::FloatType floatEpsilon = VecType::Splat(tolerance * tolerance);
-                const typename VecType::FloatType lengthSquared = VecType::SplatFirst(VecType::FromVec1(VecType::Dot(value, value)));
+                const typename VecType::FloatType lengthSquared = VecType::SplatIndex0(VecType::FromVec1(VecType::Dot(value, value)));
                 if (VecType::CmpAllLt(lengthSquared, floatEpsilon))
                 {
                     return VecType::ZeroFloat();
@@ -436,13 +436,13 @@ namespace AZ
             AZ_MATH_INLINE typename Vec4Type::FloatType QuaternionTransform(typename Vec4Type::FloatArgType quat, typename Vec3Type::FloatArgType vec3)
             {
                 const typename Vec4Type::FloatType Two = Vec4Type::Splat(2.0f);
-                const typename Vec4Type::FloatType scalar = Vec4Type::SplatFourth(quat); // Scalar portion of quat (W, W, W)
+                const typename Vec4Type::FloatType scalar = Vec4Type::SplatIndex3(quat); // Scalar portion of quat (W, W, W)
 
-                const typename Vec4Type::FloatType partial1 = Vec4Type::SplatFirst(Vec4Type::FromVec1(Vec3Type::Dot(quat, vec3)));
+                const typename Vec4Type::FloatType partial1 = Vec4Type::SplatIndex0(Vec4Type::FromVec1(Vec3Type::Dot(quat, vec3)));
                 const typename Vec4Type::FloatType partial2 = Vec4Type::Mul(quat, partial1);
                 const typename Vec4Type::FloatType sum1 = Vec4Type::Mul(partial2, Two); // quat.Dot(vec3) * vec3 * 2.0f
 
-                const typename Vec4Type::FloatType partial3 = Vec4Type::SplatFirst(Vec4Type::FromVec1(Vec3Type::Dot(quat, quat)));
+                const typename Vec4Type::FloatType partial3 = Vec4Type::SplatIndex0(Vec4Type::FromVec1(Vec3Type::Dot(quat, quat)));
                 const typename Vec4Type::FloatType partial4 = Vec4Type::Mul(scalar, scalar);
                 const typename Vec4Type::FloatType partial5 = Vec4Type::Sub(partial4, partial3);
                 const typename Vec4Type::FloatType sum2 = Vec4Type::Mul(partial5, vec3); // vec3 * (scalar * scalar - quat.Dot(quat))
@@ -459,14 +459,14 @@ namespace AZ
             AZ_MATH_INLINE typename Vec4Type::FloatType ConstructPlane(typename Vec3Type::FloatArgType normal, typename Vec3Type::FloatArgType point)
             {
                 const Vec1::FloatType distance = Vec1::Sub(Vec1::ZeroFloat(), Vec3Type::Dot(normal, point));
-                return Vec4Type::ReplaceFourth(normal, Vec4Type::SplatFirst(Vec4Type::FromVec1(distance))); // replace 'w' coordinate with distance
+                return Vec4Type::ReplaceIndex3(normal, Vec4Type::SplatIndex0(Vec4Type::FromVec1(distance))); // replace 'w' coordinate with distance
             }
 
 
             template <typename Vec4Type, typename Vec3Type>
             AZ_MATH_INLINE Vec1::FloatType PlaneDistance(typename Vec4Type::FloatArgType plane, typename Vec3Type::FloatArgType point)
             {
-                const typename Vec4Type::FloatType referencePoint = Vec4Type::ReplaceFourth(point, 1.0f); // replace 'w' coordinate with 1.0
+                const typename Vec4Type::FloatType referencePoint = Vec4Type::ReplaceIndex3(point, 1.0f); // replace 'w' coordinate with 1.0
                 return Vec4Type::Dot(referencePoint, plane);
             }
 
@@ -474,18 +474,18 @@ namespace AZ
             template <typename VecType>
             AZ_MATH_INLINE void Mat3x3Multiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatThird(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[0]), rowsB[0])));
-                out[1] = VecType::Madd(VecType::SplatThird(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[1]), rowsB[0])));
-                out[2] = VecType::Madd(VecType::SplatThird(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[2]), rowsB[0])));
+                out[0] = VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[0]), rowsB[0])));
+                out[1] = VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[1]), rowsB[0])));
+                out[2] = VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[2]), rowsB[0])));
             }
 
 
             template <typename VecType>
             AZ_MATH_INLINE void Mat3x3TransposeMultiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatFirst (rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatFirst (rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatFirst (rowsA[2]), rowsB[2])));
-                out[1] = VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatSecond(rowsA[2]), rowsB[2])));
-                out[2] = VecType::Madd(VecType::SplatThird (rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatThird (rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatThird (rowsA[2]), rowsB[2])));
+                out[0] = VecType::Madd(VecType::SplatIndex0(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex0(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[2]), rowsB[2])));
+                out[1] = VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex1(rowsA[2]), rowsB[2])));
+                out[2] = VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex2(rowsA[2]), rowsB[2])));
             }
 
 
@@ -501,7 +501,7 @@ namespace AZ
             template <typename VecType>
             AZ_MATH_INLINE typename VecType::FloatType Mat3x3TransposeTransformVector(const typename VecType::FloatType* __restrict rows, typename VecType::FloatArgType vector)
             {
-                return VecType::Madd(VecType::SplatThird(vector), rows[2], VecType::Madd(VecType::SplatSecond(vector), rows[1], VecType::Mul(VecType::SplatFirst(vector), rows[0])));
+                return VecType::Madd(VecType::SplatIndex2(vector), rows[2], VecType::Madd(VecType::SplatIndex1(vector), rows[1], VecType::Mul(VecType::SplatIndex0(vector), rows[0])));
             }
 
 
@@ -509,18 +509,18 @@ namespace AZ
             AZ_MATH_INLINE void Mat3x4Multiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
                 const typename VecType::FloatType fourth = FastLoadConstant<VecType>(g_vec0001);
-                out[0] = VecType::Madd(VecType::SplatFourth(rowsA[0]), fourth, VecType::Madd(VecType::SplatThird(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[0]), rowsB[0]))));
-                out[1] = VecType::Madd(VecType::SplatFourth(rowsA[1]), fourth, VecType::Madd(VecType::SplatThird(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[1]), rowsB[0]))));
-                out[2] = VecType::Madd(VecType::SplatFourth(rowsA[2]), fourth, VecType::Madd(VecType::SplatThird(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[2]), rowsB[0]))));
+                out[0] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), fourth, VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[0]), rowsB[0]))));
+                out[1] = VecType::Madd(VecType::SplatIndex3(rowsA[1]), fourth, VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[1]), rowsB[0]))));
+                out[2] = VecType::Madd(VecType::SplatIndex3(rowsA[2]), fourth, VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[2]), rowsB[0]))));
             }
 
 
             template <typename VecType>
             AZ_MATH_INLINE void Mat4x4InverseFast(const typename VecType::FloatType* __restrict rows, typename VecType::FloatType* __restrict out)
             {
-                const typename VecType::FloatType pos = VecType::Madd(VecType::SplatFourth(rows[2]), rows[2]
-                                                      , VecType::Madd(VecType::SplatFourth(rows[1]), rows[1]
-                                                      , VecType::Mul (VecType::SplatFourth(rows[0]), rows[0])));
+                const typename VecType::FloatType pos = VecType::Madd(VecType::SplatIndex3(rows[2]), rows[2]
+                                                      , VecType::Madd(VecType::SplatIndex3(rows[1]), rows[1]
+                                                      , VecType::Mul (VecType::SplatIndex3(rows[0]), rows[0])));
                 typename VecType::FloatType transposed[4] = { rows[0], rows[1], rows[2], VecType::Xor(pos, FastLoadConstant<VecType>(reinterpret_cast<const float*>(g_negateMask))) };
                 VecType::Mat4x4Transpose(transposed, out);
                 out[3] = FastLoadConstant<VecType>(g_vec0001);
@@ -530,37 +530,37 @@ namespace AZ
             template <typename VecType>
             AZ_MATH_INLINE void Mat4x4Multiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatFourth(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[0]), rowsB[0]))));
-                out[1] = VecType::Madd(VecType::SplatFourth(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[1]), rowsB[0]))));
-                out[2] = VecType::Madd(VecType::SplatFourth(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[2]), rowsB[0]))));
-                out[3] = VecType::Madd(VecType::SplatFourth(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[3]), rowsB[1], VecType::Mul(VecType::SplatFirst(rowsA[3]), rowsB[0]))));
+                out[0] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[0]), rowsB[0]))));
+                out[1] = VecType::Madd(VecType::SplatIndex3(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[1]), rowsB[0]))));
+                out[2] = VecType::Madd(VecType::SplatIndex3(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[2]), rowsB[0]))));
+                out[3] = VecType::Madd(VecType::SplatIndex3(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[3]), rowsB[1], VecType::Mul(VecType::SplatIndex0(rowsA[3]), rowsB[0]))));
             }
 
 
             template <typename VecType>
             AZ_MATH_INLINE void Mat4x4MultiplyAdd(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatFourth(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[0]), rowsB[0], out[0]))));
-                out[1] = VecType::Madd(VecType::SplatFourth(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[1]), rowsB[0], out[1]))));
-                out[2] = VecType::Madd(VecType::SplatFourth(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[2]), rowsB[0], out[2]))));
-                out[3] = VecType::Madd(VecType::SplatFourth(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatThird(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatSecond(rowsA[3]), rowsB[1], VecType::Madd(VecType::SplatFirst(rowsA[3]), rowsB[0], out[3]))));
+                out[0] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[0]), rowsB[0], out[0]))));
+                out[1] = VecType::Madd(VecType::SplatIndex3(rowsA[1]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[1]), rowsB[0], out[1]))));
+                out[2] = VecType::Madd(VecType::SplatIndex3(rowsA[2]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[2]), rowsB[0], out[2]))));
+                out[3] = VecType::Madd(VecType::SplatIndex3(rowsA[3]), rowsB[3], VecType::Madd(VecType::SplatIndex2(rowsA[3]), rowsB[2], VecType::Madd(VecType::SplatIndex1(rowsA[3]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[3]), rowsB[0], out[3]))));
             }
 
 
             template <typename VecType>
             AZ_MATH_INLINE void Mat4x4TransposeMultiply(const typename VecType::FloatType* __restrict rowsA, const typename VecType::FloatType* __restrict rowsB, typename VecType::FloatType* __restrict out)
             {
-                out[0] = VecType::Madd(VecType::SplatFirst (rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatFirst (rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatFirst (rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatFirst (rowsA[3]), rowsB[3]))));
-                out[1] = VecType::Madd(VecType::SplatSecond(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatSecond(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatSecond(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatSecond(rowsA[3]), rowsB[3]))));
-                out[2] = VecType::Madd(VecType::SplatThird (rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatThird (rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatThird (rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatThird (rowsA[3]), rowsB[3]))));
-                out[3] = VecType::Madd(VecType::SplatFourth(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatFourth(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatFourth(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatFourth(rowsA[3]), rowsB[3]))));
+                out[0] = VecType::Madd(VecType::SplatIndex0(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex0(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex0(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatIndex0(rowsA[3]), rowsB[3]))));
+                out[1] = VecType::Madd(VecType::SplatIndex1(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex1(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex1(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatIndex1(rowsA[3]), rowsB[3]))));
+                out[2] = VecType::Madd(VecType::SplatIndex2(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex2(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex2(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatIndex2(rowsA[3]), rowsB[3]))));
+                out[3] = VecType::Madd(VecType::SplatIndex3(rowsA[0]), rowsB[0], VecType::Madd(VecType::SplatIndex3(rowsA[1]), rowsB[1], VecType::Madd(VecType::SplatIndex3(rowsA[2]), rowsB[2], VecType::Mul(VecType::SplatIndex3(rowsA[3]), rowsB[3]))));
             }
 
 
             template <typename VecType>
             AZ_MATH_INLINE typename VecType::FloatType Mat4x4TransposeTransformVector(const typename VecType::FloatType* __restrict rows, typename VecType::FloatArgType vector)
             {
-                return VecType::Madd(VecType::SplatFourth(vector), rows[3], VecType::Madd(VecType::SplatThird(vector), rows[2], VecType::Madd(VecType::SplatSecond(vector), rows[1], VecType::Mul(VecType::SplatFirst(vector), rows[0]))));
+                return VecType::Madd(VecType::SplatIndex3(vector), rows[3], VecType::Madd(VecType::SplatIndex2(vector), rows[2], VecType::Madd(VecType::SplatIndex1(vector), rows[1], VecType::Mul(VecType::SplatIndex0(vector), rows[0]))));
             }
         }
     }

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_sse.inl
@@ -122,7 +122,7 @@ namespace AZ
             }
 
 
-            AZ_MATH_INLINE float SelectFirst(__m128 value)
+            AZ_MATH_INLINE float SelectIndex0(__m128 value)
             {
                 return _mm_cvtss_f32(value);
             }
@@ -140,75 +140,75 @@ namespace AZ
             }
 
 
-            AZ_MATH_INLINE __m128 SplatFirst(__m128 value)
+            AZ_MATH_INLINE __m128 SplatIndex0(__m128 value)
             {
                 return _mm_shuffle_ps(value, value, _MM_SHUFFLE(0, 0, 0, 0));
             }
 
 
-            AZ_MATH_INLINE __m128 SplatSecond(__m128 value)
+            AZ_MATH_INLINE __m128 SplatIndex1(__m128 value)
             {
                 return _mm_shuffle_ps(value, value, _MM_SHUFFLE(1, 1, 1, 1));
             }
 
 
-            AZ_MATH_INLINE __m128 SplatThird(__m128 value)
+            AZ_MATH_INLINE __m128 SplatIndex2(__m128 value)
             {
                 return _mm_shuffle_ps(value, value, _MM_SHUFFLE(2, 2, 2, 2));
             }
 
 
-            AZ_MATH_INLINE __m128 SplatFourth(__m128 value)
+            AZ_MATH_INLINE __m128 SplatIndex3(__m128 value)
             {
                 return _mm_shuffle_ps(value, value, _MM_SHUFFLE(3, 3, 3, 3));
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceFirst(__m128 a, __m128 b)
+            AZ_MATH_INLINE __m128 ReplaceIndex0(__m128 a, __m128 b)
             {
                 return _mm_blend_ps(a, b, 0b0001);
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceFirst(__m128 a, float b)
+            AZ_MATH_INLINE __m128 ReplaceIndex0(__m128 a, float b)
             {
-                return ReplaceFirst(a, Splat(b));
+                return ReplaceIndex0(a, Splat(b));
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceSecond(__m128 a, __m128 b)
+            AZ_MATH_INLINE __m128 ReplaceIndex1(__m128 a, __m128 b)
             {
                 return _mm_blend_ps(a, b, 0b0010);
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceSecond(__m128 a, float b)
+            AZ_MATH_INLINE __m128 ReplaceIndex1(__m128 a, float b)
             {
-                return ReplaceSecond(a, Splat(b));
+                return ReplaceIndex1(a, Splat(b));
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceThird(__m128 a, __m128 b)
+            AZ_MATH_INLINE __m128 ReplaceIndex2(__m128 a, __m128 b)
             {
                 return _mm_blend_ps(a, b, 0b0100);
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceThird(__m128 a, float b)
+            AZ_MATH_INLINE __m128 ReplaceIndex2(__m128 a, float b)
             {
-                return ReplaceThird(a, Splat(b));
+                return ReplaceIndex2(a, Splat(b));
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceFourth(__m128 a, __m128 b)
+            AZ_MATH_INLINE __m128 ReplaceIndex3(__m128 a, __m128 b)
             {
                 return _mm_blend_ps(a, b, 0b1000);
             }
 
 
-            AZ_MATH_INLINE __m128 ReplaceFourth(__m128 a, float b)
+            AZ_MATH_INLINE __m128 ReplaceIndex3(__m128 a, float b)
             {
-                return ReplaceFourth(a, Splat(b));
+                return ReplaceIndex3(a, Splat(b));
             }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_neon.inl
@@ -66,9 +66,9 @@ namespace AZ
             NeonDouble::StreamAligned(addr, value);
         }
 
-        AZ_MATH_INLINE float Vec1::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec1::SelectIndex0(FloatArgType value)
         {
-            return NeonDouble::SelectFirst(value);
+            return NeonDouble::SelectIndex0(value);
         }
 
         AZ_MATH_INLINE Vec1::FloatType Vec1::Splat(float value)
@@ -114,7 +114,7 @@ namespace AZ
         AZ_MATH_INLINE Vec1::FloatType Vec1::Div(FloatArgType arg1, FloatArgType arg2)
         {
             // In Vec1 the second element can be zero, avoid doing division by zero
-            arg2 = NeonDouble::ReplaceSecond(arg2, 1.0f);
+            arg2 = NeonDouble::ReplaceIndex1(arg2, 1.0f);
             return NeonDouble::Div(arg1, arg2);
         }
 
@@ -353,7 +353,7 @@ namespace AZ
             // In Vec1 the second element can be garbage or 0.
             // Using (value.x, 1) to avoid divisions by 0.
             return NeonDouble::Reciprocal(
-                NeonDouble::ReplaceSecond(value, 1.0f));
+                NeonDouble::ReplaceIndex1(value, 1.0f));
         }
 
         AZ_MATH_INLINE Vec1::FloatType Vec1::ReciprocalEstimate(FloatArgType value)
@@ -361,7 +361,7 @@ namespace AZ
             // In Vec1 the second element can be garbage or 0.
             // Using (value.x, 1) to avoid divisions by 0.
             return NeonDouble::ReciprocalEstimate(
-                NeonDouble::ReplaceSecond(value, 1.0f));
+                NeonDouble::ReplaceIndex1(value, 1.0f));
         }
 
         AZ_MATH_INLINE Vec1::FloatType Vec1::Mod(FloatArgType value, FloatArgType divisor)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_scalar.inl
@@ -74,7 +74,7 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec1::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec1::SelectIndex0(FloatArgType value)
         {
             return value;
         }

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_sse.inl
@@ -77,9 +77,9 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec1::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec1::SelectIndex0(FloatArgType value)
         {
-            return Sse::SelectFirst(value);
+            return Sse::SelectIndex0(value);
         }
 
 
@@ -135,7 +135,7 @@ namespace AZ
         {
             // In Vec1 the last 3 elements can be zero, avoid doing division by zero
             const FloatType ones = Sse::Splat(1.0f);
-            arg2 = Sse::ReplaceFirst(ones, arg2);
+            arg2 = Sse::ReplaceIndex0(ones, arg2);
             return Sse::Div(arg1, arg2);
         }
 
@@ -423,7 +423,7 @@ namespace AZ
             // Using (value.x, 1, 1, 1) to avoid divisions by 0.
             const FloatType ones = Sse::Splat(1.0f);
             return Sse::Reciprocal(
-                Sse::ReplaceFirst(ones, value));
+                Sse::ReplaceIndex0(ones, value));
         }
 
 
@@ -433,7 +433,7 @@ namespace AZ
             // Using (value.x, 1, 1, 1) to avoid divisions by 0.
             const FloatType ones = Sse::Splat(1.0f);
             return Sse::ReciprocalEstimate(
-                Sse::ReplaceFirst(ones, value));
+                Sse::ReplaceIndex0(ones, value));
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_neon.inl
@@ -24,7 +24,7 @@ namespace AZ
         AZ_MATH_INLINE Vec2::FloatType Vec2::FromVec1(Vec1::FloatArgType value)
         {
             // Coming from a Vec1 the last element could be garbage.
-            return NeonDouble::SplatFirst(value); // {value.x, value.x}
+            return NeonDouble::SplatIndex0(value); // {value.x, value.x}
         }
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::LoadAligned(const float* __restrict addr)
@@ -77,14 +77,14 @@ namespace AZ
             NeonDouble::StreamAligned(addr, value);
         }
 
-        AZ_MATH_INLINE float Vec2::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex0(FloatArgType value)
         {
-            return NeonDouble::SelectFirst(value);
+            return NeonDouble::SelectIndex0(value);
         }
 
-        AZ_MATH_INLINE float Vec2::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex1(FloatArgType value)
         {
-            return NeonDouble::SelectSecond(value);
+            return NeonDouble::SelectIndex1(value);
         }
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::Splat(float value)
@@ -97,34 +97,34 @@ namespace AZ
             return NeonDouble::Splat(value);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex0(FloatArgType value)
         {
-            return NeonDouble::SplatFirst(value);
+            return NeonDouble::SplatIndex0(value);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex1(FloatArgType value)
         {
-            return NeonDouble::SplatSecond(value);
+            return NeonDouble::SplatIndex1(value);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, float b)
         {
-            return NeonDouble::ReplaceFirst(a, b);
+            return NeonDouble::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return NeonDouble::ReplaceFirst(a, b);
+            return NeonDouble::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, float b)
         {
-            return NeonDouble::ReplaceSecond(a, b);
+            return NeonDouble::ReplaceIndex1(a, b);
         }
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return NeonDouble::ReplaceSecond(a, b);
+            return NeonDouble::ReplaceIndex1(a, b);
         }
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::LoadImmediate(float x, float y)
@@ -476,7 +476,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec1::FloatType Vec2::Atan2(FloatArgType value)
         {
-            return Common::Atan2<Vec1>(Vec1::Splat(SelectSecond(value)), Vec1::Splat(SelectFirst(value)));
+            return Common::Atan2<Vec1>(Vec1::Splat(SelectIndex1(value)), Vec1::Splat(SelectIndex0(value)));
         }
 
         AZ_MATH_INLINE Vec1::FloatType Vec2::Dot(FloatArgType arg1, FloatArgType arg2)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_scalar.inl
@@ -90,13 +90,13 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec2::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex0(FloatArgType value)
         {
             return value.v[0];
         }
 
 
-        AZ_MATH_INLINE float Vec2::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex1(FloatArgType value)
         {
             return value.v[1];
         }
@@ -114,37 +114,37 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex0(FloatArgType value)
         {
             return Splat(value.v[0]);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex1(FloatArgType value)
         {
             return Splat(value.v[1]);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, float b)
         {
             return {{ b, a.v[1] }};
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
             return {{ b.v[0], a.v[1] }};
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, float b)
         {
             return {{ a.v[0], b }};
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], b.v[1] }};
         }

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
@@ -24,7 +24,7 @@ namespace AZ
         AZ_MATH_INLINE Vec2::FloatType Vec2::FromVec1(Vec1::FloatArgType value)
         {
             // Coming from a Vec1 the last 3 elements could be garbage.
-            return Sse::SplatFirst(value);  // {value.x, value.x, value.x, value.x}
+            return Sse::SplatIndex0(value);  // {value.x, value.x, value.x, value.x}
         }
 
 
@@ -88,15 +88,15 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec2::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex0(FloatArgType value)
         {
-            return Sse::SelectFirst(value);
+            return Sse::SelectIndex0(value);
         }
 
 
-        AZ_MATH_INLINE float Vec2::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec2::SelectIndex1(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatSecond(value));
+            return Sse::SelectIndex0(Sse::SplatIndex1(value));
         }
 
 
@@ -112,39 +112,39 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex0(FloatArgType value)
         {
-            return Sse::SplatFirst(value);
+            return Sse::SplatIndex0(value);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::SplatIndex1(FloatArgType value)
         {
-            return Sse::SplatSecond(value);
+            return Sse::SplatIndex1(value);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, float b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, float b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec2::FloatType Vec2::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
@@ -187,7 +187,7 @@ namespace AZ
         AZ_MATH_INLINE Vec2::FloatType Vec2::Div(FloatArgType arg1, FloatArgType arg2)
         {
             // In Vec2 the last 2 elements can be zero, avoid doing division by zero
-            arg2 = Sse::ReplaceFourth(Sse::ReplaceThird(arg2, 1.0f), 1.0f);
+            arg2 = Sse::ReplaceIndex3(Sse::ReplaceIndex2(arg2, 1.0f), 1.0f);
             return Sse::Div(arg1, arg2);
         }
 
@@ -473,7 +473,7 @@ namespace AZ
         {
             // In Vec2 all the elements except the first two can be garbage or 0
             // Using (value.x, value.y, 1, 1) to avoid divisions by 0.
-            value = Sse::ReplaceFourth(Sse::ReplaceThird(value, 1.0f), 1.0f);
+            value = Sse::ReplaceIndex3(Sse::ReplaceIndex2(value, 1.0f), 1.0f);
             return Sse::Reciprocal(value);
         }
 
@@ -482,7 +482,7 @@ namespace AZ
         {
             // In Vec2 all the elements except the first two can be garbage or 0
             // Using (value.x, value.y, 1, 1) to avoid divisions by 0.
-            value = Sse::ReplaceFourth(Sse::ReplaceThird(value, 1.0f), 1.0f);
+            value = Sse::ReplaceIndex3(Sse::ReplaceIndex2(value, 1.0f), 1.0f);
             return Sse::Reciprocal(value);
         }
 
@@ -519,7 +519,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::SqrtInv(FloatArgType value)
         {
-            value = Sse::ReplaceFourth(Sse::ReplaceThird(value, 1.0f), 1.0f);
+            value = Sse::ReplaceIndex3(Sse::ReplaceIndex2(value, 1.0f), 1.0f);
             return Sse::SqrtInv(value);
         }
 
@@ -576,7 +576,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec1::FloatType Vec2::Atan2(FloatArgType value)
         {
-            return Common::Atan2<Vec1>(Vec1::Splat(SelectSecond(value)), Vec1::Splat(SelectFirst(value)));
+            return Common::Atan2<Vec1>(Vec1::Splat(SelectIndex1(value)), Vec1::Splat(SelectIndex0(value)));
         }
 
 
@@ -586,7 +586,7 @@ namespace AZ
             return _mm_dp_ps(arg1, arg2, 0x33);
 #else
             const FloatType x2 = Mul(arg1, arg2);
-            return SplatFirst(Add(SplatSecond(x2), x2));
+            return SplatIndex0(Add(SplatIndex1(x2), x2));
 #endif
         }
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
@@ -86,19 +86,19 @@ namespace AZ
             NeonQuad::StreamAligned(addr, value);
         }
 
-        AZ_MATH_INLINE float Vec3::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex0(FloatArgType value)
         {
-            return NeonQuad::SelectFirst(value);
+            return NeonQuad::SelectIndex0(value);
         }
 
-        AZ_MATH_INLINE float Vec3::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex1(FloatArgType value)
         {
-            return NeonQuad::SelectSecond(value);
+            return NeonQuad::SelectIndex1(value);
         }
 
-        AZ_MATH_INLINE float Vec3::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex2(FloatArgType value)
         {
-            return NeonQuad::SelectThird(value);
+            return NeonQuad::SelectIndex2(value);
         }
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::Splat(float value)
@@ -111,49 +111,49 @@ namespace AZ
             return NeonQuad::Splat(value);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex0(FloatArgType value)
         {
-            return NeonQuad::SplatFirst(value);
+            return NeonQuad::SplatIndex0(value);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex1(FloatArgType value)
         {
-            return NeonQuad::SplatSecond(value);
+            return NeonQuad::SplatIndex1(value);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex2(FloatArgType value)
         {
-            return NeonQuad::SplatThird(value);
+            return NeonQuad::SplatIndex2(value);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceFirst(a, b);
+            return NeonQuad::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceFirst(a, b);
+            return NeonQuad::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceSecond(a, b);
+            return NeonQuad::ReplaceIndex1(a, b);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceSecond(a, b);
+            return NeonQuad::ReplaceIndex1(a, b);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceThird(a, b);
+            return NeonQuad::ReplaceIndex2(a, b);
         }
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceThird(a, b);
+            return NeonQuad::ReplaceIndex2(a, b);
         }
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::LoadImmediate(float x, float y, float z)
@@ -189,7 +189,7 @@ namespace AZ
         AZ_MATH_INLINE Vec3::FloatType Vec3::Div(FloatArgType arg1, FloatArgType arg2)
         {
             // In Vec3 the last element can be zero, avoid doing division by zero
-            arg2 = NeonQuad::ReplaceFourth(arg2, 1.0f);
+            arg2 = NeonQuad::ReplaceIndex3(arg2, 1.0f);
             return NeonQuad::Div(arg1, arg2);
         }
 
@@ -428,7 +428,7 @@ namespace AZ
             // In Vec3 the last element can be garbage or 0
             // Using (value.x, value.y, value.z, 1) to avoid divisions by 0.
             return NeonQuad::Reciprocal(
-                NeonQuad::ReplaceFourth(value, 1.0f));
+                NeonQuad::ReplaceIndex3(value, 1.0f));
         }
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::ReciprocalEstimate(FloatArgType value)
@@ -436,7 +436,7 @@ namespace AZ
             // In Vec3 the last element can be garbage or 0
             // Using (value.x, value.y, value.z, 1) to avoid divisions by 0.
             return NeonQuad::ReciprocalEstimate(
-                NeonQuad::ReplaceFourth(value, 1.0f));
+                NeonQuad::ReplaceIndex3(value, 1.0f));
         }
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::Mod(FloatArgType value, FloatArgType divisor)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_scalar.inl
@@ -104,19 +104,19 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex0(FloatArgType value)
         {
             return value.v[0];
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex1(FloatArgType value)
         {
             return value.v[1];
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex2(FloatArgType value)
         {
             return value.v[2];
         }
@@ -134,55 +134,55 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex0(FloatArgType value)
         {
             return Splat(value.v[0]);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex1(FloatArgType value)
         {
             return Splat(value.v[1]);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex2(FloatArgType value)
         {
             return Splat(value.v[2]);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, float b)
         {
             return {{ b, a.v[1], a.v[2] }};
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
             return {{ b.v[0], a.v[1], a.v[2] }};
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, float b)
         {
             return {{ a.v[0], b, a.v[2] }};
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], b.v[1], a.v[2] }};
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, float b)
         {
             return {{ a.v[0], a.v[1], b }};
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], a.v[1], b.v[2] }};
         }

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
@@ -30,14 +30,14 @@ namespace AZ
         AZ_MATH_INLINE Vec3::FloatType Vec3::FromVec1(Vec1::FloatArgType value)
         {
             // Coming from a Vec1 the last 3 elements could be garbage.
-            return Sse::SplatFirst(value); // {value.x, value.x, value.x, value.x}
+            return Sse::SplatIndex0(value); // {value.x, value.x, value.x, value.x}
         }
 
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::FromVec2(Vec2::FloatArgType value)
         {
             // Coming from a Vec2 the last 2 elements could be garbage.
-            return Sse::ReplaceThird(value, 0.0f); // {value.x, value.y, 0.0f, unused}
+            return Sse::ReplaceIndex2(value, 0.0f); // {value.x, value.y, 0.0f, unused}
         }
 
 
@@ -101,21 +101,21 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex0(FloatArgType value)
         {
-            return Sse::SelectFirst(value);
+            return Sse::SelectIndex0(value);
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex1(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatSecond(value));
+            return Sse::SelectIndex0(Sse::SplatIndex1(value));
         }
 
 
-        AZ_MATH_INLINE float Vec3::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec3::SelectIndex2(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatThird(value));
+            return Sse::SelectIndex0(Sse::SplatIndex2(value));
         }
 
 
@@ -131,57 +131,57 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex0(FloatArgType value)
         {
-            return Sse::SplatFirst(value);
+            return Sse::SplatIndex0(value);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex1(FloatArgType value)
         {
-            return Sse::SplatSecond(value);
+            return Sse::SplatIndex1(value);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::SplatIndex2(FloatArgType value)
         {
-            return Sse::SplatThird(value);
+            return Sse::SplatIndex2(value);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, float b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, float b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, float b)
         {
-            return Sse::ReplaceThird(a, b);
+            return Sse::ReplaceIndex2(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec3::FloatType Vec3::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceThird(a, b);
+            return Sse::ReplaceIndex2(a, b);
         }
 
 
@@ -224,7 +224,7 @@ namespace AZ
         AZ_MATH_INLINE Vec3::FloatType Vec3::Div(FloatArgType arg1, FloatArgType arg2)
         {
             // In Vec3 the last element can be zero, avoid doing division by zero
-            arg2 = Sse::ReplaceFourth(arg2, 1.0f);
+            arg2 = Sse::ReplaceIndex3(arg2, 1.0f);
             return Sse::Div(arg1, arg2);
         }
 
@@ -511,7 +511,7 @@ namespace AZ
             // In Vec3 the last element (w) can be garbage or 0
             // Using (value.x, value.y, value.z, 1) to avoid divisions by 0.
             return Sse::Reciprocal(
-                Sse::ReplaceFourth(value, 1.0f));
+                Sse::ReplaceIndex3(value, 1.0f));
         }
 
 
@@ -520,7 +520,7 @@ namespace AZ
             // In Vec3 the last element (w) can be garbage or 0
             // Using (value.x, value.y, value.z, 1) to avoid divisions by 0.
             return Sse::ReciprocalEstimate(
-                Sse::ReplaceFourth(value, 1.0f)
+                Sse::ReplaceIndex3(value, 1.0f)
             );
         }
 
@@ -557,7 +557,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::SqrtInv(FloatArgType value)
         {
-            value = Sse::ReplaceFourth(value, 1.0f);
+            value = Sse::ReplaceIndex3(value, 1.0f);
             return Sse::SqrtInv(value);
         }
 
@@ -610,9 +610,9 @@ namespace AZ
             return _mm_dp_ps(arg1, arg2, 0x77);
 #else
             const FloatType x2  = Mul(arg1, arg2);
-            const FloatType xy  = Add(SplatSecond(x2), x2);
-            const FloatType xyz = Add(SplatThird (x2), xy);
-            return SplatFirst(xyz);
+            const FloatType xy  = Add(SplatIndex1(x2), x2);
+            const FloatType xyz = Add(SplatIndex2(x2), xy);
+            return SplatIndex0(xyz);
 #endif
         }
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
@@ -701,9 +701,9 @@ namespace AZ
             Common::Mat4x4Multiply<Vec4>(rowsA, rowsB, out);
         }
 
-        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, const FloatType* __restrict add, FloatType* __restrict out)
         {
-            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, out);
+            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, add, out);
         }
 
         AZ_MATH_INLINE void Vec4::Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
@@ -44,7 +44,7 @@ namespace AZ
         AZ_MATH_INLINE Vec4::FloatType Vec4::FromVec3(Vec3::FloatArgType value)
         {
             // Coming from a Vec3 the last element could be garbage.
-            return NeonQuad::ReplaceFourth(value, 0.0f); // {value.x, value.y, value.z, 0.0f}
+            return NeonQuad::ReplaceIndex3(value, 0.0f); // {value.x, value.y, value.z, 0.0f}
         }
 
         AZ_MATH_INLINE Vec4::FloatType Vec4::LoadAligned(const float* __restrict addr)
@@ -97,24 +97,24 @@ namespace AZ
             NeonQuad::StreamAligned(addr, value);
         }
 
-        AZ_MATH_INLINE float Vec4::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex0(FloatArgType value)
         {
-            return NeonQuad::SelectFirst(value);
+            return NeonQuad::SelectIndex0(value);
         }
 
-        AZ_MATH_INLINE float Vec4::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex1(FloatArgType value)
         {
-            return NeonQuad::SelectSecond(value);
+            return NeonQuad::SelectIndex1(value);
         }
 
-        AZ_MATH_INLINE float Vec4::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex2(FloatArgType value)
         {
-            return NeonQuad::SelectThird(value);
+            return NeonQuad::SelectIndex2(value);
         }
 
-        AZ_MATH_INLINE float Vec4::SelectFourth(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex3(FloatArgType value)
         {
-            return NeonQuad::SelectFourth(value);
+            return NeonQuad::SelectIndex3(value);
         }
 
         AZ_MATH_INLINE Vec4::FloatType Vec4::Splat(float value)
@@ -127,64 +127,64 @@ namespace AZ
             return NeonQuad::Splat(value);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex0(FloatArgType value)
         {
-            return NeonQuad::SplatFirst(value);
+            return NeonQuad::SplatIndex0(value);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex1(FloatArgType value)
         {
-            return NeonQuad::SplatSecond(value);
+            return NeonQuad::SplatIndex1(value);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex2(FloatArgType value)
         {
-            return NeonQuad::SplatThird(value);
+            return NeonQuad::SplatIndex2(value);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFourth(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex3(FloatArgType value)
         {
-            return NeonQuad::SplatFourth(value);
+            return NeonQuad::SplatIndex3(value);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceFirst(a, b);
+            return NeonQuad::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceFirst(a, b);
+            return NeonQuad::ReplaceIndex0(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceSecond(a, b);
+            return NeonQuad::ReplaceIndex1(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceSecond(a, b);
+            return NeonQuad::ReplaceIndex1(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceThird(a, b);
+            return NeonQuad::ReplaceIndex2(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceThird(a, b);
+            return NeonQuad::ReplaceIndex2(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, float b)
         {
-            return NeonQuad::ReplaceFourth(a, b);
+            return NeonQuad::ReplaceIndex3(a, b);
         }
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, FloatArgType b)
         {
-            return NeonQuad::ReplaceFourth(a, b);
+            return NeonQuad::ReplaceIndex3(a, b);
         }
 
         AZ_MATH_INLINE Vec4::FloatType Vec4::LoadImmediate(float x, float y, float z, float w)
@@ -644,7 +644,7 @@ namespace AZ
 
         AZ_MATH_INLINE void Vec4::Mat3x4InverseFast(const FloatType* __restrict rows, FloatType* __restrict out)
         {
-            const FloatType pos = Sub(ZeroFloat(), Madd(rows[0], SplatFourth(rows[0]), Madd(rows[1], SplatFourth(rows[1]), Mul(rows[2], SplatFourth(rows[2])))));
+            const FloatType pos = Sub(ZeroFloat(), Madd(rows[0], SplatIndex3(rows[0]), Madd(rows[1], SplatIndex3(rows[1]), Mul(rows[2], SplatIndex3(rows[2])))));
             const FloatType tmp0 = vtrn1q_f32(rows[0], rows[1]);
             const FloatType tmp1 = vtrn2q_f32(rows[0], rows[1]);
             const FloatType tmp2 = vtrn1q_f32(rows[2], pos);

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_neon.inl
@@ -701,6 +701,11 @@ namespace AZ
             Common::Mat4x4Multiply<Vec4>(rowsA, rowsB, out);
         }
 
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
+        {
+            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, out);
+        }
+
         AZ_MATH_INLINE void Vec4::Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
         {
             Common::Mat4x4TransposeMultiply<Vec4>(rowsA, rowsB, out);

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
@@ -945,12 +945,13 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* rowsA, const FloatType* rowsB, FloatType* out)
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* rowsA, const FloatType* rowsB, const FloatType* add, FloatType* out)
         {
             for (int32_t row = 0; row < 4; ++row)
             {
                 for (int32_t col = 0; col < 4; col++)
                 {
+                    out[row].v[col] = add[row].v[col];
                     for (int32_t k = 0; k < 4; ++k)
                     {
                         out[row].v[col] += rowsA[row].v[k] * rowsB[k].v[col];

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
@@ -122,25 +122,25 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex0(FloatArgType value)
         {
             return value.v[0];
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex1(FloatArgType value)
         {
             return value.v[1];
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex2(FloatArgType value)
         {
             return value.v[2];
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectFourth(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex3(FloatArgType value)
         {
             return value.v[3];
         }
@@ -158,73 +158,73 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex0(FloatArgType value)
         {
             return Splat(value.v[0]);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex1(FloatArgType value)
         {
             return Splat(value.v[1]);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex2(FloatArgType value)
         {
             return Splat(value.v[2]);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFourth(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex3(FloatArgType value)
         {
             return Splat(value.v[3]);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, float b)
         {
             return {{ b, a.v[1], a.v[2], a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
             return {{ b.v[0], a.v[1], a.v[2], a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, float b)
         {
             return {{ a.v[0], b, a.v[2], a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], b.v[1], a.v[2], a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, float b)
         {
             return {{ a.v[0], a.v[1], b, a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], a.v[1], b.v[2], a.v[3] }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, float b)
         {
             return {{ a.v[0], a.v[1], a.v[2], b }};
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, FloatArgType b)
         {
             return {{ a.v[0], a.v[1], a.v[2], b.v[3] }};
         }

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_scalar.inl
@@ -945,6 +945,21 @@ namespace AZ
         }
 
 
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* rowsA, const FloatType* rowsB, FloatType* out)
+        {
+            for (int32_t row = 0; row < 4; ++row)
+            {
+                for (int32_t col = 0; col < 4; col++)
+                {
+                    for (int32_t k = 0; k < 4; ++k)
+                    {
+                        out[row].v[col] += rowsA[row].v[k] * rowsB[k].v[col];
+                    }
+                }
+            }
+        }
+
+
         AZ_MATH_INLINE void Vec4::Mat4x4TransposeMultiply(const FloatType* rowsA, const FloatType* rowsB, FloatType* out)
         {
             const FloatType bc0 = {{ rowsB[0].v[0], rowsB[1].v[0], rowsB[2].v[0], rowsB[3].v[0] }};

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
@@ -775,9 +775,9 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, const FloatType* __restrict add, FloatType* __restrict out)
         {
-            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, out);
+            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, add, out);
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
@@ -775,6 +775,12 @@ namespace AZ
         }
 
 
+        AZ_MATH_INLINE void Vec4::Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
+        {
+            Common::Mat4x4MultiplyAdd<Vec4>(rowsA, rowsB, out);
+        }
+
+
         AZ_MATH_INLINE void Vec4::Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out)
         {
             Common::Mat4x4TransposeMultiply<Vec4>(rowsA, rowsB, out);

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
@@ -36,21 +36,21 @@ namespace AZ
         AZ_MATH_INLINE Vec4::FloatType Vec4::FromVec1(Vec1::FloatArgType value)
         {
             // Coming from a Vec1 the last 3 elements could be garbage.
-            return Sse::SplatFirst(value); // {value.x, value.x, value.x, value.x}
+            return Sse::SplatIndex0(value); // {value.x, value.x, value.x, value.x}
         }
 
 
         AZ_MATH_INLINE Vec4::FloatType Vec4::FromVec2(Vec2::FloatArgType value)
         {
             // Coming from a Vec2 the last 2 elements could be garbage.
-            return Sse::ReplaceFourth(Sse::ReplaceThird(value, 0.0f), 0.0f); // {value.x, value.x, 0.0f, 0.0f}
+            return Sse::ReplaceIndex3(Sse::ReplaceIndex2(value, 0.0f), 0.0f); // {value.x, value.x, 0.0f, 0.0f}
         }
 
 
         AZ_MATH_INLINE Vec4::FloatType Vec4::FromVec3(Vec3::FloatArgType value)
         {
             // Coming from a Vec3 the last element could be garbage.
-            return Sse::ReplaceFourth(value, 0.0f); // {value.x, value.y, value.z, 0.0f}
+            return Sse::ReplaceIndex3(value, 0.0f); // {value.x, value.y, value.z, 0.0f}
         }
 
 
@@ -114,27 +114,27 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectFirst(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex0(FloatArgType value)
         {
-            return Sse::SelectFirst(value);
+            return Sse::SelectIndex0(value);
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectSecond(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex1(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatSecond(value));
+            return Sse::SelectIndex0(Sse::SplatIndex1(value));
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectThird(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex2(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatThird(value));
+            return Sse::SelectIndex0(Sse::SplatIndex2(value));
         }
 
 
-        AZ_MATH_INLINE float Vec4::SelectFourth(FloatArgType value)
+        AZ_MATH_INLINE float Vec4::SelectIndex3(FloatArgType value)
         {
-            return Sse::SelectFirst(Sse::SplatFourth(value));
+            return Sse::SelectIndex0(Sse::SplatIndex3(value));
         }
 
 
@@ -150,75 +150,75 @@ namespace AZ
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFirst(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex0(FloatArgType value)
         {
-            return Sse::SplatFirst(value);
+            return Sse::SplatIndex0(value);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatSecond(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex1(FloatArgType value)
         {
-            return Sse::SplatSecond(value);
+            return Sse::SplatIndex1(value);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatThird(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex2(FloatArgType value)
         {
-            return Sse::SplatThird(value);
+            return Sse::SplatIndex2(value);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatFourth(FloatArgType value)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::SplatIndex3(FloatArgType value)
         {
-            return Sse::SplatFourth(value);
+            return Sse::SplatIndex3(value);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, float b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFirst(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex0(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceFirst(a, b);
+            return Sse::ReplaceIndex0(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, float b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceSecond(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex1(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceSecond(a, b);
+            return Sse::ReplaceIndex1(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, float b)
         {
-            return Sse::ReplaceThird(a, b);
+            return Sse::ReplaceIndex2(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceThird(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex2(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceThird(a, b);
+            return Sse::ReplaceIndex2(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, float b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, float b)
         {
-            return Sse::ReplaceFourth(a, b);
+            return Sse::ReplaceIndex3(a, b);
         }
 
 
-        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceFourth(FloatArgType a, FloatArgType b)
+        AZ_MATH_INLINE Vec4::FloatType Vec4::ReplaceIndex3(FloatArgType a, FloatArgType b)
         {
-            return Sse::ReplaceFourth(a, b);
+            return Sse::ReplaceIndex3(a, b);
         }
 
 
@@ -720,7 +720,7 @@ namespace AZ
 
         AZ_MATH_INLINE void Vec4::Mat3x4InverseFast(const FloatType* __restrict rows, FloatType* __restrict out)
         {
-            const FloatType pos = Sub(ZeroFloat(), Madd(rows[0], SplatFourth(rows[0]), Madd(rows[1], SplatFourth(rows[1]), Mul(rows[2], SplatFourth(rows[2])))));
+            const FloatType pos = Sub(ZeroFloat(), Madd(rows[0], SplatIndex3(rows[0]), Madd(rows[1], SplatIndex3(rows[1]), Mul(rows[2], SplatIndex3(rows[2])))));
             const FloatType tmp0 = _mm_shuffle_ps(rows[0], rows[1], 0x44);
             const FloatType tmp2 = _mm_shuffle_ps(rows[0], rows[1], 0xEE);
             const FloatType tmp1 = _mm_shuffle_ps(rows[2], pos, 0x44);
@@ -806,7 +806,7 @@ namespace AZ
         AZ_MATH_INLINE Vec3::FloatType Vec4::Mat4x4TransformPoint3(const FloatType* __restrict rows, Vec3::FloatArgType vector)
         {
             // The hadd solution is profiling slightly faster than transpose + transposetransform
-            const FloatType vecXYZ = ReplaceFourth(vector, 1.0f); // Explicitly set the w cord to 1 to include translation
+            const FloatType vecXYZ = ReplaceIndex3(vector, 1.0f); // Explicitly set the w cord to 1 to include translation
             const FloatType prod1 = Mul(rows[0], vecXYZ);
             const FloatType prod2 = Mul(rows[1], vecXYZ);
             const FloatType prod3 = Mul(rows[2], vecXYZ);

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/VectorN.h>
 #include <AzCore/Math/MathMatrixSerializer.h>
 #include <AzCore/Math/MathVectorSerializer.h>
 #include <AzCore/Math/Color.h>
@@ -30,6 +31,7 @@
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/MatrixMxN.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Plane.h>
@@ -371,10 +373,12 @@ namespace AZ
             Vector2::Reflect(context);
             Vector3::Reflect(context);
             Vector4::Reflect(context);
+            VectorN::Reflect(context);
             Quaternion::Reflect(context);
             Matrix3x3::Reflect(context);
             Matrix3x4::Reflect(context);
             Matrix4x4::Reflect(context);
+            MatrixMxN::Reflect(context);
             Frustum::Reflect(context);
             Plane::Reflect(context);
             Transform::Reflect(context);

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
@@ -37,11 +37,11 @@ namespace AZ
 
         //! Default constructor does not initialize the matrix.
         Matrix3x3() = default;
+        Matrix3x3(const Matrix3x3& rhs) = default;
+
+        Matrix3x3(Simd::Vec3::FloatArgType row0, Simd::Vec3::FloatArgType row1, Simd::Vec3::FloatArgType row2);
 
         explicit Matrix3x3(const Quaternion& quaternion);
-
-        Matrix3x3(const Matrix3x3& rhs);
-        Matrix3x3(Simd::Vec3::FloatArgType row0, Simd::Vec3::FloatArgType row1, Simd::Vec3::FloatArgType row2);
 
         static Matrix3x3 CreateIdentity();
         static Matrix3x3 CreateZero();
@@ -98,9 +98,6 @@ namespace AZ
         float GetElement(int32_t row, int32_t col) const;
         void SetElement(int32_t row, int32_t col, float value);
         //! @}
-
-        //! Assignment operator.
-        Matrix3x3& operator=(const Matrix3x3& rhs);
 
         //! Indexed access using operator().
         float operator()(int32_t row, int32_t col) const;

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
@@ -13,22 +13,6 @@
 
 namespace AZ
 {
-    AZ_MATH_INLINE Matrix3x3::Matrix3x3(const Matrix3x3& rhs)
-    {
-#if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
-        memcpy(m_rows, rhs.m_rows, sizeof(m_rows));
-#else
-        m_rows[0] = rhs.m_rows[0];
-        m_rows[1] = rhs.m_rows[1];
-        m_rows[2] = rhs.m_rows[2];
-#endif
-    }
-
-    AZ_MATH_INLINE Matrix3x3::Matrix3x3(const Quaternion& quaternion)
-    {
-        *this = CreateFromQuaternion(quaternion);
-    }
-
     AZ_MATH_INLINE Matrix3x3::Matrix3x3(Simd::Vec3::FloatArgType row0, Simd::Vec3::FloatArgType row1, Simd::Vec3::FloatArgType row2)
     {
         m_rows[0] = Vector3(row0);
@@ -36,6 +20,10 @@ namespace AZ
         m_rows[2] = Vector3(row2);
     }
 
+    AZ_MATH_INLINE Matrix3x3::Matrix3x3(const Quaternion& quaternion)
+    {
+        *this = CreateFromQuaternion(quaternion);
+    }
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateIdentity()
     {
@@ -43,7 +31,6 @@ namespace AZ
                        , Simd::Vec3::LoadAligned(Simd::g_vec0100)
                        , Simd::Vec3::LoadAligned(Simd::g_vec0010));
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateZero()
     {
@@ -57,31 +44,26 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromValue(float value)
     {
         const Simd::Vec3::FloatType values = Simd::Vec3::Splat(value);
         return Matrix3x3(values, values, values);
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromRowMajorFloat9(const float* values)
     {
         return CreateFromRows(Vector3::CreateFromFloat3(&values[0]), Vector3::CreateFromFloat3(&values[3]), Vector3::CreateFromFloat3(&values[6]));
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromRows(const Vector3& row0, const Vector3& row1, const Vector3& row2)
     {
         return Matrix3x3(row0.GetSimdValue(), row1.GetSimdValue(), row2.GetSimdValue());
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromColumnMajorFloat9(const float* values)
     {
         return CreateFromColumns(Vector3::CreateFromFloat3(&values[0]), Vector3::CreateFromFloat3(&values[3]), Vector3::CreateFromFloat3(&values[6]));
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromColumns(const Vector3& col0, const Vector3& col1, const Vector3& col2)
     {
@@ -89,7 +71,6 @@ namespace AZ
         m.SetColumns(col0, col1, col2);
         return m;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateRotationX(float angle)
     {
@@ -102,7 +83,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateRotationY(float angle)
     {
         Matrix3x3 result;
@@ -113,7 +93,6 @@ namespace AZ
         result.SetRow(2, -s, 0.0f, c);
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateRotationZ(float angle)
     {
@@ -126,14 +105,12 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromQuaternion(const Quaternion& q)
     {
         Matrix3x3 result;
         result.SetRotationPartFromQuaternion(q);
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromMatrix3x4(const Matrix3x4& m)
     {
@@ -144,7 +121,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromMatrix4x4(const Matrix4x4& m)
     {
         Matrix3x3 result;
@@ -154,18 +130,15 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateFromTransform(const Transform& t)
     {
         return Matrix3x3::CreateFromColumns(t.GetBasisX(), t.GetBasisY(), t.GetBasisZ());
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateScale(const Vector3& scale)
     {
         return CreateDiagonal(scale);
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateDiagonal(const Vector3& diagonal)
     {
@@ -176,7 +149,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::CreateCrossProduct(const Vector3& p)
     {
         Matrix3x3 result;
@@ -186,14 +158,12 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::StoreToRowMajorFloat9(float* values) const
     {
         GetRow(0).StoreToFloat4(values);
         GetRow(1).StoreToFloat4(values + 3);
         GetRow(2).StoreToFloat3(values + 6);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::StoreToColumnMajorFloat9(float* values) const
     {
@@ -202,14 +172,12 @@ namespace AZ
         GetColumn(2).StoreToFloat3(values + 6);
     }
 
-
     AZ_MATH_INLINE float Matrix3x3::GetElement(int32_t row, int32_t col) const
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
         return m_rows[row].GetElement(col);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetElement(int32_t row, int32_t col, float value)
     {
@@ -218,25 +186,10 @@ namespace AZ
         m_rows[row].SetElement(col, value);
     }
 
-
-    AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator=(const Matrix3x3& rhs)
-    {
-#if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
-        memcpy(m_rows, rhs.m_rows, sizeof(m_rows));
-#else
-        m_rows[0] = rhs.m_rows[0];
-        m_rows[1] = rhs.m_rows[1];
-        m_rows[2] = rhs.m_rows[2];
-#endif
-        return *this;
-    }
-
-
     AZ_MATH_INLINE float Matrix3x3::operator()(int32_t row, int32_t col) const
     {
         return GetElement(row, col);
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x3::GetRow(int32_t row) const
     {
@@ -244,19 +197,16 @@ namespace AZ
         return m_rows[row];
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetRow(int32_t row, float x, float y, float z)
     {
         SetRow(row, Vector3(x, y, z));
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetRow(int32_t row, const Vector3& v)
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
         m_rows[row] = v;
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::GetRows(Vector3* row0, Vector3* row1, Vector3* row2) const
     {
@@ -265,7 +215,6 @@ namespace AZ
         *row2 = GetRow(2);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetRows(const Vector3& row0, const Vector3& row1, const Vector3& row2)
     {
         SetRow(0, row0);
@@ -273,13 +222,11 @@ namespace AZ
         SetRow(2, row2);
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::GetColumn(int32_t col) const
     {
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
         return Vector3(m_rows[0].GetElement(col), m_rows[1].GetElement(col), m_rows[2].GetElement(col));
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetColumn(int32_t col, float x, float y, float z)
     {
@@ -287,7 +234,6 @@ namespace AZ
         m_rows[1].SetElement(col, y);
         m_rows[2].SetElement(col, z);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetColumn(int32_t col, const Vector3& v)
     {
@@ -297,14 +243,12 @@ namespace AZ
         m_rows[2].SetElement(col, v.GetZ());
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::GetColumns(Vector3* col0, Vector3* col1, Vector3* col2) const
     {
         *col0 = GetColumn(0);
         *col1 = GetColumn(1);
         *col2 = GetColumn(2);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetColumns(const Vector3& col0, const Vector3& col1, const Vector3& col2)
     {
@@ -321,72 +265,60 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::GetBasisX() const
     {
         return GetColumn(0);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetBasisX(float x, float y, float z)
     {
         SetColumn(0, x, y, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetBasisX(const Vector3& v)
     {
         SetColumn(0, v);
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x3::GetBasisY() const
     {
         return GetColumn(1);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetBasisY(float x, float y, float z)
     {
         SetColumn(1, x, y, z);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetBasisY(const Vector3& v)
     {
         SetColumn(1, v);
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::GetBasisZ() const
     {
         return GetColumn(2);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::SetBasisZ(float x, float y, float z)
     {
         SetColumn(2, x, y, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetBasisZ(const Vector3& v)
     {
         SetColumn(2, v);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::GetBasis(Vector3* basisX, Vector3* basisY, Vector3* basisZ) const
     {
         GetColumns(basisX, basisY, basisZ);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::SetBasis(const Vector3& basisX, const Vector3& basisY, const Vector3& basisZ)
     {
         SetColumns(basisX, basisY, basisZ);
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::TransposedMultiply(const Matrix3x3& rhs) const
     {
@@ -395,12 +327,10 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::operator*(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec3::Mat3x3TransformVector(GetSimdValues(), rhs.GetSimdValue()));
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator+(const Matrix3x3& rhs) const
     {
@@ -412,13 +342,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator+=(const Matrix3x3& rhs)
     {
         *this = *this + rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator-(const Matrix3x3& rhs) const
     {
@@ -430,13 +358,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator-=(const Matrix3x3& rhs)
     {
         *this = *this - rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator*(const Matrix3x3& rhs) const
     {
@@ -445,13 +371,11 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator*=(const Matrix3x3& rhs)
     {
         *this = *this * rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator*(float multiplier) const
     {
@@ -464,13 +388,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator*=(float multiplier)
     {
         *this = *this * multiplier;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator/(float divisor) const
     {
@@ -483,13 +405,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x3& Matrix3x3::operator/=(float divisor)
     {
         *this = *this / divisor;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::operator-() const
     {
@@ -502,7 +422,6 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE bool Matrix3x3::operator==(const Matrix3x3& rhs) const
     {
         return (Simd::Vec3::CmpAllEq(m_rows[0].GetSimdValue(), rhs.m_rows[0].GetSimdValue())
@@ -510,12 +429,10 @@ namespace AZ
              && Simd::Vec3::CmpAllEq(m_rows[2].GetSimdValue(), rhs.m_rows[2].GetSimdValue()));
     }
 
-
     AZ_MATH_INLINE bool Matrix3x3::operator!=(const Matrix3x3& rhs) const
     {
         return !(*this == rhs);
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetTranspose() const
     {
@@ -524,18 +441,15 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::Transpose()
     {
         *this = GetTranspose();
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::InvertFull()
     {
         *this = GetInverseFull();
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetInverseFull() const
     {
@@ -544,30 +458,25 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetInverseFast() const
     {
         return GetTranspose();
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::InvertFast()
     {
         *this = GetInverseFast();
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::RetrieveScale() const
     {
         return Vector3(GetBasisX().GetLength(), GetBasisY().GetLength(), GetBasisZ().GetLength());
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::RetrieveScaleSq() const
     {
         return Vector3(GetBasisX().GetLengthSq(), GetBasisY().GetLengthSq(), GetBasisZ().GetLengthSq());
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x3::ExtractScale()
     {
@@ -582,7 +491,6 @@ namespace AZ
         SetBasisZ(z / lengthZ);
         return Vector3(lengthX, lengthY, lengthZ);
     }
-
 
     AZ_MATH_INLINE void Matrix3x3::MultiplyByScale(const Vector3& scale)
     {
@@ -600,7 +508,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetReciprocalScaled() const
     {
         Matrix3x3 result = *this;
@@ -608,14 +515,12 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::GetPolarDecomposition(Matrix3x3* orthogonalOut, Matrix3x3* symmetricOut) const
     {
         *orthogonalOut = GetPolarDecomposition();
         // Could also refine symmetricOut further, by taking H = 0.5*(H + H^t)
         *symmetricOut = orthogonalOut->TransposedMultiply(*this);
     }
-
 
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetOrthogonalized() const
     {
@@ -625,12 +530,10 @@ namespace AZ
         return Matrix3x3(row0, row1, row2);
     }
 
-
     AZ_MATH_INLINE void Matrix3x3::Orthogonalize()
     {
         *this = GetOrthogonalized();
     }
-
 
     AZ_MATH_INLINE bool Matrix3x3::IsClose(const Matrix3x3& rhs, float tolerance) const
     {
@@ -646,12 +549,10 @@ namespace AZ
         return true;
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x3::GetDiagonal() const
     {
         return Vector3(GetElement(0, 0), GetElement(1, 1), GetElement(2, 2));
     }
-
 
     AZ_MATH_INLINE float Matrix3x3::GetDeterminant() const
     {
@@ -660,7 +561,6 @@ namespace AZ
              + m_rows[2].GetElement(0) * (m_rows[0].GetElement(1) * m_rows[1].GetElement(2) - m_rows[0].GetElement(2) * m_rows[1].GetElement(1));
     }
 
-
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetAdjugate() const
     {
         Matrix3x3 result;
@@ -668,24 +568,20 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE bool Matrix3x3::IsFinite() const
     {
         return GetRow(0).IsFinite() && GetRow(1).IsFinite() && GetRow(2).IsFinite();
     }
-
 
     AZ_MATH_INLINE const Simd::Vec3::FloatType* Matrix3x3::GetSimdValues() const
     {
         return reinterpret_cast<const Simd::Vec3::FloatType*>(m_rows);
     }
 
-
     AZ_MATH_INLINE Simd::Vec3::FloatType* Matrix3x3::GetSimdValues()
     {
         return reinterpret_cast<Simd::Vec3::FloatType*>(m_rows);
     }
-
 
     AZ_MATH_INLINE Vector3 operator*(const Vector3& lhs, const Matrix3x3& rhs)
     {
@@ -694,13 +590,11 @@ namespace AZ
                      , lhs(0) * rhs(0, 2) + lhs(1) * rhs(1, 2) + lhs(2) * rhs(2, 2));
     }
 
-
     AZ_MATH_INLINE Vector3& operator*=(Vector3& lhs, const Matrix3x3& rhs)
     {
         lhs = lhs * rhs;
         return lhs;
     }
-
 
     AZ_MATH_INLINE Matrix3x3 operator*(float lhs, const Matrix3x3& rhs)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
@@ -514,12 +514,12 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(eulerRadians.GetSimdValue(), sin, cos);
 
-        const float sx = Simd::Vec3::SelectFirst(sin);
-        const float sy = Simd::Vec3::SelectSecond(sin);
-        const float sz = Simd::Vec3::SelectThird(sin);
-        const float cx = Simd::Vec3::SelectFirst(cos);
-        const float cy = Simd::Vec3::SelectSecond(cos);
-        const float cz = Simd::Vec3::SelectThird(cos);
+        const float sx = Simd::Vec3::SelectIndex0(sin);
+        const float sy = Simd::Vec3::SelectIndex1(sin);
+        const float sz = Simd::Vec3::SelectIndex2(sin);
+        const float cx = Simd::Vec3::SelectIndex0(cos);
+        const float cy = Simd::Vec3::SelectIndex1(cos);
+        const float cz = Simd::Vec3::SelectIndex2(cos);
 
         SetRow(0, cy * cz, -cy * sz, sy, 0.0f);
         SetRow(1, cx * sz + sx * sy * cz, cx * cz - sx * sy * sz, -sx * cy, 0.0f);

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
@@ -40,8 +40,8 @@ namespace AZ
 
         //! Default constructor, which does not initialize the matrix.
         Matrix3x4() = default;
+        Matrix3x4(const Matrix3x4& rhs) = default;
 
-        Matrix3x4(const Matrix3x4& rhs);
         Matrix3x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2);
 
         //! Creates an identity Matrix3x4.
@@ -138,9 +138,6 @@ namespace AZ
         //! Sets the element in the specified row and column.
         //! Accessing individual elements can be slower than working with entire rows.
         void SetElement(int32_t row, int32_t col, const float value);
-
-        //! Assignment operator.
-        Matrix3x4& operator=(const Matrix3x4& rhs);
 
         //! Accesses the element in the specified row and column.
         //! Accessing individual elements can be slower than working with entire rows.

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -22,19 +22,6 @@ namespace AZ
         out4x4[3] = Simd::Vec4::LoadAligned(Simd::g_vec0001);
     }
 
-
-    AZ_MATH_INLINE Matrix3x4::Matrix3x4(const Matrix3x4& rhs)
-    {
-#if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
-        memcpy(m_rows, rhs.m_rows, sizeof(m_rows));
-#else
-        m_rows[0] = rhs.m_rows[0];
-        m_rows[1] = rhs.m_rows[1];
-        m_rows[2] = rhs.m_rows[2];
-#endif
-    }
-
-
     AZ_MATH_INLINE Matrix3x4::Matrix3x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2)
     {
         m_rows[0] = Vector4(row0);
@@ -42,14 +29,12 @@ namespace AZ
         m_rows[2] = Vector4(row2);
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateIdentity()
     {
         return Matrix3x4(Simd::Vec4::LoadAligned(Simd::g_vec1000)
                        , Simd::Vec4::LoadAligned(Simd::g_vec0100)
                        , Simd::Vec4::LoadAligned(Simd::g_vec0010));
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateZero()
     {
@@ -63,13 +48,11 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromValue(float value)
     {
         const Simd::Vec4::FloatType values = Simd::Vec4::Splat(value);
         return Matrix3x4(values, values, values);
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromRowMajorFloat12(const float values[12])
     {
@@ -80,7 +63,6 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromRows(const Vector4& row0, const Vector4& row1, const Vector4& row2)
     {
         Matrix3x4 result;
@@ -89,7 +71,6 @@ namespace AZ
         result.m_rows[2] = row2;
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromColumnMajorFloat12(const float values[12])
     {
@@ -101,14 +82,12 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromColumns(const Vector3& col0, const Vector3& col1, const Vector3& col2, const Vector3& col3)
     {
         Matrix3x4 result;
         result.SetColumns(col0, col1, col2, col3);
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromColumnMajorFloat16(const float values[16])
     {
@@ -119,7 +98,6 @@ namespace AZ
             Vector3::CreateFromFloat3(&values[12])
         );
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateRotationX(float angle)
     {
@@ -132,7 +110,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateRotationY(float angle)
     {
         Matrix3x4 result;
@@ -143,7 +120,6 @@ namespace AZ
         result.SetRow(2, -s, 0.0f, c, 0.0f);
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateRotationZ(float angle)
     {
@@ -156,7 +132,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromQuaternion(const Quaternion& quaternion)
     {
         Matrix3x4 result;
@@ -164,7 +139,6 @@ namespace AZ
         result.SetTranslation(Vector3::CreateZero());
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromQuaternionAndTranslation(const Quaternion& quaternion, const Vector3& translation)
     {
@@ -174,7 +148,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromMatrix3x3(const Matrix3x3& matrix3x3)
     {
         Matrix3x4 result;
@@ -183,7 +156,6 @@ namespace AZ
         result.SetRow(2, matrix3x3.GetRow(2), 0.0f);
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromMatrix3x3AndTranslation(const Matrix3x3& matrix3x3, const Vector3& translation)
     {
@@ -196,12 +168,10 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateFromTransform(const Transform& transform)
     {
         return Matrix3x4::CreateFromColumns(transform.GetBasisX(), transform.GetBasisY(), transform.GetBasisZ(), transform.GetTranslation());
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::UnsafeCreateFromMatrix4x4(const Matrix4x4& matrix4x4)
     {
@@ -212,18 +182,15 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateScale(const Vector3& scale)
     {
         return CreateDiagonal(scale);
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateDiagonal(const Vector3& diagonal)
     {
         return CreateFromRows(Vector4::CreateAxisX(diagonal.GetX()), Vector4::CreateAxisY(diagonal.GetY()), Vector4::CreateAxisZ(diagonal.GetZ()));
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::CreateTranslation(const Vector3& translation)
     {
@@ -232,12 +199,10 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::Identity()
     {
         return CreateIdentity();;
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::StoreToRowMajorFloat12(float values[12]) const
     {
@@ -245,7 +210,6 @@ namespace AZ
         GetRow(1).StoreToFloat4(values + 4);
         GetRow(2).StoreToFloat4(values + 8);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::StoreToColumnMajorFloat12(float values[12]) const
     {
@@ -255,7 +219,6 @@ namespace AZ
         GetColumn(3).StoreToFloat3(values + 9);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::StoreToColumnMajorFloat16(float values[16]) const
     {
         GetColumn(0).StoreToFloat4(values);
@@ -264,14 +227,12 @@ namespace AZ
         GetColumn(3).StoreToFloat4(values + 12);
     }
 
-
     AZ_MATH_INLINE float Matrix3x4::GetElement(int32_t row, int32_t col) const
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access");
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access");
         return m_rows[row].GetElement(col);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetElement(int32_t row, int32_t col, float value)
     {
@@ -280,25 +241,10 @@ namespace AZ
         m_rows[row].SetElement(col, value);
     }
 
-
-    AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator=(const Matrix3x4& rhs)
-    {
-#if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
-        memcpy(m_rows, rhs.m_rows, sizeof(m_rows));
-#else
-        m_rows[0] = rhs.m_rows[0];
-        m_rows[1] = rhs.m_rows[1];
-        m_rows[2] = rhs.m_rows[2];
-#endif
-        return *this;
-    }
-
-
     AZ_MATH_INLINE float Matrix3x4::operator()(int32_t row, int32_t col) const
     {
         return GetElement(row, col);
     }
-
 
     AZ_MATH_INLINE Vector4 Matrix3x4::GetRow(int32_t row) const
     {
@@ -306,13 +252,11 @@ namespace AZ
         return m_rows[row];
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::GetRowAsVector3(int32_t row) const
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access");
         return m_rows[row].GetAsVector3();
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetRow(int32_t row, float x, float y, float z, float w)
     {
@@ -320,20 +264,17 @@ namespace AZ
         m_rows[row].Set(x, y, z, w);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetRow(int32_t row, const Vector3& v, float w)
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access");
         m_rows[row].Set(v, w);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetRow(int32_t row, const Vector4& v)
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access");
         m_rows[row] = v;
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::GetRows(Vector4* row0, Vector4* row1, Vector4* row2) const
     {
@@ -342,7 +283,6 @@ namespace AZ
         *row2 = m_rows[2];
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetRows(const Vector4& row0, const Vector4& row1, const Vector4& row2)
     {
         m_rows[0] = row0;
@@ -350,13 +290,11 @@ namespace AZ
         m_rows[2] = row2;
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::GetColumn(int32_t col) const
     {
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access");
         return Vector3(m_rows[0].GetElement(col), m_rows[1].GetElement(col), m_rows[2].GetElement(col));
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetColumn(int32_t col, float x, float y, float z)
     {
@@ -366,12 +304,10 @@ namespace AZ
         m_rows[2].SetElement(col, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetColumn(int32_t col, const Vector3& v)
     {
         SetColumn(col, v.GetX(), v.GetY(), v.GetZ());
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::GetColumns(Vector3* col0, Vector3* col1, Vector3* col2, Vector3* col3) const
     {
@@ -381,7 +317,6 @@ namespace AZ
         *col3 = GetColumn(3);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetColumns(const Vector3& col0, const Vector3& col1, const Vector3& col2, const Vector3& col3)
     {
         for (int32_t row = 0; row < RowCount; ++row)
@@ -390,78 +325,65 @@ namespace AZ
         }
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::GetBasisX() const
     {
         return GetColumn(0);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetBasisX(float x, float y, float z)
     {
         SetColumn(0, x, y, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetBasisX(const Vector3& v)
     {
         SetColumn(0, v.GetX(), v.GetY(), v.GetZ());
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x4::GetBasisY() const
     {
         return GetColumn(1);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetBasisY(float x, float y, float z)
     {
         SetColumn(1, x, y, z);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetBasisY(const Vector3& v)
     {
         SetColumn(1, v.GetX(), v.GetY(), v.GetZ());
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::GetBasisZ() const
     {
         return GetColumn(2);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::SetBasisZ(float x, float y, float z)
     {
         SetColumn(2, x, y, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetBasisZ(const Vector3& v)
     {
         SetColumn(2, v.GetX(), v.GetY(), v.GetZ());
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x4::GetTranslation() const
     {
         return GetColumn(3);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetTranslation(float x, float y, float z)
     {
         SetColumn(3, x, y, z);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetTranslation(const Vector3& v)
     {
         SetColumn(3, v);
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::GetBasisAndTranslation(Vector3* basisX, Vector3* basisY, Vector3* basisZ, Vector3* translation) const
     {
@@ -471,12 +393,10 @@ namespace AZ
         *translation = GetColumn(3);
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetBasisAndTranslation(const Vector3& basisX, const Vector3& basisY, const Vector3& basisZ, const Vector3& translation)
     {
         SetColumns(basisX, basisY, basisZ, translation);
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator+(const Matrix3x4& rhs) const
     {
@@ -488,13 +408,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator+=(const Matrix3x4& rhs)
     {
         *this = *this + rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator-(const Matrix3x4& rhs) const
     {
@@ -506,13 +424,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator-=(const Matrix3x4& rhs)
     {
         *this = *this - rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator*(const Matrix3x4& rhs) const
     {
@@ -521,13 +437,11 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator*=(const Matrix3x4& rhs)
     {
         *this = *this * rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator*(float multiplier) const
     {
@@ -540,13 +454,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator*=(float multiplier)
     {
         *this = *this * multiplier;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator/(float divisor) const
     {
@@ -559,13 +471,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix3x4& Matrix3x4::operator/=(float divisor)
     {
         *this = *this / divisor;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::operator-() const
     {
@@ -578,7 +488,6 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::operator*(const Vector3& rhs) const
     {
         return Vector3
@@ -588,7 +497,6 @@ namespace AZ
             m_rows[2].Dot3(rhs) + m_rows[2].GetElement(3)
         );
     }
-
 
     AZ_MATH_INLINE Vector4 Matrix3x4::operator*(const Vector4& rhs) const
     {
@@ -601,7 +509,6 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::Multiply3x3(const Vector3& rhs) const
     {
         return Vector3
@@ -612,18 +519,15 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::TransformVector(const Vector3& rhs) const
     {
         return Multiply3x3(rhs);
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::TransformPoint(const Vector3& rhs) const
     {
         return Multiply3x3(rhs) + GetTranslation();
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::GetTranspose() const
     {
@@ -632,12 +536,10 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::Transpose()
     {
         *this = GetTranspose();
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::GetTranspose3x3() const
     {
@@ -648,18 +550,15 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::Transpose3x3()
     {
         *this = GetTranspose3x3();
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::InvertFull()
     {
         *this = GetInverseFull();
     }
-
 
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::GetInverseFast() const
     {
@@ -668,24 +567,20 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::InvertFast()
     {
         *this = GetInverseFast();
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScale() const
     {
         return Vector3(GetColumn(0).GetLength(), GetColumn(1).GetLength(), GetColumn(2).GetLength());
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScaleSq() const
     {
         return Vector3(GetColumn(0).GetLengthSq(), GetColumn(1).GetLengthSq(), GetColumn(2).GetLengthSq());
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix3x4::ExtractScale()
     {
@@ -693,7 +588,6 @@ namespace AZ
         MultiplyByScale(scale.GetReciprocal());
         return scale;
     }
-
 
     AZ_MATH_INLINE void Matrix3x4::MultiplyByScale(const Vector3& scale)
     {
@@ -703,7 +597,6 @@ namespace AZ
         m_rows[2].Set(Simd::Vec4::Mul(m_rows[2].GetSimdValue(), vector4Scale));
     }
 
-
     AZ_MATH_INLINE Matrix3x4 Matrix3x4::GetReciprocalScaled() const
     {
         Matrix3x4 result = *this;
@@ -711,42 +604,35 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::Orthogonalize()
     {
         *this = GetOrthogonalized();
     }
-
 
     AZ_MATH_INLINE bool Matrix3x4::IsClose(const Matrix3x4& rhs, float tolerance) const
     {
         return m_rows[0].IsClose(rhs.m_rows[0], tolerance) && m_rows[1].IsClose(rhs.m_rows[1], tolerance) && m_rows[2].IsClose(rhs.m_rows[2], tolerance);
     }
 
-
     AZ_MATH_INLINE bool Matrix3x4::operator==(const Matrix3x4& rhs) const
     {
         return m_rows[0] == rhs.m_rows[0] && m_rows[1] == rhs.m_rows[1] && m_rows[2] == rhs.m_rows[2];
     }
-
 
     AZ_MATH_INLINE bool Matrix3x4::operator!=(const Matrix3x4& rhs) const
     {
         return !(*this == rhs);
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix3x4::GetEulerDegrees() const
     {
         return Vector3RadToDeg(GetEulerRadians());
     }
 
-
     AZ_MATH_INLINE void Matrix3x4::SetFromEulerDegrees(const Vector3& eulerDegrees)
     {
         SetFromEulerRadians(Vector3DegToRad(eulerDegrees));
     }
-
 
     AZ_MATH_INLINE float Matrix3x4::GetDeterminant3x3() const
     {
@@ -755,24 +641,20 @@ namespace AZ
              + m_rows[2].GetElement(0) * (m_rows[0].GetElement(1) * m_rows[1].GetElement(2) - m_rows[0].GetElement(2) * m_rows[1].GetElement(1));
     }
 
-
     AZ_MATH_INLINE bool Matrix3x4::IsFinite() const
     {
         return m_rows[0].IsFinite() && m_rows[1].IsFinite() && m_rows[2].IsFinite();
     }
-
 
     AZ_MATH_INLINE const Simd::Vec4::FloatType* Matrix3x4::GetSimdValues() const
     {
         return reinterpret_cast<const Simd::Vec4::FloatType*>(m_rows);
     }
 
-
     AZ_MATH_INLINE Simd::Vec4::FloatType* Matrix3x4::GetSimdValues()
     {
         return reinterpret_cast<Simd::Vec4::FloatType*>(m_rows);
     }
-
 
     AZ_MATH_INLINE Matrix3x4 operator*(float lhs, const Matrix3x4& rhs)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -591,7 +591,7 @@ namespace AZ
 
     AZ_MATH_INLINE void Matrix3x4::MultiplyByScale(const Vector3& scale)
     {
-        const Simd::Vec4::FloatType vector4Scale = Simd::Vec4::ReplaceFourth(Simd::Vec4::FromVec3(scale.GetSimdValue()), 1.0f);
+        const Simd::Vec4::FloatType vector4Scale = Simd::Vec4::ReplaceIndex3(Simd::Vec4::FromVec3(scale.GetSimdValue()), 1.0f);
         m_rows[0].Set(Simd::Vec4::Mul(m_rows[0].GetSimdValue(), vector4Scale));
         m_rows[1].Set(Simd::Vec4::Mul(m_rows[1].GetSimdValue(), vector4Scale));
         m_rows[2].Set(Simd::Vec4::Mul(m_rows[2].GetSimdValue(), vector4Scale));

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
@@ -20,7 +20,6 @@ namespace AZ
             return result;
         }
 
-
         AZ::Matrix4x4 ConstructMatrix4x4FromValues
             ( float v00, float v01, float v02, float v03
             , float v10, float v11, float v12, float v13
@@ -29,7 +28,6 @@ namespace AZ
         {
             return ConstructMatrix4x4(AZ::Vector4(v00, v01, v02, v03), AZ::Vector4(v10, v11, v12, v13), AZ::Vector4(v20, v21, v22, v23), AZ::Vector4(v30, v31, v32, v33));
         }
-
 
         void Matrix4x4DefaultConstructor(Matrix4x4* thisPtr)
         {
@@ -100,7 +98,6 @@ namespace AZ
             }
         }
 
-
         void Matrix4x4SetColumnGeneric(Matrix4x4* thisPtr, ScriptDataContext& dc)
         {
             bool columnIsSet = false;
@@ -165,7 +162,6 @@ namespace AZ
             }
         }
 
-
         void Matrix4x4SetTranslationGeneric(Matrix4x4* thisPtr, ScriptDataContext& dc)
         {
             bool translationIsSet = false;
@@ -198,7 +194,6 @@ namespace AZ
             }
         }
 
-
         void Matrix4x4GetRowsMultipleReturn(const Matrix4x4* thisPtr, ScriptDataContext& dc)
         {
             Vector4 row0(Vector4::CreateZero()), row1(Vector4::CreateZero()), row2(Vector4::CreateZero()), row3(Vector4::CreateZero());
@@ -209,7 +204,6 @@ namespace AZ
             dc.PushResult(row3);
         }
 
-
         void Matrix4x4GetColumnsMultipleReturn(const Matrix4x4* thisPtr, ScriptDataContext& dc)
         {
             Vector4 column0(Vector4::CreateZero()), column1(Vector4::CreateZero()), column2(Vector4::CreateZero()), column3(Vector4::CreateZero());
@@ -219,7 +213,6 @@ namespace AZ
             dc.PushResult(column2);
             dc.PushResult(column3);
         }
-
 
         void Matrix4x4MultiplyGeneric(const Matrix4x4* thisPtr, ScriptDataContext& dc)
         {
@@ -255,7 +248,6 @@ namespace AZ
             }
         }
 
-
         AZStd::string Matrix4x4ToString(const Matrix4x4& m)
         {
             return AZStd::string::format("%s,%s,%s,%s",
@@ -263,7 +255,6 @@ namespace AZ
                 Vector4ToString(m.GetColumn(2)).c_str(), Vector4ToString(m.GetColumn(3)).c_str());
         }
     }
-
 
     void Matrix4x4::Reflect(ReflectContext* context)
     {
@@ -389,7 +380,6 @@ namespace AZ
         }
     }
 
-
     void Matrix4x4::SetRotationPartFromQuaternion(const Quaternion& q)
     {
         float tx = q.GetX() * 2.0f;
@@ -418,7 +408,6 @@ namespace AZ
         SetElement(2, 2, 1.0f - (txx + tyy));
     }
 
-
     Matrix4x4 Matrix4x4::CreateProjection(float fovY, float aspectRatio, float nearDist, float farDist)
     {
         // This section contains some notes about camera matrices and field of view, because there are some subtle differences
@@ -442,7 +431,6 @@ namespace AZ
         return CreateProjectionInternal(cotX, cotY, nearDist, farDist);
     }
 
-
     Matrix4x4 Matrix4x4::CreateProjectionFov(float fovX, float fovY, float nearDist, float farDist)
     {
         // note that the relationship between fovX and fovY is not linear with the aspect ratio, so prefer the
@@ -454,7 +442,6 @@ namespace AZ
         float cotY = Simd::Vec4::SelectFourth(values) / Simd::Vec4::SelectThird(values);
         return CreateProjectionInternal(cotX, cotY, nearDist, farDist);
     }
-
 
     Matrix4x4 Matrix4x4::CreateProjectionInternal(float cotX, float cotY, float nearDist, float farDist)
     {
@@ -480,7 +467,6 @@ namespace AZ
         return result;
     }
 
-
     // Set the projection matrix with a volume offset
     Matrix4x4 Matrix4x4::CreateProjectionOffset(float left, float right, float bottom, float top, float nearDist, float farDist)
     {
@@ -505,7 +491,6 @@ namespace AZ
 #endif
         return result;
     }
-
 
     Matrix4x4 Matrix4x4::GetInverseTransform() const
     {
@@ -546,7 +531,6 @@ namespace AZ
 
         return out;
     }
-
 
     Matrix4x4 Matrix4x4::GetInverseFull() const
     {
@@ -610,7 +594,6 @@ namespace AZ
 
         return out;
     }
-
 
     Matrix4x4 Matrix4x4::CreateInterpolated(const Matrix4x4& m1, const Matrix4x4& m2, float t)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
@@ -438,8 +438,8 @@ namespace AZ
         // FOV's exactly
         Simd::Vec4::FloatType angles = Simd::Vec4::LoadImmediate(0.5f * fovX, 0.5f * fovX, 0.5f * fovY, 0.5f * fovY);
         Simd::Vec4::FloatType values = Simd::Vec4::SinCos(angles);
-        float cotX = Simd::Vec4::SelectSecond(values) / Simd::Vec4::SelectFirst(values);
-        float cotY = Simd::Vec4::SelectFourth(values) / Simd::Vec4::SelectThird(values);
+        float cotX = Simd::Vec4::SelectIndex1(values) / Simd::Vec4::SelectIndex0(values);
+        float cotY = Simd::Vec4::SelectIndex3(values) / Simd::Vec4::SelectIndex2(values);
         return CreateProjectionInternal(cotX, cotY, nearDist, farDist);
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
@@ -42,8 +42,8 @@ namespace AZ
 
         //! Default constructor does not initialize the matrix.
         Matrix4x4() = default;
+        Matrix4x4(const Matrix4x4& rhs) = default;
 
-        Matrix4x4(const Matrix4x4& rhs);
         Matrix4x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2, Simd::Vec4::FloatArgType row3);
 
         static Matrix4x4 CreateIdentity();

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
@@ -13,19 +13,6 @@
 
 namespace AZ
 {
-    AZ_MATH_INLINE Matrix4x4::Matrix4x4(const Matrix4x4& rhs)
-    {
-#if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
-        memcpy(m_rows, rhs.m_rows, sizeof(m_rows));
-#else
-        m_rows[0] = rhs.m_rows[0];
-        m_rows[1] = rhs.m_rows[1];
-        m_rows[2] = rhs.m_rows[2];
-        m_rows[3] = rhs.m_rows[3];
-#endif
-    }
-
-
     AZ_MATH_INLINE Matrix4x4::Matrix4x4(Simd::Vec4::FloatArgType row0, Simd::Vec4::FloatArgType row1, Simd::Vec4::FloatArgType row2, Simd::Vec4::FloatArgType row3)
     {
         m_rows[0] = Vector4(row0);
@@ -34,7 +21,6 @@ namespace AZ
         m_rows[3] = Vector4(row3);
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateIdentity()
     {
         return Matrix4x4(Simd::Vec4::LoadAligned(Simd::g_vec1000)
@@ -42,7 +28,6 @@ namespace AZ
                        , Simd::Vec4::LoadAligned(Simd::g_vec0010)
                        , Simd::Vec4::LoadAligned(Simd::g_vec0001));
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateZero()
     {
@@ -56,13 +41,11 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromValue(float value)
     {
         const Simd::Vec4::FloatType values = Simd::Vec4::Splat(value);
         return Matrix4x4(values, values, values, values);
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromRowMajorFloat16(const float* values)
     {
@@ -72,14 +55,12 @@ namespace AZ
                             , Vector4::CreateFromFloat4(&values[12]));
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromRows(const Vector4& row0, const Vector4& row1, const Vector4& row2, const Vector4& row3)
     {
         Matrix4x4 m;
         m.SetRows(row0, row1, row2, row3);
         return m;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromColumnMajorFloat16(const float* values)
     {
@@ -89,14 +70,12 @@ namespace AZ
                                , Vector4::CreateFromFloat4(&values[12]));
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromColumns(const Vector4& col0, const Vector4& col1, const Vector4& col2, const Vector4& col3)
     {
         Matrix4x4 m;
         m.SetColumns(col0, col1, col2, col3);
         return m;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateRotationX(float angle)
     {
@@ -110,7 +89,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateRotationY(float angle)
     {
         Matrix4x4 result;
@@ -122,7 +100,6 @@ namespace AZ
         result.m_rows[3] = Vector4(Simd::Vec4::LoadAligned(Simd::g_vec0001));
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateRotationZ(float angle)
     {
@@ -136,7 +113,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromQuaternion(const Quaternion& q)
     {
         Matrix4x4 result;
@@ -146,7 +122,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromQuaternionAndTranslation(const Quaternion& q, const Vector3& p)
     {
         Matrix4x4 result;
@@ -155,7 +130,6 @@ namespace AZ
         result.m_rows[3] = Vector4(Simd::Vec4::LoadAligned(Simd::g_vec0001));
         return result;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromMatrix3x4(const Matrix3x4& matrix3x4)
     {
@@ -167,18 +141,15 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateFromTransform(const Transform& transform)
     {
         return CreateFromMatrix3x4(Matrix3x4::CreateFromTransform(transform));
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateScale(const Vector3& scale)
     {
         return CreateDiagonal(Vector4(scale.GetX(), scale.GetY(), scale.GetZ(), 1.0f));
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateDiagonal(const Vector4& diagonal)
     {
@@ -190,7 +161,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::CreateTranslation(const Vector3& translation)
     {
         Matrix4x4 result;
@@ -201,7 +171,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::StoreToRowMajorFloat16(float* values) const
     {
         GetRow(0).StoreToFloat4(values);
@@ -209,7 +178,6 @@ namespace AZ
         GetRow(2).StoreToFloat4(values + 8);
         GetRow(3).StoreToFloat4(values + 12);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::StoreToColumnMajorFloat16(float* values) const
     {
@@ -219,14 +187,12 @@ namespace AZ
         GetColumn(3).StoreToFloat4(values + 12);
     }
 
-
     AZ_MATH_INLINE float Matrix4x4::GetElement(int32_t row, int32_t col) const
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
         return m_rows[row].GetElement(col);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetElement(int32_t row, int32_t col, float value)
     {
@@ -235,12 +201,10 @@ namespace AZ
         m_rows[row].SetElement(col, value);
     }
 
-
     AZ_MATH_INLINE float Matrix4x4::operator()(int32_t row, int32_t col) const
     {
         return GetElement(row, col);
     }
-
 
     AZ_MATH_INLINE Vector4 Matrix4x4::GetRow(int32_t row) const
     {
@@ -248,13 +212,11 @@ namespace AZ
         return m_rows[row];
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::GetRowAsVector3(int32_t row) const
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
         return m_rows[row].GetAsVector3();
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::GetRows(Vector4* row0, Vector4* row1, Vector4* row2, Vector4* row3) const
     {
@@ -264,12 +226,10 @@ namespace AZ
         *row3 = GetRow(3);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetRow(int32_t row, float x, float y, float z, float w)
     {
         SetRow(row, Vector4(x, y, z, w));
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetRow(int32_t row, const Vector3& v)
     {
@@ -279,7 +239,6 @@ namespace AZ
         m_rows[row].SetElement(2, v.GetZ());
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetRow(int32_t row, const Vector3& v, float w)
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
@@ -287,13 +246,11 @@ namespace AZ
         m_rows[row].SetElement(3, w);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetRow(int32_t row, const Vector4& v)
     {
         AZ_MATH_ASSERT((row >= 0) && (row < RowCount), "Invalid index for component access.\n");
         m_rows[row] = v;
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetRows(const Vector4& row0, const Vector4& row1, const Vector4& row2, const Vector4& row3)
     {
@@ -303,20 +260,17 @@ namespace AZ
         SetRow(3, row3);
     }
 
-
     AZ_MATH_INLINE Vector4 Matrix4x4::GetColumn(int32_t col) const
     {
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
         return Vector4(m_rows[0].GetElement(col), m_rows[1].GetElement(col), m_rows[2].GetElement(col), m_rows[3].GetElement(col));
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::GetColumnAsVector3(int32_t col) const
     {
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
         return Vector3(m_rows[0].GetElement(col), m_rows[1].GetElement(col), m_rows[2].GetElement(col));
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::GetColumns(Vector4* col0, Vector4* col1, Vector4* col2, Vector4* col3) const
     {
@@ -326,12 +280,10 @@ namespace AZ
         *col3 = GetColumn(3);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetColumn(int32_t col, float x, float y, float z, float w)
     {
         SetColumn(col, Vector4(x, y, z, w));
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetColumn(int32_t col, const Vector3& v)
     {
@@ -340,7 +292,6 @@ namespace AZ
         m_rows[1].SetElement(col, v.GetY());
         m_rows[2].SetElement(col, v.GetZ());
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetColumn(int32_t col, const Vector3& v, float w)
     {
@@ -351,7 +302,6 @@ namespace AZ
         m_rows[3].SetElement(col, w);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetColumn(int32_t col, const Vector4& v)
     {
         AZ_MATH_ASSERT((col >= 0) && (col < ColCount), "Invalid index for component access.\n");
@@ -361,7 +311,6 @@ namespace AZ
         m_rows[3].SetElement(col, v.GetW());
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetColumns(const Vector4& col0, const Vector4& col1, const Vector4& col2, const Vector4& col3)
     {
         SetColumn(0, col0);
@@ -370,108 +319,90 @@ namespace AZ
         SetColumn(3, col3);
     }
 
-
     AZ_MATH_INLINE Vector4 Matrix4x4::GetBasisX() const
     {
         return GetColumn(0);
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::GetBasisXAsVector3() const
     {
         return GetColumnAsVector3(0);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetBasisX(float x, float y, float z, float w)
     {
         SetColumn(0, x, y, z, w);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetBasisX(const Vector4& v)
     {
         SetColumn(0, v);
     }
 
-
     AZ_MATH_INLINE Vector4 Matrix4x4::GetBasisY() const
     {
         return GetColumn(1);
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::GetBasisYAsVector3() const
     {
         return GetColumnAsVector3(1);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetBasisY(float x, float y, float z, float w)
     {
         SetColumn(1, x, y, z, w);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetBasisY(const Vector4& v)
     {
         SetColumn(1, v);
     }
 
-
     AZ_MATH_INLINE Vector4 Matrix4x4::GetBasisZ() const
     {
         return GetColumn(2);
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::GetBasisZAsVector3() const
     {
         return GetColumnAsVector3(2);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetBasisZ(float x, float y, float z, float w)
     {
         SetColumn(2, x, y, z, w);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetBasisZ(const Vector4& v)
     {
         SetColumn(2, v);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::GetBasisAndTranslation(Vector4* basisX, Vector4* basisY, Vector4* basisZ, Vector4* pos) const
     {
         GetColumns(basisX, basisY, basisZ, pos);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetBasisAndTranslation(const Vector4& basisX, const Vector4& basisY, const Vector4& basisZ, const Vector4& pos)
     {
         SetColumns(basisX, basisY, basisZ, pos);
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::GetTranslation() const
     {
         return GetColumnAsVector3(3);
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::SetTranslation(float x, float y, float z)
     {
         SetTranslation(Vector3(x, y, z));
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::SetTranslation(const Vector3& v)
     {
         SetColumn(3, v);
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::operator+(const Matrix4x4& rhs) const
     {
@@ -489,7 +420,6 @@ namespace AZ
         *this = *this + rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::operator-(const Matrix4x4& rhs) const
     {
@@ -515,13 +445,11 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Matrix4x4& Matrix4x4::operator*=(const Matrix4x4& rhs)
     {
         *this = *this * rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::operator*(float multiplier) const
     {
@@ -535,13 +463,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix4x4& Matrix4x4::operator*=(float multiplier)
     {
         *this = *this * multiplier;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::operator/(float divisor) const
     {
@@ -555,13 +481,11 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Matrix4x4& Matrix4x4::operator/=(float divisor)
     {
         *this = *this / divisor;
         return *this;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::operator-() const
     {
@@ -575,18 +499,15 @@ namespace AZ
         );
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::operator*(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec4::Mat4x4TransformPoint3(GetSimdValues(), rhs.GetSimdValue()));
     }
 
-
     AZ_MATH_INLINE Vector4 Matrix4x4::operator*(const Vector4& rhs) const
     {
         return Vector4(Simd::Vec4::Mat4x4TransformVector(GetSimdValues(), rhs.GetSimdValue()));
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::TransposedMultiply3x3(const Vector3& v) const
     {
@@ -594,13 +515,11 @@ namespace AZ
         return Vector3(Simd::Vec3::Mat3x3TransposeTransformVector(rows, v.GetSimdValue()));
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::Multiply3x3(const Vector3& v) const
     {
         const Simd::Vec3::FloatType rows[3] = { Simd::Vec4::ToVec3(m_rows[0].GetSimdValue()), Simd::Vec4::ToVec3(m_rows[1].GetSimdValue()), Simd::Vec4::ToVec3(m_rows[2].GetSimdValue()) };
         return Vector3(Simd::Vec3::Mat3x3TransformVector(rows, v.GetSimdValue()));
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::GetTranspose() const
     {
@@ -609,24 +528,20 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::Transpose()
     {
         *this = GetTranspose();
     }
-
 
     AZ_MATH_INLINE void Matrix4x4::InvertFull()
     {
         *this = GetInverseFull();
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::InvertTransform()
     {
         *this = GetInverseTransform();
     }
-
 
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::GetInverseFast() const
     {
@@ -635,24 +550,20 @@ namespace AZ
         return out;
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::InvertFast()
     {
         *this = GetInverseFast();
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::RetrieveScale() const
     {
         return Vector3(GetBasisX().GetLength(), GetBasisY().GetLength(), GetBasisZ().GetLength());
     }
 
-
     AZ_MATH_INLINE Vector3 Matrix4x4::RetrieveScaleSq() const
     {
         return Vector3(GetBasisX().GetLengthSq(), GetBasisY().GetLengthSq(), GetBasisZ().GetLengthSq());
     }
-
 
     AZ_MATH_INLINE Vector3 Matrix4x4::ExtractScale()
     {
@@ -668,7 +579,6 @@ namespace AZ
         return Vector3(lengthX, lengthY, lengthZ);
     }
 
-
     AZ_MATH_INLINE void Matrix4x4::MultiplyByScale(const Vector3& scale)
     {
         const Vector4 scalars = Vector4::CreateFromVector3AndFloat(scale, 1.0f);
@@ -677,14 +587,12 @@ namespace AZ
         m_rows[2] = m_rows[2] * scalars;
     }
 
-
     AZ_MATH_INLINE Matrix4x4 Matrix4x4::GetReciprocalScaled() const
     {
         Matrix4x4 result = *this;
         result.MultiplyByScale(RetrieveScaleSq().GetReciprocal());
         return result;
     }
-
 
     AZ_MATH_INLINE bool Matrix4x4::IsClose(const Matrix4x4& rhs, float tolerance) const
     {
@@ -700,7 +608,6 @@ namespace AZ
         return true;
     }
 
-
     AZ_MATH_INLINE bool Matrix4x4::operator==(const Matrix4x4& rhs) const
     {
         return (Simd::Vec4::CmpAllEq(m_rows[0].GetSimdValue(), rhs.m_rows[0].GetSimdValue())
@@ -709,36 +616,30 @@ namespace AZ
              && Simd::Vec4::CmpAllEq(m_rows[3].GetSimdValue(), rhs.m_rows[3].GetSimdValue()));
     }
 
-
     AZ_MATH_INLINE bool Matrix4x4::operator!=(const Matrix4x4& rhs) const
     {
         return !operator==(rhs);
     }
-
 
     AZ_MATH_INLINE Vector4 Matrix4x4::GetDiagonal() const
     {
         return Vector4(GetElement(0, 0), GetElement(1, 1), GetElement(2, 2), GetElement(3, 3));
     }
 
-
     AZ_MATH_INLINE bool Matrix4x4::IsFinite() const
     {
         return GetRow(0).IsFinite() && GetRow(1).IsFinite() && GetRow(2).IsFinite() && GetRow(3).IsFinite();
     }
-
 
     AZ_MATH_INLINE const Simd::Vec4::FloatType* Matrix4x4::GetSimdValues() const
     {
         return reinterpret_cast<const Simd::Vec4::FloatType*>(m_rows);
     }
 
-
     AZ_MATH_INLINE Simd::Vec4::FloatType* Matrix4x4::GetSimdValues()
     {
         return reinterpret_cast<Simd::Vec4::FloatType*>(m_rows);
     }
-
 
     AZ_MATH_INLINE const Vector3 operator*(const Vector3& lhs, const Matrix4x4& rhs)
     {
@@ -747,13 +648,11 @@ namespace AZ
                        lhs(0) * rhs(0, 2) + lhs(1) * rhs(1, 2) + lhs(2) * rhs(2, 2) + rhs(3, 2));
     }
 
-
     AZ_MATH_INLINE Vector3& operator*=(Vector3& lhs, const Matrix4x4& rhs)
     {
         lhs = lhs * rhs;
         return lhs;
     }
-
 
     AZ_MATH_INLINE const Vector4 operator*(const Vector4& lhs, const Matrix4x4& rhs)
     {
@@ -763,13 +662,11 @@ namespace AZ
                        lhs(0) * rhs(0, 3) + lhs(1) * rhs(1, 3) + lhs(2) * rhs(2, 3) + lhs(3) * rhs(3, 3));
     }
 
-
     AZ_MATH_INLINE Vector4& operator*=(Vector4& lhs, const Matrix4x4& rhs)
     {
         lhs = lhs * rhs;
         return lhs;
     }
-
 
     AZ_MATH_INLINE Matrix4x4 operator*(float lhs, const Matrix4x4& rhs)
     {

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/MatrixMxN.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/MathScriptHelpers.h>
+
+namespace AZ
+{
+    void MatrixMxN::Reflect([[maybe_unused]] ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<MatrixMxN>()
+                ->Version(1)
+                ->Field("RowCount", &MatrixMxN::m_rowCount)
+                ->Field("ColCount", &MatrixMxN::m_colCount)
+                ->Field("RowGroups", &MatrixMxN::m_numRowGroups)
+                ->Field("ColGroups", &MatrixMxN::m_numColGroups)
+                ->Field("Values", &MatrixMxN::m_values)
+                ;
+
+            if (EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<MatrixMxN>("N-Dimensional Vector", "")
+                    ->ClassElement(Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        Edit::UIHandlers::Default, &MatrixMxN::m_rowCount, "Total Rows", "The total number of rows in the matrix")
+                    ->DataElement(
+                        Edit::UIHandlers::Default, &MatrixMxN::m_colCount, "Total Columns", "The total number of columns in the matrix")
+                    ->DataElement(
+                        Edit::UIHandlers::Default, &MatrixMxN::m_values, "Array of values", "The array of values in the matrix")
+                    ;
+            }
+        }
+
+        auto behaviorContext = azrtti_cast<BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->Class<MatrixMxN>()->
+                Attribute(Script::Attributes::Scope, Script::Attributes::ScopeFlags::Common)->
+                Attribute(Script::Attributes::Module, "math")->
+                Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::ListOnly)->
+                Constructor<AZStd::size_t, AZStd::size_t>()->
+                Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)
+                ;
+        }
+    }
+}

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
@@ -31,10 +31,10 @@ namespace AZ
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->DataElement(
                         Edit::UIHandlers::Default, &MatrixMxN::m_rowCount, "Total Rows", "The total number of rows in the matrix")
+                        ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
                     ->DataElement(
                         Edit::UIHandlers::Default, &MatrixMxN::m_colCount, "Total Columns", "The total number of columns in the matrix")
-                    ->DataElement(
-                        Edit::UIHandlers::Default, &MatrixMxN::m_values, "Array of values", "The array of values in the matrix")
+                        ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
@@ -127,10 +127,10 @@ namespace AZ
         // Within each of those submatrices, the elements are laid out in column major ordering
         // This allows us to perform vector-matrix multiplication in a highly efficient manner
         // The final result means the values of the larger matrix are actually laid out in a tiled manner in memory
-        const AZStd::size_t m_rowCount = 0;
-        const AZStd::size_t m_colCount = 0;
-        const AZStd::size_t m_numRowGroups = 0; // (RowCount + 3) / 4
-        const AZStd::size_t m_numColGroups = 0; // (ColCount + 3) / 4
+        AZStd::size_t m_rowCount = 0;
+        AZStd::size_t m_colCount = 0;
+        AZStd::size_t m_numRowGroups = 0; // (RowCount + 3) / 4
+        AZStd::size_t m_numColGroups = 0; // (ColCount + 3) / 4
         AZStd::vector<Matrix4x4> m_values;
     };
 

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
@@ -57,6 +57,9 @@ namespace AZ
         //! Returns the number of columns in the matrix.
         AZStd::size_t GetColumnCount() const;
 
+        //! Resizes the matrix to the provided row and column count.
+        void Resize(AZStd::size_t rowCount, AZStd::size_t colCount);
+
         //! Indexed accessor functions.
         //! @{
         float GetElement(AZStd::size_t row, AZStd::size_t col) const;
@@ -90,7 +93,6 @@ namespace AZ
         MatrixMxN GetSquare() const;
 
         //! These operators perform basic arithmetic on the individual elements within the respective matrices.
-        //! These are intentionally not written as operators since they work on individual elements.
         //! @{
         MatrixMxN& operator+=(const MatrixMxN& rhs);
         MatrixMxN& operator-=(const MatrixMxN& rhs);
@@ -120,6 +122,9 @@ namespace AZ
 
         //! Zeros out unused components of any submatrices
         void FixUnusedElements();
+
+        //! Updates the matrix internals to reflect the current row and column counts.
+        void OnSizeChanged();
 
         // Note that we compose the larger matrix out of a set of smaller 4x4 submatrices (blocked matrix)
         // Those blocks of 4x4 submatrices are arranged in a column-priority layout

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/VectorN.h>
+#include <AzCore/Math/Matrix4x4.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    //! Matrix with ROW_COUNT rows and COL_COUNT columns.
+    class MatrixMxN final
+    {
+    public:
+
+        AZ_TYPE_INFO(MatrixMxN, "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}");
+
+        //! AzCore Reflection.
+        //! @param context reflection context
+        static void Reflect(ReflectContext* context);
+
+        //! Default constructor for reflection and serialization support.
+        MatrixMxN() = default;
+
+        //! Default constructor does not initialize the matrix.
+        MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount);
+
+        //! Constructs a matrix with all components set to the specified value.
+        MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount, float value);
+
+        MatrixMxN(const MatrixMxN& rhs) = default;
+
+        MatrixMxN(MatrixMxN&& rhs);
+
+        ~MatrixMxN() = default;
+
+        //! Creates an M by N matrix with all elements set to zero.
+        static MatrixMxN CreateZero(AZStd::size_t rowCount, AZStd::size_t colCount);
+
+        //! Creates an M by N matrix and loads the initial values from the packed float array.
+        //! This assumes no padding of input elements to satisfy the 4x4 blocked matrix structure.
+        static MatrixMxN CreateFromPackedFloats(AZStd::size_t rowCount, AZStd::size_t colCount, const float* inputs);
+
+        //! Creates an M by N matrix with all elements set to random numbers in the range [0, 1).
+        static MatrixMxN CreateRandom(AZStd::size_t rowCount, AZStd::size_t colCount);
+
+        //! Returns the number of rows in the matrix.
+        AZStd::size_t GetRowCount() const;
+
+        //! Returns the number of columns in the matrix.
+        AZStd::size_t GetColumnCount() const;
+
+        //! Indexed accessor functions.
+        //! @{
+        float GetElement(AZStd::size_t row, AZStd::size_t col) const;
+        void SetElement(AZStd::size_t row, AZStd::size_t col, float value);
+        //! @}
+
+        //! Indexed access using operator().
+        float operator()(AZStd::size_t row, AZStd::size_t col) const;
+
+        //! Returns the transpose of the matrix.
+        MatrixMxN GetTranspose() const;
+
+        //! Floor/Ceil/Round functions, operate on each component individually, result will be a new MatrixMxN.
+        //! @{
+        MatrixMxN GetFloor() const;
+        MatrixMxN GetCeil() const;
+        MatrixMxN GetRound() const; // Ties to even (banker's rounding)
+        //! @}
+
+        //! Min/Max functions, operate on each component individually, result will be a new MatrixMxN.
+        //! @{
+        MatrixMxN GetMin(const MatrixMxN& m) const;
+        MatrixMxN GetMax(const MatrixMxN& m) const;
+        MatrixMxN GetClamp(const MatrixMxN& min, const MatrixMxN& max) const;
+        //! @}
+
+        //! Returns a new VectorN containing the absolute value of all elements in the source MatrixMxN.
+        MatrixMxN GetAbs() const;
+
+        //! Returns a new VectorN containing the square of all elements in the source MatrixMxN.
+        MatrixMxN GetSquare() const;
+
+        //! These operators perform basic arithmetic on the individual elements within the respective matrices.
+        //! These are intentionally not written as operators since they work on individual elements.
+        //! @{
+        MatrixMxN& operator+=(const MatrixMxN& rhs);
+        MatrixMxN& operator-=(const MatrixMxN& rhs);
+        MatrixMxN& operator*=(const MatrixMxN& rhs); //! Hadamard product, not matrix multiplication.
+        MatrixMxN& operator/=(const MatrixMxN& rhs);
+
+        MatrixMxN& operator+=(float sum);
+        MatrixMxN& operator-=(float difference);
+        MatrixMxN& operator*=(float multiplier);
+        MatrixMxN& operator/=(float divisor);
+        //! @}
+
+        //! Returns the number blocks of 4x4 submatrices that span all the rows of the matrix.
+        AZStd::size_t GetRowGroups() const;
+
+        //! Returns the number blocks of 4x4 submatrices that span all the columns of the matrix.
+        AZStd::size_t GetColumnGroups() const;
+
+        //! Gets and sets individual 4x4 submatrices within the larger matrix.
+        //! @{
+        const Matrix4x4& GetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup) const;
+        Matrix4x4& GetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup);
+        void SetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup, const Matrix4x4& subMatrix);
+        //! @}
+
+    private:
+
+        //! Zeros out unused components of any submatrices
+        void FixUnusedElements();
+
+        // Note that we compose the larger matrix out of a set of smaller 4x4 submatrices (blocked matrix)
+        // Those blocks of 4x4 submatrices are arranged in a column-priority layout
+        // This is done so we can efficiently perform operations like transpose, vector, and matrix multiplication entirely in simd
+        // Within each of those submatrices, the elements are laid out in column major ordering
+        // This allows us to perform vector-matrix multiplication in a highly efficient manner
+        // The final result means the values of the larger matrix are actually laid out in a tiled manner in memory
+        const AZStd::size_t m_rowCount = 0;
+        const AZStd::size_t m_colCount = 0;
+        const AZStd::size_t m_numRowGroups = 0; // (RowCount + 3) / 4
+        const AZStd::size_t m_numColGroups = 0; // (ColCount + 3) / 4
+        AZStd::vector<Matrix4x4> m_values;
+    };
+
+    //! Multiplies the input vector of dimensionality RowCount, with the current matrix and stores the result in the provided output vector of dimensionality ColCount.
+    void VectorMatrixMultiply(const MatrixMxN& matrix, const VectorN& vector, VectorN& output);
+
+    //! Multiplies the two input matrices to produce the output matrix.
+    //! The column count of the right-hand side matrix must match the row count of the left-hand side matrix
+    //! The output matrix must have dimensionality rhs.rowCount x lhs.colCount
+    void MatrixMatrixMultiply(const MatrixMxN& lhs, const MatrixMxN& rhs, MatrixMxN& output);
+}
+
+#include <AzCore/Math/MatrixMxN.inl>

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+namespace AZ
+{
+    AZ_MATH_INLINE MatrixMxN::MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount)
+        : m_rowCount(rowCount)
+        , m_colCount(colCount)
+        , m_numRowGroups((rowCount + 3) / 4)
+        , m_numColGroups((colCount + 3) / 4)
+    {
+        m_values.resize(m_numColGroups * m_numRowGroups);
+    }
+
+    AZ_MATH_INLINE MatrixMxN::MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount, float value)
+        : MatrixMxN(rowCount, colCount)
+    {
+        Simd::Vec4::FloatType splatValue = Simd::Vec4::Splat(value);
+        for (Matrix4x4& element : m_values)
+        {
+            Simd::Vec4::FloatType* elements = element.GetSimdValues();
+            elements[0] = splatValue;
+            elements[1] = splatValue;
+            elements[2] = splatValue;
+            elements[3] = splatValue;
+        }
+        FixUnusedElements();
+    }
+
+    AZ_MATH_INLINE MatrixMxN::MatrixMxN(MatrixMxN&& rhs)
+        : m_rowCount(rhs.m_rowCount)
+        , m_colCount(rhs.m_colCount)
+        , m_numRowGroups(rhs.m_numRowGroups)
+        , m_numColGroups(rhs.m_numColGroups)
+        , m_values(AZStd::move(rhs.m_values))
+    {
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::CreateZero(AZStd::size_t rowCount, AZStd::size_t colCount)
+    {
+        MatrixMxN returnValue(rowCount, colCount);
+        for (Matrix4x4& element : returnValue.m_values)
+        {
+            Simd::Vec4::FloatType* elements = element.GetSimdValues();
+            elements[0] = Simd::Vec4::ZeroFloat();
+            elements[1] = Simd::Vec4::ZeroFloat();
+            elements[2] = Simd::Vec4::ZeroFloat();
+            elements[3] = Simd::Vec4::ZeroFloat();
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::CreateFromPackedFloats(AZStd::size_t rowCount, AZStd::size_t colCount, const float* inputs)
+    {
+        MatrixMxN returnValue(rowCount, colCount);
+        for (AZStd::size_t rowIter = 0; rowIter < rowCount; ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < colCount; ++colIter)
+            {
+                returnValue.SetElement(rowIter, colIter, *inputs);
+                ++inputs;
+            }
+        }
+        returnValue.FixUnusedElements();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::CreateRandom(AZStd::size_t rowCount, AZStd::size_t colCount)
+    {
+        SimpleLcgRandomVec4 randGen;
+        MatrixMxN returnValue(rowCount, colCount);
+        for (Matrix4x4& element : returnValue.m_values)
+        {
+            Simd::Vec4::FloatType* elements = element.GetSimdValues();
+            elements[0] = randGen.GetRandomFloat();
+            elements[1] = randGen.GetRandomFloat();
+            elements[2] = randGen.GetRandomFloat();
+            elements[3] = randGen.GetRandomFloat();
+        }
+        returnValue.FixUnusedElements();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE AZStd::size_t MatrixMxN::GetRowCount() const
+    {
+        return m_rowCount;
+    }
+
+    AZ_MATH_INLINE AZStd::size_t MatrixMxN::GetColumnCount() const
+    {
+        return m_colCount;
+    }
+
+    AZ_MATH_INLINE float MatrixMxN::GetElement(AZStd::size_t row, AZStd::size_t col) const
+    {
+        AZ_Assert(row < m_rowCount, "Out of bounds element requested");
+        AZ_Assert(col < m_colCount, "Out of bounds element requested");
+        // Note that we compose the larger matrix out of a set of smaller 4x4 submatrices
+        // Those submatrices are laid out in column major ordering
+        // Additionally, we store the elements within each 4x4 submatrix in column major ordering
+        const AZStd::size_t rowLookup = row >> 2; // Compute which matrix holds the value we want
+        const AZStd::size_t colLookup = col >> 2; // Compute which matrix holds the value we want
+        const Matrix4x4& matrixElement = GetSubmatrix(rowLookup, colLookup); // Retrieve the specific submatrix holding our value
+        return matrixElement.GetElement(col & 0x3, row & 0x3); // Retrieve the specific element within the 4x4 submatrix
+    }
+
+    AZ_MATH_INLINE void MatrixMxN::SetElement(AZStd::size_t row, AZStd::size_t col, float value)
+    {
+        AZ_Assert(row < m_rowCount, "Out of bounds element requested");
+        AZ_Assert(col < m_colCount, "Out of bounds element requested");
+        // Note that we compose the larger matrix out of a set of smaller 4x4 submatrices
+        // Those submatrices are laid out in column major ordering
+        // Additionally, we store the elements within each 4x4 submatrix in column major ordering
+        const AZStd::size_t rowLookup = row >> 2; // Compute which matrix holds the value we want
+        const AZStd::size_t colLookup = col >> 2; // Compute which matrix holds the value we want
+        Matrix4x4& matrixElement = GetSubmatrix(rowLookup, colLookup); // Retrieve the specific submatrix holding our value
+        matrixElement.SetElement(col & 0x3, row & 0x3, value); // Set the specific element within the 4x4 submatrix
+    }
+
+    AZ_MATH_INLINE float MatrixMxN::operator()(AZStd::size_t row, AZStd::size_t col) const
+    {
+        return GetElement(row, col);
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetTranspose() const
+    {
+        // Returns the transpose of this matrix
+        // This is a bit tricky, and so deserves a comment
+        // We're transposing the elements inside each 4x4 submatrix, while at the same time transposing the submatrices themselves
+        // Subdividing like this allows us to take full advantage of the simd units to perform the transpose
+        MatrixMxN returnValue(m_colCount, m_rowCount);
+        for (AZStd::size_t colIter = 0; colIter < m_numColGroups; ++colIter)
+        {
+            for (AZStd::size_t rowIter = 0; rowIter < m_numRowGroups; ++rowIter)
+            {
+                returnValue.SetSubmatrix(colIter, rowIter, GetSubmatrix(rowIter, colIter).GetTranspose());
+            }
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetFloor() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetFloor());
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetFloor());
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetFloor());
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetFloor());
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetCeil() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetCeil());
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetCeil());
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetCeil());
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetCeil());
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetRound() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetRound());
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetRound());
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetRound());
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetRound());
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetMin(const MatrixMxN& m) const
+    {
+        AZ_Assert(m_rowCount == m.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == m.m_colCount, "Dimensionality must be equal");
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetMin(m.m_values[i].GetRow(0)));
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetMin(m.m_values[i].GetRow(1)));
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetMin(m.m_values[i].GetRow(2)));
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetMin(m.m_values[i].GetRow(3)));
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetMax(const MatrixMxN& m) const
+    {
+        AZ_Assert(m_rowCount == m.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == m.m_colCount, "Dimensionality must be equal");
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetMax(m.m_values[i].GetRow(0)));
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetMax(m.m_values[i].GetRow(1)));
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetMax(m.m_values[i].GetRow(2)));
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetMax(m.m_values[i].GetRow(3)));
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetClamp(const MatrixMxN& min, const MatrixMxN& max) const
+    {
+        AZ_Assert(m_rowCount == min.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == min.m_colCount, "Dimensionality must be equal");
+        AZ_Assert(m_rowCount == max.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == max.m_colCount, "Dimensionality must be equal");
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetClamp(min.m_values[i].GetRow(0), max.m_values[i].GetRow(0)));
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetClamp(min.m_values[i].GetRow(1), max.m_values[i].GetRow(1)));
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetClamp(min.m_values[i].GetRow(2), max.m_values[i].GetRow(2)));
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetClamp(min.m_values[i].GetRow(3), max.m_values[i].GetRow(3)));
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetAbs() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0).GetAbs());
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1).GetAbs());
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2).GetAbs());
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3).GetAbs());
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::GetSquare() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i].SetRow(0, m_values[i].GetRow(0) * m_values[i].GetRow(0));
+            returnValue.m_values[i].SetRow(1, m_values[i].GetRow(1) * m_values[i].GetRow(1));
+            returnValue.m_values[i].SetRow(2, m_values[i].GetRow(2) * m_values[i].GetRow(2));
+            returnValue.m_values[i].SetRow(3, m_values[i].GetRow(3) * m_values[i].GetRow(3));
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator+=(const MatrixMxN& rhs)
+    {
+        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] += rhs.m_values[i];
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator-=(const MatrixMxN& rhs)
+    {
+        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] -= rhs.m_values[i];
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator*=(const MatrixMxN& rhs)
+    {
+        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i].SetRow(0, m_values[i].GetRow(0) * rhs.m_values[i].GetRow(0));
+            m_values[i].SetRow(1, m_values[i].GetRow(1) * rhs.m_values[i].GetRow(1));
+            m_values[i].SetRow(2, m_values[i].GetRow(2) * rhs.m_values[i].GetRow(2));
+            m_values[i].SetRow(3, m_values[i].GetRow(3) * rhs.m_values[i].GetRow(3));
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator/=(const MatrixMxN& rhs)
+    {
+        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
+        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i].SetRow(0, m_values[i].GetRow(0) / rhs.m_values[i].GetRow(0));
+            m_values[i].SetRow(1, m_values[i].GetRow(1) / rhs.m_values[i].GetRow(1));
+            m_values[i].SetRow(2, m_values[i].GetRow(2) / rhs.m_values[i].GetRow(2));
+            m_values[i].SetRow(3, m_values[i].GetRow(3) / rhs.m_values[i].GetRow(3));
+        }
+        FixUnusedElements();
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator+=(float sum)
+    {
+        const AZ::Vector4 sumRow(sum);
+        for (Matrix4x4& element : m_values)
+        {
+            element.SetRow(0,element.GetRow(0) + sumRow);
+            element.SetRow(1,element.GetRow(1) + sumRow);
+            element.SetRow(2,element.GetRow(2) + sumRow);
+            element.SetRow(3,element.GetRow(3) + sumRow);
+        }
+        FixUnusedElements();
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator-=(float difference)
+    {
+        const AZ::Vector4 diffRow(difference);
+        for (Matrix4x4& element : m_values)
+        {
+            element.SetRow(0, element.GetRow(0) - diffRow);
+            element.SetRow(1, element.GetRow(1) - diffRow);
+            element.SetRow(2, element.GetRow(2) - diffRow);
+            element.SetRow(3, element.GetRow(3) - diffRow);
+        }
+        FixUnusedElements();
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator*=(float multiplier)
+    {
+        for (Matrix4x4& element : m_values)
+        {
+            element *= multiplier;
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator/=(float divisor)
+    {
+        for (Matrix4x4& element : m_values)
+        {
+            element /= divisor;
+        }
+        FixUnusedElements();
+        return *this;
+    }
+
+    AZ_MATH_INLINE AZStd::size_t MatrixMxN::GetRowGroups() const
+    {
+        return m_numRowGroups;
+    }
+
+    AZ_MATH_INLINE AZStd::size_t MatrixMxN::GetColumnGroups() const
+    {
+        return m_numColGroups;
+    }
+
+    AZ_MATH_INLINE const Matrix4x4& MatrixMxN::GetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup) const
+    {
+        AZ_Assert(rowGroup < m_numRowGroups, "Out of range row group requested");
+        AZ_Assert(colGroup < m_numColGroups, "Out of range column group requested");
+        return m_values[rowGroup * m_numColGroups + colGroup];
+    }
+
+    AZ_MATH_INLINE Matrix4x4& MatrixMxN::GetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup)
+    {
+        AZ_Assert(rowGroup < m_numRowGroups, "Out of range row group requested");
+        AZ_Assert(colGroup < m_numColGroups, "Out of range column group requested");
+        return m_values[rowGroup * m_numColGroups + colGroup];
+    }
+
+    AZ_MATH_INLINE void MatrixMxN::SetSubmatrix(AZStd::size_t rowGroup, AZStd::size_t colGroup, const Matrix4x4& subMatrix)
+    {
+        AZ_Assert(rowGroup < m_numRowGroups, "Out of range row group requested");
+        AZ_Assert(colGroup < m_numColGroups, "Out of range column group requested");
+        m_values[rowGroup * m_numColGroups + colGroup] = subMatrix;
+    }
+
+    AZ_MATH_INLINE void MatrixMxN::FixUnusedElements()
+    {
+        const AZStd::size_t lastRowGroup = m_numRowGroups - 1;
+        const AZStd::size_t lastColGroup = m_numColGroups - 1;
+        const Simd::Vec4::FloatType zero = Simd::Vec4::ZeroFloat();
+        const uint32_t masks[] =
+        {
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000
+        };
+
+        // Fix last row values
+        {
+            const AZStd::size_t trailingZeroElements = 4 * (m_rowCount % 4);
+            const Simd::Vec4::FloatType mask = Simd::Vec4::LoadAligned(reinterpret_cast<const float*>(&masks[trailingZeroElements]));
+
+            for (AZStd::size_t colIter = 0; colIter < GetColumnGroups(); ++colIter)
+            {
+                Matrix4x4& lastBlock = GetSubmatrix(lastRowGroup, colIter);
+                Simd::Vec4::FloatType* lastBlockElements = lastBlock.GetSimdValues();
+                lastBlockElements[0] = Simd::Vec4::And(lastBlockElements[0], mask);
+                lastBlockElements[1] = Simd::Vec4::And(lastBlockElements[1], mask);
+                lastBlockElements[2] = Simd::Vec4::And(lastBlockElements[2], mask);
+                lastBlockElements[3] = Simd::Vec4::And(lastBlockElements[3], mask);
+            }
+        }
+
+        // Fix last column values
+        {
+            for (AZStd::size_t rowIter = 0; rowIter < GetRowGroups(); ++rowIter)
+            {
+                Matrix4x4& lastBlock = GetSubmatrix(rowIter, lastColGroup);
+                Simd::Vec4::FloatType* lastBlockElements = lastBlock.GetSimdValues();
+                // Fallthrough is intentional
+                switch (m_colCount % 4)
+                {
+                case 1:
+                    lastBlockElements[1] = zero;
+                case 2:
+                    lastBlockElements[2] = zero;
+                case 3:
+                    lastBlockElements[3] = zero;
+                case 0:
+                    break;
+                }
+            }
+        }
+    }
+
+    AZ_MATH_INLINE void VectorMatrixMultiply(const MatrixMxN& matrix, const VectorN& vector, VectorN& output)
+    {
+        // Because we've stored our matrix in column major ordering, we can perform a vector matrix product using only multiply-accumulate
+        // There is no requirement for horizontal sums
+        // Note we don't clear the output vector prior to starting the madd loops, this means the original value of output is included in the final accumulation
+        // This works out extremely well for having bias vectors, since if we initialize output to the bias, we include the bias in the final result for free
+        AZ_Assert(matrix.GetRowCount() == output.GetDimensionality(), "Output vector dimensionality must match matrix row count");
+        AZ_Assert(matrix.GetColumnCount() == vector.GetDimensionality(), "Input vector dimensionality must match matrix column count");
+        for (AZStd::size_t colIter = 0; colIter < matrix.GetColumnGroups(); ++colIter)
+        {
+            Simd::Vec4::FloatType vectorElement = vector.GetVectorValues()[colIter].GetSimdValue();
+            Simd::Vec4::FloatType splat0 = Simd::Vec4::SplatFirst (vectorElement);
+            Simd::Vec4::FloatType splat1 = Simd::Vec4::SplatSecond(vectorElement);
+            Simd::Vec4::FloatType splat2 = Simd::Vec4::SplatThird (vectorElement);
+            Simd::Vec4::FloatType splat3 = Simd::Vec4::SplatFourth(vectorElement);
+            for (AZStd::size_t rowIter = 0; rowIter < matrix.GetRowGroups(); ++rowIter)
+            {
+                Vector4& outputElement = output.GetVectorValues()[rowIter];
+                // Our 4x4 matrices are laid out in column priority ordering, so that we can re-use the same splat vectors without recalculating them
+                // Additionally, the values within each 4x4 matrix are also laid out with column ordering so we can avoid any horizontal accumulations
+                // Hence, fetching a row from a 4x4 submatrix is actually retrieving a subset of column values from the larger matrix
+                const Matrix4x4& matrixElement = matrix.GetSubmatrix(rowIter, colIter);
+                outputElement.SetSimdValue(Simd::Vec4::Madd(splat0, matrixElement.GetRow(0).GetSimdValue(), outputElement.GetSimdValue()));
+                outputElement.SetSimdValue(Simd::Vec4::Madd(splat1, matrixElement.GetRow(1).GetSimdValue(), outputElement.GetSimdValue()));
+                outputElement.SetSimdValue(Simd::Vec4::Madd(splat2, matrixElement.GetRow(2).GetSimdValue(), outputElement.GetSimdValue()));
+                outputElement.SetSimdValue(Simd::Vec4::Madd(splat3, matrixElement.GetRow(3).GetSimdValue(), outputElement.GetSimdValue()));
+            }
+        }
+        output.FixLastVectorElement();
+    }
+
+    AZ_MATH_INLINE void MatrixMatrixMultiply(const MatrixMxN& lhs, const MatrixMxN& rhs, MatrixMxN& output)
+    {
+        AZ_Assert(lhs.GetColumnCount() == rhs.GetRowCount(), "Left-hand side column count must match right-hand side row count");
+        AZ_Assert(lhs.GetRowCount() == output.GetRowCount(), "Left-hand side row count must match the output matrix row count");
+        AZ_Assert(rhs.GetColumnCount() == output.GetColumnCount(), "Right-hand side column count must match the output matrix column count");
+        for (AZStd::size_t rowIter = 0; rowIter < lhs.GetRowGroups(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < rhs.GetColumnGroups(); ++colIter)
+            {
+                Matrix4x4& outputElement = output.GetSubmatrix(rowIter, colIter);
+                outputElement = Matrix4x4::CreateZero();
+                for (AZStd::size_t subIter = 0; subIter < lhs.GetColumnGroups(); ++subIter)
+                {
+                    const Matrix4x4& lhsElement = lhs.GetSubmatrix(rowIter, subIter);
+                    const Matrix4x4& rhsElement = rhs.GetSubmatrix(subIter, colIter);
+                    // The submatrices are in column-major orientation, however Mat4x4Multiply expects row-major orientation
+                    // For this reason, we swap the order of operands to produce the correct calcuations
+                    Simd::Vec4::Mat4x4MultiplyAdd(rhsElement.GetSimdValues(), lhsElement.GetSimdValues(), outputElement.GetSimdValues());
+                }
+            }
+        }
+    }
+}

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -11,10 +11,8 @@ namespace AZ
     AZ_MATH_INLINE MatrixMxN::MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount)
         : m_rowCount(rowCount)
         , m_colCount(colCount)
-        , m_numRowGroups((rowCount + 3) / 4)
-        , m_numColGroups((colCount + 3) / 4)
     {
-        m_values.resize(m_numColGroups * m_numRowGroups);
+        OnSizeChanged();
     }
 
     AZ_MATH_INLINE MatrixMxN::MatrixMxN(AZStd::size_t rowCount, AZStd::size_t colCount, float value)
@@ -77,10 +75,10 @@ namespace AZ
         for (Matrix4x4& element : returnValue.m_values)
         {
             Simd::Vec4::FloatType* elements = element.GetSimdValues();
-            elements[0] = randGen.GetRandomFloat();
-            elements[1] = randGen.GetRandomFloat();
-            elements[2] = randGen.GetRandomFloat();
-            elements[3] = randGen.GetRandomFloat();
+            elements[0] = randGen.GetRandomFloat4();
+            elements[1] = randGen.GetRandomFloat4();
+            elements[2] = randGen.GetRandomFloat4();
+            elements[3] = randGen.GetRandomFloat4();
         }
         returnValue.FixUnusedElements();
         return returnValue;
@@ -94,6 +92,13 @@ namespace AZ
     AZ_MATH_INLINE AZStd::size_t MatrixMxN::GetColumnCount() const
     {
         return m_colCount;
+    }
+
+    AZ_MATH_INLINE void MatrixMxN::Resize(AZStd::size_t rowCount, AZStd::size_t colCount)
+    {
+        m_rowCount = rowCount;
+        m_colCount = colCount;
+        OnSizeChanged();
     }
 
     AZ_MATH_INLINE float MatrixMxN::GetElement(AZStd::size_t row, AZStd::size_t col) const
@@ -484,9 +489,17 @@ namespace AZ
                     const Matrix4x4& rhsElement = rhs.GetSubmatrix(subIter, colIter);
                     // The submatrices are in column-major orientation, however Mat4x4Multiply expects row-major orientation
                     // For this reason, we swap the order of operands to produce the correct calcuations
-                    Simd::Vec4::Mat4x4MultiplyAdd(rhsElement.GetSimdValues(), lhsElement.GetSimdValues(), outputElement.GetSimdValues());
+                    Simd::Vec4::Mat4x4MultiplyAdd(rhsElement.GetSimdValues(), lhsElement.GetSimdValues(), outputElement.GetSimdValues(), outputElement.GetSimdValues());
                 }
             }
         }
+    }
+
+    AZ_MATH_INLINE void MatrixMxN::OnSizeChanged()
+    {
+        m_numRowGroups = (m_rowCount + 3) / 4;
+        m_numColGroups = (m_colCount + 3) / 4;
+        m_values.resize(m_numColGroups * m_numRowGroups);
+        FixUnusedElements();
     }
 }

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -447,10 +447,10 @@ namespace AZ
         for (AZStd::size_t colIter = 0; colIter < matrix.GetColumnGroups(); ++colIter)
         {
             Simd::Vec4::FloatType vectorElement = vector.GetVectorValues()[colIter].GetSimdValue();
-            Simd::Vec4::FloatType splat0 = Simd::Vec4::SplatFirst (vectorElement);
-            Simd::Vec4::FloatType splat1 = Simd::Vec4::SplatSecond(vectorElement);
-            Simd::Vec4::FloatType splat2 = Simd::Vec4::SplatThird (vectorElement);
-            Simd::Vec4::FloatType splat3 = Simd::Vec4::SplatFourth(vectorElement);
+            Simd::Vec4::FloatType splat0 = Simd::Vec4::SplatIndex0(vectorElement);
+            Simd::Vec4::FloatType splat1 = Simd::Vec4::SplatIndex1(vectorElement);
+            Simd::Vec4::FloatType splat2 = Simd::Vec4::SplatIndex2(vectorElement);
+            Simd::Vec4::FloatType splat3 = Simd::Vec4::SplatIndex3(vectorElement);
             for (AZStd::size_t rowIter = 0; rowIter < matrix.GetRowGroups(); ++rowIter)
             {
                 Vector4& outputElement = output.GetVectorValues()[rowIter];

--- a/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixUtils.cpp
@@ -128,7 +128,7 @@ namespace AZ
     Vector3 MatrixTransformPosition(const Matrix4x4& matrix, const Vector3& inPosition)
     {
         Vector4 result;
-        result = matrix * Vector4(Simd::Vec4::ReplaceFourth(Simd::Vec4::FromVec3(inPosition.GetSimdValue()), 1.0f));
+        result = matrix * Vector4(Simd::Vec4::ReplaceIndex3(Simd::Vec4::FromVec3(inPosition.GetSimdValue()), 1.0f));
         AZ_Assert(!IsClose(result.GetW(), 0, FloatEpsilon), "w is too close to 0.f");
         return result.GetHomogenized();
     }

--- a/Code/Framework/AzCore/AzCore/Math/Plane.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Plane.inl
@@ -131,7 +131,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Plane::GetPointDist(const Vector3& pos) const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec4::PlaneDistance(m_plane.GetSimdValue(), pos.GetSimdValue()));
+        return Simd::Vec1::SelectIndex0(Simd::Vec4::PlaneDistance(m_plane.GetSimdValue(), pos.GetSimdValue()));
     }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -371,9 +371,9 @@ namespace AZ
             const Simd::Vec3::FloatType angles = Simd::Vec3::LoadImmediate(omega, (1.0f - t) * omega, t * omega);
             const Simd::Vec3::FloatType sin = Simd::Vec3::Sin(angles);
 
-            const float sinom = 1.0f / Simd::Vec3::SelectFirst(sin);
-            sclA = Simd::Vec3::SelectSecond(sin) * sinom;
-            sclB = Simd::Vec3::SelectThird(sin) * sinom;
+            const float sinom = 1.0f / Simd::Vec3::SelectIndex0(sin);
+            sclA = Simd::Vec3::SelectIndex1(sin) * sinom;
+            sclB = Simd::Vec3::SelectIndex2(sin) * sinom;
         }
         else
         {
@@ -398,12 +398,12 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sx = Simd::Vec3::SelectFirst(sin);
-        const float sy = Simd::Vec3::SelectSecond(sin);
-        const float sz = Simd::Vec3::SelectThird(sin);
-        const float cx = Simd::Vec3::SelectFirst(cos);
-        const float cy = Simd::Vec3::SelectSecond(cos);
-        const float cz = Simd::Vec3::SelectThird(cos);
+        const float sx = Simd::Vec3::SelectIndex0(sin);
+        const float sy = Simd::Vec3::SelectIndex1(sin);
+        const float sz = Simd::Vec3::SelectIndex2(sin);
+        const float cx = Simd::Vec3::SelectIndex0(cos);
+        const float cy = Simd::Vec3::SelectIndex1(cos);
+        const float cz = Simd::Vec3::SelectIndex2(cos);
 
         // rot = rotx * roty * rotz
         const float w = cx * cy * cz - sx * sy * sz;
@@ -421,12 +421,12 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sx = Simd::Vec3::SelectFirst(sin);
-        const float cx = Simd::Vec3::SelectFirst(cos);
-        const float sy = Simd::Vec3::SelectSecond(sin);
-        const float cy = Simd::Vec3::SelectSecond(cos);    
-        const float sz = Simd::Vec3::SelectThird(sin);
-        const float cz = Simd::Vec3::SelectThird(cos);
+        const float sx = Simd::Vec3::SelectIndex0(sin);
+        const float cx = Simd::Vec3::SelectIndex0(cos);
+        const float sy = Simd::Vec3::SelectIndex1(sin);
+        const float cy = Simd::Vec3::SelectIndex1(cos);    
+        const float sz = Simd::Vec3::SelectIndex2(sin);
+        const float cz = Simd::Vec3::SelectIndex2(cos);
 
         // rot = rotx * roty * rotz
         return AZ::Quaternion(
@@ -444,12 +444,12 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sx = Simd::Vec3::SelectFirst(sin);
-        const float cx = Simd::Vec3::SelectFirst(cos);
-        const float sy = Simd::Vec3::SelectSecond(sin);
-        const float cy = Simd::Vec3::SelectSecond(cos);
-        const float sz = Simd::Vec3::SelectThird(sin);
-        const float cz = Simd::Vec3::SelectThird(cos);
+        const float sx = Simd::Vec3::SelectIndex0(sin);
+        const float cx = Simd::Vec3::SelectIndex0(cos);
+        const float sy = Simd::Vec3::SelectIndex1(sin);
+        const float cy = Simd::Vec3::SelectIndex1(cos);
+        const float sz = Simd::Vec3::SelectIndex2(sin);
+        const float cz = Simd::Vec3::SelectIndex2(cos);
 
         // rot = roty * rotx * rotz
         return AZ::Quaternion(
@@ -466,12 +466,12 @@ namespace AZ
         Simd::Vec3::FloatType sin, cos;
         Simd::Vec3::SinCos(angles, sin, cos);
 
-        const float sx = Simd::Vec3::SelectFirst(sin);
-        const float cx = Simd::Vec3::SelectFirst(cos);
-        const float sy = Simd::Vec3::SelectSecond(sin);
-        const float cy = Simd::Vec3::SelectSecond(cos);
-        const float sz = Simd::Vec3::SelectThird(sin);
-        const float cz = Simd::Vec3::SelectThird(cos);
+        const float sx = Simd::Vec3::SelectIndex0(sin);
+        const float cx = Simd::Vec3::SelectIndex0(cos);
+        const float sy = Simd::Vec3::SelectIndex1(sin);
+        const float cy = Simd::Vec3::SelectIndex1(cos);
+        const float sz = Simd::Vec3::SelectIndex2(sin);
+        const float cz = Simd::Vec3::SelectIndex2(cos);
         
         // rot = rotz * roty * rotx
         return AZ::Quaternion(

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -431,7 +431,8 @@ namespace AZ
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
         return (fabsf(m_x) <= tolerance) && (fabsf(m_y) <= tolerance) && (fabsf(m_z) <= tolerance) && (fabsf(m_w) <= tolerance);
 #else
-        return IsClose(CreateZero(), tolerance);
+        Simd::Vec4::FloatType absDiff = Simd::Vec4::Abs(m_value);
+        return Simd::Vec4::CmpAllLt(absDiff, Simd::Vec4::Splat(tolerance));
 #endif
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -279,7 +279,7 @@ namespace AZ
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
         return m_x * q.m_x + m_y * q.m_y + m_z * q.m_z + m_w * q.m_w;
 #else
-        return Simd::Vec1::SelectFirst(Simd::Vec4::Dot(m_value, q.m_value));
+        return Simd::Vec1::SelectIndex0(Simd::Vec4::Dot(m_value, q.m_value));
 #endif
     }
 
@@ -293,28 +293,28 @@ namespace AZ
     AZ_MATH_INLINE float Quaternion::GetLength() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sqrt(lengthSq));
     }
 
 
     AZ_MATH_INLINE float Quaternion::GetLengthEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtEstimate(lengthSq));
     }
 
 
     AZ_MATH_INLINE float Quaternion::GetLengthReciprocal() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInv(lengthSq));
     }
 
 
     AZ_MATH_INLINE float Quaternion::GetLengthReciprocalEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInvEstimate(lengthSq));
     }
 
 
@@ -344,7 +344,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Quaternion::NormalizeWithLength()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::Sqrt(Simd::Vec4::Dot(m_value, m_value)));
         m_value = Simd::Vec4::Div(m_value, Simd::Vec4::Splat(length));
         return length;
@@ -353,7 +353,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Quaternion::NormalizeWithLengthEstimate()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::SqrtEstimate(Simd::Vec4::Dot(m_value, m_value)));
         m_value = Simd::Vec4::Div(m_value, Simd::Vec4::Splat(length));
         return length;

--- a/Code/Framework/AzCore/AzCore/Math/Random.h
+++ b/Code/Framework/AzCore/AzCore/Math/Random.h
@@ -84,7 +84,7 @@ namespace AZ
         }
 
         // Gets four random ints in the range [0, 2^31)
-        Simd::Vec4::Int32Type GetRandomInt()
+        Simd::Vec4::Int32Type GetRandomInt4()
         {
             const Simd::Vec4::Int32Type scalar = Simd::Vec4::Splat(1103515245);
             const Simd::Vec4::Int32Type constant = Simd::Vec4::Splat(12345);
@@ -94,9 +94,9 @@ namespace AZ
         }
 
         // Gets four random floats in the range [0,1)
-        Simd::Vec4::FloatType GetRandomFloat()
+        Simd::Vec4::FloatType GetRandomFloat4()
         {
-            Simd::Vec4::Int32Type randVal = GetRandomInt();
+            Simd::Vec4::Int32Type randVal = GetRandomInt4();
             randVal = Simd::Vec4::And(randVal, Simd::Vec4::Splat(0x007fffff)); // Sets mantissa to random bits
             randVal = Simd::Vec4::Or(randVal, Simd::Vec4::Splat(0x3f800000)); // Result is in [1,2), uniformly distributed
             return Simd::Vec4::Sub(Simd::Vec4::CastToFloat(randVal), Simd::Vec4::Splat(1.0f));

--- a/Code/Framework/AzCore/AzCore/Math/Random.h
+++ b/Code/Framework/AzCore/AzCore/Math/Random.h
@@ -11,6 +11,7 @@
 #include <AzCore/base.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/Math/Random_Platform.h>
+#include <AzCore/Math/SimdMath.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/containers/array.h>
 
@@ -63,6 +64,46 @@ namespace AZ
 
     private:
         u64 m_seed;
+    };
+
+    //! This class is a vectorized implementation of LCG, allowing for the generation of 4 random values in parallel
+    class SimpleLcgRandomVec4
+    {
+    public:
+        AZ_TYPE_INFO(SimpleLcgRandomVec4, "{1E24CCC8-A1CC-49FF-AFAB-D87C0104F3B7}")
+
+        SimpleLcgRandomVec4()
+        {
+            SetSeed(Simd::Vec4::LoadImmediate(rand(), rand(), rand(), rand()));
+        }
+
+        void SetSeed(Simd::Vec4::Int32ArgType seed)
+        {
+            const Simd::Vec4::Int32Type mask = Simd::Vec4::Splat(int32_t(0x7FFFFFFF)); // 2^31 - 1
+            m_seed = Simd::Vec4::And(seed, mask);
+        }
+
+        // Gets four random ints in the range [0, 2^31)
+        Simd::Vec4::Int32Type GetRandomInt()
+        {
+            const Simd::Vec4::Int32Type scalar = Simd::Vec4::Splat(1103515245);
+            const Simd::Vec4::Int32Type constant = Simd::Vec4::Splat(12345);
+            const Simd::Vec4::Int32Type mask = Simd::Vec4::Splat(int32_t(0x7FFFFFFF)); // 2^31 - 1
+            m_seed = Simd::Vec4::And(Simd::Vec4::Madd(m_seed, scalar, constant), mask);
+            return m_seed;
+        }
+
+        // Gets four random floats in the range [0,1)
+        Simd::Vec4::FloatType GetRandomFloat()
+        {
+            Simd::Vec4::Int32Type randVal = GetRandomInt();
+            randVal = Simd::Vec4::And(randVal, Simd::Vec4::Splat(0x007fffff)); // Sets mantissa to random bits
+            randVal = Simd::Vec4::Or(randVal, Simd::Vec4::Splat(0x3f800000)); // Result is in [1,2), uniformly distributed
+            return Simd::Vec4::Sub(Simd::Vec4::CastToFloat(randVal), Simd::Vec4::Splat(1.0f));
+        }
+
+    private:
+        Simd::Vec4::Int32Type m_seed;
     };
 
     /**

--- a/Code/Framework/AzCore/AzCore/Math/SimdMath.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMath.h
@@ -55,68 +55,68 @@ namespace AZ
 {
     AZ_MATH_INLINE float Abs(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Abs(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Abs(Simd::Vec1::Splat(value)));
     }
 
     AZ_MATH_INLINE float Mod(float value, float divisor)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Mod(Simd::Vec1::Splat(value), Simd::Vec1::Splat(divisor)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Mod(Simd::Vec1::Splat(value), Simd::Vec1::Splat(divisor)));
     }
 
     AZ_MATH_INLINE float Wrap(float value, float maxValue)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Wrap(Simd::Vec1::Splat(value), Simd::Vec1::ZeroFloat(), Simd::Vec1::Splat(maxValue)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Wrap(Simd::Vec1::Splat(value), Simd::Vec1::ZeroFloat(), Simd::Vec1::Splat(maxValue)));
     }
 
     AZ_MATH_INLINE float Wrap(float value, float minValue, float maxValue)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Wrap(Simd::Vec1::Splat(value), Simd::Vec1::Splat(minValue), Simd::Vec1::Splat(maxValue)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Wrap(Simd::Vec1::Splat(value), Simd::Vec1::Splat(minValue), Simd::Vec1::Splat(maxValue)));
     }
 
     AZ_MATH_INLINE float AngleMod(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::AngleMod(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::AngleMod(Simd::Vec1::Splat(value)));
     }
 
     AZ_MATH_INLINE void SinCos(float angle, float& sin, float& cos)
     {
         const Simd::Vec2::FloatType values = Simd::Vec2::SinCos(Simd::Vec1::Splat(angle));
-        sin = Simd::Vec2::SelectFirst(values);
-        cos = Simd::Vec2::SelectSecond(values);
+        sin = Simd::Vec2::SelectIndex0(values);
+        cos = Simd::Vec2::SelectIndex1(values);
     }
 
     AZ_MATH_INLINE float Sin(float angle)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sin(Simd::Vec1::Splat(angle)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sin(Simd::Vec1::Splat(angle)));
     }
 
     AZ_MATH_INLINE float Cos(float angle)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Cos(Simd::Vec1::Splat(angle)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Cos(Simd::Vec1::Splat(angle)));
     }
 
     AZ_MATH_INLINE float Acos(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Acos(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Acos(Simd::Vec1::Splat(value)));
     }
 
     AZ_MATH_INLINE float Atan(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Atan(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Atan(Simd::Vec1::Splat(value)));
     }
 
     AZ_MATH_INLINE float Atan2(float y, float x)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Atan2(Simd::Vec1::Splat(y), Simd::Vec1::Splat(x)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Atan2(Simd::Vec1::Splat(y), Simd::Vec1::Splat(x)));
     }
 
     AZ_MATH_INLINE float Sqrt(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sqrt(Simd::Vec1::Splat(value)));
     }
 
     AZ_MATH_INLINE float InvSqrt(float value)
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(Simd::Vec1::Splat(value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInv(Simd::Vec1::Splat(value)));
     }
 }

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
@@ -47,7 +47,8 @@ namespace AZ
             static void StreamAligned(float* __restrict addr, FloatArgType value); // addr *must* be 16-byte aligned
             static void StreamAligned(int32_t* __restrict addr, Int32ArgType value); // addr *must* be 16-byte aligned
 
-            static float SelectFirst(FloatArgType value);
+            static float SelectIndex0(FloatArgType value);
+            static float AZ_MATH_INLINE SelectFirst(FloatArgType value) { return SelectIndex0(value); } // Deprecated
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec1.h
@@ -48,7 +48,7 @@ namespace AZ
             static void StreamAligned(int32_t* __restrict addr, Int32ArgType value); // addr *must* be 16-byte aligned
 
             static float SelectIndex0(FloatArgType value);
-            static float AZ_MATH_INLINE SelectFirst(FloatArgType value) { return SelectIndex0(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectFirst(FloatArgType value) { return SelectIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
@@ -53,25 +53,25 @@ namespace AZ
 
             static float SelectIndex0(FloatArgType value);
             static float SelectIndex1(FloatArgType value);
-            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
 
             static FloatType SplatIndex0(FloatArgType value);
             static FloatType SplatIndex1(FloatArgType value);
-            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType ReplaceIndex0(FloatArgType a, float b);
             static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
             static FloatType ReplaceIndex1(FloatArgType a, float b);
             static FloatType ReplaceIndex1(FloatArgType a, FloatArgType b);
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType LoadImmediate(float x, float y);
             static Int32Type LoadImmediate(int32_t x, int32_t y);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec2.h
@@ -51,19 +51,27 @@ namespace AZ
             static void StreamAligned(float* __restrict addr, FloatArgType value); // addr *must* be 16-byte aligned
             static void StreamAligned(int32_t* __restrict addr, Int32ArgType value); // addr *must* be 16-byte aligned
 
-            static float SelectFirst(FloatArgType value);
-            static float SelectSecond(FloatArgType value);
+            static float SelectIndex0(FloatArgType value);
+            static float SelectIndex1(FloatArgType value);
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
 
-            static FloatType SplatFirst(FloatArgType value);
-            static FloatType SplatSecond(FloatArgType value);
+            static FloatType SplatIndex0(FloatArgType value);
+            static FloatType SplatIndex1(FloatArgType value);
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
 
-            static FloatType ReplaceFirst(FloatArgType a, float b);
-            static FloatType ReplaceFirst(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceSecond(FloatArgType a, float b);
-            static FloatType ReplaceSecond(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex0(FloatArgType a, float b);
+            static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex1(FloatArgType a, float b);
+            static FloatType ReplaceIndex1(FloatArgType a, FloatArgType b);
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
 
             static FloatType LoadImmediate(float x, float y);
             static Int32Type LoadImmediate(int32_t x, int32_t y);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec3.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec3.h
@@ -51,23 +51,35 @@ namespace AZ
             static void StreamAligned(float* __restrict addr, FloatArgType value); // addr *must* be 16-byte aligned
             static void StreamAligned(int32_t* __restrict addr, Int32ArgType value); // addr *must* be 16-byte aligned
 
-            static float SelectFirst(FloatArgType value);
-            static float SelectSecond(FloatArgType value);
-            static float SelectThird(FloatArgType value);
+            static float SelectIndex0(FloatArgType value);
+            static float SelectIndex1(FloatArgType value);
+            static float SelectIndex2(FloatArgType value);
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // Deprecated
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
 
-            static FloatType SplatFirst(FloatArgType value);
-            static FloatType SplatSecond(FloatArgType value);
-            static FloatType SplatThird(FloatArgType value);
+            static FloatType SplatIndex0(FloatArgType value);
+            static FloatType SplatIndex1(FloatArgType value);
+            static FloatType SplatIndex2(FloatArgType value);
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // Deprecated
 
-            static FloatType ReplaceFirst(FloatArgType a, float b);
-            static FloatType ReplaceFirst(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceSecond(FloatArgType a, float b);
-            static FloatType ReplaceSecond(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceThird(FloatArgType a, float b);
-            static FloatType ReplaceThird(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex0(FloatArgType a, float b);
+            static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex1(FloatArgType a, float b);
+            static FloatType ReplaceIndex1(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex2(FloatArgType a, float b);
+            static FloatType ReplaceIndex2(FloatArgType a, FloatArgType b);
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // Deprecated
 
             static FloatType LoadImmediate(float x, float y, float z);
             static Int32Type LoadImmediate(int32_t x, int32_t y, int32_t z);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec3.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec3.h
@@ -54,9 +54,9 @@ namespace AZ
             static float SelectIndex0(FloatArgType value);
             static float SelectIndex1(FloatArgType value);
             static float SelectIndex2(FloatArgType value);
-            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
@@ -64,9 +64,9 @@ namespace AZ
             static FloatType SplatIndex0(FloatArgType value);
             static FloatType SplatIndex1(FloatArgType value);
             static FloatType SplatIndex2(FloatArgType value);
-            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType ReplaceIndex0(FloatArgType a, float b);
             static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
@@ -74,12 +74,12 @@ namespace AZ
             static FloatType ReplaceIndex1(FloatArgType a, FloatArgType b);
             static FloatType ReplaceIndex2(FloatArgType a, float b);
             static FloatType ReplaceIndex2(FloatArgType a, FloatArgType b);
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType LoadImmediate(float x, float y, float z);
             static Int32Type LoadImmediate(int32_t x, int32_t y, int32_t z);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
@@ -59,10 +59,10 @@ namespace AZ
             static float SelectIndex1(FloatArgType value);
             static float SelectIndex2(FloatArgType value);
             static float SelectIndex3(FloatArgType value);
-            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // Deprecated
-            static float AZ_MATH_INLINE SelectFourth(FloatArgType value) { return SelectIndex3(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static float AZ_MATH_INLINE SelectFourth(FloatArgType value) { return SelectIndex3(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
@@ -71,10 +71,10 @@ namespace AZ
             static FloatType SplatIndex1(FloatArgType value);
             static FloatType SplatIndex2(FloatArgType value);
             static FloatType SplatIndex3(FloatArgType value);
-            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // Deprecated
-            static FloatType AZ_MATH_INLINE SplatFourth(FloatArgType value) { return SplatIndex3(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE SplatFourth(FloatArgType value) { return SplatIndex3(value); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType ReplaceIndex0(FloatArgType a, float b);
             static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
@@ -84,14 +84,14 @@ namespace AZ
             static FloatType ReplaceIndex2(FloatArgType a, FloatArgType b);
             static FloatType ReplaceIndex3(FloatArgType a, float b);
             static FloatType ReplaceIndex3(FloatArgType a, FloatArgType b);
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a,        float b) { return ReplaceIndex3(a, b); } // Deprecated
-            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a, FloatArgType b) { return ReplaceIndex3(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a,        float b) { return ReplaceIndex3(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
+            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a, FloatArgType b) { return ReplaceIndex3(a, b); } // O3DE_DEPRECATION_NOTICE(PR-16251)
 
             static FloatType LoadImmediate(float x, float y, float z, float w);
             static Int32Type LoadImmediate(int32_t x, int32_t y, int32_t z, int32_t w);
@@ -202,7 +202,7 @@ namespace AZ
             static void Mat4x4InverseFast(const FloatType* __restrict rows, FloatType* __restrict out);
             static void Mat4x4Transpose(const FloatType* __restrict rows, FloatType* __restrict out);
             static void Mat4x4Multiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Basic 4x4 matrix multiplication
-            static void Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Same as Mat4x4Multiply, but accumulates the results into out rather than overwriting
+            static void Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, const FloatType* __restrict add, FloatType* __restrict out); // Same as Mat4x4Multiply, but adds the input add into the results
             static void Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Multiplies two four by four matrices, assuming they are transposed to column major
             static FloatType Mat4x4TransformVector(const FloatType* __restrict rows, FloatArgType vector);
             static FloatType Mat4x4TransposeTransformVector(const FloatType* __restrict rows, FloatArgType vector);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
@@ -185,8 +185,9 @@ namespace AZ
 
             static void Mat4x4InverseFast(const FloatType* __restrict rows, FloatType* __restrict out);
             static void Mat4x4Transpose(const FloatType* __restrict rows, FloatType* __restrict out);
-            static void Mat4x4Multiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out);
-            static void Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out);
+            static void Mat4x4Multiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Basic 4x4 matrix multiplication
+            static void Mat4x4MultiplyAdd(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Same as Mat4x4Multiply, but accumulates the results into out rather than overwriting
+            static void Mat4x4TransposeMultiply(const FloatType* __restrict rowsA, const FloatType* __restrict rowsB, FloatType* __restrict out); // Multiplies two four by four matrices, assuming they are transposed to column major
             static FloatType Mat4x4TransformVector(const FloatType* __restrict rows, FloatArgType vector);
             static FloatType Mat4x4TransposeTransformVector(const FloatType* __restrict rows, FloatArgType vector);
             static Vec3::FloatType Mat4x4TransformPoint3(const FloatType* __restrict rows, Vec3::FloatArgType vector);

--- a/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
+++ b/Code/Framework/AzCore/AzCore/Math/SimdMathVec4.h
@@ -55,27 +55,43 @@ namespace AZ
             static void StreamAligned(float* __restrict addr, FloatArgType value); // addr *must* be 16-byte aligned
             static void StreamAligned(int32_t* __restrict addr, Int32ArgType value); // addr *must* be 16-byte aligned
 
-            static float SelectFirst(FloatArgType value);
-            static float SelectSecond(FloatArgType value);
-            static float SelectThird(FloatArgType value);
-            static float SelectFourth(FloatArgType value);
+            static float SelectIndex0(FloatArgType value);
+            static float SelectIndex1(FloatArgType value);
+            static float SelectIndex2(FloatArgType value);
+            static float SelectIndex3(FloatArgType value);
+            static float AZ_MATH_INLINE SelectFirst (FloatArgType value) { return SelectIndex0(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectSecond(FloatArgType value) { return SelectIndex1(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectThird (FloatArgType value) { return SelectIndex2(value); } // Deprecated
+            static float AZ_MATH_INLINE SelectFourth(FloatArgType value) { return SelectIndex3(value); } // Deprecated
 
             static FloatType Splat(float value);
             static Int32Type Splat(int32_t value);
 
-            static FloatType SplatFirst(FloatArgType value);
-            static FloatType SplatSecond(FloatArgType value);
-            static FloatType SplatThird(FloatArgType value);
-            static FloatType SplatFourth(FloatArgType value);
+            static FloatType SplatIndex0(FloatArgType value);
+            static FloatType SplatIndex1(FloatArgType value);
+            static FloatType SplatIndex2(FloatArgType value);
+            static FloatType SplatIndex3(FloatArgType value);
+            static FloatType AZ_MATH_INLINE SplatFirst (FloatArgType value) { return SplatIndex0(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatSecond(FloatArgType value) { return SplatIndex1(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatThird (FloatArgType value) { return SplatIndex2(value); } // Deprecated
+            static FloatType AZ_MATH_INLINE SplatFourth(FloatArgType value) { return SplatIndex3(value); } // Deprecated
 
-            static FloatType ReplaceFirst(FloatArgType a, float b);
-            static FloatType ReplaceFirst(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceSecond(FloatArgType a, float b);
-            static FloatType ReplaceSecond(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceThird(FloatArgType a, float b);
-            static FloatType ReplaceThird(FloatArgType a, FloatArgType b);
-            static FloatType ReplaceFourth(FloatArgType a, float b);
-            static FloatType ReplaceFourth(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex0(FloatArgType a, float b);
+            static FloatType ReplaceIndex0(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex1(FloatArgType a, float b);
+            static FloatType ReplaceIndex1(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex2(FloatArgType a, float b);
+            static FloatType ReplaceIndex2(FloatArgType a, FloatArgType b);
+            static FloatType ReplaceIndex3(FloatArgType a, float b);
+            static FloatType ReplaceIndex3(FloatArgType a, FloatArgType b);
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a,        float b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFirst (FloatArgType a, FloatArgType b) { return ReplaceIndex0(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a,        float b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceSecond(FloatArgType a, FloatArgType b) { return ReplaceIndex1(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a,        float b) { return ReplaceIndex2(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceThird (FloatArgType a, FloatArgType b) { return ReplaceIndex2(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a,        float b) { return ReplaceIndex3(a, b); } // Deprecated
+            static FloatType AZ_MATH_INLINE ReplaceFourth(FloatArgType a, FloatArgType b) { return ReplaceIndex3(a, b); } // Deprecated
 
             static FloatType LoadImmediate(float x, float y, float z, float w);
             static Int32Type LoadImmediate(int32_t x, int32_t y, int32_t z, int32_t w);

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -28,8 +28,8 @@ namespace AZ
         //! @param context reflection context
         static void Reflect(ReflectContext* context);
 
+        //! Default constructor, components are uninitialized.
         Vector2() = default;
-
         Vector2(const Vector2& v) = default;
 
         //! Constructs vector with all components set to the same specified value.
@@ -282,9 +282,14 @@ namespace AZ
         //! P = (v.Dot(Normal) * normal)
         Vector2 GetProjectedOnNormal(const Vector2& normal);
 
+        //! Returns true if the vector contains no nan or inf values, false if at least one element is not finite.
         bool IsFinite() const;
 
+        //! Returns the underlying SIMD vector.
         Simd::Vec2::FloatType GetSimdValue() const;
+
+        //! Directly sets the underlying SIMD vector.
+        void SetSimdValue(Simd::Vec2::FloatArgType value);
 
     private:
 

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -18,13 +18,11 @@ namespace AZ
         ;
     }
 
-
     AZ_MATH_INLINE Vector2::Vector2(float x, float y)
         : m_value(Simd::Vec2::LoadImmediate(x, y))
     {
         ;
     }
-
 
     AZ_MATH_INLINE Vector2::Vector2(Simd::Vec2::FloatArgType value)
         : m_value(value)
@@ -47,30 +45,25 @@ namespace AZ
         return Vector2(0.0f);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::CreateOne()
     {
         return Vector2(1.0f);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::CreateAxisX(float length)
     {
         return Vector2(length, 0.0f);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::CreateAxisY(float length)
     {
         return Vector2(0.0f, length);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::CreateFromFloat2(const float* values)
     {
         return Vector2(values[0], values[1]);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::CreateFromAngle(float angle)
     {
@@ -78,7 +71,6 @@ namespace AZ
         SinCos(angle, sin, cos);
         return Vector2(sin, cos);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::CreateSelectCmpEqual(const Vector2& cmp1, const Vector2& cmp2, const Vector2& vA, const Vector2& vB)
     {
@@ -90,7 +82,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::CreateSelectCmpGreaterEqual(const Vector2& cmp1, const Vector2& cmp2, const Vector2& vA, const Vector2& vB)
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -100,7 +91,6 @@ namespace AZ
         return Vector2(Simd::Vec2::Select(vA.m_value, vB.m_value, mask));
 #endif
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::CreateSelectCmpGreater(const Vector2& cmp1, const Vector2& cmp2, const Vector2& vA, const Vector2& vB)
     {
@@ -112,37 +102,31 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE void Vector2::StoreToFloat2(float* values) const
     {
         values[0] = m_x;
         values[1] = m_y;
     }
 
-
     AZ_MATH_INLINE float Vector2::GetX() const
     {
         return m_x;
     }
-
 
     AZ_MATH_INLINE float Vector2::GetY() const
     {
         return m_y;
     }
 
-
     AZ_MATH_INLINE void Vector2::SetX(float x)
     {
         m_x = x;
     }
 
-
     AZ_MATH_INLINE void Vector2::SetY(float y)
     {
         m_y = y;
     }
-
 
     AZ_MATH_INLINE float Vector2::GetElement(int index) const
     {
@@ -150,85 +134,71 @@ namespace AZ
         return m_values[index];
     }
 
-
     AZ_MATH_INLINE void Vector2::SetElement(int index, float value)
     {
         AZ_MATH_ASSERT((index >= 0) && (index < Simd::Vec2::ElementCount), "Invalid index for component access.\n");
         m_values[index] = value;
     }
 
-
     AZ_MATH_INLINE void Vector2::Set(float x)
     {
         m_value = Simd::Vec2::Splat(x);
     }
-
 
     AZ_MATH_INLINE void Vector2::Set(float x, float y)
     {
         m_value = Simd::Vec2::LoadImmediate(x, y);
     }
 
-
     AZ_MATH_INLINE float Vector2::operator()(int index) const
     {
         return GetElement(index);
     }
-
 
     AZ_MATH_INLINE float Vector2::GetLengthSq() const
     {
         return Dot(*this);
     }
 
-
     AZ_MATH_INLINE float Vector2::GetLength() const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(Simd::Vec2::Dot(m_value, m_value)));
     }
-
 
     AZ_MATH_INLINE float Vector2::GetLengthEstimate() const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(Simd::Vec2::Dot(m_value, m_value)));
     }
 
-
     AZ_MATH_INLINE float Vector2::GetLengthReciprocal() const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(Simd::Vec2::Dot(m_value, m_value)));
     }
-
 
     AZ_MATH_INLINE float Vector2::GetLengthReciprocalEstimate() const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(Simd::Vec2::Dot(m_value, m_value)));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetNormalized() const
     {
         return Vector2(Simd::Vec2::Normalize(m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetNormalizedEstimate() const
     {
         return Vector2(Simd::Vec2::NormalizeEstimate(m_value));
     }
 
-
     AZ_MATH_INLINE void Vector2::Normalize()
     {
         m_value = Simd::Vec2::Normalize(m_value);
     }
 
-
     AZ_MATH_INLINE void Vector2::NormalizeEstimate()
     {
         m_value = Simd::Vec2::NormalizeEstimate(m_value);
     }
-
 
     AZ_MATH_INLINE float Vector2::NormalizeWithLength()
     {
@@ -237,7 +207,6 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE float Vector2::NormalizeWithLengthEstimate()
     {
         float length = GetLengthEstimate();
@@ -245,30 +214,25 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetNormalizedSafe(float tolerance) const
     {
         return Vector2(Simd::Vec2::NormalizeSafe(m_value, tolerance));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetNormalizedSafeEstimate(float tolerance) const
     {
         return Vector2(Simd::Vec2::NormalizeSafeEstimate(m_value, tolerance));
     }
 
-
     AZ_MATH_INLINE void Vector2::NormalizeSafe(float tolerance)
     {
         m_value = Simd::Vec2::NormalizeSafe(m_value, tolerance);
     }
 
-
     AZ_MATH_INLINE void Vector2::NormalizeSafeEstimate(float tolerance)
     {
         m_value = Simd::Vec2::NormalizeSafeEstimate(m_value, tolerance);
     }
-
 
     AZ_MATH_INLINE float Vector2::NormalizeSafeWithLength(float tolerance)
     {
@@ -277,7 +241,6 @@ namespace AZ
         return Simd::Vec1::SelectFirst(length);
     }
 
-
     AZ_MATH_INLINE float Vector2::NormalizeSafeWithLengthEstimate(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::SqrtEstimate(Simd::Vec2::Dot(m_value, m_value));
@@ -285,12 +248,10 @@ namespace AZ
         return Simd::Vec1::SelectFirst(length);
     }
 
-
     AZ_MATH_INLINE bool Vector2::IsNormalized(float tolerance) const
     {
         return (Abs(GetLengthSq() - 1.0f) <= tolerance);
     }
-
 
     AZ_MATH_INLINE void Vector2::SetLength(float length)
     {
@@ -298,37 +259,31 @@ namespace AZ
         m_value = Simd::Vec2::Mul(m_value, Simd::Vec2::Splat(scale));
     }
 
-
     AZ_MATH_INLINE void Vector2::SetLengthEstimate(float length)
     {
         float scale = length / GetLengthEstimate();
         m_value = Simd::Vec2::Mul(m_value, Simd::Vec2::Splat(scale));
     }
 
-
     AZ_MATH_INLINE float Vector2::GetDistanceSq(const Vector2& v) const
     {
         return ((*this) - v).GetLengthSq();
     }
-
 
     AZ_MATH_INLINE float Vector2::GetDistance(const Vector2& v) const
     {
         return ((*this) - v).GetLength();
     }
 
-
     AZ_MATH_INLINE float Vector2::GetDistanceEstimate(const Vector2& v) const
     {
         return ((*this) - v).GetLengthEstimate();
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::Lerp(const Vector2& dest, float t) const
     {
         return Vector2(Simd::Vec2::Madd(Simd::Vec2::Sub(dest.m_value, m_value), Simd::Vec2::Splat(t), m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::Slerp(const Vector2& dest, float t) const
     {
@@ -343,18 +298,15 @@ namespace AZ
         return Vector2(Simd::Vec2::Madd(GetSimdValue(), Simd::Vec2::SplatSecond(sinCos), relVecSinTheta));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::Nlerp(const Vector2& dest, float t) const
     {
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetPerpendicular() const
     {
         return Vector2(-m_y, m_x);
     }
-
 
     AZ_MATH_INLINE bool Vector2::IsClose(const Vector2& v, float tolerance) const
     {
@@ -362,66 +314,56 @@ namespace AZ
         return dist.IsLessEqualThan(Vector2(tolerance));
     }
 
-
     AZ_MATH_INLINE bool Vector2::IsZero(float tolerance) const
     {
-        return IsClose(Vector2::CreateZero(), tolerance);
+        Vector2 dist = GetAbs();
+        return dist.IsLessEqualThan(Vector2(tolerance));
     }
-
 
     AZ_MATH_INLINE bool Vector2::operator==(const Vector2& rhs) const
     {
         return Simd::Vec2::CmpAllEq(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector2::operator!=(const Vector2& rhs) const
     {
         return !Simd::Vec2::CmpAllEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector2::IsLessThan(const Vector2& v) const
     {
         return Simd::Vec2::CmpAllLt(m_value, v.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector2::IsLessEqualThan(const Vector2& v) const
     {
         return Simd::Vec2::CmpAllLtEq(m_value, v.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector2::IsGreaterThan(const Vector2& v) const
     {
         return Simd::Vec2::CmpAllGt(m_value, v.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector2::IsGreaterEqualThan(const Vector2& v) const
     {
         return Simd::Vec2::CmpAllGtEq(m_value, v.m_value);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetFloor() const
     {
         return Vector2(Simd::Vec2::Floor(m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetCeil() const
     {
         return Vector2(Simd::Vec2::Ceil(m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetRound() const
     {
         return Vector2(Simd::Vec2::Round(m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetMin(const Vector2& v) const
     {
@@ -432,7 +374,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetMax(const Vector2& v) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -442,12 +383,10 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetClamp(const Vector2& min, const Vector2& max) const
     {
         return GetMin(max).GetMax(min);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetSelect(const Vector2& vCmp, const Vector2& vB)
     {
@@ -459,18 +398,15 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE void Vector2::Select(const Vector2& vCmp, const Vector2& vB)
     {
         *this = GetSelect(vCmp, vB);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetAbs() const
     {
         return Vector2(Simd::Vec2::Abs(m_value));
     }
-
 
     AZ_MATH_INLINE Vector2& Vector2::operator+=(const Vector2& rhs)
     {
@@ -478,13 +414,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector2& Vector2::operator-=(const Vector2& rhs)
     {
         m_value = Simd::Vec2::Sub(m_value, rhs.m_value);
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector2& Vector2::operator*=(const Vector2& rhs)
     {
@@ -492,13 +426,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector2& Vector2::operator/=(const Vector2& rhs)
     {
         m_value = Simd::Vec2::Div(m_value, rhs.m_value);
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector2& Vector2::operator*=(float multiplier)
     {
@@ -506,67 +438,56 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector2& Vector2::operator/=(float divisor)
     {
         m_value = Simd::Vec2::Div(m_value, Simd::Vec2::Splat(divisor));
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::operator-() const
     {
         return Vector2(-m_x, -m_y);
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::operator+(const Vector2& rhs) const
     {
         return Vector2(Simd::Vec2::Add(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::operator-(const Vector2& rhs) const
     {
         return Vector2(Simd::Vec2::Sub(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::operator*(const Vector2& rhs) const
     {
         return Vector2(Simd::Vec2::Mul(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::operator*(float multiplier) const
     {
         return Vector2(Simd::Vec2::Mul(m_value, Simd::Vec2::Splat(multiplier)));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::operator/(float divisor) const
     {
         return Vector2(Simd::Vec2::Div(m_value, Simd::Vec2::Splat(divisor)));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::operator/(const Vector2& rhs) const
     {
         return Vector2(Simd::Vec2::Div(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetSin() const
     {
         return Vector2(Simd::Vec2::Sin(m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetCos() const
     {
         return Vector2(Simd::Vec2::Cos(m_value));
     }
-
 
     AZ_MATH_INLINE void Vector2::GetSinCos(Vector2& sin, Vector2& cos) const
     {
@@ -576,30 +497,25 @@ namespace AZ
         cos = Vector2(cosValues);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetAcos() const
     {
         return Vector2(Simd::Vec2::Acos(m_value));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetAtan() const
     {
         return Vector2(Simd::Vec2::Atan(m_value));
     }
 
-
     AZ_MATH_INLINE float Vector2::GetAtan2() const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec2::Atan2(m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetAngleMod() const
     {
         return Vector2(Simd::Vec2::AngleMod(m_value));
     }
-
 
     AZ_MATH_INLINE float Vector2::Angle(const Vector2& v) const
     {
@@ -610,60 +526,50 @@ namespace AZ
         return res;
     }
 
-
     AZ_MATH_INLINE float Vector2::AngleDeg(const Vector2& v) const
     {
         return RadToDeg(Angle(v));
     }
-
 
     AZ_MATH_INLINE float Vector2::AngleSafe(const Vector2& v) const
     {
         return (!IsZero() && !v.IsZero()) ? Angle(v) : 0.0f;
     }
 
-
     AZ_MATH_INLINE float Vector2::AngleSafeDeg(const Vector2& v) const
     {
         return (!IsZero() && !v.IsZero()) ? AngleDeg(v) : 0.0f;
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetReciprocal() const
     {
         return Vector2(Simd::Vec2::Reciprocal(m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetReciprocalEstimate() const
     {
         return Vector2(Simd::Vec2::ReciprocalEstimate(m_value));
     }
-
 
     AZ_MATH_INLINE float Vector2::Dot(const Vector2& rhs) const
     {
         return Simd::Vec1::SelectFirst(Simd::Vec2::Dot(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetMadd(const Vector2& mul, const Vector2& add)
     {
         return Vector2(Simd::Vec2::Madd(m_value, mul.m_value, add.m_value));
     }
-
 
     AZ_MATH_INLINE void Vector2::Madd(const Vector2& mul, const Vector2& add)
     {
         *this = GetMadd(mul, add);
     }
 
-
     AZ_MATH_INLINE void Vector2::Project(const Vector2& rhs)
     {
         *this = rhs * (Dot(rhs) / rhs.Dot(rhs));
     }
-
 
     AZ_MATH_INLINE void Vector2::ProjectOnNormal(const Vector2& normal)
     {
@@ -671,12 +577,10 @@ namespace AZ
         *this = normal * Dot(normal);
     }
 
-
     AZ_MATH_INLINE Vector2 Vector2::GetProjected(const Vector2& rhs) const
     {
         return rhs * (Dot(rhs) / rhs.Dot(rhs));
     }
-
 
     AZ_MATH_INLINE Vector2 Vector2::GetProjectedOnNormal(const Vector2& normal)
     {
@@ -684,18 +588,20 @@ namespace AZ
         return normal * Dot(normal);
     }
 
-
     AZ_MATH_INLINE bool Vector2::IsFinite() const
     {
         return IsFiniteFloat(GetX()) && IsFiniteFloat(GetY());
     }
-
 
     AZ_MATH_INLINE Simd::Vec2::FloatType Vector2::GetSimdValue() const
     {
         return m_value;
     }
 
+    AZ_MATH_INLINE void Vector2::SetSimdValue(Simd::Vec2::FloatArgType value)
+    {
+        m_value = value;
+    }
 
     AZ_MATH_INLINE Vector2 operator*(float multiplier, const Vector2& rhs)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -162,22 +162,22 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector2::GetLength() const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(Simd::Vec2::Dot(m_value, m_value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sqrt(Simd::Vec2::Dot(m_value, m_value)));
     }
 
     AZ_MATH_INLINE float Vector2::GetLengthEstimate() const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(Simd::Vec2::Dot(m_value, m_value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtEstimate(Simd::Vec2::Dot(m_value, m_value)));
     }
 
     AZ_MATH_INLINE float Vector2::GetLengthReciprocal() const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(Simd::Vec2::Dot(m_value, m_value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInv(Simd::Vec2::Dot(m_value, m_value)));
     }
 
     AZ_MATH_INLINE float Vector2::GetLengthReciprocalEstimate() const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(Simd::Vec2::Dot(m_value, m_value)));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInvEstimate(Simd::Vec2::Dot(m_value, m_value)));
     }
 
     AZ_MATH_INLINE Vector2 Vector2::GetNormalized() const
@@ -237,15 +237,15 @@ namespace AZ
     AZ_MATH_INLINE float Vector2::NormalizeSafeWithLength(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::Sqrt(Simd::Vec2::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec2::ZeroFloat() : Simd::Vec2::Div(m_value, Simd::Vec2::SplatFirst(Simd::Vec2::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec2::ZeroFloat() : Simd::Vec2::Div(m_value, Simd::Vec2::SplatIndex0(Simd::Vec2::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE float Vector2::NormalizeSafeWithLengthEstimate(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::SqrtEstimate(Simd::Vec2::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec2::ZeroFloat() : Simd::Vec2::Div(m_value, Simd::Vec2::SplatFirst(Simd::Vec2::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec2::ZeroFloat() : Simd::Vec2::Div(m_value, Simd::Vec2::SplatIndex0(Simd::Vec2::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE bool Vector2::IsNormalized(float tolerance) const
@@ -294,8 +294,8 @@ namespace AZ
         const Simd::Vec2::FloatType relativeVec = Simd::Vec2::Sub(dest.GetSimdValue(), Simd::Vec2::Mul(GetSimdValue(), Simd::Vec2::FromVec1(dot)));
         const Simd::Vec2::FloatType relVecNorm = Simd::Vec2::NormalizeSafe(relativeVec, Constants::Tolerance);
         const Simd::Vec2::FloatType sinCos = Simd::Vec2::SinCos(theta);
-        const Simd::Vec2::FloatType relVecSinTheta = Simd::Vec2::Mul(relVecNorm, Simd::Vec2::SplatFirst(sinCos));
-        return Vector2(Simd::Vec2::Madd(GetSimdValue(), Simd::Vec2::SplatSecond(sinCos), relVecSinTheta));
+        const Simd::Vec2::FloatType relVecSinTheta = Simd::Vec2::Mul(relVecNorm, Simd::Vec2::SplatIndex0(sinCos));
+        return Vector2(Simd::Vec2::Madd(GetSimdValue(), Simd::Vec2::SplatIndex1(sinCos), relVecSinTheta));
     }
 
     AZ_MATH_INLINE Vector2 Vector2::Nlerp(const Vector2& dest, float t) const
@@ -509,7 +509,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector2::GetAtan2() const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec2::Atan2(m_value));
+        return Simd::Vec1::SelectIndex0(Simd::Vec2::Atan2(m_value));
     }
 
     AZ_MATH_INLINE Vector2 Vector2::GetAngleMod() const
@@ -553,7 +553,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector2::Dot(const Vector2& rhs) const
     {
-        return Simd::Vec1::SelectFirst(Simd::Vec2::Dot(m_value, rhs.m_value));
+        return Simd::Vec1::SelectIndex0(Simd::Vec2::Dot(m_value, rhs.m_value));
     }
 
     AZ_MATH_INLINE Vector2 Vector2::GetMadd(const Vector2& mul, const Vector2& add)

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -35,7 +35,7 @@ namespace AZ
 
         //! Default constructor, components are uninitialized.
         Vector3() = default;
-        Vector3(const Vector3& v);
+        Vector3(const Vector3& v) = default;
 
         //! Constructs vector with all components set to the same specified value.
         explicit Vector3(float x);
@@ -315,10 +315,14 @@ namespace AZ
         //! Project this vector onto a normal and return the resulting projection. P = v - (v.Dot(Normal) * normal)
         Vector3 GetProjectedOnNormal(const Vector3& normal);
 
-        //! Returns true if all elements are finite, false if at least one element is not finite
+        //! Returns true if the vector contains no nan or inf values, false if at least one element is not finite.
         bool IsFinite() const;
 
+        //! Returns the underlying SIMD vector.
         Simd::Vec3::FloatType GetSimdValue() const;
+
+        //! Directly sets the underlying SIMD vector.
+        void SetSimdValue(Simd::Vec3::FloatArgType value);
 
     private:
 

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -191,25 +191,25 @@ namespace AZ
     AZ_MATH_INLINE float Vector3::GetLength() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sqrt(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector3::GetLengthEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtEstimate(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector3::GetLengthReciprocal() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInv(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector3::GetLengthReciprocalEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInvEstimate(lengthSq));
     }
 
     AZ_MATH_INLINE Vector3 Vector3::GetNormalized() const
@@ -234,7 +234,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector3::NormalizeWithLength()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::Sqrt(Simd::Vec3::Dot(m_value, m_value)));
         m_value = Simd::Vec3::Div(m_value, Simd::Vec3::Splat(length));
         return length;
@@ -242,7 +242,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector3::NormalizeWithLengthEstimate()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::SqrtEstimate(Simd::Vec3::Dot(m_value, m_value)));
         m_value = Simd::Vec3::Div(m_value, Simd::Vec3::Splat(length));
         return length;
@@ -271,15 +271,15 @@ namespace AZ
     AZ_MATH_INLINE float Vector3::NormalizeSafeWithLength(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::Sqrt(Simd::Vec3::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec3::ZeroFloat() : Simd::Vec3::Div(m_value, Simd::Vec3::SplatFirst(Simd::Vec3::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec3::ZeroFloat() : Simd::Vec3::Div(m_value, Simd::Vec3::SplatIndex0(Simd::Vec3::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE float Vector3::NormalizeSafeWithLengthEstimate(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::SqrtEstimate(Simd::Vec3::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec3::ZeroFloat() : Simd::Vec3::Div(m_value, Simd::Vec3::SplatFirst(Simd::Vec3::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec3::ZeroFloat() : Simd::Vec3::Div(m_value, Simd::Vec3::SplatIndex0(Simd::Vec3::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE bool Vector3::IsNormalized(float tolerance) const
@@ -328,8 +328,8 @@ namespace AZ
         const Simd::Vec3::FloatType relativeVec = Simd::Vec3::Sub(dest.GetSimdValue(), Simd::Vec3::Mul(GetSimdValue(), Simd::Vec3::FromVec1(dot)));
         const Simd::Vec3::FloatType relVecNorm = Simd::Vec3::NormalizeSafe(relativeVec, Constants::Tolerance);
         const Simd::Vec3::FloatType sinCos = Simd::Vec3::FromVec2(Simd::Vec2::SinCos(theta));
-        const Simd::Vec3::FloatType relVecSinTheta = Simd::Vec3::Mul(relVecNorm, Simd::Vec3::SplatFirst(sinCos));
-        return Vector3(Simd::Vec3::Madd(GetSimdValue(), Simd::Vec3::SplatSecond(sinCos), relVecSinTheta));
+        const Simd::Vec3::FloatType relVecSinTheta = Simd::Vec3::Mul(relVecNorm, Simd::Vec3::SplatIndex0(sinCos));
+        return Vector3(Simd::Vec3::Madd(GetSimdValue(), Simd::Vec3::SplatIndex1(sinCos), relVecSinTheta));
     }
 
     AZ_MATH_INLINE Vector3 Vector3::Nlerp(const Vector3& dest, float t) const
@@ -342,7 +342,7 @@ namespace AZ
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
         return (m_x * rhs.m_x + m_y * rhs.m_y + m_z * rhs.m_z);
 #else
-        return Simd::Vec1::SelectFirst(Simd::Vec3::Dot(GetSimdValue(), rhs.GetSimdValue()));
+        return Simd::Vec1::SelectIndex0(Simd::Vec3::Dot(GetSimdValue(), rhs.GetSimdValue()));
 #endif
     }
 
@@ -628,7 +628,7 @@ namespace AZ
     AZ_MATH_INLINE bool Vector3::IsPerpendicular(const Vector3& v, float tolerance) const
     {
         Simd::Vec1::FloatType absLengthSq = Simd::Vec1::Abs(Simd::Vec3::Dot(m_value, v.m_value));
-        return Simd::Vec1::SelectFirst(absLengthSq) < tolerance;
+        return Simd::Vec1::SelectIndex0(absLengthSq) < tolerance;
     }
 
     AZ_MATH_INLINE Vector3 Vector3::GetOrthogonalVector() const

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -18,16 +18,8 @@ namespace AZ
         ;
     }
 
-
     AZ_MATH_INLINE Vector3::Vector3(float x, float y, float z)
         : m_value(Simd::Vec3::LoadImmediate(x, y, z))
-    {
-        ;
-    }
-
-
-    AZ_MATH_INLINE Vector3::Vector3(const Vector3& v)
-        : m_value(v.m_value)
     {
         ;
     }
@@ -59,36 +51,30 @@ namespace AZ
         return Vector3(Simd::Vec3::ZeroFloat());
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::CreateOne()
     {
         return Vector3(1.0f);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::CreateAxisX(float length)
     {
         return Vector3(length, 0.0f, 0.0f);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::CreateAxisY(float length)
     {
         return Vector3(0.0f, length, 0.0f);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::CreateAxisZ(float length)
     {
         return Vector3(0.0f, 0.0f, length);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::CreateFromFloat3(const float* values)
     {
         return Vector3(values[0], values[1], values[2]);
     }
-
 
     // operation ( r.x = (cmp1.x == cmp2.x) ? vA.x : vB.x ) per component
     AZ_MATH_INLINE Vector3 Vector3::CreateSelectCmpEqual(const Vector3& cmp1, const Vector3& cmp2, const Vector3& vA, const Vector3& vB)
@@ -101,7 +87,6 @@ namespace AZ
 #endif
     }
 
-
     // operation ( r.x = (cmp1.x >= cmp2.x) ? vA.x : vB.x ) per component
     AZ_MATH_INLINE Vector3 Vector3::CreateSelectCmpGreaterEqual(const Vector3& cmp1, const Vector3& cmp2, const Vector3& vA, const Vector3& vB)
     {
@@ -112,7 +97,6 @@ namespace AZ
         return Vector3(Simd::Vec3::Select(vA.m_value, vB.m_value, mask));
 #endif
     }
-
 
     // operation ( r.x = (cmp1.x > cmp2.x) ? vA.x : vB.x ) per component
     AZ_MATH_INLINE Vector3 Vector3::CreateSelectCmpGreater(const Vector3& cmp1, const Vector3& cmp2, const Vector3& vA, const Vector3& vB)
@@ -125,7 +109,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE void Vector3::StoreToFloat3(float* values) const
     {
         values[0] = m_values[0];
@@ -133,30 +116,25 @@ namespace AZ
         values[2] = m_values[2];
     }
 
-
     AZ_MATH_INLINE void Vector3::StoreToFloat4(float* values) const
     {
         Simd::Vec3::StoreUnaligned(values, m_value);
     }
-
 
     AZ_MATH_INLINE float Vector3::GetX() const
     {
         return m_x;
     }
 
-
     AZ_MATH_INLINE float Vector3::GetY() const
     {
         return m_y;
     }
 
-
     AZ_MATH_INLINE float Vector3::GetZ() const
     {
         return m_z;
     }
-
 
     AZ_MATH_INLINE float Vector3::GetElement(int32_t index) const
     {
@@ -164,30 +142,25 @@ namespace AZ
         return m_values[index];
     }
 
-
     AZ_MATH_INLINE void Vector3::SetX(float x)
     {
         m_x = x;
     }
-
 
     AZ_MATH_INLINE void Vector3::SetY(float y)
     {
         m_y = y;
     }
 
-
     AZ_MATH_INLINE void Vector3::SetZ(float z)
     {
         m_z = z;
     }
 
-
     AZ_MATH_INLINE void Vector3::Set(float x)
     {
         m_value = Simd::Vec3::Splat(x);
     }
-
 
     AZ_MATH_INLINE void Vector3::SetElement(int32_t index, float v)
     {
@@ -195,30 +168,25 @@ namespace AZ
         m_values[index] = v;
     }
 
-
     AZ_MATH_INLINE void Vector3::Set(float x, float y, float z)
     {
         m_value = Simd::Vec3::LoadImmediate(x, y, z);
     }
-
 
     AZ_MATH_INLINE void Vector3::Set(const float values[])
     {
         m_value = Simd::Vec3::LoadImmediate(values[0], values[1], values[2]);
     }
 
-
     AZ_MATH_INLINE float Vector3::operator()(int32_t index) const
     {
         return GetElement(index);
     }
 
-
     AZ_MATH_INLINE float Vector3::GetLengthSq() const
     {
         return Dot(*this);
     }
-
 
     AZ_MATH_INLINE float Vector3::GetLength() const
     {
@@ -226,13 +194,11 @@ namespace AZ
         return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(lengthSq));
     }
 
-
     AZ_MATH_INLINE float Vector3::GetLengthEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(lengthSq));
     }
-
 
     AZ_MATH_INLINE float Vector3::GetLengthReciprocal() const
     {
@@ -240,37 +206,31 @@ namespace AZ
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(lengthSq));
     }
 
-
     AZ_MATH_INLINE float Vector3::GetLengthReciprocalEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec3::Dot(m_value, m_value);
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(lengthSq));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetNormalized() const
     {
         return Vector3(Simd::Vec3::Normalize(m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetNormalizedEstimate() const
     {
         return Vector3(Simd::Vec3::NormalizeEstimate(m_value));
     }
 
-
     AZ_MATH_INLINE void Vector3::Normalize()
     {
         *this = GetNormalized();
     }
 
-
     AZ_MATH_INLINE void Vector3::NormalizeEstimate()
     {
         *this = GetNormalizedEstimate();
     }
-
 
     AZ_MATH_INLINE float Vector3::NormalizeWithLength()
     {
@@ -280,7 +240,6 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE float Vector3::NormalizeWithLengthEstimate()
     {
         const float length = Simd::Vec1::SelectFirst(
@@ -289,30 +248,25 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetNormalizedSafe(float tolerance) const
     {
         return Vector3(Simd::Vec3::NormalizeSafe(m_value, tolerance));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetNormalizedSafeEstimate(float tolerance) const
     {
         return Vector3(Simd::Vec3::NormalizeSafeEstimate(m_value, tolerance));
     }
 
-
     AZ_MATH_INLINE void Vector3::NormalizeSafe(float tolerance)
     {
         m_value = Simd::Vec3::NormalizeSafe(m_value, tolerance);
     }
 
-
     AZ_MATH_INLINE void Vector3::NormalizeSafeEstimate(float tolerance)
     {
         m_value = Simd::Vec3::NormalizeSafeEstimate(m_value, tolerance);
     }
-
 
     AZ_MATH_INLINE float Vector3::NormalizeSafeWithLength(float tolerance)
     {
@@ -321,7 +275,6 @@ namespace AZ
         return Simd::Vec1::SelectFirst(length);
     }
 
-
     AZ_MATH_INLINE float Vector3::NormalizeSafeWithLengthEstimate(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::SqrtEstimate(Simd::Vec3::Dot(m_value, m_value));
@@ -329,12 +282,10 @@ namespace AZ
         return Simd::Vec1::SelectFirst(length);
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsNormalized(float tolerance) const
     {
         return (Abs(GetLengthSq() - 1.0f) <= tolerance);
     }
-
 
     AZ_MATH_INLINE void Vector3::SetLength(float length)
     {
@@ -342,37 +293,31 @@ namespace AZ
         (*this) *= scale;
     }
 
-
     AZ_MATH_INLINE void Vector3::SetLengthEstimate(float length)
     {
         float scale(length * GetLengthReciprocalEstimate());
         (*this) *= scale;
     }
 
-
     AZ_MATH_INLINE float Vector3::GetDistanceSq(const Vector3& v) const
     {
         return ((*this) - v).GetLengthSq();
     }
-
 
     AZ_MATH_INLINE float Vector3::GetDistance(const Vector3& v) const
     {
         return ((*this) - v).GetLength();
     }
 
-
     AZ_MATH_INLINE float Vector3::GetDistanceEstimate(const Vector3& v) const
     {
         return ((*this) - v).GetLengthEstimate();
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::Lerp(const Vector3& dest, float t) const
     {
         return Vector3(Simd::Vec3::Madd(Simd::Vec3::Sub(dest.m_value, m_value), Simd::Vec3::Splat(t), m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::Slerp(const Vector3& dest, float t) const
     {
@@ -387,12 +332,10 @@ namespace AZ
         return Vector3(Simd::Vec3::Madd(GetSimdValue(), Simd::Vec3::SplatSecond(sinCos), relVecSinTheta));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::Nlerp(const Vector3& dest, float t) const
     {
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);
     }
-
 
     AZ_MATH_INLINE float Vector3::Dot(const Vector3& rhs) const
     {
@@ -403,7 +346,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::Cross(const Vector3& rhs) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -413,42 +355,35 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::CrossXAxis() const
     {
         return Vector3(0.0f, m_z, -m_y);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::CrossYAxis() const
     {
         return Vector3(-m_z, 0.0f, m_x);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::CrossZAxis() const
     {
         return Vector3(m_y, -m_x, 0.0f);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::XAxisCross() const
     {
         return Vector3(0.0f, -m_z, m_y);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::YAxisCross() const
     {
         return Vector3(m_z, 0.0f, -m_x);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::ZAxisCross() const
     {
         return Vector3(-m_y, m_x, 0.0f);
     }
-
 
     AZ_MATH_INLINE bool Vector3::IsClose(const Vector3& v, float tolerance) const
     {
@@ -456,66 +391,56 @@ namespace AZ
         return dist.IsLessEqualThan(Vector3(tolerance));
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsZero(float tolerance) const
     {
-        return IsClose(CreateZero(), tolerance);
+        Vector3 dist = GetAbs();
+        return dist.IsLessEqualThan(Vector3(tolerance));
     }
-
 
     AZ_MATH_INLINE bool Vector3::operator==(const Vector3& rhs) const
     {
         return Simd::Vec3::CmpAllEq(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector3::operator!=(const Vector3& rhs) const
     {
         return !Simd::Vec3::CmpAllEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector3::IsLessThan(const Vector3& rhs) const
     {
         return Simd::Vec3::CmpAllLt(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsLessEqualThan(const Vector3& rhs) const
     {
         return Simd::Vec3::CmpAllLtEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector3::IsGreaterThan(const Vector3& rhs) const
     {
         return Simd::Vec3::CmpAllGt(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsGreaterEqualThan(const Vector3& rhs) const
     {
         return Simd::Vec3::CmpAllGtEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetFloor() const
     {
         return Vector3(Simd::Vec3::Floor(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetCeil() const
     {
         return Vector3(Simd::Vec3::Ceil(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetRound() const
     {
         return Vector3(Simd::Vec3::Round(m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetMin(const Vector3& v) const
     {
@@ -526,7 +451,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetMax(const Vector3& v) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -536,18 +460,15 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetClamp(const Vector3& min, const Vector3& max) const
     {
         return GetMin(max).GetMax(min);
     }
 
-
     AZ_MATH_INLINE float Vector3::GetMaxElement() const
     {
         return AZStd::max<float>(m_x, AZStd::max<float>(m_y, m_z));
     }
-
 
     AZ_MATH_INLINE float Vector3::GetMinElement() const
     {
@@ -559,42 +480,35 @@ namespace AZ
         return Vector3(Simd::Vec3::Sub(Simd::Vec3::ZeroFloat(), m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::operator+(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec3::Add(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::operator-(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec3::Sub(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::operator*(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec3::Mul(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::operator/(const Vector3& rhs) const
     {
         return Vector3(Simd::Vec3::Div(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::operator*(float multiplier) const
     {
         return Vector3(Simd::Vec3::Mul(m_value, Simd::Vec3::Splat(multiplier)));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::operator/(float divisor) const
     {
         return Vector3(Simd::Vec3::Div(m_value, Simd::Vec3::Splat(divisor)));
     }
-
 
     AZ_MATH_INLINE Vector3& Vector3::operator+=(const Vector3& rhs)
     {
@@ -602,13 +516,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector3& Vector3::operator-=(const Vector3& rhs)
     {
         *this = (*this) - rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector3& Vector3::operator*=(const Vector3& rhs)
     {
@@ -616,13 +528,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector3& Vector3::operator/=(const Vector3& rhs)
     {
         *this = (*this) / rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector3& Vector3::operator*=(float multiplier)
     {
@@ -630,49 +540,41 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector3& Vector3::operator/=(float divisor)
     {
         *this = (*this) / divisor;
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetSin() const
     {
         return Vector3(Simd::Vec3::Sin(m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetCos() const
     {
         return Vector3(Simd::Vec3::Cos(m_value));
     }
 
-
     AZ_MATH_INLINE void Vector3::GetSinCos(Vector3& sin, Vector3& cos) const
     {
         Simd::Vec3::SinCos(m_value, sin.m_value, cos.m_value);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetAcos() const
     {
         return Vector3(Simd::Vec3::Acos(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetAtan() const
     {
         return Vector3(Simd::Vec3::Atan(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetAngleMod() const
     {
         return Vector3(Simd::Vec3::AngleMod(m_value));
     }
-
 
     AZ_MATH_INLINE float Vector3::Angle(const Vector3& v) const
     {
@@ -683,61 +585,51 @@ namespace AZ
         return res;
     }
 
-
     AZ_MATH_INLINE float Vector3::AngleDeg(const Vector3& v) const
     {
         return RadToDeg(Angle(v));
     }
-
 
     AZ_MATH_INLINE float Vector3::AngleSafe(const Vector3& v) const
     {
         return (!IsZero() && !v.IsZero()) ? Angle(v) : 0.0f;
     }
 
-
     AZ_MATH_INLINE float Vector3::AngleSafeDeg(const Vector3& v) const
     {
         return (!IsZero() && !v.IsZero()) ? AngleDeg(v) : 0.0f;
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetAbs() const
     {
         return Vector3(Simd::Vec3::Abs(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetReciprocal() const
     {
         return Vector3(Simd::Vec3::Reciprocal(m_value));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetReciprocalEstimate() const
     {
         return Vector3(Simd::Vec3::ReciprocalEstimate(m_value));
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetMadd(const Vector3& mul, const Vector3& add)
     {
         return Vector3(Simd::Vec3::Madd(GetSimdValue(), mul.GetSimdValue(), add.GetSimdValue()));
     }
-
 
     AZ_MATH_INLINE void Vector3::Madd(const Vector3& mul, const Vector3& add)
     {
         *this = GetMadd(mul, add);
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsPerpendicular(const Vector3& v, float tolerance) const
     {
         Simd::Vec1::FloatType absLengthSq = Simd::Vec1::Abs(Simd::Vec3::Dot(m_value, v.m_value));
         return Simd::Vec1::SelectFirst(absLengthSq) < tolerance;
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetOrthogonalVector() const
     {
@@ -746,12 +638,10 @@ namespace AZ
         return Cross(axis);
     }
 
-
     AZ_MATH_INLINE void Vector3::Project(const Vector3& rhs)
     {
         *this = rhs * (Dot(rhs) / rhs.Dot(rhs));
     }
-
 
     AZ_MATH_INLINE void Vector3::ProjectOnNormal(const Vector3& normal)
     {
@@ -759,12 +649,10 @@ namespace AZ
         *this = normal * Dot(normal);
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3::GetProjected(const Vector3& rhs) const
     {
         return rhs * (Dot(rhs) / rhs.Dot(rhs));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3::GetProjectedOnNormal(const Vector3& normal)
     {
@@ -772,30 +660,30 @@ namespace AZ
         return normal * Dot(normal);
     }
 
-
     AZ_MATH_INLINE bool Vector3::IsFinite() const
     {
         return IsFiniteFloat(m_x) && IsFiniteFloat(m_y) && IsFiniteFloat(m_z);
     }
-
 
     AZ_MATH_INLINE Simd::Vec3::FloatType Vector3::GetSimdValue() const
     {
         return m_value;
     }
 
+    AZ_MATH_INLINE void Vector3::SetSimdValue(Simd::Vec3::FloatArgType value)
+    {
+        m_value = value;
+    }
 
     AZ_MATH_INLINE Vector3 operator*(float multiplier, const Vector3& rhs)
     {
         return rhs * multiplier;
     }
 
-
     AZ_MATH_INLINE Vector3 Vector3RadToDeg(const Vector3& radians)
     {
         return Vector3(Simd::Vec3::Mul(radians.GetSimdValue(), Simd::Vec3::Splat(180.0f / Constants::Pi)));
     }
-
 
     AZ_MATH_INLINE Vector3 Vector3DegToRad(const Vector3& degrees)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.h
@@ -31,7 +31,7 @@ namespace AZ
 
         //! Default constructor, components are uninitialized.
         Vector4() = default;
-        Vector4(const Vector4& v);
+        Vector4(const Vector4& v) = default;
 
         //! Constructs vector with all components set to the same specified value.
         explicit Vector4(float x);
@@ -298,9 +298,14 @@ namespace AZ
         //! Returns the reciprocal of each component of the vector, fast but low accuracy, uses raw estimate instructions.
         Vector4 GetReciprocalEstimate() const;
 
+        //! Returns true if the vector contains no nan or inf values, false if at least one element is not finite.
         bool IsFinite() const;
 
+        //! Returns the underlying SIMD vector.
         Simd::Vec4::FloatType GetSimdValue() const;
+
+        //! Directly sets the underlying SIMD vector.
+        void SetSimdValue(Simd::Vec4::FloatArgType value);
 
     protected:
         union

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.inl
@@ -11,19 +11,11 @@
 
 namespace AZ
 {
-    AZ_MATH_INLINE Vector4::Vector4(const Vector4& v)
-        : m_value(v.m_value)
-    {
-        ;
-    }
-
-
     AZ_MATH_INLINE Vector4::Vector4(float x)
         : m_value(Simd::Vec4::Splat(x))
     {
         ;
     }
-
 
     AZ_MATH_INLINE Vector4::Vector4(float x, float y, float z, float w)
         : m_value(Simd::Vec4::LoadImmediate(x, y, z, w))
@@ -84,24 +76,20 @@ namespace AZ
         return Vector4(length, 0.0f, 0.0f, 0.0f);
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::CreateAxisY(float length)
     {
         return Vector4(0.0f, length, 0.0f, 0.0f);
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::CreateAxisZ(float length)
     {
         return Vector4(0.0f, 0.0f, length, 0.0f);
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::CreateAxisW(float length)
     {
         return Vector4(0.0f, 0.0f, 0.0f, length);
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::CreateFromFloat4(const float values[])
     {
@@ -110,7 +98,6 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::CreateFromVector3(const Vector3& v)
     {
         Vector4 result;
@@ -118,14 +105,12 @@ namespace AZ
         return result;
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::CreateFromVector3AndFloat(const Vector3& v, float w)
     {
         Vector4 result;
         result.Set(v, w);
         return result;
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::CreateSelectCmpEqual(const Vector4& cmp1, const Vector4& cmp2, const Vector4& vA, const Vector4& vB)
     {
@@ -140,7 +125,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::CreateSelectCmpGreaterEqual(const Vector4& cmp1, const Vector4& cmp2, const Vector4& vA, const Vector4& vB)
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -153,7 +137,6 @@ namespace AZ
         return Vector4(Simd::Vec4::Select(vA.m_value, vB.m_value, mask));
 #endif
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::CreateSelectCmpGreater(const Vector4& cmp1, const Vector4& cmp2, const Vector4& vA, const Vector4& vB)
     {
@@ -168,36 +151,30 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE void Vector4::StoreToFloat4(float* values) const
     {
         Simd::Vec4::StoreUnaligned(values, m_value);
     }
-
 
     AZ_MATH_INLINE float Vector4::GetX() const
     {
         return m_x;
     }
 
-
     AZ_MATH_INLINE float Vector4::GetY() const
     {
         return m_y;
     }
-
 
     AZ_MATH_INLINE float Vector4::GetZ() const
     {
         return m_z;
     }
 
-
     AZ_MATH_INLINE float Vector4::GetW() const
     {
         return m_w;
     }
-
 
     AZ_MATH_INLINE float Vector4::GetElement(int32_t index) const
     {
@@ -205,48 +182,40 @@ namespace AZ
         return m_values[index];
     }
 
-
     AZ_MATH_INLINE void Vector4::SetX(float x)
     {
         m_x = x;
     }
-
 
     AZ_MATH_INLINE void Vector4::SetY(float y)
     {
         m_y = y;
     }
 
-
     AZ_MATH_INLINE void Vector4::SetZ(float z)
     {
         m_z = z;
     }
-
 
     AZ_MATH_INLINE void Vector4::SetW(float w)
     {
         m_w = w;
     }
 
-
     AZ_MATH_INLINE void Vector4::Set(float x)
     {
         m_value = Simd::Vec4::Splat(x);
     }
-
 
     AZ_MATH_INLINE void Vector4::Set(float x, float y, float z, float w)
     {
         m_value = Simd::Vec4::LoadImmediate(x, y, z, w);
     }
 
-
     AZ_MATH_INLINE void Vector4::Set(const float values[])
     {
         m_value = Simd::Vec4::LoadUnaligned(values);
     }
-
 
     AZ_MATH_INLINE void Vector4::Set(const Vector3& v)
     {
@@ -254,19 +223,16 @@ namespace AZ
         m_w = 1.0f;
     }
 
-
     AZ_MATH_INLINE void Vector4::Set(const Vector3& v, float w)
     {
         m_value = Simd::Vec4::FromVec3(v.GetSimdValue());
         m_w = w;
     }
 
-
     AZ_MATH_INLINE void Vector4::Set(Simd::Vec4::FloatArgType v)
     {
         m_value = v;
     }
-
 
     AZ_MATH_INLINE void Vector4::SetElement(int32_t index, float v)
     {
@@ -274,24 +240,20 @@ namespace AZ
         m_values[index] = v;
     }
 
-
     AZ_MATH_INLINE Vector3 Vector4::GetAsVector3() const
     {
         return Vector3(Simd::Vec4::ToVec3(m_value));
     }
-
 
     AZ_MATH_INLINE float Vector4::operator()(int32_t index) const
     {
         return GetElement(index);
     }
 
-
     AZ_MATH_INLINE float Vector4::GetLengthSq() const
     {
         return Dot(*this);
     }
-
 
     AZ_MATH_INLINE float Vector4::GetLength() const
     {
@@ -299,13 +261,11 @@ namespace AZ
         return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(lengthSq));
     }
 
-
     AZ_MATH_INLINE float Vector4::GetLengthEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(lengthSq));
     }
-
 
     AZ_MATH_INLINE float Vector4::GetLengthReciprocal() const
     {
@@ -313,61 +273,51 @@ namespace AZ
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(lengthSq));
     }
 
-
     AZ_MATH_INLINE float Vector4::GetLengthReciprocalEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
         return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(lengthSq));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetNormalized() const
     {
         return Vector4(Simd::Vec4::Normalize(m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetNormalizedEstimate() const
     {
         return Vector4(Simd::Vec4::NormalizeEstimate(m_value));
     }
 
-
     AZ_MATH_INLINE void Vector4::Normalize()
     {
         *this = GetNormalized();
     }
-
 
     AZ_MATH_INLINE void Vector4::NormalizeEstimate()
     {
         *this = GetNormalizedEstimate();
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetNormalizedSafe(float tolerance) const
     {
         return Vector4(Simd::Vec4::NormalizeSafe(m_value, tolerance));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetNormalizedSafeEstimate(float tolerance) const
     {
         return Vector4(Simd::Vec4::NormalizeSafeEstimate(m_value, tolerance));
     }
 
-
     AZ_MATH_INLINE void Vector4::NormalizeSafe(float tolerance)
     {
         *this = GetNormalizedSafe(tolerance);
     }
 
-
     AZ_MATH_INLINE void Vector4::NormalizeSafeEstimate(float tolerance)
     {
         *this = GetNormalizedSafeEstimate(tolerance);
     }
-
 
     AZ_MATH_INLINE float Vector4::NormalizeWithLength()
     {
@@ -377,7 +327,6 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE float Vector4::NormalizeWithLengthEstimate()
     {
         const float length = Simd::Vec1::SelectFirst(
@@ -386,14 +335,12 @@ namespace AZ
         return length;
     }
 
-
     AZ_MATH_INLINE float Vector4::NormalizeSafeWithLength(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::Sqrt(Simd::Vec4::Dot(m_value, m_value));
         m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec4::ZeroFloat() : Simd::Vec4::Div(m_value, Simd::Vec4::SplatFirst(Simd::Vec4::FromVec1(length)));
         return Simd::Vec1::SelectFirst(length);
     }
-
 
     AZ_MATH_INLINE float Vector4::NormalizeSafeWithLengthEstimate(float tolerance)
     {
@@ -402,12 +349,10 @@ namespace AZ
         return Simd::Vec1::SelectFirst(length);
     }
 
-
     AZ_MATH_INLINE bool Vector4::IsNormalized(float tolerance) const
     {
         return (Abs(GetLengthSq() - 1.0f) <= tolerance);
     }
-
 
     AZ_MATH_INLINE void Vector4::SetLength(float length)
     {
@@ -415,31 +360,26 @@ namespace AZ
         (*this) *= scale;
     }
 
-
     AZ_MATH_INLINE void Vector4::SetLengthEstimate(float length)
     {
         float scale(length * GetLengthReciprocalEstimate());
         (*this) *= scale;
     }
 
-
     AZ_MATH_INLINE float Vector4::GetDistanceSq(const Vector4& v) const
     {
         return ((*this) - v).GetLengthSq();
     }
-
 
     AZ_MATH_INLINE float Vector4::GetDistance(const Vector4& v) const
     {
         return ((*this) - v).GetLength();
     }
 
-
     AZ_MATH_INLINE float Vector4::GetDistanceEstimate(const Vector4& v) const
     {
         return ((*this) - v).GetLengthEstimate();
     }
-
 
     AZ_MATH_INLINE bool Vector4::IsClose(const Vector4& v, float tolerance) const
     {
@@ -447,66 +387,56 @@ namespace AZ
         return dist.IsLessEqualThan(Vector4(tolerance));
     }
 
-
     AZ_MATH_INLINE bool Vector4::IsZero(float tolerance) const
     {
-        return IsClose(CreateZero(), tolerance);
+        Vector4 dist = GetAbs();
+        return dist.IsLessEqualThan(Vector4(tolerance));
     }
-
 
     AZ_MATH_INLINE bool Vector4::operator==(const Vector4& rhs) const
     {
         return Simd::Vec4::CmpAllEq(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector4::operator!=(const Vector4& rhs) const
     {
         return !Simd::Vec4::CmpAllEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector4::IsLessThan(const Vector4& rhs) const
     {
         return Simd::Vec4::CmpAllLt(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector4::IsLessEqualThan(const Vector4& rhs) const
     {
         return Simd::Vec4::CmpAllLtEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE bool Vector4::IsGreaterThan(const Vector4& rhs) const
     {
         return Simd::Vec4::CmpAllGt(m_value, rhs.m_value);
     }
 
-
     AZ_MATH_INLINE bool Vector4::IsGreaterEqualThan(const Vector4& rhs) const
     {
         return Simd::Vec4::CmpAllGtEq(m_value, rhs.m_value);
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetFloor() const
     {
         return Vector4(Simd::Vec4::Floor(m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetCeil() const
     {
         return Vector4(Simd::Vec4::Ceil(m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetRound() const
     {
         return Vector4(Simd::Vec4::Round(m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetMin(const Vector4& v) const
     {
@@ -517,7 +447,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetMax(const Vector4& v) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -527,18 +456,15 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetClamp(const Vector4& min, const Vector4& max) const
     {
         return GetMin(max).GetMax(min);
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::Lerp(const Vector4& dest, float t) const
     {
         return Vector4(Simd::Vec4::Madd(Simd::Vec4::Sub(dest.m_value, m_value), Simd::Vec4::Splat(t), m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::Slerp(const Vector4& dest, float t) const
     {
@@ -553,12 +479,10 @@ namespace AZ
         return Vector4(Simd::Vec4::Madd(GetSimdValue(), Simd::Vec4::SplatSecond(sinCos), relVecSinTheta));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::Nlerp(const Vector4& dest, float t) const
     {
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);
     }
-
 
     AZ_MATH_INLINE float Vector4::Dot(const Vector4& rhs) const
     {
@@ -569,7 +493,6 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE float Vector4::Dot3(const Vector3& rhs) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
@@ -579,13 +502,11 @@ namespace AZ
 #endif
     }
 
-
     AZ_MATH_INLINE void Vector4::Homogenize()
     {
         const Simd::Vec4::FloatType divisor = Simd::Vec4::SplatFourth(m_value);
         m_value = Simd::Vec4::Div(m_value, divisor);
     }
-
 
     AZ_MATH_INLINE Vector3 Vector4::GetHomogenized() const
     {
@@ -598,42 +519,35 @@ namespace AZ
         return Vector4(Simd::Vec4::Sub(Simd::Vec4::ZeroFloat(), m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::operator+(const Vector4& rhs) const
     {
         return Vector4(Simd::Vec4::Add(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::operator-(const Vector4& rhs) const
     {
         return Vector4(Simd::Vec4::Sub(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::operator*(const Vector4& rhs) const
     {
         return Vector4(Simd::Vec4::Mul(m_value, rhs.m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::operator/(const Vector4& rhs) const
     {
         return Vector4(Simd::Vec4::Div(m_value, rhs.m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::operator*(float multiplier) const
     {
         return Vector4(Simd::Vec4::Mul(m_value, Simd::Vec4::Splat(multiplier)));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::operator/(float divisor) const
     {
         return Vector4(Simd::Vec4::Div(m_value, Simd::Vec4::Splat(divisor)));
     }
-
 
     AZ_MATH_INLINE Vector4& Vector4::operator+=(const Vector4& rhs)
     {
@@ -641,13 +555,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector4& Vector4::operator-=(const Vector4& rhs)
     {
         *this = (*this) - rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector4& Vector4::operator*=(const Vector4& rhs)
     {
@@ -655,13 +567,11 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector4& Vector4::operator/=(const Vector4& rhs)
     {
         *this = (*this) / rhs;
         return *this;
     }
-
 
     AZ_MATH_INLINE Vector4& Vector4::operator*=(float multiplier)
     {
@@ -669,25 +579,21 @@ namespace AZ
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector4& Vector4::operator/=(float divisor)
     {
         *this = (*this) / divisor;
         return *this;
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetSin() const
     {
         return Vector4(Simd::Vec4::Sin(m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetCos() const
     {
         return Vector4(Simd::Vec4::Cos(m_value));
     }
-
 
     AZ_MATH_INLINE void Vector4::GetSinCos(Vector4& sin, Vector4& cos) const
     {
@@ -697,24 +603,20 @@ namespace AZ
         cos = Vector4(cosValues);
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetAcos() const
     {
         return Vector4(Simd::Vec4::Acos(m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetAtan() const
     {
         return Vector4(Simd::Vec4::Atan(m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetAngleMod() const
     {
         return Vector4(Simd::Vec4::AngleMod(m_value));
     }
-
 
     AZ_MATH_INLINE float Vector4::Angle(const Vector4& v) const
     {
@@ -725,54 +627,50 @@ namespace AZ
         return res;
     }
 
-
     AZ_MATH_INLINE float Vector4::AngleDeg(const Vector4& v) const
     {
         return RadToDeg(Angle(v));
     }
-
 
     AZ_MATH_INLINE float Vector4::AngleSafe(const Vector4& v) const
     {
         return (!IsZero() && !v.IsZero()) ? Angle(v) : 0.0f;
     }
 
-
     AZ_MATH_INLINE float Vector4::AngleSafeDeg(const Vector4& v) const
     {
         return (!IsZero() && !v.IsZero()) ? AngleDeg(v) : 0.0f;
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetAbs() const
     {
         return Vector4(Simd::Vec4::Abs(m_value));
     }
 
-
     AZ_MATH_INLINE Vector4 Vector4::GetReciprocal() const
     {
         return Vector4(Simd::Vec4::Reciprocal(m_value));
     }
-
 
     AZ_MATH_INLINE Vector4 Vector4::GetReciprocalEstimate() const
     {
         return Vector4(Simd::Vec4::ReciprocalEstimate(m_value));
     }
 
-
     AZ_MATH_INLINE bool Vector4::IsFinite() const
     {
         return IsFiniteFloat(GetX()) && IsFiniteFloat(GetY()) && IsFiniteFloat(GetZ()) && IsFiniteFloat(GetW());
     }
-
 
     AZ_MATH_INLINE Simd::Vec4::FloatType Vector4::GetSimdValue() const
     {
         return m_value;
     }
 
+    AZ_MATH_INLINE void Vector4::SetSimdValue(Simd::Vec4::FloatArgType value)
+    {
+        m_value = value;
+    }
 
     AZ_MATH_INLINE Vector4 operator*(float multiplier, const Vector4& rhs)
     {

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.inl
@@ -258,25 +258,25 @@ namespace AZ
     AZ_MATH_INLINE float Vector4::GetLength() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::Sqrt(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::Sqrt(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector4::GetLengthEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtEstimate(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector4::GetLengthReciprocal() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInv(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInv(lengthSq));
     }
 
     AZ_MATH_INLINE float Vector4::GetLengthReciprocalEstimate() const
     {
         const Simd::Vec1::FloatType lengthSq = Simd::Vec4::Dot(m_value, m_value);
-        return Simd::Vec1::SelectFirst(Simd::Vec1::SqrtInvEstimate(lengthSq));
+        return Simd::Vec1::SelectIndex0(Simd::Vec1::SqrtInvEstimate(lengthSq));
     }
 
     AZ_MATH_INLINE Vector4 Vector4::GetNormalized() const
@@ -321,7 +321,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector4::NormalizeWithLength()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::Sqrt(Simd::Vec4::Dot(m_value, m_value)));
         m_value = Simd::Vec4::Div(m_value, Simd::Vec4::Splat(length));
         return length;
@@ -329,7 +329,7 @@ namespace AZ
 
     AZ_MATH_INLINE float Vector4::NormalizeWithLengthEstimate()
     {
-        const float length = Simd::Vec1::SelectFirst(
+        const float length = Simd::Vec1::SelectIndex0(
             Simd::Vec1::SqrtEstimate(Simd::Vec4::Dot(m_value, m_value)));
         m_value = Simd::Vec4::Div(m_value, Simd::Vec4::Splat(length));
         return length;
@@ -338,15 +338,15 @@ namespace AZ
     AZ_MATH_INLINE float Vector4::NormalizeSafeWithLength(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::Sqrt(Simd::Vec4::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec4::ZeroFloat() : Simd::Vec4::Div(m_value, Simd::Vec4::SplatFirst(Simd::Vec4::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec4::ZeroFloat() : Simd::Vec4::Div(m_value, Simd::Vec4::SplatIndex0(Simd::Vec4::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE float Vector4::NormalizeSafeWithLengthEstimate(float tolerance)
     {
         const Simd::Vec1::FloatType length = Simd::Vec1::SqrtEstimate(Simd::Vec4::Dot(m_value, m_value));
-        m_value = (Simd::Vec1::SelectFirst(length) < tolerance) ? Simd::Vec4::ZeroFloat() : Simd::Vec4::Div(m_value, Simd::Vec4::SplatFirst(Simd::Vec4::FromVec1(length)));
-        return Simd::Vec1::SelectFirst(length);
+        m_value = (Simd::Vec1::SelectIndex0(length) < tolerance) ? Simd::Vec4::ZeroFloat() : Simd::Vec4::Div(m_value, Simd::Vec4::SplatIndex0(Simd::Vec4::FromVec1(length)));
+        return Simd::Vec1::SelectIndex0(length);
     }
 
     AZ_MATH_INLINE bool Vector4::IsNormalized(float tolerance) const
@@ -475,8 +475,8 @@ namespace AZ
         const Simd::Vec4::FloatType relativeVec = Simd::Vec4::Sub(dest.GetSimdValue(), Simd::Vec4::Mul(GetSimdValue(), Simd::Vec4::FromVec1(dot)));
         const Simd::Vec4::FloatType relVecNorm = Simd::Vec4::NormalizeSafe(relativeVec, Constants::Tolerance);
         const Simd::Vec4::FloatType sinCos = Simd::Vec4::FromVec2(Simd::Vec2::SinCos(theta));
-        const Simd::Vec4::FloatType relVecSinTheta = Simd::Vec4::Mul(relVecNorm, Simd::Vec4::SplatFirst(sinCos));
-        return Vector4(Simd::Vec4::Madd(GetSimdValue(), Simd::Vec4::SplatSecond(sinCos), relVecSinTheta));
+        const Simd::Vec4::FloatType relVecSinTheta = Simd::Vec4::Mul(relVecNorm, Simd::Vec4::SplatIndex0(sinCos));
+        return Vector4(Simd::Vec4::Madd(GetSimdValue(), Simd::Vec4::SplatIndex1(sinCos), relVecSinTheta));
     }
 
     AZ_MATH_INLINE Vector4 Vector4::Nlerp(const Vector4& dest, float t) const
@@ -489,7 +489,7 @@ namespace AZ
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
         return (m_x * rhs.m_x + m_y * rhs.m_y + m_z * rhs.m_z + m_w * rhs.m_w);
 #else
-        return Simd::Vec1::SelectFirst(Simd::Vec4::Dot(m_value, rhs.m_value));
+        return Simd::Vec1::SelectIndex0(Simd::Vec4::Dot(m_value, rhs.m_value));
 #endif
     }
 
@@ -498,19 +498,19 @@ namespace AZ
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR
         return (m_x * rhs.GetX() + m_y * rhs.GetY() + m_z * rhs.GetZ());
 #else
-        return Simd::Vec1::SelectFirst(Simd::Vec3::Dot(Simd::Vec4::ToVec3(m_value), rhs.GetSimdValue()));
+        return Simd::Vec1::SelectIndex0(Simd::Vec3::Dot(Simd::Vec4::ToVec3(m_value), rhs.GetSimdValue()));
 #endif
     }
 
     AZ_MATH_INLINE void Vector4::Homogenize()
     {
-        const Simd::Vec4::FloatType divisor = Simd::Vec4::SplatFourth(m_value);
+        const Simd::Vec4::FloatType divisor = Simd::Vec4::SplatIndex3(m_value);
         m_value = Simd::Vec4::Div(m_value, divisor);
     }
 
     AZ_MATH_INLINE Vector3 Vector4::GetHomogenized() const
     {
-        const Simd::Vec3::FloatType divisor = Simd::Vec4::ToVec3(Simd::Vec4::SplatFourth(m_value));
+        const Simd::Vec3::FloatType divisor = Simd::Vec4::ToVec3(Simd::Vec4::SplatIndex3(m_value));
         return Vector3(Simd::Vec3::Div(Simd::Vec4::ToVec3(m_value), divisor));
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/VectorN.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/MathScriptHelpers.h>
+
+namespace AZ
+{
+    void VectorN::Reflect([[maybe_unused]] ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<VectorN>()
+                ->Version(1)
+                ->Field("NumElements", &VectorN::m_numElements)
+                ->Field("Values", &VectorN::m_values)
+                ;
+
+            if (EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<VectorN>("N-Dimensional Vector", "")
+                    ->ClassElement(Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        Edit::UIHandlers::Default, &VectorN::m_numElements, "Total Elements", "The total number of elements in the vector")
+                    ->DataElement(
+                        Edit::UIHandlers::Default, &VectorN::m_values, "Array of values", "The array of values in the vector")
+                    ;
+            }
+        }
+
+        auto behaviorContext = azrtti_cast<BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->Class<VectorN>()->
+                Attribute(Script::Attributes::Scope, Script::Attributes::ScopeFlags::Common)->
+                Attribute(Script::Attributes::Module, "math")->
+                Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::ListOnly)->
+                Constructor<AZStd::size_t>()->
+                Constructor<AZStd::size_t, float>()->
+                Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)
+                ;
+        }
+    }
+}

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
@@ -28,8 +28,7 @@ namespace AZ
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->DataElement(
                         Edit::UIHandlers::Default, &VectorN::m_numElements, "Total Elements", "The total number of elements in the vector")
-                    ->DataElement(
-                        Edit::UIHandlers::Default, &VectorN::m_values, "Array of values", "The array of values in the vector")
+                            ->Attribute(Edit::Attributes::ChangeNotify, &VectorN::OnSizeChanged)
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.h
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Internal/MathTypes.h>
+#include <AzCore/Math/Vector4.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    //! N-dimensional vector class.
+    class VectorN final
+    {
+    public:
+
+        AZ_TYPE_INFO(VectorN, "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}");
+
+        //! AzCore Reflection.
+        //! @param context reflection context
+        static void Reflect(ReflectContext* context);
+
+        VectorN() = default;
+
+        VectorN(AZStd::size_t numElements);
+
+        VectorN(AZStd::size_t numElements, float x);
+
+        VectorN(const VectorN& v) = default;
+
+        VectorN(VectorN&& v);
+
+        ~VectorN() = default;
+
+        //! Creates a vector with all components set to zero, more efficient than calling VectorN(0.0f).
+        static VectorN CreateZero(AZStd::size_t numElements);
+
+        //! Creates a vector with all components set to one.
+        static VectorN CreateOne(AZStd::size_t numElements);
+
+        //! Creates a vector with all components set to the provided input values.
+        static VectorN CreateFromFloats(AZStd::size_t numElements, const float* inputs);
+
+        //! Creates a vector with all elements set to random numbers in the range [0, 1).
+        static VectorN CreateRandom(AZStd::size_t numElements);
+
+        //! Returns the dimensionality of the vector.
+        AZStd::size_t GetDimensionality() const;
+
+        //! Returns the value at the requested index.
+        float GetElement(AZStd::size_t index) const;
+
+        //! Returns the value at the requested index.
+        void SetElement(AZStd::size_t index, float value);
+
+        //! Checks whether two vectors of equal dimensionality are equal to each other within a floating point tolerance.
+        bool IsClose(const VectorN& v, float tolerance = 0.001f) const;
+
+        //! Checks if the vector is a zero vector, within the provided tolerance for zero.
+        bool IsZero(float tolerance = AZ::Constants::FloatEpsilon) const;
+
+        //! Applies the rectified linear unit function (ReLU) to all elements within the vector.
+        void ReLU();
+
+        //! Comparison functions, not implemented as operators since that would probably be a little dangerous.
+        //! These functions return true only if all components pass the comparison test.
+        //! @{
+        bool IsLessThan(const VectorN& v) const;
+        bool IsLessEqualThan(const VectorN& v) const;
+        bool IsGreaterThan(const VectorN& v) const;
+        bool IsGreaterEqualThan(const VectorN& v) const;
+        //! @}
+
+        //! Floor/Ceil/Round functions, operate on each component individually, result will be stored in output.
+        //! @{
+        VectorN GetFloor() const;
+        VectorN GetCeil() const;
+        VectorN GetRound() const; // Ties to even (banker's rounding)
+        //! @}
+
+        //! Min/Max functions, operate on each component individually, result will be stored in output.
+        //! @{
+        VectorN GetMin(const VectorN& v) const;
+        VectorN GetMax(const VectorN& v) const;
+        VectorN GetClamp(const VectorN& min, const VectorN& max) const;
+        //! @}
+
+        //! Returns squared length of the vector.
+        float GetLengthSq() const;
+
+        //! Returns length of the vector, full accuracy.
+        float GetLength() const;
+
+        //! Returns normalized vector, full accuracy.
+        VectorN GetNormalized() const;
+
+        //! Normalizes the vector in-place, full accuracy.
+        void Normalize();
+
+        //! Returns a new VectorN containing the absolute value of all elements in the source VectorN.
+        VectorN GetAbs() const;
+
+        //! Returns a new VectorN containing the square of all elements in the source VectorN.
+        VectorN GetSquare() const;
+
+        //! Returns the dot product of two vectors of equal dimension.
+        float Dot(const VectorN& rhs) const;
+
+        VectorN& operator+=(const VectorN& rhs);
+        VectorN& operator-=(const VectorN& rhs);
+        VectorN& operator*=(const VectorN& rhs); //! Hadamard product, not dot product.
+        VectorN& operator/=(const VectorN& rhs);
+
+        VectorN& operator+=(float sum);
+        VectorN& operator-=(float difference);
+        VectorN& operator*=(float multiplier);
+        VectorN& operator/=(float divisor);
+
+        VectorN operator-() const;
+        VectorN operator+(const VectorN& rhs) const;
+        VectorN operator-(const VectorN& rhs) const;
+        VectorN operator*(const VectorN& rhs) const; //! Hadamard product, not dot product.
+        VectorN operator/(const VectorN& rhs) const;
+
+        VectorN operator*(float multiplier) const;
+        VectorN operator/(float divisor) const;
+
+        //! Returns the raw Vector4's that represent this vector instance.
+        const AZStd::vector<Vector4>& GetVectorValues() const;
+        AZStd::vector<Vector4>& GetVectorValues();
+
+        //! Zeros out unused components of the last vector element
+        void FixLastVectorElement();
+
+    private:
+
+        const AZStd::size_t m_numElements = 0;
+        AZStd::vector<Vector4> m_values;
+    };
+}
+
+#include <AzCore/Math/VectorN.inl>

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.h
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.h
@@ -54,6 +54,9 @@ namespace AZ
         //! Returns the dimensionality of the vector.
         AZStd::size_t GetDimensionality() const;
 
+        //! Changes the dimensionality of the vector.
+        void Resize(AZStd::size_t size);
+
         //! Returns the value at the requested index.
         float GetElement(AZStd::size_t index) const;
 
@@ -140,6 +143,9 @@ namespace AZ
         void FixLastVectorElement();
 
     private:
+
+        //! Updates the vector internals to match the current dimensionality.
+        void OnSizeChanged();
 
         AZStd::size_t m_numElements = 0;
         AZStd::vector<Vector4> m_values;

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.h
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.h
@@ -141,7 +141,7 @@ namespace AZ
 
     private:
 
-        const AZStd::size_t m_numElements = 0;
+        AZStd::size_t m_numElements = 0;
         AZStd::vector<Vector4> m_values;
     };
 }

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.inl
@@ -13,7 +13,7 @@ namespace AZ
     AZ_MATH_INLINE VectorN::VectorN(AZStd::size_t numElements)
         : m_numElements(numElements)
     {
-        m_values.resize((numElements + 3) / 4);
+        OnSizeChanged();
     }
 
     AZ_MATH_INLINE VectorN::VectorN(AZStd::size_t numElements, float x)
@@ -59,7 +59,7 @@ namespace AZ
         VectorN returnValue(numElements);
         for (Vector4& element : returnValue.m_values)
         {
-            element.SetSimdValue(randGen.GetRandomFloat());
+            element.SetSimdValue(randGen.GetRandomFloat4());
         }
         returnValue.FixLastVectorElement();
         return returnValue;
@@ -68,6 +68,12 @@ namespace AZ
     AZ_MATH_INLINE AZStd::size_t VectorN::GetDimensionality() const
     {
         return m_numElements;
+    }
+
+    AZ_MATH_INLINE void VectorN::Resize(AZStd::size_t size)
+    {
+        m_numElements = size;
+        OnSizeChanged();
     }
 
     AZ_MATH_INLINE float VectorN::GetElement(AZStd::size_t index) const
@@ -479,5 +485,11 @@ namespace AZ
         const Simd::Vec4::FloatType mask = Simd::Vec4::LoadAligned(reinterpret_cast<const float*>(&masks[trailingZeroElements]));
 
         m_values[lastElement].SetSimdValue(Simd::Vec4::And(m_values[lastElement].GetSimdValue(), mask));
+    }
+
+    AZ_MATH_INLINE void VectorN::OnSizeChanged()
+    {
+        m_values.resize((m_numElements + 3) / 4);
+        FixLastVectorElement();
     }
 }

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.inl
@@ -466,7 +466,6 @@ namespace AZ
 
     AZ_MATH_INLINE void VectorN::FixLastVectorElement()
     {
-        const Simd::Vec4::FloatType zero = Simd::Vec4::ZeroFloat();
         const uint32_t masks[] =
         {
             0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.inl
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Random.h>
+
+namespace AZ
+{
+    AZ_MATH_INLINE VectorN::VectorN(AZStd::size_t numElements)
+        : m_numElements(numElements)
+    {
+        m_values.resize((numElements + 3) / 4);
+    }
+
+    AZ_MATH_INLINE VectorN::VectorN(AZStd::size_t numElements, float x)
+        : VectorN(numElements)
+    {
+        Simd::Vec4::FloatType xVec = Simd::Vec4::Splat(x);
+        for (Vector4& element : m_values)
+        {
+            element.SetSimdValue(xVec);
+        }
+        FixLastVectorElement();
+    }
+
+    AZ_MATH_INLINE VectorN::VectorN(VectorN&& v)
+        : m_numElements(v.m_numElements)
+        , m_values(AZStd::move(v.m_values))
+    {
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::CreateZero(AZStd::size_t numElements)
+    {
+        return VectorN(numElements, 0.0f);
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::CreateOne(AZStd::size_t numElements)
+    {
+        return VectorN(numElements, 1.0f);
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::CreateFromFloats(AZStd::size_t numElements, const float* inputs)
+    {
+        VectorN returnValue(numElements);
+        for (AZStd::size_t iter = 0; iter < numElements; ++iter)
+        {
+            returnValue.SetElement(iter, inputs[iter]);
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::CreateRandom(AZStd::size_t numElements)
+    {
+        SimpleLcgRandomVec4 randGen;
+        VectorN returnValue(numElements);
+        for (Vector4& element : returnValue.m_values)
+        {
+            element.SetSimdValue(randGen.GetRandomFloat());
+        }
+        returnValue.FixLastVectorElement();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE AZStd::size_t VectorN::GetDimensionality() const
+    {
+        return m_numElements;
+    }
+
+    AZ_MATH_INLINE float VectorN::GetElement(AZStd::size_t index) const
+    {
+        const AZStd::size_t element = index / 4;
+        return m_values[element].GetElement(index % 4);
+    }
+
+    AZ_MATH_INLINE void VectorN::SetElement(AZStd::size_t index, float value)
+    {
+        const AZStd::size_t element = index / 4;
+        m_values[element].SetElement(index % 4, value);
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsClose(const VectorN& v, float tolerance) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        Simd::Vec4::FloatType vecTolerance = Simd::Vec4::Splat(tolerance);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            Simd::Vec4::FloatType dist = Simd::Vec4::Abs(Simd::Vec4::Sub(m_values[i].GetSimdValue(), v.m_values[i].GetSimdValue()));
+            if (!Simd::Vec4::CmpAllLtEq(dist, vecTolerance))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsZero(float tolerance) const
+    {
+        Simd::Vec4::FloatType vecTolerance = Simd::Vec4::Splat(tolerance);
+        for (const Vector4& element : m_values)
+        {
+            if (!Simd::Vec4::CmpAllLtEq(Simd::Vec4::Abs(element.GetSimdValue()), vecTolerance))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    AZ_MATH_INLINE void VectorN::ReLU()
+    {
+        const Simd::Vec4::FloatType zero = Simd::Vec4::ZeroFloat();
+        for (Vector4& element : m_values)
+        {
+            const Simd::Vec4::FloatType mask = Simd::Vec4::CmpGtEq(element.GetSimdValue(), zero); // 1's if >= 0, 0's otherwise
+            element.SetSimdValue(Simd::Vec4::Select(element.GetSimdValue(), zero, mask)); // Returns first if mask is non-zero, returns second otherwise
+        }
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsLessThan(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            if (!Simd::Vec4::CmpAllLt(m_values[i].GetSimdValue(), v.m_values[i].GetSimdValue()))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsLessEqualThan(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            if (!Simd::Vec4::CmpAllLtEq(m_values[i].GetSimdValue(), v.m_values[i].GetSimdValue()))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsGreaterThan(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            if (!Simd::Vec4::CmpAllGt(m_values[i].GetSimdValue(), v.m_values[i].GetSimdValue()))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    AZ_MATH_INLINE bool VectorN::IsGreaterEqualThan(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            if (!Simd::Vec4::CmpAllGtEq(m_values[i].GetSimdValue(), v.m_values[i].GetSimdValue()))
+            {
+                return false;
+            }
+        }
+        return true;
+
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetFloor() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetFloor();
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetCeil() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetCeil();
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetRound() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetRound();
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetMin(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetMin(v.m_values[i]);
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetMax(const VectorN& v) const
+    {
+        AZ_Assert(m_numElements == v.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetMax(v.m_values[i]);
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetClamp(const VectorN& min, const VectorN& max) const
+    {
+        AZ_Assert(m_numElements == min.m_numElements, "Dimensionality must be equal");
+        AZ_Assert(m_numElements == max.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetClamp(min.m_values[i], max.m_values[i]);
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE float VectorN::GetLengthSq() const
+    {
+        float lengthSquared = 0.0f;
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            lengthSquared += m_values[i].GetLengthSq();
+        }
+        return lengthSquared;
+    }
+
+    AZ_MATH_INLINE float VectorN::GetLength() const
+    {
+        return AZ::Sqrt(GetLengthSq());
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetNormalized() const
+    {
+        VectorN returnValue(*this);
+        returnValue.Normalize();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE void VectorN::Normalize()
+    {
+        const float length = GetLength();
+        *this /= length;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetAbs() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i].GetAbs();
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::GetSquare() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] * m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE float VectorN::Dot(const VectorN& rhs) const
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        float dot = 0.0f;
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            dot += m_values[i].Dot(rhs.m_values[i]);
+        }
+        return dot;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator+=(const VectorN& rhs)
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] += rhs.m_values[i];
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator-=(const VectorN& rhs)
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] -= rhs.m_values[i];
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator*=(const VectorN& rhs)
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] *= rhs.m_values[i];
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator/=(const VectorN& rhs)
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] /= rhs.m_values[i];
+        }
+        FixLastVectorElement();
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator+=(float sum)
+    {
+        Vector4 sumVec = Vector4(sum);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] += sumVec;
+        }
+        FixLastVectorElement();
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator-=(float difference)
+    {
+        Vector4 diffVec = Vector4(difference);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] -= diffVec;
+        }
+        FixLastVectorElement();
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator*=(float multiplier)
+    {
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] *= multiplier;
+        }
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN& VectorN::operator/=(float divisor)
+    {
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] /= divisor;
+        }
+        FixLastVectorElement();
+        return *this;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator-() const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = -m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator+(const VectorN& rhs) const
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] + rhs.m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator-(const VectorN& rhs) const
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] - rhs.m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator*(const VectorN& rhs) const
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] * rhs.m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator/(const VectorN& rhs) const
+    {
+        AZ_Assert(m_numElements == rhs.m_numElements, "Dimensionality must be equal");
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] / rhs.m_values[i];
+        }
+        returnValue.FixLastVectorElement();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator*(float multiplier) const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] * multiplier;
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE VectorN VectorN::operator/(float divisor) const
+    {
+        VectorN returnValue(m_numElements);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] / divisor;
+        }
+        returnValue.FixLastVectorElement();
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE const AZStd::vector<Vector4>& VectorN::GetVectorValues() const
+    {
+        return m_values;
+    }
+
+    AZ_MATH_INLINE AZStd::vector<Vector4>& VectorN::GetVectorValues()
+    {
+        return m_values;
+    }
+
+    AZ_MATH_INLINE void VectorN::FixLastVectorElement()
+    {
+        const Simd::Vec4::FloatType zero = Simd::Vec4::ZeroFloat();
+        const uint32_t masks[] =
+        {
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000
+        };
+
+        const AZStd::size_t lastElement = m_values.size() - 1;
+        const AZStd::size_t trailingZeroElements = 4 * (m_numElements % 4);
+        const Simd::Vec4::FloatType mask = Simd::Vec4::LoadAligned(reinterpret_cast<const float*>(&masks[trailingZeroElements]));
+
+        m_values[lastElement].SetSimdValue(Simd::Vec4::And(m_values[lastElement].GetSimdValue(), mask));
+    }
+}

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -341,6 +341,9 @@ set(FILES
     Math/Matrix4x4.cpp
     Math/Matrix4x4.h
     Math/Matrix4x4.inl
+    Math/MatrixMxN.cpp
+    Math/MatrixMxN.h
+    Math/MatrixMxN.inl
     Math/MatrixUtils.h
     Math/MatrixUtils.cpp
     Math/Obb.cpp
@@ -391,6 +394,9 @@ set(FILES
     Math/Vector4.cpp
     Math/Vector4.h
     Math/Vector4.inl
+    Math/VectorN.cpp
+    Math/VectorN.h
+    Math/VectorN.inl
     Math/VectorConversions.h
     Math/VertexContainer.h
     Math/VertexContainer.cpp

--- a/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/MatrixMxN.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+
+namespace UnitTest
+{
+    class Math_MatrixMxN
+        : public UnitTest::LeakDetectionFixture
+    {
+    };
+
+    TEST_F(Math_MatrixMxN, TestConstructor)
+    {
+        AZ::MatrixMxN m1(3, 2, 5.0f);
+        EXPECT_EQ(m1.GetRowCount(), 3);
+        EXPECT_EQ(m1.GetColumnCount(), 2);
+        for (AZStd::size_t rowIter = 0; rowIter < m1.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < m1.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(m1.GetElement(rowIter, colIter), 5.0f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestCreate)
+    {
+        AZ::MatrixMxN zeros = AZ::MatrixMxN::CreateZero(8, 3);
+        EXPECT_EQ(zeros.GetRowCount(), 8);
+        EXPECT_EQ(zeros.GetColumnCount(), 3);
+        for (AZStd::size_t rowIter = 0; rowIter < zeros.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < zeros.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(zeros.GetElement(rowIter, colIter), 0.0f);
+            }
+        }
+
+        AZ::MatrixMxN random = AZ::MatrixMxN::CreateRandom(7, 6);
+        EXPECT_EQ(random.GetRowCount(), 7);
+        EXPECT_EQ(random.GetColumnCount(), 6);
+        for (AZStd::size_t rowIter = 0; rowIter < random.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < random.GetColumnCount(); ++colIter)
+            {
+                ASSERT_GE(random.GetElement(rowIter, colIter), 0.0f);
+                ASSERT_LE(random.GetElement(rowIter, colIter), 1.0f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestGetSetElement)
+    {
+        AZ::MatrixMxN testMatrix(15, 7);
+        EXPECT_EQ(testMatrix.GetRowCount(), 15);
+        EXPECT_EQ(testMatrix.GetColumnCount(), 7);
+
+        // Initialize each element to be the sum of the indices for that element
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                testMatrix.SetElement(rowIter, colIter, static_cast<float>(2.0f * rowIter + colIter));
+            }
+        }
+
+        // Validate that each element was stored and can be retrieved correctly
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), static_cast<float>(2.0f * rowIter + colIter));
+                EXPECT_FLOAT_EQ(testMatrix(rowIter, colIter), static_cast<float>(2.0f * rowIter + colIter));
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestTranspose)
+    {
+        AZ::MatrixMxN testMatrix(15, 7);
+        EXPECT_EQ(testMatrix.GetRowCount(), 15);
+        EXPECT_EQ(testMatrix.GetColumnCount(), 7);
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                testMatrix.SetElement(rowIter, colIter, static_cast<float>(2.0f * rowIter + colIter));
+            }
+        }
+
+        // Validate that the result has the correct dimensionality and every element was correctly transposed
+        AZ::MatrixMxN resultMatrix = testMatrix.GetTranspose();
+        EXPECT_EQ(resultMatrix.GetRowCount(), 7);
+        EXPECT_EQ(resultMatrix.GetColumnCount(), 15);
+        for (AZStd::size_t rowIter = 0; rowIter < resultMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < resultMatrix.GetColumnCount(); ++colIter)
+            {
+                // Originally we stored 2 times the row index + the column index
+                // The transpose should therefore be storing values of 2 times the column index + the row index
+                EXPECT_FLOAT_EQ(resultMatrix.GetElement(rowIter, colIter), static_cast<float>(2.0f * colIter + rowIter));
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestOperators)
+    {
+        AZ::MatrixMxN oneMatrix(5, 3, 1.0f);
+        AZ::MatrixMxN testMatrix = oneMatrix;
+        for (AZStd::size_t rowIter = 0; rowIter < oneMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < oneMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(oneMatrix.GetElement(rowIter, colIter), 1.0f);
+            }
+        }
+
+        testMatrix /= 2.0f;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 0.5f);
+            }
+        }
+
+        testMatrix *= 2.0f;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 1.0f);
+            }
+        }
+
+        testMatrix *= 2.0f;
+        testMatrix += oneMatrix;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 3.0f);
+            }
+        }
+
+        testMatrix -= oneMatrix;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 2.0f);
+            }
+        }
+
+        testMatrix *= testMatrix;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 4.0f);
+            }
+        }
+
+        testMatrix /= testMatrix;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 1.0f);
+            }
+        }
+
+        testMatrix += 7.0f;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 8.0f);
+            }
+        }
+
+        testMatrix -= 12.0f;
+        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), -4.0f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestFloorCeilRound)
+    {
+        AZ::MatrixMxN mat1 = AZ::MatrixMxN(7, 3, 4.1f);
+        AZ::MatrixMxN floor = mat1.GetFloor();
+        for (AZStd::size_t rowIter = 0; rowIter < floor.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < floor.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(floor.GetElement(rowIter, colIter), 4.0f);
+            }
+        }
+        
+        AZ::MatrixMxN ceil = mat1.GetCeil();
+        for (AZStd::size_t rowIter = 0; rowIter < floor.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < floor.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(ceil.GetElement(rowIter, colIter), 5.0f);
+            }
+        }
+        
+        AZ::MatrixMxN round = mat1.GetRound();
+        for (AZStd::size_t rowIter = 0; rowIter < floor.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < floor.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(round.GetElement(rowIter, colIter), 4.0f);
+            }
+        }
+        
+        AZ::MatrixMxN vec2 = AZ::MatrixMxN(7, 3, 4.5f);
+        AZ::MatrixMxN tie = vec2.GetRound();
+        for (AZStd::size_t rowIter = 0; rowIter < floor.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < floor.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(tie.GetElement(rowIter, colIter), 4.0f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestMinMaxClamp)
+    {
+        AZ::MatrixMxN random = AZ::MatrixMxN::CreateRandom(7, 3); // random matrix with elements between 0 and 1
+        
+        // min should be between 0.0 and 0.5
+        AZ::MatrixMxN min = random.GetMin(AZ::MatrixMxN(7, 3, 0.5f));
+        for (AZStd::size_t rowIter = 0; rowIter < min.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < min.GetColumnCount(); ++colIter)
+            {
+                EXPECT_LE(min.GetElement(rowIter, colIter), 0.5f);
+            }
+        }
+        
+        // max should be between 0.5 and 1.0
+        AZ::MatrixMxN max = random.GetMax(AZ::MatrixMxN(7, 3, 0.5f));
+        for (AZStd::size_t rowIter = 0; rowIter < max.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < max.GetColumnCount(); ++colIter)
+            {
+                EXPECT_GE(max.GetElement(rowIter, colIter), 0.5f);
+            }
+        }
+        
+        // clamp should be between 0.1 and 0.9
+        AZ::MatrixMxN clamp = random.GetClamp(AZ::MatrixMxN(7,3,  0.1f), AZ::MatrixMxN(7, 3, 0.9f));
+        for (AZStd::size_t rowIter = 0; rowIter < clamp.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < clamp.GetColumnCount(); ++colIter)
+            {
+                EXPECT_GE(clamp.GetElement(rowIter, colIter), 0.1f);
+                EXPECT_LE(clamp.GetElement(rowIter, colIter), 0.9f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestSquareAbs)
+    {
+        AZ::MatrixMxN random = AZ::MatrixMxN::CreateRandom(200, 100); // random vector between 0 and 1
+        random -= 0.5f; // random vector between -0.5 and 0.5
+
+        // absRand should be between 0.0 and 0.5
+        AZ::MatrixMxN absRand = random.GetAbs();
+        for (AZStd::size_t rowIter = 0; rowIter < absRand.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < absRand.GetColumnCount(); ++colIter)
+            {
+                EXPECT_GE(absRand.GetElement(rowIter, colIter), 0.0f);
+                EXPECT_LE(absRand.GetElement(rowIter, colIter), 0.5f);
+            }
+        }
+
+        // sqRand should be between -0.25 and 0.25
+        AZ::MatrixMxN sqRand = random.GetSquare();
+        for (AZStd::size_t rowIter = 0; rowIter < sqRand.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < sqRand.GetColumnCount(); ++colIter)
+            {
+                EXPECT_GE(sqRand.GetElement(rowIter, colIter), -0.25f);
+                EXPECT_LE(sqRand.GetElement(rowIter, colIter),  0.25f);
+            }
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestVectorMatrixMultiply)
+    {
+        const float matrixElements[] =
+        {
+            1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 0.0f, 3.0f,
+            0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 3.0f,
+            0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 3.0f,
+            1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 0.0f, 3.0f,
+            0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 1.0f, 3.0f,
+            0.0f, 0.0f, 1.0f, 0.0f, 2.0f, 0.0f, 3.0f,
+        };
+
+        const float vectorElements[] =
+        {
+            1.0f, 0.0f, 2.0f, 0.0f, 3.0f, 0.0f, 1.0f
+        };
+
+        const float outputElements[] =
+        {
+            1.0f + 0.0f + 4.0f + 0.0f + 3.0f + 0.0f + 3.0f,
+            0.0f + 0.0f + 0.0f + 0.0f + 0.0f + 0.0f + 3.0f,
+            0.0f + 0.0f + 2.0f + 0.0f + 6.0f + 0.0f + 3.0f,
+            1.0f + 0.0f + 4.0f + 0.0f + 3.0f + 0.0f + 3.0f,
+            0.0f + 0.0f + 0.0f + 0.0f + 0.0f + 0.0f + 3.0f,
+            0.0f + 0.0f + 2.0f + 0.0f + 6.0f + 0.0f + 3.0f,
+        };
+
+        const AZ::MatrixMxN matrix = AZ::MatrixMxN::CreateFromPackedFloats(6, 7, matrixElements);
+        const AZ::VectorN vector = AZ::VectorN::CreateFromFloats(7, vectorElements);
+
+        AZ::VectorN output = AZ::VectorN::CreateZero(6);
+        VectorMatrixMultiply(matrix, vector, output);
+        for (AZStd::size_t iter = 0; iter < output.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(output.GetElement(iter), outputElements[iter]);
+        }
+    }
+
+    TEST_F(Math_MatrixMxN, TestMatrixMatrixMultiplySingleBlock)
+    {
+        // 3 x 4
+        const float lhsElements[] =
+        {
+            1.0f, 2.0f, 3.0f, 4.0f,
+            5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 0.0f, 1.0f, 2.0f,
+        };
+
+        // 4 x 3
+        const float rhsElements[] =
+        {
+            1.0f, 2.0f, 3.0f,
+            4.0f, 5.0f, 6.0f,
+            7.0f, 8.0f, 9.0f,
+            0.0f, 1.0f, 2.0f,
+        };
+
+        // 3 x 3
+        const float outputElements[] =
+        {
+             30.0f,  40.0f,  50.0f,
+             78.0f, 104.0f, 130.0f,
+             16.0f,  28.0f,  40.0f,
+        };
+
+        const AZ::MatrixMxN lhs = AZ::MatrixMxN::CreateFromPackedFloats(3, 4, lhsElements);
+        const AZ::MatrixMxN rhs = AZ::MatrixMxN::CreateFromPackedFloats(4, 3, rhsElements);
+
+        AZ::MatrixMxN output = AZ::MatrixMxN::CreateZero(3, 3);
+        AZ::MatrixMatrixMultiply(lhs, rhs, output);
+
+        const float* checkResult = outputElements;
+        for (AZStd::size_t rowIter = 0; rowIter < output.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < output.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(output.GetElement(rowIter, colIter), *checkResult);
+                ++checkResult;
+            }
+        }
+    }
+
+
+    TEST_F(Math_MatrixMxN, TestMatrixMatrixMultiply)
+    {
+        // 5 x 7
+        const float lhsElements[] =
+        {
+            1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
+            8.0f, 9.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f,
+            5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 0.0f, 1.0f,
+            2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f,
+        };
+
+        // 7 x 6
+        const float rhsElements[] =
+        {
+            1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
+            7.0f, 8.0f, 9.0f, 0.0f, 1.0f, 2.0f,
+            3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f,
+            5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 0.0f,
+            1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
+            7.0f, 8.0f, 9.0f, 0.0f, 1.0f, 2.0f,
+        };
+
+        // 5 x 6
+        const float outputElements[] =
+        {
+            140.0f, 128.0f, 156.0f,  94.0f, 122.0f, 100.0f,
+            121.0f, 138.0f, 165.0f,  62.0f,  89.0f,  96.0f,
+            192.0f, 148.0f, 184.0f, 150.0f, 186.0f, 132.0f,
+            173.0f, 158.0f, 193.0f, 118.0f, 153.0f, 128.0f,
+             84.0f,  88.0f, 112.0f,  86.0f, 110.0f, 104.0f,
+        };
+
+        const AZ::MatrixMxN lhs = AZ::MatrixMxN::CreateFromPackedFloats(5, 7, lhsElements);
+        const AZ::MatrixMxN rhs = AZ::MatrixMxN::CreateFromPackedFloats(7, 6, rhsElements);
+
+        AZ::MatrixMxN output = AZ::MatrixMxN::CreateZero(5, 6);
+        AZ::MatrixMatrixMultiply(lhs, rhs, output);
+
+        const float* checkResult = outputElements;
+        for (AZStd::size_t rowIter = 0; rowIter < output.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < output.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(output.GetElement(rowIter, colIter), *checkResult);
+                ++checkResult;
+            }
+        }
+    }
+}

--- a/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
@@ -161,7 +161,8 @@ namespace UnitTest
             }
         }
 
-        testMatrix *= testMatrix;
+        AZ::MatrixMxN extraMatrix1 = testMatrix; // Need a useless temporary because clang errors/warns over self assignment [-Wself-assign-overloaded]
+        testMatrix *= extraMatrix1;
         for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
         {
             for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
@@ -170,7 +171,8 @@ namespace UnitTest
             }
         }
 
-        testMatrix /= testMatrix;
+        AZ::MatrixMxN extraMatrix2 = testMatrix;
+        testMatrix /= extraMatrix2;
         for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
         {
             for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)

--- a/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/SimdMathTests.cpp
@@ -120,7 +120,7 @@ namespace UnitTest
         float testLoadValues[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        const float selectedValue = VectorType::SelectFirst(testVector);
+        const float selectedValue = VectorType::SelectIndex0(testVector);
 
         EXPECT_NEAR(testLoadValues[0], selectedValue, AZ::Constants::Tolerance);
     }
@@ -131,7 +131,7 @@ namespace UnitTest
         float testLoadValues[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        const float selectedValue = VectorType::SelectSecond(testVector);
+        const float selectedValue = VectorType::SelectIndex1(testVector);
 
         EXPECT_NEAR(testLoadValues[1], selectedValue, AZ::Constants::Tolerance);
     }
@@ -142,7 +142,7 @@ namespace UnitTest
         float testLoadValues[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        const float selectedValue = VectorType::SelectThird(testVector);
+        const float selectedValue = VectorType::SelectIndex2(testVector);
 
         EXPECT_NEAR(testLoadValues[2], selectedValue, AZ::Constants::Tolerance);
     }
@@ -153,7 +153,7 @@ namespace UnitTest
         float testLoadValues[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        const float selectedValue = VectorType::SelectFourth(testVector);
+        const float selectedValue = VectorType::SelectIndex3(testVector);
 
         EXPECT_NEAR(testLoadValues[3], selectedValue, AZ::Constants::Tolerance);
     }
@@ -272,7 +272,7 @@ namespace UnitTest
         float testStoreValues[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        testVector = VectorType::SplatFirst(testVector);
+        testVector = VectorType::SplatIndex0(testVector);
         VectorType::StoreUnaligned(testStoreValues, testVector);
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)
@@ -288,7 +288,7 @@ namespace UnitTest
         float testStoreValues[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        testVector = VectorType::SplatSecond(testVector);
+        testVector = VectorType::SplatIndex1(testVector);
         VectorType::StoreUnaligned(testStoreValues, testVector);
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)
@@ -304,7 +304,7 @@ namespace UnitTest
         float testStoreValues[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        testVector = VectorType::SplatThird(testVector);
+        testVector = VectorType::SplatIndex2(testVector);
         VectorType::StoreUnaligned(testStoreValues, testVector);
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)
@@ -320,7 +320,7 @@ namespace UnitTest
         float testStoreValues[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
         typename VectorType::FloatType testVector = VectorType::LoadUnaligned(testLoadValues);
-        testVector = VectorType::SplatFourth(testVector);
+        testVector = VectorType::SplatIndex3(testVector);
         VectorType::StoreUnaligned(testStoreValues, testVector);
 
         for (int32_t i = 0; i < VectorType::ElementCount; ++i)

--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -17,7 +17,6 @@
 
 namespace UnitTest
 {
-
     TEST(MATH_Vector4, TestConstructors)
     {
         AZ::Vector4 v1(0.0f);

--- a/Code/Framework/AzCore/Tests/Math/VectorNTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/VectorNTests.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/VectorN.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+
+namespace UnitTest
+{
+    class Math_VectorN
+        : public UnitTest::LeakDetectionFixture
+    {
+    };
+
+    TEST_F(Math_VectorN, TestConstructor)
+    {
+        AZ::VectorN v1(5, 5.0f);
+        EXPECT_EQ(v1.GetDimensionality(), 5);
+        for (AZStd::size_t iter = 0; iter < v1.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(v1.GetElement(iter), 5.0f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestCreate)
+    {
+        AZ::VectorN zeros = AZ::VectorN::CreateZero(8);
+        EXPECT_EQ(zeros.GetDimensionality(), 8);
+        EXPECT_EQ(zeros.IsZero(), true);
+        for (AZStd::size_t iter = 0; iter < zeros.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(zeros.GetElement(iter), 0.0f);
+        }
+
+        AZ::VectorN ones = AZ::VectorN::CreateOne(3);
+        EXPECT_EQ(ones.GetDimensionality(), 3);
+        for (AZStd::size_t iter = 0; iter < ones.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(ones.GetElement(iter), 1.0f);
+        }
+
+        AZ::VectorN random = AZ::VectorN::CreateRandom(1024);
+        EXPECT_EQ(random.GetDimensionality(), 1024);
+        for (AZStd::size_t iter = 0; iter < random.GetDimensionality(); ++iter)
+        {
+            ASSERT_GE(random.GetElement(iter), 0.0f);
+            ASSERT_LE(random.GetElement(iter), 1.0f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestRelu)
+    {
+        AZ::VectorN relu = AZ::VectorN::CreateRandom(1024);
+        relu *= 100.0f;
+        relu -= 50.0f;
+        relu.ReLU();
+
+        for (AZStd::size_t iter = 0; iter < relu.GetDimensionality(); ++iter)
+        {
+            ASSERT_GE(relu.GetElement(iter), 0.0f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestLength)
+    {
+        AZ::VectorN vec1 = AZ::VectorN::CreateZero(5);
+        float vec1Length = vec1.GetLength();
+        EXPECT_FLOAT_EQ(vec1Length, 0.0f);
+
+        AZ::VectorN vec2 = AZ::VectorN::CreateOne(16);
+        float vec2LengthSq = vec2.GetLengthSq();
+        EXPECT_FLOAT_EQ(vec2LengthSq, 16.0f);
+        float vec2Length = vec2.GetLength();
+        EXPECT_FLOAT_EQ(vec2Length, 4.0f);
+    }
+
+    TEST_F(Math_VectorN, TestNormalize)
+    {
+        AZ::VectorN vec1 = AZ::VectorN(4, 4.0f);
+
+        AZ::VectorN vec2 = vec1.GetNormalized();
+        for (AZStd::size_t iter = 0; iter < vec2.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec2.GetElement(iter), 0.5f);
+        }
+
+        vec1.Normalize();
+        for (AZStd::size_t iter = 0; iter < vec1.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec1.GetElement(iter), 0.5f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestOperators)
+    {
+        AZ::VectorN vec1 = AZ::VectorN::CreateZero(5);
+        for (AZStd::size_t iter = 0; iter < vec1.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec1.GetElement(iter), 0.0f);
+        }
+
+        AZ::VectorN vec2 = AZ::VectorN::CreateOne(5);
+        for (AZStd::size_t iter = 0; iter < vec2.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec2.GetElement(iter), 1.0f);
+        }
+
+        AZ::VectorN vec3 = vec1 + vec2; // 0 + 1
+        for (AZStd::size_t iter = 0; iter < vec3.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec3.GetElement(iter), 1.0f);
+        }
+
+        AZ::VectorN vec4 = vec3 - vec2; // 1 - 1
+        for (AZStd::size_t iter = 0; iter < vec4.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec4.GetElement(iter), 0.0f);
+        }
+
+        AZ::VectorN vec5 = vec2 * 2.0f; // 1 * 2
+        for (AZStd::size_t iter = 0; iter < vec5.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec5.GetElement(iter), 2.0f);
+        }
+
+        AZ::VectorN vec6 = vec5 * vec5; // 2 * 2
+        for (AZStd::size_t iter = 0; iter < vec6.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec6.GetElement(iter), 4.0f);
+        }
+
+        AZ::VectorN vec7 = vec6 / vec5; // 4 / 2
+        for (AZStd::size_t iter = 0; iter < vec7.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec7.GetElement(iter), 2.0f);
+        }
+
+        AZ::VectorN vec8 = vec7 / 2.0f; // 2 / 2
+        for (AZStd::size_t iter = 0; iter < vec8.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec8.GetElement(iter), 1.0f);
+        }
+
+        AZ::VectorN vec9 = -vec6; // -4
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -4.0f);
+        }
+
+        vec9 += vec6; // -4 + 4
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), 0.0f);
+        }
+
+        vec9 -= vec6; // 0 - 4
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -4.0f);
+        }
+
+        vec9 *= 2.0f; // -4 * 2
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -8.0f);
+        }
+
+        vec9 /= 2.0f; // -8 / 2
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -4.0f);
+        }
+
+        vec9 *= vec5; // -4 * 2
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -8.0f);
+        }
+
+        vec9 /= vec5; // -8 / 2
+        for (AZStd::size_t iter = 0; iter < vec9.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(vec9.GetElement(iter), -4.0f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestComparisons)
+    {
+        AZ::VectorN vec1 = AZ::VectorN(4, 4.0f);
+        AZ::VectorN vec2 = AZ::VectorN(4, 4.1f);
+
+        EXPECT_TRUE(vec1.IsClose(vec2, 0.125f));
+        EXPECT_FALSE(vec1.IsClose(vec2, 0.0125f));
+
+        EXPECT_TRUE(vec1.IsLessThan(vec2));
+        EXPECT_FALSE(vec2.IsLessThan(vec1));
+        EXPECT_TRUE(vec1.IsLessEqualThan(vec1));
+        EXPECT_FALSE(vec2.IsLessEqualThan(vec1));
+
+        EXPECT_FALSE(vec1.IsGreaterThan(vec2));
+        EXPECT_TRUE(vec2.IsGreaterThan(vec1));
+        EXPECT_TRUE(vec1.IsGreaterEqualThan(vec1));
+        EXPECT_FALSE(vec1.IsGreaterEqualThan(vec2));
+    }
+
+    TEST_F(Math_VectorN, TestFloorCeilRound)
+    {
+        AZ::VectorN vec1 = AZ::VectorN(4, 4.1f);
+        AZ::VectorN floor = vec1.GetFloor();
+        for (AZStd::size_t iter = 0; iter < floor.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(floor.GetElement(iter), 4.0f);
+        }
+
+        AZ::VectorN ceil = vec1.GetCeil();
+        for (AZStd::size_t iter = 0; iter < ceil.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(ceil.GetElement(iter), 5.0f);
+        }
+
+        AZ::VectorN round = vec1.GetRound();
+        for (AZStd::size_t iter = 0; iter < round.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(round.GetElement(iter), 4.0f);
+        }
+
+        AZ::VectorN vec2 = AZ::VectorN(4, 4.5f);
+        AZ::VectorN tie = vec2.GetRound();
+        for (AZStd::size_t iter = 0; iter < tie.GetDimensionality(); ++iter)
+        {
+            EXPECT_FLOAT_EQ(tie.GetElement(iter), 4.0f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestMinMaxClamp)
+    {
+        AZ::VectorN random = AZ::VectorN::CreateRandom(7); // random vector between 0 and 1
+
+        // min should be between 0.0 and 0.5
+        AZ::VectorN min = random.GetMin(AZ::VectorN(7, 0.5f));
+        for (AZStd::size_t iter = 0; iter < min.GetDimensionality(); ++iter)
+        {
+            EXPECT_LE(min.GetElement(iter), 0.5f);
+        }
+
+        // max should be between 0.5 and 1.0
+        AZ::VectorN max = random.GetMax(AZ::VectorN(7, 0.5f));
+        for (AZStd::size_t iter = 0; iter < max.GetDimensionality(); ++iter)
+        {
+            EXPECT_GE(max.GetElement(iter), 0.5f);
+        }
+
+        // clamp should be between 0.1 and 0.9
+        AZ::VectorN clamp = random.GetClamp(AZ::VectorN(7, 0.1f), AZ::VectorN(7, 0.9f));
+        for (AZStd::size_t iter = 0; iter < clamp.GetDimensionality(); ++iter)
+        {
+            EXPECT_GE(clamp.GetElement(iter), 0.1f);
+            EXPECT_LE(clamp.GetElement(iter), 0.9f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestSquareAbs)
+    {
+        AZ::VectorN random = AZ::VectorN::CreateRandom(200); // random vector between 0 and 1
+        random -= 0.5f; // random vector between -0.5 and 0.5
+
+        // absRand should be between 0.0 and 0.5
+        AZ::VectorN absRand = random.GetAbs();
+        for (AZStd::size_t iter = 0; iter < absRand.GetDimensionality(); ++iter)
+        {
+            EXPECT_GE(absRand.GetElement(iter), 0.0f);
+            EXPECT_LE(absRand.GetElement(iter), 0.5f);
+        }
+
+        // sqRand should be between -0.25 and 0.25
+        AZ::VectorN sqRand = random.GetSquare();
+        for (AZStd::size_t iter = 0; iter < sqRand.GetDimensionality(); ++iter)
+        {
+            EXPECT_GE(sqRand.GetElement(iter), -0.25f);
+            EXPECT_LE(sqRand.GetElement(iter),  0.25f);
+        }
+    }
+
+    TEST_F(Math_VectorN, TestDot)
+    {
+        AZ::VectorN zeros = AZ::VectorN::CreateZero(15);
+        AZ::VectorN ones = AZ::VectorN::CreateOne(15);
+
+        float zerosDotOnes = zeros.Dot(ones);
+        EXPECT_FLOAT_EQ(zerosDotOnes, 0.0f);
+
+        float onesDotOnes = ones.Dot(ones);
+        EXPECT_FLOAT_EQ(onesDotOnes, 15.0f);
+    }
+}

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -133,6 +133,7 @@ set(FILES
     Math/Matrix3x4Tests.cpp
     Math/Matrix4x4PerformanceTests.cpp
     Math/Matrix4x4Tests.cpp
+    Math/MatrixMxNTests.cpp
     Math/MatrixUtilsTests.cpp
     Math/MathTest.h
     Math/MathTestData.h
@@ -159,6 +160,7 @@ set(FILES
     Math/Vector3Tests.cpp
     Math/Vector4PerformanceTests.cpp
     Math/Vector4Tests.cpp
+    Math/VectorNTests.cpp
     Memory/AllocatorBenchmarks.cpp
     Memory/HphaAllocator.cpp
     Memory/HphaAllocatorErrorDetection.cpp

--- a/Gems/EMotionFX/Code/MCore/Source/FastMath.inl
+++ b/Gems/EMotionFX/Code/MCore/Source/FastMath.inl
@@ -235,7 +235,7 @@ MCORE_INLINE uint32 Math::NextPowerOfTwo(uint32 x)
 // returns an approximation to 1/sqrt(x)
 MCORE_INLINE float Math::FastInvSqrt(float x)
 {
-    return AZ::Simd::Vec1::SelectFirst(AZ::Simd::Vec1::SqrtInvEstimate(AZ::Simd::Vec1::Splat(x)));
+    return AZ::Simd::Vec1::SelectIndex0(AZ::Simd::Vec1::SqrtInvEstimate(AZ::Simd::Vec1::Splat(x)));
 }
 
 /*


### PR DESCRIPTION
This adds two new linear algebra primitives.
VectorN is a vector class of arbitrary dimensionality. It supports basic arithmetic operations, and simple linalg ops like normalization. It is backed by an array of simd vec4's so that all operations are performed on simd.
MatrixMxN is a matrix class also of arbitrary dimensionality. It also supports basic arithmetic operations, as well as simple linear algebra operations like transpose, vector-matrix multiplication and matrix-matrix multiplication. This class uses a blocked matrix substructure, with blocks of 4x4 submatrices, which means all operations are performed in simd. Additionally these matrices are laid out in column-major ordering since this works far better with simd and avoids the need for any horizontal sums in any operation.
Some associated code cleanups and utilities have been provided, including a very basic SIMD LCG random number generator which can be used to very quickly initialize any vector or matrix to a set of random values.
Unit tests are provided to validate functionality.

```
Note: Google Test filter = Math_*
[==========] Running 22 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 11 tests from Math_VectorN
[ RUN      ] Math_VectorN.TestConstructor
[       OK ] Math_VectorN.TestConstructor (0 ms)
[ RUN      ] Math_VectorN.TestCreate
[       OK ] Math_VectorN.TestCreate (1 ms)
[ RUN      ] Math_VectorN.TestRelu
[       OK ] Math_VectorN.TestRelu (0 ms)
[ RUN      ] Math_VectorN.TestLength
[       OK ] Math_VectorN.TestLength (0 ms)
[ RUN      ] Math_VectorN.TestNormalize
[       OK ] Math_VectorN.TestNormalize (0 ms)
[ RUN      ] Math_VectorN.TestOperators
[       OK ] Math_VectorN.TestOperators (1 ms)
[ RUN      ] Math_VectorN.TestComparisons
[       OK ] Math_VectorN.TestComparisons (0 ms)
[ RUN      ] Math_VectorN.TestFloorCeilRound
[       OK ] Math_VectorN.TestFloorCeilRound (0 ms)
[ RUN      ] Math_VectorN.TestMinMaxClamp
[       OK ] Math_VectorN.TestMinMaxClamp (0 ms)
[ RUN      ] Math_VectorN.TestSquareAbs
[       OK ] Math_VectorN.TestSquareAbs (0 ms)
[ RUN      ] Math_VectorN.TestDot
[       OK ] Math_VectorN.TestDot (0 ms)
[----------] 11 tests from Math_VectorN (3 ms total)

[----------] 11 tests from Math_MatrixMxN
[ RUN      ] Math_MatrixMxN.TestConstructor
[       OK ] Math_MatrixMxN.TestConstructor (0 ms)
[ RUN      ] Math_MatrixMxN.TestCreate
[       OK ] Math_MatrixMxN.TestCreate (0 ms)
[ RUN      ] Math_MatrixMxN.TestGetSetElement
[       OK ] Math_MatrixMxN.TestGetSetElement (1 ms)
[ RUN      ] Math_MatrixMxN.TestTranspose
[       OK ] Math_MatrixMxN.TestTranspose (0 ms)
[ RUN      ] Math_MatrixMxN.TestOperators
[       OK ] Math_MatrixMxN.TestOperators (0 ms)
[ RUN      ] Math_MatrixMxN.TestFloorCeilRound
[       OK ] Math_MatrixMxN.TestFloorCeilRound (0 ms)
[ RUN      ] Math_MatrixMxN.TestMinMaxClamp
[       OK ] Math_MatrixMxN.TestMinMaxClamp (0 ms)
[ RUN      ] Math_MatrixMxN.TestSquareAbs
[       OK ] Math_MatrixMxN.TestSquareAbs (7 ms)
[ RUN      ] Math_MatrixMxN.TestVectorMatrixMultiply
[       OK ] Math_MatrixMxN.TestVectorMatrixMultiply (0 ms)
[ RUN      ] Math_MatrixMxN.TestMatrixMatrixMultiplySingleBlock
[       OK ] Math_MatrixMxN.TestMatrixMatrixMultiplySingleBlock (0 ms)
[ RUN      ] Math_MatrixMxN.TestMatrixMatrixMultiply
[       OK ] Math_MatrixMxN.TestMatrixMatrixMultiply (0 ms)
[----------] 11 tests from Math_MatrixMxN (16 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 2 test cases ran. (26 ms total)
[  PASSED  ] 22 tests.
OKAY AzRunUnitTests() returned 0
```