### PR TITLE
Add Auto Upload Github Release CLI `--upload-github-release-tag`

### DIFF
--- a/scripts/o3de/o3de/git_utils.py
+++ b/scripts/o3de/o3de/git_utils.py
@@ -64,8 +64,8 @@ class GenericGitProvider(gitproviderinterface.GitProviderInterface):
 
         return proc.returncode
 
-    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
-        logger.warning(f"GenericGitProvider does not yet support uploading a release to Git platforms other than GitHub")
+    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, git_release_tag: str) -> int:
+        logger.warning("GenericGitProvider does not yet support uploading a release to Git platforms other than GitHub")
         return 1
 
 def get_generic_git_provider(parsed_uri: ParseResult) -> GenericGitProvider or None:

--- a/scripts/o3de/o3de/git_utils.py
+++ b/scripts/o3de/o3de/git_utils.py
@@ -65,7 +65,7 @@ class GenericGitProvider(gitproviderinterface.GitProviderInterface):
         return proc.returncode
 
     def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
-        logger.warning(f"GenericGitProvider does not yet support upload release to git platforms other than GitHub")
+        logger.warning(f"GenericGitProvider does not yet support uploading a release to Git platforms other than GitHub")
         return 1
 
 def get_generic_git_provider(parsed_uri: ParseResult) -> GenericGitProvider or None:

--- a/scripts/o3de/o3de/git_utils.py
+++ b/scripts/o3de/o3de/git_utils.py
@@ -64,6 +64,10 @@ class GenericGitProvider(gitproviderinterface.GitProviderInterface):
 
         return proc.returncode
 
+    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
+        logger.warning(f"GenericGitProvider does not yet support upload release to git platforms other than GitHub")
+        return 1
+
 def get_generic_git_provider(parsed_uri: ParseResult) -> GenericGitProvider or None:
     # the only requirement we have is one of the path components ends in .git
     # this could be relaxed further 

--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -88,21 +88,21 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
 
         return proc.returncode
     
-    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
+    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, git_release_tag: str) -> int:
         """
         Uploads a release asset to a GitHub repository. 
         It enables users to specify the GitHub release tag for the asset.
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
-        :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        :param git_release_tag (str): The tag associated with the GitHub release.
         """
         access_token = getpass.getpass("Provide your GitHub access token (Must have content - read and write permission)\n"
                                         "Enter your GitHub Token (right click mouse to paste):")
         if len(access_token) == 0:
             logger.error('No input received! To paste your token into a terminal use mouse right click.')
             return 1
-        tag_name = upload_git_release_tag
+        tag_name = git_release_tag
         # Get GitHub credentials
         headers = {
             'Authorization': f'Token {access_token}',

--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -88,7 +88,7 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
 
         return proc.returncode
     
-    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
+    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str) -> int:
         """
         Uploads a release asset to a GitHub repository. 
         It enables users to specify the GitHub release tag for the asset.

--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -97,13 +97,13 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
         :param upload_github_release_tag (str): The tag associated with the GitHub release.
         """
-        access_token = getpass.getpass("Provide your github access token (Must have content - read and write permission)\n"
+        access_token = getpass.getpass("Provide your GitHub access token (Must have content - read and write permission)\n"
                                         "Enter your GitHub Token (right click mouse to paste):")
         if len(access_token) == 0:
             logger.error('No input received! To paste your token into a terminal use mouse right click.')
             return 1
         tag_name = upload_git_release_tag
-        # Get github credentials
+        # Get GitHub credentials
         headers = {
             'Authorization': f'Token {access_token}',
             'Accept': 'application/vnd.github.v3+json',
@@ -130,7 +130,7 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
         }
         # Valid release
         if response.status_code == 200:
-            # Get the release end point to retrive release id
+            # Get the release end point to retrieve release id
             get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
             response = requests.get(get_release_by_tag, headers=headers, json=release_payload)
             release_id = response.json().get('id')
@@ -147,7 +147,7 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
                 logger.error(f'Failed to retrieve release. Status code: {response.status_code}')
                 return 1
             
-        # Release doesn't exist, Create a new release endpoint with the given tag_name and upload assest  
+        # Release doesn't exist; create a new release endpoint with the given tag_name and upload assests  
         elif response.status_code == 404:
             release_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
             response = requests.post(release_url, headers=headers, json=release_payload)

--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -16,7 +16,8 @@ import urllib.parse
 from urllib.parse import ParseResult
 import urllib.request
 import subprocess
-
+import requests
+import getpass
 from o3de import gitproviderinterface, utils
 
 LOG_FORMAT = '[%(levelname)s] %(name)s: %(message)s'
@@ -86,6 +87,81 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
                 return 1
 
         return proc.returncode
+    
+    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
+        """
+        Uploads a release asset to a GitHub repository. 
+        It enables users to specify the GitHub release tag for the asset.
+        :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+        :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+        :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+        :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        """
+        access_token = getpass.getpass("Provide your github access token (Must have content - read and write permission)\n"
+                                        "Enter your GitHub Token (right click mouse to paste):")
+        if len(access_token) == 0:
+            logger.error('No input received! To paste your token into a terminal use mouse right click.')
+        
+        tag_name = upload_git_release_tag
+        # Get github credentials
+        headers = {
+            'Authorization': f'Token {access_token}',
+            'Accept': 'application/vnd.github.v3+json',
+            "Content-Type": "application/zip"
+        }
+        
+        # Get owner (required)
+        owner = response = requests.get('https://api.github.com/user', headers=headers)
+        if response.status_code == 200:
+            user_data = response.json()
+            owner = user_data['login']
+        else:
+            logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
+
+        # Get repo (required) repo_uri: https://github.com/<owner>/<repo>.git
+        repo_uri = repo_uri.geturl().split("/")
+        repo = repo_uri[-1].split(".git")[0]
+        
+        tag_check_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+        response = requests.get(tag_check_url, headers=headers)
+        
+        release_payload = {
+            'tag_name': tag_name
+        }
+        # Valid release
+        if response.status_code == 200:
+            # Get the release end point to retrive release id
+            get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+            response = requests.get(get_release_by_tag, headers=headers, json=release_payload)
+            release_id = response.json().get('id')
+        
+            if response.status_code == 200:
+                upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+                with open(zip_path, 'rb') as file:
+                    response = requests.post(upload_url, headers=headers, data=file)
+                    if not response.status_code == 201:
+                        logger.error(f'Failed to upload asset to existing release. Status code: {response.status_code}')
+            else:
+                logger.error(f'Failed to retrive release. Status code: {response.status_code}')
+
+        # Release doesn't exist, Create a new release endpoint with the given tag_name and upload assest  
+        elif response.status_code == 404:
+            release_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+            response = requests.post(release_url, headers=headers, json=release_payload)
+
+            if response.status_code == 201:
+                release_id = response.json().get('id')
+                upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+                with open(zip_path, 'rb') as file:
+                    response = requests.post(upload_url, headers=headers, data=file)
+                    if not response.status_code == 201:
+                        logger.error(f'Failed to upload asset. Status code: {response.status_code}')
+            else:
+                logger.error(f'Failed to create release. Status code: {response.status_code}')
+        else:
+            logger.error(f'Error checking tag existence. Status code: {response.status_code}')
 
 def get_github_provider(parsed_uri: ParseResult) -> GitHubProvider or None:
     if 'github.com' in parsed_uri.netloc:

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -36,11 +36,11 @@ class GitProviderInterface(ABC):
         pass
     
     @abstractmethod
-    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
+    def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, git_release_tag: str):
         """
-        Uploads a release asset to a GitHub repository. 
-        It enables users to specify the GitHub release tag for the asset. 
-        Creates a GitHub repository release if the specified tag doesn't already exist.
+        Uploads a release asset to a git repository. 
+        It enables users to specify the a release tag for the asset. 
+        Creates a git repository release if the specified tag doesn't already exist.
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -39,10 +39,12 @@ class GitProviderInterface(ABC):
     def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
         """
         Uploads a release asset to a GitHub repository. 
-        It enables users to specify the GitHub release tag for the asset.
+        It enables users to specify the GitHub release tag for the asset. 
+        Creates a GitHub repository release if the specified tag doesn't already exist.
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
         :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        :return: return code, 0 on success
         """
         pass

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -44,7 +44,7 @@ class GitProviderInterface(ABC):
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
-        :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        :param git_release_tag (str): The tag associated with the GitHub release.
         :return: return code, 0 on success
         """
         pass

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -28,9 +28,21 @@ class GitProviderInterface(ABC):
         """
         Clones a git repository from a uri into a given folder
         :param uri: uniform resource identifier
-        :param download_path: location path on disk to download file
+        :param download_path: location path on disk to download files
         :param force_overwrite: whether to force overwrite the contents that already exist on disk or not
         :param ref: optional source control reference which can be a commit hash, branch, tag or other reference type
         :return: return code, 0 on success
+        """
+        pass
+    
+    @abstractmethod
+    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
+        """
+        Uploads a release asset to a GitHub repository. 
+        It enables users to specify the GitHub release tag for the asset.
+        :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+        :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+        :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+        :param upload_github_release_tag (str): The tag associated with the GitHub release.
         """
         pass

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -39,7 +39,7 @@ class GitProviderInterface(ABC):
     def upload_release(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, git_release_tag: str):
         """
         Uploads a release asset to a git repository. 
-        It enables users to specify the a release tag for the asset. 
+        It enables users to specify the release tag for the asset. 
         Creates a git repository release if the specified tag doesn't already exist.
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -240,7 +240,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         else:
             logger.error(f'{repo_uri} is not a valid Github repository link, please update your repo_uri in your repo.json file.')
             return 1
-        download_prefix = f'https:\\github.com\{owner}\{repo}\releases\download\{upload_github_release_tag}\{archive_filename}'
+        download_prefix = f'https://github.com/{owner}/{repo}/releases/download/{upload_github_release_tag}/{archive_filename}'
      
         json_data = merge_json_data(json_data_path, {
             'repo_uri': repo_uri,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -105,8 +105,7 @@ def upload_release_to_github(repo_uri:str,
     else:
         logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
 
-    # Get repo (required)
-    # repo_uri: https://github.com/<owner>/<repo>.git
+    # Get repo (required) repo_uri: https://github.com/<owner>/<repo>.git
     repo_uri = repo_uri.split("/")
     repo = repo_uri[-1].split(".git")[0]
     
@@ -116,7 +115,7 @@ def upload_release_to_github(repo_uri:str,
     release_payload = {
         'tag_name': tag_name
     }
-    # Status code 200: valid release
+    # Valid release
     if response.status_code == 200:
         # Get the release end point to retrive release id
         get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
@@ -151,7 +150,7 @@ def upload_release_to_github(repo_uri:str,
     else:
         logger.error(f'Error checking tag existence. Status code: {response.status_code}')
   
-def is_github_link(url):
+def _is_github_link(url):
     github_url_pattern = r'^https?://github\.com/[a-zA-Z0-9\-_]+/[a-zA-Z0-9\-_]+(\.git)?$'
     return bool(re.match(github_url_pattern, url))
 
@@ -229,10 +228,15 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         logger.error(f'{zip_path} already exists.  Use --force command to overwrite the existing zip or '
                      'provide a new location to save your archive.')
         return {}
-    
+    if upload_github_release_tag is None and download_prefix is None:
+        logger.error('You need to provide a --upload-github-release-tag if you want to upload to github.\n'
+                     'If you want to use other version control systems you must provide --download-prefix argument\n'
+                     'A url prefix for a file attached to a Github release might look like this:'
+                     '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
+        return {}
     if upload_github_release_tag and download_prefix is None:
         
-        if is_github_link(repo_uri):
+        if _is_github_link(repo_uri):
         # Parse the URL to extract owner and repository name
             owner_repo = repo_uri.split("github.com/")[1].rstrip('.git').split('/')
             owner = owner_repo[0]
@@ -644,7 +648,8 @@ def add_parser_args(parser):
                                    help='A URL prefix for a file attached to a GitHub release might look like this:'
                                         '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0/')
     modify_object_group.add_argument('--upload-github-release-tag', '-ugrt', type=str, default=False,
-                                   help='Please provide a tag_name for the release. Automatically uploads your object-release-archive.zip file to specified github release.')
+                                   help='Automatically uploads your object-release-archive.zip file to specified github release.\n'
+                                        'Please provide a tag_name for the release. ')
     parser.set_defaults(func=_edit_repo_props)
 
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -17,6 +17,11 @@ import json
 import logging
 import hashlib
 import shutil
+import requests
+import sys
+import msvcrt
+import time
+import re
 from packaging.version import Version, InvalidVersion
 from packaging.specifiers import SpecifierSet
 from o3de import manifest, utils, validation
@@ -24,6 +29,131 @@ from o3de import manifest, utils, validation
 logger = logging.getLogger('o3de.repo_properties')
 logging.basicConfig(format=utils.LOG_FORMAT)
 
+def hide_credential(prompt):
+    """
+    Hide credentials displays a prompt to the user and waits for credential input. The entered characters
+    are masked with asterisks (*) to provide privacy. The function captures individual keystrokes, including backspace,
+    and supports a timeout feature to limit the duration for user input.
+
+    Args:
+        prompt (str): The prompt to display to the user.
+
+    Returns:
+        str: The user-entered credential/password as a string.
+
+    Timeout:
+        If no input is received within 60 seconds, the function will display an
+        timeout message, return an empty string, and terminate.
+    """
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+
+    secret_input = []
+    start_time = time.time()
+
+    while True:
+        if msvcrt.kbhit():
+            char = msvcrt.getch()
+            if char == b'\r':
+                break
+            elif char == b'\x08':
+                if secret_input:
+                    secret_input.pop()
+                    sys.stdout.write('\b \b')
+            else:
+                sys.stdout.write('*')
+                secret_input.append(char)
+            sys.stdout.flush()
+            start_time = time.time()
+
+        if time.time() - start_time > 60:
+            sys.stdout.write('\n')
+            print("Input timeout occurred")
+            return ""
+
+    sys.stdout.write('\n')
+    return b''.join(secret_input).decode('utf-8')
+
+def upload_release_to_github(repo_uri:str,
+                             zip_path: pathlib.Path,
+                             archive_filename: str,
+                             upload_github_release_tag: str):
+    """
+    Uploads a release asset to a GitHub repository. 
+    It enables users to specify the GitHub release tag for the asset.
+    :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+    :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+    :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+    :param upload_github_release_tag (str): The tag associated with the GitHub release.
+    """
+    access_token = hide_credential("Provide your github access token (Must have content - read and write permission)\n"
+                                   "Enter your Github Token: ")
+
+    tag_name = upload_github_release_tag
+    # Get github credentials
+    headers = {
+        'Authorization': f'Token {access_token}',
+        'Accept': 'application/vnd.github.v3+json',
+        "Content-Type": "application/zip"
+    }
+    
+    # Get owner (required)
+    owner = response = requests.get('https://api.github.com/user', headers=headers)
+    if response.status_code == 200:
+        user_data = response.json()
+        owner = user_data['login']
+    else:
+        logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
+
+    # Get repo (required)
+    # repo_uri: https://github.com/<owner>/<repo>.git
+    repo_uri = repo_uri.split("/")
+    repo = repo_uri[-1].split(".git")[0]
+    
+    tag_check_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+    response = requests.get(tag_check_url, headers=headers)
+    
+    release_payload = {
+        'tag_name': tag_name
+    }
+    # Status code 200: valid release
+    if response.status_code == 200:
+        # Get the release end point to retrive release id
+        get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+        response = requests.get(get_release_by_tag, headers=headers, json=release_payload)
+        release_id = response.json().get('id')
+       
+        if response.status_code == 200:
+            upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+            with open(zip_path, 'rb') as file:
+                response = requests.post(upload_url, headers=headers, data=file)
+                if not response.status_code == 201:
+                    logger.error(f'Failed to upload asset to existing release. Status code: {response.status_code}')
+        else:
+            logger.error(f'Failed to retrive release. Status code: {response.status_code}')
+
+    # Release doesn't exist, Create a new release endpoint with the given tag_name and upload assest  
+    elif response.status_code == 404:
+        release_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+        response = requests.post(release_url, headers=headers, json=release_payload)
+
+        if response.status_code == 201:
+            release_id = response.json().get('id')
+            upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+            with open(zip_path, 'rb') as file:
+                response = requests.post(upload_url, headers=headers, data=file)
+                if not response.status_code == 201:
+                    logger.error(f'Failed to upload asset. Status code: {response.status_code}')
+        else:
+            logger.error(f'Failed to create release. Status code: {response.status_code}')
+    else:
+        logger.error(f'Error checking tag existence. Status code: {response.status_code}')
+  
+def is_github_link(url):
+    github_url_pattern = r'^https?://github\.com/[a-zA-Z0-9\-_]+/[a-zA-Z0-9\-_]+(\.git)?$'
+    return bool(re.match(github_url_pattern, url))
 
 def merge_json_data(json_path: pathlib.Path, json_data: dict) -> dict:
     """
@@ -69,7 +199,8 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
                    releases_path: pathlib.Path, 
                    repo_uri:str,
                    force: bool,
-                   download_prefix:str) -> dict:
+                   download_prefix: str = None,
+                   upload_github_release_tag: str = None) -> dict:
     """
     Creates a release of a specific version of a 
     remote object for the given src_data_path.
@@ -92,17 +223,42 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         FileNotFoundError: If the json_data_path does not exist.
         ValueError: If the json_data_path is not a dict.
     """
-    if download_prefix is None:
-        logger.error('The --download-prefix argument must be provided. A url prefix for a file attached to a Github release might look like this:'
-                     '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
-        return {}
     zip_path = releases_path / archive_filename
     # check if a object.zip folder already exist in the path - ask user if they want to overwrite the current zip
     if not force and zip_path.exists():
         logger.error(f'{zip_path} already exists.  Use --force command to overwrite the existing zip or '
                      'provide a new location to save your archive.')
         return {}
-    else:
+    
+    if upload_github_release_tag and download_prefix is None:
+        
+        if is_github_link(repo_uri):
+        # Parse the URL to extract owner and repository name
+            owner_repo = repo_uri.split("github.com/")[1].rstrip('.git').split('/')
+            owner = owner_repo[0]
+            repo = owner_repo[1]
+        else:
+            logger.error(f'{repo_uri} is not a valid Github repository link, please update your repo_uri in your repo.json file.')
+            return 1
+        download_prefix = f'https:\\github.com\{owner}\{repo}\releases\download\{upload_github_release_tag}\{archive_filename}'
+     
+        json_data = merge_json_data(json_data_path, {
+            'repo_uri': repo_uri,
+            'download_source_uri': download_prefix
+        })
+
+        logging.info(f"Creating '{download_prefix}'")
+
+        shutil.make_archive(releases_path / pathlib.Path(archive_filename).stem, 'zip', src_data_path)
+        with zip_path.open('rb') as f:
+            json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
+        
+        # Upload release archive zip to Github
+        upload_release_to_github(repo_uri, zip_path, archive_filename, upload_github_release_tag)
+        return json_data
+    
+    # For other version control systems
+    if download_prefix:
         # create the release zip file
         json_data = merge_json_data(json_data_path, {
             'repo_uri':repo_uri,
@@ -115,7 +271,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         with zip_path.open('rb') as f:
             json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
 
-    return json_data
+        return json_data
     
 # retrieves json data of the repository from a file path
 def get_repo_props(path: pathlib.Path) -> dict or None:
@@ -149,7 +305,8 @@ def _edit_objects(object_typename:str,
                   replace_objects: pathlib.Path or list = None,
                   release_archive_path: pathlib.Path = None,
                   force: bool = None,
-                  download_prefix: str = None):
+                  download_prefix: str = None,
+                  upload_github_release_tag: str = None):
     """
     Modifies the 'gems_data/projects_data/templates_data' in repo_json
     :param object_typename: The type object field you want to change
@@ -183,9 +340,10 @@ def _edit_objects(object_typename:str,
                                 object_path / f'{object_typename}.json', 
                                 archive_filename, 
                                 release_archive_path, 
-                                repo_json['repo_uri'], 
+                                repo_json['repo_uri'],
                                 force,
-                                download_prefix)
+                                download_prefix,
+                                upload_github_release_tag)
                     # if create_remote_object_archive is not successful, then exit
                     if not json_data:
                         return 1
@@ -344,8 +502,8 @@ def edit_repo_props(repo_path: pathlib.Path = None,
                        dry_run: bool = False,
                        release_archive_path: pathlib.Path = None,
                        force: bool = None,
-                       download_prefix: str = None
-                       ) -> int:
+                       download_prefix: str = None,
+                       upload_github_release_tag: str = None) -> int:
     """
     Edits and modifies the remote repo properties for the repo.json located at 'repo_path'.
     :param repo_path: The path to the repo.json file
@@ -389,13 +547,13 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         _auto_update_json(auto_update, repo_path, repo_json)
 
     if add_gems or delete_gems or replace_gems:
-        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix)
+        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if add_projects or delete_projects or replace_projects:
-        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix)
+        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if add_templates or delete_templates or replace_templates:
-        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix)
+        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if repo_json_original != repo_json and not dry_run:
         utils.backup_file(repo_path)
@@ -426,7 +584,8 @@ def _edit_repo_props(args: argparse) -> int:
                               dry_run=args.dry_run,
                               release_archive_path=args.release_archive_path,
                               force=args.force,
-                              download_prefix=args.download_prefix
+                              download_prefix=args.download_prefix,
+                              upload_github_release_tag=args.upload_github_release_tag
                               )
 
 
@@ -484,6 +643,8 @@ def add_parser_args(parser):
     modify_object_group.add_argument('--download-prefix', '-dp', type=str, required=False,
                                    help='A URL prefix for a file attached to a GitHub release might look like this:'
                                         '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0/')
+    modify_object_group.add_argument('--upload-github-release-tag', '-ugrt', type=str, default=False,
+                                   help='Please provide a tag_name for the release. Automatically uploads your object-release-archive.zip file to specified github release.')
     parser.set_defaults(func=_edit_repo_props)
 
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -68,7 +68,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
                    json_data_path: pathlib.Path, 
                    archive_filename: str, 
                    releases_path: pathlib.Path, 
-                   repo_uri:str,
+                   repo_uri: str,
                    force: bool,
                    download_prefix: str = None,
                    upload_git_release_tag: str = None) -> dict:
@@ -160,13 +160,13 @@ def get_repo_props(path: pathlib.Path) -> dict or None:
         return None
     return repo_json
 
-def _find_index(data:list, key:str, value:str) -> int:
+def _find_index(data: list, key: str, value: str) -> int:
     for index, item in enumerate(data):
         if item.get(key) == value:
             return index
     return -1
 
-def _changed(original:dict, new:dict) -> dict:
+def _changed(original: dict, new: dict) -> dict:
     changed = {}
     for key, value in new.items():
         if key not in original:
@@ -176,8 +176,8 @@ def _changed(original:dict, new:dict) -> dict:
 
     return changed
 
-def _edit_objects(object_typename:str,
-                  validator:callable,
+def _edit_objects(object_typename: str,
+                  validator: callable,
                   repo_json: dict,
                   add_objects: pathlib.Path or list = None,
                   delete_objects: str or list = None,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -103,7 +103,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
     if not upload_git_release_tag and not download_prefix:
         logger.error('You need to provide a --upload-git-release-tag if you want to upload to a Git provider like GitHub.\n'
                      'If you want to use other version control systems you must provide --download-prefix argument\n'
-                     'A url prefix for a file attached to a Github release might look like this:'
+                     'Example GitHub URL prefix:'
                      '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
         return {}
     if upload_git_release_tag and download_prefix:
@@ -526,7 +526,7 @@ def add_parser_args(parser):
                                    help='A URL prefix for a file attached to a GitHub release might look like this:'
                                         '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0/')
     modify_object_group.add_argument('--upload-git-release-tag', '-ugrt', type=str, default=False,
-                                   help='Automatically uploads your object-release-archive.zip file to specified github release.\n'
+                                   help='Automatically uploads your object-release-archive.zip file to specified GitHub release.\n'
                                         'Please provide a tag_name for the release. ')
     parser.set_defaults(func=_edit_repo_props)
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -109,6 +109,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
     if upload_git_release_tag and download_prefix:
         logger.error('Upload to GitHub will automatically generate a download prefix for you.\n'
                      'Use the `--download-prefix` CLI only when you want to use other version control system.')
+        return {}
     if upload_git_release_tag and not download_prefix:
         repo_uri = urllib.parse.urlparse(repo_uri)
         git_provider = github_utils.get_github_provider(repo_uri)
@@ -119,7 +120,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
             repo = owner_repo[1]
         else:
             logger.error(f'Failed to determine Git provider from {repo_uri}.')
-            return 1
+            return {}
         download_prefix = f'https://github.com/{owner}/{repo}/releases/download/{upload_git_release_tag}/{archive_filename}'
      
         json_data = merge_json_data(json_data_path, {
@@ -134,7 +135,9 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
             json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
         
         # Upload release archive zip to Github
-        git_provider.upload_release_to_github(repo_uri, zip_path, archive_filename, upload_git_release_tag)
+        if git_provider.upload_release_to_github(repo_uri, zip_path, archive_filename, upload_git_release_tag) == 1:
+            logger.error('Failed to upload release to GitHub')
+            return {}
       
     # For other version control systems
     else:

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -21,7 +21,7 @@ import sys
 import urllib.parse
 from packaging.version import Version, InvalidVersion
 from packaging.specifiers import SpecifierSet
-from o3de import manifest, utils, validation, github_utils
+from o3de import manifest, utils, validation
 
 logger = logging.getLogger('o3de.repo_properties')
 logging.basicConfig(format=utils.LOG_FORMAT)
@@ -101,20 +101,20 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
                      'provide a new location to save your archive.')
         return {}
     if not upload_git_release_tag and not download_prefix:
-        logger.error('You need to provide a --upload-github-release-tag if you want to upload to github.\n'
+        logger.error('You need to provide a --upload-git-release-tag if you want to upload to a Git provider like GitHub.\n'
                      'If you want to use other version control systems you must provide --download-prefix argument\n'
                      'A url prefix for a file attached to a Github release might look like this:'
                      '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
         return {}
     if upload_git_release_tag and download_prefix:
-        logger.error('Upload to GitHub will automatically generate a download prefix for you.\n'
-                     'Use the `--download-prefix` CLI only when you want to use other version control system.')
+        logger.error('When a Git release tag is provided, no download prefix should be provided '
+                     'because the download prefix is automatically generated.')
         return {}
     if upload_git_release_tag and not download_prefix:
         repo_uri = urllib.parse.urlparse(repo_uri)
-        git_provider = github_utils.get_github_provider(repo_uri)
+        git_provider = utils.get_git_provider(repo_uri)
         if git_provider:
-        # Parse the URL to extract owner and repository name
+            # Parse the URL to extract owner and repository name
             owner_repo = repo_uri.geturl().split("github.com/")[1].rstrip('.git').split('/')
             owner = owner_repo[0]
             repo = owner_repo[1]
@@ -135,7 +135,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
             json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
         
         # Upload release archive zip to Github
-        if git_provider.upload_release_to_github(repo_uri, zip_path, archive_filename, upload_git_release_tag) == 1:
+        if git_provider.upload_release(repo_uri, zip_path, archive_filename, upload_git_release_tag) == 1:
             logger.error('Failed to upload release to GitHub')
             return {}
       


### PR DESCRIPTION
## What does this PR do?
This PR implements a --upload-github-release-tag CLI to use with the '--release-archive-path' CLI. It allows automatically uploading the release archive zip to Github with the required argument of tag_name. To use this feature, the user needs to provide their Github token with content read and write access. The CLI will detect if the current tag exists; if it does, it will upload the zip to the specified release. Otherwise, it will create a new release with the provided tag name and upload the zip to that release.

Additionally, this PR updates the current '--release-archive-path' CLI to still allow users to choose to provide '--download-prefix' if they are not using Github as their version control system.

## How was this PR tested?
Tested that the associated gem is created successfully on Github release and that the project manager is able to download the associated gem by calling this command:
`./o3de.bat edit-repo-properties -rp "C:\o3de_Projects\RemoteUp" --add-gem "C:\o3de_Projects\RemoteUp\Gems\dpGem" --release-archive-path "C:\o3de_Projects\RemoteUp\Gems" --upload-github-release-tag v1.0.0`

Ensured that the '--download-prefix' still works to create a release at the expected path and can be downloaded from the project manager by calling this command:
`./o3de.bat edit-repo-properties -rp "C:\o3de_Projects\RemoteUp" -ag "C:\o3de_Projects\RemoteUp\Gems\dpGem" -rap "C:\o3de_Projects\RemoteUp\Gems" -dp "https://github.com/VeryKaylin-player1/RemoteUp/releases/download/v1.0.0"`