### PR TITLE
Added AZ Event to notify Directional Light component config changes

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -79,11 +79,23 @@ namespace AZ
                 return;
             }
 
+            AZ::Data::AssetId shaderAssetId = passData->m_shaderAsset.m_assetId;
+            if (!shaderAssetId.IsValid())
+            {
+                // This case may happen when the PassData comes from PassRequest defined insize an *.azasset.
+                // Unlike the PassBuilder, the AnyAssetBuilder doesn't record the AssetId, so we have to discover the asset id at runtime.
+                AZStd::string azshaderPath = passData->m_shaderAsset.m_filePath;
+                AZ::StringFunc::Path::ReplaceExtension(azshaderPath, "azshader");
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    shaderAssetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, azshaderPath.c_str(),
+                    azrtti_typeid<ShaderAsset>(), false /*autoRegisterIfNotFound*/);
+            }
+
             // Load Shader
             Data::Asset<ShaderAsset> shaderAsset;
-            if (passData->m_shaderAsset.m_assetId.IsValid())
+            if (shaderAssetId.IsValid())
             {
-                shaderAsset = RPI::FindShaderAsset(passData->m_shaderAsset.m_assetId, passData->m_shaderAsset.m_filePath);
+                shaderAsset = RPI::FindShaderAsset(shaderAssetId, passData->m_shaderAsset.m_filePath);
             }
 
             if (!shaderAsset.GetId().IsValid())

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -82,7 +82,7 @@ namespace AZ
             AZ::Data::AssetId shaderAssetId = passData->m_shaderAsset.m_assetId;
             if (!shaderAssetId.IsValid())
             {
-                // This case may happen when the PassData comes from PassRequest defined insize an *.azasset.
+                // This case may happen when PassData comes from a PassRequest defined inside an *.azasset.
                 // Unlike the PassBuilder, the AnyAssetBuilder doesn't record the AssetId, so we have to discover the asset id at runtime.
                 AZStd::string azshaderPath = passData->m_shaderAsset.m_filePath;
                 AZ::StringFunc::Path::ReplaceExtension(azshaderPath, "azshader");

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
@@ -18,6 +18,10 @@ namespace AZ
 {
     namespace Render
     {
+        // This event is called whenever a configuration parameter changes
+        // in the Directional Light Component.
+        using DirectionalLightConfigurationChangedEvent = AZ::Event<>;
+
         class DirectionalLightRequests
             : public ComponentBus
         {
@@ -204,6 +208,13 @@ namespace AZ
 
             //! Sets the contribution multiplier for global illumination
             virtual void SetAffectsGIFactor(float affectsGIFactor) = 0;
+
+            //! Bind to this event to be notified whenever at least one of the
+            //! configuration properties of the Directional Light Component changes.
+            //! REMARK: This event won't be signaled when the Set*() functions are called
+            //! on a particular directional light, instead, this event will be signaled only
+            //! when the user modifies the component properties in the Inspector panel. 
+            virtual void BindConfigurationChangedEventHandler(DirectionalLightConfigurationChangedEvent::Handler& configurationChangedHandler) = 0;
         };
         using DirectionalLightRequestBus = EBus<DirectionalLightRequests>;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
@@ -514,6 +514,11 @@ namespace AZ
             }
         }
 
+        void DirectionalLightComponentController::BindConfigurationChangedEventHandler(DirectionalLightConfigurationChangedEvent::Handler& configurationChangedHandler)
+        {
+            configurationChangedHandler.Connect(m_configurationChangedEvent);
+        }
+
         const DirectionalLightComponentConfig& DirectionalLightComponentController::GetConfiguration() const
         {
             return m_configuration;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
@@ -93,6 +93,7 @@ namespace AZ
             void SetAffectsGI(bool affectsGI) override;
             float GetAffectsGIFactor() const override;
             void SetAffectsGIFactor(float affectsGIFactor) override;
+            void BindConfigurationChangedEventHandler(DirectionalLightConfigurationChangedEvent::Handler& configurationChangedHandler) override;
 
         private:
             friend class EditorDirectionalLightComponent;
@@ -131,6 +132,9 @@ namespace AZ
 
             DirectionalLightFeatureProcessorInterface* m_featureProcessor = nullptr;
             DirectionalLightFeatureProcessorInterface::LightHandle m_lightHandle;
+
+            //! Event used to signal when at least one of the properties changes.
+            DirectionalLightConfigurationChangedEvent m_configurationChangedEvent;
         };
 
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -271,6 +271,8 @@ namespace AZ
                 m_controller.m_configuration.m_intensity = m_controller.m_photometricValue.GetIntensity();
             }
 
+            m_controller.m_configurationChangedEvent.Signal();
+
             BaseClass::OnConfigurationChanged();
             return Edit::PropertyRefreshLevels::AttributesAndValues;
         }


### PR DESCRIPTION
## What does this PR do?
- Added AZ Event to notify config changes
  in Directional Light component.

- Fixed crashed in FullscreenTrianglePass that occurred when the PassData comes from PassRequest defined insize an *.azasset. Unlike the PassBuilder, the AnyAssetBuilder doesn't record the shader AssetId, so we have to discover the asset id at runtime.

## How was this PR tested?
- Placed breakpoints in `EditorDirectionalLightComponent::OnConfigurationChanged()` and the event is signaled upon change any of the configuration parameters in the Inspector panel for the EditorDirectionalLightComponent.
- Validated in another project that requires this event and it worked too.
- Also in the other project I found the crash related with FullscreenTrianglePass and the crash doesn't occur anymore.
