### PR TITLE
Compact node compatibility with nodes that have multiple execution ins/outs

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
@@ -170,7 +170,7 @@ namespace ScriptCanvasEditor
         bool CreateConnection(const GraphCanvas::ConnectionId& connectionId, const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) override;
 
         // Adds or removes an implicit execution connection between the nodes these endpoints are connected if necessary
-        void UpdateCorrospondingImplicitConnection(const ScriptCanvas::Endpoint& sourceEndpoint, const ScriptCanvas::Endpoint& targetEndpoint);
+        void UpdateCorrespondingImplicitConnection(const ScriptCanvas::Endpoint& sourceEndpoint, const ScriptCanvas::Endpoint& targetEndpoint);
 
         bool IsValidConnection(const GraphCanvas::Endpoint& sourcePoint, const GraphCanvas::Endpoint& targetPoint) const override;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
@@ -777,6 +777,12 @@ namespace ScriptCanvas
         return false;
     }
 
+    bool Graph::FindConnection(const Endpoint& firstEndpoint, const Endpoint& otherEndpoint) const
+    {
+        AZ::Entity* connectionEntity = nullptr;
+        return FindConnection(connectionEntity, firstEndpoint, otherEndpoint);
+    }
+
 
     bool Graph::Connect(const AZ::EntityId& sourceNodeId, const SlotId& sourceSlotId, const AZ::EntityId& targetNodeId, const SlotId& targetSlotId)
     {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.h
@@ -87,6 +87,7 @@ namespace ScriptCanvas
         AZStd::pair< EndpointMapConstIterator, EndpointMapConstIterator > GetConnectedEndpointIterators(const Endpoint& endpoint) const override;
         bool IsEndpointConnected(const Endpoint& endpoint) const override;
         bool FindConnection(AZ::Entity*& connectionEntity, const Endpoint& firstEndpoint, const Endpoint& otherEndpoint) const override;
+        bool FindConnection(const Endpoint& firstEndpoint, const Endpoint& otherEndpoint) const;
 
         bool Connect(const AZ::EntityId& sourceNodeId, const SlotId& sourceSlotId, const AZ::EntityId& targetNodeId, const SlotId& targetSlotId) override;
         bool Disconnect(const AZ::EntityId& sourceNodeId, const SlotId& sourceSlotId, const AZ::EntityId& targetNodeId, const SlotId& targetSlotId) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -3347,6 +3347,99 @@ namespace ScriptCanvas
         return AZ::Failure(AZStd::string::format("%s-%s The slot referenced by the slot id in the map was not found. SlotId: %s", GetNodeName().data(), executionOutSlot.GetName().data(), executionOutSlot.GetId().ToString().data()));
     }
 
+    const Slot* Node::GetCorrespondingExecutionSlot(const Slot* slot) const
+    {
+        if (!slot)
+        {
+            return nullptr;
+        }
+
+        if (slot->IsExecution())
+        {
+            return slot;
+        }
+
+        const ScriptCanvas::Slot* executionSlot = nullptr;
+
+        const ScriptCanvas::SlotExecution::Map* map = GetSlotExecutionMap();
+
+        if (map)
+        {
+            if (slot->IsInput())
+            {
+                // Find the corresponding execution input for the source
+                if (const ScriptCanvas::SlotExecution::In* sourceIn = map->FindInFromInputSlot(slot->GetId()))
+                {
+                    const ScriptCanvas::SlotId inSlotId = sourceIn->slotId;
+                    executionSlot = GetSlot(inSlotId);
+                }
+            }
+            else
+            {
+                // Find the corresponding execution output for the source
+                if (const ScriptCanvas::SlotExecution::Out* sourceOut = map->FindOutFromOutputSlot(slot->GetId()))
+                {
+                    const ScriptCanvas::SlotId outSlotId = sourceOut->slotId;
+                    executionSlot = GetSlot(outSlotId);
+                }
+            }
+        }
+        else
+        {
+            // If the node doens't have a slot execution map, we will need to just use whatever execution slot is there
+            AZStd::vector<const ScriptCanvas::Slot*> executionSlots = slot->IsInput()
+                ? GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionIn())
+                : GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionOut());
+
+            if (!executionSlots.empty())
+            {
+                executionSlot = executionSlots[0];
+            }
+        }
+
+        return executionSlot;
+    }
+
+    AZStd::vector<const Slot*> Node::GetCorrespondingDataSlots(const Slot* slot) const
+    {
+        AZStd::vector<const Slot*> dataSlots;
+
+        if (!slot)
+        {
+            return dataSlots;
+        }
+
+        const ScriptCanvas::SlotExecution::Map* map = GetSlotExecutionMap();
+
+        if (map)
+        {
+            if (slot->IsExecution())
+            {
+                ConstSlotsOutcome slotOutcome = slot->IsInput()
+                    ? GetSlotsFromMap(*map, *slot, CombinedSlotType::DataIn, nullptr)
+                    : GetSlotsFromMap(*map, *slot, CombinedSlotType::DataOut, nullptr);
+
+                if (slotOutcome.IsSuccess())
+                {
+                    dataSlots = slotOutcome.GetValue();
+                }
+            }
+            else if (slot->IsData())
+            {
+                return GetCorrespondingDataSlots(GetCorrespondingExecutionSlot(slot));
+            }
+        }
+        else
+        {
+            // If the node doens't have a slot execution map, we will need to just get whatever data slots are there
+            dataSlots = slot->IsInput()
+                ? GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::DataIn())
+                : GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::DataOut());
+        }
+
+        return dataSlots;
+    }
+
     const Slot* Node::GetIfBranchFalseOutSlot() const
     {
         return GetSlotByName("False");

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -3386,7 +3386,7 @@ namespace ScriptCanvas
         }
         else
         {
-            // If the node doens't have a slot execution map, we will need to just use whatever execution slot is there
+            // If the node doesn't have a slot execution map, we will need to just use whatever execution slot is there
             AZStd::vector<const ScriptCanvas::Slot*> executionSlots = slot->IsInput()
                 ? GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionIn())
                 : GetAllSlotsByDescriptor(ScriptCanvas::SlotDescriptors::ExecutionOut());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -835,6 +835,12 @@ namespace ScriptCanvas
 
         AZ::Outcome<AZStd::string> GetLatentOutKey(const SlotExecution::Map& map, const Slot& slot) const;
 
+        // Returns the provided slot's corresponding execution slot
+        const Slot* GetCorrespondingExecutionSlot(const Slot* slot) const;
+
+        // Returns the provided slot's corresponding data slots
+        AZStd::vector<const Slot*> GetCorrespondingDataSlots(const Slot* slot) const;
+
         void ClearDisplayType(const SlotId& slotId);
         void SetDisplayType(const SlotId& slotId, const Data::Type& dataType);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotExecutionMap.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotExecutionMap.cpp
@@ -165,6 +165,36 @@ namespace ScriptCanvas
             return iter != m_ins.end() ? iter : nullptr;
         }
 
+        const Out* Map::FindOutFromOutputSlot(const SlotId& slotID) const
+        {
+            for (const In& in : m_ins)
+            {
+                for (const Out& out : in.outs)
+                {
+                    for (const Output& output : out.outputs)
+                    {
+                        if (output.slotId == slotID)
+                        {
+                            return &out;
+                        }
+                    }
+                }
+            }
+
+            for (const Out& latent : m_latents)
+            {
+                for (const Output& output : latent.outputs)
+                {
+                    if (output.slotId == slotID)
+                    {
+                        return &latent;
+                    }
+                }
+            }
+
+            return nullptr;
+        }
+
         const In* Map::FindInFromSlotId(SlotId slotId) const
         {
             return FindInBySlotId(slotId, *const_cast<Ins*>(&m_ins));

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotExecutionMap.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotExecutionMap.h
@@ -32,6 +32,7 @@ namespace ScriptCanvas
 {
     namespace SlotExecution
     {
+        // Represents a data slot output
         struct Output final
         {
             AZ_TYPE_INFO(Output, "{61EA2FF0-3112-40DF-BA45-CF4BE680DC52}");
@@ -48,7 +49,8 @@ namespace ScriptCanvas
 
         using Outputs = AZStd::vector<Output>;
         using OutputSlotIds = AZStd::vector<SlotId>;
-        
+
+        // Represents a data slot input
         struct Input final
         {
             AZ_TYPE_INFO(Input, "{4E52A04D-C9FC-477F-8065-35F96A972CD6}");
@@ -73,6 +75,7 @@ namespace ScriptCanvas
             Inputs values;
         };
 
+        // Represents an execution slot output
         struct Out final
         {
             AZ_TYPE_INFO(Out, "{DD3D2547-868C-40DF-A37C-F60BE06FFFBA}");
@@ -86,6 +89,7 @@ namespace ScriptCanvas
         };
         using Outs = AZStd::vector<Out>;
 
+        // Represents an execution slot input
         struct In final
         {
             AZ_TYPE_INFO(In, "{4AAAEB0B-6367-46E5-B05D-E76EF884E16F}");
@@ -104,6 +108,7 @@ namespace ScriptCanvas
         InputSlotIds ToInputSlotIds(const Inputs& source);
         OutputSlotIds ToOutputSlotIds(const Outputs& source);
 
+        // Maps slots of nodes to one another to indicate what execution slots corrospond to what data slots
         class Map final
         {
         public:
@@ -120,7 +125,11 @@ namespace ScriptCanvas
 
             Map(Outs&& latents);
 
+            // Takes in a data input slot id, and returns the execution in associated with it
             const In* FindInFromInputSlot(const SlotId& slotID) const;
+
+            // Takes in a data output slot id, and returns the execution out associated with it
+            const Out* FindOutFromOutputSlot(const SlotId& slotID) const;
 
             SlotId FindInputSlotIdBySource(VariableId inputSourceId, Grammar::FunctionSourceId inSourceId) const;
 
@@ -138,6 +147,7 @@ namespace ScriptCanvas
 
             const Ins& GetIns() const;
 
+            // Takes in the slot ID of an execution in slot and returns a vector of its corresponding data inputs
             const Inputs* GetInput(SlotId in) const;
 
             const Out* GetLatent(SlotId latent) const;
@@ -150,6 +160,7 @@ namespace ScriptCanvas
 
             const Out* GetOut(SlotId in, SlotId out) const;
 
+            // Takes in the slot ID of an execution out slot and returns a vector of its corresponding data outputs
             const Outputs* GetOutput(SlotId out) const;
 
             const Outputs* GetOutput(SlotId in, SlotId out) const;
@@ -164,7 +175,7 @@ namespace ScriptCanvas
 
             bool IsEmpty() const;
 
-            // returns true iff there is at least one latent out
+            // Returns true if there is at least one latent out
             bool IsLatent() const;
 
             AZStd::string ToExecutionString() const;


### PR DESCRIPTION
## What does this PR do?

This PR makes the following changes:
- Implicit slots will now always connect to the proper execution slot, allowing upcoming compact or small operator style nodes to work properly with all nodes in ScriptCanvas, including those with multiple execution ins or outs.
- Fixed a typo by correcting "UpdateCorrospondingImplicitConnections" to "UpdateCorrespondingImplicitConnections".
- Added comments to SlotExecutionMap.h.
- Added methods to ScriptCanvas::Node for retrieving a slot's corresponding execution or data slots.

## How was this PR tested?

Testing was done manually by connecting, disconnecting, reconnecting, undoing, and redoing, and then running graphs in the interpreter. Local tests were also run. Here is an example graph that was tested to ensure that implicit connections were properly being made to latent outs (Variable 1 is set to the value 3):
![del](https://github.com/o3de/o3de/assets/105814224/3e7eacda-0407-455a-bb14-ee03c282daa9)
![delo](https://github.com/o3de/o3de/assets/105814224/88fde557-17cd-484d-9cd0-ad3b4c958b14)

