### PR TITLE
Fixed the gradient image asset handler in DPE

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1692,6 +1692,21 @@ namespace AzToolsFramework
         return ReadValuesIntoGUIInternal(index, GUI, instance, node);
     }
 
+    AZ::Data::Asset<AZ::Data::AssetData>* AssetPropertyHandlerDefault::CastToInternal(void* instance, const InstanceDataNode* node)
+    {
+        if (node->GetElementMetadata()->m_genericClassInfo && node->GetElementMetadata()->m_genericClassInfo->GetGenericTypeId() == AZ::GetAssetClassId())
+        {
+            return static_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(instance);
+        }
+
+        return nullptr;
+    }
+
+    AZ::Data::Asset<AZ::Data::AssetData>* AssetPropertyHandlerDefault::CastTo(void* instance, const InstanceDataNode* node, [[maybe_unused]] const AZ::Uuid& fromId, [[maybe_unused]] const AZ::Uuid& toId) const
+    {
+        return CastToInternal(instance, node);
+    }
+
     QWidget* AssetIdPropertyHandlerDefault::CreateGUI(QWidget* pParent)
     {
         PropertyAssetCtrl* newCtrl = aznew PropertyAssetCtrl(pParent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -305,15 +305,9 @@ namespace AzToolsFramework
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         static bool ReadValuesIntoGUIInternal(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node);
         virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
-    protected:
-        AZ::Data::Asset<AZ::Data::AssetData>* CastTo(void* instance, const InstanceDataNode* node, const AZ::Uuid& /*fromId*/, const AZ::Uuid& /*toId*/) const override
-        {
-            if (node->GetElementMetadata()->m_genericClassInfo && node->GetElementMetadata()->m_genericClassInfo->GetGenericTypeId() == AZ::GetAssetClassId())
-            {
-                return static_cast<AZ::Data::Asset<AZ::Data::AssetData>*>(instance);
-            }
-            return nullptr;
-        }
+
+        static AZ::Data::Asset<AZ::Data::AssetData>* CastToInternal(void* instance, const InstanceDataNode* node);
+        AZ::Data::Asset<AZ::Data::AssetData>* CastTo(void* instance, const InstanceDataNode* node, const AZ::Uuid& fromId, const AZ::Uuid& toId) const override;
     };
 
     class AssetIdPropertyHandlerDefault

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
@@ -90,6 +90,11 @@ namespace GradientSignal
         }
     }
 
+    AZ::TypeId StreamingImagePropertyHandler::GetHandledType() const
+    {
+        return AZ::GetAssetClassId();
+    }
+
     AZ::u32 StreamingImagePropertyHandler::GetHandlerName() const
     {
         return AZ_CRC_CE("GradientSignalStreamingImageAsset");
@@ -152,6 +157,12 @@ namespace GradientSignal
     {
         // Let the AssetPropertyHandlerDefault handle reading values into the GUI
         return AzToolsFramework::AssetPropertyHandlerDefault::ReadValuesIntoGUIInternal(index, GUI, instance, node);
+    }
+
+    AZ::Data::Asset<AZ::Data::AssetData>* StreamingImagePropertyHandler::CastTo(void* instance, const AzToolsFramework::InstanceDataNode* node, [[maybe_unused]] const AZ::Uuid& fromId, [[maybe_unused]] const AZ::Uuid& toId) const
+    {
+        // Let the AssetPropertyHandlerDefault handle the downcast
+        return AzToolsFramework::AssetPropertyHandlerDefault::CastToInternal(instance, node);
     }
 
     void StreamingImagePropertyHandler::Register()

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
@@ -60,6 +60,7 @@ namespace GradientSignal
     public:
         AZ_CLASS_ALLOCATOR(StreamingImagePropertyHandler, AZ::SystemAllocator);
 
+        AZ::TypeId GetHandledType() const override;
         AZ::u32 GetHandlerName() const override;
         bool IsDefaultHandler() const override;
         QWidget* GetFirstInTabOrder(StreamingImagePropertyAssetCtrl* widget) override;
@@ -70,6 +71,7 @@ namespace GradientSignal
         void ConsumeAttribute(StreamingImagePropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName) override;
         void WriteGUIValuesIntoProperty(size_t index, StreamingImagePropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node) override;
         bool ReadValuesIntoGUI(size_t index, StreamingImagePropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)  override;
+        AZ::Data::Asset<AZ::Data::AssetData>* CastTo(void* instance, const AzToolsFramework::InstanceDataNode* node, const AZ::Uuid& fromId, const AZ::Uuid& toId) const override;
 
         static void Register();
     };


### PR DESCRIPTION
## What does this PR do?

Fixes #16242 

The image gradient component uses a custom asset handler for its image asset field. This custom handler mostly copies from the default asset property handler and introduces some specific logic, but wasn't copying the default asset property handlers type logic, so it wasn't being found in the DPE.

BEFORE:
![ImageGradientAsset_BEFORE](https://github.com/o3de/o3de/assets/7519264/4d083410-6c15-4d23-90c6-2b9a4dea3fe2)

AFTER:
![ImageGradientAsset_AFTER](https://github.com/o3de/o3de/assets/7519264/8f56cdf6-c41d-4d68-a606-4e7d167b7dd0)

## How was this PR tested?

Tested the image gradient asset field and other asset fields (e.g. mesh, script canvas) and verified they work as expected with DPE both enabled and disabled.