### PR TITLE
Initialize the transform for static camera-components properly

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "CameraComponentController.h"
+#include "AzCore/Component/TransformBus.h"
 #include "CameraViewRegistrationBus.h"
 
 #include <Atom/RPI.Public/Pass/PassFilter.h>
@@ -260,7 +261,9 @@ namespace Camera
             m_atomCameraViewGroup->Activate();
         }
 
-        UpdateCamera();
+        AZ::Transform local, world;
+        AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::GetLocalAndWorld, local, world);
+        OnTransformChanged(local, world);
 
         CameraRequestBus::Handler::BusConnect(m_entityId);
         AZ::TransformNotificationBus::Handler::BusConnect(m_entityId);


### PR DESCRIPTION
## What does this PR do?

If a camera-Component has no other components that update the transform of the entity, the camera-transform initialized with the wrong position, and never updated.

## How was this PR tested?

Create a scene with a single, active camera that doesn't have a 'FlyCameraInputComponent', and start the GameLauncher using this scene. The camera position will be wrong without this fix.
