### PR TITLE
Add callback when RHI system has been initialized

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -77,6 +77,9 @@ namespace AZ::RHI
             
         //! Notify that the input device was removed
         virtual void OnDeviceRemoved(Device* ) {};
+
+        //! Notify that the RHISystem has been initialized
+        virtual void OnRHISystemInitialized() {};
     };
 
     using RHISystemNotificationBus = AZ::EBus<RHISystemNotificiationInterface>;

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -96,6 +96,8 @@ namespace AZ::RHI
 
         frameSchedulerDescriptor.m_platformLimitsDescriptor = platformLimitsDescriptor;
         m_frameScheduler.Init(*m_devices[MultiDevice::DefaultDeviceIndex], frameSchedulerDescriptor);
+
+        RHISystemNotificationBus::Broadcast(&RHISystemNotificationBus::Events::OnRHISystemInitialized);
     }
 
     ResultCode RHISystem::InitInternalDevices(InitDevicesFlags initializationVariant)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -346,23 +346,14 @@ namespace AZ
             physicalDevice.LoadSupportedFeatures(m_context);
 
             RHI::ResultCode resultCode = InitVmaAllocator(physicalDeviceBase);
+            RHI::RHISystemNotificationBus::Handler::BusConnect();
             return resultCode;
         }
 
         RHI::ResultCode Device::InitInternalBindlessSrg(const AZ::RHI::BindlessSrgDescriptor& bindlessSrgDesc)
         {
             RHI::ResultCode result = m_bindlessDescriptorPool.Init(*this, bindlessSrgDesc);
-            RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetPhysicalDevice());
-            if (!physicalDevice.IsFeatureSupported(DeviceFeature::NullDescriptor))
-            {
-                // Need to initialize the NullDescriptorManager AFTER the bindless descriptor pool, since we create images and buffers
-                // during the initialization of the NullDescriptorManager.
-                m_nullDescriptorManager = NullDescriptorManager::Create();
-                result = m_nullDescriptorManager->Init(*this);
-                RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            }
-            return RHI::ResultCode::Success;
+            return result;
         }
 
         RHI::ResultCode Device::InitializeLimits()
@@ -680,6 +671,8 @@ namespace AZ
 
         void Device::ShutdownInternal()
         {
+            RHI::RHISystemNotificationBus::Handler::BusDisconnect();
+
             m_imageMemoryRequirementsCache.Clear();
             m_bufferMemoryRequirementsCache.Clear();
 
@@ -1507,6 +1500,19 @@ namespace AZ
         VmaAllocator& Device::GetVmaAllocator()
         {
             return m_vmaAllocator;
+        }
+
+        void Device::OnRHISystemInitialized()
+        {
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetPhysicalDevice());
+            if (!physicalDevice.IsFeatureSupported(DeviceFeature::NullDescriptor))
+            {
+                // Need to initialize the NullDescriptorManager AFTER the bindless descriptor pool, since we create images and buffers
+                // during the initialization of the NullDescriptorManager.
+                m_nullDescriptorManager = NullDescriptorManager::Create();
+                [[maybe_unused]] RHI::ResultCode result = m_nullDescriptorManager->Init(*this);
+                AZ_Error("Vulkan", result == RHI::ResultCode::Success, "Failed to initialize Null descriptor manager");
+            }
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -10,6 +10,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
 #include <Atom/RHI/ObjectCache.h>
+#include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI/ThreadLocalContext.h>
 #include <Atom/RHI.Reflect/BufferDescriptor.h>
 #include <AzCore/Memory/SystemAllocator.h>
@@ -66,6 +67,7 @@ namespace AZ
 
         class Device final
             : public RHI::Device
+            , public RHI::RHISystemNotificationBus::Handler
         {
             using Base = RHI::Device;
         public:
@@ -143,6 +145,10 @@ namespace AZ
 
             //! Returns the VMA allocator used by this device.
             VmaAllocator& GetVmaAllocator();
+
+        protected:
+            // RHI::RHISystemNotificationBus::Handler overrides...
+            void OnRHISystemInitialized() override;
 
         private:
             Device();


### PR DESCRIPTION
## What does this PR do?

Add a callback when the RHI System has been initialized.
Move the NullDescriptorManager initialization on Vulkan from InitInternalBindlessSrg to the new callback since on some devices the InitInternalBindlessSrg was not called.

## How was this PR tested?

Run Vulkan on PC and Android.