### PR TITLE
DPE | Remove unused variable definition in LegacyReflectionBridge

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -699,11 +699,6 @@ namespace AZ::Reflection
                     }
 
                     // Iterate over non serialized elements to see if any of them should be added
-                    const char* elementName = "";
-                    if (parentData.m_classElement && parentData.m_classElement->m_editData && parentData.m_classElement->m_editData->m_name)
-                    {
-                        elementName = parentData.m_classElement->m_editData->m_name;
-                    }
                     auto iter = m_nonSerializedElements.begin();
                     while (iter != m_nonSerializedElements.end())
                     {


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/16298