### PR TITLE
Add missing include and forward declaration

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -9,12 +9,14 @@
 
 #include <Atom/RHI.Reflect/Limits.h>
 #include <AzCore/std/containers/array.h>
+#include <Atom/RHI/IndirectArguments.h>
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
 
 namespace AZ
 {
     namespace RHI
     {
+        class PipelineState;
         class RayTracingPipelineState;
         class RayTracingShaderTable;
         class ShaderResourceGroup;


### PR DESCRIPTION
## What does this PR do?

Add a missing include and a forward declaration in the file `DispatchRaysItem.h`, which led to compile errors when using this class in an external gem with a non-unity-build configuration.

## How was this PR tested?

No testing other than checking if it compile successfully, since no functionality was changed.
