### PR TITLE
Multiple fixes with game launcher for loft scene 

### DIFF
--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -591,7 +591,7 @@ namespace LegacyLevelSystem
         AzFramework::RootSpawnableInterface::Get()->ReleaseRootSpawnable();
         
         // Process the queued deactivate calls for the unloaded entities
-        AzFramework::RootSpawnableInterface::Get()->ProcessSpawnableQueue();
+        AzFramework::RootSpawnableInterface::Get()->ProcessSpawnableQueueUntilEmpty();
 
         m_lastLevelName.clear();
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -589,6 +589,9 @@ namespace LegacyLevelSystem
 
         // Delete level entities and remove them from the game entity context
         AzFramework::RootSpawnableInterface::Get()->ReleaseRootSpawnable();
+        
+        // Process the queued deactivate calls for the unloaded entities
+        AzFramework::RootSpawnableInterface::Get()->ProcessSpawnableQueue();
 
         m_lastLevelName.clear();
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -1748,7 +1748,7 @@ namespace AZ
             {
                 const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
                 const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
-                m_fullscreenShadowPass->SetLightIndex(m_shadowingLightHandle.GetIndex());
+                m_fullscreenShadowPass->SetLightRawIndex(m_shadowProperties.GetRawIndex(m_shadowingLightHandle.GetIndex()));
                 m_fullscreenShadowPass->SetBlendBetweenCascadesEnable(cascadeCount > 1 && shadowProperty.m_blendBetweenCascades);
                 m_fullscreenShadowPass->SetFilterMethod(static_cast<ShadowFilterMethod>(shadowFilterMethod));
                 m_fullscreenShadowPass->SetReceiverShadowPlaneBiasEnable(shadowProperty.m_isReceiverPlaneBiasEnabled);

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -845,6 +845,12 @@ namespace AZ
                 // Per mesh shader option flags was on, but now turned off, so reset all the shader options.
                 for (auto& modelHandle : m_modelData)
                 {
+                    // skip if the model need to be initialized
+                    if (modelHandle.m_flags.m_needsInit)
+                    {
+                        continue;
+                    }
+                    
                     for (RPI::MeshDrawPacketList& drawPacketList : modelHandle.m_drawPacketListsByLod)
                     {
                         for (RPI::MeshDrawPacket& drawPacket : drawPacketList)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -878,6 +878,11 @@ namespace AZ
                 {
                     if (modelHandle.m_cullable.m_prevShaderOptionFlags != modelHandle.m_cullable.m_shaderOptionFlags)
                     {
+                        // skip if the model need to be initialized
+                        if (modelHandle.m_flags.m_needsInit)
+                        {
+                            continue;
+                        }
                         // Per mesh shader option flags have changed, so rebuild the draw packet with the new shader options.
                         for (RPI::MeshDrawPacketList& drawPacketList : modelHandle.m_drawPacketListsByLod)
                         {

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
@@ -52,9 +52,10 @@ namespace AZ
                 m_receiverShadowPlaneBiasEnable = enable;
             }
 
-            void SetLightIndex(int lightIndex)
+            // Set directional light's raw index which is used for access directional light in shader
+            void SetLightRawIndex(int lightRawIndex)
             {
-                m_lightIndex = lightIndex;
+                m_lightIndex = lightRawIndex;
             }
 
         private:

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
@@ -52,7 +52,7 @@ namespace AZ
                 m_receiverShadowPlaneBiasEnable = enable;
             }
 
-            // Set directional light's raw index which is used for access directional light in shader
+            // Set directional light's raw index which is used for accessing the directional light in the shader
             void SetLightRawIndex(int lightRawIndex)
             {
                 m_lightIndex = lightRawIndex;


### PR DESCRIPTION
## What does this PR do?
- Crash when start loft scene game launcher: it was trying to build cullable before mesh was loaded.
- Lighting was wrong when load a new level while there is a level loaded: the new level entities were activated before entities from old level are deactivated. This leads to IBL fp reset its diffuse & specular maps to default.

## How was this PR tested?
Run game launcher for loft-arch-vis-sample project. 
Load Interior_03.prefab level.
Load Interior_03.prefab level again. 
Make sure the 3d rendering is same before and after load the Interior_03.prefab level the second time. 
Try switch to different levels then load Interior_03.prefab again. The rendering result should be the same.

