### PR TITLE
Modified canvas asset to use custom property handler

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1760,7 +1760,7 @@ namespace AzToolsFramework
         ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
     }
 
-    void SimpleAssetPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
+    void SimpleAssetPropertyHandlerDefault::WriteGUIValuesIntoPropertyInternal(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
     {
         (void)index;
         (void)node;
@@ -1772,7 +1772,12 @@ namespace AzToolsFramework
         instance.SetAssetPath(assetPath.c_str());
     }
 
-    bool SimpleAssetPropertyHandlerDefault::ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+    void SimpleAssetPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
+    {
+        WriteGUIValuesIntoPropertyInternal(index, GUI, instance, node);
+    }
+
+    bool SimpleAssetPropertyHandlerDefault::ReadValuesIntoGUIInternal(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)
     {
         (void)index;
         (void)node;
@@ -1793,6 +1798,11 @@ namespace AzToolsFramework
 
         GUI->blockSignals(false);
         return false;
+    }
+
+    bool SimpleAssetPropertyHandlerDefault::ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)
+    {
+        return ReadValuesIntoGUIInternal(index, GUI, instance, node);
     }
 
     void RegisterAssetPropertyHandler()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -349,7 +349,9 @@ namespace AzToolsFramework
 
         virtual QWidget* CreateGUI(QWidget* pParent) override;
         virtual void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        static void WriteGUIValuesIntoPropertyInternal(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node);
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        static bool ReadValuesIntoGUIInternal(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node);
         virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
     };
 

--- a/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include "LyShineEditorSystemComponent.h"
 #include "EditorWindow.h"
+#include "PropertyHandlerCanvasAsset.h"
 
 // UI_ANIMATION_REVISIT, added includes so that we can register the UI Animation system on startup
 #include "Animation/UiAnimViewSequenceManager.h"
@@ -89,6 +90,7 @@ namespace LyShineEditor
         AzToolsFramework::EditorEventsBus::Handler::BusConnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
         LyShine::LyShineRequestBus::Handler::BusConnect();
+        CanvasAssetPropertyHandler::Register();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Editor/PropertyHandlerCanvasAsset.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerCanvasAsset.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+
+#include <Editor/PropertyHandlerCanvasAsset.h>
+
+namespace LyShineEditor
+{
+    AZ::u32 CanvasAssetPropertyHandler::GetHandlerName() const
+    {
+        return AZ_CRC_CE("CanvasAssetRef");
+    }
+
+    bool CanvasAssetPropertyHandler::IsDefaultHandler() const
+    {
+        return false;
+    }
+
+    QWidget* CanvasAssetPropertyHandler::GetFirstInTabOrder(AzToolsFramework::PropertyAssetCtrl* widget)
+    {
+        return widget->GetFirstInTabOrder();
+    }
+
+    QWidget* CanvasAssetPropertyHandler::GetLastInTabOrder(AzToolsFramework::PropertyAssetCtrl* widget)
+    {
+        return widget->GetLastInTabOrder();
+    }
+
+    void CanvasAssetPropertyHandler::UpdateWidgetInternalTabbing(AzToolsFramework::PropertyAssetCtrl* widget)
+    {
+        widget->UpdateTabOrder();
+    }
+
+    QWidget* CanvasAssetPropertyHandler::CreateGUI(QWidget* parent)
+    {
+        AzToolsFramework::PropertyAssetCtrl* newCtrl = aznew AzToolsFramework::PropertyAssetCtrl(parent);
+
+        QObject::connect(newCtrl, &AzToolsFramework::PropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
+        {
+            (void)newAssetID;
+            AzToolsFramework::PropertyEditorGUIMessagesBus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessagesBus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
+        });
+
+        return newCtrl;
+    }
+
+    void CanvasAssetPropertyHandler::ConsumeAttribute(AzToolsFramework::PropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        // Let ConsumeAttributeForPropertyAssetCtrl handle all of the attributes
+        AzToolsFramework::ConsumeAttributeForPropertyAssetCtrl(GUI, attrib, attrValue, debugName);
+    }
+
+    void CanvasAssetPropertyHandler::WriteGUIValuesIntoProperty(size_t index, AzToolsFramework::PropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node)
+    {
+        // Let the SimpleAssetPropertyHandlerDefault handle writing the GUI value into the property
+        AzToolsFramework::SimpleAssetPropertyHandlerDefault::WriteGUIValuesIntoPropertyInternal(index, GUI, instance, node);
+    }
+
+    bool CanvasAssetPropertyHandler::ReadValuesIntoGUI(size_t index, AzToolsFramework::PropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)
+    {
+        // Let the SimpleAssetPropertyHandlerDefault handle reading values into the GUI
+        return AzToolsFramework::SimpleAssetPropertyHandlerDefault::ReadValuesIntoGUIInternal(index, GUI, instance, node);
+    }
+
+    void CanvasAssetPropertyHandler::Register()
+    {
+        using namespace AzToolsFramework;
+
+        PropertyTypeRegistrationMessageBus::Broadcast(
+            &PropertyTypeRegistrationMessages::RegisterPropertyType, aznew CanvasAssetPropertyHandler());
+    }
+}

--- a/Gems/LyShine/Code/Editor/PropertyHandlerCanvasAsset.h
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerCanvasAsset.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
+
+#include <LyShine/UiAssetTypes.h>
+#endif
+
+namespace LyShineEditor
+{
+    class CanvasAssetPropertyHandler
+        : QObject
+        , public AzToolsFramework::PropertyHandler<AzFramework::SimpleAssetReference<LyShine::CanvasAsset>, AzToolsFramework::PropertyAssetCtrl>
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(CanvasAssetPropertyHandler, AZ::SystemAllocator);
+
+        AZ::u32 GetHandlerName() const override;
+        bool IsDefaultHandler() const override;
+        QWidget* GetFirstInTabOrder(AzToolsFramework::PropertyAssetCtrl* widget) override;
+        QWidget* GetLastInTabOrder(AzToolsFramework::PropertyAssetCtrl* widget) override;
+        void UpdateWidgetInternalTabbing(AzToolsFramework::PropertyAssetCtrl* widget);
+
+        QWidget* CreateGUI(QWidget* parent) override;
+        void ConsumeAttribute(AzToolsFramework::PropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, AzToolsFramework::PropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, AzToolsFramework::PropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)  override;
+
+        static void Register();
+    };
+}

--- a/Gems/LyShine/Code/Source/World/UiCanvasAssetRefComponent.cpp
+++ b/Gems/LyShine/Code/Source/World/UiCanvasAssetRefComponent.cpp
@@ -177,7 +177,7 @@ void UiCanvasAssetRefComponent::Reflect(AZ::ReflectContext* context)
                 ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/ui/canvas-asset-ref/")
                 ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c));
 
-            editInfo->DataElement("SimpleAssetRef", &UiCanvasAssetRefComponent::m_canvasAssetRef,
+            editInfo->DataElement("CanvasAssetRef", &UiCanvasAssetRefComponent::m_canvasAssetRef,
                 "Canvas pathname", "The pathname of the canvas.")
                 ->Attribute("BrowseIcon", ":/stylesheet/img/UI20/browse-edit-select-files.svg")
                 ->Attribute("EditButton", "")

--- a/Gems/LyShine/Code/lyshine_uicanvaseditor_files.cmake
+++ b/Gems/LyShine/Code/lyshine_uicanvaseditor_files.cmake
@@ -118,6 +118,8 @@ set(FILES
     Editor/PropertiesWrapper.h
     Editor/PropertyHandlerAnchor.cpp
     Editor/PropertyHandlerAnchor.h
+    Editor/PropertyHandlerCanvasAsset.cpp
+    Editor/PropertyHandlerCanvasAsset.h
     Editor/PropertyHandlerChar.cpp
     Editor/PropertyHandlerChar.h
     Editor/PropertyHandlerDirectory.cpp


### PR DESCRIPTION
## What does this PR do?

Fixes #16084 

This fixes the issue with the canvas asset property on the `UI Canvas Asset Ref` component not showing up. The short answer is its using a simple reference asset type, which uses an underlying base-class handler that doesn't function properly in the DPE, so to resolve this I registered a custom handler for the explicit property type that makes uses of the default asset property handler.

BEFORE:
![SimpleAssetReference_BEFORE](https://github.com/o3de/o3de/assets/7519264/12c60279-a538-4528-8439-e9285b7882bc)

AFTER:
![CanvasAsset_AFTER](https://github.com/o3de/o3de/assets/7519264/5aac0554-cea8-4e14-b122-fc937fa30880)

I've created a backlog item to potentially revisit the generic base class handler property type support, but I believe the proper workflow going forward is either registering the property handler with the expected type (which covers most of our properties), or use a templated data type like the asset property handlers: https://github.com/o3de/o3de/issues/16347

## How was this PR tested?

Tested the canvas asset property with both RPE and DPE and verified they work as expected.