### PR TITLE
Pipelineviewtag from parent followup

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
@@ -28,7 +28,6 @@ namespace AZ
                 m_drawListTagName = passData->m_drawListTag;
                 auto* rhiSystem = RHI::RHISystemInterface::Get();
                 m_drawListTag = rhiSystem->GetDrawListTagRegistry()->AcquireTag(passData->m_drawListTag);
-                m_basePipelineViewTag = passData->m_pipelineViewTag;
             }
 
             SetShadowmapSize(ShadowmapSize::None, 1);
@@ -56,6 +55,7 @@ namespace AZ
             auto passData = AZStd::make_shared<RPI::RasterPassData>();
             passData->m_drawListTag = m_drawListTagName;
             passData->m_pipelineViewTag = GetPipelineViewTags()[cascadeIndex];
+            passData->m_bindViewSrg = true;
 
             auto pass = ShadowmapPass::CreateWithPassRequest(passName, passData);
 
@@ -144,11 +144,13 @@ namespace AZ
         {
             if (m_childrenPipelineViewTags.size() != Shadow::MaxNumberOfCascades)
             {
+                auto basePipelineViewTag{ GetPipelineViewTag() };
                 m_childrenPipelineViewTags.resize(Shadow::MaxNumberOfCascades);
                 for (uint16_t cascadeIndex = 0; cascadeIndex < Shadow::MaxNumberOfCascades; ++cascadeIndex)
                 {
                     // These pipeline view tags are used to distinguish transient views, so we offer distinct tag for each cascade index and for each camera view.
-                    m_childrenPipelineViewTags[cascadeIndex] = AZStd::string::format("%s_%d_%s", m_basePipelineViewTag.GetCStr(), cascadeIndex, m_cameraViewName.c_str());
+                    m_childrenPipelineViewTags[cascadeIndex] =
+                        AZStd::string::format("%s_%d_%s", basePipelineViewTag.GetCStr(), cascadeIndex, m_cameraViewName.c_str());
                 }
             }
             return m_childrenPipelineViewTags;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.h
@@ -62,9 +62,6 @@ namespace AZ
             Name m_drawListTagName;
             RHI::DrawListTag m_drawListTag;
 
-            // The base name of the pipeline view tags for the children.
-            RPI::PipelineViewTag m_basePipelineViewTag;
-
             // The name of the camera view associated to the shadow.
             // It is used to generate distinct child's pipeline view tags for each camera view.
             AZStd::string m_cameraViewName;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -376,10 +376,10 @@ namespace AZ
 
             if (m_requiresViewSrg)
             {
-                const AZStd::vector<RPI::ViewPtr>& views = m_pipeline->GetViews(m_passData->m_pipelineViewTag);
-                if (views.size() > 0)
+                RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
+                if (view)
                 {
-                    shaderResourceGroups.push_back(views[0]->GetRHIShaderResourceGroup());
+                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup());
                 }
             }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -152,6 +152,11 @@ namespace AZ
             virtual bool IsEnabled() const { return m_flags.m_enabled; }
 
             bool HasDrawListTag() const { return m_flags.m_hasDrawListTag; }
+            
+            [[deprecated( "Use BindViewSrg() instead." )]]
+            bool HasPipelineViewTag() const { return BindViewSrg(); }
+            
+            // The shader needs a View-Srg. Use GetPipelineViewTag() to find out which one.
             bool BindViewSrg() const
             {
                 return m_flags.m_bindViewSrg;

--- a/Gems/Atom/RPI/gem.json
+++ b/Gems/Atom/RPI/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "Atom_RPI",
-    "version": "0.0.0",
+    "version": "0.0.1",
     "display_name": "Atom API",
     "license": "Apache-2.0 Or MIT",
     "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",


### PR DESCRIPTION
## What does this PR do?

Follow-up to MR #16269:
- Fixed a few passes that used the `m_pipelineViewTag` variable directly, and may not get the right viewTag from the pipeline.
- Restored the function `HasPipelineViewTag()` and marked it as deprecated
- Increased the ATOM_RPI version from "0.0.0" to "0.0.1", as suggested by @AMZN-alexpete 

## How was this PR tested?

Make sure a default level still renders with the default renderpipeline