### PR TITLE
Improve error-messages for Pass::ProcessConnection

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -434,15 +434,23 @@ namespace AZ
 
         void Pass::ProcessConnection(const PassConnection& connection, uint32_t slotTypeMask)
         {
+            auto prefix = [&]() -> AZStd::string
+            {
+                return AZStd::string::format(
+                    "Pass::ProcessConnection %s:%s -> %s:%s",
+                    m_path.GetCStr(),
+                    connection.m_localSlot.GetCStr(),
+                    connection.m_attachmentRef.m_pass.GetCStr(),
+                    connection.m_attachmentRef.m_attachment.GetCStr());
+            };
+
             // -- Find Local Binding --
 
             // Get the input from this pass that forms one end of the connection
             PassAttachmentBinding* localBinding = FindAttachmentBinding(connection.m_localSlot);
             if (!localBinding)
             {
-                AZ_RPI_PASS_ERROR(false, "Pass::ProcessConnection - Pass [%s] failed to find slot [%s].",
-                    m_path.GetCStr(),
-                    connection.m_localSlot.GetCStr());
+                AZ_RPI_PASS_ERROR(false, "%s: failed to find Local Slot.", prefix().c_str());
                 return;
             }
 
@@ -469,18 +477,15 @@ namespace AZ
                 foundPass = true;
                 attachment = FindOwnedAttachment(connectedSlotName);
 
-                AZ_RPI_PASS_ERROR(attachment, "Pass::ProcessConnection - Pass [%s] doesn't own an attachment named [%s].",
-                    m_path.GetCStr(),
-                    connectedSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(
+                    attachment, "%s: Current Pass doesn't own an attachment named [%s].", prefix().c_str(), connectedSlotName.GetCStr());
             }
 
             // -- Search Pipeline --
 
             else if (connectedPassName == PipelineGlobalKeyword)
             {
-                AZ_RPI_PASS_ERROR(m_pipeline != nullptr, "Pass::ProcessConnection - Pass [%s] references pipeline attachment [%s] doesn't have a valid pipeline pointer",
-                    m_path.GetCStr(),
-                    connectedSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(m_pipeline != nullptr, "%s: Pass doesn't have a valid pipeline pointer.", prefix().c_str());
 
                 foundPass = true;   // Using the "Pipeline" keyword, no need to continue searching for passes
 
@@ -492,9 +497,7 @@ namespace AZ
                         connectedBinding = globalBinding->m_binding;
                     }
 
-                    AZ_RPI_PASS_ERROR(connectedBinding , "Pass::ProcessConnection - Pass [%s] cannot find a pipeline global connection named [%s].",
-                        m_path.GetCStr(),
-                        connectedSlotName.GetCStr());
+                    AZ_RPI_PASS_ERROR(connectedBinding, "%s: Cannot find pipeline global connection.", prefix().c_str());
                 }
             }
 
@@ -559,7 +562,11 @@ namespace AZ
 
             if (slotTypeMismatch)
             {
-                AZ_RPI_PASS_ERROR(false, "Pass::ProcessConnection - When connecting to a child slot, both slots must be of the same type (or one must be InputOutput)");
+                AZ_RPI_PASS_ERROR(
+                    false,
+                    "%s: Slot Type Mismatch - When connecting to a child slot, both slots must be of the same type, or one must be "
+                    "InputOutput.",
+                    prefix().c_str());
                 connectedBinding = nullptr;
             }
 
@@ -580,23 +587,15 @@ namespace AZ
                     // [GFX TODO][ATOM-13693]: REMOVE POST R1 - passes not in hierarchy should no longer have this function called
                     // When view is changing, removal of the passes can occur (cascade shadow passes for example)
                     // resulting in temporary orphan passes that will be removed over the next frame.
-                    AZ_RPI_PASS_WARNING(false,
-                        "Pass::ProcessConnection - Pass [%s] is no longer part of the heirarchy and about to be removed",
-                        m_path.GetCStr());
+                    AZ_RPI_PASS_WARNING(false, "%s: Pass is no longer part of the hierarchy and about to be removed.", prefix().c_str());
                 }
                 else if (foundPass)
                 {
-                    AZ_RPI_PASS_ERROR(false, "Pass::ProcessConnection - Pass [%s] couldn't find a valid binding [%s] on [%s].",
-                        m_path.GetCStr(),
-                        connectedSlotName.GetCStr(),
-                        connectedPassName.GetCStr());
+                    AZ_RPI_PASS_ERROR(false, "%s: Could not find binding on target.", prefix().c_str());
                 }
                 else
                 {
-                    AZ_RPI_PASS_ERROR(
-                        false, "Pass::ProcessConnection - Pass [%s] could not find neighbor or child pass named [%s].",
-                        m_path.GetCStr(),
-                        connectedPassName.GetCStr());
+                    AZ_RPI_PASS_ERROR(false, "%s: Could not find target pass.", prefix().c_str());
                 }
             }
         }
@@ -606,13 +605,19 @@ namespace AZ
             PassAttachmentBinding* inputBinding = FindAttachmentBinding(connection.m_inputSlotName);
             PassAttachmentBinding* outputBinding = FindAttachmentBinding(connection.m_outputSlotName);
 
+            auto prefix = [&]() -> AZStd::string
+            {
+                return AZStd::string::format(
+                    "Pass::ProcessFallbackConnection: %s, %s -> %s",
+                    m_path.GetCStr(),
+                    connection.m_inputSlotName.GetCStr(),
+                    connection.m_outputSlotName.GetCStr());
+            };
             if (!outputBinding || !inputBinding)
             {
-                AZ_RPI_PASS_ERROR(inputBinding, "Pass::ProcessFallbackConnection - Pass [%s] failed to find input slot [%s].",
-                    m_path.GetCStr(), connection.m_inputSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(inputBinding, "%s: failed to find input slot.", prefix().c_str());
 
-                AZ_RPI_PASS_ERROR(outputBinding, "Pass::ProcessFallbackConnection - Pass [%s] failed to find output slot [%s].",
-                    m_path.GetCStr(), connection.m_outputSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(outputBinding, "%s: failed to find output slot.", prefix().c_str());
 
                 return;
             }
@@ -621,11 +626,11 @@ namespace AZ
 
             if (!typesAreValid)
             {
-                AZ_RPI_PASS_ERROR(inputBinding->m_slotType == PassSlotType::Input, "Pass::ProcessFallbackConnection - Pass [%s] specifies fallback connection input [%s], which is not an input.",
-                    m_path.GetCStr(), connection.m_inputSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(
+                    inputBinding->m_slotType == PassSlotType::Input, "%s: Input doesn't have SlotType::Input.", prefix().c_str());
 
-                AZ_RPI_PASS_ERROR(outputBinding->m_slotType == PassSlotType::Output, "Pass::ProcessFallbackConnection - Pass [%s] specifies fallback connection output [%s], which is not an output.",
-                    m_path.GetCStr(), connection.m_inputSlotName.GetCStr());
+                AZ_RPI_PASS_ERROR(
+                    outputBinding->m_slotType == PassSlotType::Output, "%s: Output doesn't have SlotType::Output.", prefix().c_str());
 
                 return;
             }


### PR DESCRIPTION
## What does this PR do?

Provide more information about which exact connection is actually causing an error.

Old:
`Pass::ProcessConnection - Pass [MainPipeline_0.SkinningPass] failed to find slot [SkinnedMeshOutputStreams].`

New:
`Pass::ProcessConnection MainPipeline_0.SkinningPass:SkinnedMeshOutputStreams -> MorphTargetPass:MorphTargetDeltaOutput: failed to find Local Slot.`

## How was this PR tested?

Introduce a faulty connection in the MainPipeline and watch the debug output.