### PR TITLE
Adds AddNetworkInitHandler and sv_versionMismatch_check_enabled

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -62,6 +62,7 @@ namespace Multiplayer
     using ClientMigrationStartEvent = AZ::Event<ClientInputId>;
     using ClientMigrationEndEvent = AZ::Event<>;
     using EndpointDisconnectedEvent = AZ::Event<MultiplayerAgentType>;
+    using NetworkInitEvent = AZ::Event<AzNetworking::INetworkInterface*>;
     using NotifyClientMigrationEvent = AZ::Event<AzNetworking::ConnectionId, const HostId&, uint64_t, ClientInputId, NetEntityId>;
     using NotifyEntityMigrationEvent = AZ::Event<const ConstNetworkEntityHandle&, const HostId&>;
     using ConnectionAcquiredEvent = AZ::Event<MultiplayerAgentDatum>;
@@ -147,6 +148,10 @@ namespace Multiplayer
         //! Adds a ServerAcceptanceReceived Handler which is invoked when the client receives the accept packet from the server.
         //! @param handler The ServerAcceptanceReceived Handler to add
         virtual void AddServerAcceptanceReceivedHandler(ServerAcceptanceReceivedEvent::Handler& handler) = 0;
+
+        //! Adds a NetworkInitEvent Handler which is invoked when the network is initialized on the dedicated server or client-server.
+        //! @param handler The NetworkInitEvent Handler to add
+        virtual void AddNetworkInitHandler(NetworkInitEvent::Handler& handler) = 0;
 
         //! @deprecated If looking for an event when a multiplayer session is created, use SessionNotificationBus::OnCreateSessionBegin or SessionNotificationBus::OnCreateSessionEnd
         virtual void AddSessionInitHandler(SessionInitEvent::Handler& handler) = 0;

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -1334,8 +1334,7 @@ namespace Multiplayer
 
         if (sessionStarted)
         {
-            SessionConfig sessionConfig; // TODO find a better place or populate this data
-            SessionNotificationBus::Broadcast(&SessionNotificationBus::Events::OnCreateSessionBegin, sessionConfig);
+            m_networkInitEvent.Signal(m_networkInterface);
         }
     }
 
@@ -1367,6 +1366,11 @@ namespace Multiplayer
     void MultiplayerSystemComponent::AddConnectionAcquiredHandler(ConnectionAcquiredEvent::Handler& handler)
     {
         handler.Connect(m_connectionAcquiredEvent);
+    }
+
+    void MultiplayerSystemComponent::AddNetworkInitHandler(NetworkInitEvent::Handler& handler)
+    {
+        handler.Connect(m_networkInitEvent);
     }
 
     void MultiplayerSystemComponent::AddServerAcceptanceReceivedHandler(ServerAcceptanceReceivedEvent::Handler& handler)

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -109,6 +109,13 @@ namespace Multiplayer
         "Should the server send all its individual multiplayer component version information to the client when there's a mismatch? "
         "Upon receiving the information, the client will print the mismatch information to the game log. "
         "Provided for debugging during development, but you may want to mark false for release builds.");
+    AZ_CVAR(
+        bool,
+        sv_versionMismatch_check_enabled,
+        true,
+        nullptr,
+        AZ::ConsoleFunctorFlags::DontReplicate,
+        "If true, the server will check that client version of multiplayer component matches the server's.");
 
     AZ_CVAR(bool, bg_capturePhysicsTickMetric, true, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "Should the Multiplayer gem record average physics tick time?");
@@ -729,7 +736,8 @@ namespace Multiplayer
             }
         }
 
-        if (static_cast<AZ::CVarFixedString>(sv_map).empty())
+        const char* levelName = AZ::Interface<AzFramework::ILevelSystemLifecycle>::Get()->GetCurrentLevelName();
+        if (!levelName || strlen(levelName) == 0)
         {
             AZLOG_WARN("Server does not have a multiplayer level loaded! Make sure the server has a level loaded before accepting clients.");
             m_noServerLevelLoadedEvent.Signal();
@@ -738,7 +746,7 @@ namespace Multiplayer
             return true;
         }
 
-        if (connection->SendReliablePacket(MultiplayerPackets::Accept(sv_map)))
+        if (connection->SendReliablePacket(MultiplayerPackets::Accept(levelName)))
         {
             reinterpret_cast<ServerToClientConnectionData*>(connection->GetUserData())->SetDidHandshake(true);
 
@@ -777,7 +785,7 @@ namespace Multiplayer
         }
 
         // Make sure the client that's trying to connect has the same multiplayer components
-        if (GetMultiplayerComponentRegistry()->GetSystemVersionHash() != packet.GetSystemVersionHash())
+        if (sv_versionMismatch_check_enabled && GetMultiplayerComponentRegistry()->GetSystemVersionHash() != packet.GetSystemVersionHash())
         {
             // There's a multiplayer component mismatch. Send the server's component information back to the client so they can compare.
             if (sv_versionMismatch_sendManifestToClient)
@@ -1238,6 +1246,8 @@ namespace Multiplayer
 
     void MultiplayerSystemComponent::InitializeMultiplayer(MultiplayerAgentType multiplayerType)
     {
+        bool sessionStarted = false;
+
         if (bg_capturePhysicsTickMetric)
         {
             if (auto* physXSystem = PhysX::GetPhysXSystem())
@@ -1268,6 +1278,7 @@ namespace Multiplayer
             m_spawnNetboundEntities = false;
             if (multiplayerType == MultiplayerAgentType::ClientServer || multiplayerType == MultiplayerAgentType::DedicatedServer)
             {
+                sessionStarted = true;
                 m_spawnNetboundEntities = true;
                 if (!m_networkEntityManager.IsInitialized())
                 {
@@ -1319,6 +1330,12 @@ namespace Multiplayer
         if (auto* statSystem = AZ::Interface<IMultiplayerStatSystem>::Get())
         {
             statSystem->Register();
+        }
+
+        if (sessionStarted)
+        {
+            SessionConfig sessionConfig; // TODO find a better place or populate this data
+            SessionNotificationBus::Broadcast(&SessionNotificationBus::Events::OnCreateSessionBegin, sessionConfig);
         }
     }
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -131,6 +131,7 @@ namespace Multiplayer
         void AddNotifyClientMigrationHandler(NotifyClientMigrationEvent::Handler& handler) override;
         void AddNotifyEntityMigrationEventHandler(NotifyEntityMigrationEvent::Handler& handler) override;
         void AddConnectionAcquiredHandler(ConnectionAcquiredEvent::Handler& handler) override;
+        void AddNetworkInitHandler(NetworkInitEvent::Handler& handler) override;
 
         //! @deprecated If looking for an event when a multiplayer session is created, use SessionNotificationBus::OnCreateSessionBegin or
         //! SessionNotificationBus::OnCreateSessionEnd.
@@ -202,6 +203,7 @@ namespace Multiplayer
         IFilterEntityManager* m_filterEntityManager = nullptr; // non-owning pointer
 
         ConnectionAcquiredEvent m_connectionAcquiredEvent;
+        NetworkInitEvent m_networkInitEvent;
         ServerAcceptanceReceivedEvent m_serverAcceptanceReceivedEvent;
         EndpointDisconnectedEvent m_endpointDisconnectedEvent;
         ClientMigrationStartEvent m_clientMigrationStartEvent;

--- a/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
@@ -308,6 +308,7 @@ namespace Multiplayer
         bool StartHosting([[maybe_unused]] uint16_t port, [[maybe_unused]] bool isDedicated) override { return {}; }
         bool Connect([[maybe_unused]] const AZStd::string& remoteAddress, [[maybe_unused]] uint16_t port) override { return {}; }
         void Terminate([[maybe_unused]] AzNetworking::DisconnectReason reason) override {}
+        void AddNetworkInitHandler([[maybe_unused]] NetworkInitEvent::Handler& handler) override {}
         void AddEndpointDisconnectedHandler([[maybe_unused]] EndpointDisconnectedEvent::Handler& handler) override {}
         void AddConnectionAcquiredHandler([[maybe_unused]] ConnectionAcquiredEvent::Handler& handler) override {}
         void AddServerAcceptanceReceivedHandler([[maybe_unused]] ServerAcceptanceReceivedEvent::Handler& handler) override {}

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -25,6 +25,7 @@ namespace UnitTest
         MOCK_METHOD2(StartHosting, bool(uint16_t, bool));
         MOCK_METHOD2(Connect, bool(const AZStd::string&, uint16_t));
         MOCK_METHOD1(Terminate, void(AzNetworking::DisconnectReason));
+        MOCK_METHOD1(AddNetworkInitHandler, void(AZ::Event<INetworkInterface*>::Handler&));
         MOCK_METHOD1(AddClientMigrationStartEventHandler, void(Multiplayer::ClientMigrationStartEvent::Handler&));
         MOCK_METHOD1(AddClientMigrationEndEventHandler, void(Multiplayer::ClientMigrationEndEvent::Handler&));
         MOCK_METHOD1(AddEndpointDisconnectedHandler, void(Multiplayer::EndpointDisconnectedEvent::Handler&));

--- a/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/MultiplayerSystemTests.cpp
@@ -46,6 +46,7 @@ namespace Multiplayer
             AZ::Interface<AZ::ComponentApplicationRequests>::Register(m_ComponentApplicationRequests.get());
 
             m_mockTime = AZStd::make_unique<AZ::NiceTimeSystemMock>();
+            m_mockLevelSystem = AZStd::make_unique<MockLevelSystemLifecycle>();
 
             m_console.reset(aznew AZ::Console());
             AZ::Interface<AZ::IConsole>::Register(m_console.get());
@@ -86,6 +87,7 @@ namespace Multiplayer
             AZ::Interface<AZ::IConsole>::Unregister(m_console.get());
             m_console.reset();
             m_mockTime.reset();
+            m_mockLevelSystem.reset();
             AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(m_ComponentApplicationRequests.get());
             m_ComponentApplicationRequests.reset();
             AZ::NameDictionary::Destroy();
@@ -123,6 +125,34 @@ namespace Multiplayer
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_netBindDescriptor;
         AZStd::unique_ptr<AZ::IConsole> m_console;
         AZStd::unique_ptr<AZ::NiceTimeSystemMock> m_mockTime;
+
+        class MockLevelSystemLifecycle : public AzFramework::ILevelSystemLifecycle
+        {
+        public:
+            MockLevelSystemLifecycle()
+            {
+                AZ::Interface<AzFramework::ILevelSystemLifecycle>::Register(this);
+            }
+
+            ~MockLevelSystemLifecycle() override
+            {
+                AZ::Interface<AzFramework::ILevelSystemLifecycle>::Unregister(this);
+            }
+
+            const char* GetCurrentLevelName() const override
+            {
+                return m_levelName.c_str();
+            }
+
+            bool IsLevelLoaded() const override
+            {
+                return true;
+            }
+
+            AZStd::string m_levelName;
+        };
+
+        AZStd::unique_ptr<MockLevelSystemLifecycle> m_mockLevelSystem;
 
         uint32_t m_connectionAcquiredCount = 0;
         uint32_t m_endpointDisconnectedCount = 0;
@@ -444,7 +474,7 @@ namespace Multiplayer
 
         // server doesn't have a level loaded, expect a disconnect
         EXPECT_CALL(connection, Disconnect(DisconnectReason::ServerNoLevelLoaded, TerminationEndpoint::Local));
-        sv_map = "";
+        m_mockLevelSystem->m_levelName = "";
         m_mpComponent->HandleRequest(&connection, UdpPacketHeader(), connectPacket);
 
         AZ::Interface<IMultiplayerSpawner>::Unregister(&m_mpSpawnerMock);
@@ -462,7 +492,7 @@ namespace Multiplayer
         connection.SetUserData(&connectionUserData);
 
         // no mismatch, expect an acceptance packet
-        sv_map = "dummylevel";
+        m_mockLevelSystem->m_levelName = "dummylevel";
         EXPECT_CALL(connection, SendReliablePacket(IsMultiplayerPacketType(MultiplayerPackets::Accept::Type)));
         m_mpComponent->HandleRequest(&connection, UdpPacketHeader(), connectPacket);
 
@@ -475,6 +505,7 @@ namespace Multiplayer
         //   1. sv_versionMismatch_autoDisconnect
         //   2. sv_versionMismatch_sendManifestToClient
 
+        m_mockLevelSystem->m_levelName = "dummylevel";
         m_mpComponent->InitializeMultiplayer(MultiplayerAgentType::DedicatedServer);
 
         // Send a connection request with a different component hash to trigger a mismatch


### PR DESCRIPTION
## What does this PR do?

- Adds AddNetworkInitHandler for dedicated servers and client-servers
- Adds sv_versionMismatch_check_enabled, allows disabling the server side checking the versions for debug purposes
- Fixes a case when a server level isn't correctly detected on a client joining

## How was this PR tested?

Locally with a multiplayer template project
