### PR TITLE
normalize the direction of simple spot lights on the CPU

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -15,7 +15,7 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
     real3 posToLight = real3(light.m_position - surface.position);
     
     real3 dirToLight = normalize(posToLight);
-    real dotWithDirection = dot(dirToLight, -normalize(real3(light.m_direction)));
+    real dotWithDirection = dot(dirToLight, -real3(light.m_direction));
 
     // If outside the outer cone angle return.
     if (dotWithDirection < real(light.m_cosOuterConeAngle))

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
@@ -187,7 +187,7 @@ void ApplySimpleSpotLight(RayTracingSceneSrg::SimpleSpotLight light, RayTracingL
         return;
 
     // test for outside of outer cone
-    float dotWithDirection = dot(dirToLight, -normalize(light.m_direction));
+    float dotWithDirection = dot(dirToLight, -light.m_direction);
     if (dotWithDirection <= light.m_cosOuterConeAngle)
         return;
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
@@ -148,7 +148,7 @@ namespace AZ
             AZ_Assert(handle.IsValid(), "Invalid LightHandle passed to SimpleSpotLightFeatureProcessor::SetDirection().");
 
             AZStd::array<float, 3>& direction = m_lightData.GetData(handle.GetIndex()).m_direction;
-            lightDirection.StoreToFloat3(direction.data());
+            lightDirection.GetNormalized().StoreToFloat3(direction.data());
             m_deviceBufferNeedsUpdate = true;
         }
 

--- a/Gems/AtomTressFX/Assets/Shaders/HairLightTypes.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairLightTypes.azsli
@@ -218,7 +218,7 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
 {
     float3 posToLight = light.m_position - surface.position;
     float3 dirToLight = normalize(posToLight);
-   float dotWithDirection = dot(dirToLight, -normalize(light.m_direction));
+    float dotWithDirection = dot(dirToLight, -light.m_direction);
 
     // If outside the outer cone angle return.
     if (dotWithDirection < light.m_cosOuterConeAngle)


### PR DESCRIPTION
## What does this PR do?

Normalizes the direction-vector of simple spot lights before uploading it to the GPU, to mirror the DiskLightFeatureProcessor.

## How was this PR tested?

Create a default scene with one simple spot light as the only light source and modify the direction.