### PR TITLE
Fixed element attributes instance in DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -922,9 +922,18 @@ namespace AZ::Reflection
 
                 auto checkAttribute = [&](const AttributePair* it, void* instance, bool shouldDescribeChildren)
                 {
+                    bool describesChildren = it->second->m_describesChildren;
                     if (it->second->m_describesChildren != shouldDescribeChildren)
                     {
                         return;
+                    }
+
+                    // The m_describesChildren flag is true if the attribute is an ElementAttribute,
+                    // in which case the instance we want to invoke on is the actual container element
+                    // instance, as opposed to the usual invoke instance.
+                    if (describesChildren)
+                    {
+                        instance = nodeData.m_instance;
                     }
 
                     Name name = propertyEditorSystem->LookupNameFromId(it->first);

--- a/Gems/Vegetation/Code/Source/Descriptor.cpp
+++ b/Gems/Vegetation/Code/Source/Descriptor.cpp
@@ -170,6 +170,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Position Modifier")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_positionOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Position Modifier has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -218,6 +219,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Rotation Modifier")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_rotationOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Rotation Modifier has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -266,6 +268,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Scale Modifier")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_scaleOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Scale Modifier has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -286,6 +289,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Altitude Filter")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_altitudeFilterOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Altitude Filter has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -298,6 +302,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Distance Between Filter (Radius)")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_radiusOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Distance Between Filter has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -316,6 +321,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Surface Slope Alignment")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_surfaceAlignmentOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Surface Slope Alignment Modifier has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -332,6 +338,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Slope Filter")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(0, &Descriptor::m_slopeFilterOverrideEnabled, "Override Enabled", "Enable per-item override settings for this item when the Slope Filter has 'Allow Per-Item Overrides' enabled.")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
@@ -348,6 +355,7 @@ namespace Vegetation
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Surface Mask Filter")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                         ->DataElement(AZ::Edit::UIHandlers::ComboBox, &Descriptor::m_surfaceFilterOverrideMode, "Override Mode", "Enable per-item override settings for this item when the Surface Mask Filter has 'Allow Per-Item Overrides' enabled.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &Descriptor::GetAdvancedGroupVisibility)
                             ->EnumAttribute(OverrideMode::Disable, "Disable")


### PR DESCRIPTION
## What does this PR do?

Fixes #16337

Fixed crash when adding a `Vegetation Asset List` component due to the wrong instance pointer being used when evaluating `ElementAttribute`. The `ElementAttribute` are meant to be invoked against the actual element instances in the container, as opposed to normal `Attribute` which are (typically) invoked against the parent instance. The `ElementAttribute` sets the `m_describesChildren` on the attribute so we can check that flag to determine which instance pointer to use.

Another issue found once I fixed the crash was that all the advanced groups in the `Vegetation Asset List` were being shown but empty in the DPE (if the advanced toggle wasn't enabled). This is due to a limitation in the RPE where they don't process all attributes such as Visibility on groups, so you have to hide all of the children individually to hide a group. DPE doesn't support this workaround, and instead supports all intended attributes on groups. So for this PR I've added the Visibility attributes properly on the groups so that groups can be hidden in both the DPE and RPE, and have created a backlog item to go throughout components and fix-up this workaround once the DPE has been enabled by default: https://github.com/o3de/o3de/issues/16462

![AssetListWorking](https://github.com/o3de/o3de/assets/7519264/5a6fd8eb-a42a-41c4-b860-1c11cfb340c0)

## How was this PR tested?

Tested Vegetation Asset List component with both DPE and RPE enabled and verified they work as intended.