### PR TITLE
Fixed race condition in directory calls in ly_test_tools

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/artifact_manager.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/artifact_manager.py
@@ -74,7 +74,7 @@ class ArtifactManager(object):
             try:
                 logger.debug(f'Attempting to create new artifact path: "{self.dest_path}"')
                 if not os.path.exists(self.dest_path):
-                    os.makedirs(self.dest_path)
+                    os.makedirs(self.dest_path, exist_ok=True)
                     logger.info(f'Created new artifact path: "{self.dest_path}"')
                     return self.dest_path
             except (IOError, OSError, WindowsError) as err:

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/workspace.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/workspace.py
@@ -83,11 +83,11 @@ class AbstractWorkspaceManager:
                 ly_test_tools.environment.file_system.delete([self.tmp_path], True, True)
 
             print("Creating tmp path")
-            os.makedirs(self.tmp_path)
+            os.makedirs(self.tmp_path, exist_ok=True)
 
         if not os.path.exists(self.output_path):
             print(f"Creating logs path at {self.output_path}")
-            os.makedirs(self.output_path)
+            os.makedirs(self.output_path, exist_ok=True)
 
         print(f"Configuring Artifact Manager with path {self.output_path}")
         self.artifact_manager = artifact_manager.ArtifactManager(self.output_path)
@@ -139,7 +139,7 @@ class AbstractWorkspaceManager:
         temp_file_dir = os.path.join(tempfile.gettempdir(), "LyTestTools")
         temp_file_path = os.path.join(temp_file_dir, log_file_name)
         if not os.path.exists(temp_file_dir):
-            os.makedirs(temp_file_dir)
+            os.makedirs(temp_file_dir, exist_ok=True)
 
         if os.path.exists(temp_file_path):
             # assume temp is not being used for long-term storage, and safe to delete

--- a/Tools/LyTestTools/ly_test_tools/environment/file_system.py
+++ b/Tools/LyTestTools/ly_test_tools/environment/file_system.py
@@ -41,7 +41,7 @@ def safe_makedirs(dest_path):
     """ This allows an OSError in the case the directory cannot be created, which is logged but does not propagate."""
     try:
         logger.info(f'Creating directory "{dest_path}"')
-        os.makedirs(dest_path)
+        os.makedirs(dest_path, exist_ok=True)
 
     except OSError as e:
         if e.errno == errno.EEXIST:

--- a/Tools/LyTestTools/ly_test_tools/mobile/android.py
+++ b/Tools/LyTestTools/ly_test_tools/mobile/android.py
@@ -136,7 +136,7 @@ def pull_files_to_pc(package_name, logs_path, device=None):
     """
     directory = os.path.join(logs_path, device)
     if not os.path.exists(directory):
-        os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
     pull_cmd = ['adb']
     if device is not None:

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -719,7 +719,7 @@ class AssetProcessor(object):
         for copy_dir in [self._workspace.project, 'Assets/Engine', 'Registry']:
             make_dir = os.path.join(self._temp_asset_root, copy_dir)
             if not os.path.isdir(make_dir):
-                os.makedirs(make_dir)
+                os.makedirs(make_dir, exist_ok=True)
         for copyfile_name in ['Registry/AssetProcessorPlatformConfig.setreg',
                               os.path.join(self._workspace.project, "project.json"),
                               os.path.join('Assets', 'Engine', 'exclude.filetag')]:
@@ -813,7 +813,7 @@ class AssetProcessor(object):
             scan_folder = os.path.join(self._temp_asset_root if self._temp_asset_root else self._workspace.paths.engine_root(),
                                        folder_name)
             if not os.path.isdir(scan_folder):
-                os.makedirs(scan_folder)
+                os.makedirs(scan_folder, exist_ok=True)
             if folder_name not in self._override_scan_folders:
                 self._override_scan_folders.append(scan_folder)
                 logger.debug(f"Adding scan folder {scan_folder}")
@@ -865,7 +865,7 @@ class AssetProcessor(object):
         test_folder = os.path.join(test_asset_root, function_name if existing_function_name is None
                                    else existing_function_name)
         if not os.path.isdir(test_folder):
-            os.makedirs(test_folder)
+            os.makedirs(test_folder, exist_ok=True)
         if add_scan_folder:
             self.add_scan_folder(test_asset_root)
         self._function_name = function_name
@@ -962,7 +962,7 @@ class AssetProcessor(object):
         dest_root = dest_root or self._temp_asset_root
         make_dir = os.path.dirname(os.path.join(dest_root, relative_asset))
         if not os.path.isdir(make_dir):
-            os.makedirs(make_dir)
+            os.makedirs(make_dir, exist_ok=True)
         shutil.copyfile(os.path.join(source_root, relative_asset),
                         os.path.join(dest_root, relative_asset))
 

--- a/Tools/LyTestTools/ly_test_tools/o3de/pipeline_utils.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/pipeline_utils.py
@@ -197,7 +197,7 @@ def create_asset_processor_backup_directories(backup_root_directory: str, test_b
     :return: None
     """
     if not os.path.exists(os.path.join(backup_root_directory, test_backup_directory)):
-        os.makedirs(os.path.join(backup_root_directory, test_backup_directory))
+        os.makedirs(os.path.join(backup_root_directory, test_backup_directory), exist_ok=True)
 
 
 def backup_asset_processor_logs(bin_directory: str, backup_directory: str) -> None:

--- a/Tools/LyTestTools/tests/unit/test_workspace.py
+++ b/Tools/LyTestTools/tests/unit/test_workspace.py
@@ -86,7 +86,7 @@ class TestSetup(unittest.TestCase):
 
         self.mock_workspace.setup()
 
-        mock_makedirs.assert_called_once_with(self.mock_workspace.tmp_path)
+        mock_makedirs.assert_called_once_with(self.mock_workspace.tmp_path, exist_ok=True)
 
     @mock.patch('os.makedirs')
     @mock.patch('os.path.exists')
@@ -117,7 +117,7 @@ class TestSetup(unittest.TestCase):
         self.mock_workspace.output_path = 'mock_output_path'
 
         self.mock_workspace.setup()
-        mock_makedirs.assert_called_with(self.mock_workspace.output_path)
+        mock_makedirs.assert_called_with(self.mock_workspace.output_path, exist_ok=True)
         assert mock_makedirs.call_count == 2  # ArtifactManager.__init__() calls os.path.exists()
 
 


### PR DESCRIPTION
Between the logic of checking whether a directory exist and making a call to create that directory in the ly_test_tools python script, a parallel execution of another test could create that directory

This would cause the directory creation in the current test to raise a python exception causing the test to fail.

## How was this PR tested?

Ran the `AutomatedTesting::EditorTestTesting` CTest Test successively which was exhibiting the race condition

```
[2023-07-18T13:52:49.321Z] ============================== warnings summary ===============================

[2023-07-18T13:52:49.321Z] test_parallel_1_pass_1_fail_1_crash.py::TestAutomation::run_parallel_tests[windows-AutomatedTesting-windows_editor]

[2023-07-18T13:52:49.321Z]   D:\workspace\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib\site-packages\_pytest\threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-16 (run)

[2023-07-18T13:52:49.321Z]   

[2023-07-18T13:52:49.321Z]   Traceback (most recent call last):

[2023-07-18T13:52:49.321Z]     File "d:\workspace\o3de\tools\lytesttools\ly_test_tools\_internal\managers\artifact_manager.py", line 77, in set_dest_path

[2023-07-18T13:52:49.321Z]       os.makedirs(self.dest_path)

[2023-07-18T13:52:49.321Z]     File "D:\workspace\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib\os.py", line 225, in makedirs

[2023-07-18T13:52:49.321Z]       mkdir(name, mode)

[2023-07-18T13:52:49.321Z]   FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'D:\\workspace\\o3de\\build\\windows\\Testing\\LyTestTools\\AutomatedTesting_EditorTestTesting\\test_parallel_1_pass_1_fail_1_crash_TestAutomation_run_paral_1\\run_parallel_tests\\run_parallel_tests\\run_parallel_tests'

[2023-07-18T13:52:49.321Z]   

[2023-07-18T13:52:49.321Z]   The above exception was the direct cause of the following exception:

[2023-07-18T13:52:49.321Z]   

[2023-07-18T13:52:49.321Z]   Traceback (most recent call last):

[2023-07-18T13:52:49.321Z]     File "D:\workspace\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib\threading.py", line 1016, in _bootstrap_inner

[2023-07-18T13:52:49.321Z]       self.run()

[2023-07-18T13:52:49.321Z]     File "D:\workspace\o3de\python\runtime\python-3.10.5-rev1-windows\python\lib\threading.py", line 953, in run

[2023-07-18T13:52:49.322Z]       self._target(*self._args, **self._kwargs)

[2023-07-18T13:52:49.322Z]     File "d:\workspace\o3de\tools\lytesttools\ly_test_tools\o3de\multi_test_framework.py", line 1022, in run

[2023-07-18T13:52:49.322Z]       raise e

[2023-07-18T13:52:49.322Z]     File "d:\workspace\o3de\tools\lytesttools\ly_test_tools\o3de\multi_test_framework.py", line 1016, in run

[2023-07-18T13:52:49.322Z]       results = self._exec_single_test(

[2023-07-18T13:52:49.322Z]     File "d:\workspace\o3de\tools\lytesttools\ly_test_tools\o3de\multi_test_framework.py", line 901, in _exec_single_test

[2023-07-18T13:52:49.322Z]       workspace.artifact_manager.set_dest_path(request.node.originalname)

[2023-07-18T13:52:49.322Z]     File "d:\workspace\o3de\tools\lytesttools\ly_test_tools\_internal\managers\artifact_manager.py", line 82, in set_dest_path

[2023-07-18T13:52:49.322Z]       six.raise_from(problem, err)

[2023-07-18T13:52:49.322Z]     File "<string>", line 3, in raise_from

[2023-07-18T13:52:49.322Z]   OSError: Failed to create new artifact path: "D:\workspace\o3de\build\windows\Testing\LyTestTools\AutomatedTesting_EditorTestTesting\test_parallel_1_pass_1_fail_1_crash_TestAutomation_run_paral_1\run_parallel_tests\run_parallel_tests\run_parallel_tests"

[2023-07-18T13:52:49.322Z]   

[2023-07-18T13:52:49.322Z]     warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

[2023-07-18T13:52:49.322Z] 

[2023-07-18T13:52:49.322Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

[2023-07-18T13:52:49.322Z] - generated xml file: D:\workspace\o3de\build\windows\Testing\Pytest\AutomatedTesting_EditorTestTesting.xml -
```
