### PR TITLE
Fixed spelling: changed DeplayedFunction to DelayedFunction

### DIFF
--- a/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp
+++ b/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp
@@ -19,11 +19,11 @@ namespace Profiler
 {
     static constexpr AZ::Crc32 profilerServiceCrc = AZ_CRC_CE("ProfilerService");
 
-    struct DeplayedFunction
+    struct DelayedFunction
     {
         using func_type = AZStd::function<void()>;
 
-        DeplayedFunction(int framesToDelay, func_type&& function)
+        DelayedFunction(int framesToDelay, func_type&& function)
             : m_function(AZStd::move(function))
             , m_framesLeft(framesToDelay)
         {
@@ -38,7 +38,7 @@ namespace Profiler
             else
             {
                 AZ::SystemTickBus::QueueFunction(
-                    [](DeplayedFunction&& delayedFunc)
+                    [](DelayedFunction&& delayedFunc)
                     {
                         delayedFunc.Run();
                     },
@@ -183,7 +183,7 @@ namespace Profiler
         }
 
         const int frameDelay = 5; // arbitrary number
-        DeplayedFunction delayedFunc(frameDelay,
+        DelayedFunction delayedFunc(frameDelay,
             [this, outputFilePath, wasEnabled]()
             {
                 // Blocking call for a single frame of data, avoid thread overhead


### PR DESCRIPTION
## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

This is a spelling fix in a cpp file.

In [o3de/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp](https://github.com/o3de/o3de/blob/42e8f1f66373a0ea995a564b5ff7500df7fe9bab/Gems/Profiler/Code/Source/ProfilerSystemComponent.cpp), the struct name DeplayedFunction is corrected to DelayedFunction in all 4 instances of it in the file.

_Please add links to any issues, RFCs or other items that are relevant to this PR._

https://github.com/o3de/o3de/issues/16493

## How was this PR tested?

_Please describe any testing performed._

According to the testing page: https://www.docs.o3de.org/docs/user-guide/build/configure-and-build/#simulate-an-automated-review-run

Is this the test that I should run?:  python\python.cmd -u scripts\build\ci_build.py --platform Windows --type profile_vs2019

Sorry I'm new to this project and not sure exactly how to run a test, even though I read the documentation.
