### PR TITLE
Fix Vulkan validation errors on Android

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Formats.inl
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Formats.inl
@@ -99,10 +99,6 @@
         _Func(ETC2A1_UNORM_SRGB,       VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK,      1,    0,    0) \
         _Func(ETC2A_UNORM,             VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK,     1,    0,    0) \
         _Func(ETC2A_UNORM_SRGB,        VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK,      1,    0,    0) \
-        _Func(PVRTC2_UNORM,            VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG,   1,    0,    0) \
-        _Func(PVRTC2_UNORM_SRGB,       VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG,    1,    0,    0) \
-        _Func(PVRTC4_UNORM,            VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG,   1,    0,    0) \
-        _Func(PVRTC4_UNORM_SRGB,       VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG,    1,    0,    0) \
         _Func(ASTC_4x4_UNORM,          VK_FORMAT_ASTC_4x4_UNORM_BLOCK,          1,    0,    0) \
         _Func(ASTC_4x4_UNORM_SRGB,     VK_FORMAT_ASTC_4x4_SRGB_BLOCK,           1,    0,    0) \
         _Func(ASTC_5x4_UNORM,          VK_FORMAT_ASTC_5x4_UNORM_BLOCK,          1,    0,    0) \

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -100,6 +100,7 @@ namespace AZ
             m_enabledDeviceFeatures.sampleRateShading = deviceFeatures.sampleRateShading;
             m_enabledDeviceFeatures.shaderImageGatherExtended = deviceFeatures.shaderImageGatherExtended;
             m_enabledDeviceFeatures.shaderInt64 = deviceFeatures.shaderInt64;
+            m_enabledDeviceFeatures.shaderInt16 = deviceFeatures.shaderInt16;
             m_enabledDeviceFeatures.sparseBinding = deviceFeatures.sparseBinding;
             m_enabledDeviceFeatures.sparseResidencyImage2D = deviceFeatures.sparseResidencyImage2D;
             m_enabledDeviceFeatures.sparseResidencyImage3D = deviceFeatures.sparseResidencyImage3D;


### PR DESCRIPTION
## What does this PR do?

Remove PVRTC format for Vulkan. PVRTC support is provided by the VK_IMG_format_pvrtc extension, which has been deprecated. Querying information about this format triggers validation errors on Android. We are not currently using PVRTC images on Android, only ASTC for compressed images.
Also enable Int16 support for shaders on Vulkan.

## How was this PR tested?

Run Vulkan on Android