### PR TITLE
Add Auto Update CLI and Unit Test

### DIFF
--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -395,7 +395,7 @@ def add_parser_args(parser):
     group.add_argument('--auto-update', '-au', type=str, nargs='*', required=False,
                        help='Checks for any new Gems/Projects/Templates in the associated directories that have not been added'
                        ' to your repo.json fields.'
-                       ' Pass in lower case object type as args that should look like this: gem/ project/ template'
+                       ' Optionally, provide the object types to update as args like this: --auto-update gem project template'
                        ' Note: This does not update the deleted gems/projects/templates, please use'
                         '--delete-gems if you want to delete data from repo.json file')
     

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -265,8 +265,8 @@ def _edit_objects(object_typename:str,
     repo_json[f'{object_typename}s_data'] = repo_objects_data
 
 def _auto_update_json(object_type: str or list,
-                      repo_path: pathlib.Path = None,
-                      repo_json: dict = None,
+                      repo_path: pathlib.Path,
+                      repo_json: dict,
                       ):
     
     repo_directory = os.path.dirname(repo_path)
@@ -281,7 +281,8 @@ def _auto_update_json(object_type: str or list,
                 expected_files[filename].append(file_path)
     
     objects = object_type.split() if isinstance(object_type, str) else object_type
-    for object_name in objects:
+    for object in objects:
+        object_name = object.lower()
         if object_name == 'gem':
             _edit_objects(object_name, validation.valid_o3de_gem_json, repo_json, expected_files.get("gem.json"))
         if object_name == 'project':
@@ -319,7 +320,7 @@ def edit_repo_props(repo_path: pathlib.Path = None,
     :add_templates: Any template paths to be added to the list
     :delete_templates: Any template names to be removed from the list
     :replace_templates: A list of template paths that will completely replace the current list of path
-    :auto_update: Automatically updates your selected gem/project/template to your remote repository
+    :auto_update: List of object types (gem/project/template) to automatically to your remote repository. `None` if no auto update is desired.
     :release_archive_path: Path where you want your release to be located
     :force: Replaces current directory with new user input directory or file
     :download_prefix: The string prefix of the download uri
@@ -391,7 +392,7 @@ def add_parser_args(parser):
     group.add_argument('--repo-name','-rn',  type=str, required=False,
                        help='The name of the remote repository.')
     group.add_argument('--auto-update', '-au', type=str, nargs='*', required=False,
-                       help='Checks for any new Gems/Projects/Templates in the asscoiated directories that has not been added'
+                       help='Checks for any new Gems/Projects/Templates in the associated directories that have not been added'
                        ' to your repo.json fields.'
                        ' Pass in lower case object type as args that should look like this: gem/ project/ template'
                        ' Note: This does not update the deleted gems/projects/templates, please use'

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -363,7 +363,6 @@ def edit_repo_props(repo_path: pathlib.Path = None,
 
 
 def _edit_repo_props(args: argparse) -> int:
-
     return edit_repo_props(repo_path=args.repo_path,
                               repo_name=args.repo_name,
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -346,7 +346,6 @@ def edit_repo_props(repo_path: pathlib.Path = None,
 
     if auto_update:
         _auto_update_json(auto_update, repo_path, repo_json)
-        logger.warning(f'here is auto update: {auto_update}')
 
     if add_gems or delete_gems or replace_gems:
         _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix)

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -444,17 +444,15 @@ class TestEditRepoProperties:
             
         def _auto_update_json(object_type: str or list = None,
                       repo_path: pathlib.Path = None,
-                      repo_json: dict = None,
-                      ):
-            self.repo_json.data = repo_json
+                      repo_json: dict = None):
             objects = object_type.split() if isinstance(object_type, str) else object_type
             for object_type in objects:
                 if object_type == 'gem':
-                    return repo_json.get('gems_data').append(str(JSON_DICT['gem_archive_json_key']))
+                    self.repo_json.data.get('gems_data').append(str(JSON_DICT['gem_archive_json_key']))
                 if object_type == 'project':
-                    return repo_json.get('projects_data').append(str(JSON_DICT['project_json_key']))
+                    self.repo_json.data.get('projects_data').append(str(JSON_DICT['project_json_key']))
                 if object_type == 'template':
-                    return repo_json.get('templates_data').append(str(JSON_DICT['template_json_key']))
+                    self.repo_json.data.get('templates_data').append(str(JSON_DICT['template_json_key']))
             return 0
 
         with patch('o3de.repo_properties.get_repo_props', side_effect=get_repo_props) as get_repo_props_patch, \

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -391,15 +391,15 @@ class TestEditRepoProperties:
                          None, None, None, None,
                          'project', None, None, None,
                          0),
-            # Test Auto update a project 
-            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateProject',
+            # Test Auto update a template 
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateTemplate',
                          None, None, None, None,
                          None, None, None, None,
                          None, None, None, None,
                          'template', None, None, None,
                          0),
             # Test Auto update all object types 
-            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateProject',
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateAll',
                          None, None, None, None,
                          None, None, None, None,
                          None, None, None, None,

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -60,47 +60,79 @@ TEST_GEM_JSON_PAYLOAD = {
     ]
 }
 
+TEST_PROJECT_JSON_PAYLOAD = {
+    "project_name": "ProjectSample",
+    "version": "1.0.0",
+    "project_id": "{0A341AFF-E129-482E-B6E3-48467F18CA31}",
+    "origin": "The primary repo for ProjectSample goes here: i.e. http://www.mydomain.com",
+    "license": "What license ProjectSample uses goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT etc.",
+    "display_name": "ProjectSample",
+    "summary": "A short description of ProjectSample.",
+    "canonical_tags": [
+        "Project"
+    ],
+    "user_tags": [
+        "ProjectSample"
+    ],
+    "icon_path": "preview.png",
+    "engine": "o3de",
+    "external_subdirectories": [
+        "Gem"
+    ],
+    "gem_names": [
+        "Kaylin",
+        "Gene"
+    ],
+    "restricted": "ProjectSample",
+    "engine_version": "2.1.0",
+    "repo_uri": "https://github.com/ready-player1/o3deRemoteRepo.git",
+    "download_source_uri": "None/projectsample-1.0.0-project.zip"
+}
+
+TEST_TEMPLATE_JSON_PAYLOAD = {
+    "template_name": "MinimalProject"
+}
 
 GEM_VERSION_ONE_JSON={
     "gem_name": "TestGem",
     "version": "1.0.0"
 }
 
-GEM_VERSION_TWO_JSON={
+GEM_VERSION_TWO_JSON= {
     "gem_name": "TestGem",
     "version": "2.0.0"
 }
 
-GEM_VERSION_THREE_JSON={
+GEM_VERSION_THREE_JSON= {
     "gem_name": "TestGem",
     "version": "3.0.0"
 }
 
-GEM_VERSION_ONE_TOBE_UPDATED={
+GEM_VERSION_ONE_TOBE_UPDATED= {
     "gem_name": "TestGemUpdate",
     "version": "1.0.0",
     "display_name": "testGem"
 }
 
-GEM_VERSION_ONE_WITH_UPDATED_FIELD={
+GEM_VERSION_ONE_WITH_UPDATED_FIELD= {
     "gem_name": "TestGemUpdate",
     "version": "1.0.0",
     "display_name": "hiWorld"
 }
 
-GEM_VERSION_TWO_TOBE_UPDATED={
+GEM_VERSION_TWO_TOBE_UPDATED= {
     "gem_name": "TestGem",
     "version": "2.0.0",
     "display_name": "wastwo"
 }
 
-GEM_VERSION_TWO_WITH_UPDATED_FIELD={
+GEM_VERSION_TWO_WITH_UPDATED_FIELD= {
     "gem_name": "TestGem",
     "version": "2.0.0",
     "display_name": "hiWorld"
 }
 
-GEM_WITH_NO_VERSION={
+GEM_WITH_NO_VERSION= {
     "gem_name": "TestGem"
 }
 
@@ -112,7 +144,9 @@ JSON_DICT={'gem_version1_json_key': GEM_VERSION_ONE_JSON,
            'gem_version2_tobe_updated_key': GEM_VERSION_TWO_TOBE_UPDATED,
            'gem_version2_updated_key': GEM_VERSION_TWO_WITH_UPDATED_FIELD,
            'gem_with_no_version_key': GEM_WITH_NO_VERSION,
-           'gem_archive_json_key': TEST_GEM_JSON_PAYLOAD}
+           'gem_archive_json_key': TEST_GEM_JSON_PAYLOAD,
+           'project_json_key': TEST_PROJECT_JSON_PAYLOAD,
+           'template_json_key': TEST_TEMPLATE_JSON_PAYLOAD}
 
 # class returns a dictionary of the template repo json
 @pytest.fixture(scope='function')
@@ -152,63 +186,63 @@ class TestEditRepoProperties:
                               add_gems, delete_gems, replace_gems, expected_gems, \
                               add_projects, delete_projects, replace_projects, expected_projects, \
                               add_templates, delete_templates, replace_templates, expected_templates, \
-                              release_archive_path, force, download_prefix, \
+                              auto_update, release_archive_path, force, download_prefix, \
                               expected_result", [
             # test add gems
             pytest.param(pathlib.Path('F:/repotest'),'Repotest1',
                          'gem1 gem3', None, None, [{'gem_name':'gem1'}, {'gem_name':'gem3'}],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test remove a gem
             pytest.param(pathlib.Path('D:/repotest'),'Repotest2',
                          'gem1 gem2', 'gem2', None, [{'gem_name':'gem1'}],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test replace with multiple gems
             pytest.param(pathlib.Path('F:/repotest/AFH'),'Repotest3',
                          'gem1 gem2', None, 'gem3 gem4', [{'gem_name':'gem3'}, {'gem_name':'gem4'}],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test replace a gem with an empty parameter
             pytest.param(pathlib.Path('F:/repotest'),'Repo',
                          'gem1 gem2', None, '', [{'gem_name':'gem1'}, {'gem_name':'gem2'}],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test add projects
             pytest.param(pathlib.Path('F:/repotest'),'test',
                          None, None, None, None,
                          'project1 project2', None, None, [{'project_name':'project1'}, {'project_name':'project2'}],
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test remove a project
             pytest.param(pathlib.Path('F:/repotest'),'random',
                          None, None, None, None,
                          'project1 project2 project3', 'project2', None, [{'project_name':'project1'}, {'project_name':'project3'}],
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test replace a project
             pytest.param(pathlib.Path('F:/repotest'),'RepoReplace',
                          None, None, None, None,
                          'project1 project2', None, 'project3', [{'project_name':'project3'}],
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test remove project with a empty parameter
             pytest.param(pathlib.Path('F:/repotest'),'RepoRemove', 
                          None, None, None, None,
                          'project1 project2', '', None, [{'project_name':'project1'}, {'project_name':'project2'}],
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test add template
             pytest.param(pathlib.Path('F:/repotest'),'RepoAdd',
@@ -216,35 +250,35 @@ class TestEditRepoProperties:
                          None, None, None, None,
                          'template1 template2 template3', None, None, [{'template_name':'template1'}, {'template_name':'template2'}, 
                                                                        {'template_name':'template3'}],
-                        None, None, None,
+                         None, None, None, None,
                          0),
             # test remove multiple templates
             pytest.param(pathlib.Path('F:/repotest'),'removeTemplate',
                          None, None, None, None,
                          None, None, None, None,
                          'template1 template2 template3', 'template1 template2', None, [{'template_name':'template3'}],
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test replace a temlpate
             pytest.param(pathlib.Path('F:/repotest'),'replaceTemp',
                          None, None, None, None,
                          None, None, None, None,
                          'template1 template2 template3', None, "template48", [{'template_name':'template48'}],
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test add all objects
             pytest.param(pathlib.Path('F:/repotest'),'addAll',
                          'gem1', None, None, [{'gem_name':'gem1'}],
                          'project1', None, None, [{'project_name':'project1'}],
                          'template1 template2', None, None, [{'template_name':'template1'}, {'template_name':'template2'}],
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # test remove all object types
             pytest.param(pathlib.Path('F:/repotest'),'removeAll',
                          'gem1 gem2', 'gem1', None, [{'gem_name':'gem2'}],
                          'project1', 'project1', None, [],
                          'template1 template2 template3', 'template1 template3', None, [{'template_name':'template2'}],
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0
             pytest.param(pathlib.Path('F:/repotest'),'GemAddVersion',
@@ -254,7 +288,7 @@ class TestEditRepoProperties:
                                                                                     }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 2.0.0             
             pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveVersion',
@@ -264,7 +298,7 @@ class TestEditRepoProperties:
                                                                                                 }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 1.0.0
             pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveBaseVersion',
@@ -274,14 +308,14 @@ class TestEditRepoProperties:
                                                                                                 }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then removing version 1.0.0 and 2.0.0
             pytest.param(pathlib.Path('F:/repotest'),'GemAddAndRemoveAllVersion',
                          'gem_version1_json_key gem_version2_json_key', 'TestGem==1.0.0 TestGem==2.0.0', None, [],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with the same version but other updated gem.json fields
             pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
@@ -291,7 +325,7 @@ class TestEditRepoProperties:
                                                                                                             }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with version 1.0.0 and then the same gem with version 2.0.0 and then adding version 2.0.0 with updated gem.json fields
             pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
@@ -304,7 +338,7 @@ class TestEditRepoProperties:
                                                                                                                         }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem with multiple versions and then replacing all gems with another set of gems             
             pytest.param(pathlib.Path('F:/repotest'),'ReplaceGem',
@@ -312,7 +346,7 @@ class TestEditRepoProperties:
                                                                                                          'version': '3.0.0'}],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Deleting a gem with version>2.0.0
             pytest.param(pathlib.Path('F:/repotest'),'DeletingGemVersion',
@@ -324,7 +358,7 @@ class TestEditRepoProperties:
                                                                                                                         }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Adding a gem without a version, then adding a gem with the same name but with a version
             pytest.param(pathlib.Path('F:/repotest'),'GemAddSameVersionWithUpdateField',
@@ -334,14 +368,42 @@ class TestEditRepoProperties:
                                                                                         }],
                          None, None, None, None,
                          None, None, None, None,
-                         None, None, None,
+                         None, None, None, None,
                          0),
             # Add a gem and create an archive
             pytest.param(pathlib.Path('F:/repotest'),'testArchive',
                          'na', None, None, [JSON_DICT['gem_archive_json_key']],
                          None, None, None, None,
                          None, None, None, None,
-                         'na', None, 'http://testGemPath',
+                         None, 'na', None, 'http://testGemPath',
+                         0),
+            # Test Auto update a gem 
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateGem',
+                         None, None, None, None,
+                         None, None, None, None,
+                         None, None, None, None,
+                         'gem', None, None, None,
+                         0),
+            # Test Auto update a project 
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateProject',
+                         None, None, None, None,
+                         None, None, None, None,
+                         None, None, None, None,
+                         'project', None, None, None,
+                         0),
+            # Test Auto update a project 
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateProject',
+                         None, None, None, None,
+                         None, None, None, None,
+                         None, None, None, None,
+                         'template', None, None, None,
+                         0),
+            # Test Auto update all object types 
+            pytest.param(pathlib.Path('F:/repotest'),'testAutoUpdateProject',
+                         None, None, None, None,
+                         None, None, None, None,
+                         None, None, None, None,
+                         'gem project template', None, None, None,
                          0),
             ]
     ) 
@@ -349,7 +411,7 @@ class TestEditRepoProperties:
     def test_edit_repo_obj_version(self, temp_folder, repo_path, repo_name, add_gems, delete_gems, replace_gems, expected_gems,
                                      add_projects, delete_projects, replace_projects, expected_projects, 
                                      add_templates, delete_templates, replace_templates, expected_templates,
-                                     release_archive_path, force, download_prefix,  
+                                     auto_update, release_archive_path, force, download_prefix,  
                                      expected_result):
         def backup_file(file_name: str or pathlib.Path) -> None:
             self.backup_file_name = file_name
@@ -379,10 +441,26 @@ class TestEditRepoProperties:
                 return {'project_name': object_path}
             if object_typename == "template":
                 return {'template_name': object_path}
+            
+        def _auto_update_json(object_type: str or list = None,
+                      repo_path: pathlib.Path = None,
+                      repo_json: dict = None,
+                      ):
+            self.repo_json.data = repo_json
+            objects = object_type.split() if isinstance(object_type, str) else object_type
+            for object_type in objects:
+                if object_type == 'gem':
+                    return repo_json.get('gems_data').append(str(JSON_DICT['gem_archive_json_key']))
+                if object_type == 'project':
+                    return repo_json.get('projects_data').append(str(JSON_DICT['project_json_key']))
+                if object_type == 'template':
+                    return repo_json.get('templates_data').append(str(JSON_DICT['template_json_key']))
+            return 0
 
         with patch('o3de.repo_properties.get_repo_props', side_effect=get_repo_props) as get_repo_props_patch, \
                 patch('o3de.manifest.save_o3de_manifest', side_effect=save_o3de_manifest) as save_o3de_manifest_patch, \
                 patch('o3de.utils.backup_file', side_effect=backup_file) as backup_file_patch, \
+                patch('o3de.repo_properties._auto_update_json', side_effect=_auto_update_json) as _auto_update_json_patch, \
                 patch('o3de.manifest.get_json_data', side_effect=get_json_data) as get_json_data_patch:
             if release_archive_path:
                 add_gems = [temp_folder / 'gem']
@@ -390,7 +468,7 @@ class TestEditRepoProperties:
             result = repo_properties.edit_repo_props(repo_path, repo_name, add_gems, delete_gems, replace_gems,
                                                      add_projects, delete_projects, replace_projects, 
                                                      add_templates, delete_templates, replace_templates, 
-                                                     release_archive_path, force, download_prefix)
+                                                     auto_update, release_archive_path, force, download_prefix)
             assert result == expected_result
             if result == 0:
                 assert self.repo_json.data.get('repo_name') == repo_name
@@ -402,9 +480,17 @@ class TestEditRepoProperties:
                     if release_archive_path:
                         zip_path = release_archive_path / pathlib.Path(gem['download_source_uri']).name
                         download.validate_downloaded_zip_sha256(gem, zip_path, "gem.json")
+                    elif auto_update:
+                        assert gem in str(JSON_DICT.get('gem_archive_json_key'))
                     else:
                         assert gem in expected_gems
                 for project in self.repo_json.data.get('projects_data', []):
-                    assert project in expected_projects
+                    if auto_update:
+                        assert project in str(JSON_DICT.get('project_json_key'))
+                    else:
+                        assert project in expected_projects
                 for template in self.repo_json.data.get('templates_data', []):
-                    assert template in expected_templates
+                    if auto_update:
+                        assert template in str(JSON_DICT.get('template_json_key'))
+                    else:
+                        assert template in expected_templates


### PR DESCRIPTION
## What does this PR do?

Add the --auto-update CLI option to repo-properties.py and include the associated unit test. This CLI should be capable of automatically detecting any Gems/Projects/Templates present in the remote repository folder but not registered with the repo.json file, then update that object in the user's repo.json file.

- User can specify which type of object they want to auto-update. The command for using this CLI is:  `o3de.bat edit-repo-properties -rp "C:\o3de_Projects\test2\repo.json" -au gem`
- you can use the last argument parameter with other objects
For example : `-au gem`, `-au project`, `-au template`, or `-au gem project template`

## How was this PR tested?

1. I added unit tests that made sure the _auto_update function got called and mocked that function to make sue the correct object gets updated in the repo.json file. Run all unit tests to make sure all functions still passes the tests.
2. Run above command and made sure that repo.json file gets updated with the correct object and data.
