### PR TITLE
Fixes the generated code for ExtendConfigureSlots

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
@@ -102,7 +102,7 @@ public: \
               void ConfigureSlots() override;
 
 {% if Class.attrib['ExtendConfigureSlots'] is defined %}
-              void ExtendConfigureSlots([[maybe_unused]] SlotExecution::Ins& ins, [[maybe_unused]] SlotExecution::Outs& latents);
+              void ExtendConfigureSlots([[maybe_unused]] ScriptCanvas::SlotExecution::Ins& ins, [[maybe_unused]] ScriptCanvas::SlotExecution::Outs& latents);
 
 {% else %}
               /* no slot configuration extension, Use Class attribute 'ExtendConfigureSlots' to extend them */


### PR DESCRIPTION
Fixes the generated code for ExtendConfigureSlots so that it compiles properly for nodes outside the ScriptCanvas namespace
