### PR TITLE
fix for components like Fly Camera Input, that are their own reference

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -656,7 +656,7 @@ namespace AZ::Reflection
                 StackEntry& parentData = m_stack.back();
 
                 // search up the stack for the "true parent", which is the last entry created by the serialize enumerate itself
-                void* instanceToInvoke = nullptr;
+                void* instanceToInvoke = instance;
                 for (auto rIter = m_stack.rbegin(), rEnd = m_stack.rend(); rIter != rEnd; ++rIter)
                 {
                     auto* currInstance = rIter->m_instance;


### PR DESCRIPTION
## What does this PR do?
Fixes components that don't have a parent invoke instance, such as Camera Rig and Fly Camera Input
fixes #16441 

## How was this PR tested?
Locally in the Editor app