### PR TITLE
Allow navigation in up and down direction.

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
@@ -303,15 +303,15 @@ void FlyCameraInputComponent::OnKeyboardEvent(const InputChannel& inputChannel)
         m_movement.x = inputChannel.GetValue();
     }
 
-	if(channelId == InputDeviceKeyboard::Key::AlphanumericE)
-	{
-		m_movement.z = inputChannel.GetValue();
-	}
+    if(channelId == InputDeviceKeyboard::Key::AlphanumericE)
+    {
+        m_movement.z = inputChannel.GetValue();
+    }
 
-	if(channelId == InputDeviceKeyboard::Key::AlphanumericQ)
-	{
-		m_movement.z = -inputChannel.GetValue();
-	}
+    if(channelId == InputDeviceKeyboard::Key::AlphanumericQ)
+    {
+        m_movement.z = -inputChannel.GetValue();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -328,15 +328,15 @@ void FlyCameraInputComponent::OnGamepadEvent(const InputChannel& inputChannel)
         m_movement.y = inputChannel.GetValue();
     }
 
-	if (channelId == InputDeviceGamepad::Trigger::L2)
-	{
-		m_movement.z = inputChannel.GetValue();
-	}
+    if (channelId == InputDeviceGamepad::Trigger::L2)
+    {
+        m_movement.z = -inputChannel.GetValue();
+    }
 
-	if (channelId == InputDeviceGamepad::Trigger::R2)
-	{
-		m_movement.z = -inputChannel.GetValue();
-	}
+    if (channelId == InputDeviceGamepad::Trigger::R2)
+    {
+        m_movement.z = inputChannel.GetValue();
+    }
 
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::RX)
     {

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
@@ -178,7 +178,9 @@ void FlyCameraInputComponent::OnTick(float deltaTime, AZ::ScriptTimePoint /*time
     const float moveSpeed = m_moveSpeed * deltaTime;
     const AZ::Vector3 right = worldTransform.GetBasisX();
     const AZ::Vector3 forward = worldTransform.GetBasisY();
-    const AZ::Vector3 movement = (forward * m_movement.y) + (right * m_movement.x);
+    const AZ::Vector3 up = worldTransform.GetBasisZ();
+
+    const AZ::Vector3 movement = (forward * m_movement.y) + (right * m_movement.x) + (up * m_movement.z);
     const AZ::Vector3 newPosition = worldTransform.GetTranslation() + (movement * moveSpeed);
     worldTransform.SetTranslation(newPosition);
 
@@ -300,6 +302,16 @@ void FlyCameraInputComponent::OnKeyboardEvent(const InputChannel& inputChannel)
     {
         m_movement.x = inputChannel.GetValue();
     }
+
+	if(channelId == InputDeviceKeyboard::Key::AlphanumericE)
+	{
+		m_movement.z = inputChannel.GetValue();
+	}
+
+	if(channelId == InputDeviceKeyboard::Key::AlphanumericQ)
+	{
+		m_movement.z = -inputChannel.GetValue();
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -315,7 +327,17 @@ void FlyCameraInputComponent::OnGamepadEvent(const InputChannel& inputChannel)
     {
         m_movement.y = inputChannel.GetValue();
     }
-    
+
+	if (channelId == InputDeviceGamepad::Trigger::L2)
+	{
+		m_movement.z = inputChannel.GetValue();
+	}
+
+	if (channelId == InputDeviceGamepad::Trigger::R2)
+	{
+		m_movement.z = -inputChannel.GetValue();
+	}
+
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::RX)
     {
         m_rotation.x = inputChannel.GetValue();

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.h
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.h
@@ -73,7 +73,7 @@ namespace AZ
             bool m_isEnabled = true;
 
             // Run-time Properties
-            Vec2 m_movement = ZERO;
+            Vec3 m_movement = ZERO;
             Vec2 m_rotation = ZERO;
 
             Vec2 m_leftDownPosition = ZERO;


### PR DESCRIPTION
## What does this PR do?

This pull request introduces an enhancement to the FlyCameraInputComponent by incorporating up/down navigation control using the keys 'Q' and 'E' for keyboard input, as well as utilizing the left and right triggers for controller input.

In certain instances, particularly while navigating in Game Mode, there is often a need to move vertically without adjusting the camera's pitch. Hence, the inclusion of this feature as an extension to the FlyCameraInputComponent would prove beneficial.

## How was this PR tested?

Validation of this pull request was conducted through testing within the Editor's Game Mode.

