### PR TITLE
Fix second scroll bar in AB

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/AssetBrowser_SearchFiltering.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/AssetBrowser_SearchFiltering.py
@@ -159,7 +159,7 @@ def AssetBrowser_SearchFiltering():
         Report.result(Tests.asset_type_filtered, remove_filtered)
 
         # 8) Remove all of the filter asset types from the list of filters
-        filetag_close_button = filter_layout.children()[1]
+        filetag_close_button = filter_layout.children()[3]
         second_close_button = filetag_close_button.findChild(QtWidgets.QPushButton, "closeTag")
         second_close_button.click()
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.h
@@ -39,6 +39,7 @@ class QLabel;
 class QHBoxLayout;
 class QIcon;
 class QBoxLayout;
+class QSpacerItem;
 
 namespace AzQtComponents
 {
@@ -380,6 +381,8 @@ namespace AzQtComponents
         FilterTextButton* m_filterTextButton = nullptr;
         SelectionCountButton* m_selectionCountButton = nullptr;
         QToolButton* m_addFavoritesButton = nullptr;
+        QHBoxLayout* m_favoritesLayout = nullptr;
+        QSpacerItem* m_endSpacer = nullptr;
     private:
         int FindFilterIndex(const QString& category, const QString& displayName) const;
         void SetupContainerLayout();


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the Asset Browser's favorite system was being added to the` AzQtComponents::FlowLayout` and the interaction was causing a second scroll bar to appear. Whenever the favorite system is being used, the FlowLayout is no longer used. 

This means that there will no longer be overflow control if a user has too many filters set, but since the new asset browser is docked to the bottom this should not be a concern for the majority of users. If the window is resized too small, the names of each filter will resize to their minimum sizes. 

Fixes #16345

Previously:
![WithFrame](https://github.com/o3de/o3de/assets/84731577/0deec62e-8127-4d59-87f9-aeae61f49b5f)

Now:
![FixedScroll](https://github.com/o3de/o3de/assets/84731577/3d26bc56-d935-4dc9-a78f-6f470b7f0767)

## How was this PR tested?

Tested by using the asset browser, and by using material canvas which uses the FilteredSearchWidget without favorites.
