### PR TITLE
Fix invalid replace arg count error handling

### DIFF
--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -100,6 +100,11 @@ namespace PhysX
         return currentEntity;
     }
 
+    AZStd::vector<AzPhysics::SimulatedBodyHandle> ArticulationLinkComponent::GetSimulatedBodyHandles() const
+    {
+        return m_articulationLinks;
+    }
+
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
     void ArticulationLinkComponent::Activate()
     {

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -87,6 +87,7 @@ namespace PhysX
         const AZStd::vector<AZ::u32> GetSensorIndices(const AZ::EntityId entityId);
         const physx::PxArticulationJointReducedCoordinate* GetDriveJoint() const;
         physx::PxArticulationJointReducedCoordinate* GetDriveJoint();
+        AZStd::vector<AzPhysics::SimulatedBodyHandle> GetSimulatedBodyHandles() const;
         AZStd::shared_ptr<ArticulationLinkData> m_articulationLinkData;
         ArticulationLinkConfiguration m_config;
 

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -1243,10 +1243,18 @@ def create_from_template(destination_path: pathlib.Path,
     # if replacements are provided we need an even number of
     # replace arguments because they are A->B pairs
     if replace and len(replace) % 2 == 1:
+        replacement_pairs = []
+        for replace_index in range(0, len(replace), 2):
+            if replace_index + 1 < len(replace):
+                replacement_pairs.append(f' {replace[replace_index]} -> {replace[replace_index + 1]}')
+            else:
+                replacement_pairs.append(f' {replace[replace_index]} is missing replacement')
         logger.error("Invalid replacement argument pairs.  "
                      "Verify you have provided replacement match and value pairs "
                      "and your replacement arguments are in single quotes "
-                     "e.g. -r '${GemName}' 'NameValue'")
+                     "e.g. -r '${GemName}' 'NameValue'\n\n"
+                     "The current set of replacement pairs are:\n" + 
+                     ("\n".join(replacement_pairs)))
         return 1
 
     if template_name:

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -1240,6 +1240,15 @@ def create_from_template(destination_path: pathlib.Path,
         logger.error(f'Template Name or Template Path must be specified.')
         return 1
 
+    # if replacements are provided we need an even number of
+    # replace arguments because they are A->B pairs
+    if replace and len(replace) % 2 == 1:
+        logger.error("Invalid replacement argument pairs.  "
+                     "Verify you have provided replacement match and value pairs "
+                     "and your replacement arguments are in single quotes "
+                     "e.g. -r '${GemName}' 'NameValue'")
+        return 1
+
     if template_name:
         template_path = manifest.get_registered(template_name=template_name)
 
@@ -2639,7 +2648,7 @@ def add_args(subparsers) -> None:
     create_from_template_subparser.add_argument('-r', '--replace', type=str, required=False,
                                                 nargs='*',
                                                 help='String that specifies A->B replacement pairs.'
-                                                     ' Ex. --replace CoolThing ${the_thing} ${id} 1723905'
+                                                     ' Ex. --replace CoolThing \'${the_thing}\' \'${id}\' 1723905'
                                                      ' Note: <DestinationName> is the last component of destination_path'
                                                      ' Note: ${Name} is automatically <DestinationName>'
                                                      ' Note: ${NameLower} is automatically <destinationname>'
@@ -2730,7 +2739,7 @@ def add_args(subparsers) -> None:
                                                ' all other standard project replacements will be automatically'
                                                ' inferred from the project name. These replacements will superseded'
                                                ' all inferred replacements.'
-                                               ' Ex. --replace ${DATE} 1/1/2020 ${id} 1723905'
+                                               ' Ex. --replace \'${DATE}\' 1/1/2020 \'${id}\' 1723905'
                                                ' Note: <ProjectName> is the last component of project_path'
                                                ' Note: ${Name} is automatically <ProjectName>'
                                                ' Note: ${NameLower} is automatically <projectname>'
@@ -2824,7 +2833,7 @@ def add_args(subparsers) -> None:
                                            ' all other standard gem replacements will be automatically inferred'
                                            ' from the gem name. These replacements will superseded all inferred'
                                            ' replacement pairs.'
-                                           ' Ex. --replace ${DATE} 1/1/2020 ${id} 1723905'
+                                           ' Ex. --replace \'${DATE}\' 1/1/2020 \'${id}\' 1723905'
                                            ' Note: <GemName> is the last component of gem_path'
                                            ' Note: ${Name} is automatically <GemName>'
                                            ' Note: ${NameLower} is automatically <gemname>'
@@ -2920,7 +2929,7 @@ def add_args(subparsers) -> None:
                                            ' all other standard gem replacements will be automatically inferred'
                                            ' from the repo name. These replacements will superseded all inferred'
                                            ' replacement pairs.'
-                                           ' Ex. --replace ${DATE} 1/1/2020 ${id} 1723905'
+                                           ' Ex. --replace \'${DATE}\' 1/1/2020 \'${id}\' 1723905'
                                            ' Note: <RepoName> is the last component of repo_path'
                                            ' Note: ${Name} is automatically <Name>')
     create_repo_subparser.add_argument('--no-register', action='store_true', default=False,

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -553,7 +553,7 @@ def create_template(source_path: pathlib.Path,
         template_path = default_templates_folder / source_name
         logger.info(f'Template path empty. Using default templates folder {template_path}')
     if not force and template_path.is_dir() and len(list(template_path.iterdir())):
-        logger.error(f'Template path {template_path} already exists.')
+        logger.error(f'Template path {template_path} already exists; use --force to overwrite existing contents.')
         return 1
 
     # Make sure the output directory for the template is outside the source path directory
@@ -1388,7 +1388,7 @@ def create_from_template(destination_path: pathlib.Path,
         logger.error('Destination path cannot be empty.')
         return 1
     if not force and os.path.isdir(destination_path):
-        logger.error(f'Destination path {destination_path} already exists.')
+        logger.error(f'Destination path {destination_path} already exists; use --force to overwrite existing contents.')
         return 1
     else:
         os.makedirs(destination_path, exist_ok=force)

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -435,7 +435,7 @@ def download_file(parsed_uri: ParseResult, download_path: pathlib.Path, force_ov
         parsed_uri_path = urllib.parse.unquote(parsed_uri.path)
         if isinstance(download_path, pathlib.PureWindowsPath):
             # On Windows we want to remove the initial slash in front of the drive letter
-            if parsed_uri_path[0] == '/':
+            if parsed_uri_path.startswith('/'):
                 parsed_uri_path = parsed_uri_path[1:]
             else:
                 logger.warning(f"The provided path URI '{parsed_uri_path}' may be missing a '/', "


### PR DESCRIPTION
## What does this PR do?
When the replacement arg count is odd, one of the pairs will be missing a value  resulting in a script error.  This  PR checks for this case and provides better error messaging and a unit test.

Related documentation here: https://docs.o3de.org/docs/user-guide/programming/components/create-component/

Related command:
```cmd
scripts\o3de.bat create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem
```

Also fixes #13644
Also fixes an issue where a file download would silently fail on Windows if a file URI was provided in an invalid format.

## How was this PR tested?

New unit tests were added and commands were testing in Windows terminal (bash and cmd).
Used the new remote repo functionality to generate a repo, add a gem with an archive to it and test downloading it using a `file:///` uri in Project Manager and via the o3de CLI
