### PR TITLE
Pass attachment: Fetch *sources for attachments recursively

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -112,9 +112,19 @@ namespace AZ
                     u8 m_getSizeFromPipeline : 1;
                     u8 m_getFormatFromPipeline : 1;
                     u8 m_getMultisampleStateFromPipeline : 1;
+                    u8 m_updatingImageFormat : 1;
+                    u8 m_updatingMultisampleState : 1;
+                    u8 m_updatingSize : 1;
+                    u8 m_updatingArraySize : 1;
                 };
                 u8 m_allFlags = 0;
             };
+
+        protected:
+            void UpdateImageFormat();
+            void UpdateImageMultisampleState();
+            void UpdateImageSize();
+            void UpdateImageArraySize();
         };
 
         //! An attachment binding points to a PassAttachment and specifies how the pass uses that attachment.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -127,6 +127,16 @@ namespace AZ
                 UpdateImageMultisampleState();
                 UpdateImageSize();
                 UpdateImageArraySize();
+
+                if (m_generateFullMipChain)
+                {
+                    uint32_t width = m_descriptor.m_image.m_size.m_width;
+                    uint32_t height = m_descriptor.m_image.m_size.m_height;
+
+                    double maxDimension = static_cast<double>(AZStd::max(width, height));
+                    double mipMapLevels = floor(log2(maxDimension)) + 1;
+                    m_descriptor.m_image.m_mipLevels = static_cast<uint16_t>(mipMapLevels);
+                }
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -199,11 +199,11 @@ namespace AZ
 
                 if (m_arraySizeSource && m_arraySizeSource->GetAttachment())
                 {
+                    int tries{ 0 };
                     auto arraySizeSource = m_arraySizeSource;
                     while (arraySizeSource->GetAttachment() && arraySizeSource->GetAttachment()->m_arraySizeSource &&
                            arraySizeSource->GetAttachment()->m_arraySizeSource->GetAttachment())
                     {
-                        int tries{ 0 };
                         arraySizeSource = arraySizeSource->GetAttachment()->m_arraySizeSource;
                         if (tries > maxRecursionTries) // crude circular dependency detection
                         {


### PR DESCRIPTION
## What does this PR do?

When creating a pass request, e.g. the size of an attachment might depend on the size of another image/buffer. For this a size/format/multisampling/arraysize can be specified.
This does currently not work, if:
- The referenced image/buffer attachment, also has a size source
- The referenced attachment has a `Transient' lifetime
- The current attachment has an `Imported` lifetime

This happens e.g. when an images size is dependent on the input image size, which again is dependent on the PipelineOutput size.

This PR solves this issue, by recursively searching for the "original" size source, and use it.

The same is also true for the format/multipsampling/arraysize members.

## How was this PR tested?

Windows and DX12/Vulkan.
