### PR TITLE
Added Volume(3D) Texture support to StreamingImage.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageObject.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageObject.h
@@ -41,12 +41,15 @@ namespace ImageProcessingAtom
         eAlphaContent_Greyscale           // alpha contains grey tones
     };
 
-    //interface for image object. The image object may have mipmaps.
+    // Interface for image object. The image object may have mipmaps.
+    // The image may be a Volume Texture (3D Image), the 3rd dimension is named Depth.
+    // For 2D Images, Depth == 1.
     class IImageObject
     {
     public:
         //static functions
         static IImageObject* CreateImage(AZ::u32 width, AZ::u32 height, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
+        static IImageObject* CreateImage(AZ::u32 width, AZ::u32 height, AZ::u32 depth, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
 
         virtual ~IImageObject() {};
     public:
@@ -62,6 +65,7 @@ namespace ImageProcessingAtom
         virtual AZ::u32 GetPixelCount(AZ::u32 mip) const = 0;
         virtual AZ::u32 GetWidth(AZ::u32 mip) const = 0;
         virtual AZ::u32 GetHeight(AZ::u32 mip) const = 0;
+        virtual AZ::u32 GetDepth(AZ::u32 /*mip*/) const { return 1; }
         virtual AZ::u32 GetMipCount() const = 0;
 
         //get pixel data buffer

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
@@ -46,7 +46,7 @@ namespace ImageProcessingAtom
 
             uint32_t width = header.dwWidth;
             uint32_t height = header.dwHeight;
-            uint32_t depth = header.dwDepth;
+            uint32_t depth = AZStd::max(header.dwDepth, 1u);
             uint32_t mips = 1;
             if (header.dwFlags & DDS_HEADER_FLAGS_MIPMAP)
             {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
@@ -46,6 +46,7 @@ namespace ImageProcessingAtom
 
             uint32_t width = header.dwWidth;
             uint32_t height = header.dwHeight;
+            uint32_t depth = header.dwDepth;
             uint32_t mips = 1;
             if (header.dwFlags & DDS_HEADER_FLAGS_MIPMAP)
             {
@@ -60,6 +61,12 @@ namespace ImageProcessingAtom
                 }
                 imageFlags |= EIF_Cubemap;
                 height *= 6;
+            }
+            else if (depth > 1)
+            {
+                AZ_Warning("Image Processing", header.dwCaps_2 & DDS_FLAGS_VOLUME,
+                    "Got a 3D image wih depth=%u, but it doesn't claim to be a volume texture. We'll treat it as volume texture.", depth);
+                imageFlags |= EIF_Volumetexture;
             }
 
             // Get pixel format
@@ -206,7 +213,7 @@ namespace ImageProcessingAtom
                 height = pFormatInfo->blockHeight;
             }
 
-            IImageObject* newImage = IImageObject::CreateImage(width, height, mips, format);
+            IImageObject* newImage = IImageObject::CreateImage(width, height, depth, mips, format);
 
             //set properties
             newImage->SetImageFlags(imageFlags);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -166,6 +166,17 @@ namespace ImageProcessingAtom
             // set start time
             m_startTime = AZStd::GetTimeUTCMilliSecond();
 
+            // Volume Textures are special. They are saved in the asset catalog
+            // as-is. They are expected to have the mipmaps precalculated and we don't do any kind
+            // of processing on them.
+            if (m_input->m_inputImage->HasImageFlags(EIF_Volumetexture))
+            {
+                m_image = new ImageToProcess(m_input->m_inputImage);
+                // And go straight into the final step next time UpdateProcess() is called.
+                m_progressStep = StepSaveToFile - 1;
+                break;
+            }
+
             // identify the alpha content of input image if gloss from normal wasn't set
             m_alphaContent = m_input->m_inputImage->GetAlphaContent();
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageObjectImpl.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageObjectImpl.h
@@ -15,7 +15,7 @@
 namespace ImageProcessingAtom
 {
     // ImageObject allows the abstraction of different kinds of
-    // images generated during conversion
+    // images generated during conversion. Supports 3D Image.
     class CImageObject
         : public IImageObject
     {
@@ -25,6 +25,8 @@ namespace ImageProcessingAtom
     public:
         // Constructors
         CImageObject(AZ::u32 width, AZ::u32 height, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
+        CImageObject(AZ::u32 width, AZ::u32 height, AZ::u32 depth, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
+
         ~CImageObject();
 
         //virtual functions from IImageObject
@@ -35,6 +37,7 @@ namespace ImageProcessingAtom
         AZ::u32 GetPixelCount(AZ::u32 mip) const override;
         AZ::u32 GetWidth(AZ::u32 mip) const override;
         AZ::u32 GetHeight(AZ::u32 mip) const override;
+        AZ::u32 GetDepth(AZ::u32 mip) const override;
         AZ::u32 GetMipCount() const override;
 
         void GetImagePointer(AZ::u32 mip, AZ::u8*& pMem, AZ::u32& pitch) const override;
@@ -103,6 +106,8 @@ namespace ImageProcessingAtom
 
             AZ::u32 m_width;
             AZ::u32 m_height;
+            AZ::u32 m_depth;
+            // m_rowCount is the number of rows for each depth slice.
             AZ::u32 m_rowCount;  // for compressed textures m_rowCount is usually less than m_height
             AZ::u32 m_pitch;     // row size in bytes
             AZ::u8* m_pData;
@@ -111,6 +116,7 @@ namespace ImageProcessingAtom
             MipLevel()
                 : m_width(0)
                 , m_height(0)
+                , m_depth(1)
                 , m_rowCount(0)
                 , m_pitch(0)
                 , m_pData(0)
@@ -126,21 +132,21 @@ namespace ImageProcessingAtom
             void Alloc()
             {
                 AZ_Assert(m_pData == 0, "Mip data must be empty before Allocation!");
-                m_pData = new AZ::u8[m_pitch * m_rowCount];
+                m_pData = new AZ::u8[GetSize()];
             }
 
             AZ::u32 GetSize() const
             {
                 AZ_Assert(m_pitch, "Pitch must be greater than zero!");
-                return m_pitch * m_rowCount;
+                return m_pitch * m_rowCount * m_depth;
             }
 
             bool operator==(const MipLevel& other)
             {
-                if (m_width == other.m_width && m_height == other.m_height
+                if (m_width == other.m_width && m_height == other.m_height && m_depth == other.m_depth
                     && m_rowCount == other.m_rowCount && m_pitch == other.m_pitch)
                 {
-                    return (memcmp(m_pData, other.m_pData, m_pitch * m_rowCount) == 0);
+                    return (memcmp(m_pData, other.m_pData, GetSize()) == 0);
                 }
                 return false;
             }
@@ -158,11 +164,14 @@ namespace ImageProcessingAtom
         AZ::u32       m_numPersistentMips;           // number of mipmaps won't be splitted
 
     public:
-        //reset this image object to specified format and size
+        // Reset this image object to specified format and size. Calling this function on a pre-existing
+        // 3D Image, will result in a new 2D image.
         void ResetImage(AZ::u32 width, AZ::u32 height, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
+        void ResetImage(AZ::u32 width, AZ::u32 height, AZ::u32 depth, AZ::u32 maxMipCount, EPixelFormat pixelFormat);
 
         //get mip count and the origin (top mip) size
         void GetExtent(AZ::u32& width, AZ::u32& height, AZ::u32& mipCount) const;
+        void GetExtent(AZ::u32& width, AZ::u32& height, AZ::u32& depth, AZ::u32& mipCount) const;
 
         AZ::u32 GetMipDataSize(AZ::u32 mip) const;
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.cpp
@@ -246,7 +246,7 @@ namespace ImageProcessingAtom
         return !m_pixelFormatInfo[format].bHasAlpha;
     }
 
-    uint32 CPixelFormats::ComputeMaxMipCount(EPixelFormat format, uint32 width, uint32 height)
+    uint32 CPixelFormats::ComputeMaxMipCount(EPixelFormat format, uint32 width, uint32 height, uint32_t depth)
     {
         const PixelFormatInfo* const pFormatInfo = GetPixelFormatInfo(format);
 
@@ -254,6 +254,7 @@ namespace ImageProcessingAtom
 
         uint32 tmpWidth = width;
         uint32 tmpHeight = height;
+        uint32 tmpDepth = depth;
 
         bool bIgnoreBlockSize = CanImageSizeIgnoreBlockSize(format);
 
@@ -271,11 +272,18 @@ namespace ImageProcessingAtom
             tmpHeight >>= 1;
         }
 
+        uint32 mipCountD = 0;
+        while ((tmpDepth >= 1))
+        {
+            ++mipCountD;
+            tmpDepth >>= 1;
+        }
+
         //for compressed image, use minmum mip out of W and H because any size below won't be compressed properly
         //for non-compressed image. use maximum mip count. for example the lowest two mips of 128x64 would be 2x1 and 1x1
         const uint32 mipCount = (pFormatInfo->bCompressed)
             ? AZStd::min<uint32>(mipCountW, mipCountH)
-            : AZStd::max<uint32>(mipCountW, mipCountH);
+            : AZStd::max(AZStd::max<uint32>(mipCountW, mipCountH), mipCountD);
 
         // In some cases, user may call this function for image size which is qualified for this pixel format,
         // the mipCount could be 0 for those cases. Round it to 1 if it happend.

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.h
@@ -176,7 +176,7 @@ namespace ImageProcessingAtom
         EPixelFormat FindPixelFormatByName(const char* name);
 
         //returns maximum lod levels for image which has certain pixel format, width and height.
-        uint32 ComputeMaxMipCount(EPixelFormat format, uint32 imageWidth, uint32 imageHeight);
+        uint32 ComputeMaxMipCount(EPixelFormat format, uint32 imageWidth, uint32 imageHeight, uint32_t imageDepth = 1);
 
         //check if the input image size work with the pixel format. Some compression formats have requirements with the input image size.
         bool IsImageSizeValid(EPixelFormat format, uint32 imageWidth, uint32 imageHeight, bool logWarning);


### PR DESCRIPTION
## What does this PR do?

In addition to Width(x) and Height(y), the IImageObject interface now has awareness of Depth(z). This means the interface now supports Volume Textures, including mip levels. Consequently, relevant updates were made to CImageObject.

In terms of Asset Processing, only the `DdsLoader` was added the capability of loading Volume Textures.

Unlike Image2D, Volume Textures do not support
automatic generation of Mip Levels during asset processing. The Volume Texture is assumed to contain all the mips and the output streaming mip chain assets will contain the pixels for all Mip Levels.

The runtime can now load a StreaminImage from a dds.streamingimage asset that contains 3D Texture data.

## How was this PR tested?

First, it was validated that the existing 2D Image functionality is not broken. All ASV samples work as expected.
Regarding loading StreamingImage resoruces from a Volume Texture, it was validated with my Volumetric Cloudscape Gem.
