### PR TITLE
Updating the CMakePresets to set the CMAKE_EXPORT COMPILE_COMMANDS option

### DIFF
--- a/cmake/Platform/Common/CMakePresets.json
+++ b/cmake/Platform/Common/CMakePresets.json
@@ -45,6 +45,17 @@
             }
         },
         {
+            "name": "compile-commands-json",
+            "description": "Generate compile_commands.json file when used with a Makefile or Ninja Generator",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        },
+        {
             "name": "no-unity",
             "description": "unity: off",
             "hidden": true,
@@ -93,14 +104,20 @@
             "displayName": "Unix Makefiles",
             "description": "Configure using Unix Makefile generator",
             "generator": "Unix Makefiles",
-            "hidden": true
+            "hidden": true,
+            "inherits":[
+                "compile-commands-json"
+            ]
         },
         {
             "name": "ninja-multi-config",
             "displayName": "Ninja Multi-Config",
             "description": "Configure using Ninja Multi-Config generator",
             "hidden": true,
-            "generator": "Ninja Multi-Config"
+            "generator": "Ninja Multi-Config",
+            "inherits":[
+                "compile-commands-json"
+            ]
         },
         {
             "name": "vs2022",


### PR DESCRIPTION

The `CMAKE_EXPORT_COMPILE_COMMANDS` cache variable is set to generate a compile_commands.json file.

It is only supported for Makefile generators and the Ninja generator per the [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html).

## How was this PR tested?
Validated that a `compile_commands.json` file was generated when using the Linux `linux-default` cmake preset, which uses the ninja-generator
