### PR TITLE
Add integration tests for implicitly connecting slots

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurationDefaults.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurationDefaults.h
@@ -39,11 +39,8 @@ namespace ScriptCanvas
         struct FloatData : public DataSlotConfiguration
         {
             FloatData(AZStd::string_view name, ConnectionType connectionType, bool isLatent = false)
-                : DataSlotConfiguration()
+                : DataSlotConfiguration(Data::Type::Number(), name, connectionType)
             {
-                m_name = name;
-                SetConnectionType(connectionType);
-                SetAZType<float>();
                 m_isLatent = isLatent;
             }
         };

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurationDefaults.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurationDefaults.h
@@ -34,6 +34,30 @@ namespace ScriptCanvas
                 : ExecutionSlotConfiguration(GetName(), ConnectionType::Output)
             {
             }
-        };        
+        };
+
+        struct FloatData : public DataSlotConfiguration
+        {
+            FloatData(AZStd::string_view name, ConnectionType connectionType, bool isLatent = false)
+                : DataSlotConfiguration()
+            {
+                m_name = name;
+                SetConnectionType(connectionType);
+                SetAZType<float>();
+                m_isLatent = isLatent;
+            }
+        };
+
+        struct Execution : public ExecutionSlotConfiguration
+        {
+            Execution(AZStd::string_view name, ConnectionType connectionType, bool isLatent = false, bool createsImplicitConnections = false)
+                : ExecutionSlotConfiguration()
+            {
+                m_name = name;
+                SetConnectionType(connectionType);
+                m_isLatent = isLatent;
+                m_createsImplicitConnections = createsImplicitConnections;
+            }
+        };
     }    
 }

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -185,23 +185,17 @@ namespace ScriptCanvasTests
 
         ScriptCanvas::Graph* CreateGraph()
         {
-            if (m_graph == nullptr)
-            {
-                m_graph = aznew ScriptCanvas::Graph();
-                m_graph->Init();
-            }
-
+            AZ_Assert(!m_graph, "Only one graph should be created per test.");
+            m_graph = aznew ScriptCanvas::Graph();
+            m_graph->Init();
             return m_graph;
         }
 
         ScriptCanvasEditor::EditorGraph* CreateEditorGraph()
         {
-            if (m_graph == nullptr)
-            {
-                m_graph = aznew ScriptCanvasEditor::EditorGraph();
-                m_graph->Init();
-            }
-
+            AZ_Assert(!m_graph, "Only one graph should be created per test.");
+            m_graph = aznew ScriptCanvasEditor::EditorGraph();
+            m_graph->Init();
             return static_cast<ScriptCanvasEditor::EditorGraph*>(m_graph);
         }
 
@@ -210,9 +204,11 @@ namespace ScriptCanvasTests
             AZ::Entity* configurableNodeEntity = new AZ::Entity(entityName.c_str());
             auto configurableNode = configurableNodeEntity->CreateComponent<TestNodes::ConfigurableUnitTestNode>();
 
-            if (m_graph == nullptr)
+            AZ_Assert(m_graph, "A graph must be created before any nodes are created.");
+
+            if (!m_graph)
             {
-                CreateGraph();
+                return nullptr;
             }
 
             ScriptCanvas::ScriptCanvasId scriptCanvasId = m_graph->GetScriptCanvasId();
@@ -263,7 +259,6 @@ namespace ScriptCanvasTests
             AZ::Entity* ent;
 
             EXPECT_EQ(m_graph->FindConnection(ent, sourceEndpoint, targetEndpoint), isValid);
-            EXPECT_EQ(m_graph->FindConnection(ent, targetEndpoint, sourceEndpoint), isValid);
         }
 
         // Tests implicit connections between nodes by connecting and disconnecting every data source and data slot while checking to make

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -21,6 +21,7 @@
 #include <TestAutoGenNodeableRegistry.generated.h>
 #include <Nodes/BehaviorContextObjectTestNode.h>
 #include <Nodes/TestAutoGenFunctions.h>
+#include <ScriptCanvas/Components/EditorGraph.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/SlotConfigurationDefaults.h>
 #include <ScriptCanvas/ScriptCanvasGem.h>
@@ -193,6 +194,17 @@ namespace ScriptCanvasTests
             return m_graph;
         }
 
+        ScriptCanvasEditor::EditorGraph* CreateEditorGraph()
+        {
+            if (m_graph == nullptr)
+            {
+                m_graph = aznew ScriptCanvasEditor::EditorGraph();
+                m_graph->Init();
+            }
+
+            return static_cast<ScriptCanvasEditor::EditorGraph*>(m_graph);
+        }
+
         TestNodes::ConfigurableUnitTestNode* CreateConfigurableNode(AZStd::string entityName = "ConfigurableNodeEntity")
         {
             AZ::Entity* configurableNodeEntity = new AZ::Entity(entityName.c_str());
@@ -243,6 +255,71 @@ namespace ScriptCanvasTests
 
             EXPECT_EQ(m_graph->CanCreateConnectionBetween(sourceEndpoint, targetEndpoint).IsSuccess(), isValid);
             EXPECT_EQ(m_graph->CanCreateConnectionBetween(targetEndpoint, sourceEndpoint).IsSuccess(), isValid);
+        }
+
+        // Test if there is an existing connection between the provided endpoints
+        void TestIsConnectionBetween(const ScriptCanvas::Endpoint& sourceEndpoint, const ScriptCanvas::Endpoint& targetEndpoint, bool isValid = true)
+        {
+            AZ::Entity* ent;
+
+            EXPECT_EQ(m_graph->FindConnection(ent, sourceEndpoint, targetEndpoint), isValid);
+            EXPECT_EQ(m_graph->FindConnection(ent, targetEndpoint, sourceEndpoint), isValid);
+        }
+
+        // Tests implicit connections between nodes by connecting and disconnecting every data source and data slot while checking to make
+        // sure that a connection is maintained between the source and target execution slots as long as at least one set of source and target
+        // data slots are connected, and that no other execution out slots are connected to the target execution slot
+        void TestAllImplicitConnections(
+            ScriptCanvasEditor::EditorGraph* editorGraph,
+            AZStd::vector<ScriptCanvas::Endpoint> sourceDataSlots,
+            AZStd::vector<ScriptCanvas::Endpoint> targetDataSlots,
+            ScriptCanvas::Endpoint sourceExecSlot,
+            ScriptCanvas::Endpoint targetExecSlot,
+            AZStd::vector<ScriptCanvas::Endpoint> allExecutionOutSlots)
+        {
+            // Connect all of the data slots
+            for (auto sourceDataSlot : sourceDataSlots)
+            {
+                for (auto targetDataSlot : targetDataSlots)
+                {
+                    TestConnectionBetween(sourceDataSlot, targetDataSlot, true);
+                    editorGraph->UpdateCorrespondingImplicitConnection(sourceDataSlot, targetDataSlot);
+
+                    // Ensure the implicit connection exists
+                    TestIsConnectionBetween(sourceExecSlot, targetExecSlot, true);
+                    for (auto otherExecSlot : allExecutionOutSlots)
+                    {
+                        if (otherExecSlot.GetSlotId() != sourceExecSlot.GetSlotId())
+                        {
+                            // Ensure that no implicit connections exist between any of the other execution out slots and the target
+                            // execution slot
+                            TestIsConnectionBetween(otherExecSlot, targetExecSlot, false);
+                        }
+                    }
+                }
+            }
+            // Disconnect all of the data slots
+            for (int i = 0; i < sourceDataSlots.size(); i++)
+            {
+                for (int j = 0; j < targetDataSlots.size(); j++)
+                {
+                    editorGraph->DisconnectByEndpoint(sourceDataSlots[i], targetDataSlots[j]);
+                    editorGraph->UpdateCorrespondingImplicitConnection(sourceDataSlots[i], targetDataSlots[j]);
+
+                    // Ensure the implicit connection exists only if this is not the last data connection. If it is, then ensure that
+                    // no implicit connection exists
+                    TestIsConnectionBetween(sourceExecSlot, targetExecSlot, (i < sourceDataSlots.size() - 1 || j < targetDataSlots.size() - 1));
+                    for (auto otherExecSlot : allExecutionOutSlots)
+                    {
+                        if (otherExecSlot.GetSlotId() != sourceExecSlot.GetSlotId())
+                        {
+                            // Ensure that no implicit connections exist between any of the other execution out slots and the target
+                            // execution slot
+                            TestIsConnectionBetween(otherExecSlot, targetExecSlot, false);
+                        }
+                    }
+                }
+            }
         }
 
         void CreateExecutionFlowBetween(AZStd::vector<TestNodes::ConfigurableUnitTestNode*> unitTestNodes)

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.cpp
@@ -329,6 +329,16 @@ namespace TestNodes
     bool ConfigurableUnitTestNode::TestIsSlotConnectedToConcreteDisplayType(const ScriptCanvas::Slot& slot, ExploredDynamicGroupCache& exploredGroupCache) const
     {
         return FindConnectedConcreteDisplayType(slot, exploredGroupCache).IsValid();
-    }    
+    }
+
+    void ConfigurableUnitTestNode::SetSlotExecutionMap(ScriptCanvas::SlotExecution::Map* executionMap)
+    {
+        m_slotExecutionMap = executionMap;
+    }
+
+    const ScriptCanvas::SlotExecution::Map* ConfigurableUnitTestNode::GetSlotExecutionMap() const
+    {
+        return m_slotExecutionMap;
+    }
 }
 

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.h
@@ -151,7 +151,11 @@ namespace TestNodes
 
         bool TestIsSlotConnectedToConcreteDisplayType(const ScriptCanvas::Slot& slot, ExploredDynamicGroupCache& exploredGroupCache) const;
 
-    protected:
+        void SetSlotExecutionMap(ScriptCanvas::SlotExecution::Map* executionMap);
+        const ScriptCanvas::SlotExecution::Map* GetSlotExecutionMap() const override;
+
+    private:
+        ScriptCanvas::SlotExecution::Map* m_slotExecutionMap = nullptr;
     };
 
 

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
@@ -286,6 +286,194 @@ TEST_F(ScriptCanvasTestFixture, SlotConnecting_ExecutionBasic)
     TestConnectionBetween(outputEndpoint, inputEndpoint, true);
 }
 
+// Test implicit connections against a simple node that has no slot execution map
+TEST_F(ScriptCanvasTestFixture, SlotConnecting_ImplicitConnections)
+{
+    using namespace ScriptCanvas;
+
+    auto editorGraph = CreateEditorGraph();
+
+    // Node before node that creates implicit connections
+    ConfigurableUnitTestNode* sourceNode = CreateConfigurableNode();
+    Endpoint execOutSlot = sourceNode->AddTestingSlot(CommonSlots::Execution("Out", ConnectionType::Output))->GetEndpoint();
+    Endpoint dataOutSlot1 = sourceNode->AddTestingSlot(CommonSlots::FloatData("out1", ConnectionType::Output))->GetEndpoint();
+    Endpoint dataOutSlot2 = sourceNode->AddTestingSlot(CommonSlots::FloatData("out2", ConnectionType::Output))->GetEndpoint();
+
+    // Node that creates implicit connections
+    ConfigurableUnitTestNode* targetNode = CreateConfigurableNode();
+    Endpoint implicitSlot = targetNode->AddTestingSlot(CommonSlots::Execution("In", ConnectionType::Input, false, true))->GetEndpoint();
+    Endpoint dataInSlot1 = targetNode->AddTestingSlot(CommonSlots::FloatData("in1", ConnectionType::Input))->GetEndpoint();
+    Endpoint dataInSlot2 = targetNode->AddTestingSlot(CommonSlots::FloatData("in2", ConnectionType::Input))->GetEndpoint();
+
+    // Test the implicit connections between the two nodes
+    TestAllImplicitConnections(editorGraph, { dataOutSlot1, dataOutSlot2 }, { dataInSlot1, dataInSlot2 }, execOutSlot, implicitSlot, { execOutSlot });
+}
+
+// Test implicit connections against a complex node that has a slot execution map
+TEST_F(ScriptCanvasTestFixture, SlotConnecting_ImplicitConnectionsSlotExecutionMap)
+{
+    using namespace ScriptCanvas;
+
+    auto editorGraph = CreateEditorGraph();
+
+    // These vectors store each "set" of data output endpoints that correspond with one execution out
+    AZStd::vector<Endpoint> dataOutEndpointSet1;
+    AZStd::vector<Endpoint> dataOutEndpointSet2;
+    AZStd::vector<Endpoint> dataOutEndpointSet3;
+    AZStd::vector<Endpoint> dataOutEndpointSet4;
+    AZStd::vector<Endpoint> dataOutEndpointSet5;
+
+    // The data in slots for the compact node
+    AZStd::vector<Endpoint> dataInEndpointSet;
+
+    // Vector of every execution output pin. Used to make sure implicit connections are only being made when they need to
+    AZStd::vector<Endpoint> executions;
+
+    // Execution ins and outs for slot execution map
+    SlotExecution::Ins ins;
+    SlotExecution::Outs outs;
+
+
+    // Node before the node that creates implicit connections
+    ConfigurableUnitTestNode* sourceNode = CreateConfigurableNode();
+
+    // Simple execution in mapped to one execution out with two corresponding data out slots
+    SlotExecution::In in1;
+
+    Endpoint execIn1 = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("In1", ConnectionType::Input))->GetEndpoint();
+    in1.slotId = execIn1.GetSlotId();
+
+    SlotExecution::Out out1;
+
+    Endpoint execOut1 = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("Out1", ConnectionType::Output))->GetEndpoint();
+    out1.slotId = execOut1.GetSlotId();
+    executions.push_back(execOut1);
+
+    Endpoint dataOut1a = sourceNode->AddTestingSlot(CommonSlots::FloatData("out1a", ConnectionType::Output))->GetEndpoint();
+    out1.outputs.emplace_back(dataOut1a.GetSlotId());
+    dataOutEndpointSet1.push_back(dataOut1a);
+
+    Endpoint dataOut1b = sourceNode->AddTestingSlot(CommonSlots::FloatData("out1b", ConnectionType::Output))->GetEndpoint();
+    out1.outputs.emplace_back(dataOut1b.GetSlotId());
+    dataOutEndpointSet1.push_back(dataOut1b);
+
+    in1.outs.emplace_back(out1);
+
+    ins.push_back(in1);
+
+    // Execution in mapped to two execution out slots. Each execution out slot has two corresponding data out slots
+    SlotExecution::In in2;
+
+    Endpoint execIn2 = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("In2", ConnectionType::Input))->GetEndpoint();
+    in2.slotId = execIn2.GetSlotId();
+
+    SlotExecution::Out out2a;
+
+    Endpoint execOut2a = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("Out2a", ConnectionType::Output))->GetEndpoint();
+    out2a.slotId = execOut2a.GetSlotId();
+    executions.push_back(execOut2a);
+
+    Endpoint dataOut2aa = sourceNode->AddTestingSlot(CommonSlots::FloatData("out2aa", ConnectionType::Output))->GetEndpoint();
+    out2a.outputs.emplace_back(dataOut2aa.GetSlotId());
+    dataOutEndpointSet2.push_back(dataOut2aa);
+
+    Endpoint dataOut2ab = sourceNode->AddTestingSlot(CommonSlots::FloatData("out2ab", ConnectionType::Output))->GetEndpoint();
+    out2a.outputs.emplace_back(dataOut2ab.GetSlotId());
+    dataOutEndpointSet2.push_back(dataOut2ab);
+
+    in2.outs.emplace_back(out2a);
+
+    SlotExecution::Out out2b;
+
+    Endpoint execOut2b = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("Out2b", ConnectionType::Output))->GetEndpoint();
+    out2b.slotId = execOut2b.GetSlotId();
+    executions.push_back(execOut2b);
+
+    Endpoint dataOut2ba = sourceNode->AddTestingSlot(CommonSlots::FloatData("out2ba", ConnectionType::Output))->GetEndpoint();
+    out2b.outputs.emplace_back(dataOut2ba.GetSlotId());
+    dataOutEndpointSet3.push_back(dataOut2ba);
+
+    Endpoint dataOut2bb = sourceNode->AddTestingSlot(CommonSlots::FloatData("out2bb", ConnectionType::Output))->GetEndpoint();
+    out2b.outputs.emplace_back(dataOut2bb.GetSlotId());
+    dataOutEndpointSet3.push_back(dataOut2bb);
+
+    in2.outs.emplace_back(out2b);
+
+    ins.push_back(in2);
+
+    // Simple execution in mapped to one execution out with one corresponding data out slot
+    SlotExecution::In in3;
+
+    Endpoint execIn3 = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("In3", ConnectionType::Input))->GetEndpoint();
+    in3.slotId = execIn3.GetSlotId();
+
+    SlotExecution::Out out3;
+
+    Endpoint execOut3 = sourceNode->AddTestingSlot(ExecutionSlotConfiguration("Out3", ConnectionType::Output))->GetEndpoint();
+    out3.slotId = execOut3.GetSlotId();
+    executions.push_back(execOut3);
+
+    Endpoint dataOut3 = sourceNode->AddTestingSlot(CommonSlots::FloatData("out3", ConnectionType::Output))->GetEndpoint();
+    out3.outputs.emplace_back(dataOut3.GetSlotId());
+    dataOutEndpointSet4.push_back(dataOut3);
+
+    in3.outs.emplace_back(out3);
+
+    ins.push_back(in3);
+
+    // Latent execution out slot with two corresponding data out slots
+    SlotExecution::Out latOut1;
+
+    Endpoint latExecOut1 =
+        sourceNode->AddTestingSlot(CommonSlots::Execution("LatOut1", ConnectionType::Output, true))->GetEndpoint();
+    latOut1.slotId = latExecOut1.GetSlotId();
+    executions.push_back(latExecOut1);
+
+    Endpoint latDataOut1a =
+        sourceNode->AddTestingSlot(CommonSlots::FloatData("latOut1a", ConnectionType::Output, true))->GetEndpoint();
+    latOut1.outputs.emplace_back(latDataOut1a.GetSlotId());
+    dataOutEndpointSet5.push_back(latDataOut1a);
+
+    Endpoint latDataOut1b =
+        sourceNode->AddTestingSlot(CommonSlots::FloatData("latOut1b", ConnectionType::Output, true))->GetEndpoint();
+    latOut1.outputs.emplace_back(latDataOut1b.GetSlotId());
+    dataOutEndpointSet5.push_back(latDataOut1b);
+
+    outs.push_back(latOut1);
+
+    // Configure the slot execution map on the source node
+    auto map = aznew SlotExecution::Map(AZStd::move(ins), AZStd::move(outs));
+
+    sourceNode->SetSlotExecutionMap(map);
+
+
+    // Node that creates implicit connections
+    ConfigurableUnitTestNode* targetNode = CreateConfigurableNode();
+
+    // Implicit Execution input with two data inputs
+    Endpoint compImpExecIn = targetNode->AddTestingSlot(CommonSlots::Execution("impExec", ConnectionType::Input, false, true))->GetEndpoint();
+
+    Endpoint compDataIn1 = targetNode->AddTestingSlot(CommonSlots::FloatData("compDataIn1", ConnectionType::Input))->GetEndpoint();
+    dataInEndpointSet.push_back(compDataIn1);
+
+    Endpoint compDataIn2 = targetNode->AddTestingSlot(CommonSlots::FloatData("compDataIn2", ConnectionType::Input))->GetEndpoint();
+    dataInEndpointSet.push_back(compDataIn2);
+
+
+    // Test to make sure implicit connections are being made correctly in each set of data slots
+    TestAllImplicitConnections(editorGraph, dataOutEndpointSet1, dataInEndpointSet, execOut1, compImpExecIn, executions);
+
+    TestAllImplicitConnections(editorGraph, dataOutEndpointSet2, dataInEndpointSet, execOut2a, compImpExecIn, executions);
+
+    TestAllImplicitConnections(editorGraph, dataOutEndpointSet3, dataInEndpointSet, execOut2b, compImpExecIn, executions);
+
+    TestAllImplicitConnections(editorGraph, dataOutEndpointSet4, dataInEndpointSet, execOut3, compImpExecIn, executions);
+
+    TestAllImplicitConnections(editorGraph, dataOutEndpointSet5, dataInEndpointSet, latExecOut1, compImpExecIn, executions);
+
+    delete map;
+}
+
 // Exhaustive test of connecting Execution to a variety of invalid targets.
 TEST_F(ScriptCanvasTestFixture, SlotConnecting_ExecutionFailure)
 {

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_Slots.cpp
@@ -105,6 +105,8 @@ TEST_F(ScriptCanvasTestFixture, SlotCreation_GeneralCreation)
 {
     using namespace ScriptCanvas;
 
+    CreateGraph();
+
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
     {
@@ -202,6 +204,8 @@ TEST_F(ScriptCanvasTestFixture, SlotCreation_GeneralCreation)
 TEST_F(ScriptCanvasTestFixture, SlotCreation_DataSlotCreation)
 {
     using namespace ScriptCanvas;
+
+    CreateGraph();
 
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
@@ -648,6 +652,8 @@ TEST_F(ScriptCanvasTestFixture, TypeMatching_SubClassShouldMatchBaseClassSlot)
 
     using namespace ScriptCanvas;
 
+    CreateGraph();
+
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
     for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
@@ -675,6 +681,8 @@ TEST_F(ScriptCanvasTestFixture, TypeMatching_BaseClassShouldNotMatchSubClassSlot
 
     using namespace ScriptCanvas;
 
+    CreateGraph();
+
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
     for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
@@ -700,6 +708,8 @@ TEST_F(ScriptCanvasTestFixture, DynamicSlotCreation_SubClassShouldMatchBaseClass
     // When a dynamic slot is created with a base class type, it should match both base classes and subclasses.
 
     using namespace ScriptCanvas;
+
+    CreateGraph();
 
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
@@ -731,6 +741,8 @@ TEST_F(ScriptCanvasTestFixture, DynamicSlotCreation_BaseClassShouldNotMatchSubCl
 
     using namespace ScriptCanvas;
 
+    CreateGraph();
+
     ConfigurableUnitTestNode* emptyNode = CreateConfigurableNode();
 
     for (const ConnectionType& connectionType : { ConnectionType::Input, ConnectionType::Output })
@@ -761,6 +773,8 @@ TEST_F(ScriptCanvasTestFixture, TypeMatching_BaseClassSlotWithSubClassVariableSh
     // the slot should still match base classes. This is important for being able to change what is hooked to the slot.
 
     using namespace ScriptCanvas;
+
+    CreateGraph();
 
     // Create a slot of type TestBaseClass
 


### PR DESCRIPTION
## What does this PR do?

This PR adds two integration tests to test nodes with slots that make implicit connections:
- SlotConnecting_ImplicitConnections, which tests if implicit connections are being made correctly between two nodes that do not have a Slot Execution Map
- SlotConnecting_ImplicitConnectionsSlotExecutionMap, which tests if implicit connections are being made correctly with a more complex node that does have a Slot Execution Map

Both tests make ConfigurableUnitTestNodes and configure one to have an execution input that makes implicit connections, and another to have execution output(s). Each node is given data slots that are connected and disconnected with checks to make sure implicit connections are being properly made/removed.

## How was this PR tested?

Manual testing was done to ensure that the tests passed and failed when expected. The tests were run while the rest of the codebase was left unchanged which passed. I also tested by temporarily changing the UpdateCorrespondingImplicitConnections function to not work properly and the tests failed as expected.
