### PR TITLE
Change LuaIDE save dialog to use project path by default

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -1737,9 +1737,6 @@ namespace LUAEditor
         {
             // the document was probably closed, request it be reopened
             m_dProcessFindListClicked.push_back(result);
-            //EditorFramework::AssetManagementMessages::Bus::Event(LUAEditor::ContextID, &EditorFramework::AssetManagementMessages::Bus::Events::AssetOpenRequested,
-            //    result.m_assetId,
-            //    AZ::ScriptAsset::StaticAssetType());
             AZ_Assert(false, "Fix assets!");
         }
     }
@@ -1811,18 +1808,14 @@ namespace LUAEditor
     {
         m_lastFocusedAssetId = assetId;
 
-        //AZ_TracePrintf(LUAEditorDebugName, AZStd::string::format("OnFocusInEvent, %s\n", assetId.c_str()).c_str());
-
         if (!m_bIgnoreFocusRequests)
         {
             SetGUIToMatch(m_StateTrack);
         }
     }
 
-    void LUAEditorMainWindow::OnFocusOutEvent(const AZStd::string& assetId)
+    void LUAEditorMainWindow::OnFocusOutEvent(const AZStd::string&)
     {
-        (void)assetId;
-        //AZ_Assert(m_dOpenLUAView.find(documentID) != m_dOpenLUAView.end(), "LUAEditorMainWindow::OnFocusInEvent() : DocumentID does not exist");
     }
 
     void LUAEditorMainWindow::OnRequestCheckOut(const AZStd::string& assetId)
@@ -1881,8 +1874,6 @@ namespace LUAEditor
     // externally driven context sensitive widget states
     void LUAEditorMainWindow::SetDebugControlsToInitial()
     {
-        //AZ_TracePrintf(LUAEditorDebugName, "SetDebugControlsToInitial()\n");
-
         m_StateTrack.Init();
         SetGUIToMatch(m_StateTrack);
     }
@@ -1916,15 +1907,11 @@ namespace LUAEditor
     }
     void LUAEditorMainWindow::SetEditContolsToNoFilesOpen()
     {
-        //AZ_TracePrintf(LUAEditorDebugName, "SetDebugControlsToNoFilesOpen()\n");
-
         m_StateTrack.atLeastOneFileOpen = false;
         SetGUIToMatch(m_StateTrack);
     }
     void LUAEditorMainWindow::SetEditContolsToAtLeastOneFileOpen()
     {
-        //AZ_TracePrintf(LUAEditorDebugName, "SetDebugControlsToAtLeastOneFileOpen()\n");
-
         m_StateTrack.atLeastOneFileOpen = true;
         SetGUIToMatch(m_StateTrack);
     }
@@ -2006,9 +1993,6 @@ namespace LUAEditor
 
     void LUAEditorMainWindow::SetGUIToMatch(StateTrack& track)
     {
-        //AZ_TracePrintf(LUAEditorDebugName, "conn(%d) attach(%d) running(%d) atbreak(%d) hasexecuted(%d)  \n",
-        //  track.targetConnected, track.debuggerAttached, track.scriptRunning, track.atBreak, track.hasExecuted);
-
         if (track.atLeastOneFileOpen)
         {
             m_gui->actionSave->setEnabled(true);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Utils/Utils.h>
 #include <AzFramework/Script/ScriptRemoteDebuggingConstants.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
@@ -1762,12 +1763,7 @@ namespace LUAEditor
 
     bool LUAEditorMainWindow::OnFileSaveDialog(const AZStd::string& assetName, AZStd::string& newAssetName)
     {
-        const char* rootDirString;
-        AZ::ComponentApplicationBus::BroadcastResult(rootDirString, &AZ::ComponentApplicationBus::Events::GetExecutableFolder);
-
-        QDir rootDir;
-        rootDir.setPath(rootDirString);
-        rootDir.cdUp();
+        const QDir rootDir { AZ::Utils::GetProjectPath().c_str() };
 
         QString name = QFileDialog::getSaveFileName(this, QString(AZStd::string::format("Save File {%s}", assetName.c_str()).c_str()), m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(), QString("*.lua"));
         if (name.isEmpty())


### PR DESCRIPTION
## What does this PR do?

Changes the LuaIDE editor's save dialog to use the project path by default.

Fixes #15934

## How was this PR tested?

Built profile and release on Linux with Clang 16.0.6

Launched LuaIDE with `./LuaIDE --project-path=/my/project/path and confirmed the new file dialog opens to the project root.

Launched LuaIDE without a project path and it behaves as normal (complains that the executable's path doesn't contain a project"