### PR TITLE
Fix slice save error

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
@@ -1024,9 +1024,9 @@ namespace AzToolsFramework
                 AZStd::string userPath = fileIO->GetAlias("@user@");
                 AZStd::string tempPath = fullPath;
                 AzFramework::ApplicationRequests::Bus::Broadcast(
-                    &AzFramework::ApplicationRequests::Bus::Events::NormalizePath, devAssetPath);
-                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePath, userPath);
-                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePath, tempPath);
+                    &AzFramework::ApplicationRequests::Bus::Events::NormalizePathKeepCase, devAssetPath);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePathKeepCase, userPath);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePathKeepCase, tempPath);
                 AzFramework::StringFunc::Replace(tempPath, "@projectroot@", devAssetPath.c_str());
                 AzFramework::StringFunc::Replace(tempPath, devAssetPath.c_str(), userPath.c_str());
                 tempPath.append(".slicetemp");


### PR DESCRIPTION
… fix it by keeping the original path cases

## What does this PR do?

Fix the error in https://github.com/o3de/o3de/issues/16309 which was caused by normalizing the save path with lower case letters. This pr  preserves the pull temp path and the full path in its original casing.


## How was this PR tested?

Compiled a fresh project as source build. Used UI editor to create and save new UI slices. Slices were now getting saved in the requested location without any error.
