### PR TITLE
Adding native support for VectorN and MatrixMxN to script canvas

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
@@ -27,13 +27,11 @@ namespace AZ
 
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<MatrixMxN>("N-Dimensional Vector", "")
+                editContext->Class<MatrixMxN>("MxN-Dimensional Matrix", "")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
-                    ->DataElement(
-                        Edit::UIHandlers::Default, &MatrixMxN::m_rowCount, "Total Rows", "The total number of rows in the matrix")
+                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_rowCount, "Total Rows", "The total number of rows in the matrix")
                         ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
-                    ->DataElement(
-                        Edit::UIHandlers::Default, &MatrixMxN::m_colCount, "Total Columns", "The total number of columns in the matrix")
+                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_colCount, "Total Columns", "The total number of columns in the matrix")
                         ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
                     ;
             }
@@ -47,7 +45,22 @@ namespace AZ
                 Attribute(Script::Attributes::Module, "math")->
                 Attribute(Script::Attributes::ExcludeFrom, Script::Attributes::ExcludeFlags::ListOnly)->
                 Constructor<AZStd::size_t, AZStd::size_t>()->
-                Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)
+                Attribute(Script::Attributes::Storage, Script::Attributes::StorageType::Value)->
+                Method("CreateZero", &MatrixMxN::CreateZero)->
+                Method("CreateRandom", &MatrixMxN::CreateRandom)->
+                Method("GetElement", &MatrixMxN::GetElement)->
+                Method("SetElement", &MatrixMxN::SetElement)->
+                Method("GetTranspose", &MatrixMxN::GetTranspose)->
+                Method("GetFloor", &MatrixMxN::GetFloor)->
+                Method("GetCeil", &MatrixMxN::GetCeil)->
+                Method("GetRound", &MatrixMxN::GetRound)->
+                Method("GetMin", &MatrixMxN::GetMin)->
+                Method("GetMax", &MatrixMxN::GetMax)->
+                Method("GetClamp", &MatrixMxN::GetClamp)->
+                Method("GetAbs", &MatrixMxN::GetAbs)->
+                Method("GetSquare", &MatrixMxN::GetSquare)->
+                Method("VectorMatrixMultiply", &VectorMatrixMultiply)->
+                Method("MatrixMatrixMultiply", &MatrixMatrixMultiply)
                 ;
         }
     }

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
@@ -107,7 +107,6 @@ namespace AZ
 
         MatrixMxN& operator+=(const MatrixMxN& rhs);
         MatrixMxN& operator-=(const MatrixMxN& rhs);
-        MatrixMxN& operator*=(const MatrixMxN& rhs);
 
         MatrixMxN& operator+=(float sum);
         MatrixMxN& operator-=(float difference);

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.h
@@ -41,6 +41,10 @@ namespace AZ
 
         ~MatrixMxN() = default;
 
+        MatrixMxN& operator=(MatrixMxN&&) = default;
+
+        MatrixMxN& operator=(const MatrixMxN&) = default;
+
         //! Creates an M by N matrix with all elements set to zero.
         static MatrixMxN CreateZero(AZStd::size_t rowCount, AZStd::size_t colCount);
 
@@ -86,18 +90,24 @@ namespace AZ
         MatrixMxN GetClamp(const MatrixMxN& min, const MatrixMxN& max) const;
         //! @}
 
-        //! Returns a new VectorN containing the absolute value of all elements in the source MatrixMxN.
+        //! Returns a new MatrixMxN containing the absolute value of all elements in the source MatrixMxN.
         MatrixMxN GetAbs() const;
 
-        //! Returns a new VectorN containing the square of all elements in the source MatrixMxN.
+        //! Returns a new MatrixMxN containing the square of all elements in the source MatrixMxN.
         MatrixMxN GetSquare() const;
 
-        //! These operators perform basic arithmetic on the individual elements within the respective matrices.
+        //! Aside from multiplication, these operators perform basic arithmetic on the individual elements within the respective matrices.
         //! @{
+        MatrixMxN operator-() const;
+        MatrixMxN operator+(const MatrixMxN& rhs) const;
+        MatrixMxN operator-(const MatrixMxN& rhs) const;
+        MatrixMxN operator*(const MatrixMxN& rhs) const;
+        MatrixMxN operator*(float multiplier) const;
+        MatrixMxN operator/(float divisor) const;
+
         MatrixMxN& operator+=(const MatrixMxN& rhs);
         MatrixMxN& operator-=(const MatrixMxN& rhs);
-        MatrixMxN& operator*=(const MatrixMxN& rhs); //! Hadamard product, not matrix multiplication.
-        MatrixMxN& operator/=(const MatrixMxN& rhs);
+        MatrixMxN& operator*=(const MatrixMxN& rhs);
 
         MatrixMxN& operator+=(float sum);
         MatrixMxN& operator-=(float difference);

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -293,7 +293,7 @@ namespace AZ
 
     AZ_MATH_INLINE MatrixMxN MatrixMxN::operator*(const MatrixMxN& rhs) const
     {
-        MatrixMxN result;
+        MatrixMxN result(GetRowCount(), rhs.GetColumnCount());
         MatrixMatrixMultiply(*this, rhs, result);
         return result;
     }
@@ -337,14 +337,6 @@ namespace AZ
         {
             m_values[i] -= rhs.m_values[i];
         }
-        return *this;
-    }
-
-    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator*=(const MatrixMxN& rhs)
-    {
-        // We overwrite elements in the output during multiplication, so unfortunately we require a copy of the lhs to operate on
-        const MatrixMxN lhs = *this;
-        MatrixMatrixMultiply(lhs, rhs, *this);
         return *this;
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -261,6 +261,63 @@ namespace AZ
         return returnValue;
     }
 
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator-() const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = -m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator+(const MatrixMxN& rhs) const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] + rhs.m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator-(const MatrixMxN& rhs) const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] - rhs.m_values[i];
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator*(const MatrixMxN& rhs) const
+    {
+        MatrixMxN result;
+        MatrixMatrixMultiply(*this, rhs, result);
+        return result;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator*(float multiplier) const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] * multiplier;
+        }
+        return returnValue;
+    }
+
+    AZ_MATH_INLINE MatrixMxN MatrixMxN::operator/(float divisor) const
+    {
+        MatrixMxN returnValue(m_rowCount, m_colCount);
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            returnValue.m_values[i] = m_values[i] / divisor;
+        }
+        return returnValue;
+    }
+
     AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator+=(const MatrixMxN& rhs)
     {
         AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
@@ -285,30 +342,9 @@ namespace AZ
 
     AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator*=(const MatrixMxN& rhs)
     {
-        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
-        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
-        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
-        {
-            m_values[i].SetRow(0, m_values[i].GetRow(0) * rhs.m_values[i].GetRow(0));
-            m_values[i].SetRow(1, m_values[i].GetRow(1) * rhs.m_values[i].GetRow(1));
-            m_values[i].SetRow(2, m_values[i].GetRow(2) * rhs.m_values[i].GetRow(2));
-            m_values[i].SetRow(3, m_values[i].GetRow(3) * rhs.m_values[i].GetRow(3));
-        }
-        return *this;
-    }
-
-    AZ_MATH_INLINE MatrixMxN& MatrixMxN::operator/=(const MatrixMxN& rhs)
-    {
-        AZ_Assert(m_rowCount == rhs.m_rowCount, "Dimensionality must be equal");
-        AZ_Assert(m_colCount == rhs.m_colCount, "Dimensionality must be equal");
-        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
-        {
-            m_values[i].SetRow(0, m_values[i].GetRow(0) / rhs.m_values[i].GetRow(0));
-            m_values[i].SetRow(1, m_values[i].GetRow(1) / rhs.m_values[i].GetRow(1));
-            m_values[i].SetRow(2, m_values[i].GetRow(2) / rhs.m_values[i].GetRow(2));
-            m_values[i].SetRow(3, m_values[i].GetRow(3) / rhs.m_values[i].GetRow(3));
-        }
-        FixUnusedElements();
+        // We overwrite elements in the output during multiplication, so unfortunately we require a copy of the lhs to operate on
+        const MatrixMxN lhs = *this;
+        MatrixMatrixMultiply(lhs, rhs, *this);
         return *this;
     }
 

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.inl
@@ -310,6 +310,7 @@ namespace AZ
 
     AZ_MATH_INLINE MatrixMxN MatrixMxN::operator/(float divisor) const
     {
+        AZ_Assert(fabs(divisor) > Constants::FloatEpsilon, "Potential division by zero");
         MatrixMxN returnValue(m_rowCount, m_colCount);
         for (AZStd::size_t i = 0; i < m_values.size(); ++i)
         {

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.h
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.h
@@ -39,6 +39,10 @@ namespace AZ
 
         ~VectorN() = default;
 
+        VectorN& operator=(VectorN&&) = default;
+
+        VectorN& operator=(const VectorN&) = default;
+
         //! Creates a vector with all components set to zero, more efficient than calling VectorN(0.0f).
         static VectorN CreateZero(AZStd::size_t numElements);
 
@@ -110,8 +114,14 @@ namespace AZ
         //! Returns a new VectorN containing the absolute value of all elements in the source VectorN.
         VectorN GetAbs() const;
 
+        //! Absolute value in-place.
+        void Absolute();
+
         //! Returns a new VectorN containing the square of all elements in the source VectorN.
         VectorN GetSquare() const;
+
+        //! Square value in-place.
+        void Square();
 
         //! Returns the dot product of two vectors of equal dimension.
         float Dot(const VectorN& rhs) const;

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.inl
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.inl
@@ -281,6 +281,14 @@ namespace AZ
         return returnValue;
     }
 
+    AZ_MATH_INLINE void VectorN::Absolute()
+    {
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] = m_values[i].GetAbs();
+        }
+    }
+
     AZ_MATH_INLINE VectorN VectorN::GetSquare() const
     {
         VectorN returnValue(m_numElements);
@@ -289,6 +297,14 @@ namespace AZ
             returnValue.m_values[i] = m_values[i] * m_values[i];
         }
         return returnValue;
+    }
+
+    AZ_MATH_INLINE void VectorN::Square()
+    {
+        for (AZStd::size_t i = 0; i < m_values.size(); ++i)
+        {
+            m_values[i] *= m_values[i];
+        }
     }
 
     AZ_MATH_INLINE float VectorN::Dot(const VectorN& rhs) const

--- a/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
@@ -161,23 +161,12 @@ namespace UnitTest
             }
         }
 
-        AZ::MatrixMxN extraMatrix1 = testMatrix; // Need a useless temporary because clang errors/warns over self assignment [-Wself-assign-overloaded]
-        testMatrix *= extraMatrix1;
+        testMatrix *= 2.0f;
         for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
         {
             for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
             {
                 EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 4.0f);
-            }
-        }
-
-        AZ::MatrixMxN extraMatrix2 = testMatrix;
-        testMatrix /= extraMatrix2;
-        for (AZStd::size_t rowIter = 0; rowIter < testMatrix.GetRowCount(); ++rowIter)
-        {
-            for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
-            {
-                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 1.0f);
             }
         }
 

--- a/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixMxNTests.cpp
@@ -175,7 +175,7 @@ namespace UnitTest
         {
             for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
             {
-                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 8.0f);
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), 11.0f);
             }
         }
 
@@ -184,7 +184,7 @@ namespace UnitTest
         {
             for (AZStd::size_t colIter = 0; colIter < testMatrix.GetColumnCount(); ++colIter)
             {
-                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), -4.0f);
+                EXPECT_FLOAT_EQ(testMatrix.GetElement(rowIter, colIter), -1.0f);
             }
         }
     }
@@ -376,7 +376,6 @@ namespace UnitTest
         }
     }
 
-
     TEST_F(Math_MatrixMxN, TestMatrixMatrixMultiply)
     {
         // 5 x 7
@@ -411,8 +410,8 @@ namespace UnitTest
              84.0f,  88.0f, 112.0f,  86.0f, 110.0f, 104.0f,
         };
 
-        const AZ::MatrixMxN lhs = AZ::MatrixMxN::CreateFromPackedFloats(5, 7, lhsElements);
-        const AZ::MatrixMxN rhs = AZ::MatrixMxN::CreateFromPackedFloats(7, 6, rhsElements);
+        AZ::MatrixMxN lhs = AZ::MatrixMxN::CreateFromPackedFloats(5, 7, lhsElements);
+        AZ::MatrixMxN rhs = AZ::MatrixMxN::CreateFromPackedFloats(7, 6, rhsElements);
 
         AZ::MatrixMxN output = AZ::MatrixMxN::CreateZero(5, 6);
         AZ::MatrixMatrixMultiply(lhs, rhs, output);
@@ -423,6 +422,17 @@ namespace UnitTest
             for (AZStd::size_t colIter = 0; colIter < output.GetColumnCount(); ++colIter)
             {
                 EXPECT_FLOAT_EQ(output.GetElement(rowIter, colIter), *checkResult);
+                ++checkResult;
+            }
+        }
+
+        AZ::MatrixMxN result = lhs * rhs;
+        checkResult = outputElements;
+        for (AZStd::size_t rowIter = 0; rowIter < result.GetRowCount(); ++rowIter)
+        {
+            for (AZStd::size_t colIter = 0; colIter < result.GetColumnCount(); ++colIter)
+            {
+                EXPECT_FLOAT_EQ(result.GetElement(rowIter, colIter), *checkResult);
                 ++checkResult;
             }
         }

--- a/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
+++ b/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
@@ -1,0 +1,1 @@
+AzNetworking/AutoGen/AutoPacketDispatcher_Header.jinja;AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Header.jinja;AzNetworking/AutoGen/AutoPackets_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Source.jinja;AzNetworking/AutoGen/CorePackets.AutoPackets.xml

--- a/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
+++ b/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
@@ -1,1 +1,0 @@
-AzNetworking/AutoGen/AutoPacketDispatcher_Header.jinja;AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Header.jinja;AzNetworking/AutoGen/AutoPackets_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Source.jinja;AzNetworking/AutoGen/CorePackets.AutoPackets.xml

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetColumnCount.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetColumnCount.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_GetColumnCount",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Column Count"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_GetColumnCount",
+                    "details": {
+                        "name": "Get Column Count"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Column"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetElement.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetElement.names
@@ -1,0 +1,48 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_GetElement",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Element"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_GetElement",
+                    "details": {
+                        "name": "Get Element"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Row"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Column"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetRowCount.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_GetRowCount.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_GetRowCount",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Row Count"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_GetRowCount",
+                    "details": {
+                        "name": "Get Row Count"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_MultiplyByMatrix.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_MultiplyByMatrix.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_MultiplyByMatrix",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Multiply By Matrix"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_MultiplyByMatrix",
+                    "details": {
+                        "name": "Multiply By Matrix"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Vector"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Matrix MxN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_MultiplyByVector.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_MultiplyByVector.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_MultiplyByVector",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Multiply By Vector"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_MultiplyByVector",
+                    "details": {
+                        "name": "Multiply By Vector"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Vector"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Random.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Random.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_Random",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Random"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_Random",
+                    "details": {
+                        "name": "Random"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Rows"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Columns"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Matrix MxN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Transpose.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Transpose.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_Transpose",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Transpose"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_Transpose",
+                    "details": {
+                        "name": "Transpose"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Matrix MxN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Zero.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_MatrixMxNFunctions_Zero.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_MatrixMxNFunctions_Zero",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Zero"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_MatrixMxNFunctions_Zero",
+                    "details": {
+                        "name": "Zero"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Rows"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Columns"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{B751D885-87D0-40BF-A6B3-48EFF0147AFA}",
+                            "details": {
+                                "name": "Matrix MxN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Absolute.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Absolute.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Absolute",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Absolute"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Absolute",
+                    "details": {
+                        "name": "Absolute"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Dot.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Dot.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Dot",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Dot"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Dot",
+                    "details": {
+                        "name": "Dot"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "A"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "B"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetClamp.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetClamp.names
@@ -1,0 +1,48 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_GetClamp",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Clamp"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_GetClamp",
+                    "details": {
+                        "name": "Get Clamp"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Min"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Max"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetDimensionality.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetDimensionality.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_GetDimensionality",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Dimensionality"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_GetDimensionality",
+                    "details": {
+                        "name": "Get Dimensionality"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetElement.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetElement.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_GetElement",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Element"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_GetElement",
+                    "details": {
+                        "name": "Get Element"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Index"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetMax.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetMax.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_GetMax",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Max"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_GetMax",
+                    "details": {
+                        "name": "Get Max"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "A"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "B"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetMin.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_GetMin.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_GetMin",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Get Min"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_GetMin",
+                    "details": {
+                        "name": "Get Min"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "A"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "B"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_IsClose.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_IsClose.names
@@ -1,0 +1,48 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_IsClose",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Is Close"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_IsClose",
+                    "details": {
+                        "name": "Is Close"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "A"
+                            }
+                        },
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "B"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Tolerance"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "bool"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_IsZero.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_IsZero.names
@@ -1,0 +1,42 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_IsZero",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Is Zero"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_IsZero",
+                    "details": {
+                        "name": "Is Zero"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Tolerance"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "bool"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Length.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Length.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Length",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Length"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Length",
+                    "details": {
+                        "name": "Length"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_LengthSquared.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_LengthSquared.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_LengthSquared",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Length Squared"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_LengthSquared",
+                    "details": {
+                        "name": "Length Squared"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "double"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Normalize.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Normalize.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Normalize",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Normalize"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Normalize",
+                    "details": {
+                        "name": "Normalize"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_One.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_One.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_One",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "One"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_One",
+                    "details": {
+                        "name": "One"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Size"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Random.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Random.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Random",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Random"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Random",
+                    "details": {
+                        "name": "Random"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Size"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_ReLU.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_ReLU.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_ReLU",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "ReLU"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_ReLU",
+                    "details": {
+                        "name": "ReLU"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Square.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Square.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Square",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Square"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Square",
+                    "details": {
+                        "name": "Square"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "Source"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Zero.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_VectorNFunctions_Zero.names
@@ -1,0 +1,36 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_VectorNFunctions_Zero",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Zero"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_VectorNFunctions_Zero",
+                    "details": {
+                        "name": "Zero"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Size"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3C5A461A-3412-4D97-9CBC-856EE737B6DB}",
+                            "details": {
+                                "name": "VectorN"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
@@ -136,6 +136,9 @@ namespace ScriptCanvas
             case eType::Matrix4x4:
                 return eTraits<eType::Matrix4x4>::GetName();
 
+            case eType::MatrixMxN:
+                return eTraits<eType::MatrixMxN>::GetName();
+
             case eType::Number:
                 return eTraits<eType::Number>::GetName();
 
@@ -162,6 +165,9 @@ namespace ScriptCanvas
 
             case eType::Vector4:
                 return eTraits<eType::Vector4>::GetName();
+
+            case eType::VectorN:
+                return eTraits<eType::VectorN>::GetName();
 
             default:
                 AZ_Assert(false, "Invalid type!");

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataMacros.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataMacros.h
@@ -20,6 +20,7 @@
     MACRO(Color)\
     MACRO(Matrix3x3)\
     MACRO(Matrix4x4)\
+    MACRO(MatrixMxN)\
     MACRO(OBB)\
     MACRO(Plane)\
     MACRO(Quaternion)\
@@ -27,6 +28,7 @@
     MACRO(Vector2)\
     MACRO(Vector3)\
     MACRO(Vector4)\
+    MACRO(VectorN)\
     MACRO(AssetId)
 
 #define SCRIPT_CANVAS_PER_DATA_TYPE_1(MACRO, EXPOSE_TYPE)\
@@ -39,6 +41,7 @@
     MACRO(Color, EXPOSE_TYPE)\
     MACRO(Matrix3x3, EXPOSE_TYPE)\
     MACRO(Matrix4x4, EXPOSE_TYPE)\
+    MACRO(MatrixMxN, EXPOSE_TYPE)\
     MACRO(OBB, EXPOSE_TYPE)\
     MACRO(Plane, EXPOSE_TYPE)\
     MACRO(Quaternion, EXPOSE_TYPE)\
@@ -46,4 +49,5 @@
     MACRO(Vector2, EXPOSE_TYPE)\
     MACRO(Vector3, EXPOSE_TYPE)\
     MACRO(Vector4, EXPOSE_TYPE)\
+    MACRO(VectorN, EXPOSE_TYPE)\
     MACRO(AssetId, EXPOSE_TYPE)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
@@ -230,7 +230,7 @@ namespace ScriptCanvas
             static Data::Type GetSCType(const AZ::TypeId & = AZ::TypeId::CreateNull()) { return Data::Type::MatrixMxN(); }
             static AZStd::string GetName(const Data::Type & = {}) { return "MatrixMxN"; }
             static Type GetDefault(const Data::Type & = {}) { return MatrixMxNType::CreateZero(0, 0); }
-            static bool IsDefault(const Type&, const Data::Type& = {}) { false; }
+            static bool IsDefault(const Type&, const Data::Type& = {}) { return false; }
         };
 
         template<>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTrait.h
@@ -219,6 +219,21 @@ namespace ScriptCanvas
         };
 
         template<>
+        struct Traits<MatrixMxNType> : public TraitsBase<MatrixMxNType>
+        {
+            using Type = MatrixMxNType;
+            static const bool s_isAutoBoxed = false;
+            static const bool s_isNative = true;
+            static const eType s_type = eType::MatrixMxN;
+
+            static AZ::Uuid GetAZType(const Data::Type & = {}) { return azrtti_typeid<MatrixMxNType>(); }
+            static Data::Type GetSCType(const AZ::TypeId & = AZ::TypeId::CreateNull()) { return Data::Type::MatrixMxN(); }
+            static AZStd::string GetName(const Data::Type & = {}) { return "MatrixMxN"; }
+            static Type GetDefault(const Data::Type & = {}) { return MatrixMxNType::CreateZero(0, 0); }
+            static bool IsDefault(const Type&, const Data::Type& = {}) { false; }
+        };
+
+        template<>
         struct Traits<NumberType> : public TraitsBase<NumberType>
         {
             using Type = NumberType;
@@ -362,6 +377,21 @@ namespace ScriptCanvas
             static bool IsDefault(const Type& value, const Data::Type& = {}) { return value == GetDefault(); }
         };
 
+        template<>
+        struct Traits<VectorNType> : public TraitsBase<VectorNType>
+        {
+            using Type = VectorNType;
+            static const bool s_isAutoBoxed = false;
+            static const bool s_isNative = true;
+            static const eType s_type = eType::VectorN;
+
+            static AZ::Uuid GetAZType(const Data::Type & = {}) { return azrtti_typeid<VectorNType>(); }
+            static Data::Type GetSCType(const AZ::TypeId & = AZ::TypeId::CreateNull()) { return Data::Type::VectorN(); }
+            static AZStd::string GetName(const Data::Type & = {}) { return "VectorN"; }
+            static Type GetDefault(const Data::Type & = {}) { return VectorNType::CreateZero(0); }
+            static bool IsDefault(const Type&, const Data::Type& = {}) { return false; }
+        };
+
         /*template<>
         struct Traits<AzFramework::SliceInstantiationTicket> : public TraitsBase<AzFramework::SliceInstantiationTicket>
         {
@@ -446,6 +476,9 @@ namespace ScriptCanvas
         struct eTraits<eType::Matrix4x4> : Traits<Matrix4x4Type> {};
 
         template<>
+        struct eTraits<eType::MatrixMxN> : Traits<MatrixMxNType> {};
+
+        template<>
         struct eTraits<eType::Number> : Traits<NumberType> {};
 
         template<>
@@ -472,5 +505,7 @@ namespace ScriptCanvas
         template<>
         struct eTraits<eType::Vector4> : Traits<Vector4Type> {};
 
-    } 
+        template<>
+        struct eTraits<eType::VectorN> : Traits<VectorNType> {};
+    }
 } 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.cpp
@@ -100,6 +100,11 @@ namespace ScriptCanvas
             return Type(eType::Matrix4x4);
         }
 
+        Type Type::MatrixMxN()
+        {
+            return Type(eType::MatrixMxN);
+        }
+
         Type Type::Number()
         {
             return Type(eType::Number);
@@ -143,6 +148,11 @@ namespace ScriptCanvas
         Type Type::Vector4()
         {
             return Type(eType::Vector4);
+        }
+
+        Type Type::VectorN()
+        {
+            return Type(eType::VectorN);
         }
 
         AZ::Uuid Type::GetAZType() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.h
@@ -59,7 +59,10 @@ namespace ScriptCanvas
             // List,
             AssetId,
             VectorN,
-            MatrixMxN
+            MatrixMxN,
+            
+            // Add any new types above this. This is used to provide a count of all the types defined.
+            Count
         };
 
         using AABBType = AZ::Aabb;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataType.h
@@ -16,6 +16,7 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/MatrixMxN.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Plane.h>
 #include <AzCore/Math/Quaternion.h>
@@ -24,6 +25,7 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/VectorN.h>
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/std/string/string.h>
 
@@ -56,6 +58,8 @@ namespace ScriptCanvas
             // Function,
             // List,
             AssetId,
+            VectorN,
+            MatrixMxN
         };
 
         using AABBType = AZ::Aabb;
@@ -67,6 +71,7 @@ namespace ScriptCanvas
         using NamedEntityIDType = AZ::NamedEntityId;
         using Matrix3x3Type = AZ::Matrix3x3;
         using Matrix4x4Type = AZ::Matrix4x4;
+        using MatrixMxNType = AZ::MatrixMxN;
         using NumberType = double;
         using OBBType = AZ::Obb;
         using PlaneType = AZ::Plane;
@@ -76,6 +81,7 @@ namespace ScriptCanvas
         using Vector2Type = AZ::Vector2;
         using Vector3Type = AZ::Vector3;
         using Vector4Type = AZ::Vector4;
+        using VectorNType = AZ::VectorN;
 
         class Type final
         {
@@ -95,6 +101,7 @@ namespace ScriptCanvas
             static Type Invalid();
             static Type Matrix3x3();
             static Type Matrix4x4();
+            static Type MatrixMxN();
             static Type Number();
             static Type OBB();
             static Type Plane();
@@ -104,6 +111,7 @@ namespace ScriptCanvas
             static Type Vector2();
             static Type Vector3();
             static Type Vector4();
+            static Type VectorN();
 
             // the default ctr produces the invalid type, and is only here to help the compiler
             Type();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
@@ -72,6 +72,10 @@ namespace ScriptCanvas
             {
                 return { true, Type::Matrix4x4() };
             }
+            else if (IsMatrixMxN(type))
+            {
+                return { true, Type::MatrixMxN() };
+            }
             else if (IsNumber(type))
             {
                 return { true, Type::Number() };
@@ -107,6 +111,10 @@ namespace ScriptCanvas
             else if (IsVector4(type))
             {
                 return { true, Type::Vector4() };
+            }
+            else if (IsVectorN(type))
+            {
+                return { true, Type::VectorN() };
             }
             else
             {
@@ -148,6 +156,9 @@ namespace ScriptCanvas
             case eType::Matrix4x4:
                 return azrtti_typeid<AZ::Matrix4x4>();
 
+            case eType::MatrixMxN:
+                return azrtti_typeid<AZ::MatrixMxN>();
+
             case eType::Number:
                 return azrtti_typeid<NumberType>();
 
@@ -174,6 +185,9 @@ namespace ScriptCanvas
 
             case eType::Vector4:
                 return azrtti_typeid<AZ::Vector4>();
+
+            case eType::VectorN:
+                return azrtti_typeid<AZ::VectorN>();
 
             default:
                 AZ_Assert(false, "Invalid type!");
@@ -309,6 +323,16 @@ namespace ScriptCanvas
             return type.GetType() == eType::Matrix4x4;
         }
 
+        bool IsMatrixMxN(const AZ::Uuid& type)
+        {
+            return type == azrtti_typeid<AZ::MatrixMxN>();
+        }
+
+        bool IsMatrixMxN(const Type& type)
+        {
+            return type.GetType() == eType::MatrixMxN;
+        }
+
         bool IsNumber(const AZ::Uuid& type)
         {
             return type == azrtti_typeid<AZ::s8>() || type == azrtti_typeid<AZ::s16>() || type == azrtti_typeid<AZ::s32>() ||
@@ -402,9 +426,19 @@ namespace ScriptCanvas
             return type.GetType() == eType::Vector4;
         }
 
+        bool IsVectorN(const AZ::Uuid& type)
+        {
+            return type == azrtti_typeid<AZ::VectorN>();
+        }
+
+        bool IsVectorN(const Type& type)
+        {
+            return type.GetType() == eType::VectorN;
+        }
+
         bool IsVectorType(const AZ::Uuid& type)
         {
-            return type == azrtti_typeid<AZ::Vector3>() || type == azrtti_typeid<AZ::Vector2>() || type == azrtti_typeid<AZ::Vector4>();
+            return type == azrtti_typeid<AZ::Vector3>() || type == azrtti_typeid<AZ::Vector2>() || type == azrtti_typeid<AZ::Vector4>() || type == azrtti_typeid<AZ::VectorN>();
         }
 
         bool IsVectorType(const Type& type)
@@ -412,7 +446,8 @@ namespace ScriptCanvas
             static const AZ::u32 s_vectorTypes = {
                 1 << static_cast<AZ::u32>(eType::Vector3) |
                 1 << static_cast<AZ::u32>(eType::Vector2) |
-                1 << static_cast<AZ::u32>(eType::Vector4)
+                1 << static_cast<AZ::u32>(eType::Vector4) |
+                1 << static_cast<AZ::u32>(eType::VectorN)
             };
 
             return ((1 << static_cast<AZ::u32>(type.GetType())) & s_vectorTypes) != 0;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
@@ -456,11 +456,17 @@ namespace ScriptCanvas
         bool IsAutoBoxedType(const Type& type)
         {
             static const AZ::u32 s_autoBoxedTypes = {
-                1 << static_cast<AZ::u32>(eType::AABB) | 1 << static_cast<AZ::u32>(eType::Color) |
-                1 << static_cast<AZ::u32>(eType::CRC) | 1 << static_cast<AZ::u32>(eType::Matrix3x3) |
-                1 << static_cast<AZ::u32>(eType::Matrix4x4) | 1 << static_cast<AZ::u32>(eType::OBB) |
-                1 << static_cast<AZ::u32>(eType::Quaternion) | 1 << static_cast<AZ::u32>(eType::Transform) |
-                1 << static_cast<AZ::u32>(eType::Vector2) | 1 << static_cast<AZ::u32>(eType::Vector3) | 1 << static_cast<AZ::u32>(eType::Vector4)
+                1 << static_cast<AZ::u32>(eType::AABB) |
+                1 << static_cast<AZ::u32>(eType::Color) |
+                1 << static_cast<AZ::u32>(eType::CRC) |
+                1 << static_cast<AZ::u32>(eType::Matrix3x3) |
+                1 << static_cast<AZ::u32>(eType::Matrix4x4) |
+                1 << static_cast<AZ::u32>(eType::OBB) |
+                1 << static_cast<AZ::u32>(eType::Quaternion) |
+                1 << static_cast<AZ::u32>(eType::Transform) |
+                1 << static_cast<AZ::u32>(eType::Vector2) |
+                1 << static_cast<AZ::u32>(eType::Vector3) |
+                1 << static_cast<AZ::u32>(eType::Vector4)
             };
 
             return ((1 << static_cast<AZ::u32>(type.GetType())) & s_autoBoxedTypes) != 0;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.h
@@ -51,6 +51,8 @@ namespace ScriptCanvas
         bool IsMatrix3x3(const Type& type);
         bool IsMatrix4x4(const AZ::Uuid& type);
         bool IsMatrix4x4(const Type& type);
+        bool IsMatrixMxN(const AZ::Uuid& type);
+        bool IsMatrixMxN(const Type& type);
         bool IsOBB(const AZ::Uuid& type);
         bool IsOBB(const Type& type);
         bool IsPlane(const AZ::Uuid& type);
@@ -67,6 +69,8 @@ namespace ScriptCanvas
         bool IsVector3(const Type& type);
         bool IsVector4(const AZ::Uuid& type);
         bool IsVector4(const Type& type);
+        bool IsVectorN(const AZ::Uuid& type);
+        bool IsVectorN(const Type& type);
 
         bool IsVectorType(const AZ::Uuid& type);
         bool IsVectorType(const Type& type);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.ScriptCanvasFunction.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptCanvas>
+    <Library
+        Include="Include/ScriptCanvas/Libraries/Math/MatrixMxN.h"
+        Namespace="ScriptCanvas::MatrixMxNFunctions"
+        Category="Math/MatrixMxN">
+
+        <Function Name="Zero">
+            <Parameter Name="Rows"/>
+            <Parameter Name="Columns"/>
+        </Function>
+
+        <Function Name="Random">
+            <Parameter Name="Rows"/>
+            <Parameter Name="Columns"/>
+        </Function>
+
+        <Function Name="GetRowCount">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="GetColumnCount">
+            <Parameter Name="Column"/>
+        </Function>
+        
+        <Function Name="GetElement">
+            <Parameter Name="Source"/>
+            <Parameter Name="Row"/>
+            <Parameter Name="Column"/>
+        </Function>
+
+        <Function Name="Transpose">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="MultiplyByVector">
+            <Parameter Name="Source"/>
+            <Parameter Name="Vector"/>
+        </Function>
+
+        <Function Name="MultiplyByMatrix">
+            <Parameter Name="Source"/>
+            <Parameter Name="Vector"/>
+        </Function>
+    </Library>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MatrixMxN.h"
+
+namespace ScriptCanvas
+{
+    namespace MatrixMxNFunctions
+    {
+        Data::MatrixMxNType Zero(Data::NumberType rows, Data::NumberType cols)
+        {
+            return Data::MatrixMxNType::CreateZero(aznumeric_cast<AZStd::size_t>(rows), aznumeric_cast<AZStd::size_t>(cols));
+        }
+
+        Data::MatrixMxNType Random(Data::NumberType rows, Data::NumberType cols)
+        {
+            return Data::MatrixMxNType::CreateRandom(aznumeric_cast<AZStd::size_t>(rows), aznumeric_cast<AZStd::size_t>(cols));
+        }
+
+        Data::NumberType GetRowCount(const Data::MatrixMxNType& source)
+        {
+            return static_cast<Data::NumberType>(source.GetRowCount());
+        }
+
+        Data::NumberType GetColumnCount(const Data::MatrixMxNType& source)
+        {
+            return static_cast<Data::NumberType>(source.GetColumnCount());
+        }
+
+        Data::NumberType GetElement(const Data::MatrixMxNType& source, Data::NumberType row, Data::NumberType col)
+        {
+            const auto rowIndex = aznumeric_cast<AZStd::size_t>(row);
+            const auto colIndex = aznumeric_cast<AZStd::size_t>(col);
+            return rowIndex < source.GetRowCount()
+                && colIndex < source.GetColumnCount() ? source.GetElement(rowIndex, colIndex) : Data::NumberType();
+        }
+
+        Data::MatrixMxNType Transpose(const Data::MatrixMxNType& source)
+        {
+            return source.GetTranspose();
+        }
+
+        Data::VectorNType MultiplyByVector(const Data::MatrixMxNType& lhs, const Data::VectorNType& rhs)
+        {
+            if (rhs.GetDimensionality() == lhs.GetColumnCount())
+            {
+                Data::VectorNType result(lhs.GetRowCount());
+                AZ::VectorMatrixMultiply(lhs, rhs, result);
+                return result;
+            }
+            return Data::VectorNType(0);
+        }
+
+        Data::MatrixMxNType MultiplyByMatrix(const Data::MatrixMxNType& lhs, const Data::MatrixMxNType& rhs)
+        {
+            if (lhs.GetColumnCount() == rhs.GetRowCount())
+            {
+                Data::MatrixMxNType result(lhs.GetRowCount(), rhs.GetColumnCount());
+                AZ::MatrixMatrixMultiply(lhs, rhs, result);
+                return result;
+            }
+            return Data::MatrixMxNType(0, 0);
+        }
+    } // namespace MatrixMxNFunctions
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MatrixMxN.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/tuple.h>
+#include <ScriptCanvas/Data/NumericData.h>
+
+namespace ScriptCanvas
+{
+    namespace MatrixMxNFunctions
+    {
+        Data::MatrixMxNType Zero(Data::NumberType rows, Data::NumberType cols);
+
+        Data::MatrixMxNType Random(Data::NumberType rows, Data::NumberType cols);
+
+        Data::NumberType GetRowCount(const Data::MatrixMxNType& source);
+
+        Data::NumberType GetColumnCount(const Data::MatrixMxNType& source);
+
+        Data::NumberType GetElement(const Data::MatrixMxNType& source, Data::NumberType row, Data::NumberType col);
+
+        Data::MatrixMxNType Transpose(const Data::MatrixMxNType& source);
+
+        Data::VectorNType MultiplyByVector(const Data::MatrixMxNType& lhs, const Data::VectorNType& rhs);
+
+        Data::MatrixMxNType MultiplyByMatrix(const Data::MatrixMxNType& lhs, const Data::MatrixMxNType& rhs);
+    } // namespace MatrixMxNFunctions
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.ScriptCanvasFunction.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptCanvas>
+    <Library
+        Include="Include/ScriptCanvas/Libraries/Math/VectorN.h"
+        Namespace="ScriptCanvas::VectorNFunctions"
+        Category="Math/VectorN">
+
+        <Function Name="Zero">
+            <Parameter Name="Size"/>
+        </Function>
+
+        <Function Name="One">
+            <Parameter Name="Size"/>
+        </Function>
+
+        <Function Name="Random">
+            <Parameter Name="Size"/>
+        </Function>
+
+        <Function Name="GetDimensionality">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="GetElement">
+            <Parameter Name="Source"/>
+            <Parameter Name="Index"/>
+        </Function>
+
+        <Function Name="IsClose">
+            <Parameter Name="A"/>
+            <Parameter Name="B"/>
+            <Parameter Name="Tolerance" DefaultValue="0.01"/>
+        </Function>
+
+        <Function Name="IsZero">
+            <Parameter Name="Source"/>
+            <Parameter Name="Tolerance" DefaultValue="Data::ToleranceEpsilon()"/>
+        </Function>
+
+        <Function Name="ReLU">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="GetMin">
+            <Parameter Name="A"/>
+            <Parameter Name="B"/>
+        </Function>
+
+        <Function Name="GetMax">
+            <Parameter Name="A"/>
+            <Parameter Name="B"/>
+        </Function>
+
+        <Function Name="GetClamp">
+            <Parameter Name="Source"/>
+            <Parameter Name="Min"/>
+            <Parameter Name="Max"/>
+        </Function>
+
+        <Function Name="LengthSquared">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="Length">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="Normalize">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="Absolute">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="Square">
+            <Parameter Name="Source"/>
+        </Function>
+
+        <Function Name="Dot">
+            <Parameter Name="A"/>
+            <Parameter Name="B"/>
+        </Function>
+    </Library>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "Vector4.h"
+
+namespace ScriptCanvas
+{
+    namespace VectorNFunctions
+    {
+        Data::VectorNType Zero(Data::NumberType size)
+        {
+            return Data::VectorNType::CreateZero(aznumeric_cast<AZStd::size_t>(size));
+        }
+
+        Data::VectorNType One(Data::NumberType size)
+        {
+            return Data::VectorNType::CreateOne(aznumeric_cast<AZStd::size_t>(size));
+        }
+
+        Data::VectorNType Random(Data::NumberType size)
+        {
+            return Data::VectorNType::CreateRandom(aznumeric_cast<AZStd::size_t>(size));
+        }
+
+        Data::NumberType GetDimensionality(const Data::VectorNType& source)
+        {
+            return static_cast<Data::NumberType>(source.GetDimensionality());
+        }
+
+        Data::NumberType GetElement(const Data::VectorNType& source, const Data::NumberType index)
+        {
+            return source.GetElement(AZ::GetClamp<AZStd::size_t>(aznumeric_cast<AZStd::size_t>(index), 0, source.GetDimensionality() - 1));
+        }
+
+        Data::BooleanType IsClose(const Data::VectorNType& a, const Data::VectorNType& b, Data::NumberType tolerance)
+        {
+            return a.IsClose(b, aznumeric_cast<float>(tolerance));
+        }
+
+        Data::BooleanType IsZero(const Data::VectorNType& source, Data::NumberType tolerance)
+        {
+            return source.IsZero(aznumeric_cast<float>(tolerance));
+        }
+
+        Data::VectorNType& ReLU(Data::VectorNType& source)
+        {
+            source.ReLU();
+            return source;
+        }
+
+        Data::VectorNType GetMin(const Data::VectorNType& a, const Data::VectorNType& b)
+        {
+            if (a.GetDimensionality() == b.GetDimensionality())
+            {
+                return a.GetMin(b);
+            }
+            return Data::VectorNType(0);
+        }
+
+        Data::VectorNType GetMax(const Data::VectorNType& a, const Data::VectorNType& b)
+        {
+            if (a.GetDimensionality() == b.GetDimensionality())
+            {
+                return a.GetMax(b);
+            }
+            return Data::VectorNType(0);
+        }
+
+        Data::VectorNType GetClamp(const Data::VectorNType& source, const Data::VectorNType& min, const Data::VectorNType& max)
+        {
+            if (source.GetDimensionality() == min.GetDimensionality() && source.GetDimensionality() == max.GetDimensionality())
+            {
+                return source.GetClamp(min, max);
+            }
+            return Data::VectorNType(0);
+        }
+
+        Data::NumberType LengthSquared(const Data::VectorNType& source)
+        {
+            return source.GetLengthSq();
+        }
+
+        Data::NumberType Length(const Data::VectorNType& source)
+        {
+            return source.GetLength();
+        }
+
+        Data::VectorNType& Normalize(Data::VectorNType& source)
+        {
+            source.Normalize();
+            return source;
+        }
+
+        Data::VectorNType& Absolute(Data::VectorNType& source)
+        {
+            source.Absolute();
+            return source;
+        }
+
+        Data::VectorNType& Square(Data::VectorNType& source)
+        {
+            source.Square();
+            return source;
+        }
+
+        Data::NumberType Dot(const Data::VectorNType& lhs, const Data::VectorNType& rhs)
+        {
+            return lhs.Dot(rhs);
+        }
+    } // namespace VectorNFunctions
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/VectorN.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/tuple.h>
+#include <ScriptCanvas/Data/NumericData.h>
+
+namespace ScriptCanvas
+{
+    namespace VectorNFunctions
+    {
+        Data::VectorNType Zero(Data::NumberType size);
+
+        Data::VectorNType One(Data::NumberType size);
+
+        Data::VectorNType Random(Data::NumberType size);
+
+        Data::NumberType GetDimensionality(const Data::VectorNType& source);
+
+        Data::NumberType GetElement(const Data::VectorNType& source, const Data::NumberType index);
+
+        Data::BooleanType IsClose(const Data::VectorNType& a, const Data::VectorNType& b, Data::NumberType tolerance);
+
+        Data::BooleanType IsZero(const Data::VectorNType& source, Data::NumberType tolerance);
+
+        Data::VectorNType& ReLU(Data::VectorNType& source);
+
+        Data::VectorNType GetMin(const Data::VectorNType& a, const Data::VectorNType& b);
+
+        Data::VectorNType GetMax(const Data::VectorNType& a, const Data::VectorNType& b);
+
+        Data::VectorNType GetClamp(const Data::VectorNType& source, const Data::VectorNType& min, const Data::VectorNType& max);
+
+        Data::NumberType LengthSquared(const Data::VectorNType& source);
+
+        Data::NumberType Length(const Data::VectorNType& source);
+
+        Data::VectorNType& Normalize(Data::VectorNType& source);
+
+        Data::VectorNType& Absolute(Data::VectorNType& source);
+
+        Data::VectorNType& Square(Data::VectorNType& source);
+
+        Data::NumberType Dot(const Data::VectorNType& lhs, const Data::VectorNType& rhs);
+    } // namespace VectorNFunctions
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.cpp
@@ -94,6 +94,9 @@ namespace ScriptCanvas
                 case Data::eType::Vector4:
                     OperatorEvaluator::Evaluate<Data::Vector4Type>(OperatorAddImpl<Data::Vector4Type>(), operands, result);
                     break;
+                case Data::eType::VectorN:
+                    OperatorEvaluator::Evaluate<Data::VectorNType>(OperatorAddImpl<Data::VectorNType>(), operands, result);
+                    break;
                 case Data::eType::String:
                     OperatorEvaluator::Evaluate<Data::StringType>(OperatorAddImpl<Data::StringType>(), operands, result);
                     break;
@@ -109,6 +112,9 @@ namespace ScriptCanvas
                 case Data::eType::Matrix4x4:
                     OperatorEvaluator::Evaluate<Data::Matrix4x4Type>(OperatorAddImpl<Data::Matrix4x4Type>(), operands, result);
                     break;
+                case Data::eType::MatrixMxN:
+                    OperatorEvaluator::Evaluate<Data::MatrixMxNType>(OperatorAddImpl<Data::MatrixMxNType>(), operands, result);
+                    break;
                 default:
                     AZ_Assert(false, "Addition operator not defined for type: %s", Data::ToAZType(type).ToString<AZStd::string>().c_str());
                     break;
@@ -122,11 +128,13 @@ namespace ScriptCanvas
                     Data::Type::Vector2(),
                     Data::Type::Vector3(),
                     Data::Type::Vector4(),
+                    Data::Type::VectorN(),
                     Data::Type::Color(),
                     Data::Type::Quaternion(),
                     Data::Type::AABB(),
                     Data::Type::Matrix3x3(),
-                    Data::Type::Matrix4x4()
+                    Data::Type::Matrix4x4(),
+                    Data::Type::MatrixMxN()
                 };
             }
 
@@ -148,6 +156,8 @@ namespace ScriptCanvas
                         return !datum->GetAs<Data::Matrix3x3Type>()->IsClose(Data::Matrix3x3Type::CreateIdentity());
                     case Data::eType::Matrix4x4:
                         return !datum->GetAs<Data::Matrix4x4Type>()->IsClose(Data::Matrix4x4Type::CreateIdentity());
+                    case Data::eType::MatrixMxN:
+                        return true;
                     default:
                         break;
                     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.h
@@ -54,11 +54,13 @@ namespace ScriptCanvas
                         Data::Type::Vector2(),
                         Data::Type::Vector3(),
                         Data::Type::Vector4(),
+                        Data::Type::VectorN(),
                         Data::Type::Color(),
                         Data::Type::Quaternion(),
                         Data::Type::Transform(),
                         Data::Type::Matrix3x3(),
-                        Data::Type::Matrix4x4()
+                        Data::Type::Matrix4x4(),
+                        Data::Type::MatrixMxN()
                     };
                 }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.cpp
@@ -113,7 +113,7 @@ namespace ScriptCanvas
                 Data::VectorNType operator()(const Data::VectorNType& a, const Datum& b)
                 {
                     const Data::VectorNType* divisor = b.GetAs<Data::VectorNType>();
-                    if (divisor->IsZero())
+                    if (!divisor || divisor->IsZero())
                     {
                         // Divide by zero
                         SCRIPTCANVAS_REPORT_ERROR((*m_node), "Divide by Zero");

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.cpp
@@ -104,6 +104,30 @@ namespace ScriptCanvas
             };
 
             template <>
+            struct OperatorDivImpl<Data::VectorNType>
+            {
+                OperatorDivImpl(Node* node)
+                    : m_node(node)
+                {}
+
+                Data::VectorNType operator()(const Data::VectorNType& a, const Datum& b)
+                {
+                    const Data::VectorNType* divisor = b.GetAs<Data::VectorNType>();
+                    if (divisor->IsZero())
+                    {
+                        // Divide by zero
+                        SCRIPTCANVAS_REPORT_ERROR((*m_node), "Divide by Zero");
+                        return Data::VectorNType(0);
+                    }
+
+                    return a / (*divisor);
+                }
+
+            private:
+                Node* m_node;
+            };
+
+            template <>
             struct OperatorDivImpl<Data::ColorType>
             {
                 OperatorDivImpl(Node* node)
@@ -174,6 +198,7 @@ namespace ScriptCanvas
                     Data::Type::Vector2(),
                     Data::Type::Vector3(),
                     Data::Type::Vector4(),
+                    Data::Type::VectorN()
                 };
             }
 
@@ -192,6 +217,9 @@ namespace ScriptCanvas
                     break;
                 case Data::eType::Vector4:
                     OperatorEvaluator::Evaluate<Data::Vector4Type>(OperatorDivImpl<Data::Vector4Type>(this), operands, result);
+                    break;
+                case Data::eType::VectorN:
+                    OperatorEvaluator::Evaluate<Data::VectorNType>(OperatorDivImpl<Data::VectorNType>(this), operands, result);
                     break;
                 default:
                     AZ_Assert(false, "Division operator not defined for type: %s", Data::ToAZType(type).ToString<AZStd::string>().c_str());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.cpp
@@ -52,9 +52,11 @@ namespace ScriptCanvas
                     Data::Type::Transform(),
                     Data::Type::Matrix3x3(),
                     Data::Type::Matrix4x4(),
+                    Data::Type::MatrixMxN(),
                     Data::Type::Vector2(),
                     Data::Type::Vector3(),
                     Data::Type::Vector4(),
+                    Data::Type::VectorN(),
                     Data::Type::Color()
                 };
             }
@@ -80,6 +82,9 @@ namespace ScriptCanvas
                 case Data::eType::Matrix4x4:
                     OperatorEvaluator::Evaluate<Data::Matrix4x4Type>(OperatorMulImpl<Data::Matrix4x4Type>(), operands, result);
                     break;
+                case Data::eType::MatrixMxN:
+                    OperatorEvaluator::Evaluate<Data::MatrixMxNType>(OperatorMulImpl<Data::MatrixMxNType>(), operands, result);
+                    break;
                 case Data::eType::Vector2:
                     OperatorEvaluator::Evaluate<Data::Vector2Type>(OperatorMulImpl<Data::Vector2Type>(), operands, result);
                     break;
@@ -88,6 +93,9 @@ namespace ScriptCanvas
                     break;
                 case Data::eType::Vector4:
                     OperatorEvaluator::Evaluate<Data::Vector4Type>(OperatorMulImpl<Data::Vector4Type>(), operands, result);
+                    break;
+                case Data::eType::VectorN:
+                    OperatorEvaluator::Evaluate<Data::VectorNType>(OperatorMulImpl<Data::VectorNType>(), operands, result);
                     break;
                 case Data::eType::Color:
                     OperatorEvaluator::Evaluate<Data::ColorType>(OperatorMulImpl<Data::ColorType>(), operands, result);
@@ -114,6 +122,8 @@ namespace ScriptCanvas
                         return !datum->GetAs<Data::Matrix3x3Type>()->IsClose(Data::Matrix3x3Type::CreateIdentity());
                     case Data::eType::Matrix4x4:
                         return !datum->GetAs<Data::Matrix4x4Type>()->IsClose(Data::Matrix4x4Type::CreateIdentity());
+                    case Data::eType::MatrixMxN:
+                        return true;
                     default:
                         break;
                     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.cpp
@@ -72,9 +72,11 @@ namespace ScriptCanvas
                     Data::Type::Vector2(),
                     Data::Type::Vector3(),
                     Data::Type::Vector4(),
+                    Data::Type::VectorN(),
                     Data::Type::Color(),
                     Data::Type::Matrix3x3(),
-                    Data::Type::Matrix4x4()
+                    Data::Type::Matrix4x4(),
+                    Data::Type::MatrixMxN()
                 };
             }
 
@@ -98,11 +100,17 @@ namespace ScriptCanvas
                 case Data::eType::Vector4:
                     OperatorEvaluator::Evaluate<Data::Vector4Type>(OperatorSubImpl<Data::Vector4Type>(), operands, result);
                     break;
+                case Data::eType::VectorN:
+                    OperatorEvaluator::Evaluate<Data::VectorNType>(OperatorSubImpl<Data::VectorNType>(), operands, result);
+                    break;
                 case Data::eType::Matrix3x3:
                     OperatorEvaluator::Evaluate<Data::Matrix3x3Type>(OperatorSubImpl<Data::Matrix3x3Type>(), operands, result);
                     break;
                 case Data::eType::Matrix4x4:
                     OperatorEvaluator::Evaluate<Data::Matrix4x4Type>(OperatorSubImpl<Data::Matrix4x4Type>(), operands, result);
+                    break;
+                case Data::eType::MatrixMxN:
+                    OperatorEvaluator::Evaluate<Data::MatrixMxNType>(OperatorSubImpl<Data::MatrixMxNType>(), operands, result);
                     break;
                 default:
                     AZ_Assert(false, "Subtraction operator not defined for type: %s", Data::ToAZType(type).ToString<AZStd::string>().c_str());

--- a/Gems/ScriptCanvas/Code/Tests/Data/DataTypeUtilsTest.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Data/DataTypeUtilsTest.cpp
@@ -573,7 +573,7 @@ namespace ScriptCanvasUnitTest
     TEST_F(ScriptCanvasUnitTestDataTypeUtils, ToAZType_GetNullUuid_WhileCheckingInvalidType)
     {
         AZ_TEST_START_TRACE_SUPPRESSION;
-        auto actualResult = ToAZType((eType) 32);
+        auto actualResult = ToAZType(eType::Count);
         AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
         EXPECT_TRUE(actualResult.IsNull());
     }

--- a/Gems/ScriptCanvas/Code/Tests/Data/DataTypeUtilsTest.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Data/DataTypeUtilsTest.cpp
@@ -74,6 +74,10 @@ namespace ScriptCanvasUnitTest
         actualType = FromAZType(ToAZType(expectedType));
         EXPECT_EQ(actualType, expectedType);
 
+        expectedType = Type::MatrixMxN();
+        actualType = FromAZType(ToAZType(expectedType));
+        EXPECT_EQ(actualType, expectedType);
+
         expectedType = Type::Number();
         actualType = FromAZType(ToAZType(expectedType));
         EXPECT_EQ(actualType, expectedType);
@@ -107,6 +111,10 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualType, expectedType);
 
         expectedType = Type::Vector4();
+        actualType = FromAZType(ToAZType(expectedType));
+        EXPECT_EQ(actualType, expectedType);
+
+        expectedType = Type::VectorN();
         actualType = FromAZType(ToAZType(expectedType));
         EXPECT_EQ(actualType, expectedType);
 
@@ -243,6 +251,15 @@ namespace ScriptCanvasUnitTest
         EXPECT_TRUE(actualResult);
     }
 
+    TEST_F(ScriptCanvasUnitTestDataTypeUtils, IsMatrixMxN_GetExpectedResult_WhileCheckingMatrixMxNType)
+    {
+        auto actualResult = IsMatrixMxN(AZ::MatrixMxN::TYPEINFO_Uuid());
+        EXPECT_TRUE(actualResult);
+
+        actualResult = IsMatrixMxN(Type::MatrixMxN());
+        EXPECT_TRUE(actualResult);
+    }
+
     TEST_F(ScriptCanvasUnitTestDataTypeUtils, IsOBB_GetExpectedResult_WhileCheckingOBBType)
     {
         auto actualResult = IsOBB(AZ::Obb::TYPEINFO_Uuid());
@@ -315,6 +332,15 @@ namespace ScriptCanvasUnitTest
         EXPECT_TRUE(actualResult);
     }
 
+    TEST_F(ScriptCanvasUnitTestDataTypeUtils, IsVectorN_GetExpectedResult_WhileCheckingVectorNType)
+    {
+        auto actualResult = IsVectorN(AZ::VectorN::TYPEINFO_Uuid());
+        EXPECT_TRUE(actualResult);
+
+        actualResult = IsVectorN(Type::VectorN());
+        EXPECT_TRUE(actualResult);
+    }
+
     TEST_F(ScriptCanvasUnitTestDataTypeUtils, IsVectorType_GetExpectedResult_WhileCheckingVectorType)
     {
         auto result = IsVectorType(AZ::Vector2::TYPEINFO_Uuid());
@@ -330,6 +356,11 @@ namespace ScriptCanvasUnitTest
         result = IsVectorType(AZ::Vector4::TYPEINFO_Uuid());
         EXPECT_TRUE(result);
         result = IsVectorType(Type::Vector4());
+        EXPECT_TRUE(result);
+
+        result = IsVectorType(AZ::VectorN::TYPEINFO_Uuid());
+        EXPECT_TRUE(result);
+        result = IsVectorType(Type::VectorN());
         EXPECT_TRUE(result);
 
         result = IsVectorType(AZ::Transform::TYPEINFO_Uuid());
@@ -542,7 +573,7 @@ namespace ScriptCanvasUnitTest
     TEST_F(ScriptCanvasUnitTestDataTypeUtils, ToAZType_GetNullUuid_WhileCheckingInvalidType)
     {
         AZ_TEST_START_TRACE_SUPPRESSION;
-        auto actualResult = ToAZType((eType) 20);
+        auto actualResult = ToAZType((eType) 32);
         AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
         EXPECT_TRUE(actualResult.IsNull());
     }

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
@@ -136,6 +136,7 @@ set(FILES
     Include/ScriptCanvas/Libraries/Math/MathNodeUtilities.cpp
     Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
     Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
+    Include/ScriptCanvas/Libraries/Math/MatrixMxN.cpp
     Include/ScriptCanvas/Libraries/Math/OBB.cpp
     Include/ScriptCanvas/Libraries/Math/Plane.cpp
     Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -143,6 +144,7 @@ set(FILES
     Include/ScriptCanvas/Libraries/Math/Vector2.cpp
     Include/ScriptCanvas/Libraries/Math/Vector3.cpp
     Include/ScriptCanvas/Libraries/Math/Vector4.cpp
+    Include/ScriptCanvas/Libraries/Math/VectorN.cpp
     Include/ScriptCanvas/Libraries/Comparison/ComparisonLibrary.cpp
     Include/ScriptCanvas/Libraries/Time/DelayNodeable.cpp
     Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.cpp

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -201,6 +201,8 @@ set(FILES
     Include/ScriptCanvas/Libraries/Math/Matrix3x3.ScriptCanvasFunction.xml
     Include/ScriptCanvas/Libraries/Math/Matrix4x4.h
     Include/ScriptCanvas/Libraries/Math/Matrix4x4.ScriptCanvasFunction.xml
+    Include/ScriptCanvas/Libraries/Math/MatrixMxN.h
+    Include/ScriptCanvas/Libraries/Math/MatrixMxN.ScriptCanvasFunction.xml
     Include/ScriptCanvas/Libraries/Math/OBB.h
     Include/ScriptCanvas/Libraries/Math/OBB.ScriptCanvasFunction.xml
     Include/ScriptCanvas/Libraries/Math/Plane.h
@@ -215,6 +217,8 @@ set(FILES
     Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
     Include/ScriptCanvas/Libraries/Math/Vector4.h
     Include/ScriptCanvas/Libraries/Math/Vector4.ScriptCanvasFunction.xml
+    Include/ScriptCanvas/Libraries/Math/VectorN.h
+    Include/ScriptCanvas/Libraries/Math/VectorN.ScriptCanvasFunction.xml
     Include/ScriptCanvas/Libraries/Comparison/ComparisonLibrary.h
     Include/ScriptCanvas/Libraries/Comparison/EqualTo.h
     Include/ScriptCanvas/Libraries/Comparison/NotEqualTo.h


### PR DESCRIPTION
Adding native support for VectorN and MatrixMxN as script canvas math primitives. Adjusts the operators on MatrixMxN to be less dangerous (removal of operator /, conversion of operator * from a hadamard product to standard matrix multiplication.

![image](https://github.com/o3de/o3de/assets/82241079/5b1be1d8-9dbc-4372-b091-1c87063dc0ec)
