### PR TITLE
AWS ClientAuth Identity Pool Spam Reduction

### DIFF
--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
@@ -46,8 +46,8 @@ namespace AWSClientAuth
             const Aws::String identityPoolId = identityRepository.GetIdentityPoolId();
 
             Aws::CognitoIdentity::Model::GetIdRequest getIdRequest;
-            // Only SetIdentityPoolId if there's actually a pool id.
-            // SetIdentityPoolId will cause AWS to think there's an id even it's empty.
+            // Only call SetIdentityPoolId if there's actually a pool id.
+            // SetIdentityPoolId will cause AWS to think there's an id even if it's empty.
             // This leads AWS API calls to pass back a warning about an "invalid" pool id,
             //     rather than (properly) passing back an error about not having a pool id.
             if (!identityPoolId.empty())

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
@@ -55,7 +55,7 @@ namespace AWSClientAuth
             }
 
             auto accountId = identityRepository.GetAccountId();
-            if (!accountId.empty()) // new check
+            if (!accountId.empty())
             {
                 getIdRequest.SetAccountId(accountId);
                 AWS_LOGSTREAM_INFO(logTag, "Identity not found, requesting an id for accountId "

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
@@ -43,10 +43,17 @@ namespace AWSClientAuth
         if (!identityRepository.HasIdentityId())
         {
             auto accountId = identityRepository.GetAccountId();
-            auto identityPoolId = identityRepository.GetIdentityPoolId();
+            const Aws::String identityPoolId = identityRepository.GetIdentityPoolId();
 
             Aws::CognitoIdentity::Model::GetIdRequest getIdRequest;
-            getIdRequest.SetIdentityPoolId(identityPoolId);
+            // Only SetIdentityPoolId if there's actually a pool id.
+            // SetIdentityPoolId will cause AWS to think there's an id even it's empty.
+            // This leads AWS API calls to pass back a warning about an "invalid" pool id,
+            //     rather than (properly) passing back an error about not having a pool id.
+            if (!identityPoolId.empty())
+            {
+                getIdRequest.SetIdentityPoolId(identityPoolId);
+            }
 
             if (!accountId.empty()) // new check
             {

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
@@ -42,19 +42,19 @@ namespace AWSClientAuth
 
         if (!identityRepository.HasIdentityId())
         {
-            auto accountId = identityRepository.GetAccountId();
-            const Aws::String identityPoolId = identityRepository.GetIdentityPoolId();
-
             Aws::CognitoIdentity::Model::GetIdRequest getIdRequest;
+
             // Only call SetIdentityPoolId if there's actually a pool id.
             // SetIdentityPoolId will cause AWS to think there's an id even if it's empty.
             // This leads AWS API calls to pass back a warning about an "invalid" pool id,
             //     rather than (properly) passing back an error about not having a pool id.
+            const Aws::String identityPoolId = identityRepository.GetIdentityPoolId();
             if (!identityPoolId.empty())
             {
                 getIdRequest.SetIdentityPoolId(identityPoolId);
             }
 
+            auto accountId = identityRepository.GetAccountId();
             if (!accountId.empty()) // new check
             {
                 getIdRequest.SetAccountId(accountId);

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
@@ -275,9 +275,16 @@ namespace AWSClientAuth
             }
         }
 
-        // lock to protect getting identity id.
-        AZStd::lock_guard<AZStd::mutex> lock(m_persistentAnonymousCognitoIdentityProviderMutex);
         // Check anonymous credentials as they are optional settings in Cognito Identity pool.
+        if (m_cognitoIdentityPoolId.empty())
+        {
+            // If the identity pool isn't set, then the anonymous credential won't be found.
+            // Return null, instead of asking AWS for credentials to avoid failing AWS requests and AWS errors due to a null identity pool id.
+            return nullptr;
+        }
+
+        // Lock to protect getting identity id.
+        AZStd::lock_guard<AZStd::mutex> lock(m_persistentAnonymousCognitoIdentityProviderMutex);
         if (!m_cognitoCachingAnonymousCredentialsProvider->GetAWSCredentials().IsEmpty())
         {
             AZ_Warning("AWSCognitoAuthorizationCredentialHandler", false, "No logins found. Using Anonymous credential provider");

--- a/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
@@ -325,6 +325,8 @@ TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_ForPersiste
 
 TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersistedLogins_ResultIsAnonymousCredentials)
 {
+    m_mockController->Initialize();
+
     EXPECT_CALL(*m_cognitoIdentityClientMock, GetId(testing::_)).Times(1);
     EXPECT_CALL(*m_cognitoIdentityClientMock, GetCredentialsForIdentity(testing::_)).Times(1);
 
@@ -333,20 +335,14 @@ TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersisted
     EXPECT_TRUE(actualCredentialsProvider == m_mockController->m_cognitoCachingAnonymousCredentialsProvider);
 }
 
-TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr) // fails
+TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr)
 {
-    Aws::Client::AWSError<Aws::CognitoIdentity::CognitoIdentityErrors> error;
-    error.SetExceptionName(AWSClientAuthUnitTest::TEST_EXCEPTION);
-    Aws::CognitoIdentity::Model::GetIdOutcome outcome(error);
-
-    EXPECT_CALL(*m_cognitoIdentityClientMock, GetId(testing::_)).Times(1).WillOnce(testing::Return(outcome));
+    EXPECT_CALL(*m_cognitoIdentityClientMock, GetId(testing::_)).Times(0);
     EXPECT_CALL(*m_cognitoIdentityClientMock, GetCredentialsForIdentity(testing::_)).Times(0);
 
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> actualCredentialsProvider;
-    AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCore::AWSCredentialRequestBus::BroadcastResult(
         actualCredentialsProvider, &AWSCore::AWSCredentialRequests::GetCredentialsProvider);
-    AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
     EXPECT_TRUE(actualCredentialsProvider == nullptr);
 }
 
@@ -354,6 +350,8 @@ TEST_F(
     AWSCognitoAuthorizationControllerTest,
     GetCredentialsProvider_OneThreadPersistLogins_SecondThreadGetCredentialsProvider_GetCredentialsSuccess)
 {
+    m_mockController->Initialize();
+
     AZStd::vector<AZStd::thread> testThreads;
     AZStd::atomic_bool loginsAdded = false;
     AZStd::atomic_int anonymousLogin = 0;


### PR DESCRIPTION
Reduces AWS Authorization spam. 
Avoid making AWS requests if the Cognito identity pool was never set in the first place.

Tested by opening Editor and GameLauncher with AWSAuthClient gem enabled.
Ensured authorization still works after game initializes AWS with a proper Cognito identity pool.

Old spam is gone...
```
[Warning] (AwsNativeSDK) - [AWS] AWSErrorMarshaller - Encountered AWSError 'ValidationException': 2 validation errors detected: Value '' at 'identityPoolId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w-]:[0-9a-f-]; Value '' at 'identityPoolId' failed to satisfy constraint: Member must have length greater than or equal to 1

Exception name: ValidationException
Error message: 2 validation errors detected: Value '' at 'identityPoolId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w-]:[0-9a-f-]; Value '' at 'identityPoolId' failed to satisfy constraint: Member must have length greater than or equal to 1
```