### PR TITLE
Add compact node preset to AZAutogen Nodeables

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
@@ -66,6 +66,7 @@
 						<xs:attribute name="Description" type="xs:string" use="required" />
 						<xs:attribute name="Base" type="xs:string" use="optional" />
 						<xs:attribute name="Style" type="xs:string" use="optional" />
+						<xs:attribute name="Preset" type="xs:string" use="optional" />
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable.xsd
@@ -14,7 +14,7 @@
 												<xs:attribute name="Name" type="xs:string" use="required" />
 												<xs:attribute name="Type" type="xs:string" use="required" />
 												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
-												<xs:attribute name="Description" type="xs:string" use="required" />
+												<xs:attribute name="Description" type="xs:string" use="optional" />
 												<xs:attribute name="HideInputField" type="xs:boolean" use="optional" />
 												<xs:attribute name="HideName" type="xs:boolean" use="optional"/>
 												<xs:attribute name="DisplayGroup" type="xs:string" use="optional"/>
@@ -22,7 +22,7 @@
 										</xs:element>
 									</xs:sequence>
 									<xs:attribute name="Name" type="xs:string" use="required" />
-									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="optional" />
 									<xs:attribute name="OutputName" type="xs:string" use="optional" />
 									<xs:attribute name="DisplayGroup" type="xs:string" use="optional" />
 									<xs:attribute name="Implicit" type="xs:boolean" use="optional"/>
@@ -36,7 +36,7 @@
 											<xs:complexType>
 												<xs:attribute name="Name" type="xs:string" use="required" />
 												<xs:attribute name="Type" type="xs:string" use="required" />
-												<xs:attribute name="Description" type="xs:string" use="required" />
+												<xs:attribute name="Description" type="xs:string" use="optional" />
 												<xs:attribute name="DefaultValue" type="xs:string" use="optional" />
 												<xs:attribute name="HideName" type="xs:boolean" use="optional"/>
 												<xs:attribute name="DisplayGroup" type="xs:string" use="optional"/>
@@ -44,7 +44,7 @@
 										</xs:element>
 									</xs:sequence>
 									<xs:attribute name="Name" type="xs:string" use="required" />
-									<xs:attribute name="Description" type="xs:string" use="required" />
+									<xs:attribute name="Description" type="xs:string" use="optional" />
 									<xs:attribute name="DisplayGroup" type="xs:string" use="optional" />
 								</xs:complexType>
 							</xs:element>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -46,6 +46,18 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%- set attribute_Deprecated = Class.attrib['Deprecated'] %}
 {%- set attribute_Style = Class.attrib['Style'] %}
 
+{%- set attribute_Preset = Class.attrib['Preset'] %}
+
+{% if attribute_Preset is defined %}
+{%- set attribute_Preset = Class.attrib['Preset'].lower() %}
+{% else %}
+{%- set attribute_Preset = "" %}
+{% endif %}
+
+{% if attribute_Preset == "compact" %}
+{%- set attribute_Style = ".compact" %}
+{% endif %}
+
 {%- set attribute_Base = "ScriptCanvas::Nodeable" %}
 {% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
 {%    set attribute_Base = Class.attrib['Base'] %}
@@ -361,16 +373,22 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
 
 {%- for item in Class.findall('Input') %}
 {%-     set itemName = item.attrib['Name'] %}
-{%      set itemDisplayGroup = item.attrib['DisplayGroup'] if item.attrib['DisplayGroup'] is defined else macros.SlotName(itemName) %}
+{% if item.attrib['DisplayGroup'] is defined %}
+{%      set itemDisplayGroup = item.attrib['DisplayGroup'] %}
+{% elif attribute_Preset == "compact" %}
+{%      set itemDisplayGroup = "" %}
+{% else %}
+{%      set itemDisplayGroup = macros.SlotName(itemName) %}
+{% endif %}
     // execution in begin 
     { 
         SlotExecution::In in;
 
-{{      nodemacro.CreateExecutionSlot(item, "Input", undefined) }}
+{{      nodemacro.CreateExecutionSlot(item, "Input", undefined, attribute_Preset) }}
         in.slotId = slotId{{ macros.CleanName(itemName) }}Input;
 
 {% for paraItem in item.findall('Parameter') %}
-        {{ nodemacro.AddDataSlot("true", "in.inputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
+        {{ nodemacro.AddDataSlot("true", "in.inputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName'], attribute_Preset) }}
 {% endfor %}
         { // execution outs begin    
 {%      if item.findall("Branch")|length == 0 %}
@@ -389,8 +407,12 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
 {% endif %}
             outSlotConfiguration.m_displayGroup = "{{ itemDisplayGroup }}";
             outSlotConfiguration.SetConnectionType(ScriptCanvas::ConnectionType::Output);
-{%          if item.attrib['Hidden'] %}
-            outSlotConfiguration{{executionDirection}}.m_isVisible = false;
+{%          if item.attrib['Hidden'] is defined %}
+{%          if item.attrib['Hidden'] == "true" %}
+            outSlotConfiguration.m_isVisible = false;
+{%          endif %}
+{%          elif attribute_Preset == "compact" %}
+            outSlotConfiguration.m_isVisible = false;
 {%          endif %}
             outSlotConfiguration.m_isLatent = false;
             out.name = outSlotConfiguration.m_name;
@@ -400,7 +422,7 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
 {%          for return in item.findall('Return') %}
                 {# Default to the input's display group if no group for this tag is defined #}
                 {% set displayGroup = return.attrib['DisplayGroup'] if return.attrib['DisplayGroup'] is defined else itemDisplayGroup %}
-                {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], item.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName']) }}
+                {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], item.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName'], attribute_Preset) }}
 {%          endfor %}
             in.outs.push_back(out);
 {%      else %}
@@ -422,7 +444,7 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
 {%              for return in branchItem.findall('Return') %}
                     {# Default to the branch's display group if no group for this tag is defined #}
                     {% set displayGroup = return.attrib['DisplayGroup'] if return.attrib['DisplayGroup'] is defined else branchDisplayGroup %}
-                    {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], branchItem.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName']) }}
+                    {{ nodemacro.AddDataSlot("false", "out.outputs", displayGroup, return.attrib['Name'], return.attrib['Description'], return.attrib['DefaultValue'], return.attrib['Type'], branchItem.attrib['Name'], return.attrib['HideInputField'], return.attrib['HideName'], attribute_Preset) }}
 {%              endfor %}
                 in.outs.push_back(out);
             }
@@ -438,14 +460,14 @@ void Nodes::{{ nodeableNodeName }}::ConfigureSlots()
     // Latent out
     {
         SlotExecution::Out out;
-{{      nodemacro.CreateExecutionSlot(item, "Output", item.attrib['Latent']) }}
+{{      nodemacro.CreateExecutionSlot(item, "Output", item.attrib['Latent'], attribute_Preset) }}
         out.slotId = slotId{{ nodemacro.SlotName(itemName) }}Output;
         out.name = "{{itemName}}";
 {%      for paraItem in item.findall('Parameter') %}
-{{     nodemacro.AddDataSlot("false", "out.outputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
+{{     nodemacro.AddDataSlot("false", "out.outputs", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName'], attribute_Preset) }}
 {%      endfor %}
 {%      for paraItem in item.findall('Return') %}
-{{     nodemacro.AddDataSlot("true", "out.returnValues.values", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName']) }}
+{{     nodemacro.AddDataSlot("true", "out.returnValues.values", paraItem.attrib['DisplayGroup'], paraItem.attrib['Name'], paraItem.attrib['Description'], paraItem.attrib['DefaultValue'], paraItem.attrib['Type'], item.attrib['Name'], paraItem.attrib['HideInputField'], paraItem.attrib['HideName'], attribute_Preset) }}
 {%      endfor %}
         outs.push_back(out);
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -131,9 +131,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 {# ------- #}
 
-{% macro AddDataSlot(isInput, executionName, displayGroup, slotName, slotDescription, slotDefaultValue, valueType, parentName, hideInputField, hideName) %}
+{% macro AddDataSlot(isInput, executionName, displayGroup, slotName, slotDescription, slotDefaultValue, valueType, parentName, hideInputField, hideName, preset) %}
 
-        // Data Slot: {{slotName}} ({% if isInput == "true" %}Input{% else %}Output{% endif %})
+        // Data Slot: {{slotName}} ({% if isInput == true %}Input{% else %}Output{% endif %})
         {
 
 {% if valueType is undefined %}
@@ -142,15 +142,25 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
             ScriptCanvas::DataSlotConfiguration dataSlotConfiguration;
             dataSlotConfiguration.m_name = "{{ slotName }}";
             dataSlotConfiguration.m_toolTip = "{{ slotDescription }}";
-{% if hideInputField %}
+{% if hideInputField is defined %}
+{% if hideInputField == "true" %}
             dataSlotConfiguration.m_canHaveInputField = false;
 {% endif %}
-{% if hideName %}
+{% elif preset == "compact" %}
+            dataSlotConfiguration.m_canHaveInputField = false;
+{% endif %}
+{% if hideName is defined %}
+{% if hideName == "true" %}
+            dataSlotConfiguration.m_isNameHidden = true;
+{% endif %}
+{% elif preset == "compact" %}
             dataSlotConfiguration.m_isNameHidden = true;
 {% endif %}
 {% if displayGroup is defined %}
             dataSlotConfiguration.m_displayGroup = "{{ displayGroup }}";
-{% elif parentName is defined%}
+{% elif preset == "compact" %}
+            dataSlotConfiguration.m_displayGroup = "";
+{% elif parentName is defined %}
             dataSlotConfiguration.m_displayGroup = "{{ parentName }}";
 {% endif %}
             dataSlotConfiguration.SetConnectionType(ScriptCanvas::ConnectionType::{% if isInput == "true" %}Input{% else %}Output{% endif %});
@@ -211,7 +221,7 @@ false
 
 
 {# slotType is Input or Output #}
-{% macro CreateExecutionSlot(tag, executionDirection, isLatent) %}
+{% macro CreateExecutionSlot(tag, executionDirection, isLatent, preset) %}
 {%- set slotName = tag.attrib['Name'] %}
 {%- set slotNameClean = CleanName(slotName) %}
 {%- set slotDescription = tag.attrib['Description'] %}
@@ -225,14 +235,24 @@ false
         slotConfiguration{{executionDirection}}.SetConnectionType(ScriptCanvas::ConnectionType::{{ executionDirection }});
 {% if tag.attrib['DisplayGroup'] is defined %}
         slotConfiguration{{executionDirection}}.m_displayGroup = "{{ tag.attrib['DisplayGroup'] }}";
+{% elif preset == "compact" %}
+        slotConfiguration{{executionDirection}}.m_displayGroup = "";
 {% else %}
         slotConfiguration{{executionDirection}}.m_displayGroup = "{{ slotName }}";
 {% endif %}
-{% if tag.attrib['Implicit'] %}
-        slotConfiguration{{executionDirection}}.m_createsImplicitConnections = true;
+{% if tag.attrib['Implicit'] is defined %}
+{% if tag.attrib['Implicit'] == "true" %}
+            slotConfiguration{{executionDirection}}.m_createsImplicitConnections = true;
 {% endif %}
-{% if tag.attrib['Hidden'] %}
-        slotConfiguration{{executionDirection}}.m_isVisible = false;
+{% elif preset == "compact" %}
+            slotConfiguration{{executionDirection}}.m_createsImplicitConnections = true;
+{% endif %}
+{% if tag.attrib['Hidden'] is defined %}
+{% if tag.attrib['Hidden'] == "true" %}
+            slotConfiguration{{executionDirection}}.m_isVisible = false;
+{% endif %}
+{% elif preset == "compact" %}
+            slotConfiguration{{executionDirection}}.m_isVisible = false;
 {% endif %}
 {% if isLatent is defined or executionDirection == "Output" %}
         slotConfiguration{{executionDirection}}.m_isLatent = true;


### PR DESCRIPTION
## What does this PR do?

This PR allows users to add a "Preset" attribute to AZAutogen nodes. Users can set this attribute to "compact" to automatically set default attributes for compact style nodes.

This PR also makes giving a description for slots optional. Slot descriptions for many compact nodes shouldn't be necessary, and for implicit slots that do not appear in the editor, descriptions are completely redundant.

## How was this PR tested?

This PR was tested manually by creating compact nodes using this preset with slots that do and do not have descriptions.