### PR TITLE
Cognito User Pools Warning Cleanup

### DIFF
--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
@@ -182,7 +182,7 @@ namespace AWSClientAuth
         // Create a controller for user pools and identity pools.
         bool awsCognitoUserPoolDefined = false;
         AWSCore::AWSResourceMappingRequestBus::BroadcastResult(
-            awsCognitoUserPoolDefined, &AWSCore::AWSResourceMappingRequests::HasResourceType, CognitoUserPoolIdResourceMappingKey);
+            awsCognitoUserPoolDefined, &AWSCore::AWSResourceMappingRequests::HasResource, CognitoUserPoolIdResourceMappingKey);
         if (awsCognitoUserPoolDefined)
         {
             m_awsCognitoUserManagementController = AZStd::make_unique<AWSCognitoUserManagementController>();
@@ -190,7 +190,7 @@ namespace AWSClientAuth
 
         bool awsCognitoIdentityPoolDefined = false;
         AWSCore::AWSResourceMappingRequestBus::BroadcastResult(
-            awsCognitoIdentityPoolDefined, &AWSCore::AWSResourceMappingRequests::HasResourceType, CognitoIdentityPoolIdResourceMappingKey);
+            awsCognitoIdentityPoolDefined, &AWSCore::AWSResourceMappingRequests::HasResource, CognitoIdentityPoolIdResourceMappingKey);
         if (awsCognitoIdentityPoolDefined)
         {
             m_awsCognitoAuthorizationController = AZStd::make_unique<AWSCognitoAuthorizationController>();

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
@@ -82,7 +82,7 @@ namespace AWSClientAuth
         AZStd::string userPoolId;
         AWSCore::AWSResourceMappingRequestBus::BroadcastResult(
             userPoolId, &AWSCore::AWSResourceMappingRequests::GetResourceNameId, CognitoUserPoolIdResourceMappingKey);
-        AZ_Warning("AWSCognitoAuthorizationController", !userPoolId.empty(), "Missing Cognito User pool id in resource mappings. Cognito IDP authenticated identities will no work.");
+        AZ_Warning("AWSCognitoAuthorizationController", !userPoolId.empty(), "Missing Cognito User pool id in resource mappings. Cognito IDP authenticated identities will not work.");
 
         AZStd::string defaultRegion;
         AWSCore::AWSResourceMappingRequestBus::BroadcastResult(

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -92,9 +92,9 @@ namespace AWSClientAuthUnitTest
 
             ON_CALL(*this, GetResourceRegion).WillByDefault(testing::Return(TEST_REGION));
             ON_CALL(*this, GetDefaultAccountId).WillByDefault(testing::Return(TEST_ACCOUNT_ID));
+            ON_CALL(*this, HasResource).WillByDefault(testing::Return(true));
             ON_CALL(*this, GetResourceAccountId).WillByDefault(testing::Return(TEST_ACCOUNT_ID));
             ON_CALL(*this, GetResourceNameId).WillByDefault(testing::Return(TEST_RESOURCE_NAME_ID));
-            ON_CALL(*this, HasResourceType).WillByDefault(testing::Return(true));
             ON_CALL(*this, GetDefaultRegion).WillByDefault(testing::Return(TEST_REGION));
         }
 
@@ -105,10 +105,10 @@ namespace AWSClientAuthUnitTest
 
         MOCK_CONST_METHOD0(GetDefaultAccountId, AZStd::string());
         MOCK_CONST_METHOD0(GetDefaultRegion, AZStd::string());
+        MOCK_CONST_METHOD1(HasResource, bool(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceAccountId, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceNameId, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceRegion, AZStd::string(const AZStd::string& resourceKeyName));
-        MOCK_CONST_METHOD1(HasResourceType, bool(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceType, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetServiceUrlByServiceName, AZStd::string(const AZStd::string& serviceName));
         MOCK_CONST_METHOD2(

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -107,6 +107,7 @@ namespace AWSClientAuthUnitTest
         MOCK_CONST_METHOD1(GetResourceAccountId, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceNameId, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceRegion, AZStd::string(const AZStd::string& resourceKeyName));
+        MOCK_CONST_METHOD1(HasResourceType, bool(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetResourceType, AZStd::string(const AZStd::string& resourceKeyName));
         MOCK_CONST_METHOD1(GetServiceUrlByServiceName, AZStd::string(const AZStd::string& serviceName));
         MOCK_CONST_METHOD2(

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -94,6 +94,7 @@ namespace AWSClientAuthUnitTest
             ON_CALL(*this, GetDefaultAccountId).WillByDefault(testing::Return(TEST_ACCOUNT_ID));
             ON_CALL(*this, GetResourceAccountId).WillByDefault(testing::Return(TEST_ACCOUNT_ID));
             ON_CALL(*this, GetResourceNameId).WillByDefault(testing::Return(TEST_RESOURCE_NAME_ID));
+            ON_CALL(*this, HasResourceType).WillByDefault(testing::Return(true));
             ON_CALL(*this, GetDefaultRegion).WillByDefault(testing::Return(TEST_REGION));
         }
 

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
@@ -216,11 +216,11 @@ TEST_F(AWSClientAuthSystemComponentTest, GetCognitoClients_Success)
 
 TEST_F(AWSClientAuthSystemComponentTest, SkipCognitoControllers_Success)
 {
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResourceType(AZStd::string(CognitoUserPoolIdResourceMappingKey)))
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResource(AZStd::string(CognitoUserPoolIdResourceMappingKey)))
         .Times(1)
         .WillOnce(testing::Return(false));
 
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResourceType(AZStd::string(CognitoIdentityPoolIdResourceMappingKey)))
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResource(AZStd::string(CognitoIdentityPoolIdResourceMappingKey)))
         .Times(1)
         .WillOnce(testing::Return(false));
 

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthSystemComponentTest.cpp
@@ -216,13 +216,13 @@ TEST_F(AWSClientAuthSystemComponentTest, GetCognitoClients_Success)
 
 TEST_F(AWSClientAuthSystemComponentTest, SkipCognitoControllers_Success)
 {
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetResourceNameId(AZStd::string(CognitoUserPoolIdResourceMappingKey)))
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResourceType(AZStd::string(CognitoUserPoolIdResourceMappingKey)))
         .Times(1)
-        .WillOnce(testing::Return(""));
+        .WillOnce(testing::Return(false));
 
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetResourceNameId(AZStd::string(CognitoIdentityPoolIdResourceMappingKey)))
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, HasResourceType(AZStd::string(CognitoIdentityPoolIdResourceMappingKey)))
         .Times(1)
-        .WillOnce(testing::Return(""));
+        .WillOnce(testing::Return(false));
 
     // activate component
     m_entity->Init();

--- a/Gems/AWSCore/Code/Include/ResourceMapping/AWSResourceMappingBus.h
+++ b/Gems/AWSCore/Code/Include/ResourceMapping/AWSResourceMappingBus.h
@@ -69,6 +69,13 @@ namespace AWSCore
         //! @return Resource type in string
         virtual AZStd::string GetResourceType(const AZStd::string& resourceKeyName) const = 0;
 
+        //! HasResourceType
+        //! Check if an AWS resource is defined
+        //! @param resourceKeyName Resource mapping key name is used to identify individual
+        //!        resource attributes
+        //! @return True if the resource exists; otherwise false.
+        virtual bool HasResourceType(const AZStd::string& resourceKeyName) const = 0;
+
         //! GetServiceUrl
         //! Returns the base url for a registered APIGateway service endpoint
         //! @param serviceName The name of the Gem or mapping name that provides the services

--- a/Gems/AWSCore/Code/Include/ResourceMapping/AWSResourceMappingBus.h
+++ b/Gems/AWSCore/Code/Include/ResourceMapping/AWSResourceMappingBus.h
@@ -37,6 +37,13 @@ namespace AWSCore
         //! @return Default region in string
         virtual AZStd::string GetDefaultRegion() const = 0;
 
+        //! HasResource
+        //! Check if an AWS resource is defined
+        //! @param resourceKeyName Resource mapping key name is used to identify individual
+        //!        resource attributes
+        //! @return True if the resource exists; otherwise false.
+        virtual bool HasResource(const AZStd::string& resourceKeyName) const = 0;
+
         //! GetResourceAccountId
         //! Get individual resource account id by using its mapping key name.
         //! If resource account id is not present in resource attributes, will use
@@ -68,13 +75,6 @@ namespace AWSCore
         //!        resource attributes
         //! @return Resource type in string
         virtual AZStd::string GetResourceType(const AZStd::string& resourceKeyName) const = 0;
-
-        //! HasResourceType
-        //! Check if an AWS resource is defined
-        //! @param resourceKeyName Resource mapping key name is used to identify individual
-        //!        resource attributes
-        //! @return True if the resource exists; otherwise false.
-        virtual bool HasResourceType(const AZStd::string& resourceKeyName) const = 0;
 
         //! GetServiceUrl
         //! Returns the base url for a registered APIGateway service endpoint

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
@@ -118,6 +118,11 @@ namespace AWSCore
         }, resourceKeyName);
     }
 
+    bool AWSResourceMappingManager::HasResourceType(const AZStd::string& resourceKeyName) const
+    {
+        return m_resourceMappings.contains(resourceKeyName);
+    }
+
     AZStd::string AWSResourceMappingManager::GetServiceUrlByServiceName(const AZStd::string& serviceName) const
     {
         return GetServiceUrlByRESTApiIdAndStage(

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
@@ -82,6 +82,11 @@ namespace AWSCore
         return m_defaultRegion;
     }
 
+    bool AWSResourceMappingManager::HasResource(const AZStd::string& resourceKeyName) const
+    {
+        return m_resourceMappings.contains(resourceKeyName);
+    }
+
     AZStd::string AWSResourceMappingManager::GetResourceAccountId(const AZStd::string& resourceKeyName) const
     {
         return GetResourceAttribute([this](auto& attributes) {
@@ -116,11 +121,6 @@ namespace AWSCore
         return GetResourceAttribute([](auto& attributes) {
             return attributes.resourceType;
         }, resourceKeyName);
-    }
-
-    bool AWSResourceMappingManager::HasResourceType(const AZStd::string& resourceKeyName) const
-    {
-        return m_resourceMappings.contains(resourceKeyName);
     }
 
     AZStd::string AWSResourceMappingManager::GetServiceUrlByServiceName(const AZStd::string& serviceName) const

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.h
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.h
@@ -79,11 +79,11 @@ namespace AWSCore
         // AWSResourceMappingRequestBus interface implementation
         AZStd::string GetDefaultAccountId() const override;
         AZStd::string GetDefaultRegion() const override;
+        bool HasResource(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceAccountId(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceNameId(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceRegion(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceType(const AZStd::string& resourceKeyName) const override;
-        bool HasResourceType(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetServiceUrlByServiceName(const AZStd::string& serviceName) const override;
         AZStd::string GetServiceUrlByRESTApiIdAndStage(
             const AZStd::string& restApiIdKeyName, const AZStd::string& restApiStageKeyName) const override;

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.h
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.h
@@ -83,6 +83,7 @@ namespace AWSCore
         AZStd::string GetResourceNameId(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceRegion(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetResourceType(const AZStd::string& resourceKeyName) const override;
+        bool HasResourceType(const AZStd::string& resourceKeyName) const override;
         AZStd::string GetServiceUrlByServiceName(const AZStd::string& serviceName) const override;
         AZStd::string GetServiceUrlByRESTApiIdAndStage(
             const AZStd::string& restApiIdKeyName, const AZStd::string& restApiStageKeyName) const override;

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
@@ -45,53 +45,44 @@ class ServiceClientJobConfigTest
         return "";
     }
 
-    AZStd::string GetResourceAccountId(const AZStd::string& resourceKeyName) const override
+    AZStd::string GetResourceAccountId([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
-        AZ_UNUSED(resourceKeyName);
         return "";
     }
 
-    AZStd::string GetResourceNameId(const AZStd::string& resourceKeyName) const override
+    AZStd::string GetResourceNameId([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
-        AZ_UNUSED(resourceKeyName);
         return "";
     }
 
-    AZStd::string GetResourceRegion(const AZStd::string& resourceKeyName) const override
+    AZStd::string GetResourceRegion([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
-        AZ_UNUSED(resourceKeyName);
         return "";
     }
 
-    AZStd::string GetResourceType(const AZStd::string& resourceKeyName) const override
+    AZStd::string GetResourceType([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
-        AZ_UNUSED(resourceKeyName);
         return "";
     }
 
-    bool HasResourceType(const AZStd::string& resourceKeyName) const override
+    bool HasResourceType([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
-        AZ_UNUSED(resourceKeyName);
         return false;
     }
 
-    AZStd::string GetServiceUrlByServiceName(const AZStd::string& serviceName) const override
+    AZStd::string GetServiceUrlByServiceName([[maybe_unused]] const AZStd::string& serviceName) const override
     {
-        AZ_UNUSED(serviceName);
         return TEST_EXPECTED_FEATURE_SERVICE_URL;
     }
 
     AZStd::string GetServiceUrlByRESTApiIdAndStage(
-        const AZStd::string& restApiIdKeyName, const AZStd::string& restApiStageKeyName) const override
+        [[maybe_unused]] const AZStd::string& restApiIdKeyName, [[maybe_unused]] const AZStd::string& restApiStageKeyName) const override
     {
-        AZ_UNUSED(restApiIdKeyName);
-        AZ_UNUSED(restApiStageKeyName);
         return TEST_EXPECTED_CUSTOM_SERVICE_URL;
     }
 
-    void ReloadConfigFile(bool reloadConfigFileName = false) override
+    void ReloadConfigFile([[maybe_unused]] bool reloadConfigFileName = false) override
     {
-        AZ_UNUSED(reloadConfigFileName);
     }
 };
 

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
@@ -69,6 +69,12 @@ class ServiceClientJobConfigTest
         return "";
     }
 
+    bool HasResourceType(const AZStd::string& resourceKeyName) const override
+    {
+        AZ_UNUSED(resourceKeyName);
+        return false;
+    }
+
     AZStd::string GetServiceUrlByServiceName(const AZStd::string& serviceName) const override
     {
         AZ_UNUSED(serviceName);

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
@@ -45,6 +45,11 @@ class ServiceClientJobConfigTest
         return "";
     }
 
+    bool HasResource([[maybe_unused]] const AZStd::string& resourceKeyName) const override
+    {
+        return false;
+    }
+
     AZStd::string GetResourceAccountId([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
         return "";
@@ -63,11 +68,6 @@ class ServiceClientJobConfigTest
     AZStd::string GetResourceType([[maybe_unused]] const AZStd::string& resourceKeyName) const override
     {
         return "";
-    }
-
-    bool HasResourceType([[maybe_unused]] const AZStd::string& resourceKeyName) const override
-    {
-        return false;
     }
 
     AZStd::string GetServiceUrlByServiceName([[maybe_unused]] const AZStd::string& serviceName) const override

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
@@ -78,6 +78,7 @@ public:
     MOCK_CONST_METHOD1(GetResourceNameId, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceRegion, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceType, AZStd::string(const AZStd::string&));
+    MOCK_CONST_METHOD1(HasResourceType, bool(const AZStd::string&));
     MOCK_CONST_METHOD1(GetServiceUrlByServiceName, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD2(GetServiceUrlByRESTApiIdAndStage, AZStd::string(const AZStd::string&, const AZStd::string&));
     MOCK_METHOD1(ReloadConfigFile, void(bool));

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
@@ -74,11 +74,11 @@ public:
 
     MOCK_CONST_METHOD0(GetDefaultRegion, AZStd::string());
     MOCK_CONST_METHOD0(GetDefaultAccountId, AZStd::string());
+    MOCK_CONST_METHOD1(HasResource, bool(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceAccountId, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceNameId, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceRegion, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD1(GetResourceType, AZStd::string(const AZStd::string&));
-    MOCK_CONST_METHOD1(HasResourceType, bool(const AZStd::string&));
     MOCK_CONST_METHOD1(GetServiceUrlByServiceName, AZStd::string(const AZStd::string&));
     MOCK_CONST_METHOD2(GetServiceUrlByRESTApiIdAndStage, AZStd::string(const AZStd::string&, const AZStd::string&));
     MOCK_METHOD1(ReloadConfigFile, void(bool));


### PR DESCRIPTION
- Adding HasResourceType to AWSResourceMappingManager, thus allowing users to check if a property exists instead of requesting the property and receiving a warning that it doesn't exist.
- Cleaning up AWS warning about undefined Cognito User Pools. User Pools aren't required, so the warning was giving developers a sense that something is wrong when it's fine.