### PR TITLE
reorder the shutdown sequence for vulkan to fix a few crashes

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -658,8 +658,6 @@ namespace AZ
 
             m_nullDescriptorManager.reset();
 
-            m_commandQueueContext.Shutdown();
-
             m_bindlessDescriptorPool.Shutdown();
             m_stagingBufferPool.reset();
             m_constantBufferPool.reset();
@@ -669,11 +667,14 @@ namespace AZ
             m_samplerCache.first.Clear();
             m_pipelineLayoutCache.first.Clear();
             m_semaphoreAllocator.Shutdown();
-            m_asyncUploadQueue.reset();
-            m_commandListAllocator.Shutdown();
 
             // Make sure this is last to flush any objects released in the above calls.
             m_releaseQueue.Shutdown();
+
+            // The Objects in the release-queue need the command / upload queues for shutting down
+            m_asyncUploadQueue.reset();
+            m_commandListAllocator.Shutdown();
+            m_commandQueueContext.Shutdown();
         }
 
         void Device::ShutdownInternal()


### PR DESCRIPTION
## What does this PR do?

During shutdown of a GameLauncher we get a few crashes when using vulkan. 

## How was this PR tested?

Press the [x] in the game-launcher when running in the debugger, and observer fewer crashes.