### PR TITLE
Introduce multi-device queries and fences

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceFence.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Fence.h>
+#include <Atom/RHI/MultiDeviceObject.h>
+
+namespace AZ::RHI
+{
+    //! A multi-device synchronization primitive, holding device-specific Fences, than can be used to insert
+    //! dependencies between a queue and a host
+    class MultiDeviceFence : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceFence, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceFence, "{5FF150A4-2C1E-4EC6-AE36-8EBD1CE22C31}", MultiDeviceObject);
+
+        MultiDeviceFence() = default;
+        virtual ~MultiDeviceFence() = default;
+
+        //! Initializes the multi-device fence using the provided deviceMask.
+        //! It creates on device-specific fence for each bit set in the deviceMask and
+        //! passes on the initial FenceState to each Fence
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, FenceState initialState);
+
+        //! Waits on m_waitThread and shuts down all device-specific fences.
+        void Shutdown() override final;
+
+        //! Signals the device-specific fences managed by this class
+        RHI::ResultCode SignalOnCpu();
+
+        //! Waits (blocks) for all device-specific fences managed by this class
+        RHI::ResultCode WaitOnCpu() const;
+
+        //! Resets the device-specific fences.
+        RHI::ResultCode Reset();
+
+        using SignalCallback = AZStd::function<void()>;
+
+        //! Spawns a dedicated thread to wait on all device-specific fences. The provided callback
+        //! is invoked when the fences complete.
+        ResultCode WaitOnCpuAsync(SignalCallback callback);
+
+        //! Returns the device-specific Fence for the given index
+        const Ptr<Fence>& GetDeviceFence(int deviceIndex)
+        {
+            AZ_Error(
+                "MultiDeviceFence",
+                m_deviceFences.find(deviceIndex) != m_deviceFences.end(),
+                "No Fence found for device index %d\n",
+                deviceIndex);
+            return m_deviceFences.at(deviceIndex);
+        }
+
+    protected:
+        bool ValidateIsInitialized() const;
+
+        //! This can be used to asynchronously wait on all fences by calling WaitOnCpuAsync
+        AZStd::thread m_waitThread;
+
+        //! A map of all device-specific Fences, indexed by the device index
+        AZStd::unordered_map<int, Ptr<Fence>> m_deviceFences;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/Query.h>
+
+namespace AZ::RHI
+{
+    class CommandList;
+    class MultiDeviceQueryPool;
+
+    //! MultiDeviceQuery resource for recording gpu data like occlusion, timestamp or pipeline statistics.
+    //! Queries belong to a MultiDeviceQueryPool and their types are determined by the pool.
+    class MultiDeviceQuery : public MultiDeviceResource
+    {
+        friend class MultiDeviceQueryPool;
+
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceQuery, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceQuery, "{F72033E8-7A91-40BF-80E2-7262223362DB}", MultiDeviceResource);
+        MultiDeviceQuery() = default;
+        virtual ~MultiDeviceQuery() override = default;
+
+        //! Returns the device-specific Query for the given index
+        inline Ptr<Query> GetDeviceQuery(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceQuery",
+                m_deviceQueries.find(deviceIndex) != m_deviceQueries.end(),
+                "No DeviceQuery found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceQueries.at(deviceIndex);
+        }
+
+        //! Returns the query pool that this query belongs to.
+        const MultiDeviceQueryPool* GetQueryPool() const;
+        MultiDeviceQueryPool* GetQueryPool();
+
+        //! Returns the device-specific query handle
+        //! @param deviceIndex Specify from which device the query handle should be retrieved
+        QueryHandle GetHandle(int deviceIndex)
+        {
+            AZ_Assert(
+                m_deviceQueries.find(deviceIndex) != m_deviceQueries.end(), "No DeviceQuery found for device index %d\n", deviceIndex);
+            return m_deviceQueries.at(deviceIndex)->GetHandle();
+        }
+
+        //! Shuts down the device-specific resources by detaching them from their parent pool.
+        void Shutdown() override final;
+
+        //! Invalidates all views by setting off events on all device-specific ResourceInvalidateBusses
+        void InvalidateViews() override final;
+
+    private:
+        //! A map of all device-specific Queries, indexed by the device index
+        AZStd::unordered_map<int, Ptr<Query>> m_deviceQueries;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
@@ -62,10 +62,20 @@ namespace AZ::RHI
         //!  @param queryCount Number of queries.
         ResultCode InitQuery(MultiDeviceQuery** queries, uint32_t queryCount);
 
+        //! Get the number of results that have to be allocated.
+        //! The number returned is the number of results per query, multiplied by the number of queries and the number of devices.
+        //! The number of devices can also be queried from the RHISystem.
+        //! If the queryCount is omitted or equal to 0, the total number of queries in the pool is used.
+        uint32_t GetResultsCount(uint32_t queryCount = 0, uint32_t deviceCount = 0);
+
         //! Get the results from all queries (from all devices) in the pool, which are returned as uint64_t data.
-        //! The parameter "resultsCount" denotes the number of results requested per device.
+        //! The parameter "resultsCount" denotes the total number of results requested. It can be determined by calling GetResultsCount().
         //! The "results" parameter must contain enough space to save the results from all queries (from all devices) in the pool,
-        //! i.e. resultCount * deviceCount * sizeof(uint64_t) must be pre-allocated.
+        //! i.e. resultCount * sizeof(uint64_t), must be pre-allocated.
+        //! Results are ordered by device (using the deviceIndex) first and then per query, i.e., all results from a device are
+        //! consecutive in memory.
+        //! Data will only be written to the results array if the device actually exists, i.e., if its bit in the query's device mask is
+        //! set and the device index is lower than the RHISystem's device count.
         //! The function can return partial results. In case of failure of requesting results from a specific device, only results from
         //! lower-indexed devices (which already have successfully returned results) are returned.
         //! For further details related to device-specific query functionality, please check the related header.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Interval.h>
+#include <Atom/RHI.Reflect/QueryPoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/QueryPool.h>
+#include <Atom/RHI/QueryPoolSubAllocator.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/sort.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceQuery;
+
+    //! MultiDeviceQueryPool manages a map of device-specific QueryPools, which provide backing storage and context for query instances. The
+    //! QueryPoolDescriptor contains properties defining memory characteristics of query pools. All queries created on a pool share the same
+    //! backing and type.
+    class MultiDeviceQueryPool : public MultiDeviceResourcePool
+    {
+        using Base = MultiDeviceResourcePool;
+
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceQueryPool, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceQueryPool, "{F46A756D-99F1-4A2A-AE4C-A2A8BE6845CC}", MultiDeviceResourcePool)
+        MultiDeviceQueryPool() = default;
+        virtual ~MultiDeviceQueryPool() override = default;
+
+        //! Returns the device-specific QueryPool for the given index
+        inline Ptr<QueryPool> GetDeviceQueryPool(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceQueryPool",
+                m_deviceQueryPools.find(deviceIndex) != m_deviceQueryPools.end(),
+                "No DeviceQueryPool found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceQueryPools.at(deviceIndex);
+        }
+
+        //!  Initialize the MultiDeviceQueryPool by initializing all device-specific QueryPools for each device mentioned in the deviceMask.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor);
+
+        //! Initialize a query from the pool (one device-specific query for each QueryPool).
+        //! When initializing multiple queries use the other version of InitQuery
+        //! because the pool will try to group the queries together.
+        //!  @param query MultiDeviceQuery to initialize.
+        ResultCode InitQuery(MultiDeviceQuery* query);
+
+        //!  Initialize a group of queries from the pool. The initialization will try to allocate
+        //!  the queries in a consecutive space (consecutive per device). The reason for this is that is more efficient when requesting
+        //!  results or copying multiple query results.
+        //!  @param queries Pointer to an array of queries to initialize.
+        //!  @param queryCount Number of queries.
+        ResultCode InitQuery(MultiDeviceQuery** queries, uint32_t queryCount);
+
+        //! Get the results from all queries (from all devices) in the pool, which are returned as uint64_t data.
+        //! The parameter "resultsCount" denotes the number of results requested per device.
+        //! The "results" parameter must contain enough space to save the results from all queries (from all devices) in the pool,
+        //! i.e. resultCount * deviceCount * sizeof(uint64_t) must be pre-allocated.
+        //! The function can return partial results. In case of failure of requesting results from a specific device, only results from
+        //! lower-indexed devices (which already have successfully returned results) are returned.
+        //! For further details related to device-specific query functionality, please check the related header.
+        ResultCode GetResults(uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags);
+
+        //! Same as GetResults(uint64_t, uint32_t, QueryResultFlagBits) but for a specific multi-device query.
+        ResultCode GetResults(MultiDeviceQuery* query, uint64_t* result, uint32_t resultsCount, QueryResultFlagBits flags);
+
+        //!  Same as GetResults(MultiDeviceQuery*, uint64_t, uint32_t, QueryResultFlagBits) but for a list of queries.
+        //!  It's more efficient if the list of queries is sorted by handle in ascending order because there's no need to sort the
+        //!  results before returning.
+        ResultCode GetResults(
+            MultiDeviceQuery** queries, uint32_t queryCount, uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags);
+
+        //!  Returns the buffer descriptor used to initialize the query pool. Descriptor contents
+        //!  are undefined for uninitialized pools.
+        const QueryPoolDescriptor& GetDescriptor() const override final;
+
+        //! Forwards the shutdown call to all device-specific QueryPools.
+        void Shutdown() override final;
+
+    private:
+        //! Validates that the queries are not null and that they belong to this pool.
+        ResultCode ValidateQueries(MultiDeviceQuery** queries, uint32_t queryCount);
+
+        QueryPoolDescriptor m_descriptor;
+        //! A map of all device-specific QueryPools, indexed by the device index
+        AZStd::unordered_map<int, Ptr<QueryPool>> m_deviceQueryPools;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQueryPool.h
@@ -64,9 +64,9 @@ namespace AZ::RHI
 
         //! Get the number of results that have to be allocated.
         //! The number returned is the number of results per query, multiplied by the number of queries and the number of devices.
-        //! The number of devices can also be queried from the RHISystem.
+        //! The number of devices is queried from the RHISystem.
         //! If the queryCount is omitted or equal to 0, the total number of queries in the pool is used.
-        uint32_t GetResultsCount(uint32_t queryCount = 0, uint32_t deviceCount = 0);
+        uint32_t CalculateResultsCount(uint32_t queryCount = 0);
 
         //! Get the results from all queries (from all devices) in the pool, which are returned as uint64_t data.
         //! The parameter "resultsCount" denotes the total number of results requested. It can be determined by calling GetResultsCount().
@@ -98,6 +98,11 @@ namespace AZ::RHI
         void Shutdown() override final;
 
     private:
+        //! Get the number of results that have to be allocated per device.
+        //! The number returned is the number of results per query, multiplied by the number of queries.
+        //! If the queryCount is omitted or equal to 0, the total number of queries in the pool is used.
+        uint32_t CalculatePerDeviceResultsCount(uint32_t queryCount = 0);
+
         //! Validates that the queries are not null and that they belong to this pool.
         ResultCode ValidateQueries(MultiDeviceQuery** queries, uint32_t queryCount);
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceFence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceFence.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceFence.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/Debug/Profiler.h>
+
+namespace AZ::RHI
+{
+    bool MultiDeviceFence::ValidateIsInitialized() const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!IsInitialized())
+            {
+                AZ_Error("MultiDeviceFence", false, "MultiDeviceFence is not initialized!");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    ResultCode MultiDeviceFence::Init(MultiDevice::DeviceMask deviceMask, FenceState initialState)
+    {
+        if (Validation::IsEnabled())
+        {
+            if (IsInitialized())
+            {
+                AZ_Error("MultiDeviceFence", false, "MultiDeviceFence is already initialized!");
+                return ResultCode::InvalidOperation;
+            }
+        }
+
+        MultiDeviceObject::Init(deviceMask);
+
+        ResultCode resultCode = ResultCode::Success;
+
+        IterateDevices(
+            [this, initialState, &resultCode](int deviceIndex)
+            {
+                auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                m_deviceFences[deviceIndex] = Factory::Get().CreateFence();
+                resultCode = m_deviceFences[deviceIndex]->Init(*device, initialState);
+
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific Fences and set deviceMask to 0
+            m_deviceFences.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    void MultiDeviceFence::Shutdown()
+    {
+        if (IsInitialized())
+        {
+            if (m_waitThread.joinable())
+            {
+                m_waitThread.join();
+            }
+
+            for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+            {
+                deviceFence->Shutdown();
+            }
+
+            MultiDeviceObject::Shutdown();
+        }
+    }
+
+    ResultCode MultiDeviceFence::SignalOnCpu()
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        ResultCode resultCode;
+
+        for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+        {
+            resultCode = deviceFence->SignalOnCpu();
+
+            if (resultCode != ResultCode::Success)
+            {
+                return resultCode;
+            }
+        }
+
+        return ResultCode::Success;
+    }
+
+    ResultCode MultiDeviceFence::WaitOnCpu() const
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        ResultCode resultCode;
+
+        for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+        {
+            resultCode = deviceFence->WaitOnCpu();
+
+            if (resultCode != ResultCode::Success)
+            {
+                return resultCode;
+            }
+        }
+
+        return ResultCode::Success;
+    }
+
+    ResultCode MultiDeviceFence::WaitOnCpuAsync(SignalCallback callback)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!callback)
+        {
+            AZ_Error("MultiDeviceFence", false, "Callback is null.");
+            return ResultCode::InvalidOperation;
+        }
+
+        if (m_waitThread.joinable())
+        {
+            m_waitThread.join();
+        }
+
+        AZStd::thread_desc threadDesc{ "MultiDeviceFence WaitOnCpu Thread" };
+
+        m_waitThread = AZStd::thread(
+            threadDesc,
+            [this, callback]()
+            {
+                ResultCode resultCode = WaitOnCpu();
+                if (resultCode != ResultCode::Success)
+                {
+                    AZ_Error("MultiDeviceFence", false, "Failed to call WaitOnCpu in async thread.");
+                }
+                callback();
+            });
+
+        return ResultCode::Success;
+    }
+
+    ResultCode MultiDeviceFence::Reset()
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        ResultCode resultCode;
+
+        for (auto& [deviceIndex, deviceFence] : m_deviceFences)
+        {
+            resultCode = deviceFence->Reset();
+
+            if (resultCode != ResultCode::Success)
+            {
+                return resultCode;
+            }
+        }
+
+        return ResultCode::Success;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+
+namespace AZ::RHI
+{
+    const MultiDeviceQueryPool* MultiDeviceQuery::GetQueryPool() const
+    {
+        return static_cast<const MultiDeviceQueryPool*>(GetPool());
+    }
+
+    MultiDeviceQueryPool* MultiDeviceQuery::GetQueryPool()
+    {
+        return static_cast<MultiDeviceQueryPool*>(GetPool());
+    }
+
+    void MultiDeviceQuery::Shutdown()
+    {
+        for (auto& [_, deviceQuery] : m_deviceQueries)
+        {
+            deviceQuery->Shutdown();
+        }
+
+        MultiDeviceResource::Shutdown();
+    }
+
+    void MultiDeviceQuery::InvalidateViews()
+    {
+        for (auto& [_, deviceQuery] : m_deviceQueries)
+        {
+            deviceQuery->InvalidateViews();
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/std/parallel/lock.h>
+
+namespace AZ::RHI
+{
+    ResultCode MultiDeviceQueryPool::Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor)
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!descriptor.m_queriesCount)
+            {
+                AZ_Error("RHI", false, "MultiDeviceQueryPool size can't be zero");
+                return ResultCode::InvalidArgument;
+            }
+
+            if (descriptor.m_type == QueryType::PipelineStatistics && descriptor.m_pipelineStatisticsMask == PipelineStatisticsFlags::None)
+            {
+                AZ_Error("RHI", false, "Missing pipeline statistics flags");
+                return ResultCode::InvalidArgument;
+            }
+
+            if (descriptor.m_type != QueryType::PipelineStatistics && descriptor.m_pipelineStatisticsMask != PipelineStatisticsFlags::None)
+            {
+                AZ_Warning(
+                    "RHI",
+                    false,
+                    "Pipeline statistics flags are only valid for PipelineStatistics pools. Ignoring m_pipelineStatisticsMask");
+            }
+        }
+
+        auto resultCode = MultiDeviceResourcePool::Init(
+            deviceMask,
+            [this, &descriptor]()
+            {
+                // Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                // for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                // possibility that users will get garbage values from GetDescriptor().
+                m_descriptor = descriptor;
+
+                auto resultCode{ ResultCode::Success };
+
+                IterateDevices(
+                    [this, &descriptor, &resultCode](int deviceIndex)
+                    {
+                        auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                        m_deviceQueryPools[deviceIndex] = Factory::Get().CreateQueryPool();
+                        resultCode = m_deviceQueryPools[deviceIndex]->Init(*device, descriptor);
+                        return resultCode == ResultCode::Success;
+                    });
+
+                return resultCode;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific QueryPools and set deviceMask to 0
+            m_deviceQueryPools.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceQueryPool::InitQuery(MultiDeviceQuery* query)
+    {
+        return InitQuery(&query, 1);
+    }
+
+    ResultCode MultiDeviceQueryPool::InitQuery(MultiDeviceQuery** queries, uint32_t queryCount)
+    {
+        AZ_Assert(queries, "Null queries");
+        auto resultCode{ ResultCode::Success };
+
+        for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+        {
+            AZStd::vector<RHI::Ptr<Query>> deviceQueries(queryCount);
+            AZStd::vector<Query*> rawDeviceQueries(queryCount);
+            for (auto index{ 0u }; index < queryCount; ++index)
+            {
+                deviceQueries[index] = RHI::Factory::Get().CreateQuery();
+                rawDeviceQueries[index] = deviceQueries[index].get();
+            }
+
+            resultCode = deviceQueryPool->InitQuery(rawDeviceQueries.data(), queryCount);
+
+            for (auto index{ 0u }; index < queryCount; ++index)
+            {
+                queries[index]->m_deviceQueries[deviceIndex] = deviceQueries[index];
+            }
+
+            if (resultCode != ResultCode::Success)
+            {
+                break;
+            }
+        }
+
+        if (resultCode == ResultCode::Success)
+        {
+            for (auto index{ 0u }; index < queryCount; ++index)
+            {
+                MultiDeviceResourcePool::InitResource(
+                    queries[index],
+                    []()
+                    {
+                        return ResultCode::Success;
+                    });
+            }
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceQueryPool::ValidateQueries(MultiDeviceQuery** queries, uint32_t queryCount)
+    {
+        if (!queryCount)
+        {
+            AZ_Error("RHI", false, "MultiDeviceQuery count is 0");
+            return RHI::ResultCode::InvalidArgument;
+        }
+
+        for (uint32_t i = 0; i < queryCount; ++i)
+        {
+            auto* query = queries[i];
+            if (!query)
+            {
+                AZ_Error("RHI", false, "Null query %i", i);
+                return RHI::ResultCode::InvalidArgument;
+            }
+
+            if (query->GetQueryPool() != this)
+            {
+                AZ_Error("RHI", false, "MultiDeviceQuery does not belong to this pool");
+                return RHI::ResultCode::InvalidArgument;
+            }
+        }
+        return ResultCode::Success;
+    }
+
+    ResultCode MultiDeviceQueryPool::GetResults(MultiDeviceQuery* query, uint64_t* result, uint32_t resultsCount, QueryResultFlagBits flags)
+    {
+        auto resultCode{ ResultCode::Success };
+
+        for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+        {
+            auto deviceQuery{ query->m_deviceQueries[deviceIndex].get() };
+            auto deviceResult{ result + (deviceIndex * resultsCount) };
+
+            resultCode = deviceQueryPool->GetResults(&deviceQuery, 1, deviceResult, resultsCount, flags);
+            if (resultCode != ResultCode::Success)
+            {
+                break;
+            }
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceQueryPool::GetResults(
+        MultiDeviceQuery** queries, uint32_t queryCount, uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags)
+    {
+        AZ_Assert(queries && queryCount, "Null queries");
+        AZ_Assert(results && resultsCount, "Null results");
+        uint32_t perResultSize = m_descriptor.m_type == QueryType::PipelineStatistics
+            ? CountBitsSet(static_cast<uint64_t>(m_descriptor.m_pipelineStatisticsMask))
+            : 1;
+
+        if (Validation::IsEnabled())
+        {
+            auto validationResult = ValidateQueries(queries, queryCount);
+            if (validationResult != ResultCode::Success)
+            {
+                return validationResult;
+            }
+
+            if (perResultSize * queryCount > resultsCount)
+            {
+                AZ_Error("RHI", false, "Results count is too small. Needed at least %d", perResultSize * queryCount);
+                return RHI::ResultCode::InvalidArgument;
+            }
+        }
+
+        auto resultCode{ ResultCode::Success };
+
+        for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+        {
+            AZStd::vector<Query*> deviceQueries(queryCount);
+            for (auto index{ 0u }; index < queryCount; ++index)
+            {
+                deviceQueries[index] = queries[index]->m_deviceQueries[deviceIndex].get();
+            }
+
+            auto deviceResults{ results + (deviceIndex * resultsCount) };
+            resultCode = deviceQueryPool->GetResults(deviceQueries.data(), queryCount, deviceResults, resultsCount, flags);
+
+            if (resultCode != ResultCode::Success)
+                break;
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceQueryPool::GetResults(uint64_t* results, uint32_t resultsCount, QueryResultFlagBits flags)
+    {
+        auto resultCode{ ResultCode::Success };
+
+        for (auto& [deviceIndex, deviceQueryPool] : m_deviceQueryPools)
+        {
+            auto deviceResults{ results + (deviceIndex * resultsCount) };
+            resultCode = deviceQueryPool->GetResults(deviceResults, resultsCount, flags);
+
+            if (resultCode != ResultCode::Success)
+            {
+                break;
+            }
+        }
+
+        return resultCode;
+    }
+
+    const QueryPoolDescriptor& MultiDeviceQueryPool::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    void MultiDeviceQueryPool::Shutdown()
+    {
+        for (auto [_, pool] : m_deviceQueryPools)
+        {
+            pool->Shutdown();
+        }
+
+        MultiDeviceResourcePool::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQueryPool.cpp
@@ -206,7 +206,9 @@ namespace AZ::RHI
             resultCode = deviceQueryPool->GetResults(deviceQueries.data(), queryCount, deviceResults, resultsCount, flags);
 
             if (resultCode != ResultCode::Success)
+            {
                 break;
+            }
         }
 
         return resultCode;

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <AzCore/std/containers/bitset.h>
+#include <Tests/Device.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceQueryTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceQueryTests()
+            : MultiDeviceRHITestFixture()
+        {
+        }
+
+    private:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceQueryTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceQuery> noopQuery;
+        noopQuery = aznew RHI::MultiDeviceQuery;
+        AZ_TEST_ASSERT(noopQuery);
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> noopQueryPool;
+        noopQueryPool = aznew RHI::MultiDeviceQueryPool;
+        AZ_TEST_ASSERT(noopQueryPool);
+    }
+
+    TEST_F(MultiDeviceQueryTests, Test)
+    {
+        RHI::Ptr<RHI::MultiDeviceQuery> queryA;
+        queryA = aznew RHI::MultiDeviceQuery;
+
+        queryA->SetName(Name("QueryA"));
+        AZ_TEST_ASSERT(queryA->GetName().GetStringView() == "QueryA");
+        AZ_TEST_ASSERT(queryA->use_count() == 1);
+
+        {
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+
+            EXPECT_EQ(1, queryPool->use_count());
+
+            RHI::Ptr<RHI::MultiDeviceQuery> queryB;
+            queryB = aznew RHI::MultiDeviceQuery;
+            EXPECT_EQ(1, queryB->use_count());
+
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 2;
+            queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+            queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+            queryPool->Init(DeviceMask, queryPoolDesc);
+
+            EXPECT_FALSE(queryA->IsInitialized());
+            EXPECT_FALSE(queryB->IsInitialized());
+
+            queryPool->InitQuery(queryA.get());
+
+            EXPECT_EQ(1, queryA->use_count());
+            EXPECT_TRUE(queryA->IsInitialized());
+
+            queryPool->InitQuery(queryB.get());
+
+            EXPECT_TRUE(queryB->IsInitialized());
+
+            EXPECT_EQ(queryA->GetPool(), queryPool.get());
+            EXPECT_EQ(queryB->GetPool(), queryPool.get());
+            EXPECT_EQ(queryPool->GetResourceCount(), 2);
+
+            {
+                uint32_t queryIndex = 0;
+
+                const RHI::MultiDeviceQuery* queries[] = { queryA.get(), queryB.get() };
+
+                queryPool->ForEach<RHI::MultiDeviceQuery>(
+                    [&queryIndex, &queries]([[maybe_unused]] RHI::MultiDeviceQuery& query)
+                    {
+                        AZ_UNUSED(queries); // Prevent unused warning in release builds
+                        AZ_Assert(queries[queryIndex] == &query, "Queries don't match");
+                        queryIndex++;
+                    });
+            }
+
+            queryB->Shutdown();
+            EXPECT_EQ(queryB->GetPool(), nullptr);
+
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPoolB;
+            queryPoolB = aznew RHI::MultiDeviceQueryPool;
+            queryPoolB->Init(DeviceMask, queryPoolDesc);
+
+            queryPoolB->InitQuery(queryB.get());
+            EXPECT_EQ(queryB->GetPool(), queryPoolB.get());
+
+            // Since we are switching queryPool for queryB it adds a refcount and invalidates the views.
+            // We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            queryPoolB->Shutdown();
+            EXPECT_EQ(queryPoolB->GetResourceCount(), 0);
+        }
+
+        EXPECT_EQ(queryA->GetPool(), nullptr);
+        EXPECT_EQ(queryA->use_count(), 1);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestAllocations)
+    {
+        static const uint32_t numQueries = 10;
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQuery>, numQueries> queries;
+        for (auto& query : queries)
+        {
+            query = aznew RHI::MultiDeviceQuery;
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = numQueries;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        queryPool->Init(DeviceMask, queryPoolDesc);
+
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToInitialize(numQueries);
+        for (size_t i = 0; i < queries.size(); ++i)
+        {
+            queriesToInitialize[i] = queries[i].get();
+        }
+
+        RHI::ResultCode result = queryPool->InitQuery(queriesToInitialize.data(), static_cast<uint32_t>(queriesToInitialize.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+        auto checkSlotsFunc = [](const AZStd::vector<RHI::MultiDeviceQuery*>& queries)
+        {
+            if (queries.size() < 2)
+            {
+                return true;
+            }
+
+            AZStd::vector<uint32_t> indices;
+            for (auto& query : queries)
+            {
+                indices.push_back(query->GetHandle(AZ::RHI::MultiDevice::DefaultDeviceIndex).GetIndex());
+            }
+
+            AZStd::sort(indices.begin(), indices.end());
+            for (size_t i = 0; i < indices.size() - 1; ++i)
+            {
+                if (indices[i] != (indices[i + 1] + 1))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        checkSlotsFunc(queriesToInitialize);
+
+        RHI::Ptr<RHI::MultiDeviceQuery> extraQuery = aznew RHI::MultiDeviceQuery;
+        EXPECT_EQ(queryPool->InitQuery(extraQuery.get()), RHI::ResultCode::OutOfMemory);
+        AZ_TEST_ASSERT(!extraQuery->IsInitialized());
+
+        AZStd::vector<uint32_t> queriesIndicesToShutdown = { 5, 6 };
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToShutdown;
+        for (auto& index : queriesIndicesToShutdown)
+        {
+            queries[index]->Shutdown();
+            queriesToShutdown.push_back(queries[index].get());
+        }
+
+        EXPECT_EQ(queryPool->GetResourceCount(), numQueries - static_cast<uint32_t>(queriesIndicesToShutdown.size()));
+
+        result = queryPool->InitQuery(queriesToShutdown.data(), static_cast<uint32_t>(queriesIndicesToShutdown.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+        checkSlotsFunc(queriesToShutdown);
+
+        queriesIndicesToShutdown = { 2, 5, 9 };
+        queriesToShutdown.clear();
+        for (auto& index : queriesIndicesToShutdown)
+        {
+            queries[index]->Shutdown();
+            queriesToShutdown.push_back(queries[index].get());
+        }
+
+        EXPECT_EQ(queryPool->GetResourceCount(), (numQueries - static_cast<uint32_t>(queriesIndicesToShutdown.size())));
+
+        result = queryPool->InitQuery(queriesToShutdown.data(), static_cast<uint32_t>(queriesToShutdown.size()));
+
+        // Since we are switching queryPools for some queries it adds a refcount and invalidates the views.
+        // We need to ensure the views are fully invalidated in order to release the refcount and avoid leaks.
+        RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+        checkSlotsFunc(queriesToInitialize);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestIntervals)
+    {
+        static const uint32_t numQueries = 10;
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQuery>, numQueries> queries;
+        for (auto& query : queries)
+        {
+            query = aznew RHI::MultiDeviceQuery;
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = numQueries;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        queryPool->Init(DeviceMask, queryPoolDesc);
+
+        AZStd::vector<RHI::MultiDeviceQuery*> queriesToInitialize(numQueries);
+        for (size_t i = 0; i < queries.size(); ++i)
+        {
+            queriesToInitialize[i] = queries[i].get();
+        }
+
+        RHI::ResultCode result = queryPool->InitQuery(queriesToInitialize.data(), static_cast<uint32_t>(queriesToInitialize.size()));
+        EXPECT_EQ(result, RHI::ResultCode::Success);
+
+        uint64_t results[numQueries * DeviceCount] = {};
+
+        for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            auto* testQueryPool = static_cast<UnitTest::QueryPool*>(queryPool->GetDeviceQueryPool(deviceIndex).get());
+            auto& testQueryPoolIntervals = testQueryPool->m_calledIntervals;
+            testQueryPoolIntervals.clear();
+
+            EXPECT_EQ(queryPool->GetResults(results, numQueries, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+
+            EXPECT_EQ(testQueryPoolIntervals.size(), 1);
+            EXPECT_EQ(testQueryPoolIntervals.front(), RHI::Interval(0, numQueries - 1));
+
+            testQueryPoolIntervals.clear();
+            auto* queryToTest = queries[5].get();
+            EXPECT_EQ(queryPool->GetResults(queryToTest, results, 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+
+            EXPECT_EQ(testQueryPoolIntervals.size(), 1);
+            EXPECT_EQ(
+                testQueryPoolIntervals.front(),
+                RHI::Interval(queryToTest->GetHandle(deviceIndex).GetIndex(), queryToTest->GetHandle(deviceIndex).GetIndex()));
+
+            AZStd::vector<RHI::Interval> intervalsToTest = { RHI::Interval(5, 5), RHI::Interval(0, 3), RHI::Interval(8, 9) };
+            AZStd::vector<RHI::MultiDeviceQuery*> queriesToTest;
+            for (auto& interval : intervalsToTest)
+            {
+                for (uint32_t i = interval.m_min; i <= interval.m_max; ++i)
+                {
+                    queriesToTest.push_back(queries[i].get());
+                }
+            }
+            testQueryPoolIntervals.clear();
+            EXPECT_EQ(
+                queryPool->GetResults(
+                    queriesToTest.data(), static_cast<uint32_t>(queriesToTest.size()), results, numQueries, RHI::QueryResultFlagBits::None),
+                RHI::ResultCode::Success);
+            EXPECT_EQ(testQueryPoolIntervals.size(), intervalsToTest.size());
+            for (auto& interval : intervalsToTest)
+            {
+                auto foundIt = AZStd::find(testQueryPoolIntervals.begin(), testQueryPoolIntervals.end(), interval);
+                EXPECT_NE(foundIt, testQueryPoolIntervals.end());
+            }
+        }
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestQuery)
+    {
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQueryPool>, RHI::QueryTypeCount> queryPools;
+        for (size_t i = 0; i < queryPools.size(); ++i)
+        {
+            auto& queryPool = queryPools[i];
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 1;
+            queryPoolDesc.m_type = static_cast<RHI::QueryType>(i);
+            queryPoolDesc.m_pipelineStatisticsMask = queryPoolDesc.m_type == RHI::QueryType::PipelineStatistics
+                ? RHI::PipelineStatisticsFlags::CInvocations
+                : RHI::PipelineStatisticsFlags::None;
+            queryPool->Init(DeviceMask, queryPoolDesc);
+        }
+
+        auto& occlusionQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::Occlusion)];
+        auto& timestampQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::Timestamp)];
+        auto& statisticsQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::PipelineStatistics)];
+
+        uint64_t data;
+        RHI::CommandList& dummyCommandList = reinterpret_cast<RHI::CommandList&>(data);
+
+        // Correct begin and end for occlusion
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            EXPECT_EQ(occlusionQueryPool->InitQuery(query.get()), RHI::ResultCode::Success);
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList), RHI::ResultCode::Success);
+                EXPECT_EQ(query->GetDeviceQuery(deviceIndex)->End(dummyCommandList), RHI::ResultCode::Success);
+            }
+        }
+
+        // Double Begin
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList);
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // End without Begin
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->End(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // End with another command list
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            uint64_t anotherData;
+            RHI::CommandList& anotherDummyCmdList = reinterpret_cast<RHI::CommandList&>(anotherData);
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(RHI::ResultCode::Success, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::InvalidArgument, query->GetDeviceQuery(deviceIndex)->End(anotherDummyCmdList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid flag
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            statisticsQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(
+                    RHI::ResultCode::InvalidArgument,
+                    query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList, RHI::QueryControlFlags::PreciseOcclusion));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid Begin for Timestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->Begin(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid End for Timestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->End(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Invalid WriteTimestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            occlusionQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_START_ASSERTTEST;
+                EXPECT_EQ(RHI::ResultCode::Fail, query->GetDeviceQuery(deviceIndex)->WriteTimestamp(dummyCommandList));
+                AZ_TEST_STOP_ASSERTTEST(1);
+            }
+        }
+        // Correct WriteTimestamp
+        {
+            RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+            timestampQueryPool->InitQuery(query.get());
+            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                EXPECT_EQ(RHI::ResultCode::Success, query->GetDeviceQuery(deviceIndex)->WriteTimestamp(dummyCommandList));
+            }
+        }
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestQueryPoolInitialization)
+    {
+        RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool;
+        queryPool = aznew RHI::MultiDeviceQueryPool;
+        RHI::QueryPoolDescriptor queryPoolDesc;
+        queryPoolDesc.m_queriesCount = 0;
+        queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        // Count of 0
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // valid m_pipelineStatisticsMask for Occlusion QueryType
+        queryPoolDesc.m_queriesCount = 1;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::CInvocations;
+        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+
+        // invalid m_pipelineStatisticsMask for PipelineStatistics QueryType
+        queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
+        queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+    }
+
+    TEST_F(MultiDeviceQueryTests, TestResults)
+    {
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceQueryPool>, 2> queryPools;
+        RHI::PipelineStatisticsFlags mask = RHI::PipelineStatisticsFlags::CInvocations | RHI::PipelineStatisticsFlags::CPrimitives |
+            RHI::PipelineStatisticsFlags::IAPrimitives;
+        for (auto& queryPool : queryPools)
+        {
+            queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 2;
+            queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
+            queryPoolDesc.m_pipelineStatisticsMask = mask;
+            EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+        }
+
+        RHI::Ptr<RHI::MultiDeviceQuery> query = aznew RHI::MultiDeviceQuery;
+        uint32_t numPipelineStatistics = RHI::CountBitsSet(static_cast<uint64_t>(mask));
+        AZStd::vector<uint64_t> results(numPipelineStatistics * 2 * DeviceCount);
+        // Using uninitialized query
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(3);
+
+        // Wrong size for results count.
+        queryPools[0]->InitQuery(query.get());
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(queryPools[0]->GetResults(results.data(), 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Using a query from another pool
+        RHI::Ptr<RHI::MultiDeviceQuery> anotherQuery = aznew RHI::MultiDeviceQuery;
+        queryPools[1]->InitQuery(anotherQuery.get());
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(anotherQuery.get(), results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Results count is too small
+        anotherQuery->Shutdown();
+        queryPools[0]->InitQuery(anotherQuery.get());
+        RHI::MultiDeviceQuery* queries[] = { query.get(), anotherQuery.get() };
+        AZ_TEST_START_ASSERTTEST;
+        EXPECT_EQ(
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::InvalidArgument);
+        AZ_TEST_STOP_ASSERTTEST(1);
+
+        // Correct usage
+        EXPECT_EQ(
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics * 5, RHI::QueryResultFlagBits::None),
+            RHI::ResultCode::Success);
+
+        // Unsorted queries
+        {
+            const size_t numQueries = 5;
+            AZStd::array<RHI::Ptr<AZ::RHI::MultiDeviceQuery>, numQueries> queries2;
+            AZStd::vector<uint64_t> results2(numQueries * DeviceCount);
+
+            RHI::Ptr<RHI::MultiDeviceQueryPool> queryPool = aznew RHI::MultiDeviceQueryPool;
+            RHI::QueryPoolDescriptor queryPoolDesc;
+            queryPoolDesc.m_queriesCount = 5;
+            queryPoolDesc.m_type = RHI::QueryType::Occlusion;
+            EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+
+            for (size_t i = 0; i < queries2.size(); ++i)
+            {
+                queries2[i] = aznew RHI::MultiDeviceQuery;
+                queryPool->InitQuery(queries2[i].get());
+            }
+
+            AZStd::array<RHI::MultiDeviceQuery*, numQueries> queriesPtr = {
+                queries2[2].get(), queries2[0].get(), queries2[1].get(), queries2[3].get(), queries2[4].get()
+            };
+            EXPECT_EQ(
+                queryPool->GetResults(queriesPtr.data(), numQueries, results2.data(), numQueries, RHI::QueryResultFlagBits::None),
+                RHI::ResultCode::Success);
+            for (uint32_t i = 0; i < numQueries; ++i)
+            {
+                EXPECT_EQ(results2[i], queriesPtr[i]->GetHandle(AZ::RHI::MultiDevice::DefaultDeviceIndex).GetIndex());
+            }
+        }
+
+        // Since we are switching queryPools for some queries it adds a refcount and invalidates the views.
+        // We need to ensure the views are fully invalidated in order to release the refcount and avoid leaks.
+        RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+    }
+
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
@@ -249,14 +249,14 @@ namespace UnitTest
             auto& testQueryPoolIntervals = testQueryPool->m_calledIntervals;
             testQueryPoolIntervals.clear();
 
-            EXPECT_EQ(queryPool->GetResults(results, numQueries, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+            EXPECT_EQ(queryPool->GetResults(results, numQueries * DeviceCount, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
 
             EXPECT_EQ(testQueryPoolIntervals.size(), 1);
             EXPECT_EQ(testQueryPoolIntervals.front(), RHI::Interval(0, numQueries - 1));
 
             testQueryPoolIntervals.clear();
             auto* queryToTest = queries[5].get();
-            EXPECT_EQ(queryPool->GetResults(queryToTest, results, 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
+            EXPECT_EQ(queryPool->GetResults(queryToTest, results, DeviceCount, RHI::QueryResultFlagBits::None), RHI::ResultCode::Success);
 
             EXPECT_EQ(testQueryPoolIntervals.size(), 1);
             EXPECT_EQ(
@@ -275,9 +275,9 @@ namespace UnitTest
             testQueryPoolIntervals.clear();
             EXPECT_EQ(
                 queryPool->GetResults(
-                    queriesToTest.data(), static_cast<uint32_t>(queriesToTest.size()), results, numQueries, RHI::QueryResultFlagBits::None),
+                    queriesToTest.data(), static_cast<uint32_t>(queriesToTest.size()), results, numQueries * DeviceCount, RHI::QueryResultFlagBits::None),
                 RHI::ResultCode::Success);
-            EXPECT_EQ(testQueryPoolIntervals.size(), intervalsToTest.size());
+             EXPECT_EQ(testQueryPoolIntervals.size(), intervalsToTest.size());
             for (auto& interval : intervalsToTest)
             {
                 auto foundIt = AZStd::find(testQueryPoolIntervals.begin(), testQueryPoolIntervals.end(), interval);
@@ -461,14 +461,14 @@ namespace UnitTest
         // Using uninitialized query
         AZ_TEST_START_ASSERTTEST;
         EXPECT_EQ(
-            queryPools[0]->GetResults(results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            queryPools[0]->GetResults(results.data(), numPipelineStatistics * 2 * DeviceCount, RHI::QueryResultFlagBits::None),
             RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(3);
 
         // Wrong size for results count.
         queryPools[0]->InitQuery(query.get());
         AZ_TEST_START_ASSERTTEST;
-        EXPECT_EQ(queryPools[0]->GetResults(results.data(), 1, RHI::QueryResultFlagBits::None), RHI::ResultCode::InvalidArgument);
+        EXPECT_EQ(queryPools[0]->GetResults(results.data(), DeviceCount, RHI::QueryResultFlagBits::None), RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(1);
 
         // Using a query from another pool
@@ -476,7 +476,7 @@ namespace UnitTest
         queryPools[1]->InitQuery(anotherQuery.get());
         AZ_TEST_START_ASSERTTEST;
         EXPECT_EQ(
-            queryPools[0]->GetResults(anotherQuery.get(), results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            queryPools[0]->GetResults(anotherQuery.get(), results.data(), numPipelineStatistics * DeviceCount, RHI::QueryResultFlagBits::None),
             RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(1);
 
@@ -486,13 +486,13 @@ namespace UnitTest
         RHI::MultiDeviceQuery* queries[] = { query.get(), anotherQuery.get() };
         AZ_TEST_START_ASSERTTEST;
         EXPECT_EQ(
-            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics, RHI::QueryResultFlagBits::None),
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics * DeviceCount, RHI::QueryResultFlagBits::None),
             RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(1);
 
         // Correct usage
         EXPECT_EQ(
-            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics * 5, RHI::QueryResultFlagBits::None),
+            queryPools[0]->GetResults(queries, 2, results.data(), numPipelineStatistics * 5 * DeviceCount, RHI::QueryResultFlagBits::None),
             RHI::ResultCode::Success);
 
         // Unsorted queries
@@ -517,7 +517,7 @@ namespace UnitTest
                 queries2[2].get(), queries2[0].get(), queries2[1].get(), queries2[3].get(), queries2[4].get()
             };
             EXPECT_EQ(
-                queryPool->GetResults(queriesPtr.data(), numQueries, results2.data(), numQueries, RHI::QueryResultFlagBits::None),
+                queryPool->GetResults(queriesPtr.data(), numQueries, results2.data(), numQueries * DeviceCount, RHI::QueryResultFlagBits::None),
                 RHI::ResultCode::Success);
             for (uint32_t i = 0; i < numQueries; ++i)
             {

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -63,7 +63,9 @@ set(FILES
     Source/RHI/Factory.cpp
     Include/Atom/RHI/FactoryManagerBus.h
     Include/Atom/RHI/Fence.h
+    Include/Atom/RHI/MultiDeviceFence.h
     Source/RHI/Fence.cpp
+    Source/RHI/MultiDeviceFence.cpp
     Include/Atom/RHI/BufferFrameAttachment.h
     Include/Atom/RHI/FrameAttachment.h
     Include/Atom/RHI/ImageFrameAttachment.h
@@ -133,10 +135,14 @@ set(FILES
     Source/RHI/PipelineStateCache.cpp
     Source/RHI/PipelineStateDescriptor.cpp
     Include/Atom/RHI/Query.h
+    Include/Atom/RHI/MultiDeviceQuery.h
     Source/RHI/Query.cpp
+    Source/RHI/MultiDeviceQuery.cpp
     Include/Atom/RHI/QueryPool.h
+    Include/Atom/RHI/MultiDeviceQueryPool.h
     Include/Atom/RHI/QueryPoolSubAllocator.h
     Source/RHI/QueryPool.cpp
+    Source/RHI/MultiDeviceQueryPool.cpp
     Source/RHI/QueryPoolSubAllocator.cpp
     Include/Atom/RHI/Resource.h
     Include/Atom/RHI/MultiDeviceResource.h

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -52,8 +52,8 @@ set(FILES
     Tests/ImagePropertyTests.cpp
     Tests/BufferPropertyTests.cpp
     Tests/IntervalMapTests.cpp
-
     Tests/MultiDevicePipelineStateTests.cpp
+    Tests/MultiDeviceQueryTests.cpp
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, in particular:

- `MultiDeviceFence`
- `MultiDeviceQuery`
- `MultiDeviceQueryPool`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | open |
|Independent Resources| This commit | open|
| Buffers & Images | | |
|Indirect*|||
| Items | | |
| SRGs| | |
|RayTracing Resources|||


## How was this PR tested?

This PR also introduces a new testset, which adapts the tests from `QueryTests` for multiple devices in:
- `MultiDeviceQueryTests`
