### PR TITLE
Disable reference slots for compact nodes

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
@@ -145,9 +145,11 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {% if hideInputField is defined %}
 {% if hideInputField == "true" %}
             dataSlotConfiguration.m_canHaveInputField = false;
+            dataSlotConfiguration.m_isUserAdded = true;
 {% endif %}
 {% elif preset == "compact" %}
             dataSlotConfiguration.m_canHaveInputField = false;
+            dataSlotConfiguration.m_isUserAdded = true;
 {% endif %}
 {% if hideName is defined %}
 {% if hideName == "true" %}


### PR DESCRIPTION
## What does this PR do?

Small PR that disables the use of references for compact style nodes, as compatibility between compact style nodes and references is still under development.

## How was this PR tested?

Manual testing was preformed by dragging and dropping variables from the variable browser.
