### PR TITLE
NumericEditor attribute fix for better Min/Max support in the DPE Inspector

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -36,13 +36,13 @@ namespace AZ::DocumentPropertyEditor
         return {};
     }
 
-    AZStd::shared_ptr<AZ::Attribute> TypeIdAttributeDefinition::DomValueToLegacyAttribute(const AZ::Dom::Value& value) const
+    AZStd::shared_ptr<AZ::Attribute> TypeIdAttributeDefinition::DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool) const
     {
         AZ::Uuid uuidValue = DomToValue(value).value_or(AZ::Uuid::CreateNull());
         return AZStd::make_shared<AZ::AttributeData<AZ::Uuid>>(AZStd::move(uuidValue));
     }
 
-    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
+    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const
     {
         AZ::AttributeReader reader(instance, attribute);
         AZ::Uuid value;
@@ -67,7 +67,7 @@ namespace AZ::DocumentPropertyEditor
         return {};
     }
 
-    AZStd::shared_ptr<AZ::Attribute> NamedCrcAttributeDefinition::DomValueToLegacyAttribute(const AZ::Dom::Value& value) const
+    AZStd::shared_ptr<AZ::Attribute> NamedCrcAttributeDefinition::DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool) const
     {
         AZ::Crc32 crc = 0;
         if (value.IsString())
@@ -78,7 +78,7 @@ namespace AZ::DocumentPropertyEditor
         return AZStd::make_shared<AZ::AttributeData<AZ::Crc32>>(crc);
     }
 
-    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
+    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const
     {
         AZ::Name result;
         AZ::AttributeReader reader(instance, attribute);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -42,7 +42,7 @@ namespace AZ::DocumentPropertyEditor
         return AZStd::make_shared<AZ::AttributeData<AZ::Uuid>>(AZStd::move(uuidValue));
     }
 
-    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const
+    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
     {
         AZ::AttributeReader reader(instance, attribute);
         AZ::Uuid value;
@@ -78,7 +78,7 @@ namespace AZ::DocumentPropertyEditor
         return AZStd::make_shared<AZ::AttributeData<AZ::Crc32>>(crc);
     }
 
-    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const
+    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
     {
         AZ::Name result;
         AZ::AttributeReader reader(instance, attribute);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -120,7 +120,7 @@ namespace AZ::DocumentPropertyEditor
 
         /*! Converts this attribute from an AZ::Attribute to a Dom::Value usable in the DocumentPropertyEditor.
             @param fallback if false, a Read<AttributeType> failure will return a null Value; if true, it will attempt a fallback on failure */
-        virtual AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool fallback = true) const = 0;
+        virtual AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const = 0;
     };
 
     //! Defines an attribute applicable to a Node.
@@ -197,7 +197,7 @@ namespace AZ::DocumentPropertyEditor
             }
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool fallback = true) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -215,7 +215,7 @@ namespace AZ::DocumentPropertyEditor
                 if (!reader.Read<AttributeType>(value))
                 {
                     // Handle the attribute providing an invokable function instead of the value directly
-                    if (fallback && attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
+                    if (attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
                     {
                         return attribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
                     }
@@ -244,7 +244,7 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value ValueToDom(const AZ::TypeId& attribute) const override;
         AZStd::optional<AZ::TypeId> DomToValue(const Dom::Value& value) const override;
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool fallback = true) const override;
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool fallback = true) const override;
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
     };
 
     //! Represents an attribute that should be stored as an AZ::Name, but legacy attribute instances (AZ::Attribute*)
@@ -260,7 +260,7 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value ValueToDom(const AZ::Name& attribute) const override;
         AZStd::optional<AZ::Name> DomToValue(const Dom::Value& value) const override;
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool fallback = true) const override;
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool fallback = true) const override;
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
     };
 
     template<typename GenericValueType>
@@ -285,7 +285,7 @@ namespace AZ::DocumentPropertyEditor
             return result;
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -360,7 +360,7 @@ namespace AZ::DocumentPropertyEditor
             return result;
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -645,7 +645,7 @@ namespace AZ::DocumentPropertyEditor
             return AZStd::make_shared<AZ::AttributeInvocable<CallbackSignature>>(function.value());
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute, bool) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
         {
             return attribute->GetAsDomValue(instance);
         }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -174,6 +174,11 @@ namespace AZ::DocumentPropertyEditor::Nodes
     };
 
     template<typename T = Dom::Value>
+    struct NumericEditor;
+
+    AZ_TYPE_INFO_TEMPLATE_WITH_NAME(NumericEditor, "NumericEditor", "{C891BF19-B60C-45E2-BFD0-027D15DDC939}", AZ_TYPE_INFO_CLASS);
+
+    template<typename T>
     struct NumericEditor : PropertyEditorDefinition
     {
         static_assert(
@@ -182,9 +187,9 @@ namespace AZ::DocumentPropertyEditor::Nodes
         using StorageType = AZStd::conditional_t<
             AZStd::is_same_v<T, Dom::Value>,
             Dom::Value,
-            AZStd::conditional_t<AZStd::is_floating_point_v<T>, double, AZStd::conditional_t<AZStd::is_signed_v<T>, int64_t, uint64_t>>>;
+            AZStd::conditional_t<AZStd::is_floating_point_v<T>, double, AZStd::conditional_t<AZStd::is_signed_v<T>, AZ::s64, AZ::u64>>>;
 
-        static constexpr AZStd::string_view Name = "NumericEditor";
+        inline static const AZStd::string_view Name = AzTypeInfo<NumericEditor>::Name();
         static constexpr auto Min = AttributeDefinition<StorageType>("Min");
         static constexpr auto Max = AttributeDefinition<StorageType>("Max");
         static constexpr auto Step = AttributeDefinition<StorageType>("Step");

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1006,25 +1006,14 @@ namespace AZ::Reflection
                         // See if any registered attribute definitions can read this attribute
                         Dom::Value attributeValue;
 
-                        bool fallback = false;
                         auto readValue = [&](const DocumentPropertyEditor::AttributeDefinitionInterface& attributeReader)
                         {
                             if (attributeValue.IsNull())
                             {
-                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance, it->second, fallback);
+                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance, it->second);
                             }
                         };
-
-
-                        // try it once without allowing type fallback
                         propertyEditorSystem->EnumerateRegisteredAttributes(name, readValue);
-
-                        if (attributeValue.IsNull())
-                        {
-                            // failed to read without fallback, try with it on
-                            fallback = true;
-                            propertyEditorSystem->EnumerateRegisteredAttributes(name, readValue);
-                        }
 
                         // Fall back on a generic read that handles primitives.
                         if (attributeValue.IsNull())

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -656,7 +656,7 @@ namespace AZ::Reflection
                 StackEntry& parentData = m_stack.back();
 
                 // search up the stack for the "true parent", which is the last entry created by the serialize enumerate itself
-                void* instanceToInvoke = nullptr;
+                void* instanceToInvoke = instance;
                 for (auto rIter = m_stack.rbegin(), rEnd = m_stack.rend(); rIter != rEnd; ++rIter)
                 {
                     auto* currInstance = rIter->m_instance;

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/main.cpp
@@ -202,6 +202,26 @@ namespace DPEDebugView
             return m_toggle ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
         }
 
+        double DoubleMin() const
+        {
+            return -9.0;
+        }
+
+        double DoubleMax() const
+        {
+            return 9.0;
+        }
+
+        int IntMin() const
+        {
+            return -8;
+        }
+
+        int IntMax() const
+        {
+            return 8;
+        }
+
         static void Reflect(AZ::ReflectContext* context)
         {
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -248,11 +268,13 @@ namespace DPEDebugView
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_toggle, "toggle switch", "")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleInt, "simple int", "")
+                        ->Attribute(AZ::Edit::Attributes::Min, &TestContainer::IntMin)
+                        ->Attribute(AZ::Edit::Attributes::Max, &TestContainer::IntMax)
                         ->DataElement(AZ::Edit::UIHandlers::Slider, &TestContainer::m_doubleSlider, "double slider", "")
+                        ->Attribute(AZ::Edit::Attributes::Min, &TestContainer::DoubleMin)
+                        ->Attribute(AZ::Edit::Attributes::Max, &TestContainer::DoubleMax)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_simpleString, "simple string", "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &TestContainer::IsToggleEnabled)
-                        ->Attribute(AZ::Edit::Attributes::Min, -10.0)
-                        ->Attribute(AZ::Edit::Attributes::Max, 10.0)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Containers")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &TestContainer::m_vector, "vector<string>", "")

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -282,7 +282,14 @@ namespace AzToolsFramework
                     {
                         if (marshalledAttribute == nullptr)
                         {
-                            marshalledAttribute = attributeReader.DomValueToLegacyAttribute(attributeIt->second);
+                            // try the conversion once without type fallback
+                            marshalledAttribute = attributeReader.DomValueToLegacyAttribute(attributeIt->second, false);
+
+                            if (marshalledAttribute == nullptr)
+                            {
+                                // still null, try it again allowing type fallback
+                                attributeReader.DomValueToLegacyAttribute(attributeIt->second, true);
+                            }
                         }
                     });
 


### PR DESCRIPTION
## What does this PR do?
- Fixes NumericEditors of different types to use different Names, so that they can coexist in the PropertyEditorSystem and not overwrite each others' entries.
- Makes sure that the correctly typed reader/writer is used (no fallback), so that attributes of the wrong type are not skipped.
- fixes: #16453 #16455  #16476 #16477 #16488 #16489 #16490 #16475 

## How was this PR tested?
locally in both the Editor and DPEStandalone projects
