### PR TITLE
Added feature to prompt user on container clear for DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -72,6 +72,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(Container::RemoveNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ClearNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ContainerCanBeModified);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::PromptOnContainerClear);
 
         system->RegisterPropertyEditor<UIElement>();
         system->RegisterNodeAttribute<UIElement>(UIElement::Handler);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -116,6 +116,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t index)>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
         static constexpr auto ContainerCanBeModified = AttributeDefinition<bool>("ContainerCanBeModified");
+        static constexpr auto PromptOnContainerClear = AttributeDefinition<bool>("PromptOnContainerClear");
     };
 
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -714,6 +714,12 @@ namespace AZ::DocumentPropertyEditor
                             isDisabled = disabledValue->IsBool() && disabledValue->GetBool();
                         }
 
+                        bool shouldPromptOnClear = true;
+                        if (auto promptOnClearValue = attributes.Find(Nodes::Container::PromptOnContainerClear.GetName()); promptOnClearValue)
+                        {
+                            shouldPromptOnClear = promptOnClearValue->IsBool() && promptOnClearValue->GetBool();
+                        }
+
                         m_builder.BeginPropertyEditor<Nodes::ContainerActionButton>();
                         m_builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
                         m_builder.Attribute(Nodes::PropertyEditor::UseMinimumWidth, true);
@@ -732,6 +738,10 @@ namespace AZ::DocumentPropertyEditor
                         if (isDisabled)
                         {
                             m_builder.Attribute(Nodes::PropertyEditor::Disabled, true);
+                        }
+                        if (!shouldPromptOnClear)
+                        {
+                            m_builder.Attribute(Nodes::Container::PromptOnContainerClear, false);
                         }
                         m_builder.AddMessageHandler(m_adapter, Nodes::ContainerActionButton::OnActivate.GetName());
                         m_builder.EndPropertyEditor();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -8,6 +8,8 @@
 
 #include <AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h>
 
+#include <QMessageBox>
+
 namespace AzToolsFramework
 {
     ContainerActionButtonHandler::ContainerActionButtonHandler()
@@ -25,8 +27,8 @@ namespace AzToolsFramework
         using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
         using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
 
-        ContainerAction action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
-        switch (action)
+        m_action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
+        switch (m_action)
         {
         case ContainerAction::AddElement:
             setIcon(s_iconAdd);
@@ -41,5 +43,31 @@ namespace AzToolsFramework
             setToolTip(tr("Remove all elements"));
             break;
         }
+    }
+
+    void ContainerActionButtonHandler::OnClicked()
+    {
+        using AZ::DocumentPropertyEditor::Nodes::Container;
+        using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
+
+        if (m_action == ContainerAction::Clear)
+        {
+            // Default to true if the PromptOnContainerClear attribute isn't present
+            bool shouldPromptOnClear = Container::PromptOnContainerClear.ExtractFromDomNode(m_node).value_or(true);
+
+            if (shouldPromptOnClear)
+            {
+                auto result = QMessageBox::question(
+                    this,
+                    QObject::tr("Clear container?"),
+                    QObject::tr("Are you sure you want to remove all elements from this container?"));
+                if (result == QMessageBox::No)
+                {
+                    return;
+                }
+            }
+        }
+
+        GenericButtonHandler::OnClicked();
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
@@ -23,5 +23,10 @@ namespace AzToolsFramework
         {
             return AZ::DocumentPropertyEditor::Nodes::ContainerActionButton::Name;
         }
+
+    protected:
+        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_action;
+
+        void OnClicked() override;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.cpp
@@ -14,13 +14,7 @@ namespace AzToolsFramework
     {
         setAutoRaise(true);
 
-        connect(
-            this, &QToolButton::clicked, this,
-            [this]()
-            {
-                using AZ::DocumentPropertyEditor::Nodes::GenericButton;
-                GenericButton::OnActivate.InvokeOnDomNode(m_node);
-            });
+        connect(this, &QToolButton::clicked, this, &GenericButtonHandler::OnClicked);
     }
 
     void GenericButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)
@@ -30,5 +24,11 @@ namespace AzToolsFramework
         m_node = node;
         auto buttonText = GenericButton::ButtonText.ExtractFromDomNode(node).value_or("");
         setText(QString::fromUtf8(AZStd::string(buttonText).c_str()));
+    }
+
+    void GenericButtonHandler::OnClicked()
+    {
+        using AZ::DocumentPropertyEditor::Nodes::GenericButton;
+        GenericButton::OnActivate.InvokeOnDomNode(m_node);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
@@ -28,5 +28,7 @@ namespace AzToolsFramework
 
     protected:
         AZ::Dom::Value m_node;
+
+        virtual void OnClicked();
     };
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?

Fixes #16437 

This adds the feature for prompting the user when clearing a container in the DPE. I've added an improvement over the RPE, where previously this prompt was always displayed, but now in the DPE you can op-out of it for your container by setting the `PromptOnContainerClear` on your container element to `false`.

![ClearContainerPrompt](https://github.com/o3de/o3de/assets/7519264/823de8f1-7e76-4eb0-9ddc-0b9ad69da9d0)

## How was this PR tested?

Tested all container buttons to make sure they all work as expected. Verified that the prompt only shows when attempting to clear at the container level, not just deleting a single element.