### PR TITLE
Correcting physics mutex to be recursive

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
@@ -27,7 +27,7 @@ namespace Physics
         : public AZ::ComponentBus
     {
     public:
-        using MutexType = AZStd::mutex;
+        using MutexType = AZStd::recursive_mutex;
 
         virtual void EnablePhysics() = 0;
         virtual void DisablePhysics() = 0;


### PR DESCRIPTION
## What does this PR do?

On Linux AZStd::mutex is non-recursive, however some use cases of physics require that mutex to be recursive.

## How was this PR tested?

Tested on Linux with a multiplayer template project.
