### PR TITLE
Add Copy-To-Repo-Subfolder CLI and Unit Test

### DIFF
--- a/scripts/o3de/o3de/github_utils.py
+++ b/scripts/o3de/o3de/github_utils.py
@@ -16,7 +16,8 @@ import urllib.parse
 from urllib.parse import ParseResult
 import urllib.request
 import subprocess
-
+import requests
+import getpass
 from o3de import gitproviderinterface, utils
 
 LOG_FORMAT = '[%(levelname)s] %(name)s: %(message)s'
@@ -86,6 +87,81 @@ class GitHubProvider(gitproviderinterface.GitProviderInterface):
                 return 1
 
         return proc.returncode
+    
+    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
+        """
+        Uploads a release asset to a GitHub repository. 
+        It enables users to specify the GitHub release tag for the asset.
+        :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+        :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+        :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+        :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        """
+        access_token = getpass.getpass("Provide your github access token (Must have content - read and write permission)\n"
+                                        "Enter your GitHub Token (right click mouse to paste):")
+        if len(access_token) == 0:
+            logger.error('No input received! To paste your token into a terminal use mouse right click.')
+        
+        tag_name = upload_git_release_tag
+        # Get github credentials
+        headers = {
+            'Authorization': f'Token {access_token}',
+            'Accept': 'application/vnd.github.v3+json',
+            "Content-Type": "application/zip"
+        }
+        
+        # Get owner (required)
+        owner = response = requests.get('https://api.github.com/user', headers=headers)
+        if response.status_code == 200:
+            user_data = response.json()
+            owner = user_data['login']
+        else:
+            logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
+
+        # Get repo (required) repo_uri: https://github.com/<owner>/<repo>.git
+        repo_uri = repo_uri.geturl().split("/")
+        repo = repo_uri[-1].split(".git")[0]
+        
+        tag_check_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+        response = requests.get(tag_check_url, headers=headers)
+        
+        release_payload = {
+            'tag_name': tag_name
+        }
+        # Valid release
+        if response.status_code == 200:
+            # Get the release end point to retrive release id
+            get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+            response = requests.get(get_release_by_tag, headers=headers, json=release_payload)
+            release_id = response.json().get('id')
+        
+            if response.status_code == 200:
+                upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+                with open(zip_path, 'rb') as file:
+                    response = requests.post(upload_url, headers=headers, data=file)
+                    if not response.status_code == 201:
+                        logger.error(f'Failed to upload asset to existing release. Status code: {response.status_code}')
+            else:
+                logger.error(f'Failed to retrive release. Status code: {response.status_code}')
+
+        # Release doesn't exist, Create a new release endpoint with the given tag_name and upload assest  
+        elif response.status_code == 404:
+            release_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+            response = requests.post(release_url, headers=headers, json=release_payload)
+
+            if response.status_code == 201:
+                release_id = response.json().get('id')
+                upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+                with open(zip_path, 'rb') as file:
+                    response = requests.post(upload_url, headers=headers, data=file)
+                    if not response.status_code == 201:
+                        logger.error(f'Failed to upload asset. Status code: {response.status_code}')
+            else:
+                logger.error(f'Failed to create release. Status code: {response.status_code}')
+        else:
+            logger.error(f'Error checking tag existence. Status code: {response.status_code}')
 
 def get_github_provider(parsed_uri: ParseResult) -> GitHubProvider or None:
     if 'github.com' in parsed_uri.netloc:

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -39,10 +39,12 @@ class GitProviderInterface(ABC):
     def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
         """
         Uploads a release asset to a GitHub repository. 
-        It enables users to specify the GitHub release tag for the asset.
+        It enables users to specify the GitHub release tag for the asset. 
+        Creates a GitHub repository release if the specified tag doesn't already exist.
         :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
         :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
         :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
         :param upload_github_release_tag (str): The tag associated with the GitHub release.
+        :return: return code, 0 on success
         """
         pass

--- a/scripts/o3de/o3de/gitproviderinterface.py
+++ b/scripts/o3de/o3de/gitproviderinterface.py
@@ -28,9 +28,21 @@ class GitProviderInterface(ABC):
         """
         Clones a git repository from a uri into a given folder
         :param uri: uniform resource identifier
-        :param download_path: location path on disk to download file
+        :param download_path: location path on disk to download files
         :param force_overwrite: whether to force overwrite the contents that already exist on disk or not
         :param ref: optional source control reference which can be a commit hash, branch, tag or other reference type
         :return: return code, 0 on success
+        """
+        pass
+    
+    @abstractmethod
+    def upload_release_to_github(self, repo_uri: ParseResult, zip_path: pathlib.Path, archive_filename: str, upload_git_release_tag: str):
+        """
+        Uploads a release asset to a GitHub repository. 
+        It enables users to specify the GitHub release tag for the asset.
+        :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+        :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+        :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+        :param upload_github_release_tag (str): The tag associated with the GitHub release.
         """
         pass

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -240,7 +240,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         else:
             logger.error(f'{repo_uri} is not a valid Github repository link, please update your repo_uri in your repo.json file.')
             return 1
-        download_prefix = f'https:\\github.com\{owner}\{repo}\releases\download\{upload_github_release_tag}\{archive_filename}'
+        download_prefix = f'https://github.com/{owner}/{repo}/releases/download/{upload_github_release_tag}/{archive_filename}'
      
         json_data = merge_json_data(json_data_path, {
             'repo_uri': repo_uri,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -105,8 +105,7 @@ def upload_release_to_github(repo_uri:str,
     else:
         logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
 
-    # Get repo (required)
-    # repo_uri: https://github.com/<owner>/<repo>.git
+    # Get repo (required) repo_uri: https://github.com/<owner>/<repo>.git
     repo_uri = repo_uri.split("/")
     repo = repo_uri[-1].split(".git")[0]
     
@@ -116,7 +115,7 @@ def upload_release_to_github(repo_uri:str,
     release_payload = {
         'tag_name': tag_name
     }
-    # Status code 200: valid release
+    # Valid release
     if response.status_code == 200:
         # Get the release end point to retrive release id
         get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
@@ -151,7 +150,7 @@ def upload_release_to_github(repo_uri:str,
     else:
         logger.error(f'Error checking tag existence. Status code: {response.status_code}')
   
-def is_github_link(url):
+def _is_github_link(url):
     github_url_pattern = r'^https?://github\.com/[a-zA-Z0-9\-_]+/[a-zA-Z0-9\-_]+(\.git)?$'
     return bool(re.match(github_url_pattern, url))
 
@@ -229,10 +228,15 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         logger.error(f'{zip_path} already exists.  Use --force command to overwrite the existing zip or '
                      'provide a new location to save your archive.')
         return {}
-    
+    if upload_github_release_tag is None and download_prefix is None:
+        logger.error('You need to provide a --upload-github-release-tag if you want to upload to github.\n'
+                     'If you want to use other version control systems you must provide --download-prefix argument\n'
+                     'A url prefix for a file attached to a Github release might look like this:'
+                     '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
+        return {}
     if upload_github_release_tag and download_prefix is None:
         
-        if is_github_link(repo_uri):
+        if _is_github_link(repo_uri):
         # Parse the URL to extract owner and repository name
             owner_repo = repo_uri.split("github.com/")[1].rstrip('.git').split('/')
             owner = owner_repo[0]
@@ -644,7 +648,8 @@ def add_parser_args(parser):
                                    help='A URL prefix for a file attached to a GitHub release might look like this:'
                                         '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0/')
     modify_object_group.add_argument('--upload-github-release-tag', '-ugrt', type=str, default=False,
-                                   help='Please provide a tag_name for the release. Automatically uploads your object-release-archive.zip file to specified github release.')
+                                   help='Automatically uploads your object-release-archive.zip file to specified github release.\n'
+                                        'Please provide a tag_name for the release. ')
     parser.set_defaults(func=_edit_repo_props)
 
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -17,6 +17,11 @@ import json
 import logging
 import hashlib
 import shutil
+import requests
+import sys
+import msvcrt
+import time
+import re
 from packaging.version import Version, InvalidVersion
 from packaging.specifiers import SpecifierSet
 from o3de import manifest, utils, validation
@@ -24,6 +29,131 @@ from o3de import manifest, utils, validation
 logger = logging.getLogger('o3de.repo_properties')
 logging.basicConfig(format=utils.LOG_FORMAT)
 
+def hide_credential(prompt):
+    """
+    Hide credentials displays a prompt to the user and waits for credential input. The entered characters
+    are masked with asterisks (*) to provide privacy. The function captures individual keystrokes, including backspace,
+    and supports a timeout feature to limit the duration for user input.
+
+    Args:
+        prompt (str): The prompt to display to the user.
+
+    Returns:
+        str: The user-entered credential/password as a string.
+
+    Timeout:
+        If no input is received within 60 seconds, the function will display an
+        timeout message, return an empty string, and terminate.
+    """
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+
+    secret_input = []
+    start_time = time.time()
+
+    while True:
+        if msvcrt.kbhit():
+            char = msvcrt.getch()
+            if char == b'\r':
+                break
+            elif char == b'\x08':
+                if secret_input:
+                    secret_input.pop()
+                    sys.stdout.write('\b \b')
+            else:
+                sys.stdout.write('*')
+                secret_input.append(char)
+            sys.stdout.flush()
+            start_time = time.time()
+
+        if time.time() - start_time > 60:
+            sys.stdout.write('\n')
+            print("Input timeout occurred")
+            return ""
+
+    sys.stdout.write('\n')
+    return b''.join(secret_input).decode('utf-8')
+
+def upload_release_to_github(repo_uri:str,
+                             zip_path: pathlib.Path,
+                             archive_filename: str,
+                             upload_github_release_tag: str):
+    """
+    Uploads a release asset to a GitHub repository. 
+    It enables users to specify the GitHub release tag for the asset.
+    :param repo_uri (str): The URL of the GitHub repository (e.g., "https://github.com/owner/repo.git").
+    :param zip_path (pathlib.Path): The path to the ZIP file that needs to be uploaded.
+    :param archive_filename (str): The filename to be used for the uploaded asset in the GitHub release.
+    :param upload_github_release_tag (str): The tag associated with the GitHub release.
+    """
+    access_token = hide_credential("Provide your github access token (Must have content - read and write permission)\n"
+                                   "Enter your Github Token: ")
+
+    tag_name = upload_github_release_tag
+    # Get github credentials
+    headers = {
+        'Authorization': f'Token {access_token}',
+        'Accept': 'application/vnd.github.v3+json',
+        "Content-Type": "application/zip"
+    }
+    
+    # Get owner (required)
+    owner = response = requests.get('https://api.github.com/user', headers=headers)
+    if response.status_code == 200:
+        user_data = response.json()
+        owner = user_data['login']
+    else:
+        logger.error(f'Failed to retrieve github user name. Status code: {response.status_code}')
+
+    # Get repo (required)
+    # repo_uri: https://github.com/<owner>/<repo>.git
+    repo_uri = repo_uri.split("/")
+    repo = repo_uri[-1].split(".git")[0]
+    
+    tag_check_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+    response = requests.get(tag_check_url, headers=headers)
+    
+    release_payload = {
+        'tag_name': tag_name
+    }
+    # Status code 200: valid release
+    if response.status_code == 200:
+        # Get the release end point to retrive release id
+        get_release_by_tag = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag_name}"
+        response = requests.get(get_release_by_tag, headers=headers, json=release_payload)
+        release_id = response.json().get('id')
+       
+        if response.status_code == 200:
+            upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+            with open(zip_path, 'rb') as file:
+                response = requests.post(upload_url, headers=headers, data=file)
+                if not response.status_code == 201:
+                    logger.error(f'Failed to upload asset to existing release. Status code: {response.status_code}')
+        else:
+            logger.error(f'Failed to retrive release. Status code: {response.status_code}')
+
+    # Release doesn't exist, Create a new release endpoint with the given tag_name and upload assest  
+    elif response.status_code == 404:
+        release_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+        response = requests.post(release_url, headers=headers, json=release_payload)
+
+        if response.status_code == 201:
+            release_id = response.json().get('id')
+            upload_url = f'https://uploads.github.com/repos/{owner}/{repo}/releases/{release_id}/assets?name={archive_filename}'
+
+            with open(zip_path, 'rb') as file:
+                response = requests.post(upload_url, headers=headers, data=file)
+                if not response.status_code == 201:
+                    logger.error(f'Failed to upload asset. Status code: {response.status_code}')
+        else:
+            logger.error(f'Failed to create release. Status code: {response.status_code}')
+    else:
+        logger.error(f'Error checking tag existence. Status code: {response.status_code}')
+  
+def is_github_link(url):
+    github_url_pattern = r'^https?://github\.com/[a-zA-Z0-9\-_]+/[a-zA-Z0-9\-_]+(\.git)?$'
+    return bool(re.match(github_url_pattern, url))
 
 def merge_json_data(json_path: pathlib.Path, json_data: dict) -> dict:
     """
@@ -69,7 +199,8 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
                    releases_path: pathlib.Path, 
                    repo_uri:str,
                    force: bool,
-                   download_prefix:str) -> dict:
+                   download_prefix: str = None,
+                   upload_github_release_tag: str = None) -> dict:
     """
     Creates a release of a specific version of a 
     remote object for the given src_data_path.
@@ -92,17 +223,42 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         FileNotFoundError: If the json_data_path does not exist.
         ValueError: If the json_data_path is not a dict.
     """
-    if download_prefix is None:
-        logger.error('The --download-prefix argument must be provided. A url prefix for a file attached to a Github release might look like this:'
-                     '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0')
-        return {}
     zip_path = releases_path / archive_filename
     # check if a object.zip folder already exist in the path - ask user if they want to overwrite the current zip
     if not force and zip_path.exists():
         logger.error(f'{zip_path} already exists.  Use --force command to overwrite the existing zip or '
                      'provide a new location to save your archive.')
         return {}
-    else:
+    
+    if upload_github_release_tag and download_prefix is None:
+        
+        if is_github_link(repo_uri):
+        # Parse the URL to extract owner and repository name
+            owner_repo = repo_uri.split("github.com/")[1].rstrip('.git').split('/')
+            owner = owner_repo[0]
+            repo = owner_repo[1]
+        else:
+            logger.error(f'{repo_uri} is not a valid Github repository link, please update your repo_uri in your repo.json file.')
+            return 1
+        download_prefix = f'https:\\github.com\{owner}\{repo}\releases\download\{upload_github_release_tag}\{archive_filename}'
+     
+        json_data = merge_json_data(json_data_path, {
+            'repo_uri': repo_uri,
+            'download_source_uri': download_prefix
+        })
+
+        logging.info(f"Creating '{download_prefix}'")
+
+        shutil.make_archive(releases_path / pathlib.Path(archive_filename).stem, 'zip', src_data_path)
+        with zip_path.open('rb') as f:
+            json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
+        
+        # Upload release archive zip to Github
+        upload_release_to_github(repo_uri, zip_path, archive_filename, upload_github_release_tag)
+        return json_data
+    
+    # For other version control systems
+    if download_prefix:
         # create the release zip file
         json_data = merge_json_data(json_data_path, {
             'repo_uri':repo_uri,
@@ -115,7 +271,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
         with zip_path.open('rb') as f:
             json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
 
-    return json_data
+        return json_data
     
 # retrieves json data of the repository from a file path
 def get_repo_props(path: pathlib.Path) -> dict or None:
@@ -149,7 +305,8 @@ def _edit_objects(object_typename:str,
                   replace_objects: pathlib.Path or list = None,
                   release_archive_path: pathlib.Path = None,
                   force: bool = None,
-                  download_prefix: str = None):
+                  download_prefix: str = None,
+                  upload_github_release_tag: str = None):
     """
     Modifies the 'gems_data/projects_data/templates_data' in repo_json
     :param object_typename: The type object field you want to change
@@ -183,9 +340,10 @@ def _edit_objects(object_typename:str,
                                 object_path / f'{object_typename}.json', 
                                 archive_filename, 
                                 release_archive_path, 
-                                repo_json['repo_uri'], 
+                                repo_json['repo_uri'],
                                 force,
-                                download_prefix)
+                                download_prefix,
+                                upload_github_release_tag)
                     # if create_remote_object_archive is not successful, then exit
                     if not json_data:
                         return 1
@@ -344,8 +502,8 @@ def edit_repo_props(repo_path: pathlib.Path = None,
                        dry_run: bool = False,
                        release_archive_path: pathlib.Path = None,
                        force: bool = None,
-                       download_prefix: str = None
-                       ) -> int:
+                       download_prefix: str = None,
+                       upload_github_release_tag: str = None) -> int:
     """
     Edits and modifies the remote repo properties for the repo.json located at 'repo_path'.
     :param repo_path: The path to the repo.json file
@@ -389,13 +547,13 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         _auto_update_json(auto_update, repo_path, repo_json)
 
     if add_gems or delete_gems or replace_gems:
-        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix)
+        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if add_projects or delete_projects or replace_projects:
-        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix)
+        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if add_templates or delete_templates or replace_templates:
-        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix)
+        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix, upload_github_release_tag)
 
     if repo_json_original != repo_json and not dry_run:
         utils.backup_file(repo_path)
@@ -426,7 +584,8 @@ def _edit_repo_props(args: argparse) -> int:
                               dry_run=args.dry_run,
                               release_archive_path=args.release_archive_path,
                               force=args.force,
-                              download_prefix=args.download_prefix
+                              download_prefix=args.download_prefix,
+                              upload_github_release_tag=args.upload_github_release_tag
                               )
 
 
@@ -484,6 +643,8 @@ def add_parser_args(parser):
     modify_object_group.add_argument('--download-prefix', '-dp', type=str, required=False,
                                    help='A URL prefix for a file attached to a GitHub release might look like this:'
                                         '-dp https://github.com/o3de/o3de-extras/releases/download/2305.0/')
+    modify_object_group.add_argument('--upload-github-release-tag', '-ugrt', type=str, default=False,
+                                   help='Please provide a tag_name for the release. Automatically uploads your object-release-archive.zip file to specified github release.')
     parser.set_defaults(func=_edit_repo_props)
 
 

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -68,7 +68,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
                    json_data_path: pathlib.Path, 
                    archive_filename: str, 
                    releases_path: pathlib.Path, 
-                   repo_uri:str,
+                   repo_uri: str,
                    force: bool,
                    download_prefix: str = None,
                    upload_git_release_tag: str = None) -> dict:
@@ -160,13 +160,13 @@ def get_repo_props(path: pathlib.Path) -> dict or None:
         return None
     return repo_json
 
-def _find_index(data:list, key:str, value:str) -> int:
+def _find_index(data: list, key: str, value: str) -> int:
     for index, item in enumerate(data):
         if item.get(key) == value:
             return index
     return -1
 
-def _changed(original:dict, new:dict) -> dict:
+def _changed(original: dict, new: dict) -> dict:
     changed = {}
     for key, value in new.items():
         if key not in original:
@@ -176,8 +176,8 @@ def _changed(original:dict, new:dict) -> dict:
 
     return changed
 
-def _edit_objects(object_typename:str,
-                  validator:callable,
+def _edit_objects(object_typename: str,
+                  validator: callable,
                   repo_json: dict,
                   add_objects: pathlib.Path or list = None,
                   delete_objects: str or list = None,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -188,7 +188,9 @@ def _edit_objects(object_typename: str,
                   release_archive_path: pathlib.Path = None,
                   force: bool = None,
                   download_prefix: str = None,
-                  upload_git_release_tag: str = None):
+                  upload_git_release_tag: str = None,
+                  copy_to_repo_subfolder: bool = None,
+                  repo_path: pathlib.Path = None):
     """
     Modifies the 'gems_data/projects_data/templates_data' in repo_json
     :param object_typename: The type object field you want to change
@@ -198,6 +200,7 @@ def _edit_objects(object_typename: str,
     :param replace_objects: A list of object paths that will completely replace the current object_list
     :param release_archive_path: Optional local path to a folder where a release archive should be written
     :param download_prefix: The prefix of the download uri
+    :param copy_to_repo_subfolder: Copies over the object you want to register to yout repo.json to associated repo object folder 
     """
     # The beginning remote repo json template
     repo_objects_data = repo_json.get(f'{object_typename}s_data',[])
@@ -212,6 +215,8 @@ def _edit_objects(object_typename: str,
             # object JSON data of the object you want to add
             json_data = manifest.get_json_data(object_typename, object_path, validator)
             if json_data:
+                if copy_to_repo_subfolder:
+                    _copy_to_repo_subfolder(repo_path, object_path, force)
                 # for a project called TestProject that is version 1.0.0, 
                 # --release_archive_path would create a filename of `testproject-1.0.0-project.zip`
                 if release_archive_path:
@@ -368,6 +373,28 @@ def print_repo_diff(repo_json: dict,
             else:
                 pretty_print_string.append(f'{object_key.capitalize()}s Modified: {len(modified_objects)}')
     print('\n'.join(pretty_print_string))
+
+# Copies over user specified object into associated repo object folder.
+def _copy_to_repo_subfolder(repo_path: pathlib.Path,
+                            object_path: pathlib.Path,
+                            force: bool) -> int:
+    if isinstance(object_path, pathlib.Path):
+        object_name = object_path.name
+        object_folder = object_path.parent.name
+        remote_repo_directory = os.path.dirname(repo_path)
+        copy_result_path = pathlib.Path(remote_repo_directory) / object_folder / object_name
+        if not copy_result_path.exists():
+            shutil.copytree(object_path, copy_result_path)
+        elif force:
+            shutil.rmtree(copy_result_path)
+            shutil.copytree(object_path, copy_result_path)
+        else:
+            logger.warning(f'{object_name} already exists at path {copy_result_path}. Use --force command to overwrite the existing folder or '
+                     'provide a new location to save your object.')
+            return 1
+    else:
+        logger.error(f'Invalid object path: {object_path}') 
+        return 1
     
 def edit_repo_props(repo_path: pathlib.Path = None,
                        repo_name: str = None,
@@ -385,7 +412,9 @@ def edit_repo_props(repo_path: pathlib.Path = None,
                        release_archive_path: pathlib.Path = None,
                        force: bool = None,
                        download_prefix: str = None,
-                       upload_git_release_tag: str = None) -> int:
+                       upload_git_release_tag: str = None,
+                       copy_to_repo_subfolder: pathlib.Path = None
+                       ) -> int:
     """
     Edits and modifies the remote repo properties for the repo.json located at 'repo_path'.
     :param repo_path: The path to the repo.json file
@@ -429,13 +458,16 @@ def edit_repo_props(repo_path: pathlib.Path = None,
         _auto_update_json(auto_update, repo_path, repo_json)
 
     if add_gems or delete_gems or replace_gems:
-        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force, download_prefix, upload_git_release_tag)
+        _edit_objects('gem', validation.valid_o3de_gem_json, repo_json, add_gems, delete_gems, replace_gems, release_archive_path, force,
+                      download_prefix, upload_git_release_tag, copy_to_repo_subfolder, repo_path)
 
     if add_projects or delete_projects or replace_projects:
-        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force, download_prefix, upload_git_release_tag)
+        _edit_objects('project', validation.valid_o3de_project_json, repo_json, add_projects, delete_projects, replace_projects, release_archive_path, force,
+                      download_prefix, upload_git_release_tag, copy_to_repo_subfolder, repo_path)
 
     if add_templates or delete_templates or replace_templates:
-        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force, download_prefix, upload_git_release_tag)
+        _edit_objects('template', validation.valid_o3de_template_json, repo_json, add_templates, delete_templates, replace_templates, release_archive_path, force,
+                      download_prefix, upload_git_release_tag, copy_to_repo_subfolder, repo_path)
 
     if repo_json_original != repo_json and not dry_run:
         utils.backup_file(repo_path)
@@ -467,8 +499,8 @@ def _edit_repo_props(args: argparse) -> int:
                               release_archive_path=args.release_archive_path,
                               force=args.force,
                               download_prefix=args.download_prefix,
-                              upload_git_release_tag=args.upload_git_release_tag
-                              )
+                              upload_git_release_tag=args.upload_git_release_tag,
+                              copy_to_repo_subfolder=args.copy_to_repo_subfolder)
 
 
 def add_parser_args(parser):
@@ -490,6 +522,8 @@ def add_parser_args(parser):
                                help='Prints the anticipated changes to your repo.json file object fields without actually writing to repo.json file.')
     general_group.add_argument('--force', '-f', action='store_true', default=False,
                                    help='Overwrite the release-archive zip file if there is already an existing zip with the same name.')
+    general_group.add_argument('--copy-to-repo-subfolder', '-cr', action='store_true', default=False,
+                                   help='Copies the object at the provided path to your remote repo')
 
     gem_group = parser.add_argument_group('Gem Modification Args')
     gem_group.add_argument('--add-gems', '-ag', type=pathlib.Path, nargs='*', required=False,

--- a/scripts/o3de/o3de/repo_properties.py
+++ b/scripts/o3de/o3de/repo_properties.py
@@ -109,6 +109,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
     if upload_git_release_tag and download_prefix:
         logger.error('Upload to GitHub will automatically generate a download prefix for you.\n'
                      'Use the `--download-prefix` CLI only when you want to use other version control system.')
+        return {}
     if upload_git_release_tag and not download_prefix:
         repo_uri = urllib.parse.urlparse(repo_uri)
         git_provider = github_utils.get_github_provider(repo_uri)
@@ -119,7 +120,7 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
             repo = owner_repo[1]
         else:
             logger.error(f'Failed to determine Git provider from {repo_uri}.')
-            return 1
+            return {}
         download_prefix = f'https://github.com/{owner}/{repo}/releases/download/{upload_git_release_tag}/{archive_filename}'
      
         json_data = merge_json_data(json_data_path, {
@@ -134,7 +135,9 @@ def create_remote_object_archive(src_data_path: pathlib.Path,
             json_data['sha256'] = hashlib.sha256(f.read()).hexdigest()
         
         # Upload release archive zip to Github
-        git_provider.upload_release_to_github(repo_uri, zip_path, archive_filename, upload_git_release_tag)
+        if git_provider.upload_release_to_github(repo_uri, zip_path, archive_filename, upload_git_release_tag) == 1:
+            logger.error('Failed to upload release to GitHub')
+            return {}
       
     # For other version control systems
     else:

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -13,7 +13,7 @@ import pytest
 import pathlib
 from unittest.mock import patch
 
-from o3de import download, repo_properties, utils
+from o3de import download, repo_properties
 
 TEST_TEMPLATE_REPO_JSON = '''{
     "repo_name": "repotest",
@@ -188,7 +188,8 @@ def init_repo_json_data(request):
 
 @pytest.fixture(scope="session")
 def temp_folder(tmpdir_factory):
-    temp_path = pathlib.Path(tmpdir_factory.mktemp('temp'))
+    custom_name = "Gems"
+    temp_path = pathlib.Path(tmpdir_factory.mktemp(custom_name, numbered=False))
     gem_path = temp_path / 'gem'
     os.makedirs(gem_path)
     gem_json_path = gem_path / 'gem.json'
@@ -540,3 +541,54 @@ class TestEditRepoProperties:
                             assert template in str(JSON_DICT.get('template_json_key'))
                         else:
                             assert template in expected_templates
+
+    # test copy_to_repo_subfolder
+    @pytest.mark.parametrize("repo_path, repo_name, add_gems, copy_to_repo_subfolder, \
+                            expected_result", [
+        # test copy a gem to repo subfolder
+        pytest.param(pathlib.Path('F:/repotest'), 'copytest1', [JSON_DICT['gem_archive_json_key']], temp_folder, 0)
+        
+    ])
+    def test_copy_to_repo_subfolder(self, temp_folder, repo_path, repo_name, add_gems, copy_to_repo_subfolder,
+                                    expected_result):
+        def get_repo_props(repo_path: str or pathlib.Path = None) -> dict or None:
+            if not repo_path:
+                self.repo_json.data = None
+                return None
+            return self.repo_json.data
+        
+        def save_o3de_manifest(json_data: dict, manifest_path: pathlib.Path = None) -> bool:
+            self.repo_json.data = json_data
+            return True
+        
+        def backup_file(file_name: str or pathlib.Path) -> None:
+            self.backup_file_name = file_name
+        
+        object_paths = [
+            temp_folder / 'gem'
+        ]
+        with patch('o3de.repo_properties.get_repo_props', side_effect=get_repo_props) as get_repo_props_patch, \
+            patch('o3de.utils.backup_file', side_effect=backup_file) as backup_file_patch, \
+            patch('o3de.manifest.save_o3de_manifest', side_effect=save_o3de_manifest) as save_o3de_manifest_patch:
+            if copy_to_repo_subfolder:
+                add_gems = object_paths
+                temp_repo_folder = temp_folder / 'repo'
+                os.makedirs(temp_repo_folder)
+                repo_path = temp_repo_folder
+            result = repo_properties.edit_repo_props(repo_path, repo_name, add_gems, copy_to_repo_subfolder=copy_to_repo_subfolder)
+            assert self.repo_json.data.get('repo_name') == repo_name
+            assert result == expected_result
+            # Make sure the object got copied over to the repo folder you created
+            assert pathlib.Path(temp_repo_folder / 'Gems' / 'gem').exists()
+            # Check if the duplicated gem.json file matches the original gem.json file
+            duplicated_gem_json_data = pathlib.Path(temp_repo_folder) / 'Gems' / 'gem' / 'gem.json'
+            original_gem_json_data = pathlib.Path(object_paths[0]) / 'gem.json'
+            with duplicated_gem_json_data.open('r') as s:
+                data = json.load(s)
+            with original_gem_json_data.open('r') as o:
+                original_data = json.load(o)
+                assert data == original_data
+            # check if the repo.json's gems_data field updated after calling copy-to-repo-subfolder
+            for gem in self.repo_json.data.get('gems_data', []):
+                assert str(gem) in str(data)
+            shutil.rmtree(temp_repo_folder)


### PR DESCRIPTION
## What does this PR do?

Use with the `--add-gems` command to copy over the object you want to add to the repo.json file on to your associated local repository object folder by calling this command:
`./o3de.bat edit-repo-properties --repo-path "C:\o3de_ProjectS\remoteEx" --add-gem "C:\o3de_Projects\o3de\Gems\Archive" --copy-to-repo-subfolder`


_Please describe any testing performed._

1. Made sure correct folders were created in the expected location, after calling the above command and repo.json got updated with the object user is looking to add
2. Created python unit test for this function
3. Made sure the previous tests all passed
