### PR TITLE
Fixed debug font size and layout issue with high DPI

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -290,7 +290,7 @@ namespace AtomToolsFramework
         AzFramework::WindowNotificationBus::Event(
             windowId, &AzFramework::WindowNotifications::OnWindowResized, windowSize.width(), windowSize.height());
         AzFramework::WindowNotificationBus::Event(
-            windowId, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, uiWindowSize.width(), uiWindowSize.height());
+            windowId, &AzFramework::WindowNotificationBus::Events::OnResolutionChanged, windowSize.width(), windowSize.height());
     }
 
     void RenderViewportWidget::SendWindowCloseEvent()
@@ -462,7 +462,7 @@ namespace AtomToolsFramework
 
     AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
     {
-        return AzFramework::WindowSize{aznumeric_cast<uint32_t>(width()), aznumeric_cast<uint32_t>(height())};
+        return GetClientAreaSize();
     }
 
     void RenderViewportWidget::SetRenderResolution([[maybe_unused]]AzFramework::WindowSize resolution)

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1638,7 +1638,9 @@ AZ::FFont::DrawParameters AZ::FFont::ExtractDrawParameters(const AzFramework::Te
     internalParams.m_ctx.EnableFrame(false);
     internalParams.m_ctx.SetProportional(!params.m_monospace && params.m_scaleWithWindow);
     internalParams.m_ctx.SetSizeIn800x600(params.m_scaleWithWindow && params.m_virtual800x600ScreenSize);
-    internalParams.m_ctx.SetSize(AZVec2ToLYVec2(AZ::Vector2(params.m_textSizeFactor, params.m_textSizeFactor) * params.m_scale));
+    internalParams.m_ctx.SetSize(AZVec2ToLYVec2(
+        AZ::Vector2(params.m_textSizeFactor, params.m_textSizeFactor) * params.m_scale *
+        internalParams.m_viewportContext->GetDpiScalingFactor()));
     internalParams.m_ctx.SetLineSpacing(params.m_lineSpacing);
 
     if (params.m_hAlign != AzFramework::TextHorizontalAlignment::Left ||
@@ -1680,7 +1682,7 @@ AZ::FFont::DrawParameters AZ::FFont::ExtractDrawParameters(const AzFramework::Te
         {
             posY -= textSize.y;
         }
-        internalParams.m_size = AZ::Vector2{textSize.x, textSize.y} * internalParams.m_viewportContext->GetDpiScalingFactor();
+        internalParams.m_size = AZ::Vector2{textSize.x, textSize.y};
     }
     SetCommonContextFlags(internalParams.m_ctx, params);
     internalParams.m_ctx.m_drawTextFlags |= eDrawText_2D;


### PR DESCRIPTION
## What does this PR do?
Use actual pixel resolution for render resolution.
Apply DPI factor to debug font size and layout
This change fixed debug font size and layout issue when DPI is set to any value other than 100%

## How was this PR tested?
AutomatedTesting project, AutomatedTesting\Levels\Graphics\hermanubis_high level
Open the said level in both editor and game launcher with dpi 100 and dpi 150. Vulkan and DX12

Editor DPI 100% Vulkan
![dpi100_vulkan](https://github.com/o3de/o3de/assets/55564570/c87c930d-c77b-480d-a6bb-83f5fe94f5da)
Editor DPI 150% Vulkan
![dpi150_vulkan](https://github.com/o3de/o3de/assets/55564570/dd7c991b-60f6-4d5f-8861-1efa0cba8175)
Editor DPI 150% DX12
<img width="960" alt="dpi150_DX12" src="https://github.com/o3de/o3de/assets/55564570/f06cf77e-e6c1-4ad8-956c-b222572dea79">
GameLauncher DPI 150% DX12
<img width="955" alt="gamelauncher_dpi150_DX12" src="https://github.com/o3de/o3de/assets/55564570/0cf3780a-f070-40a8-8772-481b7bd79409">

