### PR TITLE
GCC 13/Clang 14 build fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.cpp
@@ -312,14 +312,12 @@ namespace AZ
         ResultCode mergePatchResult{ Tasks::Import, Outcomes::Success };
 
         // Check if the target data already contains a field with the same name
-        rapidjson::Value* targetFieldName{};
         rapidjson::Value* targetFieldValue{};
         if (target.IsObject())
         {
             if (auto targetMemberIter = target.FindMember(fieldNameStringRef);
                 targetMemberIter != target.MemberEnd())
             {
-                targetFieldName = &targetMemberIter->name;
                 targetFieldValue = &targetMemberIter->value;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -81,8 +81,6 @@ namespace AzToolsFramework
             auto data = index.data(AssetBrowserModel::Roles::EntryRole);
             if (data.canConvert<const AssetBrowserEntry*>())
             {
-                bool isEnabled = (option.state & QStyle::State_Enabled) != 0;
-
                 QStyle* style = option.widget ? option.widget->style() : QApplication::style();
 
                 // draw the background
@@ -113,7 +111,6 @@ namespace AzToolsFramework
                         // sources with no children should be greyed out.
                         if (sourceEntry->GetChildCount() == 0)
                         {
-                            isEnabled = false; // draw in disabled style.
                             actualPalette.setCurrentColorGroup(QPalette::Disabled);
                         }
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -147,8 +147,7 @@ namespace AzToolsFramework
             const AZ::IO::Path filepath = AZ::IO::Path(fullFilepath);
             if (filepath.Extension() == LuaExtension)
             {
-                const AZStd::string_view& filename = filepath.Stem().Native();
-                const AZStd::string scriptBoilerplate = GenerateLuaComponentBoilerplate(filename);
+                const AZStd::string scriptBoilerplate = GenerateLuaComponentBoilerplate(filepath.Stem().Native());
 
                 const auto outcome = SaveLuaScriptFile(fullFilepath, scriptBoilerplate);
                 if (!outcome.IsSuccess())

--- a/Code/Legacy/CryCommon/IMovieSystem.cpp
+++ b/Code/Legacy/CryCommon/IMovieSystem.cpp
@@ -36,13 +36,6 @@ void CAnimParamType::operator =(const AZStd::string& name)
     m_name = name;
 }
 
-// Convert to enum. This needs to be explicit,
-// otherwise operator== will be ambiguous
-AnimParamType CAnimParamType::GetType() const { return m_type; }
-
-// Get name
-const char* CAnimParamType::GetName() const { return m_name.c_str(); }
-
 bool CAnimParamType::operator ==(const CAnimParamType& animParamType) const
 {
     if (m_type == kAnimParamTypeByString && animParamType.m_type == kAnimParamTypeByString)

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -120,10 +120,10 @@ public:
 
     // Convert to enum. This needs to be explicit,
     // otherwise operator== will be ambiguous
-    AnimParamType GetType() const;
+    constexpr AnimParamType GetType() const { return m_type; }
 
     // Get name
-    const char* GetName() const;
+    const char* GetName() const { return m_name.c_str(); }
 
     bool operator ==(const CAnimParamType& animParamType) const;
 
@@ -131,7 +131,7 @@ public:
 
     bool operator <(const CAnimParamType& animParamType) const;
 
-    constexpr operator size_t() const
+    operator size_t() const
     {
         AZStd::hash<AnimParamType> paramTypeHasher;
         size_t retVal = paramTypeHasher(GetType());

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -40,7 +40,7 @@ namespace AssetProcessor
     const char* const AutoFailOmitFromDatabaseKey = "failreason_omitFromDatabase"; // if set in your job info hash, your job will not be tracked by the database.
     const unsigned int g_RetriesForFenceFile = 5; // number of retries for fencing
     constexpr int RetriesForJobLostConnection = ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES; // number of times to retry a job when a network error due to network issues or a crashed AssetBuilder process is determined to have caused a job failure
-    constexpr const char* IntermediateAssetsFolderName = "Intermediate Assets"; // name of the intermediate assets folder
+    [[maybe_unused]] constexpr const char* IntermediateAssetsFolderName = "Intermediate Assets"; // name of the intermediate assets folder
     // Even though AP can handle files with path length greater than window's legacy path length limit, we have some 3rdparty sdk's
     // which do not handle this case ,therefore we will make AP fail any jobs whose either source file or output file name exceeds the windows legacy path length limit
 #define AP_MAX_PATH_LEN 260

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/sort.h>
 
+#include <native/assetprocessor.h>
 #include <native/utilities/BuilderConfigurationManager.h>
 #include <native/resourcecompiler/rccontroller.h>
 #include <native/AssetManager/assetScanner.h>

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -7,6 +7,7 @@
  */
 #include "native/utilities/PlatformConfiguration.h"
 #include "native/AssetManager/FileStateCache.h"
+#include "native/assetprocessor.h"
 
 #include <QDirIterator>
 
@@ -980,7 +981,7 @@ namespace AssetProcessor
     {
         for (const auto& scanfolder : m_scanFolders)
         {
-            if (scanfolder.GetPortableKey() == IntermediateAssetsFolderName)
+            if (scanfolder.GetPortableKey() == AssetProcessor::IntermediateAssetsFolderName)
             {
                 m_intermediateAssetScanFolderId = scanfolder.ScanFolderID();
                 return;
@@ -1861,7 +1862,7 @@ namespace AssetProcessor
         settingsRegistry->Get(cacheRootFolder, AZ::SettingsRegistryMergeUtils::FilePathKey_CacheProjectRootFolder);
 
         AZ::IO::Path scanfolderPath = cacheRootFolder.c_str();
-        scanfolderPath /= IntermediateAssetsFolderName;
+        scanfolderPath /= AssetProcessor::IntermediateAssetsFolderName;
 
         AZStd::vector<AssetBuilderSDK::PlatformInfo> platforms;
         PopulatePlatformsForScanFolder(platforms);
@@ -1874,8 +1875,8 @@ namespace AssetProcessor
 
         AddScanFolder(ScanFolderInfo{
             scanfolderPath.c_str(),
-            IntermediateAssetsFolderName,
-            IntermediateAssetsFolderName,
+            AssetProcessor::IntermediateAssetsFolderName,
+            AssetProcessor::IntermediateAssetsFolderName,
             false,
             true,
             platforms,

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Math/Sha1.h>
 
+#include <native/assetprocessor.h>
 #include <native/utilities/PlatformConfiguration.h>
 #include <native/utilities/StatsCapture.h>
 #include <native/AssetManager/FileStateCache.h>

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -510,7 +510,7 @@ namespace O3DE::ProjectManager
 
         for (QString& gemName : dependingGemNames)
         {
-            const QModelIndex& dependingIndex = FindIndexByNameString(gemName);
+            const QModelIndex dependingIndex = FindIndexByNameString(gemName);
             if (dependingIndex.isValid())
             {
                 tags.push_back({ GetDisplayName(dependingIndex), GetName(dependingIndex) });

--- a/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
+++ b/Gems/Archive/Code/Source/Clients/ArchiveReader.cpp
@@ -441,7 +441,7 @@ namespace Archive
         {
             return AZStd::unexpected(ResultString::format("Compression Algorithm with ID %x is not registered"
                 " with the decompression registrar.",
-                extractFileResult.m_compressionAlgorithm));
+                static_cast<AZ::u32>(extractFileResult.m_compressionAlgorithm)));
         }
 
         // Retrieve a subspan of the block lines for the file being extracted

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1837,7 +1837,8 @@ namespace AZ
             
             for (size_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
             {
-                const RPI::ModelLod::Mesh& mesh = modelLod.GetMeshes()[meshIndex];
+                const auto meshes = modelLod.GetMeshes();
+                const RPI::ModelLod::Mesh& mesh = meshes[meshIndex];
 
                 // Determine if there is a custom material specified for this submission
                 const CustomMaterialId customMaterialId(aznumeric_cast<AZ::u64>(modelLodIndex), mesh.m_materialSlotStableId);
@@ -2096,7 +2097,8 @@ namespace AZ
             RayTracingFeatureProcessor::SubMeshVector subMeshes;
             for (uint32_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
             {
-                const RPI::ModelLod::Mesh& mesh = modelLod->GetMeshes()[meshIndex];
+                const auto meshes = modelLod->GetMeshes();
+                const RPI::ModelLod::Mesh& mesh = meshes[meshIndex];
 
                 // retrieve the material
                 const CustomMaterialId customMaterialId(rayTracingLod, mesh.m_materialSlotStableId);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
@@ -84,7 +84,8 @@ namespace AZ
         void DepthOfFieldMaskPass::CompileResources(const RHI::FrameGraphCompileContext& context)
         {
             // Update resolution size
-            const RPI::PassAttachmentBinding& attachmentBinding = GetAttachmentBindings()[0];
+            const auto attachmentBindings = GetAttachmentBindings();
+            const RPI::PassAttachmentBinding& attachmentBinding = attachmentBindings[0];
             if (attachmentBinding.GetAttachment())
             {
                 RHI::Size size = attachmentBinding.GetAttachment()->m_descriptor.m_image.m_size;
@@ -113,6 +114,6 @@ namespace AZ
             m_radiusMin = min;
             m_radiusMax = max;
         }
-        
+
     }   // namespace Render
 }   // namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamBufferView.cpp
@@ -77,7 +77,8 @@ namespace AZ
 
                 for (int i = 0; i < inputStreamLayout.GetStreamBuffers().size() && i < streamBufferViews.size(); ++i)
                 {
-                    auto& bufferDescriptor = inputStreamLayout.GetStreamBuffers()[i];
+                    auto bufferDescriptors = inputStreamLayout.GetStreamBuffers();
+                    auto& bufferDescriptor = bufferDescriptors[i];
                     auto& bufferView = streamBufferViews[i];
 
                     // It can be valid to have a null buffer if this stream is not actually used by the shader, which can be the case for streams marked optional.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
@@ -202,11 +202,10 @@ namespace AZ
 
             if (desc.stride == 0)
             {
-                const auto& streamChannels = inputStreamLayout.GetStreamChannels();
+                const auto streamChannels = inputStreamLayout.GetStreamChannels();
 
                 for (uint32_t channelIndex = 0; channelIndex < streamChannels.size(); ++channelIndex)
                 {
-                    const auto streamChannels = inputStreamLayout.GetStreamChannels();
                     const RHI::StreamChannelDescriptor& chanDesc = streamChannels[channelIndex];
                     if (chanDesc.m_bufferIndex == index)
                     {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
@@ -30,9 +30,9 @@ namespace AZ
             AZ_Assert(descriptor.m_pipelineDescritor->GetType() == RHI::PipelineStateType::Draw, "Invalid pipeline descriptor type");
 
             const auto* drawDescriptor = static_cast<const RHI::PipelineStateDescriptorForDraw*>(descriptor.m_pipelineDescritor);
-            const RHI::RenderAttachmentLayout& renderAttachmentLayout = drawDescriptor->m_renderAttachmentConfiguration.m_renderAttachmentLayout;            
+            const RHI::RenderAttachmentLayout& renderAttachmentLayout = drawDescriptor->m_renderAttachmentConfiguration.m_renderAttachmentLayout;
             auto renderpassDescriptor = RenderPass::ConvertRenderAttachmentLayout(
-                *descriptor.m_device, renderAttachmentLayout, drawDescriptor->m_renderStates.m_multisampleState);            
+                *descriptor.m_device, renderAttachmentLayout, drawDescriptor->m_renderStates.m_multisampleState);
             m_renderPass = descriptor.m_device->AcquireRenderPass(renderpassDescriptor);
 
             return BuildNativePipeline(descriptor, pipelineLayout);
@@ -135,7 +135,7 @@ namespace AZ
             }
         }
 
-        void GraphicsPipeline::BuildPipelineVertexInputStateCreateInfo(const RHI::InputStreamLayout& inputStreamLayout) 
+        void GraphicsPipeline::BuildPipelineVertexInputStateCreateInfo(const RHI::InputStreamLayout& inputStreamLayout)
         {
             const auto& streamChannels = inputStreamLayout.GetStreamChannels();
             m_vertexInputAttributeDescriptions.resize(streamChannels.size());
@@ -165,7 +165,8 @@ namespace AZ
             uint32_t index, VkVertexInputAttributeDescription& desc)
         {
             AZ_Assert(index < inputStreamLayout.GetStreamChannels().size(), "Index is wrong.");
-            const RHI::StreamChannelDescriptor& chanDesc = inputStreamLayout.GetStreamChannels()[index];
+            const auto streamChannels = inputStreamLayout.GetStreamChannels();
+            const RHI::StreamChannelDescriptor& chanDesc = streamChannels[index];
 
             desc = {};
             desc.location = index;
@@ -178,7 +179,8 @@ namespace AZ
             uint32_t index, VkVertexInputBindingDescription& desc)
         {
             AZ_Assert(index < inputStreamLayout.GetStreamBuffers().size(), "Index is wrong.");
-            const RHI::StreamBufferDescriptor& buffDesc = inputStreamLayout.GetStreamBuffers()[index];
+            const auto streamBuffers = inputStreamLayout.GetStreamBuffers();
+            const RHI::StreamBufferDescriptor& buffDesc = streamBuffers[index];
 
             VkVertexInputRate inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
             switch (buffDesc.m_stepFunction)
@@ -200,16 +202,17 @@ namespace AZ
 
             if (desc.stride == 0)
             {
-                 const auto& streamChannels = inputStreamLayout.GetStreamChannels();
-                 
-                 for (uint32_t channelIndex = 0; channelIndex < streamChannels.size(); ++channelIndex)
-                 {
-                     const RHI::StreamChannelDescriptor& chanDesc = inputStreamLayout.GetStreamChannels()[channelIndex];
-                     if (chanDesc.m_bufferIndex == index)
-                     {
-                         desc.stride += GetFormatSize(chanDesc.m_format);
-                     }
-                 }
+                const auto& streamChannels = inputStreamLayout.GetStreamChannels();
+
+                for (uint32_t channelIndex = 0; channelIndex < streamChannels.size(); ++channelIndex)
+                {
+                    const auto streamChannels = inputStreamLayout.GetStreamChannels();
+                    const RHI::StreamChannelDescriptor& chanDesc = streamChannels[channelIndex];
+                    if (chanDesc.m_bufferIndex == index)
+                    {
+                        desc.stride += GetFormatSize(chanDesc.m_format);
+                    }
+                }
             }
         }
 
@@ -261,14 +264,14 @@ namespace AZ
             info.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
             info.pNext = nullptr;
             info.depthClampEnable = VK_FALSE;
-            info.flags = 0;            
+            info.flags = 0;
             info.rasterizerDiscardEnable = VK_FALSE;
 
             VkPipelineRasterizationDepthClipStateCreateInfoEXT& depthClipState = m_pipelineRasterizationDepthClipStateInfo;
             depthClipState.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT;
             if (physicalDevice.IsFeatureSupported(DeviceFeature::DepthClipEnable))
             {
-                depthClipState.depthClipEnable = rasterState.m_depthClipEnable;                
+                depthClipState.depthClipEnable = rasterState.m_depthClipEnable;
                 info.pNext = &depthClipState;
             }
             else if (enabledFeatures.depthClamp)
@@ -355,7 +358,7 @@ namespace AZ
             info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
             info.flags = 0;
             info.rasterizationSamples = ConvertSampleCount(multisampleState.m_samples);
- 
+
             info.sampleShadingEnable = VK_FALSE;
             info.pSampleMask = nullptr;
 
@@ -368,7 +371,7 @@ namespace AZ
                 if (physicalDevice.IsFeatureSupported(DeviceFeature::CustomSampleLocation))
                 {
                     AZStd::transform(
-                        multisampleState.m_customPositions.begin(), 
+                        multisampleState.m_customPositions.begin(),
                         multisampleState.m_customPositions.begin() + multisampleState.m_customPositionsCount,
                         AZStd::back_inserter(m_customSampleLocations), [&](const auto& item)
                     {
@@ -482,7 +485,7 @@ namespace AZ
             m_dynamicStates =
             {
                 VK_DYNAMIC_STATE_VIEWPORT,
-                VK_DYNAMIC_STATE_SCISSOR, 
+                VK_DYNAMIC_STATE_SCISSOR,
                 VK_DYNAMIC_STATE_STENCIL_REFERENCE
             };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -158,7 +158,7 @@ namespace AZ
 
                 // Builds all attachment descriptions from the descriptor.
                 void BuildAttachmentDescriptions(AZStd::vector<VkAttachmentDescriptionType>& attachmentDescriptions) const
-                {           
+                {
                     for (uint32_t i = 0; i < m_descriptor->m_attachmentCount; ++i)
                     {
                         const RenderPass::AttachmentBinding& binding = m_descriptor->m_attachments[i];
@@ -197,8 +197,8 @@ namespace AZ
                 void BuildAttachmentReferences(uint32_t subpassIndex, SubpassInfo& subpassInfo) const
                 {
                     // A template cannot be specialized inside of another template
-                    // therefore if constexpr is used to filter the Preserve AttachmentType functionality
-                    // in the template member function
+                    // therefore the `if constexpr` statement is used to filter the Preserve AttachmentType functionality
+                    // in this single template member function
                     if constexpr (type == AttachmentType::Preserve)
                     {
                         auto& subpassDescriptor = const_cast<RenderPass::SubpassDescriptor&>(m_descriptor->m_subpassDescriptors[subpassIndex]);
@@ -334,7 +334,7 @@ namespace AZ
                             RHI::FilterBits(subpassDependency.srcAccessMask, GetSupportedAccessFlags(subpassDependency.srcStageMask));
                         dependency.dstAccessMask =
                             RHI::FilterBits(subpassDependency.dstAccessMask, GetSupportedAccessFlags(subpassDependency.dstStageMask));
-                        dependency.dependencyFlags = subpassDependency.dependencyFlags;                            
+                        dependency.dependencyFlags = subpassDependency.dependencyFlags;
                     }
                 }
 
@@ -568,7 +568,7 @@ namespace AZ
             }
 
             return renderPassDesc;
-        }        
+        }
 
         void RenderPass::SetNameInternal(const AZStd::string_view& name)
         {
@@ -587,7 +587,7 @@ namespace AZ
                 m_nativeRenderPass = VK_NULL_HANDLE;
             }
             Base::Shutdown();
-        }       
+        }
     }
 }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -132,26 +132,28 @@ namespace AZ
                 template<typename> struct int_ { typedef int type; };
 
                 template<typename vkCreateRenderPassType>
-                RenderPassResult Create(VkRenderPassCreateInfoType& createInfo);
-
-                // Specialization for creating a renderpass using the standard function.
-                template<>
-                RenderPassResult Create<VkRenderPassCreateInfo>(VkRenderPassCreateInfoType& createInfo)
+                RenderPassResult Create(VkRenderPassCreateInfoType& createInfo)
                 {
-                    VkRenderPass renderPass = VK_NULL_HANDLE;
-                    VkResult result = m_device.GetContext().CreateRenderPass(
-                        m_device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &renderPass);
-                    return AZStd::make_tuple(result, renderPass);
-                }
-
-                // Specialization for creating a renderpass using the renderpass2 extension.
-                template<>
-                RenderPassResult Create<VkRenderPassCreateInfo2>(VkRenderPassCreateInfoType& createInfo)
-                {
-                    VkRenderPass renderPass = VK_NULL_HANDLE;
-                    VkResult result = m_device.GetContext().CreateRenderPass2KHR(
-                        m_device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &renderPass);
-                    return AZStd::make_tuple(result, renderPass);
+                    if constexpr (AZStd::is_same_v<vkCreateRenderPassType, VkRenderPassCreateInfo>)
+                    {
+                        VkRenderPass renderPass = VK_NULL_HANDLE;
+                        VkResult result = m_device.GetContext().CreateRenderPass(
+                            m_device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &renderPass);
+                        return AZStd::make_tuple(result, renderPass);
+                    }
+                    else if constexpr (AZStd::is_same_v<vkCreateRenderPassType, VkRenderPassCreateInfo2>)
+                    {
+                        VkRenderPass renderPass = VK_NULL_HANDLE;
+                        VkResult result = m_device.GetContext().CreateRenderPass2KHR(
+                            m_device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &renderPass);
+                        return AZStd::make_tuple(result, renderPass);
+                    }
+                    else
+                    {
+                        static_assert(AZStd::is_same_v<vkCreateRenderPassType, VkRenderPassCreateInfo>
+                            || AZStd::is_same_v<vkCreateRenderPassType, VkRenderPassCreateInfo2>);
+                        return {};
+                    }
                 }
 
                 // Builds all attachment descriptions from the descriptor.
@@ -194,38 +196,40 @@ namespace AZ
                 template<AttachmentType type>
                 void BuildAttachmentReferences(uint32_t subpassIndex, SubpassInfo& subpassInfo) const
                 {
-                    AZStd::span<const RenderPass::SubpassAttachment> subpassAttachmentList = GetSubpassAttachments(subpassIndex, type);
-                    AZStd::vector<VkAttachmentReferenceType>& attachmentReferenceList =
-                        subpassInfo.m_attachmentReferences[static_cast<uint32_t>(type)];
-                    attachmentReferenceList.resize(subpassAttachmentList.size());
-                    for (uint32_t index = 0; index < subpassAttachmentList.size(); ++index)
+                    // A template cannot be specialized inside of another template
+                    // therefore if constexpr is used to filter the Preserve AttachmentType functionality
+                    // in the template member function
+                    if constexpr (type == AttachmentType::Preserve)
                     {
-                        if (subpassAttachmentList[index].IsValid())
-                        {
-                            attachmentReferenceList[index].attachment = subpassAttachmentList[index].m_attachmentIndex;
-                            attachmentReferenceList[index].layout = subpassAttachmentList[index].m_layout;
-                            SetImageAspectFlags(
-                                attachmentReferenceList[index], subpassAttachmentList[index].m_imageAspectFlags, special_());
-                        }
-                        else
-                        {
-                            attachmentReferenceList[index].attachment = VK_ATTACHMENT_UNUSED;
-                        }
-                        SetStructureType(attachmentReferenceList[index], VkAttachmentReferenceTraits::struct_type, special_());
+                        auto& subpassDescriptor = const_cast<RenderPass::SubpassDescriptor&>(m_descriptor->m_subpassDescriptors[subpassIndex]);
+                        AZStd::vector<uint32_t>& attachmentReferenceList = subpassInfo.m_preserveAttachments;
+                        attachmentReferenceList.insert(
+                            attachmentReferenceList.end(),
+                            subpassDescriptor.m_preserveAttachments.begin(),
+                            subpassDescriptor.m_preserveAttachments.begin() + subpassDescriptor.m_preserveAttachmentCount);
                     }
-                }
-
-                // Specialization for "Preserve" attachment references.
-                template<>
-                void BuildAttachmentReferences<AttachmentType::Preserve>(uint32_t subpassIndex, SubpassInfo& subpassInfo) const
-                {
-
-                    auto& subpassDescriptor = const_cast<RenderPass::SubpassDescriptor&>(m_descriptor->m_subpassDescriptors[subpassIndex]);
-                    AZStd::vector<uint32_t>& attachmentReferenceList = subpassInfo.m_preserveAttachments;
-                    attachmentReferenceList.insert(
-                        attachmentReferenceList.end(),
-                        subpassDescriptor.m_preserveAttachments.begin(),
-                        subpassDescriptor.m_preserveAttachments.begin() + subpassDescriptor.m_preserveAttachmentCount);
+                    else
+                    {
+                        AZStd::span<const RenderPass::SubpassAttachment> subpassAttachmentList = GetSubpassAttachments(subpassIndex, type);
+                        AZStd::vector<VkAttachmentReferenceType>& attachmentReferenceList =
+                            subpassInfo.m_attachmentReferences[static_cast<uint32_t>(type)];
+                        attachmentReferenceList.resize(subpassAttachmentList.size());
+                        for (uint32_t index = 0; index < subpassAttachmentList.size(); ++index)
+                        {
+                            if (subpassAttachmentList[index].IsValid())
+                            {
+                                attachmentReferenceList[index].attachment = subpassAttachmentList[index].m_attachmentIndex;
+                                attachmentReferenceList[index].layout = subpassAttachmentList[index].m_layout;
+                                SetImageAspectFlags(
+                                    attachmentReferenceList[index], subpassAttachmentList[index].m_imageAspectFlags, special_());
+                            }
+                            else
+                            {
+                                attachmentReferenceList[index].attachment = VK_ATTACHMENT_UNUSED;
+                            }
+                            SetStructureType(attachmentReferenceList[index], VkAttachmentReferenceTraits::struct_type, special_());
+                        }
+                    }
                 }
 
                 // Return the list of attachment depending on the type.
@@ -298,18 +302,14 @@ namespace AZ
                 void SetFragmentShadingRateAttachmentInfo(
                     [[maybe_unused]] SubpassInfo& subpassInfo, [[maybe_unused]] const VkAttachmentReferenceType* reference) const
                 {
-                    // Do nothing
-                }
-
-                template<>
-                void SetFragmentShadingRateAttachmentInfo<VkAttachmentReference2>(
-                    SubpassInfo& subpassInfo, const VkAttachmentReferenceType* reference) const
-                {
-                    auto& tileSize = m_device.GetLimits().m_shadingRateTileSize;
-                    subpassInfo.m_shadingRateAttachmentExtension.sType = VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR;
-                    subpassInfo.m_shadingRateAttachmentExtension.pFragmentShadingRateAttachment = reference;
-                    subpassInfo.m_shadingRateAttachmentExtension.shadingRateAttachmentTexelSize =
-                        VkExtent2D{ tileSize.m_width, tileSize.m_height };
+                    if constexpr (AZStd::is_same_v<AttachmentType, VkAttachmentReference2>)
+                    {
+                        auto& tileSize = m_device.GetLimits().m_shadingRateTileSize;
+                        subpassInfo.m_shadingRateAttachmentExtension.sType = VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR;
+                        subpassInfo.m_shadingRateAttachmentExtension.pFragmentShadingRateAttachment = reference;
+                        subpassInfo.m_shadingRateAttachmentExtension.shadingRateAttachmentTexelSize =
+                            VkExtent2D{ tileSize.m_width, tileSize.m_height };
+                    }
                 }
 
                 // Builds the dependencies between the subpasses.
@@ -590,3 +590,4 @@ namespace AZ
         }       
     }
 }
+

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -10,7 +10,7 @@
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
-#include <Atom/RPI.Public/Scene.h> 
+#include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
@@ -18,7 +18,7 @@
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
 
 namespace AZ
-{   
+{
     namespace RPI
     {
         AZ_CVAR(bool,
@@ -55,7 +55,7 @@ namespace AZ
         {
             return m_material;
         }
-        
+
         const ModelLod::Mesh& MeshDrawPacket::GetMesh() const
         {
             AZ_Assert(m_modelLodMeshIndex < m_modelLod->GetMeshes().size(), "m_modelLodMeshIndex %zu is out of range %zu", m_modelLodMeshIndex, m_modelLod->GetMeshes().size());
@@ -127,7 +127,7 @@ namespace AZ
                     return false; // stop checking other shader items.
                 }
             );
-            
+
             m_needUpdate = true;
             return true;
         }
@@ -215,14 +215,15 @@ namespace AZ
 
         bool MeshDrawPacket::DoUpdate(const Scene& parentScene)
         {
-            const ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[m_modelLodMeshIndex];
+            const auto meshes = m_modelLod->GetMeshes();
+            const ModelLod::Mesh& mesh = meshes[m_modelLodMeshIndex];
 
             if (!m_material)
             {
                 AZ_Warning("MeshDrawPacket", false, "No material provided for mesh. Skipping.");
                 return false;
             }
-            
+
             ShaderReloadDebugTracker::ScopedSection reloadSection("MeshDrawPacket::DoUpdate");
 
             RHI::DrawPacketBuilder drawPacketBuilder;
@@ -430,7 +431,7 @@ namespace AZ
                 }
 
                 drawPacketBuilder.AddDrawItem(drawRequest);
-                
+
                 ShaderData shaderData;
                 shaderData.m_shader = AZStd::move(shader);
                 shaderData.m_materialPipelineName = materialPipelineName;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/Model.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/Model.cpp
@@ -30,7 +30,7 @@ namespace AZ
                 modelAsset);
         }
 
-        
+
         void Model::TEMPOrphanFromDatabase(const Data::Asset<ModelAsset>& modelAsset)
         {
             for (auto& modelLodAsset : modelAsset->GetLodAssets())
@@ -84,7 +84,8 @@ namespace AZ
 
             for (size_t lodIndex = 0; lodIndex < m_lods.size(); ++lodIndex)
             {
-                const Data::Asset<ModelLodAsset>& lodAsset = modelAsset->GetLodAssets()[lodIndex];
+                const auto lodAssets = modelAsset->GetLodAssets();
+                const Data::Asset<ModelLodAsset> lodAsset = lodAssets[lodIndex];
 
                 if (!lodAsset)
                 {
@@ -151,13 +152,13 @@ namespace AZ
         bool Model::LocalRayIntersection(const AZ::Vector3& rayStart, const AZ::Vector3& rayDir, float& distanceNormalized, AZ::Vector3& normal) const
         {
             AZ_PROFILE_SCOPE(RPI, "Model: LocalRayIntersection");
-            
+
             if (!GetModelAsset())
             {
                 AZ_Assert(false, "Invalid Model - not created from a ModelAsset?");
                 return false;
             }
-            
+
             float start;
             float end;
             const int result = Intersect::IntersectRayAABB2(rayStart, rayDir.GetReciprocal(), GetModelAsset()->GetAabb(), start, end);

--- a/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
@@ -117,7 +117,7 @@ namespace UnitTest
             m_materialAsset = AZ::Data::Asset<AZ::RPI::MaterialAsset>(assetId, typeId, "");
 
             // Some tests attempt to serialize-in the model asset, which should not attempt to actually load this dummy asset reference.
-            m_materialAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehaviorNamespace::NoLoad); 
+            m_materialAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehaviorNamespace::NoLoad);
         }
 
         AZ::RHI::ShaderSemantic GetPositionSemantic() const
@@ -257,7 +257,7 @@ namespace UnitTest
 
             creator.Begin(Data::AssetId(AZ::Uuid::CreateRandom()));
             creator.SetName("TestModel");
-            
+
             for (RPI::ModelMaterialSlot::StableId materialSlotId = 0; materialSlotId < sharedMeshCount + separateMeshCount; ++materialSlotId)
             {
                 RPI::ModelMaterialSlot slot;
@@ -302,7 +302,8 @@ namespace UnitTest
 
             for (size_t i = 0; i < lodAsset->GetMeshes().size(); ++i)
             {
-                const AZ::RPI::ModelLodAsset::Mesh& mesh = lodAsset->GetMeshes()[i];
+                const auto meshes = lodAsset->GetMeshes();
+                const AZ::RPI::ModelLodAsset::Mesh& mesh = meshes[i];
                 const ExpectedMesh& expectedMesh = expectedLod.m_meshes[i];
 
                 ValidateMesh(mesh, expectedMesh);
@@ -997,7 +998,7 @@ namespace UnitTest
        This class creates a Model with one LOD, whose mesh contains 2 planes. Plane 1 is in the XY plane at Z=-0.5, and
        plane 2 is in the XY plane at Z=0.5. The two planes each have 9 quads which have been triangulated. It only has
        a position and index buffer.
-      
+
             -0.33
           -1     0.33  1
        0.5 *---*---*---*

--- a/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
@@ -521,7 +521,8 @@ namespace UnitTest
 
             for (size_t i = 0; i < shaderAsset->GetShaderResourceGroupLayouts().size(); ++i)
             {
-                auto& srgLayout = shaderAsset->GetShaderResourceGroupLayouts()[i];
+                auto srgLayouts = shaderAsset->GetShaderResourceGroupLayouts();
+                auto& srgLayout = srgLayouts[i];
                 EXPECT_EQ(srgLayout->GetHash(), m_srgLayouts[i]->GetHash());
                 EXPECT_EQ(shaderAsset->FindShaderResourceGroupLayout(CreateShaderResourceGroupId(i))->GetHash(), srgLayout->GetHash());
             }
@@ -541,19 +542,19 @@ namespace UnitTest
             ShaderResourceGroupLayoutSpan shaderAssetResourceGroupLayoutSpan = shader->GetShaderResourceGroupLayouts();
             EXPECT_EQ(shaderResourceGroupLayoutSpan.data(), shaderAssetResourceGroupLayoutSpan.data());
             EXPECT_EQ(shaderResourceGroupLayoutSpan.size(), shaderAssetResourceGroupLayoutSpan.size());
-            
+
             const RPI::ShaderVariant& rootShaderVariant = shader->GetVariant( RPI::ShaderVariantStableId{0} );
-            
+
             RHI::PipelineStateDescriptorForDraw descriptorForDraw;
             rootShaderVariant.ConfigurePipelineState(descriptorForDraw);
-            
+
             EXPECT_EQ(descriptorForDraw.m_pipelineLayoutDescriptor->GetHash(), m_pipelineLayoutDescriptor->GetHash());
             EXPECT_NE(descriptorForDraw.m_vertexFunction, nullptr);
             EXPECT_NE(descriptorForDraw.m_fragmentFunction, nullptr);
             EXPECT_EQ(descriptorForDraw.m_renderStates.GetHash(), m_renderStates.GetHash());
             EXPECT_EQ(descriptorForDraw.m_inputStreamLayout.GetHash(), HashValue64{ 0 }); // ConfigurePipelineState shouldn't touch descriptorForDraw.m_inputStreamLayout
             EXPECT_EQ(descriptorForDraw.m_renderAttachmentConfiguration.GetHash(), RHI::RenderAttachmentConfiguration().GetHash()); // ConfigurePipelineState shouldn't touch descriptorForDraw.m_outputAttachmentLayout
-            
+
             // Actual layout content doesn't matter for this test, it just needs to be set up to pass validation inside AcquirePipelineState().
             descriptorForDraw.m_inputStreamLayout.SetTopology(RHI::PrimitiveTopology::TriangleList);
             descriptorForDraw.m_inputStreamLayout.Finalize();
@@ -562,7 +563,7 @@ namespace UnitTest
                 ->RenderTargetAttachment(RHI::Format::R8G8B8A8_SNORM)
                 ->DepthStencilAttachment(RHI::Format::R32_FLOAT);
             builder.End(descriptorForDraw.m_renderAttachmentConfiguration.m_renderAttachmentLayout);
-            
+
             const RHI::PipelineState* pipelineState = shader->AcquirePipelineState(descriptorForDraw);
             EXPECT_NE(pipelineState, nullptr);
         }
@@ -752,7 +753,7 @@ namespace UnitTest
         success = shaderOptionGroupLayout->AddShaderOption(AZ::RPI::ShaderOptionDescriptor{ Name{"Invalid"}, intRangeType, RPI::ShaderVariantKeyBitCount - 4, order++, list1, Name("0") });
         EXPECT_FALSE(success);
         errorMessageFinder.CheckExpectedErrorsFound();
-        
+
         // Add shader option with empty name.
         errorMessageFinder.Reset();
         errorMessageFinder.AddExpectedErrorMessage("empty name");
@@ -874,7 +875,7 @@ namespace UnitTest
 
         EXPECT_FALSE(shaderOptionGroupLayout->FindShaderOptionIndex(Name{ "Invalid" }).IsValid());
     }
-    
+
     TEST_F(ShaderTests, ImplicitDefaultValue)
     {
         // Add shader option with no default value.
@@ -1178,11 +1179,11 @@ namespace UnitTest
     }
 
     TEST_F(ShaderTests, ShaderAsset_PipelineStateType_VertexImpliesDraw)
-    {    
+    {
         AZ::RPI::ShaderAssetCreator creator;
         BeginCreatingTestShaderAsset(creator, {RHI::ShaderStage::Vertex});
         AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
-    
+
         EXPECT_TRUE(shaderAsset);
         EXPECT_EQ(shaderAsset->GetPipelineStateType(), RHI::PipelineStateType::Draw);
     }
@@ -1192,7 +1193,7 @@ namespace UnitTest
         AZ::RPI::ShaderAssetCreator creator;
         BeginCreatingTestShaderAsset(creator, {AZ::RHI::ShaderStage::Compute});
         AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
-    
+
         EXPECT_TRUE(shaderAsset);
         EXPECT_EQ(shaderAsset->GetPipelineStateType(), RHI::PipelineStateType::Dispatch);
     }
@@ -1202,13 +1203,13 @@ namespace UnitTest
         ErrorMessageFinder messageFinder("both Draw functions and Dispatch functions");
         messageFinder.AddExpectedErrorMessage("Invalid root variant");
         messageFinder.AddExpectedErrorMessage("Cannot continue building ShaderAsset because 1 error(s) reported");
-    
+
         AZ::RPI::ShaderAssetCreator creator;
         BeginCreatingTestShaderAsset(creator,
             {AZ::RHI::ShaderStage::Vertex, AZ::RHI::ShaderStage::Fragment, AZ::RHI::ShaderStage::Compute});
 
         AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
-    
+
         EXPECT_FALSE(shaderAsset);
     }
 
@@ -1220,11 +1221,11 @@ namespace UnitTest
 
         AZ::RPI::ShaderAssetCreator creator;
         BeginCreatingTestShaderAsset(creator, {AZ::RHI::ShaderStage::Fragment});
-  
+
         AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
-    
+
         messageFinder.CheckExpectedErrorsFound();
-    
+
         EXPECT_FALSE(shaderAsset);
     }
 
@@ -1240,7 +1241,7 @@ namespace UnitTest
         AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
 
         messageFinder.CheckExpectedErrorsFound();
-    
+
         EXPECT_FALSE(shaderAsset);
     }
 
@@ -1293,7 +1294,7 @@ namespace UnitTest
     TEST_F(ShaderTests, ShaderAsset_DefaultShaderOptions)
     {
         using namespace AZ;
-               
+
         RPI::ShaderAssetCreator creator;
         BeginCreatingTestShaderAsset(creator);
         // Override two of the default values. The others will maintain the default value from the shader options layout, see SetUp().
@@ -1314,9 +1315,9 @@ namespace UnitTest
     {
         using namespace AZ;
 
-        
+
         Data::Instance<RPI::Shader> shader = RPI::Shader::FindOrCreate(CreateShaderAsset());
-      
+
         ValidateShader(shader);
     }
 
@@ -1690,7 +1691,7 @@ namespace UnitTest
            All searches so far found exactly the node we were looking for
            The next couple of searches will not find the requested node
             and will instead default to its parent, up the tree to the root
-          
+
            []                       [Root]
                                     /    \
            [Color]              [Teal]  [Fuchsia]

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.cpp
@@ -742,7 +742,7 @@ namespace MaterialCanvas
                 return srgMember;
             }
 
-            if (auto v = AZStd::any_cast<const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>>(&slotValue))
+            if (AZStd::any_cast<const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>>(&slotValue))
             {
                 return AZStd::string::format("Texture2D SLOTNAME;\n");
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -214,8 +214,12 @@ namespace AZ
                 return lodAssignment;
             }
 
+            // GCC is incorrectly flaging the const reference returned from GetMaterialAssignmentFromMap
+            // as a dangling reference, despite the function returning a const reference.
+        AZ_PUSH_DISABLE_WARNING_GCC("-Wdangling-reference")
             const MaterialAssignment& assetAssignment =
                 GetMaterialAssignmentFromMap(materials, MaterialAssignmentId::CreateFromStableIdOnly(id.m_materialSlotStableId));
+        AZ_POP_DISABLE_WARNING_GCC
             if (assetAssignment.m_materialInstance.get())
             {
                 return assetAssignment;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -214,7 +214,7 @@ namespace AZ
                 return lodAssignment;
             }
 
-            // GCC is incorrectly flaging the const reference returned from GetMaterialAssignmentFromMap
+            // GCC is incorrectly flagging the const reference returned from GetMaterialAssignmentFromMap
             // as a dangling reference, despite the function returning a const reference.
         AZ_PUSH_DISABLE_WARNING_GCC("-Wdangling-reference")
             const MaterialAssignment& assetAssignment =

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -62,7 +62,7 @@ namespace AZ
             AZStd::vector<float>& blendWeightBufferData)
         {
             EMotionFX::SkinningInfoVertexAttributeLayer* sourceSkinningInfo = static_cast<EMotionFX::SkinningInfoVertexAttributeLayer*>(mesh->FindSharedVertexAttributeLayer(EMotionFX::SkinningInfoVertexAttributeLayer::TYPE_ID));
-            
+
             // EMotionFX source gives 16 bit indices and 32 bit float weights
             // Atom consumes 32 bit uint indices and 32 bit float weights (range 0-1)
             const uint32_t* sourceOriginalVertex = static_cast<uint32_t*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_ORGVTXNUMBERS));
@@ -112,7 +112,7 @@ namespace AZ
                 }
             }
         }
-        
+
         static void ProcessMorphsForLod(
             uint32_t lodIndex,
             const EMotionFX::Actor* actor,
@@ -148,7 +148,8 @@ namespace AZ
                             float minWeight = morphTarget->GetRangeMin();
                             float maxWeight = morphTarget->GetRangeMax();
 
-                            const auto& modelLodMesh = modelLodAsset->GetMeshes()[metaData.m_meshIndex];
+                            const auto lodMeshes = modelLodAsset->GetMeshes();
+                            const auto& modelLodMesh = lodMeshes[metaData.m_meshIndex];
 
                             const RPI::BufferAssetView* morphBufferAssetView =
                                 modelLodMesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
@@ -252,7 +253,7 @@ namespace AZ
                 for (const auto& modelLodMesh : modelLodAsset->GetMeshes())
                 {
                     // TODO: operate on a per-mesh basis
-                    
+
                     // If the joint id/weight buffers haven't been found on a mesh yet, keep looking
                     if (!jointIndicesBufferView)
                     {

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/DrawableMeshEntity.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/DrawableMeshEntity.cpp
@@ -73,7 +73,7 @@ namespace AZ::Render
     {
         AZ::Render::MeshHandleStateNotificationBus::Handler::BusConnect(m_entityId);
     }
-        
+
     DrawableMeshEntity::~DrawableMeshEntity()
     {
         AZ::Render::MeshHandleStateNotificationBus::Handler::BusDisconnect();
@@ -84,7 +84,7 @@ namespace AZ::Render
         m_modelLodIndex = RPI::ModelLodIndex::Null;
         m_meshDrawPackets.clear();
     }
- 
+
     bool DrawableMeshEntity::CanDraw() const
     {
         return !m_meshDrawPackets.empty();
@@ -99,10 +99,10 @@ namespace AZ::Render
                 false,
                 "Attempted to draw entity '%s' but entity has no draw data!",
                 m_entityId.ToString().c_str());
-        
+
             return;
         }
-        
+
         const DrawableMetaData drawabaleMetaData(m_entityId);
 
         // If the mesh level of detail index has changed, rebuild the mesh draw packets with the new index
@@ -112,7 +112,7 @@ namespace AZ::Render
         }
 
         const auto model = drawabaleMetaData.GetFeatureProcessor()->GetModel(*m_meshHandle);
-        
+
         if (!model)
         {
             return;
@@ -123,7 +123,7 @@ namespace AZ::Render
         {
             CreateOrUpdateMeshDrawPackets(drawabaleMetaData.GetFeatureProcessor(), modelLodIndex, model);
         }
-        
+
         AZ::RPI::DynamicDrawInterface* dynamicDraw = AZ::RPI::GetDynamicDraw();
         for (auto& drawPacket : m_meshDrawPackets)
         {
@@ -135,13 +135,13 @@ namespace AZ::Render
             }
         }
     }
-         
+
     RPI::ModelLodIndex DrawableMeshEntity::GetModelLodIndex(const RPI::ViewPtr view, Data::Instance<RPI::Model> model) const
     {
         const auto worldTM = AzToolsFramework::GetWorldTransform(m_entityId);
         return RPI::ModelLodUtils::SelectLod(view.get(), worldTM, *model);
     }
-        
+
     void DrawableMeshEntity::OnMeshHandleSet(const MeshFeatureProcessorInterface::MeshHandle* meshHandle)
     {
         m_meshHandle = meshHandle;
@@ -158,7 +158,7 @@ namespace AZ::Render
             CreateOrUpdateMeshDrawPackets(drawabaleMetaData.GetFeatureProcessor(), modelLodIndex, model);
         }
     }
-        
+
     void DrawableMeshEntity::CreateOrUpdateMeshDrawPackets(
         const MeshFeatureProcessorInterface* featureProcessor, const RPI::ModelLodIndex modelLodIndex, Data::Instance<RPI::Model> model)
     {
@@ -168,7 +168,7 @@ namespace AZ::Render
         {
             return;
         }
-        
+
         if (m_meshHandle->IsValid())
         {
             const auto maskMeshObjectSrg = CreateMaskShaderResourceGroup(featureProcessor);
@@ -180,7 +180,8 @@ namespace AZ::Render
     void DrawableMeshEntity::BuildMeshDrawPackets(
         const Data::Asset<RPI::ModelAsset> modelAsset, Data::Instance<RPI::ShaderResourceGroup> meshObjectSrg)
     {
-        const Data::Asset<RPI::ModelLodAsset>& modelLodAsset = modelAsset->GetLodAssets()[m_modelLodIndex.m_index];
+        const auto modelLodAssets = modelAsset->GetLodAssets();
+        const Data::Asset<RPI::ModelLodAsset>& modelLodAsset = modelLodAssets[m_modelLodIndex.m_index];
         Data::Instance<RPI::ModelLod> modelLod = RPI::ModelLod::FindOrCreate(modelLodAsset, modelAsset).get();
 
         for (size_t i = 0; i < modelLod->GetMeshes().size(); i++)

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -11,7 +11,7 @@
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
-#include <Atom/RPI.Public/Scene.h> 
+#include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
@@ -35,7 +35,8 @@ namespace AZ::Render
     {
         if (!m_material)
         {
-            const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[m_modelLodMeshIndex];
+            const auto meshes = m_modelLod->GetMeshes();
+            const RPI::ModelLod::Mesh& mesh = meshes[m_modelLodMeshIndex];
             m_material = mesh.m_material;
         }
 
@@ -114,7 +115,8 @@ namespace AZ::Render
 
     bool EditorStateMeshDrawPacket::DoUpdate(const RPI::Scene& parentScene)
     {
-        const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[m_modelLodMeshIndex];
+        const auto meshes = m_modelLod->GetMeshes();
+        const RPI::ModelLod::Mesh& mesh = meshes[m_modelLodMeshIndex];
 
         if (!m_material)
         {

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -173,7 +173,7 @@ namespace AZ
                 return;
             }
 
-            AZ_Warning("DiffuseProbeGridFeatureProcessor", m_diffuseProbeGrids.size() == 0, 
+            AZ_Warning("DiffuseProbeGridFeatureProcessor", m_diffuseProbeGrids.size() == 0,
                 "Deactivating the DiffuseProbeGridFeatureProcessor, but there are still outstanding probe grids probes. Components\n"
                 "using DiffuseProbeGridHandles should free them before the DiffuseProbeGridFeatureProcessor is deactivated.\n"
             );
@@ -769,7 +769,7 @@ namespace AZ
 
             AZ::RHI::ValidateStreamBufferViews(m_boxStreamLayout, m_probeGridRenderData.m_boxPositionBufferView);
         }
-        
+
         void DiffuseProbeGridFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* renderPipeline,
                 RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
@@ -795,7 +795,7 @@ namespace AZ
             }
             m_needUpdatePipelineStates = true;
         }
-                
+
         void DiffuseProbeGridFeatureProcessor::AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline)
         {
             // only add to this pipeline if it contains the DiffuseGlobalFullscreen pass
@@ -834,7 +834,7 @@ namespace AZ
             UpdatePasses();
             m_needUpdatePipelineStates = true;
         }
-        
+
         void DiffuseProbeGridFeatureProcessor::AddPassRequest(RPI::RenderPipeline* renderPipeline, const char* passRequestAssetFilePath, const char* insertionPointPassName)
         {
             auto passRequestAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::AnyAsset>(passRequestAssetFilePath, RPI::AssetUtils::TraceLevel::Warning);
@@ -925,7 +925,8 @@ namespace AZ
                 return;
             }
 
-            const RPI::ModelLod::Mesh& mesh = modelLod->GetMeshes()[0];
+            const auto meshes = modelLod->GetMeshes();
+            const RPI::ModelLod::Mesh& mesh = meshes[0];
 
             // setup a stream layout and shader input contract for the position vertex stream
             static const char* PositionSemantic = "POSITION";

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -171,7 +171,7 @@ namespace EMotionFX
     {
         AZ::u32 modelVertexCount = 0;
         AZ::u32 modelIndexCount = 0;
-        
+
         // Find the maximum skin influences across all meshes to use when pre-allocating memory
         AZ::u32 maxSkinInfluences = 0;
         for (const AZ::RPI::ModelLodAsset::Mesh& mesh : sourceModelLod->GetMeshes())
@@ -194,7 +194,8 @@ namespace EMotionFX
         // The lod has shared buffers that combine the data from each submesh.
         // These buffers can be accessed through the first submesh in their entirety
         // by using the BufferViewDescriptor from the Buffer instead of the one from the sub-mesh's BufferAssetView
-        const AZ::RPI::ModelLodAsset::Mesh& sourceMesh0 = sourceModelLod->GetMeshes()[0];
+        const auto sourceLodMeshes = sourceModelLod->GetMeshes();
+        const AZ::RPI::ModelLodAsset::Mesh& sourceMesh0 = sourceLodMeshes[0];
 
         // Copy the index buffer for the entire lod
         AZStd::span<const uint8_t> indexBuffer = sourceMesh0.GetIndexBufferAssetView().GetBufferAsset()->GetBuffer();
@@ -259,7 +260,7 @@ namespace EMotionFX
             else if (name == AZ::Name("SKIN_JOINTINDICES"))
             {
                 // Atom stores the skin indices as uint16, but the buffer itself is a buffer of uint32 with two id's per element
-                AZ_Assert(bufferAssetViewDescriptor.m_elementSize == 4, "Expect skin joint indices to be stored in a raw 32-bit per element buffer"); 
+                AZ_Assert(bufferAssetViewDescriptor.m_elementSize == 4, "Expect skin joint indices to be stored in a raw 32-bit per element buffer");
 
                 // Multiply element offset by 2 here since m_elementOffset is referring to 32-bit elements
                 // and the pointer we're offsetting is pointing to 16-bit data
@@ -300,7 +301,7 @@ namespace EMotionFX
                 const AZ::RPI::BufferAssetView* weightView = sourceMesh.GetSemanticBufferAssetView(AZ::Name{"SKIN_WEIGHTS"});
                 const AZ::RPI::BufferAssetView* jointIdView = sourceMesh.GetSemanticBufferAssetView(AZ::Name{"SKIN_JOINTINDICES"});
                 if (weightView && jointIdView)
-                {                    
+                {
                     const AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / meshVertexCount;
                     const AZ::u32 weightOffsetInElements = weightView->GetBufferViewDescriptor().m_elementOffset;
                     // We multiply by two here since there are two jointId's packed per-element
@@ -323,7 +324,7 @@ namespace EMotionFX
 
                                 const AZ::u16 skeletonJointIndex = skinToSkeletonIndexMap.at(skinJointIndex);
                                 skinningLayer->AddInfluence(currentVertex, skeletonJointIndex, weight, 0);
-                                
+
                                 usedJoints.set(skeletonJointIndex);
                                 highestJointIndex = AZStd::max(highestJointIndex, skeletonJointIndex);
                             }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/Endpoint.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/Endpoint.h
@@ -46,8 +46,8 @@ namespace GraphCanvas
         static void Reflect(AZ::ReflectContext* reflection);
         bool IsValid() const { return m_nodeId.IsValid() && m_slotId.IsValid(); }
 
-        const AZ::EntityId& GetNodeId() const { return m_nodeId; }
-        const AZ::EntityId& GetSlotId() const { return m_slotId; }
+        constexpr const AZ::EntityId& GetNodeId() const { return m_nodeId; }
+        constexpr const AZ::EntityId& GetSlotId() const { return m_slotId; }
 
         constexpr operator size_t() const
         {

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1004,8 +1004,8 @@ namespace Multiplayer
                     "Because this component is missing, the name isn't available, only its hash. "
                     "To find the missing component go to the other machine and search for 's_versionHash = AZ::HashValue64{ 0x%llx }' "
                     "inside the generated multiplayer auto-component build folder.",
-                    theirComponentHash,
-                    theirComponentHash);
+                    static_cast<AZ::u64>(theirComponentHash),
+                    static_cast<AZ::u64>(theirComponentHash));
             }
         }
 

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
@@ -24,7 +24,7 @@ namespace NvCloth
     namespace Internal
     {
         bool ObtainSkinningInfluences(
-            AZ::EntityId entityId, 
+            AZ::EntityId entityId,
             const MeshNodeInfo& meshNodeInfo,
             AZStd::vector<SkinningInfluence>& skinningInfluences,
             AZStd::vector<AZ::u32>& numInfluencesPerSubmesh)
@@ -42,7 +42,8 @@ namespace NvCloth
                 return false;
             }
 
-            const AZ::Data::Asset<AZ::RPI::ModelLodAsset>& modelLodAsset = modelAsset->GetLodAssets()[meshNodeInfo.m_lodLevel];
+            const auto modelLodAssets = modelAsset->GetLodAssets();
+            const AZ::Data::Asset<AZ::RPI::ModelLodAsset> modelLodAsset = modelLodAssets[meshNodeInfo.m_lodLevel];
             if (!modelLodAsset.GetId().IsValid())
             {
                 return false;
@@ -79,7 +80,8 @@ namespace NvCloth
                     return false;
                 }
 
-                const AZ::RPI::ModelLodAsset::Mesh& subMesh = modelLodAsset->GetMeshes()[subMeshInfo.m_primitiveIndex];
+                const auto subMeshes = modelLodAsset->GetMeshes();
+                const AZ::RPI::ModelLodAsset::Mesh& subMesh = subMeshes[subMeshInfo.m_primitiveIndex];
 
                 const auto sourcePositions = subMesh.GetSemanticBufferTyped<AZ::PackedVector3f>(AZ::Name("POSITION"));
                 if (sourcePositions.size() != subMeshInfo.m_numVertices)
@@ -119,7 +121,8 @@ namespace NvCloth
             for (size_t meshIndex = 0; meshIndex < meshNodeInfo.m_subMeshes.size(); ++meshIndex)
             {
                 const auto& subMeshInfo = meshNodeInfo.m_subMeshes[meshIndex];
-                const AZ::RPI::ModelLodAsset::Mesh& subMesh = modelLodAsset->GetMeshes()[subMeshInfo.m_primitiveIndex];
+                const auto subMeshes = modelLodAsset->GetMeshes();
+                const AZ::RPI::ModelLodAsset::Mesh& subMesh = subMeshes[subMeshInfo.m_primitiveIndex];
                 const auto sourceSkinJointIndices = subMesh.GetSemanticBufferTyped<uint16_t>(AZ::Name("SKIN_JOINTINDICES"));
                 const auto sourceSkinWeights = subMesh.GetSemanticBufferTyped<float>(AZ::Name("SKIN_WEIGHTS"));
 
@@ -171,7 +174,7 @@ namespace NvCloth
         const AZ::Matrix3x4* ObtainSkinningMatrices(AZ::EntityId entityId)
         {
             EMotionFX::ActorInstance* actorInstance = nullptr;
-            EMotionFX::Integration::ActorComponentRequestBus::EventResult(actorInstance, entityId, 
+            EMotionFX::Integration::ActorComponentRequestBus::EventResult(actorInstance, entityId,
                 &EMotionFX::Integration::ActorComponentRequestBus::Events::GetActorInstance);
             if (!actorInstance)
             {
@@ -434,7 +437,7 @@ namespace NvCloth
     }
 
     AZStd::unique_ptr<ActorClothSkinning> ActorClothSkinning::Create(
-        AZ::EntityId entityId, 
+        AZ::EntityId entityId,
         const MeshNodeInfo& meshNodeInfo,
         const AZStd::vector<SimParticleFormat>& originalMeshParticles,
         const size_t numSimulatedVertices,
@@ -479,7 +482,7 @@ namespace NvCloth
         actorClothSkinning->m_simulatedVertices.resize(numSimulatedVertices);
         actorClothSkinning->m_nonSimulatedVertices.reserve(numVertices);
 
-        
+
         // For each submesh...
         int meshIndexOffset = 0;
         AZ::u32 meshInfluenceOffset = 0;
@@ -491,7 +494,7 @@ namespace NvCloth
             {
                 const AZ::u32 influenceOffset = meshInfluenceOffset + (vertexIndex - meshIndexOffset) * numInfluencesPerSubmesh[subMeshIndex];
 
-                // The cloth cooker has previously simplified the original mesh and re-mapped the vertices 
+                // The cloth cooker has previously simplified the original mesh and re-mapped the vertices
                 const int remappedIndex = meshRemappedVertices[vertexIndex];
 
                 // If the vertex has been remapped, it's part of the simulation

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -503,7 +503,8 @@ namespace NvCloth
             return;
         }
 
-        const AZ::Data::Asset<AZ::RPI::ModelLodAsset>& modelLodAsset = modelAsset->GetLodAssets()[m_meshNodeInfo.m_lodLevel];
+        const auto modelLodAssets = modelAsset->GetLodAssets();
+        const AZ::Data::Asset<AZ::RPI::ModelLodAsset> modelLodAsset = modelLodAssets[m_meshNodeInfo.m_lodLevel];
         if (!modelLodAsset.GetId().IsValid())
         {
             AZ_Error("ClothComponentMesh", false,
@@ -531,7 +532,9 @@ namespace NvCloth
                     modelLodAsset->GetMeshes().size());
                 continue;
             }
-            const AZ::RPI::ModelLodAsset::Mesh& subMesh = modelLodAsset->GetMeshes()[subMeshInfo.m_primitiveIndex];
+            
+            const auto subMeshes = modelLodAsset->GetMeshes();
+            const AZ::RPI::ModelLodAsset::Mesh& subMesh = subMeshes[subMeshInfo.m_primitiveIndex];
 
             const int numVertices = subMeshInfo.m_numVertices;
             const int firstVertex = subMeshInfo.m_verticesFirstIndex;

--- a/Gems/PhysX/Code/Include/PhysX/EditorColliderComponentRequestBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/EditorColliderComponentRequestBus.h
@@ -217,9 +217,9 @@ namespace PhysX
         virtual void ValidateRigidBodyMeshGeometryType() = 0;
     };
 
-    AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations")
+    AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations", "-Wdeprecated-declarations");
     using EditorColliderValidationRequestBus = AZ::EBus<EditorColliderValidationRequests>;
-    AZ_POP_DISABLE_WARNING
+    AZ_POP_DISABLE_WARNING;
     
     //! Bus used to validate that non-convex meshes are not used with simulation types which do not support them.
     class EditorMeshColliderValidationRequests : public AZ::ComponentBus

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -29,17 +29,17 @@ namespace PhysX
 {
     // ShapeInfoCache
     AZ::Aabb BaseColliderComponent::ShapeInfoCache::GetAabb(const AZStd::vector<AZStd::shared_ptr<Physics::Shape>>& shapes)
-    { 
+    {
         if (m_cacheOutdated)
         {
             UpdateCache(shapes);
         }
-        return m_aabb; 
+        return m_aabb;
     }
 
     void BaseColliderComponent::ShapeInfoCache::InvalidateCache()
-    { 
-        m_cacheOutdated = true; 
+    {
+        m_cacheOutdated = true;
     }
 
     const AZ::Transform& BaseColliderComponent::ShapeInfoCache::GetWorldTransform()
@@ -71,9 +71,10 @@ namespace PhysX
             physx::PxTransform pxWorldTransform = PxMathConvert(m_worldTransform);
 
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
-            const physx::PxGeometry pxShapeGeom = pxShape->getGeometry();
+            const physx::PxGeometry& pxShapeGeom = pxShape->getGeometry();
 #else
-            const physx::PxGeometry pxShapeGeom = pxShape->getGeometry().any();
+            const auto pxGeometryHolder = pxShape->getGeometry();
+            const physx::PxGeometry& pxShapeGeom = pxGeometryHolder.any();
 #endif
 
             physx::PxBounds3 bounds = physx::PxGeometryQuery::getWorldBounds(pxShapeGeom,
@@ -166,7 +167,7 @@ namespace PhysX
 
     void BaseColliderComponent::SetCollisionLayer(const AZStd::string& layerName, AZ::Crc32 colliderTag)
     {
-        for(auto& shape : m_shapes) 
+        for(auto& shape : m_shapes)
         {
             if (Physics::Utils::FilterTag(shape->GetTag(), colliderTag))
             {
@@ -273,7 +274,7 @@ namespace PhysX
     bool BaseColliderComponent::InitShapes()
     {
         UpdateScaleForShapeConfigs();
-        
+
         if (IsMeshCollider())
         {
             return InitMeshCollider();
@@ -299,7 +300,7 @@ namespace PhysX
 
                 AZStd::shared_ptr<Physics::Shape> shape;
                 Physics::SystemRequestBus::BroadcastResult(shape, &Physics::SystemRequests::CreateShape, colliderConfiguration, *shapeConfiguration);
-                
+
                 if (!shape)
                 {
                     AZ_Error("PhysX", false, "Failed to create a PhysX shape. Entity: %s", GetEntity()->GetName().c_str());
@@ -312,7 +313,7 @@ namespace PhysX
             return true;
         }
     }
-    
+
     bool BaseColliderComponent::IsMeshCollider() const
     {
         return m_shapeConfigList.size() == 1 && m_shapeConfigList.begin()->second &&
@@ -325,7 +326,7 @@ namespace PhysX
 
         const AzPhysics::ShapeColliderPair& shapeConfigurationPair = *(m_shapeConfigList.begin());
         const Physics::ColliderConfiguration& componentColliderConfiguration = *(shapeConfigurationPair.first.get());
-        const Physics::PhysicsAssetShapeConfiguration& physicsAssetConfiguration = 
+        const Physics::PhysicsAssetShapeConfiguration& physicsAssetConfiguration =
             *(static_cast<const Physics::PhysicsAssetShapeConfiguration*>(shapeConfigurationPair.second.get()));
 
         if (!physicsAssetConfiguration.m_asset.IsReady())

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -71,9 +71,9 @@ namespace PhysX
             physx::PxTransform pxWorldTransform = PxMathConvert(m_worldTransform);
 
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
-            const physx::PxGeometry& pxShapeGeom = pxShape->getGeometry();
+            const physx::PxGeometry pxShapeGeom = pxShape->getGeometry();
 #else
-            const physx::PxGeometry& pxShapeGeom = pxShape->getGeometry().any();
+            const physx::PxGeometry pxShapeGeom = pxShape->getGeometry().any();
 #endif
 
             physx::PxBounds3 bounds = physx::PxGeometryQuery::getWorldBounds(pxShapeGeom,

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/tests/PrefabGroupTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/tests/PrefabGroupTests.cpp
@@ -71,8 +71,9 @@ namespace UnitTest
         SceneData::PrefabGroup instancePrefabGroup;
         EXPECT_EQ(AZ::JsonSerialization::Load(instancePrefabGroup, document).GetOutcome(), JSR::Outcomes::PartialDefaults);
 
-        ASSERT_TRUE(instancePrefabGroup.GetPrefabDomRef().has_value());
-        const AzToolsFramework::Prefab::PrefabDom& dom = instancePrefabGroup.GetPrefabDomRef().value();
+        auto prefabDomRef = instancePrefabGroup.GetPrefabDomRef();
+        ASSERT_TRUE(prefabDomRef.has_value());
+        const auto& dom = prefabDomRef.value().get();
         EXPECT_TRUE(dom.IsObject());
         EXPECT_TRUE(dom.GetObject().HasMember("foo"));
         EXPECT_STREQ(dom.GetObject().FindMember("foo")->value.GetString(), "bar");
@@ -101,7 +102,9 @@ namespace UnitTest
         prefabGroup.SetName("tester");
         prefabGroup.SetPrefabDom(AZStd::move(document));
 
-        const AzToolsFramework::Prefab::PrefabDom& dom = prefabGroup.GetPrefabDomRef().value();
+        auto prefabDomRef = prefabGroup.GetPrefabDomRef();
+        ASSERT_TRUE(prefabDomRef.has_value());
+        const auto& dom = prefabDomRef.value().get();
         EXPECT_TRUE(dom.IsNull());
         EXPECT_STREQ("tester", prefabGroup.GetName().c_str());
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasDataRegistry_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasDataRegistry_Source.jinja
@@ -48,23 +48,6 @@ namespace ScriptCanvas
 
     void {{autogenTargetName}}DataRegistry::Reflect(AZ::ReflectContext* context)
     {
-        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-{% for ScriptCanvas in dataFiles %}
-{%     for Data in ScriptCanvas -%}
-{%         set dataName = Data.attrib['Name'] %}
-{%         set namespaceName = '' %}
-{%         if Data.attrib['Namespace'] is defined and Data.attrib['Namespace'] %}
-{%             set namespaceName = Data.attrib['Namespace'] + '::' %}
-{%         endif %}
-            //serializeContext->RegisterGenericType<AZStd::vector<{{namespaceName}}{{dataName}}>>();
-            //serializeContext->RegisterGenericType<AZStd::unordered_map<AZStd::string, {{namespaceName}}{{dataName}}>>();
-            //serializeContext->RegisterGenericType<AZStd::unordered_map<double, {{namespaceName}}{{dataName}}>>();
-
-{%     endfor %}
-{% endfor %}
-        }
-
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
 {% for ScriptCanvas in dataFiles %}

--- a/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxDefaultMode.cpp
+++ b/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxDefaultMode.cpp
@@ -322,7 +322,7 @@ namespace WhiteBox
         const AZ::EntityComponentIdPair& entityComponentIdPair)
     {
         // edge selection test - ensure an edge is selected before allowing this shortcut
-        if (auto modifier = AZStd::get_if<AZStd::unique_ptr<EdgeTranslationModifier>>(&m_selectedModifier))
+        if ([[maybe_unused]] auto modifier = AZStd::get_if<AZStd::unique_ptr<EdgeTranslationModifier>>(&m_selectedModifier))
         {
             return AZStd::vector<AzToolsFramework::ActionOverride>{
                 AzToolsFramework::ActionOverride()
@@ -340,7 +340,7 @@ namespace WhiteBox
                 };
         }
         // vertex selection test - ensure a vertex is selected before allowing this shortcut
-        else if (auto modifier2 = AZStd::get_if<AZStd::unique_ptr<VertexTranslationModifier>>(&m_selectedModifier))
+        else if ([[maybe_unused]] auto modifier2 = AZStd::get_if<AZStd::unique_ptr<VertexTranslationModifier>>(&m_selectedModifier))
         {
             return AZStd::vector<AzToolsFramework::ActionOverride>{
                 AzToolsFramework::ActionOverride()

--- a/cmake/Platform/Linux/CMakePresets.json
+++ b/cmake/Platform/Linux/CMakePresets.json
@@ -288,6 +288,24 @@
             ]
         },
         {
+            "name": "linux-clang-default",
+            "displayName": "Linux",
+            "description": "Builds all targets for Linux using the Clang compiler",
+            "configurePreset": "linux-clang-default",
+            "inherits":[
+                "host-linux"
+            ]
+        },
+        {
+            "name": "linux-gcc-default",
+            "displayName": "Linux",
+            "description": "Builds all targets for Linux using the GCC compiler",
+            "configurePreset": "linux-gcc-default",
+            "inherits":[
+                "host-linux"
+            ]
+        },
+        {
             "name": "linux-editor",
             "displayName": "Linux Editor",
             "description": "Builds the Editor application for Linux",

--- a/cmake/Platform/Linux/CMakePresets.json
+++ b/cmake/Platform/Linux/CMakePresets.json
@@ -13,6 +13,7 @@
             "name": "linux-default",
             "displayName": "Linux",
             "description": "Linux default configuration",
+            "binaryDir": "${sourceDir}/build/linux",
             "inherits": [
                 "linux-ninja",
                 "linux-unity",
@@ -22,7 +23,7 @@
         {
             "name": "linux-mono-default",
             "displayName": "Linux Monolithic with Unity and Ninja",
-            "description": "Configures Mac to build the Monolithic permutation using Ninja with Unity builds",
+            "description": "Configures Linux to build the Monolithic permutation using Ninja with Unity builds",
             "binaryDir": "${sourceDir}/build/linux_mono",
             "inherits": [
                 "linux-ninja",
@@ -56,7 +57,7 @@
             "name": "linux-unity",
             "displayName": "Linux Unity",
             "description": "Linux build which uses unity files",
-            "binaryDir": "${sourceDir}/build/linux",
+            "binaryDir": "${sourceDir}/build/linux_unity",
             "inherits": [
                 "unity",
                 "host-linux"
@@ -76,6 +77,7 @@
             "name": "linux-non-monolithic",
             "displayName": "Linux Non-monolithic",
             "description": "Default configuration for non-monolithic builds",
+            "binaryDir": "${sourceDir}/build/linux_non_mono",
             "inherits": [
                 "non-monolithic",
                 "host-linux"


### PR DESCRIPTION
GCC 13 Build Fixes

Most of the changes are around unused variables or potential dangling references.

The dangling references case occurs when a function that return a value, then invokes a function that returns a reference.

fixes #16153

Clang 14+ build fixes in relation to variables that are only set, but never read.

## How was this PR tested?

Built O3DE using GCC13 on ArchLinux
