### PR TITLE
Fixes runtime crash that was introduced by

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -541,14 +541,6 @@
                 "Path": "Passes/MultiViewTransparentParent.pass"
             },
             {
-                "Name": "MultiViewXRLeftPipelineTemplate",
-                "Path": "Passes/MultiViewXRLeftPipeline.pass"
-            },
-            {
-                "Name": "MultiViewXRRightPipelineTemplate",
-                "Path": "Passes/MultiViewXRRightPipeline.pass"
-            },
-            {
                 "Name": "KawaseShadowBlurTemplate",
                 "Path": "Passes/KawaseShadowBlur.pass"
             },


### PR DESCRIPTION
## What does this PR do?

Fixes runtime crash that was introduced by
PR https://github.com/o3de/o3de/pull/16326

It caused the AP to fail building
Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset

Which in turn caused the Editor to crash at startup in Debug mode


## How was this PR tested?

The AP doesn't complain anymore and The Editor doesn't crash anymore when loading.
