### PR TITLE
Feature: Use the PipelineViewTag of a parent pass in the pipeline hierarchy

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/CameraMotionVector.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CameraMotionVector.pass
@@ -52,7 +52,7 @@
             ],
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderAsset": {
                     "FilePath": "Shaders/MotionVector/CameraMotionVector.shader"
                 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
@@ -314,7 +314,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
                         },
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
@@ -219,7 +219,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Checkerboard/CheckerboardColorResolveCS.shader"
                 },
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "Make Fullscreen Pass": true
             }
         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DebugOverlayParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DebugOverlayParent.pass
@@ -49,7 +49,7 @@
                     ],
                     "PassData": {
                         "$type": "RasterPassData",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -67,7 +67,7 @@
                     ],
                     "PassData": {
                         "$type": "RasterPassData",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -106,7 +106,7 @@
                     ],
                     "PassData": {
                         "$type": "RasterPassData",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 }
             ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/DeferredFog.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DeferredFog.pass
@@ -39,7 +39,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
                 },
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderDataMappings": {
                     "Float3Mappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthDownsample.pass
@@ -60,7 +60,7 @@
                     "FilePath": "Shaders/PostProcessing/DepthDownsample.shader"
                 },
                 "Make Fullscreen Pass": true,
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldBlurBokeh.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldBlurBokeh.pass
@@ -55,7 +55,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldBlurBokeh.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldComposite.pass
@@ -96,7 +96,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldComposite.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldDownSample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldDownSample.pass
@@ -53,7 +53,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldDownSample.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldMask.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldMask.pass
@@ -49,7 +49,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldMask.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldPrepare.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldPrepare.pass
@@ -59,7 +59,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldPrepare.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthParent.pass
@@ -61,7 +61,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "depth",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     },
                     "Connections": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthToLinearDepth.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthToLinearDepth.pass
@@ -55,7 +55,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthToLinearDepth.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthUpsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthUpsample.pass
@@ -69,7 +69,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthUpsample.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DiffuseGlobalFullscreen.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DiffuseGlobalFullscreen.pass
@@ -49,7 +49,7 @@
                     "FilePath": "Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.shader"
                 },
                 "StencilRef": 128, // See RenderCommon.h and DiffuseGlobalFullscreen.shader
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/EyeAdaptation.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EyeAdaptation.pass
@@ -26,7 +26,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/EyeAdaptation.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
@@ -98,7 +98,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Shadow/FullscreenShadow.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
             // Todo: test Compute Shader version with async compute and LDS optimizations
             // "PassData": {
@@ -107,7 +107,7 @@
             //         "FilePath": "Shaders/Shadow/FullscreenShadow.shader"
             //     },
             //     "Make Fullscreen Pass": true,
-            //     "PipelineViewTag": "MainCamera"
+            //     "BindViewSrg": true
             // }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParent.pass
@@ -57,7 +57,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "depthTransparentMin",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     },
                     "Connections": [
                         {
@@ -75,7 +75,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "depthTransparentMax",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     },
                     "Connections": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/LookModificationComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LookModificationComposite.pass
@@ -59,7 +59,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/LookModificationTransform.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
@@ -172,7 +172,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "lowEndForward",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }
@@ -324,7 +324,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "auxgeom",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/MSAAResolveCustom.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MSAAResolveCustom.pass
@@ -60,7 +60,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/MSAAResolveCustom.shader"
                 },
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderDataMappings": {
                     "UintMappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
@@ -314,7 +314,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
                         },
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -388,7 +388,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "auxgeom",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/MotionVectorParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MotionVectorParent.pass
@@ -71,7 +71,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "motion",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 }
             ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/MultiViewPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MultiViewPipeline.pass
@@ -45,7 +45,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "multiViewForward",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }
@@ -128,7 +128,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "auxgeom",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/MultiViewSkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MultiViewSkyBox.pass
@@ -23,7 +23,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyBox/MultiViewSkyBox.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/MultiViewTransparentParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MultiViewTransparentParent.pass
@@ -43,7 +43,7 @@
                         "$type": "RasterPassData",
                         "DrawListTag": "multiviewTransparent",
                         "DrawListSortType": "KeyThenReverseDepth",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldComposite.pass
@@ -35,7 +35,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldComposite.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldDownsample.pass
@@ -65,7 +65,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldDownsample.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldFilterLarge.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldFilterLarge.pass
@@ -55,7 +55,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldFilterLarge.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldFilterSmall.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldFilterSmall.pass
@@ -55,7 +55,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldFilterSmall.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldTile3x3.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldTile3x3.pass
@@ -50,7 +50,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldTile3x3.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldTileReduce.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/NewDepthOfFieldTileReduce.pass
@@ -56,7 +56,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/NewDepthOfFieldTileReduce.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
@@ -125,7 +125,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "forward",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }
@@ -225,7 +225,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "forwardWithSubsurfaceOutput",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }
@@ -423,7 +423,7 @@
                             "FilePath": "Shaders/Reflections/ReflectionComposite.shader"
                         },
                         "StencilRef": 1, // See RenderCommon.h and ReflectionComposite.shader
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -456,7 +456,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/PostProcessing/MSAAResolveCustom.shader"
                         },
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "ShaderDataMappings": {
                             "UintMappings": [
                                 {
@@ -519,7 +519,7 @@
                             "FilePath": "Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.shader"
                         },
                         "Make Fullscreen Pass": true,
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionGlobalFullscreen.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionGlobalFullscreen.pass
@@ -118,7 +118,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionGlobalFullscreen.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceBlurHorizontal.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceBlurHorizontal.pass
@@ -46,7 +46,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceBlurVertical.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceBlurVertical.pass
@@ -47,7 +47,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceBlurVertical.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceComposite.pass
@@ -59,7 +59,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceComposite.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceDownsampleDepthLinearChild.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceDownsampleDepthLinearChild.pass
@@ -33,7 +33,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceDownsampleDepthLinear.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceFilter.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceFilter.pass
@@ -95,7 +95,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceFilter.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
@@ -226,7 +226,7 @@
                 "MaxPayloadSize": 80,
                 "MaxRecursionDepth": 5,
                 "Make Fullscreen Pass": true,
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceTrace.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceTrace.pass
@@ -175,7 +175,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Reflections/ReflectionScreenSpaceTrace.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/Reflections.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Reflections.pass
@@ -67,7 +67,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "reflectionprobestencil",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -92,7 +92,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "reflectionprobeblendweight",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/Reflections/ReflectionProbeBlendWeight.shader"
                         }
@@ -152,7 +152,7 @@
                             "FilePath": "Shaders/Reflections/ReflectionGlobalFullscreen.shader"
                         },
                         "StencilRef": 3, // See RenderCommon.h and ReflectionGlobalFullscreen.shader
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -206,7 +206,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "reflectionproberenderouter",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/Reflections/ReflectionProbeRenderOuter.shader"
                         }
@@ -256,7 +256,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "reflectionproberenderinner",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/Reflections/ReflectionProbeRenderInner.shader"
                         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyBox.pass
@@ -23,7 +23,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyBox/SkyBox.shader"
                 },
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderDataMappings": {
                     "FloatMappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyBox_TwoOutputs.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyBox_TwoOutputs.pass
@@ -28,7 +28,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyBox/SkyBox_TwoOutputs.shader"
                 },
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderDataMappings": {
                     "FloatMappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyRayMarching.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyRayMarching.pass
@@ -71,7 +71,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyAtmosphere/SkyRayMarching.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyViewLUT.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyViewLUT.pass
@@ -25,7 +25,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyAtmosphere/SkyViewLUT.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyVolumeLUT.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyVolumeLUT.pass
@@ -29,7 +29,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyAtmosphere/SkyVolumeLUT.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/SplashScreen.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SplashScreen.pass
@@ -11,7 +11,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SplashScreen/SplashScreenPass.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             },
             "Slots": [
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
@@ -50,7 +50,7 @@
                     "FilePath": "Shaders/PostProcessing/SsaoCompute.shader"
                 },
                 "Make Fullscreen Pass": true,
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             },
             "FallbackConnections": [
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
@@ -321,7 +321,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
                         },
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -395,7 +395,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "auxgeom",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/TransparentParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/TransparentParent.pass
@@ -122,7 +122,7 @@
                         "$type": "RasterPassData",
                         "DrawListTag": "transparent",
                         "DrawListSortType": "KeyThenReverseDepth",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/ForwardPassSrg.shader"
                         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/UIParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/UIParent.pass
@@ -41,7 +41,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "2dpass",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "DrawListSortType": "KeyThenReverseDepth"
                     }
                 },

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -213,7 +213,7 @@ namespace AZ
                 uint32_t             m_padding[3];
             } cullingConstants{};
 
-            RPI::ViewPtr view = m_pipeline->GetDefaultView();
+            RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             view->GetWorldToViewMatrix().StoreToRowMajorFloat16(cullingConstants.m_worldToView.data());
             cullingConstants.m_screenUVToRay = GenerateScreenUVToRayConstants(view->GetViewToClipMatrix());
             cullingConstants.m_gridPixel = ComputeGridPixelSize();

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
@@ -69,7 +69,7 @@ namespace AZ
         AZStd::array<float, 2> LightCullingTilePreparePass::ComputeUnprojectConstants() const
         {
             AZStd::array<float, 2> unprojectConstants;
-            const auto& view = m_pipeline->GetDefaultView();
+            const auto& view = m_pipeline->GetFirstView(GetPipelineViewTag());
 
             // Our view to clip matrix is right-hand and column major
             // i.e. something like this:

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -417,7 +417,7 @@ namespace AZ
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+                AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -109,7 +109,7 @@ namespace AZ
 
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
@@ -94,7 +94,7 @@ namespace AZ
  
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
@@ -92,7 +92,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomParentPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomParentPass.cpp
@@ -40,7 +40,7 @@ namespace AZ
                 return false;
             }
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            const RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            const RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (!fp)
             {
                 return false;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
@@ -38,11 +38,11 @@ namespace AZ
                 return false;
             }
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            const RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
             if (!fp)
             {
                 return false;
             }
+            const RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
             if (!postProcessSettings)
             {
@@ -71,7 +71,7 @@ namespace AZ
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
             if (fp)
             {
-                RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+                RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
                 if (postProcessSettings)
                 {

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
@@ -106,7 +106,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
@@ -88,7 +88,7 @@ namespace AZ
 
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldParentPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldParentPass.cpp
@@ -40,7 +40,7 @@ namespace AZ
                 return false;
             }
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (!fp)
             {
                 return false;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldReadBackFocusDepthPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldReadBackFocusDepthPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
@@ -79,7 +79,7 @@ namespace AZ
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+                AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
@@ -108,7 +108,7 @@ namespace AZ
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
                 if (fp)
                 {
-                    AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+                    AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
                     if (postProcessSettings)
                     {

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/HDRColorGradingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/HDRColorGradingPass.cpp
@@ -128,7 +128,7 @@
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+                AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -132,7 +132,7 @@ namespace AZ
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+                AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
@@ -157,7 +157,7 @@ namespace AZ
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+                AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
@@ -56,7 +56,7 @@ namespace AZ
                 return false;
             }
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (!fp)
             {
                 return false;
@@ -74,7 +74,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
@@ -44,7 +44,7 @@ namespace AZ
                 return false;
             }
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            const RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
+            const RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
             if (!fp)
             {
                 return true;
@@ -84,7 +84,7 @@ namespace AZ
         {
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
@@ -154,7 +154,7 @@ namespace AZ
 
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -77,11 +77,13 @@ namespace AZ::Render
     {
         RHI::Size inputSize = m_inputColorBinding->GetAttachment()->m_descriptor.m_image.m_size;
         Vector2 rcpInputSize = Vector2(1.0f / inputSize.m_width, 1.0f / inputSize.m_height);
-
-        RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
-        m_offsetIndex = (m_offsetIndex + 1) % m_subPixelOffsets.size();
-        Offset offset = m_subPixelOffsets.at(m_offsetIndex);
-        view->SetClipSpaceOffset(offset.m_xOffset * rcpInputSize.GetX(), offset.m_yOffset * rcpInputSize.GetY());
+        RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
+        if (view)
+        {
+            m_offsetIndex = (m_offsetIndex + 1) % m_subPixelOffsets.size();
+            Offset offset = m_subPixelOffsets.at(m_offsetIndex);
+            view->SetClipSpaceOffset(offset.m_xOffset * rcpInputSize.GetX(), offset.m_yOffset * rcpInputSize.GetY());
+        }
 
         if (!ShouldCopyHistoryBuffer)
         {

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
@@ -67,7 +67,7 @@ namespace AZ
             }
 
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-            AZ::RPI::ViewPtr view = scene->GetDefaultRenderPipeline()->GetDefaultView();
+            AZ::RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
             if (fp)
             {
                 PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -153,7 +153,10 @@ namespace AZ
             virtual bool IsEnabled() const { return m_flags.m_enabled; }
 
             bool HasDrawListTag() const { return m_flags.m_hasDrawListTag; }
-            bool HasPipelineViewTag() const { return m_flags.m_hasPipelineViewTag; }
+            bool BindViewSrg() const
+            {
+                return m_flags.m_bindViewSrg;
+            }
 
             // Searches this pass's attachment bindings for one with the provided Name (nullptr if none found)
             PassAttachmentBinding* FindAttachmentBinding(const Name& slotName);
@@ -422,6 +425,9 @@ namespace AZ
             // Pointer to the parent pass if this pass is a child pass
             ParentPass* m_parent = nullptr;
 
+            // View tag used to associate a pipeline view for this pass or its child-passes.
+            PipelineViewTag m_viewTag;
+
             struct
             {
                 union
@@ -451,7 +457,7 @@ namespace AZ
                         uint64_t m_hasDrawListTag : 1;
 
                         // Whether this pass has a PipelineViewTag
-                        uint64_t m_hasPipelineViewTag : 1;
+                        uint64_t m_bindViewSrg : 1;
 
                         // Whether the pass should gather timestamp query metrics
                         uint64_t m_timestampQueryEnabled : 1;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -55,9 +55,6 @@ namespace AZ
             //! Returns a pointer to the Pass ShaderResourceGroup
             Data::Instance<ShaderResourceGroup> GetShaderResourceGroup();
 
-            // Pass overrides...
-            const PipelineViewTag& GetPipelineViewTag() const override;
-
             //! Return the View if this pass is associated with a pipeline view via PipelineViewTag.
             //! It may return nullptr if this pass is independent with any views.
             ViewPtr GetView() const;
@@ -154,9 +151,6 @@ namespace AZ
             // List of all ShaderResourceGroups to be bound during rendering or computing
             // Derived classed may call BindSrg function to add other srgs the list
             AZStd::unordered_map<uint8_t, const RHI::ShaderResourceGroup*> m_shaderResourceGroupsToBind;
-            
-            // View tag used to associate a pipeline view for this pass.
-            PipelineViewTag m_viewTag;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -133,6 +133,10 @@ namespace AZ
             //! It's the same as GetViews(GetMainViewTag()) and using first element.
             ViewPtr GetDefaultView();
 
+            //! Get the frist view for the view tag.
+            //! It's the same as GetViews("tag") and using first element.
+            ViewPtr GetFirstView(const PipelineViewTag& viewTag);
+
             //! Set default view from an entity which should have a ViewProvider handler.
             void SetDefaultViewFromEntity(EntityId entityId);
 
@@ -140,7 +144,7 @@ namespace AZ
             bool HasViewTag(const PipelineViewTag& viewTag) const;
 
             //! Get the main view tag (the tag used for the default view).
-            PipelineViewTag GetMainViewTag() const;
+            const PipelineViewTag& GetMainViewTag() const;
 
             //! Get views that are associated with specified view tag.
             const AZStd::vector<ViewPtr>& GetViews(const PipelineViewTag& viewTag) const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
@@ -49,6 +49,8 @@ namespace AZ
 
             // Specifies global pipeline connections to the pipeline's immediate child passes
             PipelineGlobalConnectionList m_pipelineGlobalConnections;
+
+            Name m_pipelineViewTag;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
@@ -30,7 +30,7 @@ namespace AZ
             //! A grouping of values and value names used to bind data to the per-pass shader resource groups.
             RHI::ShaderDataMappings m_mappings;
 
-            Name m_pipelineViewTag;
+            bool m_bindViewSrg = false;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
@@ -53,7 +53,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc builder;
             builder.m_name = PassBuilderJobKey;
-            builder.m_version = 15; // Changed dependency type to OrderOnce
+            builder.m_version = 16; // Move PipelineViewTag from RenderPassData to PassData; add BindViewSrg to RenderPassData
             builder.m_busId = azrtti_typeid<PassBuilder>();
             builder.m_createJobFunction = AZStd::bind(&PassBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
             builder.m_processJobFunction = AZStd::bind(&PassBuilder::ProcessJob, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
@@ -6,8 +6,10 @@
  *
  */
 
-#include <Pass/PassBuilder.h>
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
+#include <Atom/RPI.Reflect/Pass/PassTemplate.h>
+#include <Atom/RPI.Reflect/Pass/RenderPassData.h>
+#include <Pass/PassBuilder.h>
 
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -328,6 +330,36 @@ namespace AZ
             AZStd::string destPath;
             AzFramework::StringFunc::Path::GetFullFileName(request.m_fullPath.c_str(), destFileName);
             AzFramework::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), destFileName.c_str(), destPath, true);
+
+            // --- Ensure the BindPassSrg - flag is set if the pass-data has a PipelineViewTag set
+            auto& passTemplate{ passAsset.GetPassTemplate() };
+            if (passTemplate && passTemplate->m_passData)
+            {
+                auto* passData = azrtti_cast<RenderPassData*>(passTemplate->m_passData.get());
+                if (passData && !passData->m_pipelineViewTag.IsEmpty())
+                {
+                    // "PipelineViewTag": "MainCamera" is deprecated, discard the view-tag and set BindViewSrg to true
+                    if (passData->m_pipelineViewTag == AZ::Name("MainCamera"))
+                    {
+                        AZ_Warning(
+                            PassBuilderName,
+                            false,
+                            "Asset %s: '\"PipelineViewTag\": \"MainCamera\"' is deprecated, use '\"BindViewSrg\": true' instead",
+                            request.m_fullPath.c_str());
+                        passData->m_pipelineViewTag = AZ::Name();
+                    }
+                    else if (!passData->m_bindViewSrg)
+                    {
+                        // Explicitly set "PipelineViewTag": implicitly set BindViewSrg to true as well, if it isn't yet.
+                        AZ_Info(
+                            PassBuilderName,
+                            "Asset %s: Pass has explicit PipelineViewTag '%s' -> setting \"BindViewSrg\" to true as well.",
+                            request.m_fullPath.c_str(),
+                            passData->m_pipelineViewTag.GetCStr());
+                        passData->m_bindViewSrg = true;
+                    }
+                }
+            }
 
             // --- Save the asset to binary format for production ---
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.cpp
@@ -347,6 +347,7 @@ namespace AZ
                             "Asset %s: '\"PipelineViewTag\": \"MainCamera\"' is deprecated, use '\"BindViewSrg\": true' instead",
                             request.m_fullPath.c_str());
                         passData->m_pipelineViewTag = AZ::Name();
+                        passData->m_bindViewSrg = true;
                     }
                     else if (!passData->m_bindViewSrg)
                     {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -6,9 +6,9 @@
  *
  */
 
-
 #include <Atom/RHI/DrawListTagRegistry.h>
 
+#include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Public/Pass/PassSystem.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
@@ -423,13 +423,17 @@ namespace AZ
 
         ViewPtr RenderPipeline::GetDefaultView()
         {
-            ViewPtr defaultView;
-            const AZStd::vector<ViewPtr>& views = GetViews(m_mainViewTag);
+            return GetFirstView(m_mainViewTag);
+        }
+
+        ViewPtr RenderPipeline::GetFirstView(const PipelineViewTag& viewTag)
+        {
+            const AZStd::vector<ViewPtr>& views = GetViews(viewTag);
             if (!views.empty())
             {
-                defaultView = views[0];
+                return views[0];
             }
-            return defaultView;
+            return {};
         }
 
         void RenderPipeline::SetDefaultViewFromEntity(EntityId entityId)
@@ -489,7 +493,7 @@ namespace AZ
             return m_pipelineViewsByTag.find(viewTag) != m_pipelineViewsByTag.end();
         }
 
-        PipelineViewTag RenderPipeline::GetMainViewTag() const
+        const PipelineViewTag& RenderPipeline::GetMainViewTag() const
         {
             return m_mainViewTag;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -52,7 +52,7 @@ namespace AZ
             {
                 serializeContext->Class<RenderPassData, PassData>()
                     ->Version(1)
-                    ->Field("PipelineViewTag", &RenderPassData::m_pipelineViewTag)
+                    ->Field("BindViewSrg", &RenderPassData::m_bindViewSrg)
                     ->Field("ShaderDataMappings", &RenderPassData::m_mappings);
             }
         }
@@ -92,6 +92,7 @@ namespace AZ
             {
                 serializeContext->Class<PassData>()
                     ->Version(1)
+                    ->Field("PipelineViewTag", &PassData::m_pipelineViewTag)
                     ->Field("PipelineGlobalConnections", &PassData::m_pipelineGlobalConnections);
             }
         }

--- a/Gems/Atom/RPI/Code/Tests/System/RenderPipelineTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/RenderPipelineTests.cpp
@@ -45,7 +45,7 @@ namespace UnitTest
                 m_drawListTag = drawListTagRegistry->AcquireTag(drawListTagString);
                 m_viewTag = viewTag;
                 m_flags.m_hasDrawListTag = true;
-                m_flags.m_hasPipelineViewTag = true;
+                m_flags.m_bindViewSrg = true;
             }
 
             AZ::RHI::DrawListTag GetDrawListTag() const override

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeBlurParent.pass
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeBlurParent.pass
@@ -71,7 +71,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/EditorModeBlur.shader"
                         },
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "ShaderDataMappings": {
                             "UintMappings": [
                                 {
@@ -114,7 +114,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/EditorModeBlur.shader"
                         },
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "ShaderDataMappings": {
                             "UintMappings": [
                                 {

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeDesaturation.pass
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeDesaturation.pass
@@ -75,7 +75,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/EditorModeDesaturation.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeOutline.pass
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeOutline.pass
@@ -76,7 +76,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/EditorModeOutline.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeTint.pass
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Passes/Child/EditorModeTint.pass
@@ -75,7 +75,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/EditorModeTint.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomTressFX/Assets/Passes/AtomTressFX_MainPipeline.pass
+++ b/Gems/AtomTressFX/Assets/Passes/AtomTressFX_MainPipeline.pass
@@ -406,7 +406,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/ScreenSpace/DeferredFog.shader"
                         },
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {
@@ -480,7 +480,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "auxgeom",
-                        "PipelineViewTag": "MainCamera"
+                        "BindViewSrg": true
                     }
                 },
                 {

--- a/Gems/AtomTressFX/Assets/Passes/HairDepthToLinear.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairDepthToLinear.pass
@@ -31,7 +31,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthToLinearDepth.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomTressFX/Assets/Passes/HairFillPPLL.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairFillPPLL.pass
@@ -123,7 +123,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "hairFillPass",
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomTressFX/Assets/Passes/HairResolvePPLL.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairResolvePPLL.pass
@@ -139,7 +139,7 @@
             ],
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "ShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairRenderingResolvePPLL.shader"

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryDepthAlpha.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryDepthAlpha.pass
@@ -89,7 +89,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "HairGeometryDepthAlphaDrawList",
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "PassSrgShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutGeometryDepthAlpha.shader"

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryShading.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryShading.pass
@@ -149,7 +149,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "HairGeometryShadingDrawList",
-                "PipelineViewTag": "MainCamera",
+                "BindViewSrg": true,
                 "PassSrgShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutGeometryShading.shader"

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveColor.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveColor.pass
@@ -38,7 +38,7 @@
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutResolveColor.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveDepth.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutResolveDepth.pass
@@ -30,7 +30,7 @@
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairShortCutResolveDepth.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseComposite.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseComposite.pass
@@ -69,7 +69,7 @@
                     "FilePath": "Shaders/DiffuseGlobalIllumination/DiffuseComposite.shader"
                 },
                 "StencilRef": 128, // See RenderCommon.h and DiffuseComposite.shader
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridDownsample.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridDownsample.pass
@@ -108,7 +108,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridRender.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridRender.pass
@@ -41,7 +41,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "diffuseprobegridrender",
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridVisualizationComposite.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridVisualizationComposite.pass
@@ -33,7 +33,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridVisualizationComposite.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
@@ -37,7 +37,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "lyshinepass",
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/LyShine/Assets/Passes/RttChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/RttChildPass.pass
@@ -66,7 +66,7 @@
             "PassData": {
                 "$type": "RasterPassData",
                 "DrawListTag": "lyshinerttpass",
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Meshlets/Assets/Passes/MeshletsParent.pass
+++ b/Gems/Meshlets/Assets/Passes/MeshletsParent.pass
@@ -54,7 +54,7 @@
                     "PassData": {
                         "$type": "RasterPassData",
                         "DrawListTag": "MeshletsDrawList",
-                        "PipelineViewTag": "MainCamera",
+                        "BindViewSrg": true,
                         "PassSrgShaderAsset": {
                             "FilePath": "Shaders/MeshletsDebugRenderShader.shader"
                         }

--- a/Gems/Terrain/Assets/Passes/TerrainClipmapDebugPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainClipmapDebugPass.pass
@@ -11,7 +11,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainClipmapDebugPass.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             },
             "Slots": [
                 {

--- a/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainDetailClipmapGenerationPass.pass
@@ -11,7 +11,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainDetailClipmapGenerationPass.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }

--- a/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainMacroClipmapGenerationPass.pass
@@ -11,7 +11,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/Terrain/TerrainMacroClipmapGenerationPass.shader"
                 },
-                "PipelineViewTag": "MainCamera"
+                "BindViewSrg": true
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Currently many passes have a hardcoded `"PipelineViewTag" : "MainCamera"` set in the pass template. This makes it somewhat impossible to use existing pass-templates in a context where more than one active Camera exists. Also, many post-processing passes (e.g. `TaaPass.cpp`) use `GetDefaultView()` of the pipeline to get access to a view, since they do not want to bind a View-SRG, but need access to a view. 

This PR now splits the functionality of the `"PipelineViewTag"` into two separate concepts: 
  - The first one is determining which view-tag is relevant for the current pass
    - either set explicitly for each pass or taken from the pass hierarchy, ending with the Main view-tag of the pipeline.
  - The second one is binding the View-SRG. 

The concrete changes for this are:
- Move the `PipelineViewTag` from the `RenderPassData` to the `PassData` struct, so parent-passes can also specify a view-tag relevant for their child-passes.
    - This should not change the json-structure at all, but it does mean assets need to be reprocessed 
- Moved the `m_viewTag` from the `RenderPass` class to the `Pass` class.
- Changed the function `GetPipelineViewTag()` so it always returns a view-tag:
    - from the current pass, if set explicitly
    - recursively from the first parent pass that has an explicitly set view tag 
    - the `MainViewTag` of the pipeline, if the hierarchy is at the root pass
- Added the flag `BindViewSrg` to the `RenderPassData`, to explicitly mark that the shader needs a view-Srg.
- Renamed the flag `m_flags.m_hasPipelineViewTag` to `m_flags.m_bindViewSrg` 
    - this is set to true if the pass has an explicitly declared view tag, so the behaviour should stay unchanged for exising passes
- Renamed all `"PipelineViewTag" : "MainCamera"` to `"BindViewSrg": true` via search/replace of all .pass files
- Added `GetFirstView(viewTag)` to the `RenderPipeline` class
- Changed the usage of `GetDefaultView()` in all pass-classes to `GetFirstView(GetPipelineViewTag())`

This is the first solution we had for our issue. It works as is, but i am welcoming feedback on how to improve this.

## How was this PR tested?

- Confirmed that the Main Pipeline still works unchanged
- Use a single pipeline with two cameras, where each camera has its own post-processing passes
