### PR TITLE
Remove old small operator / data driven node code

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -32,22 +32,6 @@
 namespace ScriptCanvasEditor::Nodes
 {
 
-    void DataDrivenNodeCreationData::Reflect(AZ::ReflectContext* reflectContext)
-    {
-        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext);
-        if (serializeContext)
-        {
-            serializeContext->Class<DataDrivenNodeCreationData>()
-                ->Version(0)
-                ->Field("LexicalId", &DataDrivenNodeCreationData::m_lexicalId)
-                ->Field("UserData", &DataDrivenNodeCreationData::m_userData)
-                ->Field("Title", &DataDrivenNodeCreationData::m_title)
-                ->Field("ToolTip", &DataDrivenNodeCreationData::m_toolTip)
-                ->Field("DataType", &DataDrivenNodeCreationData::m_dataType)
-                ->Field("SubStyle", &DataDrivenNodeCreationData::m_subStyle);
-        }
-    }
-
     NodeIdPair CreateFunctionDefinitionNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, bool isInput, AZStd::string rootName)
     {
         ScriptCanvasEditor::Nodes::StyleConfiguration styleConfiguration;
@@ -252,47 +236,6 @@ namespace ScriptCanvasEditor::Nodes
         EditorGraphRequestBus::EventResult(graphCanvasGraphId, scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
 
         nodeIdPair.m_graphCanvasId = DisplayEbusWrapperNode(graphCanvasGraphId, busNode);
-
-        return nodeIdPair;
-    }
-
-    NodeIdPair CreateDataDrivenNode(const ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
-    {
-        ScriptCanvas::Node* node = aznew ScriptCanvas::Node();
-        node->SetNodeName(nodeData.m_title);
-        node->SetNodeToolTip(nodeData.m_toolTip);
-        node->SetNodeLexicalId(nodeData.m_lexicalId);
-
-        ScriptCanvas::DynamicDataSlotConfiguration inputPin;
-        inputPin.m_name = " ";
-        inputPin.m_toolTip = "Input";
-        inputPin.m_canHaveInputField = false;
-        inputPin.SetConnectionType(ScriptCanvas::ConnectionType::Input);
-        inputPin.m_displayType = nodeData.m_dataType;
-
-        ScriptCanvas::DynamicDataSlotConfiguration outputPin;
-        outputPin.m_name = " ";
-        outputPin.m_toolTip = "Output";
-        outputPin.SetConnectionType(ScriptCanvas::ConnectionType::Output);
-        outputPin.m_displayType = nodeData.m_dataType;
-
-        AZ::Entity* nodeEntity{ aznew AZ::Entity };
-        nodeEntity->Init();
-        nodeEntity->SetName(node->GetNodeName());
-        nodeEntity->AddComponent(node);
-        ScriptCanvas::GraphRequestBus::Event(scriptCanvasId, &ScriptCanvas::GraphRequests::AddNode, nodeEntity->GetId());
-
-        node->AddSlot(inputPin, true);
-        node->AddSlot(outputPin, true);
-
-        node->SetNodeStyle(nodeData.m_subStyle);
-
-        AZ::EntityId graphCanvasGraphId;
-        EditorGraphRequestBus::EventResult(graphCanvasGraphId, scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
-
-        NodeIdPair nodeIdPair;
-        nodeIdPair.m_scriptCanvasId = nodeEntity->GetId();
-        nodeIdPair.m_graphCanvasId = DisplayScriptCanvasNode(graphCanvasGraphId, node);
 
         return nodeIdPair;
     }

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
@@ -29,21 +29,6 @@ namespace ScriptEvents
 namespace ScriptCanvasEditor::Nodes
 {
 
-    struct DataDrivenNodeCreationData
-    {
-        AZ_TYPE_INFO(DataDrivenNodeCreationData, "{A7DE9ECF-81F9-4A03-B3E4-3510591A50BB}");
-        AZ_CLASS_ALLOCATOR(DataDrivenNodeCreationData, AZ::SystemAllocator);
-
-        static void Reflect(AZ::ReflectContext* reflectContext);
-
-        AZ::Crc32 m_lexicalId;
-        AZStd::any m_userData;
-        AZStd::string m_title;
-        AZStd::string m_toolTip;
-        ScriptCanvas::Data::Type m_dataType;
-        AZStd::string m_subStyle;
-    };
-
     // Specific create methods which will also handle displaying the node.
     AZStd::pair<ScriptCanvas::Node*, NodeIdPair> CreateAndGetNode(const AZ::Uuid& classData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const StyleConfiguration& styleConfiguration, AZStd::function<void(ScriptCanvas::Node*)> = nullptr);
     NodeIdPair CreateNode(const AZ::Uuid& classData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const StyleConfiguration& styleConfiguration);
@@ -51,9 +36,6 @@ namespace ScriptCanvasEditor::Nodes
     NodeIdPair CreateObjectMethodOverloadNode(AZStd::string_view className, AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasGraphId);
     NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, bool isProperty, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
     NodeIdPair CreateEbusWrapperNode(AZStd::string_view busName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
-
-    // Create methods for data driven nodes
-    NodeIdPair CreateDataDrivenNode(const ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Script Events
     NodeIdPair CreateScriptEventReceiverNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const AZ::Data::AssetId& assetId);

--- a/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
@@ -130,7 +130,6 @@ namespace ScriptCanvasEditor
         CreateNodeGroupMimeEvent::Reflect(context);
         CreateCommentNodeMimeEvent::Reflect(context);
         CreateCustomNodeMimeEvent::Reflect(context);
-        CreateDataDrivenNodeMimeEvent::Reflect(context);
         CreateEBusHandlerMimeEvent::Reflect(context);
         CreateEBusHandlerEventMimeEvent::Reflect(context);
         CreateEBusSenderMimeEvent::Reflect(context);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -315,47 +315,4 @@ namespace ScriptCanvasEditor
         ScriptCanvasEditorTools::TranslationGeneration translation;
         translation.TranslateNode(m_typeId);
     }
-
-    //////////////////////////////
-    // CreateDataDrivenNodeMimeEvent
-    //////////////////////////////
-
-    void CreateDataDrivenNodeMimeEvent::Reflect(AZ::ReflectContext* reflectContext)
-    {
-        ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData::Reflect(reflectContext);
-
-
-        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext);
-        if (serializeContext)
-        {
-            serializeContext->Class<CreateDataDrivenNodeMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
-                ->Version(0)
-                ->Field("NodeData", &CreateDataDrivenNodeMimeEvent::m_nodeData);
-        }
-    }
-
-    CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData& nodeData)
-        : m_nodeData(nodeData)
-    {
-    }
-
-    ScriptCanvasEditor::NodeIdPair CreateDataDrivenNodeMimeEvent::CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const
-    {
-        return Nodes::CreateDataDrivenNode(m_nodeData, scriptCanvasId);
-    }
-
-    //////////////////////////////
-    // DataDrivenNodePaletteTreeItem
-    //////////////////////////////
-
-    DataDrivenNodePaletteTreeItem::DataDrivenNodePaletteTreeItem(const ScriptCanvasEditor::DataDrivenNodeModelInformation& nodeData)
-        : DraggableNodePaletteTreeItem(nodeData.m_displayName, ScriptCanvasEditor::AssetEditorId)
-        , m_nodeModelInformation(nodeData)
-    {
-    }
-
-    GraphCanvas::GraphCanvasMimeEvent* DataDrivenNodePaletteTreeItem::CreateMimeEvent() const
-    {
-        return aznew CreateDataDrivenNodeMimeEvent(m_nodeModelInformation.m_nodeData);
-    }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
@@ -166,47 +166,4 @@ namespace ScriptCanvasEditor
     };
 
     // </CustomNode>
-
-    // <DataDrivenNode>
-    class CreateDataDrivenNodeMimeEvent : public CreateNodeMimeEvent
-    {
-    public:
-        AZ_RTTI(CreateDataDrivenNodeMimeEvent, "{AD78B758-2F30-4379-B1fD-7AD17F16975F}", CreateNodeMimeEvent);
-        AZ_CLASS_ALLOCATOR(CreateDataDrivenNodeMimeEvent, AZ::SystemAllocator);
-
-        static void Reflect(AZ::ReflectContext* reflectContext);
-
-        CreateDataDrivenNodeMimeEvent() = default;
-        CreateDataDrivenNodeMimeEvent(const ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData& nodeData);
-        ~CreateDataDrivenNodeMimeEvent() = default;
-
-    protected:
-        ScriptCanvasEditor::NodeIdPair CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const override;
-
-    private:
-        ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData m_nodeData;
-    };
-
-    class DataDrivenNodePaletteTreeItem : public GraphCanvas::DraggableNodePaletteTreeItem
-    {
-    public:
-        AZ_CLASS_ALLOCATOR(DataDrivenNodePaletteTreeItem, AZ::SystemAllocator);
-        AZ_RTTI(DataDrivenNodePaletteTreeItem, "{0A9BC500-D4A9-4B86-8804-96F576CDF0FC}", GraphCanvas::DraggableNodePaletteTreeItem);
-
-        explicit DataDrivenNodePaletteTreeItem(const ScriptCanvasEditor::DataDrivenNodeModelInformation&);
-        ~DataDrivenNodePaletteTreeItem() = default;
-
-        GraphCanvas::GraphCanvasMimeEvent* CreateMimeEvent() const override;
-
-        const ScriptCanvasEditor::DataDrivenNodeModelInformation& GetInfo() const
-        {
-            return m_nodeModelInformation;
-        }
-
-    private:
-        ScriptCanvasEditor::DataDrivenNodeModelInformation m_nodeModelInformation;
-
-    };
-
-    // </CustomNode>
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -34,11 +34,6 @@
 
 AZ_DEFINE_BUDGET(NodePaletteModel);
 
-namespace ScriptCanvasEditor
-{
-    AZ_CVAR(bool, ed_showSmallOperators, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Show small operator nodes in the palette");
-}
-
 namespace
 {
     static constexpr char DefaultGlobalConstantCategory[] = "Global Constants";
@@ -786,166 +781,6 @@ namespace
         }
     }
 
-    void PopulateDataDrivenNodes(ScriptCanvasEditor::NodePaletteModel& nodePaletteModel)
-    {
-        if (ScriptCanvasEditor::ed_showSmallOperators)
-        {
-            // Increment
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData incrementNodeData;    // This data is in charge of the node to be created
-            incrementNodeData.m_lexicalId = AZ_CRC_CE("Increment");
-            incrementNodeData.m_title = "++";
-            incrementNodeData.m_toolTip = "Increments the input number by 1";
-            incrementNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            incrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* incrementPaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();             // This data is in charge of the node palette item
-            incrementPaletteData->m_nodeData = incrementNodeData;
-            incrementPaletteData->m_displayName = "Increment";
-            incrementPaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(incrementPaletteData);
-
-            // Decrement
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData decrementNodeData;
-            decrementNodeData.m_lexicalId = AZ_CRC_CE("Decrement");
-            decrementNodeData.m_title = "--";
-            decrementNodeData.m_toolTip = "Decrements the input number by 1";
-            decrementNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            decrementNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* decrementPaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            decrementPaletteData->m_nodeData = decrementNodeData;
-            decrementPaletteData->m_displayName = "Decrement";
-            decrementPaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(decrementPaletteData);
-
-            // Double
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData doubleNodeData;
-            doubleNodeData.m_lexicalId = AZ_CRC_CE("Double");
-            doubleNodeData.m_title = "*2";
-            doubleNodeData.m_toolTip = "Doubles input number";
-            doubleNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            doubleNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* doublePaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            doublePaletteData->m_nodeData = doubleNodeData;
-            doublePaletteData->m_displayName = "Double";
-            doublePaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(doublePaletteData);
-
-            // Negative
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData negativeNodeData;
-            negativeNodeData.m_lexicalId = AZ_CRC_CE("Negative");
-            negativeNodeData.m_title = "*-1";
-            negativeNodeData.m_toolTip = "Multiplies input number by -1";
-            negativeNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            negativeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* negativePaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            negativePaletteData->m_nodeData = negativeNodeData;
-            negativePaletteData->m_displayName = "Negative";
-            negativePaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(negativePaletteData);
-
-            // Square
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData squareNodeData;
-            squareNodeData.m_lexicalId = AZ_CRC_CE("Square");
-            squareNodeData.m_title = "^2";
-            squareNodeData.m_toolTip = "Squares input number";
-            squareNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            squareNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* squarePaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            squarePaletteData->m_nodeData = squareNodeData;
-            squarePaletteData->m_displayName = "Square";
-            squarePaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(squarePaletteData);
-
-            // Cube
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData cubeNodeData;
-            cubeNodeData.m_lexicalId = AZ_CRC_CE("Cube");
-            cubeNodeData.m_title = "^3";
-            cubeNodeData.m_toolTip = "Cubes input number";
-            cubeNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            cubeNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* cubePaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            cubePaletteData->m_nodeData = cubeNodeData;
-            cubePaletteData->m_displayName = "Cube";
-            cubePaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(cubePaletteData);
-
-            // Square Root
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData squareRootNodeData;
-            squareRootNodeData.m_lexicalId = AZ_CRC_CE("Square Root");
-            squareRootNodeData.m_title = "sqrt";
-            squareRootNodeData.m_toolTip = "Gets the square root of input number";
-            squareRootNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            squareRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* squareRootPaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            squareRootPaletteData->m_nodeData = squareRootNodeData;
-            squareRootPaletteData->m_displayName = "Square Root";
-            squareRootPaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(squareRootPaletteData);
-
-            // Cube Root
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData cubeRootNodeData;
-            cubeRootNodeData.m_lexicalId = AZ_CRC_CE("Cube Root");
-            cubeRootNodeData.m_title = "cbrt";
-            cubeRootNodeData.m_toolTip = "Gets the cube root of input number";
-            cubeRootNodeData.m_dataType = ScriptCanvas::Data::Type::Number();
-            cubeRootNodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* cubeRootPaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            cubeRootPaletteData->m_nodeData = cubeRootNodeData;
-            cubeRootPaletteData->m_displayName = "Cube Root";
-            cubeRootPaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(cubeRootPaletteData);
-
-            // Invert Vector 2
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData invertVector2NodeData;
-            invertVector2NodeData.m_lexicalId = AZ_CRC_CE("Invert Vector 2");
-            invertVector2NodeData.m_title = "inv";
-            invertVector2NodeData.m_toolTip = "Inverts the input vector 2";
-            invertVector2NodeData.m_dataType = ScriptCanvas::Data::Type::Vector2();
-            invertVector2NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector2PaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            invertVector2PaletteData->m_nodeData = invertVector2NodeData;
-            invertVector2PaletteData->m_displayName = "Invert Vector 2";
-            invertVector2PaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(invertVector2PaletteData);
-
-            // Invert Vector 3
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData invertVector3NodeData;
-            invertVector3NodeData.m_lexicalId = AZ_CRC_CE("Invert Vector 3");
-            invertVector3NodeData.m_title = "inv";
-            invertVector3NodeData.m_toolTip = "Inverts the input vector 3";
-            invertVector3NodeData.m_dataType = ScriptCanvas::Data::Type::Vector3();
-            invertVector3NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector3PaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            invertVector3PaletteData->m_nodeData = invertVector3NodeData;
-            invertVector3PaletteData->m_displayName = "Invert Vector 3";
-            invertVector3PaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(invertVector3PaletteData);
-
-            // Invert Vector 4
-            ScriptCanvasEditor::Nodes::DataDrivenNodeCreationData invertVector4NodeData;
-            invertVector4NodeData.m_lexicalId = AZ_CRC_CE("Invert Vector 4");
-            invertVector4NodeData.m_title = "inv";
-            invertVector4NodeData.m_toolTip = "Inverts the input vector";
-            invertVector4NodeData.m_dataType = ScriptCanvas::Data::Type::Vector4();
-            invertVector4NodeData.m_subStyle = GraphCanvas::Styling::Elements::Compact;
-            ScriptCanvasEditor::DataDrivenNodeModelInformation* invertVector4PaletteData =
-                aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-            invertVector4PaletteData->m_nodeData = invertVector4NodeData;
-            invertVector4PaletteData->m_displayName = "Invert Vector 4";
-            invertVector4PaletteData->m_categoryPath = "Math/Small Operators";
-            nodePaletteModel.RegisterDataDrivenNode(invertVector4PaletteData);
-        }
-    }
-
     // Helper function for populating the node palette model.
     // Pulled out just to make the tabbing a bit nicer, since it's a huge method.
     void PopulateNodePaletteModel(ScriptCanvasEditor::NodePaletteModel& nodePaletteModel)
@@ -989,9 +824,6 @@ namespace
 
         // Populates the NodePalette with Properties reflected directly on the BehaviorContext
         PopulateBehaviorContextGlobalProperties(nodePaletteModel, *behaviorContext);
-
-        // Populates the NodePalette with nodes that are instances of the Node class instead of inherited classes of Node
-        PopulateDataDrivenNodes(nodePaletteModel);
 
     }
 }
@@ -1091,20 +923,6 @@ namespace ScriptCanvasEditor
         }
 
         NodePaletteModelNotificationBus::Event(m_paletteId, &NodePaletteModelNotifications::OnAssetModelRepopulated);
-    }
-
-    // Register a node given its specific attributes
-    void NodePaletteModel::RegisterDataDrivenNode(DataDrivenNodeModelInformation* nodePaletteItemInformation)
-    {
-        if (nodePaletteItemInformation->m_displayName.empty())
-        {
-            nodePaletteItemInformation->m_displayName = nodePaletteItemInformation->m_nodeData.m_title;
-        }
-        if (nodePaletteItemInformation->m_toolTip.empty())
-        {
-            nodePaletteItemInformation->m_toolTip = nodePaletteItemInformation->m_nodeData.m_toolTip;
-        }
-        m_registeredNodes.emplace(AZStd::make_pair(nodePaletteItemInformation->m_nodeData.m_lexicalId, nodePaletteItemInformation));
     }
 
     void NodePaletteModel::RegisterCustomNode(const AZ::SerializeContext::ClassData* classData, const AZStd::string& categoryPath)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -53,14 +53,6 @@ namespace ScriptCanvasEditor
         AZStd::string                    m_titlePaletteOverride;
     };
 
-    struct DataDrivenNodeModelInformation : public NodePaletteModelInformation
-    {
-        AZ_RTTI(DataDrivenNodeModelInformation, "{D44D697D-7462-456B-B305-E9931FC02E6B}", NodePaletteModelInformation);
-        AZ_CLASS_ALLOCATOR(DataDrivenNodeModelInformation, AZ::SystemAllocator);
-
-        Nodes::DataDrivenNodeCreationData m_nodeData;
-    };
-
     struct CategoryInformation
     {
         AZStd::string m_styleOverride;
@@ -86,8 +78,6 @@ namespace ScriptCanvasEditor
         void AssignAssetModel(AzToolsFramework::AssetBrowser::AssetBrowserFilterModel* assetModel);
 
         void RepopulateModel();
-
-        void RegisterDataDrivenNode(DataDrivenNodeModelInformation* nodePaletteItemInformation);
 
         void RegisterCustomNode(const AZ::SerializeContext::ClassData* classData, const AZStd::string& categoryPath = "Nodes");
         void RegisterClassNode(const AZStd::string& categoryPath, const AZStd::string& methodClass, const AZStd::string& methodName, const AZ::BehaviorMethod* behaviorMethod, const AZ::BehaviorContext* behaviorContext, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
@@ -135,11 +135,6 @@ namespace ScriptCanvasEditor
                         createdItem = parentItem->CreateChildNode<ScriptCanvasEditor::EBusSendEventPaletteTreeItem>(ebusSenderNodeModelInformation->m_busName, ebusSenderNodeModelInformation->m_eventName, ebusSenderNodeModelInformation->m_busId, ebusSenderNodeModelInformation->m_eventId, ebusSenderNodeModelInformation->m_isOverload, ebusSenderNodeModelInformation->m_propertyStatus);
                     }
                 }
-                else if (auto dataDrivenModelInformation = azrtti_cast<const DataDrivenNodeModelInformation*>(modelInformation))
-                {
-                    createdItem = parentItem->CreateChildNode<DataDrivenNodePaletteTreeItem>(*dataDrivenModelInformation);
-                    createdItem->SetToolTip(QString(dataDrivenModelInformation->m_toolTip.c_str()));
-                }
 
                 if (createdItem)
                 {


### PR DESCRIPTION
## What does this PR do?

This PR removes some unused code designed for creating data driven nodes, that was previously only used for the unfinished small operator nodes hidden behind a cvar. This code can be restored in the future if someone wanted to refactor how nodes in ScriptCanvas are created.

## How was this PR tested?

Local tests were run to make sure I wasn't breaking anything.
