### PR TITLE
Fixed issues with handling enums in DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -977,13 +977,18 @@ namespace AZ::Reflection
                                 genericValueCache.ArrayPushBack(attributeValue);
                                 return;
                             }
-                            // Collect EnumValueKey attributes unless this node has an EnumValues or GenericValueList
-                            // attribute. If an EnumValues or GenericValueList attribute is present we do not cache
+                            // Collect EnumValueKey attributes unless this node has an EnumValues, GenericValue or GenericValueList
+                            // attribute. If an EnumValues, GenericValue or GenericValueList attribute is present we do not cache
                             // because such nodes also have internal EnumValueKey attributes that we won't use.
                             // The cached values will be stored as a GenericValueList attribute.
-                            if (name == enumValueKeyName && !visitedAttributes.contains(enumValuesCrcName) &&
-                                !visitedAttributes.contains(genericValueListName))
+                            if (name == enumValueKeyName)
                             {
+                                if (visitedAttributes.contains(enumValuesCrcName) || visitedAttributes.contains(genericValueListName) ||
+                                    visitedAttributes.contains(genericValueName))
+                                {
+                                    return;
+                                }
+
                                 genericValueCache.ArrayPushBack(attributeValue);
                                 // Forcing the node's typeId to AZ::u64 so the correct property handler will be chosen
                                 // in the PropertyEditorSystem.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -256,7 +256,7 @@ namespace AzToolsFramework
                     }
                     continue;
                 }
-                // Use the SerializedPath as the prxy class element name, which prior to this is always an empty string
+                // Use the SerializedPath as the proxy class element name, which prior to this was always an empty string
                 // since it isn't used by the property handler. This helps when debugging the ConsumeAttribute method
                 // in the property handlers because the class element name gets passed as the debugName, so its easier
                 // to tell which property is currently processing the attributes.

--- a/Gems/LmbrCentral/Code/Source/Audio/EditorAudioMultiPositionComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Audio/EditorAudioMultiPositionComponent.cpp
@@ -24,6 +24,11 @@ namespace LmbrCentral
                 ->Field("Behavior Type", &EditorAudioMultiPositionComponent::m_behaviorType)
                 ;
 
+            serializeContext->Enum<Audio::MultiPositionBehaviorType>()
+                ->Value("Separate", Audio::MultiPositionBehaviorType::Separate)
+                ->Value("Blended", Audio::MultiPositionBehaviorType::Blended)
+                ;
+
             if (auto editContext = serializeContext->GetEditContext())
             {
                 editContext->Enum<Audio::MultiPositionBehaviorType>("Behavior Type", "How multiple position audio behaves")

--- a/Gems/LmbrCentral/Code/Source/Audio/EditorAudioPreloadComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Audio/EditorAudioPreloadComponent.cpp
@@ -25,6 +25,11 @@ namespace LmbrCentral
                 ->Field("Load Type", &EditorAudioPreloadComponent::m_loadType)
                 ;
 
+            serializeContext->Enum<AudioPreloadComponent::LoadType>()
+                ->Value("Auto", AudioPreloadComponent::LoadType::Auto)
+                ->Value("Manual", AudioPreloadComponent::LoadType::Manual)
+                ;
+
             if (auto editContext = serializeContext->GetEditContext())
             {
                 editContext->Enum<AudioPreloadComponent::LoadType>("Load Type", "Automatic or Manual loading and unloading")

--- a/Gems/LmbrCentral/Code/Source/Audio/EditorAudioTriggerComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Audio/EditorAudioTriggerComponent.cpp
@@ -27,6 +27,12 @@ namespace LmbrCentral
                 ->Field("Plays Immediately", &EditorAudioTriggerComponent::m_playsImmediately)
                 ;
 
+            serializeContext->Enum<Audio::ObstructionType>()
+                ->Value("Ignore", Audio::ObstructionType::Ignore)
+                ->Value("SingleRay", Audio::ObstructionType::SingleRay)
+                ->Value("MultiRay", Audio::ObstructionType::MultiRay)
+                ;
+
             if (auto editContext = serializeContext->GetEditContext())
             {
                 editContext->Enum<Audio::ObstructionType>("Obstruction Type", "The types of ray-casts available for obstruction and occlusion")

--- a/Gems/PhysX/Code/Editor/EditorJointConfiguration.cpp
+++ b/Gems/PhysX/Code/Editor/EditorJointConfiguration.cpp
@@ -285,6 +285,12 @@ namespace PhysX
                 ->Field("Self Collide", &EditorJointConfig::m_selfCollide)
                 ;
 
+            serializeContext->Enum<EditorJointConfig::DisplaySetupState>()
+                ->Value("Never", EditorJointConfig::DisplaySetupState::Never)
+                ->Value("Selected", EditorJointConfig::DisplaySetupState::Selected)
+                ->Value("Always", EditorJointConfig::DisplaySetupState::Always)
+                ;
+
             if (auto* editContext = serializeContext->GetEditContext())
             {
                 editContext->Enum<EditorJointConfig::DisplaySetupState>("Joint Display Setup State", "Options for displaying joint setup.")


### PR DESCRIPTION
## What does this PR do?

Fixes #16063 and #16076 

This resolves two separate enum handling issues in the DPE. Cases that reflect the enum to the EditContext need to also have them reflected to the SerializeContext if they want to provide the values through EnumAttribute attributes. The other case is for specialized enum types that don't use u64 as the base type, they need special handling to make sure their value list gets passed on properly and that the changed value uses the proper proxy value.

![FixedEnums](https://github.com/o3de/o3de/assets/7519264/1b4ff466-3a67-4261-8b0a-2279f97785f9)

## How was this PR tested?

Tested the repro cases in the listed issues and verified they now work as expected. Also tested various enum cases in the Editor.