### PR TITLE
Added ArticulationLink to services provided by ArticulationLinkComponent

### DIFF
--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -49,6 +49,7 @@ namespace PhysX
     {
         provided.push_back(AZ_CRC_CE("PhysicsWorldBodyService"));
         provided.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        provided.push_back(AZ_CRC_CE("ArticulationLinkService"));
     }
 
     void ArticulationLinkComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -259,6 +259,7 @@ namespace PhysX
     {
         provided.push_back(AZ_CRC_CE("PhysicsWorldBodyService"));
         provided.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        provided.push_back(AZ_CRC_CE("ArticulationLinkService"));
     }
 
     void EditorArticulationLinkComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)


### PR DESCRIPTION

## What does this PR do?

Added ArticulationLinkService to list of services provided by ArticulationLinkComponent and EditorArticulationLinkComponent.
This is needed to resolve https://github.com/o3de/o3de-extras/issues/389, where JointsArticulationControllerComponent requires this component, but currently cannot list it as requirement.

https://github.com/o3de/o3de-extras/pull/393 relies on this PR to resolve https://github.com/o3de/o3de-extras/issues/389.


## How was this PR tested?

1. Add JointsArticulationControllerComponent to empty entity.
2. Component is not active. There is notification visible, informing of missing required component and suggesting to add PhysX Articulation Link.
