### PR TITLE
Fix various issues related to iOS build and run on Iphone 8

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -749,13 +749,13 @@ void AzAssetBrowserWindow::SetTwoColumnMode(QWidget* viewToShow)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(true);
         m_ui->m_tableView->SetTableViewActive(false);
-        m_ui->m_searchWidget->SetSelectionCount(m_ui->m_thumbnailView->GetSelectedAssets().size());
+        m_ui->m_searchWidget->SetSelectionCount(aznumeric_cast<uint32_t>(m_ui->m_thumbnailView->GetSelectedAssets().size()));
     }
     else if (tableView)
     {
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
         m_ui->m_tableView->SetTableViewActive(true);
-        m_ui->m_searchWidget->SetSelectionCount(m_ui->m_tableView->GetSelectedAssets().size());
+        m_ui->m_searchWidget->SetSelectionCount(aznumeric_cast<uint32_t>(m_ui->m_tableView->GetSelectedAssets().size()));
     }
 }
 
@@ -772,7 +772,7 @@ void AzAssetBrowserWindow::SetOneColumnMode()
         }
         m_ui->m_thumbnailView->SetThumbnailActiveView(false);
         m_ui->m_tableView->SetTableViewActive(false);
-        m_ui->m_searchWidget->SetSelectionCount(m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets().size());
+        m_ui->m_searchWidget->SetSelectionCount(aznumeric_cast<uint32_t>(m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets().size()));
     }
 }
 
@@ -1019,15 +1019,15 @@ int AzAssetBrowserWindow::GetSelectionCount()
 {
     if (m_ui->m_thumbnailView->GetThumbnailActiveView())
     {
-        return m_ui->m_thumbnailView->GetSelectedAssets().size();
+        return aznumeric_cast<uint32_t>(m_ui->m_thumbnailView->GetSelectedAssets().size());
     }
 
     if (m_ui->m_tableView->GetTableViewActive())
     {
-        return m_ui->m_tableView->GetSelectedAssets().size();
+        return aznumeric_cast<uint32_t>(m_ui->m_tableView->GetSelectedAssets().size());
     }
 
-    return m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets().size();
+    return aznumeric_cast<uint32_t>(m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets().size());
 }
 
 void AzAssetBrowserWindow::OnFilterCriteriaChanged()

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
@@ -70,6 +70,9 @@ namespace AZStd
         // QOS_CLASS_BACKGROUN         |           0          |           4          |  Will be prevented from using whole core.
         uint8_t GetDefaultThreadPriority()
         {
+            // We currently set the thread priority somewhere in the middle of QOS_CLASS_DEFAULT by default, since our threads generally
+            // don't need to finish in a single frame. Set this value higher if the default thread priorities are causing the threads to
+            // get starved too often.
             return 25;
         }
     }

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
@@ -70,7 +70,7 @@ namespace AZStd
         // QOS_CLASS_BACKGROUN         |           0          |           4          |  Will be prevented from using whole core.
         uint8_t GetDefaultThreadPriority()
         {
-            return 10;
+            return 25;
         }
     }
 }

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/Module/DynamicModuleHandle_iOS.cpp
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/Module/DynamicModuleHandle_iOS.cpp
@@ -18,7 +18,7 @@ namespace AZ::Platform
         return AZ::IO::FixedMaxPath(AZ::Utils::GetExecutableDirectory()) / "Frameworks";
     }
 
-    void* OpenModule(const AZ::OSString& fileName, bool& alreadyOpen)
+    void* OpenModule(const AZ::IO::FixedMaxPathString& fileName, bool& alreadyOpen)
     {
         void* handle = dlopen(fileName.c_str(), RTLD_NOLOAD);
         alreadyOpen = (handle != nullptr);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -266,14 +266,14 @@ namespace AzToolsFramework
             // Entries are in reverse order, so fix this
             AZStd::reverse(entries.begin(), entries.end());
 
-            uint32_t lastEntry = entries.size() - 1;
+            uint32_t lastEntry = aznumeric_cast<uint32_t>(entries.size()) - 1;
 
             // If we're in the thumbnail or table view, the actual asset will not appear in this treeview.
             // Trying to find the file in the treeview will fail, so don't search to the end.
             if ((m_attachedThumbnailView && m_attachedThumbnailView->GetThumbnailActiveView()) ||
                 (m_attachedTableView && m_attachedTableView->GetTableViewActive()))
             {
-                lastEntry = entries.size() - 2;
+                lastEntry = aznumeric_cast<uint32_t>(entries.size()) - 2;
             }
 
             SelectEntry(QModelIndex(), entries, lastEntry);
@@ -497,7 +497,7 @@ namespace AzToolsFramework
             AZStd::vector<AZStd::string> entries;
             AZ::StringFunc::Tokenize(folderPath, entries, "/");
 
-            SelectEntry(QModelIndex(), entries, entries.size() - 1, 0, true);
+            SelectEntry(QModelIndex(), entries, aznumeric_cast<uint32_t>(entries.size()) - 1, 0, true);
         }
 
 
@@ -535,7 +535,7 @@ namespace AzToolsFramework
 
             AZStd::reverse(entries.begin(), entries.end());
 
-            uint32_t lastEntry = entries.size() - 1;
+            uint32_t lastEntry = aznumeric_cast<uint32_t>(entries.size()) - 1;
 
             SelectEntry(QModelIndex(), entries, lastEntry, 0, true);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -284,7 +284,7 @@ namespace AzToolsFramework
                     if (AZ::StringFunc::LooksLikeInt(name.GetCStr()))
                     {
                         AZStd::string attributeIdString(name.GetStringView());
-                        AZ::u32 attributeIdHash = AZStd::stoul(attributeIdString);
+                        AZ::u32 attributeIdHash = static_cast<AZ::u32>(AZStd::stoul(attributeIdString));
                         attributeId = AZ::Crc32(attributeIdHash);
 
                         // If we failed to marshal the attribute in the above AZ::Reflection::WriteDomValueToGenericAttribute,

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -83,7 +83,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 120; // Remove build timestamp
+            shaderAssetBuilderDescriptor.m_version = 121; // Add support for metal shader language 2.2
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -108,7 +108,7 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 37; // Remove build timestamp
+                shaderVariantAssetBuilderDescriptor.m_version = 38; // Add support for metal shader language 2.2
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();

--- a/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
@@ -12,7 +12,7 @@
               , "-enable-16bit-types"
         ],
         "spirv-cross": [],
-        "metalair": ["-sdk", "iphoneos", "metal" // For xcrun
+        "metalair": ["-sdk", "iphoneos", "metal", "-std=ios-metal2.2", "-target air64-apple-ios14.0" // For xcrun
                    , "-gline-tables-only", "-MO" //Debug symbols are always enabled at the moment. Need to turn them off for optimized shader assets.
                    , "-fpreserve-invariance"
                    , "-c"

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -535,7 +535,11 @@ namespace AZ
             desc.m_byteCount = 64;
             desc.m_bufferData = instanceData;
             m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
-            m_instanceBufferView = RHI::StreamBufferView(*m_instanceBuffer->GetRHIBuffer(), 0, 64, 4);
+            m_instanceBufferView = RHI::StreamBufferView(
+                *m_instanceBuffer->GetRHIBuffer(),
+                0,
+                aznumeric_cast<uint32_t>(desc.m_byteCount),
+                aznumeric_cast<uint32_t>(desc.m_elementSize));
 
             ImGui::NewFrame();
             AzFramework::InputChannelEventListener::Connect();

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -469,7 +469,7 @@ namespace AZ
                     ->Channel("UV", RHI::Format::R32G32_FLOAT)
                     ->Channel("COLOR", RHI::Format::R8G8B8A8_UNORM);
                 layoutBuilder.AddBuffer(RHI::StreamStepFunction::PerInstance)
-                    ->Channel("INSTANCE_DATA", RHI::Format::R8_UINT);
+                    ->Channel("INSTANCE_DATA", RHI::Format::R32_UINT);
                 m_pipelineState->InputStreamLayout() = layoutBuilder.End();
 
             }
@@ -527,15 +527,15 @@ namespace AZ
             m_imguiFontTexId = io.Fonts->TexID;
 
             // ImGuiPass will support binding 16 textures at most per frame. 
-            const uint8_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+            const uint32_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
             RPI::CommonBufferDescriptor desc;
             desc.m_poolType = RPI::CommonBufferPoolType::StaticInputAssembly;
             desc.m_bufferName = "InstanceBuffer";
-            desc.m_elementSize = 1;
-            desc.m_byteCount = 16;
+            desc.m_elementSize = 4;
+            desc.m_byteCount = 64;
             desc.m_bufferData = instanceData;
             m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
-            m_instanceBufferView = RHI::StreamBufferView(*m_instanceBuffer->GetRHIBuffer(), 0, 16, 1);
+            m_instanceBufferView = RHI::StreamBufferView(*m_instanceBuffer->GetRHIBuffer(), 0, 64, 4);
 
             ImGui::NewFrame();
             AzFramework::InputChannelEventListener::Connect();

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -184,6 +184,7 @@ namespace AZ::RHI
     {
         AZ_PROFILE_SCOPE(RHI, "FrameScheduler: Compile");
 
+        //Go through each scope and call their SetupFrameGraphDependencies to build the framegraph
         PrepareProducers();
 
         m_compileRequest = compileRequest;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -215,7 +215,7 @@ namespace AZ
             {
                 usageFlags |= MTLTextureUsageRenderTarget;
             }
-            if (RHI::CheckBitsAll(imageFlags, RHI::ImageBindFlags::DepthStencil))
+            if (RHI::CheckBitsAny(imageFlags, RHI::ImageBindFlags::DepthStencil))
             {
                 usageFlags |= MTLTextureUsageRenderTarget;
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
@@ -395,8 +395,8 @@ namespace AZ
             m_limits.m_minConstantBufferViewOffset = Alignment::Constant;
             m_limits.m_maxConstantBufferSize = m_metalDevice.maxBufferLength;
             m_limits.m_maxBufferSize = m_metalDevice.maxBufferLength;
-            
-            AZ_Assert(m_metalDevice.argumentBuffersSupport, "Atom needs Argument buffer support to run");
+ 
+            AZ_Assert(m_metalDevice.argumentBuffersSupport >= MTLArgumentBuffersTier1, "Atom needs Argument buffer support to run");
         }
 
         CommandList* Device::AcquireCommandList(RHI::HardwareQueueClass hardwareQueueClass)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -243,13 +243,14 @@ namespace AZ
         void FullscreenTrianglePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
             RenderPass::SetupFrameGraphDependencies(frameGraph);
-            
+
+            // Update scissor/viewport regions based on the mip level of the render target that is being written into
             uint16_t viewMinMip = RHI::ImageSubresourceRange::HighestSliceIndex;
             for (const PassAttachmentBinding& attachmentBinding : m_attachmentBindings)
             {
                 if (attachmentBinding.GetAttachment() != nullptr &&
                     frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentBinding.GetAttachment()->GetAttachmentId()) &&
-                    attachmentBinding.m_unifiedScopeDesc.GetType() ==RHI::AttachmentType::Image &&
+                    attachmentBinding.m_unifiedScopeDesc.GetType() == RHI::AttachmentType::Image &&
                     RHI::CheckBitsAny(attachmentBinding.GetAttachmentAccess(), RHI::ScopeAttachmentAccess::Write) &&
                     attachmentBinding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::RenderTarget)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -260,9 +260,11 @@ namespace AZ
             
             if(viewMinMip < RHI::ImageSubresourceRange::HighestSliceIndex)
             {
-                m_viewportState.m_maxX = static_cast<uint32_t>(m_viewportState.m_maxX) >> viewMinMip;
-                m_viewportState.m_maxY = static_cast<uint32_t>(m_viewportState.m_maxY) >> viewMinMip;
-                
+                uint32_t viewportStateMaxX = static_cast<uint32_t>(m_viewportState.m_maxX);
+                uint32_t viewportStateMaxY = static_cast<uint32_t>(m_viewportState.m_maxY);
+                m_viewportState.m_maxX = static_cast<float>(viewportStateMaxX >> viewMinMip);
+                m_viewportState.m_maxY = static_cast<float>(viewportStateMaxY >> viewMinMip);
+
                 m_scissorState.m_maxX = static_cast<uint32_t>(m_scissorState.m_maxX) >> viewMinMip;
                 m_scissorState.m_maxY = static_cast<uint32_t>(m_scissorState.m_maxY) >> viewMinMip;
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/EditorCommonFeaturesSystemComponent.cpp
@@ -143,7 +143,8 @@ namespace AZ
 
                             AzToolsFramework::SliceEditorEntityOwnershipServiceNotificationBus::Handler::BusConnect();
 
-                            if (IEditor* editor = GetLegacyEditor(); !editor->IsUndoSuspended())
+                            IEditor* editor = GetLegacyEditor();
+                            if (editor && !editor->IsUndoSuspended())
                             {
                                 editor->SuspendUndo();
                             }
@@ -180,12 +181,15 @@ namespace AZ
 
                 IEditor* editor = GetLegacyEditor();
 
-                //save after level default slice fully instantiated
-                editor->SaveDocument();
-
-                if (editor->IsUndoSuspended())
+                if(editor)
                 {
-                    editor->ResumeUndo();
+                    //save after level default slice fully instantiated
+                    editor->SaveDocument();
+                    
+                    if (editor->IsUndoSuspended())
+                    {
+                        editor->ResumeUndo();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

- Crash related to incorrect shader language. Explicitly setting it to metal shader language 2.2 as oppose to it picking one based not he operating system of the Mac where AP is running
- Crash related incorrect deployment target. Explicitly setting the OS version to iOS 14.0.
- Crash related to Imgui - Fixed Imgui's UV index stream to hold 4 byte integers as oppose to 1 byte as the drivers do not like that. Other option was to uncompress explicitly in the shader but it wasn't worth it to save 48 bytes. 
- Crash related to incorrect scissors when writing to non zero mip - Add support to clamp scissors based on the mip level of the render target
- Address Slow AP speeds by increasing thread priority - Increased thread priority for Apple to help AP processing.
- Address iOS compile/link errors

## How was this PR tested?

Tested ASV on Mac and iOS
