### PR TITLE
Add mathematical function compact nodes

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactCeilingNodeable"
+        QualifiedName="Nodeables::CompactCeilingNodeable"
+        PreferredClassName="ceil"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Ceilings the input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactCeilingNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactCeilingNodeable::In(float a)
+    {
+        return ceil(a);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactCeilingNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactCeilingNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactCeilingNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactFloorNodeable"
+        QualifiedName="Nodeables::CompactFloorNodeable"
+        PreferredClassName="floor"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Floors the input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactFloorNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactFloorNodeable::In(float a)
+    {
+        return floor(a);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactFloorNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactFloorNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactFloorNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactModuloNodeable"
+        QualifiedName="Nodeables::CompactModuloNodeable"
+        PreferredClassName="mod"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Gets the remainder of the first input number divided by the second input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Parameter Name="b" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactModuloNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactModuloNodeable::In(float a, float b)
+    {
+        AZ_Error("ScriptCanvas", b != 0, "Attempted to divide by zero for modulo operation");
+        return fmod(a, b);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactModuloNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactModuloNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactModuloNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactPowerNodeable"
+        QualifiedName="Nodeables::CompactPowerNodeable"
+        PreferredClassName="pow"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Gets the first input number to the power of the second input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Parameter Name="b" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactPowerNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactPowerNodeable::In(float a, float b)
+    {
+        return pow(a, b);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactPowerNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactPowerNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactPowerNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactRoundNodeable"
+        QualifiedName="Nodeables::CompactRoundNodeable"
+        PreferredClassName="round"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Rounds the input number to the nearest whole number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactRoundNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactRoundNodeable::In(float a)
+    {
+        return round(a);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactRoundNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactRoundNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactRoundNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactSquareNodeable"
+        QualifiedName="Nodeables::CompactSquareNodeable"
+        PreferredClassName="square"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Squares the input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactSquareNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactSquareNodeable::In(float a)
+    {
+        return pow(a, 2.0f);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactSquareNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactSquareNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactSquareNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.ScriptCanvasNodeable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScriptCanvas Include="Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:noNamespaceSchemaLocation="../../../AutoGen/ScriptCanvasNodeable.xsd">
+    <Class Name="CompactSquareRootNodeable"
+        QualifiedName="Nodeables::CompactSquareRootNodeable"
+        PreferredClassName="sqrt"
+        Category="Compact/Mathematical Functions"
+        Namespace="ScriptCanvas"
+        Description="Gets the square root of the input number"
+        Preset="compact">
+
+        <Input Name="In" OutputName="Out">
+            <Parameter Name="a" Type="float"/>
+            <Return Name="Out" Type="float"/>
+        </Input>
+
+    </Class>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CompactSquareRootNodeable.h"
+
+namespace ScriptCanvas::Nodeables
+{
+    float CompactSquareRootNodeable::In(float a)
+    {
+        return sqrt(a);
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ScriptCanvas/CodeGen/NodeableCodegen.h>
+#include <ScriptCanvas/Core/Nodeable.h>
+#include <ScriptCanvas/Core/NodeableNode.h>
+
+#include <Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.generated.h>
+
+namespace ScriptCanvas::Nodeables
+{
+    class CompactSquareRootNodeable : public Nodeable
+    {
+        SCRIPTCANVAS_NODE(CompactSquareRootNodeable);
+
+    public:
+        AZ_CLASS_ALLOCATOR(CompactSquareRootNodeable, AZ::SystemAllocator)
+    };
+}

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_common_files.cmake
@@ -104,6 +104,13 @@ set(FILES
     Include/ScriptCanvas/Libraries/Compact/BasicOperators/CompactNegateNodeable.cpp
     Include/ScriptCanvas/Libraries/Compact/BasicOperators/CompactSubtractNodeable.cpp
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArccosineNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.cpp
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.cpp
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArcsineNodeable.cpp
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArctangent2Nodeable.cpp
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArctangentNodeable.cpp

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -140,6 +140,20 @@ set(FILES
     Include/ScriptCanvas/Libraries/Compact/BasicOperators/CompactNegateNodeable.ScriptCanvasNodeable.xml
     Include/ScriptCanvas/Libraries/Compact/BasicOperators/CompactSubtractNodeable.h
     Include/ScriptCanvas/Libraries/Compact/BasicOperators/CompactSubtractNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactCeilingNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactFloorNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactModuloNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactPowerNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactRoundNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareNodeable.ScriptCanvasNodeable.xml
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.h
+    Include/ScriptCanvas/Libraries/Compact/MathematicalFunctions/CompactSquareRootNodeable.ScriptCanvasNodeable.xml
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArccosineNodeable.h
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArccosineNodeable.ScriptCanvasNodeable.xml
     Include/ScriptCanvas/Libraries/Compact/Trigonometry/CompactArcsineNodeable.h

--- a/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_CompactNodeMathematicalFunctions.scriptcanvas
+++ b/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_CompactNodeMathematicalFunctions.scriptcanvas
@@ -1,0 +1,4551 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "ScriptCanvasData",
+    "ClassData": {
+        "m_scriptCanvas": {
+            "Id": {
+                "id": 3087803924340
+            },
+            "Name": "Script Canvas Graph",
+            "Components": {
+                "Component_[12233139935643849610]": {
+                    "$type": "EditorGraph",
+                    "Id": 12233139935643849610,
+                    "m_graphData": {
+                        "m_nodes": [
+                            {
+                                "Id": {
+                                    "id": 3139343531892
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 1.5,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3126458630004
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 2.828,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3117868695412
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 17.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3130753597300
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 18.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3143638499188
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 18.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 15285511044980
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 64.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 14405042749300
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[11426251776564189443]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 11426251776564189443,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 512.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{5E4B52BB-9F15-4E9E-9D7B-D16C90997C74}"
+                                            },
+                                            {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            },
+                                            {
+                                                "m_id": "{EE06A47D-4292-4DF7-9673-F616F9FA2461}"
+                                            },
+                                            {
+                                                "m_id": "{F3CF7A09-14E2-4B52-BB25-0C5786A29107}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 19391499779956
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[11928949438966811711]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 11928949438966811711,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{E17CCDFA-93C6-4215-BA08-8DB2810D2F5C}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AA39A17C-2133-4922-B26E-0B96E650657B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{1E33F881-260C-4011-BEBA-5B428BDA79AE}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{8BE500F9-8B8E-48F2-A40B-4F3715D1A124}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{1E33F881-260C-4011-BEBA-5B428BDA79AE}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3113573728116
+                                },
+                                "Name": "SC-Node(CompactFloorNodeableNode)",
+                                "Components": {
+                                    "Component_[13905557228746530127]": {
+                                        "$type": "CompactFloorNodeableNode",
+                                        "Id": 13905557228746530127,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{C6BF3462-0A4B-4890-A34C-11AE1126EAD9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{C8560AAB-508C-4EC7-8579-818ABE1BE754}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{87F42B05-61E6-4F52-B93C-CB0A48B2A19D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0B915EDD-7054-4BBD-8453-48F7F64813D4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{C6BF3462-0A4B-4890-A34C-11AE1126EAD9}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{C8560AAB-508C-4EC7-8579-818ABE1BE754}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{87F42B05-61E6-4F52-B93C-CB0A48B2A19D}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{0B915EDD-7054-4BBD-8453-48F7F64813D4}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3109278760820
+                                },
+                                "Name": "SC-Node(CompactSquareRootNodeableNode)",
+                                "Components": {
+                                    "Component_[15824397813615199211]": {
+                                        "$type": "CompactSquareRootNodeableNode",
+                                        "Id": 15824397813615199211,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{5B8677E6-5D3C-402B-883B-856D27745973}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{783591D3-69D6-4943-9A7C-56BD0577F8E0}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{403FD0CC-0396-4F48-A50F-C9B0F09EF74C}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{C12F9ECB-271F-471F-9D5A-41B269612E87}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{5B8677E6-5D3C-402B-883B-856D27745973}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{783591D3-69D6-4943-9A7C-56BD0577F8E0}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{403FD0CC-0396-4F48-A50F-C9B0F09EF74C}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{C12F9ECB-271F-471F-9D5A-41B269612E87}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3100688826228
+                                },
+                                "Name": "SC-Node(CompactRoundNodeableNode)",
+                                "Components": {
+                                    "Component_[16047186172395936592]": {
+                                        "$type": "CompactRoundNodeableNode",
+                                        "Id": 16047186172395936592,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{B6CE800A-EDDC-4423-8A32-CD5087637978}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6366508E-DB15-43EA-996E-E35ABD8BA55B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{AC85074F-B262-48A0-B2AD-D86444F954E6}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D08068AE-BF93-47E2-ABA1-A610E7EBDD4D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{B6CE800A-EDDC-4423-8A32-CD5087637978}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{6366508E-DB15-43EA-996E-E35ABD8BA55B}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{AC85074F-B262-48A0-B2AD-D86444F954E6}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{D08068AE-BF93-47E2-ABA1-A610E7EBDD4D}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 11110802833268
+                                },
+                                "Name": "SC-Node(CompactPowerNodeableNode)",
+                                "Components": {
+                                    "Component_[17159672386288171097]": {
+                                        "$type": "CompactPowerNodeableNode",
+                                        "Id": 17159672386288171097,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{49C78664-F6AC-4020-A55B-5735008B9E84}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{BC296DFB-E8FE-4E62-BCF3-8D0FF42296E1}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{5991C5F5-56E2-4AAB-AD29-DCBFC502EBB9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "b",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{8361BA9D-6FFD-47C7-BD3C-98306290B2E2}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{98A29ED1-CFFA-440D-9B38-953E1B4C1CE9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "b"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{49C78664-F6AC-4020-A55B-5735008B9E84}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{BC296DFB-E8FE-4E62-BCF3-8D0FF42296E1}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{5991C5F5-56E2-4AAB-AD29-DCBFC502EBB9}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{8361BA9D-6FFD-47C7-BD3C-98306290B2E2}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{98A29ED1-CFFA-440D-9B38-953E1B4C1CE9}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3092098891636
+                                },
+                                "Name": "SC-Node(CompactModuloNodeableNode)",
+                                "Components": {
+                                    "Component_[17888697911934479980]": {
+                                        "$type": "CompactModuloNodeableNode",
+                                        "Id": 17888697911934479980,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{E685C2A0-2267-4D46-AB61-F266A175B041}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{BD4851D2-98F1-49E3-B201-31FF4CC85FEF}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{298732AB-EE93-4B74-A2E8-6FDB13A80FA1}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "b",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{EEA67ACF-E7A0-46AF-AFED-E937CDFFEC16}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{8E81A799-C7C3-46EE-AFAA-9AE09E659184}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "b"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{E685C2A0-2267-4D46-AB61-F266A175B041}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{BD4851D2-98F1-49E3-B201-31FF4CC85FEF}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{298732AB-EE93-4B74-A2E8-6FDB13A80FA1}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{EEA67ACF-E7A0-46AF-AFED-E937CDFFEC16}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{8E81A799-C7C3-46EE-AFAA-9AE09E659184}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3104983793524
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[2141391597663766500]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 2141391597663766500,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{703CA62B-5194-49EA-9BC3-27D56F52187B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{0A1FC637-B930-438F-AD73-7752298CCED6}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 11527414660980
+                                },
+                                "Name": "SC-Node(CompactSquareNodeableNode)",
+                                "Components": {
+                                    "Component_[3103214437364457781]": {
+                                        "$type": "CompactSquareNodeableNode",
+                                        "Id": 3103214437364457781,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{EAB0C98E-9FC7-4563-9FDB-21D55F604609}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{69596D47-1E6A-4690-8321-0993FB9F206B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{0C16D396-ADC5-4C5B-88E5-C82CA7602C10}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E47C38DB-E25A-4269-A61B-3EE7C5FA0947}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{EAB0C98E-9FC7-4563-9FDB-21D55F604609}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{69596D47-1E6A-4690-8321-0993FB9F206B}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{0C16D396-ADC5-4C5B-88E5-C82CA7602C10}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{E47C38DB-E25A-4269-A61B-3EE7C5FA0947}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3135048564596
+                                },
+                                "Name": "SC-Node(Mark Complete)",
+                                "Components": {
+                                    "Component_[3658467419253389705]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 3658467419253389705,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{F93C096C-6AE3-40AC-80DE-4856A07A4EB4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Invalid BehaviorContext::Class name: 0",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{77845A68-73B9-4091-83D4-10BF7A7CFA91}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{C4393162-AC60-4B59-8A6C-46F09F16417D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{2046D280-7DF9-4CC1-A42B-E1E4FFCBF2CD}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{85C66E59-F012-460E-9756-B36819753F4D}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Invalid BehaviorContext::Class name: 0"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Mark Complete",
+                                        "className": "Unit Testing",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{F93C096C-6AE3-40AC-80DE-4856A07A4EB4}"
+                                            },
+                                            {
+                                                "m_id": "{77845A68-73B9-4091-83D4-10BF7A7CFA91}"
+                                            }
+                                        ],
+                                        "prettyClassName": "Unit Testing"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3096393858932
+                                },
+                                "Name": "SC-Node(Start)",
+                                "Components": {
+                                    "Component_[4574909123556580129]": {
+                                        "$type": "Start",
+                                        "Id": 4574909123556580129,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{C7DFEC8A-9924-4D37-AC45-E0E6DBC2D620}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled when the entity that owns this graph is fully activated.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3122163662708
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[9315196776274192546]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 9315196776274192546,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{6A631C2B-009A-43E1-9F99-7246BD9EDCD4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{A00A54F1-6225-42E8-ADBF-70FFA5181045}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3147933466484
+                                },
+                                "Name": "SC-Node(CompactCeilingNodeableNode)",
+                                "Components": {
+                                    "Component_[9497988946794877054]": {
+                                        "$type": "CompactCeilingNodeableNode",
+                                        "Id": 9497988946794877054,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{B31A0816-08D7-4914-8CAE-D2C6FCB58320}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                },
+                                                "CreatesImplicitConnections": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{284F8D40-4675-4C73-BC33-B35F8C501B2F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "a",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{76BE95D0-1A7C-49DE-BE86-925046D564E4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{C81FBBF6-C042-4F73-808D-54106BB51287}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "CanHaveInputField": false,
+                                                "IsNameHidden": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "a"
+                                            }
+                                        ],
+                                        "Style": ".compact",
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{B31A0816-08D7-4914-8CAE-D2C6FCB58320}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{284F8D40-4675-4C73-BC33-B35F8C501B2F}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{76BE95D0-1A7C-49DE-BE86-925046D564E4}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{C81FBBF6-C042-4F73-808D-54106BB51287}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "m_connections": [
+                            {
+                                "Id": {
+                                    "id": 3156523401076
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[4743474689065040376]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 4743474689065040376,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{703CA62B-5194-49EA-9BC3-27D56F52187B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3160818368372
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[13623862990050949589]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 13623862990050949589,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3130753597300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3165113335668
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[5051637583569462709]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5051637583569462709,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3130753597300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3117868695412
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3169408302964
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[5944569164588339730]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5944569164588339730,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3117868695412
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3139343531892
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3173703270260
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[17860364292190016962]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17860364292190016962,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3139343531892
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3143638499188
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3177998237556
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[2941864005979036137]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2941864005979036137,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3143638499188
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3126458630004
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3182293204852
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(ceil: a)",
+                                "Components": {
+                                    "Component_[1180316394962169934]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 1180316394962169934,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3147933466484
+                                            },
+                                            "slotId": {
+                                                "m_id": "{284F8D40-4675-4C73-BC33-B35F8C501B2F}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3186588172148
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(ceil: In)",
+                                "Components": {
+                                    "Component_[17693243828764210227]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17693243828764210227,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3147933466484
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B31A0816-08D7-4914-8CAE-D2C6FCB58320}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3190883139444
+                                },
+                                "Name": "srcEndpoint=(ceil: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[16569085778508465014]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 16569085778508465014,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3147933466484
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C81FBBF6-C042-4F73-808D-54106BB51287}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3130753597300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3195178106740
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(floor: a)",
+                                "Components": {
+                                    "Component_[14741097801974055175]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 14741097801974055175,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3113573728116
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C8560AAB-508C-4EC7-8579-818ABE1BE754}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3199473074036
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(floor: In)",
+                                "Components": {
+                                    "Component_[1164826474792731224]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 1164826474792731224,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3113573728116
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C6BF3462-0A4B-4890-A34C-11AE1126EAD9}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3203768041332
+                                },
+                                "Name": "srcEndpoint=(floor: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[791810552054149199]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 791810552054149199,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3113573728116
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0B915EDD-7054-4BBD-8453-48F7F64813D4}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3117868695412
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3208063008628
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(mod: a)",
+                                "Components": {
+                                    "Component_[14327574355212502541]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 14327574355212502541,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3092098891636
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BD4851D2-98F1-49E3-B201-31FF4CC85FEF}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3212357975924
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(mod: In)",
+                                "Components": {
+                                    "Component_[8650857249614696949]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 8650857249614696949,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3092098891636
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E685C2A0-2267-4D46-AB61-F266A175B041}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3216652943220
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(mod: b)",
+                                "Components": {
+                                    "Component_[7081332693776306022]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7081332693776306022,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3092098891636
+                                            },
+                                            "slotId": {
+                                                "m_id": "{298732AB-EE93-4B74-A2E8-6FDB13A80FA1}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3220947910516
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(mod: In)",
+                                "Components": {
+                                    "Component_[10200513152593102141]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10200513152593102141,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3092098891636
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E685C2A0-2267-4D46-AB61-F266A175B041}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3225242877812
+                                },
+                                "Name": "srcEndpoint=(mod: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[16038631350404174101]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 16038631350404174101,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3092098891636
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8E81A799-C7C3-46EE-AFAA-9AE09E659184}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3139343531892
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3229537845108
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(round: a)",
+                                "Components": {
+                                    "Component_[18165569160218142139]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 18165569160218142139,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{47B3DD8B-E3BF-4566-B51E-FC6FC9496F4F}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3100688826228
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6366508E-DB15-43EA-996E-E35ABD8BA55B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3233832812404
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(round: In)",
+                                "Components": {
+                                    "Component_[14076421335429470409]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 14076421335429470409,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{ADF541CB-D01B-4F09-A5F1-AE8389861495}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3100688826228
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B6CE800A-EDDC-4423-8A32-CD5087637978}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3238127779700
+                                },
+                                "Name": "srcEndpoint=(round: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[11465360492580748858]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 11465360492580748858,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3100688826228
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D08068AE-BF93-47E2-ABA1-A610E7EBDD4D}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3143638499188
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3242422746996
+                                },
+                                "Name": "srcEndpoint=(sqrt: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[1506662171210539167]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 1506662171210539167,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3109278760820
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C12F9ECB-271F-471F-9D5A-41B269612E87}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3126458630004
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3246717714292
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(sqrt: a)",
+                                "Components": {
+                                    "Component_[15285927443831582314]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15285927443831582314,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3109278760820
+                                            },
+                                            "slotId": {
+                                                "m_id": "{783591D3-69D6-4943-9A7C-56BD0577F8E0}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3251012681588
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(sqrt: In)",
+                                "Components": {
+                                    "Component_[16624471940634731598]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 16624471940634731598,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3109278760820
+                                            },
+                                            "slotId": {
+                                                "m_id": "{5B8677E6-5D3C-402B-883B-856D27745973}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 13202451906420
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(pow: In)",
+                                "Components": {
+                                    "Component_[2461050396013998476]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2461050396013998476,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11110802833268
+                                            },
+                                            "slotId": {
+                                                "m_id": "{49C78664-F6AC-4020-A55B-5735008B9E84}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 13623358701428
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(square: a)",
+                                "Components": {
+                                    "Component_[13374889796902038986]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 13374889796902038986,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11527414660980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{69596D47-1E6A-4690-8321-0993FB9F206B}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 13627653668724
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(square: In)",
+                                "Components": {
+                                    "Component_[5003572694223300989]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 5003572694223300989,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DBC032FC-1552-476E-A0ED-5D41C0F1EF74}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11527414660980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{EAB0C98E-9FC7-4563-9FDB-21D55F604609}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 16664195546996
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[2104436226229025419]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2104436226229025419,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3126458630004
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 14405042749300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17304145674100
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[17058612263493431291]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17058612263493431291,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 14405042749300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 15285511044980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A110F5F8-0CAE-4F59-81DF-125188588D71}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17755117240180
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Mark Complete: In)",
+                                "Components": {
+                                    "Component_[11219126911689600705]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 11219126911689600705,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 15285511044980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A2BDB76-368F-4818-8383-60061F56E174}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3135048564596
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C4393162-AC60-4B59-8A6C-46F09F16417D}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18386477432692
+                                },
+                                "Name": "srcEndpoint=(pow: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[12940982545898857291]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12940982545898857291,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 11110802833268
+                                            },
+                                            "slotId": {
+                                                "m_id": "{98A29ED1-CFFA-440D-9B38-953E1B4C1CE9}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 14405042749300
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18734369783668
+                                },
+                                "Name": "srcEndpoint=(square: Out), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[11065292673870636256]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 11065292673870636256,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 11527414660980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E47C38DB-E25A-4269-A61B-3EE7C5FA0947}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 15285511044980
+                                            },
+                                            "slotId": {
+                                                "m_id": "{955B2135-6A19-40FC-8E36-3A5FBE2E6FB4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 24485330993012
+                                },
+                                "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[10944692787494317916]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10944692787494317916,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3096393858932
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C7DFEC8A-9924-4D37-AC45-E0E6DBC2D620}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 19391499779956
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E17CCDFA-93C6-4215-BA08-8DB2810D2F5C}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 24558345437044
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[2862721572627630775]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2862721572627630775,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 19391499779956
+                                            },
+                                            "slotId": {
+                                                "m_id": "{AA39A17C-2133-4922-B26E-0B96E650657B}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3122163662708
+                                            },
+                                            "slotId": {
+                                                "m_id": "{6A631C2B-009A-43E1-9F99-7246BD9EDCD4}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 25271310008180
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(pow: a)",
+                                "Components": {
+                                    "Component_[12439406296345281444]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12439406296345281444,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3104983793524
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8FA548E1-E3FE-456D-8AEE-1008674CCCBA}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11110802833268
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BC296DFB-E8FE-4E62-BCF3-8D0FF42296E1}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 25791001050996
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(pow: b)",
+                                "Components": {
+                                    "Component_[14182117752852428481]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 14182117752852428481,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 19391499779956
+                                            },
+                                            "slotId": {
+                                                "m_id": "{1E33F881-260C-4011-BEBA-5B428BDA79AE}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11110802833268
+                                            },
+                                            "slotId": {
+                                                "m_id": "{5991C5F5-56E2-4AAB-AD29-DCBFC502EBB9}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 25795296018292
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(pow: In)",
+                                "Components": {
+                                    "Component_[13967791319016332863]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 13967791319016332863,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 19391499779956
+                                            },
+                                            "slotId": {
+                                                "m_id": "{AA39A17C-2133-4922-B26E-0B96E650657B}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 11110802833268
+                                            },
+                                            "slotId": {
+                                                "m_id": "{49C78664-F6AC-4020-A55B-5735008B9E84}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "versionData": {
+                        "_grammarVersion": 1,
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
+                    },
+                    "m_variableCounter": 2,
+                    "GraphCanvasData": [
+                        {
+                            "Key": {
+                                "id": 3087803924340
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
+                                        "$type": "SceneComponentSaveData",
+                                        "ViewParams": {
+                                            "Scale": 0.7810572419258938,
+                                            "AnchorX": 1058.8212890625,
+                                            "AnchorY": -656.8020629882813
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3092098891636
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{6986413A-2F6D-44C6-99BE-F37FA5F3C44E}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3096393858932
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -660.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{A33C065E-4A08-42AC-8593-78EC2E977CCF}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3100688826228
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            380.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{C2071892-BB47-41C1-9B18-134EAF0A03AC}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3104983793524
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -180.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{ADE944FF-B444-4A28-94A8-BB6462ED1384}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3109278760820
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            420.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{8AB4C15E-45EC-4C2F-9DEE-1EB34B3C7100}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3113573728116
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{3F2010B5-581F-4FD9-9C2F-BD9F1C368DAB}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3117868695412
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            440.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{222999BA-821E-49D7-A515-B911076F4843}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3122163662708
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -340.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{0D1380DB-9520-4D82-B0BF-43C55CD1CBEE}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3126458630004
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1340.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{CEE34F08-F5AF-4D36-A038-1C9B2F256576}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3130753597300
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            140.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{DB6157CB-2448-4C76-813E-9A826DF20BDB}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3135048564596
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2240.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F5007BB1-67F5-4946-912A-842B0512C42A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3139343531892
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            740.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{E0CD8C4F-5912-4527-ABC3-86574477BCAB}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3143638499188
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1040.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{72F4DFB4-8B75-495A-8727-9C821A4FDB51}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 3147933466484
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{3E5F7B36-5536-4F4D-8168-B65B5F25CD8C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 11110802833268
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            460.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{9DA5758F-71DE-4554-A0F1-6BC00D2275A2}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 11527414660980
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -60.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".compact"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{FEF1EFBD-1488-4AF4-AAC1-F4A016837F9D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 14405042749300
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1640.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{32289F4D-BD84-4F73-B645-AD8EF3922283}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 15285511044980
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1940.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{8402B419-8E8C-46DD-80E9-F95B8A117E5B}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 19391499779956
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -500.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{36B37BF6-142D-46F6-A620-C44B7B794AA8}"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "StatisticsHelper": {
+                        "InstanceCounter": [
+                            {
+                                "Key": 625417921756020548,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 2030367031757852778,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 3064319196456221353,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 3209255366127054248,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 4053150093067829293,
+                                "Value": 7
+                            },
+                            {
+                                "Key": 4199610336680704683,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 7126709429689877615,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 8050724002049668610,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 10204019744198319120,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 11756143629325306601,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 13054893700285801948,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 15603295423170358959,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 18227371080084256436,
+                                "Value": 1
+                            }
+                        ]
+                    }
+                },
+                "Component_[6401908228521485472]": {
+                    "$type": "EditorGraphVariableManagerComponent",
+                    "Id": 6401908228521485472,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{0A1FC637-B930-438F-AD73-7752298CCED6}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 3
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "double",
+                                        "value": 8.0
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{0A1FC637-B930-438F-AD73-7752298CCED6}"
+                                    },
+                                    "VariableName": "testvar2"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{8BE500F9-8B8E-48F2-A40B-4F3715D1A124}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 3
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "double",
+                                        "value": 3.0
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{8BE500F9-8B8E-48F2-A40B-4F3715D1A124}"
+                                    },
+                                    "VariableName": "testvar3"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{A00A54F1-6225-42E8-ADBF-70FFA5181045}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "isOverloadedStorage": false,
+                                        "scriptCanvasType": {
+                                            "m_type": 3
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "double",
+                                        "value": 17.5
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{A00A54F1-6225-42E8-ADBF-70FFA5181045}"
+                                    },
+                                    "VariableName": "testvar1"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
@@ -977,14 +977,14 @@ TEST_F(ScriptCanvasTestFixture, CompactNodeBasicOperators)
     RunUnitTestGraph("LY_SC_UnitTest_CompactNodeBasicOperators", ExecutionMode::Interpreted);
 }
 
-TEST_F(ScriptCanvasTestFixture, CompactNodeTrigonometry)
-{
-    RunUnitTestGraph("LY_SC_UnitTest_CompactNodeTrigonometry", ExecutionMode::Interpreted);
-}
-
 TEST_F(ScriptCanvasTestFixture, CompactNodeMathematicalFunctions)
 {
     RunUnitTestGraph("LY_SC_UnitTest_CompactNodeMathematicalFunctions", ExecutionMode::Interpreted);
+}
+
+TEST_F(ScriptCanvasTestFixture, CompactNodeTrigonometry)
+{
+    RunUnitTestGraph("LY_SC_UnitTest_CompactNodeTrigonometry", ExecutionMode::Interpreted);
 }
 
 TEST_F(ScriptCanvasTestFixture, CompactNodeChain)

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
@@ -982,6 +982,11 @@ TEST_F(ScriptCanvasTestFixture, CompactNodeTrigonometry)
     RunUnitTestGraph("LY_SC_UnitTest_CompactNodeTrigonometry", ExecutionMode::Interpreted);
 }
 
+TEST_F(ScriptCanvasTestFixture, CompactNodeMathematicalFunctions)
+{
+    RunUnitTestGraph("LY_SC_UnitTest_CompactNodeMathematicalFunctions", ExecutionMode::Interpreted);
+}
+
 TEST_F(ScriptCanvasTestFixture, CompactNodeChain)
 {
     RunUnitTestGraph("LY_SC_UnitTest_CompactNodeChain", ExecutionMode::Interpreted);


### PR DESCRIPTION
## What does this PR do?

This is the third PR of a series of 3 PRs for adding compact nodes to the node palette in Script Canvas. This PR adds nodes for common mathematical functions. More specifically, the following nodes were added:
- ceil
- floor
- mod
- pow
- round
- square
- sqrt

![image](https://github.com/o3de/o3de/assets/105814224/6dcc6dce-579f-4665-8615-bd33b4a852f6)

Link to first PR: https://github.com/o3de/o3de/pull/16382
Link to second PR: https://github.com/o3de/o3de/pull/16403

## How was this PR tested?

A unit test was created using the Script Canvas Testing framework to test that the nodes are producing their expected results:
![image](https://github.com/o3de/o3de/assets/105814224/89025433-d4e3-405f-8d74-88934df9eb43)

