### PR TITLE
updating cmake asset file lists

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -6,6 +6,35 @@
 # 
 
 set(FILES
+    Materials/Pipelines/Common/DepthPass.azsli
+    Materials/Pipelines/Common/DepthPass_CustomZ.azsli
+    Materials/Pipelines/Common/DoubleSided.lua
+    Materials/Pipelines/Common/MeshMotionVector.azsli
+    Materials/Pipelines/Common/ShaderEnable.lua
+    Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
+    Materials/Pipelines/LowEndPipeline/ForwardPass_BaseLighting.azsli
+    Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting.azsli
+    Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting_CustomZ.azsli
+    Materials/Pipelines/LowEndPipeline/LowEndForwardPassVertexAndPixel.azsli
+    Materials/Pipelines/LowEndPipeline/LowEndPipelineScript.lua
+    Materials/Pipelines/LowEndPipeline/Transparent_StandardLighting.azsli
+    Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_BaseLighting.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting_CustomZ.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_SkinLighting.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting.azsli
+    Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting_CustomZ.azsli
+    Materials/Pipelines/MainPipeline/MainPipelineScript.lua
+    Materials/Pipelines/MainPipeline/Transparent_EnhancedLighting.azsli
+    Materials/Pipelines/MainPipeline/Transparent_StandardLighting.azsli
+    Materials/Pipelines/MultiView/ForwardPass_BaseLighting.azsli
+    Materials/Pipelines/MultiView/ForwardPass_StandardLighting.azsli
+    Materials/Pipelines/MultiView/ForwardPass_StandardLighting_CustomZ.azsli
+    Materials/Pipelines/MultiView/MultiViewForwardPassVertexAndPixel.azsli
+    Materials/Pipelines/MultiView/MultiViewPipelineScript.lua
+    Materials/Pipelines/MultiView/Transparent_StandardLighting.azsli
+    Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
     Materials/ReflectionProbe/ReflectionProbeVisualization.materialtype
     Materials/Special/DebugVertexStreams.azsl
     Materials/Special/DebugVertexStreams.materialtype
@@ -14,18 +43,24 @@ set(FILES
     Materials/Special/ShadowCatcher.azsl
     Materials/Special/ShadowCatcher.materialtype
     Materials/Special/ShadowCatcher.shader
+    Materials/Types/BasePBR.azsli
     Materials/Types/BasePBR.materialtype
+    Materials/Types/EnhancedPBR.azsli
     Materials/Types/EnhancedPBR.materialtype
     Materials/Types/EnhancedPBR_Anisotropy.lua
     Materials/Types/EnhancedPBR_SubsurfaceState.lua
+    Materials/Types/Eye.azsli
     Materials/Types/Eye.materialtype
+    Materials/Types/Skin.azsli
     Materials/Types/Skin.materialtype
     Materials/Types/Skin_SpecularF0.lua
     Materials/Types/Skin_WrinkleMaps.lua
+    Materials/Types/StandardMultilayerPBR.azsli
     Materials/Types/StandardMultilayerPBR.materialtype
     Materials/Types/StandardMultilayerPBR_ClearCoatEnableFeature.lua
     Materials/Types/StandardMultilayerPBR_Displacement.lua
     Materials/Types/StandardMultilayerPBR_LayerEnable.lua
+    Materials/Types/StandardPBR.azsli
     Materials/Types/StandardPBR.materialtype
     Materials/Types/StandardPBR_ClearCoatEnableFeature.lua
     Materials/Types/StandardPBR_ClearCoatState.lua
@@ -45,6 +80,7 @@ set(FILES
     Passes/BRDFTexture.pass
     Passes/BRDFTexturePipeline.pass
     Passes/CameraMotionVector.pass
+    Passes/CameraPipeline.pass
     Passes/CascadedShadowmaps.pass
     Passes/CheckerboardResolveColor.pass
     Passes/CheckerboardResolveDepth.pass
@@ -145,7 +181,12 @@ set(FILES
     Passes/ReflectionScreenSpaceBlurMobile.pass
     Passes/ReflectionScreenSpaceBlurVertical.pass
     Passes/ReflectionScreenSpaceComposite.pass
+    Passes/ReflectionScreenSpaceCopyHistory.pass
+    Passes/ReflectionScreenSpaceDownsampleDepthLinear.pass
+    Passes/ReflectionScreenSpaceDownsampleDepthLinearChild.pass
+    Passes/ReflectionScreenSpaceFilter.pass
     Passes/ReflectionScreenSpaceMobile.pass
+    Passes/ReflectionScreenSpaceRayTracing.pass
     Passes/ReflectionScreenSpaceTrace.pass
     Passes/ShadowParent.pass
     Passes/Skinning.pass
@@ -169,6 +210,7 @@ set(FILES
     Passes/SsaoParent.pass
     Passes/SubsurfaceScattering.pass
     Passes/Taa.pass
+    Passes/TaaParent.pass
     Passes/ToolsPipeline.pass
     Passes/ToolsPipelineRenderToTexture.pass
     Passes/Transparent.pass
@@ -180,14 +222,17 @@ set(FILES
     ShaderLib/3rdParty/Features/PostProcessing/KelvinToRgb.azsli
     ShaderLib/3rdParty/Features/PostProcessing/PSstyleColorBlends_NonSeparable.azsli
     ShaderLib/3rdParty/Features/PostProcessing/PSstyleColorBlends_Separable.azsli
+    ShaderLib/Atom/Features/Bindless.azsli
     ShaderLib/Atom/Features/BlendUtility.azsli
     ShaderLib/Atom/Features/Debug.azsli
     ShaderLib/Atom/Features/IndirectRendering.azsli
+    ShaderLib/Atom/Features/InstancedTransforms.azsli
     ShaderLib/Atom/Features/MatrixUtility.azsli
     ShaderLib/Atom/Features/ParallaxMapping.azsli
     ShaderLib/Atom/Features/ShaderQualityOptions.azsli
     ShaderLib/Atom/Features/SphericalHarmonicsUtility.azsli
     ShaderLib/Atom/Features/SrgSemantics.azsli
+    ShaderLib/Atom/Features/VertexUtility.azsli
     ShaderLib/Atom/Features/ColorManagement/TransformColor.azsli
     ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/AcesCcToAcesCg.azsli
     ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/AcesCgToAcesCc.azsli
@@ -223,12 +268,14 @@ set(FILES
     ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
     ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
     ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
+    ShaderLib/Atom/Features/PBR/Lights/IblForward.azsli
     ShaderLib/Atom/Features/PBR/Lights/Lights.azsli
     ShaderLib/Atom/Features/PBR/Lights/LightTypesCommon.azsli
     ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
     ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
     ShaderLib/Atom/Features/PBR/Lights/PolygonLight.azsli
     ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
+    ShaderLib/Atom/Features/PBR/Lights/ReflectionProbeData.azsli
     ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
     ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
     ShaderLib/Atom/Features/PBR/Microfacet/Brdf.azsli
@@ -239,6 +286,8 @@ set(FILES
     ShaderLib/Atom/Features/PBR/Surfaces/DualSpecularSurface.azsli
     ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
     ShaderLib/Atom/Features/PBR/Surfaces/TransmissionSurfaceData.azsli
+    ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli
+    ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
     ShaderLib/Atom/Features/PostProcessing/Aces.azsli
     ShaderLib/Atom/Features/PostProcessing/AcesColorSpaceConversion.azsli
     ShaderLib/Atom/Features/PostProcessing/FullscreenPixelInfo.azsli
@@ -250,6 +299,7 @@ set(FILES
     ShaderLib/Atom/Features/PostProcessing/HDRColorGradingCommon.azsl
     ShaderLib/Atom/Features/PostProcessing/PostProcessUtil.azsli
     ShaderLib/Atom/Features/PostProcessing/Shapers.azsli
+    ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
     ShaderLib/Atom/Features/RayTracing/RayTracingMaterialSrg.azsli
     ShaderLib/Atom/Features/RayTracing/RayTracingMaterialUtils.azsli
     ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -307,6 +357,8 @@ set(FILES
     Shaders/LightCulling/LightCullingRemap.shader
     Shaders/LightCulling/LightCullingTilePrepare.azsl
     Shaders/LightCulling/LightCullingTilePrepare.shader
+    Shaders/Materials/DepthPass_VertexData.azsli
+    Shaders/Materials/DepthPass_VertexEval.azsli
     Shaders/Materials/BasePBR/BasePBR_LightingBrdf.azsli
     Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
     Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli
@@ -352,6 +404,8 @@ set(FILES
     Shaders/Materials/MaterialInputs/TransmissionInput.azsli
     Shaders/Materials/MaterialInputs/UvSetCount.azsli
     Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Common.azsli
+    Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_DepthPass_WithPS.azsl
+    Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Shadowmap_WithPS.azsl
     Shaders/Materials/Skin/Skin_LightingBrdf.azsli
     Shaders/Materials/Skin/Skin_MaterialSrg.azsli
     Shaders/Materials/Skin/Skin_PixelGeometryData.azsli
@@ -503,11 +557,24 @@ set(FILES
     Shaders/Reflections/ReflectionScreenSpaceBlurVertical.shader
     Shaders/Reflections/ReflectionScreenSpaceComposite.azsl
     Shaders/Reflections/ReflectionScreenSpaceComposite.shader
+    Shaders/Reflections/ReflectionScreenSpaceDownsampleDepthLinear.azsl
+    Shaders/Reflections/ReflectionScreenSpaceDownsampleDepthLinear.shader
+    Shaders/Reflections/ReflectionScreenSpaceFilter.azsl
+    Shaders/Reflections/ReflectionScreenSpaceFilter.shader
+    Shaders/Reflections/ReflectionScreenSpaceRayTracing.azsl
+    Shaders/Reflections/ReflectionScreenSpaceRayTracing.shader
+    Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHit.azsl
+    Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHit.shader
+    Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
+    Shaders/Reflections/ReflectionScreenSpaceRayTracingMiss.azsl
+    Shaders/Reflections/ReflectionScreenSpaceRayTracingMiss.shader
     Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
     Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
     Shaders/Reflections/ReflectionScreenSpaceTrace.shader
     Shaders/ScreenSpace/DeferredFog.azsl
     Shaders/ScreenSpace/DeferredFog.shader
+    Shaders/Shadow/ClearShadow.shader
+    Shaders/Shadow/ClearShadowmap.azsl
     Shaders/Shadow/DepthExponentiation.azsl
     Shaders/Shadow/DepthExponentiation.shader
     Shaders/Shadow/FullscreenShadow.azsl
@@ -528,8 +595,10 @@ set(FILES
     Shaders/SkyAtmosphere/SkyViewLUT.shader
     Shaders/SkyAtmosphere/SkyVolumeLUT.azsl
     Shaders/SkyAtmosphere/SkyVolumeLUT.shader
+    Shaders/SkyBox/MultiViewSkyBox.shader
     Shaders/SkyBox/SkyBox.azsl
     Shaders/SkyBox/SkyBox.shader
     Shaders/SkyBox/SkyBox_TwoOutputs.shader
-    Shaders/SkyBox/MultiViewSkyBox.shader
+    Shaders/SplashScreen/SplashScreenPass.azsl
+    Shaders/SplashScreen/SplashScreenPass.shader
 ) 

--- a/Gems/Atom/RPI/Assets/atom_rpi_asset_files.cmake
+++ b/Gems/Atom/RPI/Assets/atom_rpi_asset_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     ShaderLib/Atom/RPI/TangentSpace.azsli
     ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
     ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultSceneSrg.azsli
+    ShaderLib/Atom/RPI/ShaderResourceGroups/UnusedFallbackDrawSrg.azsli
     ShaderLib/External/FidelityFX/ffx-spd/ffx_a.h
     ShaderLib/External/FidelityFX/ffx-spd/ffx_spd.h
     Shaders/DecomposeMsImage.azsl


### PR DESCRIPTION
Updated the cmake asset file lists, which adds .pass, .aszl, .shader and other files to the project list show they show up in Visual Studio. Updated them by running atom_rpi_asset_files.cmake and atom_feature_common_asset_files.cmake.