### PR TITLE
Don't crash if a framegraph attachment is unused

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -106,7 +106,7 @@ namespace AZ::RHI
                 if (attachment->GetFirstScopeAttachment() == nullptr)
                 {
                     //We allow the rendering to continue even if an attachment is not used.
-                    AZ_Error(
+                    AZ_ErrorOnce(
                         "FrameGraph", false,
                         "Invalid State: attachment '%s' was added but never used!",
                         attachment->GetId().GetCStr());

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -284,6 +284,11 @@ namespace AZ::RHI
         for (FrameAttachment* transientImage : attachmentDatabase.GetTransientImageAttachments())
         {
             Scope* firstScope = transientImage->GetFirstScope();
+            if (firstScope == nullptr)
+            {
+                // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
+                continue;
+            }
             const HardwareQueueClass mostCapableQueueUsage = GetMostCapableHardwareQueue(transientImage->GetSupportedQueueMask());
 
             if (firstScope->GetHardwareQueueClass() != mostCapableQueueUsage)
@@ -547,8 +552,15 @@ namespace AZ::RHI
             for (uint32_t attachmentIndex = 0; attachmentIndex < (uint32_t)transientBufferGraphAttachments.size(); ++attachmentIndex)
             {
                 BufferFrameAttachment* transientBuffer = transientBufferGraphAttachments[attachmentIndex];
-                const uint32_t scopeIndexFirst = transientBuffer->GetFirstScope()->GetIndex();
-                const uint32_t scopeIndexLast = transientBuffer->GetLastScope()->GetIndex();
+                const auto* firstScope = transientBuffer->GetFirstScope();
+                const auto* lastScope = transientBuffer->GetLastScope();
+                if (firstScope == nullptr || lastScope == nullptr)
+                {
+                    // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
+                    continue;
+                }
+                const uint32_t scopeIndexFirst = firstScope->GetIndex();
+                const uint32_t scopeIndexLast = lastScope->GetIndex();
                 commands.emplace_back(scopeIndexFirst, Action::ActivateBuffer, attachmentIndex);
                 commands.emplace_back(scopeIndexLast, Action::DeactivateBuffer, attachmentIndex);
             }
@@ -557,8 +569,15 @@ namespace AZ::RHI
             for (uint32_t attachmentIndex = 0; attachmentIndex < (uint32_t)transientImageGraphAttachments.size(); ++attachmentIndex)
             {
                 ImageFrameAttachment* transientImage = transientImageGraphAttachments[attachmentIndex];
-                const uint32_t scopeIndexFirst = transientImage->GetFirstScope()->GetIndex();
-                const uint32_t scopeIndexLast = transientImage->GetLastScope()->GetIndex();
+                const auto* firstScope = transientImage->GetFirstScope();
+                const auto* lastScope = transientImage->GetLastScope();
+                if (firstScope == nullptr || lastScope == nullptr)
+                {
+                        // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
+                        continue;
+                }
+                const uint32_t scopeIndexFirst = firstScope->GetIndex();
+                const uint32_t scopeIndexLast = lastScope->GetIndex();
                 commands.emplace_back(scopeIndexFirst, Action::ActivateImage, attachmentIndex);
                 commands.emplace_back(scopeIndexLast, Action::DeactivateImage, attachmentIndex);
             }

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -286,7 +286,9 @@ namespace AZ::RHI
             Scope* firstScope = transientImage->GetFirstScope();
             if (firstScope == nullptr)
             {
-                // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
+                // If the attachment is owned by a pass that isn't a scope-producer (e.g. Parent-Pass), and is not connected to
+                // anything, the first and last scope will be empty. We will get a warning its unused in ValidateEnd(), but we don't want to
+                // crash here
                 continue;
             }
             const HardwareQueueClass mostCapableQueueUsage = GetMostCapableHardwareQueue(transientImage->GetSupportedQueueMask());
@@ -556,7 +558,9 @@ namespace AZ::RHI
                 const auto* lastScope = transientBuffer->GetLastScope();
                 if (firstScope == nullptr || lastScope == nullptr)
                 {
-                    // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
+                    // If the attachment is owned by a pass that isn't a scope-producer (e.g. Parent-Pass), and is not connected to
+                    // anything, the first and last scope will be empty. We will get a warning its unused in ValidateEnd(), but we don't
+                    // want to crash here
                     continue;
                 }
                 const uint32_t scopeIndexFirst = firstScope->GetIndex();
@@ -573,8 +577,10 @@ namespace AZ::RHI
                 const auto* lastScope = transientImage->GetLastScope();
                 if (firstScope == nullptr || lastScope == nullptr)
                 {
-                        // The attachment is unused: We will get a warning in ValidateEnd(), but we don't want to crash here
-                        continue;
+                    // If the attachment is owned by a pass that isn't a scope-producer (e.g. Parent-Pass), and is not connected to
+                    // anything, the first and last scope will be empty. We will get a warning its unused in ValidateEnd(), but we don't
+                    // want to crash here
+                    continue;
                 }
                 const uint32_t scopeIndexFirst = firstScope->GetIndex();
                 const uint32_t scopeIndexLast = lastScope->GetIndex();


### PR DESCRIPTION
## What does this PR do?

Adds a few checks to avoid an exception when an attachment is unused. 

## How was this PR tested?

Add an image-attachment without any connections to the Parent-Pass in `MainPipeline.pass`. The result is now the message 
`[Error] (FrameGraph) - Invalid State: attachment 'Root.MainPipeline_0.TestImage' was added but never used!`, but no crash.
