### PR TITLE
Fixed segfault caused by resizing a non-existent tab

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
@@ -364,6 +364,12 @@ namespace ProjectSettingsTool
             }
         }
 
+        if (index == -1)
+        {
+            // If there is no current tab, return
+            return;
+        }
+
         // resize for current tab
         m_ui->platformTabs->widget(index)->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
         m_ui->platformTabs->widget(index)->resize(m_ui->platformTabs->widget(index)->minimumSizeHint());


### PR DESCRIPTION
In line 348, ResizeTabs is connected to the function currentChanged.
However, currentChanged returns -1 in case there is no new current widget:
https://doc.qt.io/qt-5/qtabwidget.html#currentChanged
This will cause a segfault, as the function ResizeTabs was not prepared to handle this case. This PR fixes that.

Issue:
resolves #16410 