### PR TITLE
DPE | Fix UI Element grouping

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
@@ -17,7 +17,7 @@ namespace UnitTest
     // These index paths depend on multiple factors like the data in the component, how its reflected to serialize and edit contexts,
     // how different DPE adapters likes ReflectionAdapter and PrefabAdapter construct the DPE DOM etc. Therefore, these may
     // change in the future if the data stored in the DPE DOM itself changes and need to be modified accordingly to prevent test failures.
-    constexpr AZStd::string_view pathToTranslateRow = "/2/2";
+    constexpr AZStd::string_view pathToTranslateRow = "/1/2";
 
     TEST_F(PrefabInspectorOverrideTest, ValidatePresenceOfOverrideProperty)
     {


### PR DESCRIPTION
## What does this PR do?

Fixes the DPE logic that determined where UI Elements are placed in the Inspector Component Cards.
Code now correctly places buttons in groups.

## How was this PR tested?
Manual testing.

BEFORE:
![image](https://github.com/o3de/o3de/assets/82231674/ced171f3-d9d0-4476-9ae6-33fff2d6fced)

AFTER:
![image](https://github.com/o3de/o3de/assets/82231674/cd41185b-d186-429d-9364-db4689a6e31b)