### PR TITLE
Initial quality system component

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfoSimple.h
@@ -131,7 +131,7 @@ namespace AZ
     /**
     * Use this macro outside a class to allow it to be identified across modules and serialized (in different contexts).
     * The expected input is the class and the assigned uuid as a string or an instance of a uuid.
-    * Note that the AZ_TYPE_INFO_SPECIALIZE does NOT need has to be declared in "namespace AZ".
+    * Note that the AZ_TYPE_INFO_SPECIALIZE does NOT need to be declared in "namespace AZ".
     * It can be declared outside the namespace as mechanism for adding TypeInfo uses function overloading
     * instead of template specialization
     * Example:

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -56,7 +56,6 @@
 #include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
 #include <AzFramework/Physics/Utils.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialSystemComponent.h>
-#include <AzFramework/Quality/QualitySystemComponent.h>
 #include <AzFramework/Render/GameIntersectorComponent.h>
 #include <AzFramework/Platform/PlatformDefaults.h>
 #include <AzFramework/Archive/Archive.h>
@@ -370,7 +369,6 @@ namespace AzFramework
             azrtti_typeid<AzFramework::SpawnableSystemComponent>(),
             azrtti_typeid<Physics::MaterialSystemComponent>(),
             AZ::Uuid("{624a7be2-3c7e-4119-aee2-1db2bdb6cc89}"), // ScriptDebugAgent
-            azrtti_typeid<AzFramework::QualitySystemComponent>(),
             });
 
         return components;

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -56,6 +56,7 @@
 #include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
 #include <AzFramework/Physics/Utils.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialSystemComponent.h>
+#include <AzFramework/Quality/QualitySystemComponent.h>
 #include <AzFramework/Render/GameIntersectorComponent.h>
 #include <AzFramework/Platform/PlatformDefaults.h>
 #include <AzFramework/Archive/Archive.h>
@@ -369,6 +370,7 @@ namespace AzFramework
             azrtti_typeid<AzFramework::SpawnableSystemComponent>(),
             azrtti_typeid<Physics::MaterialSystemComponent>(),
             AZ::Uuid("{624a7be2-3c7e-4119-aee2-1db2bdb6cc89}"), // ScriptDebugAgent
+            azrtti_typeid<AzFramework::QualitySystemComponent>(),
             });
 
         return components;

--- a/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
+++ b/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
@@ -69,6 +69,7 @@ namespace AzFramework
         return AZ::ComponentTypeList
         {
             azrtti_typeid<AzFramework::OctreeSystemComponent>(),
+            azrtti_typeid<AzFramework::QualitySystemComponent>(),
         };
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
+++ b/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
@@ -19,6 +19,7 @@
 #include <AzFramework/Input/Contexts/InputContextComponent.h>
 #include <AzFramework/Input/System/InputSystemComponent.h>
 #include <AzFramework/PaintBrush/PaintBrushSystemComponent.h>
+#include <AzFramework/Quality/QualitySystemComponent.h>
 #include <AzFramework/Render/GameIntersectorComponent.h>
 #include <AzFramework/Scene/SceneSystemComponent.h>
 #include <AzFramework/Script/ScriptComponent.h>
@@ -55,6 +56,7 @@ namespace AzFramework
             AzFramework::SceneSystemComponent::CreateDescriptor(),
             AzFramework::StreamingInstall::StreamingInstallSystemComponent::CreateDescriptor(),
             AzFramework::AzFrameworkConfigurationSystemComponent::CreateDescriptor(),
+            AzFramework::QualitySystemComponent::CreateDescriptor(),
 
             AzFramework::OctreeSystemComponent::CreateDescriptor(),
             AzFramework::SpawnableSystemComponent::CreateDescriptor(),

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Quality/QualityCVarGroup.h>
+#include <AzFramework/Quality/QualitySystemBus.h>
+
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+namespace AzFramework
+{
+    QualityCVarGroup::QualityCVarGroup(AZ::SettingsRegistryInterface* registry, AZ::IConsole* console, AZStd::string_view name, AZStd::string_view path)
+        : m_console(console)
+        , m_numQualityLevels(0)
+        , m_path(path)
+        , m_qualityLevel(0)
+        , m_settingsRegistry(registry)
+    {
+        AZ_Assert(registry, "QualityCVarGroup requireds a valid settings registry.");
+        AZ_Assert(console, "QualityCVarGroup requireds a valid settings registry.");
+
+        using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
+        // optional default quality level
+        registry->Get(m_qualityLevel, FixedValueString::format("%.*s/Default", AZ_STRING_ARG(path)));
+
+        // count the number of quality levels for error checking
+        auto callback = [&]([[maybe_unused]] const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+        {
+            m_numQualityLevels++;
+            return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+        };
+        auto levelsKey = FixedValueString::format("%.*s/Levels", AZ_STRING_ARG(path));
+        AZ::SettingsRegistryVisitorUtils::VisitArray(*registry, callback, levelsKey);
+
+        // optional description
+        FixedValueString description;
+        registry->Get(description, FixedValueString::format("%.*s/Description", AZ_STRING_ARG(path)));
+
+        m_functor = AZStd::make_unique<QualityCVarGroupFunctor>(
+            name.data(),
+            description.data(),
+            AZ::ConsoleFunctorFlags::DontReplicate,
+            AZ::AzTypeInfo<ValueType>::Uuid(),
+            *this,
+            &QualityCVarGroup::CvarFunctor);
+    }
+
+    QualityCVarGroup::~QualityCVarGroup()
+    {
+    }
+
+    inline void QualityCVarGroup::CvarFunctor(const AZ::ConsoleCommandContainer& arguments)
+    {
+        StringToValue(arguments);
+    }
+
+    QualityCVarGroup::ValueType QualityCVarGroup::GetQualityLevelFromName(AZStd::string_view levelName)
+    {
+        using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
+        ValueType levelIndex = -1;
+        ValueType currentIndex = 0;
+        FixedValueString level;
+
+        // walk the quality group levels and find the one matching name 
+        auto callback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+        {
+            if (visitArgs.m_registry.Get(level, visitArgs.m_jsonKeyPath))
+            {
+                if (levelName.compare(level.c_str()) == 0)
+                {
+                    levelIndex = currentIndex;
+                    return AZ::SettingsRegistryInterface::VisitResponse::Done;
+                }
+            }
+
+            currentIndex++;
+            return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+        };
+
+        auto key = FixedValueString::format("%s/Levels", m_path.c_str());
+        AZ::SettingsRegistryVisitorUtils::VisitArray(*m_settingsRegistry, callback, key);
+        return levelIndex;
+    }
+
+    QualityCVarGroup::ValueType QualityCVarGroup::GetHighestQualityForSetting(AZStd::string_view path)
+    {
+        ValueType maxQualityLevel = -1;
+        auto callback = [&]([[maybe_unused]] const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+        {
+            maxQualityLevel++;
+            return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+        };
+        AZ::SettingsRegistryVisitorUtils::VisitArray(*m_settingsRegistry, callback, path);
+        return maxQualityLevel;
+    }
+
+    void QualityCVarGroup::LoadQualityLevel(ValueType qualityLevel)
+    {
+        using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+        using VisitResponse = AZ::SettingsRegistryInterface::VisitResponse;
+        using Type = AZ::SettingsRegistryInterface::Type;
+
+        if (qualityLevel >= m_numQualityLevels || qualityLevel < 0)
+        {
+            AZ_Warning("QualityCVarGroup",
+                       false,
+                       "Invalid quality level %lld requested for %s which only supports quality levels 0..%lld",
+                       qualityLevel,
+                       m_functor->GetName(),
+                       m_numQualityLevels - 1);
+            return;
+        }
+
+        auto key = FixedValueString::format("%s/Settings", m_path.c_str());
+        auto settingsVisitorCallback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+        {
+            if (visitArgs.m_type == Type::Object ||
+                visitArgs.m_type == Type::Null ||
+                visitArgs.m_type == Type::NoType)
+            {
+                AZ_Warning("QualityCVarGroup", false, "Invalid setting value type for %.*s, objects and null are not supported, only arrays, bool, string, or numbers.", AZ_STRING_ARG(visitArgs.m_fieldName));
+                return VisitResponse::Skip;
+            }
+
+            AZStd::string_view command = visitArgs.m_fieldName;
+            AZStd::string_view valueKey = visitArgs.m_jsonKeyPath;
+            if (visitArgs.m_type == Type::Array)
+            {
+                valueKey = FixedValueString::format("%.*s/%d", AZ_STRING_ARG(valueKey), qualityLevel);
+                if (visitArgs.m_registry.GetType(valueKey) == Type::NoType)
+                {
+                    // if the array index doesn't exist, use the value for the highest index
+                    ValueType maxQualityLevel = GetHighestQualityForSetting(visitArgs.m_jsonKeyPath);
+                    if (maxQualityLevel < 0)
+                    {
+                        AZ_Warning("QualityCVarGroup", false, "Not applying settings for %.s because the array is empty.", AZ_STRING_ARG(command));
+                        return VisitResponse::Continue;
+                    }
+                    valueKey = FixedValueString::format("%.*s/%d", AZ_STRING_ARG(visitArgs.m_jsonKeyPath), maxQualityLevel);
+                }
+            }
+
+            PerformConsoleCommand(command, valueKey);
+
+            return VisitResponse::Continue;
+        };
+        AZ::SettingsRegistryVisitorUtils::VisitObject(*m_settingsRegistry, settingsVisitorCallback, key);
+    }
+
+    void QualityCVarGroup::PerformConsoleCommand(AZStd::string_view command, AZStd::string_view key)
+    {
+        AZStd::string value;
+        switch (m_settingsRegistry->GetType(key))
+        {
+        case AZ::SettingsRegistryInterface::Type::FloatingPoint:
+            {
+                double floatingPointValue;
+                if (m_settingsRegistry->Get(floatingPointValue, key))
+                {
+                    value = AZStd::to_string(floatingPointValue);
+                }
+            }
+            break;
+        case AZ::SettingsRegistryInterface::Type::Boolean:
+            {
+                bool boolValue;
+                if (m_settingsRegistry->Get(boolValue, key))
+                {
+                    value = boolValue ? "True" : "False";
+                }
+            }
+            break;
+        case AZ::SettingsRegistryInterface::Type::Integer:
+            {
+                AZ::s64 intValue;
+                if (m_settingsRegistry->Get(intValue, key))
+                {
+                    value = AZStd::to_string(intValue);
+                }
+            }
+            break;
+        case AZ::SettingsRegistryInterface::Type::String:
+        default:
+            {
+                m_settingsRegistry->Get(value, key);
+            }
+            break;
+        }
+
+        if (!value.empty())
+        {
+            m_console->PerformCommand(command, { value }, AZ::ConsoleSilentMode::Silent);
+        }
+        else
+        {
+            AZ_Warning("QualityCVarGroup", false, "Failed to convert the value for %.*s to a string, or the value is empty.", AZ_STRING_ARG(command));
+        }
+    }
+
+    bool QualityCVarGroup::StringToValue(const AZ::ConsoleCommandContainer& arguments)
+    {
+        if (!arguments.empty())
+        {
+            AZ::CVarFixedString convertCandidate{ arguments.front() };
+            char* endPtr = nullptr;
+
+            // TODO support loading quality levels using names
+
+            ValueType qualityLevel = aznumeric_cast<ValueType>(strtoll(convertCandidate.c_str(), &endPtr, 0));
+            if (qualityLevel == aznumeric_cast<ValueType>(QualitySystemEvents::LevelFromDeviceRules))
+            {
+                using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
+                // TODO use device rules
+
+                // fall back to default
+                m_settingsRegistry->Get(qualityLevel, FixedValueString::format("%.*s/Default", AZ_STRING_ARG(m_path)));
+            }
+            m_qualityLevel = qualityLevel;
+
+            LoadQualityLevel(m_qualityLevel);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    void QualityCVarGroup::ValueToString(AZ::CVarFixedString& outString) const
+    {
+        AZStd::to_string(outString, m_qualityLevel);
+    }
+} // namespace AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
@@ -12,36 +12,31 @@
 #include <AzCore/Console/ConsoleFunctor.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
-#include <AzCore/Preprocessor/Enum.h> 
+
+#include <AzFramework/Quality/QualitySystemBus.h>
 
 namespace AzFramework
 {
-    AZ_ENUM_CLASS(QualityLevels,
-        (LevelFromDeviceRules, -1),
-        (DefaultQualityLevel, 0)
-    );
-    AZ_DEFINE_ENUM_ARITHMETIC_OPERATORS(QualityLevels);
-    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(QualityLevels);
-
-    // QualityCVarGroup wraps an integer CVar for a quality group that, when set,
-    // notifies the QualitySystemBus to load all the settings for the group and the
-    // requested level
+    // QualityCVarGroup wraps a QualityLevel CVAR for a quality group that, when set,
+    // iterates over all settings in the group and performs console commands to
+    // apply the settings for the requested quality level.
+    // Quality levels are assumed to be ordered low to high as in the example below.
     //
     // Example:
-    // A q_shadows group CVar could be created with 4 levels (low=0,medium=1,high=2,veryhigh=3)
-    // When the level of q_shadows is set to 2 the QualitySystem will be notified
-    // and apply all console settings defined in the SettingsRegistry for that
+    // A q_shadows group CVAR exists with 4 levels (low=0,medium=1,high=2,veryhigh=3)
+    // When the level of q_shadows is set to 2 LoadQualityLevel will apply all
+    // console settings defined in the SettingsRegistry for that
     // group at level 2 (high).
     //
     class QualityCVarGroup
     {
     public:
-        using ValueType = QualityLevels;
+        AZ_CLASS_ALLOCATOR_DECL;
 
         QualityCVarGroup(AZStd::string_view name, AZStd::string_view path);
         ~QualityCVarGroup();
 
-        explicit inline operator ValueType() const { return m_qualityLevel; }
+        explicit inline operator QualityLevel() const { return m_qualityLevel; }
 
         //! required to set the value
         inline void CvarFunctor(const AZ::ConsoleCommandContainer& arguments);
@@ -53,23 +48,27 @@ namespace AzFramework
         void ValueToString(AZ::CVarFixedString& outString) const;
 
         //! load the requested quality level CVar settings
-        void LoadQualityLevel(ValueType qualityLevel);
+        void LoadQualityLevel(QualityLevel qualityLevel);
+
+        QualityLevel GetQualityLevel(const AZ::CVarFixedString& value) const;
 
     private:
         AZ_DISABLE_COPY(QualityCVarGroup);
+
+        QualityLevel FromNumber(const AZ::CVarFixedString& value) const;
+        QualityLevel FromEnum(const AZ::CVarFixedString& value) const;
+        QualityLevel FromName(const AZ::CVarFixedString& value) const;
 
         AZ::PerformCommandResult PerformConsoleCommand(AZStd::string_view command, AZStd::string_view key);
 
         inline static constexpr bool ReplicateCommand = true;
         using QualityCVarGroupFunctor = AZ::ConsoleFunctor<QualityCVarGroup, ReplicateCommand>;
-        AZStd::unique_ptr<QualityCVarGroupFunctor> m_functor;
+        AZStd::string m_description;
         AZStd::string m_name;
+        AZStd::unique_ptr<QualityCVarGroupFunctor> m_functor;
         AZStd::string m_path;
-        ValueType m_qualityLevel = QualityLevels::DefaultQualityLevel;
+        int32_t m_numQualityLevels{ 0 };
+        QualityLevel m_qualityLevel = QualityLevel::DefaultQualityLevel;
     };
 } // namespace AzFramework
 
-namespace AZ
-{
-    AZ_TYPE_INFO_SPECIALIZE(AzFramework::QualityLevels, "{9AABD1B2-D433-49FE-A89D-2BEF09A252C0}");
-}

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
@@ -20,6 +20,26 @@ namespace AzFramework
     // QualityCVarGroup wraps a QualityLevel CVAR for a quality group that, when set,
     // iterates over all settings in the group and performs console commands to
     // apply the settings for the requested quality level.
+    // The general format of a quality group entry in the Settings Registry is:
+    // {
+    //     "O3DE" : {
+    //         "Quality" : {
+    //             "Groups" : {
+    //                 "<group CVAR>" : {
+    //                      "Description" : "<optional description>",
+    //                      "Levels" : [ "<quality level 0>", "<quality level n>" ],
+    //                      "Default" : "<default quality level>",
+    //                      "Settings" : {
+    //                          "<setting CVAR>" : [<level 0 value>, <level n value> ]
+    //                      }
+    //                  }
+    //             }
+    //         }
+    //     }
+    // }
+    //    
+    // QualityCVarGroup only creates a CVAR for the quality group itself, it does not
+    // create CVARs for any entries in the quality groups "Settings" object.
     // Quality levels are assumed to be ordered low to high as in the example below.
     //
     // Example:

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/Console/ConsoleFunctor.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace AZ
+{
+    class SettingsRegistryInterface;
+}
+
+namespace AzFramework
+{
+    // QualityCVarGroup wraps an integer CVar for a quality group that, when set,
+    // notifies the QualitySystemBus to load all the settings for the group and the
+    // requested level
+    //
+    // Example:
+    // A q_shadows group CVar could be created with 4 levels (low=0,medium=1,high=2,veryhigh=3)
+    // When the level of q_shadows is set to 2 the QualitySystem will be notified
+    // and apply all console settings defined in the SettingsRegistry for that
+    // group at level 2 (high).
+    //
+    class QualityCVarGroup
+    {
+    public:
+        typedef AZ::s64 ValueType;
+
+        QualityCVarGroup(AZ::SettingsRegistryInterface* registry, AZ::IConsole* console, AZStd::string_view name, AZStd::string_view path);
+        ~QualityCVarGroup();
+
+        inline operator ValueType() const { return m_qualityLevel; }
+
+        //! required to set the value
+        inline void CvarFunctor(const AZ::ConsoleCommandContainer& arguments);
+
+        //! get the quality level from a name, or -1 if not found
+        ValueType GetQualityLevelFromName(AZStd::string_view levelName);
+
+        //! required to set the value
+        bool StringToValue(const AZ::ConsoleCommandContainer& arguments);
+
+        //! required to get the current value
+        void ValueToString(AZ::CVarFixedString& outString) const;
+
+        //! load the requested quality level CVar settings
+        void LoadQualityLevel(ValueType qualityLevel);
+
+    private:
+        AZ_DISABLE_COPY(QualityCVarGroup);
+
+        ValueType GetHighestQualityForSetting(AZStd::string_view path);
+        void PerformConsoleCommand(AZStd::string_view command, AZStd::string_view key);
+
+        AZ::IConsole* m_console;
+        using QualityCVarGroupFunctor = AZ::ConsoleFunctor<QualityCVarGroup, /*replicate=*/true>;
+        AZStd::unique_ptr<QualityCVarGroupFunctor> m_functor;
+        AZ::u16 m_numQualityLevels;
+        AZStd::string m_path;
+        ValueType m_qualityLevel;
+        AZ::SettingsRegistryInterface* m_settingsRegistry;
+    };
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace AzFramework
+{
+    class QualitySystemEvents
+        : public AZ::EBusTraits
+    {
+    public:
+        using Bus = AZ::EBus<QualitySystemEvents>;
+
+        // When loading quality group settings using a level value of LevelFromDeviceRules
+        // the device rules will be used to determine the quality level to use.
+        static constexpr int LevelFromDeviceRules = -1;
+
+        // Loads the default quality group level.
+        // @param level Optional quality level.  If LevelFromDeviceRules, the level will be
+        //              determined from existing device rules.
+        virtual void LoadDefaultQualityGroup(int level = LevelFromDeviceRules) = 0;
+    };
+} //AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
@@ -8,23 +8,39 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/std/string/string_view.h>
 
 namespace AzFramework
 {
+    AZ_ENUM_CLASS(QualityLevel,
+        (Invalid, -2),
+        // When loading quality group settings using a level value of LevelFromDeviceRules
+        // the device rules will be used to determine the quality level to use.
+        // Quality levels are assumed to be ordered low to high with 0 being the lowest
+        // quality.
+        (LevelFromDeviceRules, -1),
+        (DefaultQualityLevel, 0)
+    );
+    AZ_TYPE_INFO_SPECIALIZE(QualityLevel, "{9AABD1B2-D433-49FE-A89D-2BEF09A252C0}");
+    AZ_DEFINE_ENUM_ARITHMETIC_OPERATORS(QualityLevel);
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(QualityLevel);
+
     class QualitySystemEvents
         : public AZ::EBusTraits
     {
     public:
         using Bus = AZ::EBus<QualitySystemEvents>;
 
-        // When loading quality group settings using a level value of LevelFromDeviceRules
-        // the device rules will be used to determine the quality level to use.
-        static constexpr int LevelFromDeviceRules = -1;
-
-        // Loads the default quality group level.
-        // @param level Optional quality level.  If LevelFromDeviceRules, the level will be
-        //              determined from existing device rules.
-        virtual void LoadDefaultQualityGroup(int level = LevelFromDeviceRules) = 0;
+        // Loads the default quality group if one is defined in /O3DE/Quality/DefaultGroup
+        // If the requested QualityLevel is 0 or higher, settings for that level will be loaded.
+        // If the requested QualityLevel is LevelFromDeviceRules, device rules will be used to
+        // determine the quality level, and if no device rule match is found the default
+        // level for that group will be used if it has one.
+        //
+        // @param level Optional quality level to load. If LevelFromDeviceRules, the level will be
+        //              determined from device rules. If there is no matching device rule, the
+        //              default level for the group will be used.
+        virtual void LoadDefaultQualityGroup(QualityLevel level = QualityLevel::LevelFromDeviceRules) = 0;
     };
 } //AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Quality/QualitySystemComponent.h>
+#include <AzFramework/Quality/QualityCVarGroup.h>
+
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+
+namespace AzFramework
+{
+    inline constexpr const char* QualitySettingsGroupsRootKey = "/O3DE/Quality/Groups";
+    inline constexpr const char* QualitySettingsDefaultGroupKey = "/O3DE/Quality/DefaultGroup";
+
+    // constructor and destructor defined here to prevent compiler errors
+    // if default constructor/destructor is defined in header because of
+    // the member vector of unique_ptrs
+    QualitySystemComponent::QualitySystemComponent() = default;
+    QualitySystemComponent::~QualitySystemComponent() = default;
+
+    void QualitySystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<QualitySystemComponent, AZ::Component>();
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<QualitySystemComponent>(
+                    "AzFramework Quality Component", "System component responsible for quality settings")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ;
+            }
+        }
+    }
+
+    void QualitySystemComponent::Activate()
+    {
+        m_settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ_Assert(m_settingsRegistry, "QualitySystemComponent requires a SettingsRegistry but no instance has been created.");
+
+        m_console = AZ::Interface<AZ::IConsole>::Get();
+        AZ_Assert(m_console, "QualitySystemComponent requires an IConsole interface but no instance has been created.");
+
+        if (m_settingsRegistry && m_console)
+        {
+            QualitySystemEvents::Bus::Handler::BusConnect();
+            m_settingsRegistry->Get(m_defaultGroupName, QualitySettingsDefaultGroupKey);
+            RegisterCvars();
+        }
+    }
+
+    void QualitySystemComponent::Deactivate()
+    {
+        QualitySystemEvents::Bus::Handler::BusDisconnect();
+        m_settingsGroupCVars.clear();
+        m_qualityGroupStack.clear();
+    }
+
+    void QualitySystemComponent::LoadDefaultQualityGroup(int qualityLevel)
+    {
+        if (m_defaultGroupName.empty())
+        {
+            AZ_Warning("QualitySystemComponent", false, "No default quality group settings will be loaded because no default group name was defined at %s", QualitySettingsDefaultGroupKey);
+            return;
+        }
+
+        m_console->PerformCommand(AZStd::string_view(m_defaultGroupName),
+            { AZStd::to_string(qualityLevel).c_str() }, AZ::ConsoleSilentMode::Silent);
+    }
+
+    void QualitySystemComponent::RegisterCvars()
+    {
+        // walk the quality groups in the settings registry and create cvars for every group
+        auto groupVisitorCallback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+        {
+            if (visitArgs.m_type != AZ::SettingsRegistryInterface::Type::Object)
+            {
+                AZ_Warning(
+                    "QualitySystemComponent",
+                    false,
+                    "Skipping quality setting group entry '%.*s' that is not an object type.",
+                    AZ_STRING_ARG(visitArgs.m_fieldName));
+                return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+            }
+
+            m_settingsGroupCVars.push_back(AZStd::make_unique<QualityCVarGroup>(m_settingsRegistry, m_console, visitArgs.m_fieldName, visitArgs.m_jsonKeyPath));
+            return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+        };
+        AZ::SettingsRegistryVisitorUtils::VisitObject(*m_settingsRegistry, groupVisitorCallback, QualitySettingsGroupsRootKey);
+    }
+
+    void QualitySystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC("QualitySystemComponentService"));
+    }
+
+    void QualitySystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC("QualitySystemComponentService"));
+    }
+
+    void QualitySystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+} // AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzFramework/Quality/QualitySystemBus.h>
+
+namespace AZ
+{
+    class IConsole;
+    class SettingsRegistryInterface;
+}
+
+namespace AzFramework
+{
+    class QualityCVarGroup;
+
+    // QualitySystemComponent manages quality groups, levels and cvar settings
+    // stored in the SettingsRegistry
+    class QualitySystemComponent final
+        : public AZ::Component
+        , public AzFramework::QualitySystemEvents::Bus::Handler
+    {
+    public:
+        AZ_COMPONENT(QualitySystemComponent, "{CA269E6A-A420-4B68-93E9-2E09A604D29A}", AZ::Component);
+
+        QualitySystemComponent();
+        ~QualitySystemComponent() override;
+
+        AZ_DISABLE_COPY(QualitySystemComponent);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+        static void Reflect(AZ::ReflectContext* context);
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // AzFramework::QualitySystemBus
+        void LoadDefaultQualityGroup(int qualityLevel = QualitySystemEvents::LevelFromDeviceRules) override;
+
+    private:
+        void RegisterCvars();
+
+        AZ::IConsole* m_console = nullptr;
+        AZStd::string m_defaultGroupName;
+        AZStd::vector<AZStd::string> m_qualityGroupStack;
+        AZStd::vector<AZStd::unique_ptr<QualityCVarGroup>> m_settingsGroupCVars;
+        AZ::SettingsRegistryInterface* m_settingsRegistry = nullptr;
+    };
+} // AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
@@ -20,7 +20,7 @@ namespace AzFramework
     // stored in the SettingsRegistry
     class QualitySystemComponent final
         : public AZ::Component
-        , public AzFramework::QualitySystemEvents::Bus::Handler
+        , public QualitySystemEvents::Bus::Handler
     {
     public:
         AZ_COMPONENT(QualitySystemComponent, "{CA269E6A-A420-4B68-93E9-2E09A604D29A}", AZ::Component);
@@ -40,7 +40,7 @@ namespace AzFramework
         void Deactivate() override;
 
         // AzFramework::QualitySystemBus
-        void LoadDefaultQualityGroup(int qualityLevel = QualitySystemEvents::LevelFromDeviceRules) override;
+        void LoadDefaultQualityGroup(QualityLevel qualityLevel = QualityLevel::LevelFromDeviceRules) override;
 
     private:
         void RegisterCvars();

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
@@ -12,12 +12,6 @@
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Quality/QualitySystemBus.h>
 
-namespace AZ
-{
-    class IConsole;
-    class SettingsRegistryInterface;
-}
-
 namespace AzFramework
 {
     class QualityCVarGroup;
@@ -51,11 +45,8 @@ namespace AzFramework
     private:
         void RegisterCvars();
 
-        AZ::IConsole* m_console = nullptr;
         AZStd::string m_defaultGroupName;
-        AZStd::vector<AZStd::string> m_qualityGroupStack;
         AZStd::vector<AZStd::unique_ptr<QualityCVarGroup>> m_settingsGroupCVars;
-        AZ::SettingsRegistryInterface* m_settingsRegistry = nullptr;
     };
 } // AzFramework
 

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -328,6 +328,11 @@ set(FILES
     Process/ProcessUtils.h
     ProjectManager/ProjectManager.h
     ProjectManager/ProjectManager.cpp
+    Quality/QualityCVarGroup.cpp
+    Quality/QualityCVarGroup.h
+    Quality/QualitySystemComponent.cpp
+    Quality/QualitySystemComponent.h
+    Quality/QualitySystemBus.h
     Render/GameIntersectorComponent.h
     Render/GameIntersectorComponent.cpp
     Render/GeometryIntersectionBus.h

--- a/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
@@ -136,7 +136,7 @@ namespace UnitTest
                         "DefaultGroup":"q_test",
                         "Groups": {
                             "q_test": {
-                                "Levels": [ "low", "medium","high", "veryhigh"],
+                                "Levels": [ "low", "medium", "high", "veryhigh"],
                                 "Default": 2,
                                 "Description": "q_test quality group",
                                 "Settings": {
@@ -164,11 +164,11 @@ namespace UnitTest
         int32_t intValue = -42;
         AZ::CVarFixedString stringValue;
 
-        // expect the value  defaults
+        // expect the value defaults
         EXPECT_EQ(m_console->GetCvarValue("a_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, 0);
         EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
-        EXPECT_STREQ(stringValue.c_str(), "default");
+        EXPECT_EQ(stringValue, "default");
         EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, -1);
         EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
@@ -187,7 +187,7 @@ namespace UnitTest
         EXPECT_EQ(intValue, 2);
 
         EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
-        EXPECT_STREQ(stringValue.c_str(), "c");
+        EXPECT_EQ(stringValue, "c");
 
         EXPECT_EQ(m_console->GetCvarValue("q_test_sub", value), AZ::GetValueResult::Success);
         EXPECT_EQ(value, AzFramework::QualityLevel{1});
@@ -206,7 +206,7 @@ namespace UnitTest
         EXPECT_EQ(intValue, 1);
 
         EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
-        EXPECT_STREQ(stringValue.c_str(), "b");
+        EXPECT_EQ(stringValue, "b");
 
         EXPECT_EQ(m_console->GetCvarValue("q_test_sub", value), AZ::GetValueResult::Success);
         EXPECT_EQ(value, AzFramework::QualityLevel{1});
@@ -227,7 +227,7 @@ namespace UnitTest
         EXPECT_EQ(intValue, 0);
 
         EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
-        EXPECT_STREQ(stringValue.c_str(), "a");
+        EXPECT_EQ(stringValue, "a");
 
         EXPECT_EQ(m_console->GetCvarValue("q_test_sub", value), AZ::GetValueResult::Success);
         EXPECT_EQ(value, AzFramework::QualityLevel{0});

--- a/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/Console/Console.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzFramework/Quality/QualitySystemComponent.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+    using namespace AzFramework;
+
+    class QualitySystemComponentTestFixture : public LeakDetectionFixture
+    {
+    public:
+        QualitySystemComponentTestFixture()
+            : LeakDetectionFixture()
+        {
+        }
+
+    protected:
+        void SetUp() override
+        {
+            m_settingsRegistry = AZStd::make_unique<SettingsRegistryImpl>();
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
+
+            m_console = AZStd::make_unique<AZ::Console>();
+            m_console->LinkDeferredFunctors(AZ::ConsoleFunctorBase::GetDeferredHead());
+            AZ::Interface<AZ::IConsole>::Register(m_console.get());
+
+            m_qualitySystemComponent = AZStd::make_unique<QualitySystemComponent>();
+        }
+
+        void TearDown() override
+        {
+            // reset the console first so all the variables are moved to deferred head
+            AZ::Interface<AZ::IConsole>::Unregister(m_console.get());
+            m_console.reset();
+
+            // next deactivate/reset to unlink from deferred head
+            m_qualitySystemComponent->Deactivate();
+            m_qualitySystemComponent.reset();
+
+
+            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
+            m_settingsRegistry.reset();
+        }
+
+        AZStd::unique_ptr<AZ::Console> m_console;
+        AZStd::unique_ptr<QualitySystemComponent> m_qualitySystemComponent;
+        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
+    };
+
+    TEST_F(QualitySystemComponentTestFixture, QualitySystem_Registers_Group_CVars)
+    {
+        auto result = m_settingsRegistry->MergeSettings(R"(
+            {
+                "O3DE": {
+                    "Quality": {
+                        "Groups": {
+                            "q_test": {
+                                "Levels": [ "low", "high" ],
+                                "Default": 1,
+                                "Description": "q_test quality group",
+                                "Settings": {
+                                    "q_test_sub": [0,1]
+                                }
+                            },
+                            "q_test_sub": {
+                                "Levels": [ "low", "high" ],
+                                "Default": 0,
+                                "Description": "q_test_sub quality group",
+                                "Settings": {
+                                    "a_cvar": [123,234]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            )",
+            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
+            "");
+        ASSERT_TRUE(result);
+
+        // when the quality system component registers group cvars
+        m_qualitySystemComponent->Activate();
+
+        // expect the cvars are created with their default values
+        int value = -1;
+        EXPECT_EQ(m_console->GetCvarValue("q_test", value), AZ::GetValueResult::Success);
+        EXPECT_EQ(value, 1);
+
+        EXPECT_EQ(m_console->GetCvarValue("q_test_sub", value), AZ::GetValueResult::Success);
+        EXPECT_EQ(value, 0);
+    }
+
+    AZ_CVAR(int32_t, a_setting, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 1");
+    AZ_CVAR(AZ::CVarFixedString, b_setting, "default", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example string setting 2");
+    AZ_CVAR(int32_t, c_setting, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 3");
+    AZ_CVAR(int32_t, d_setting, -2, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 4");
+
+    TEST_F(QualitySystemComponentTestFixture, QualitySystem_Loads_Group_Level)
+    {
+        auto result = m_settingsRegistry->MergeSettings(R"(
+            {
+                "O3DE": {
+                    "Quality": {
+                        "DefaultGroup":"q_test",
+                        "Groups": {
+                            "q_test": {
+                                "Levels": [ "low", "medium","high", "veryhigh"],
+                                "Default": 2,
+                                "Description": "q_test quality group",
+                                "Settings": {
+                                    "a_setting": [0,1,2,3],
+                                    "b_setting": ["a","b","c","d"],
+                                    "q_test_sub": [0,1,1,1]
+                                }
+                            },
+                            "q_test_sub": {
+                                "Levels": [ "low", "high" ],
+                                "Default": 0,
+                                "Description": "q_test_sub quality group",
+                                "Settings": {
+                                    "c_setting": [123,234],
+                                    "d_setting": [42] // test missing high level setting
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            )",
+            AZ::SettingsRegistryInterface::Format::JsonMergePatch,
+            "");
+        ASSERT_TRUE(result);
+
+        // when the cvar values are first created 
+        m_qualitySystemComponent->Activate();
+
+        int intValue = -1;
+        AZ::CVarFixedString stringValue;
+
+        // expect the value  defaults
+        EXPECT_EQ(m_console->GetCvarValue("a_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 0);
+        EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
+        EXPECT_STREQ(stringValue.c_str(), "default");
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, -1);
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, -2);
+
+        // when the default group is loaded
+        QualitySystemEvents::Bus::Broadcast(&QualitySystemEvents::LoadDefaultQualityGroup, QualitySystemEvents::LevelFromDeviceRules);
+
+        // expect the values are set based on the default for q_test which is 2 
+        EXPECT_EQ(m_console->GetCvarValue("q_test", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 2);
+
+        EXPECT_EQ(m_console->GetCvarValue("a_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 2);
+
+        EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
+        EXPECT_STREQ(stringValue.c_str(), "c");
+
+        EXPECT_EQ(m_console->GetCvarValue("q_test_sub", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 1);
+
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 234);
+
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 42);
+
+        // when the group level is loaded 1 : "medium" ( which is "high" for q_test_sub )
+        m_console->PerformCommand("q_test", { "1" });
+
+        // expect the values are set based on the group level settings
+        EXPECT_EQ(m_console->GetCvarValue("a_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 1);
+
+        EXPECT_EQ(m_console->GetCvarValue("b_setting", stringValue), AZ::GetValueResult::Success);
+        EXPECT_STREQ(stringValue.c_str(), "b");
+
+        EXPECT_EQ(m_console->GetCvarValue("q_test_sub", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 1);
+
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 234);
+
+        // d_settings doesn't specify a value for "high" so it should use highest available setting
+        // which is "low" -> 42
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 42);
+    }
+} // namespace UnitTest
+

--- a/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
@@ -219,8 +219,8 @@ namespace UnitTest
         EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, 42);
 
-        // when the group level 0 is loaded (low)
-        m_console->PerformCommand("q_test", { "low" });
+        // when the group level 0 is loaded (low) using mixed-case name 
+        m_console->PerformCommand("q_test", { "LoW" });
 
         // settings at index 0 are correctly loaded
         EXPECT_EQ(m_console->GetCvarValue("a_setting", intValue), AZ::GetValueResult::Success);

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -44,4 +44,5 @@ set(FILES
     PaintBrush/PaintBrushPaintLocationTests.cpp
     PaintBrush/PaintBrushPaintSettingsTests.cpp
     PaintBrush/PaintBrushSmoothLocationTests.cpp
+    QualitySystemComponentTests.cpp
 )

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -33,6 +33,7 @@
 
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
+#include <AzFramework/Quality/QualitySystemBus.h>
 
 #include "AZCoreLogSink.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
@@ -1111,6 +1112,12 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     }
 
     InlineInitializationProcessing("CSystem::Init End");
+
+    // All CVARs should now be registered, load and apply quality settings for the default quality group
+    // using device rules to auto-detected the correct quality level 
+    AzFramework::QualitySystemEvents::Bus::Broadcast(
+        &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
+        AzFramework::QualitySystemEvents::LevelFromDeviceRules);
 
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1117,7 +1117,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     // using device rules to auto-detected the correct quality level 
     AzFramework::QualitySystemEvents::Bus::Broadcast(
         &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
-        AzFramework::QualitySystemEvents::LevelFromDeviceRules);
+        AzFramework::QualityLevel::LevelFromDeviceRules);
 
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);

--- a/Gems/Atom/Feature/Common/Registry/quality.setreg
+++ b/Gems/Atom/Feature/Common/Registry/quality.setreg
@@ -1,0 +1,38 @@
+{
+    "O3DE": {
+        "Quality": {
+            "Groups": {
+                "q_general": {
+                    "Settings": {
+                        "q_graphics": [ 0, 1, 2, 3 ] // map q_general levels 1 to 1 with graphics levels
+                    }
+                },
+                "q_graphics": {
+                    "Description": "Graphics quality settings.  0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [
+                        "Low",
+                        "Medium",
+                        "High",
+                        "VeryHigh"
+                    ],
+                    "Default": 3,
+                    "Settings": {
+                        "q_shadows": [ 0, 1, 2, 3 ]
+                    }
+                },
+                "q_shadows": {
+                    "Description": "Shadow quality settings.  0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [
+                        "Low",
+                        "Medium",
+                        "High",
+                        "VeryHigh"
+                    ],
+                    "Settings": {
+                        // shadows console variable settings
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Registry/quality.setreg
+++ b/Registry/quality.setreg
@@ -1,0 +1,19 @@
+{
+    "O3DE": {
+        "Quality": {
+            "DefaultGroup": "q_general",
+            "Groups": {
+                "q_general": {
+                    "Description" : "Default quality group. 0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [
+                        "Low",
+                        "Medium",
+                        "High",
+                        "VeryHigh"
+                    ],
+                    "Default": 3
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds initial quality system component, cvar groups and a `q_general`, `q_graphics`, and `q_shadows` quality groups setting registry files.

Quality group CVARs found in `/O3DE/Quality/Groups` are automatically created on application start and their quality level can be set from the console using the level name (e.g. "low" or "high") or the level index (e.g. 0 or 1).

If a default quality group is defined at `/O3DE/Quality/DefaultGroup` (currently `q_general`), the quality level for that group will be automatically loaded in `SystemInit.cpp` based on the default quality level for that group (currently "high") and eventually the level can be determined from device rules (future task).

Relevant RFC:  https://github.com/o3de/sig-core/issues/57

## How was this PR tested?

- Unit tests added for basic functionality
- Stepped through settings in game launcher, changed quality cvar values and verified settings were propogated
- Temporarily added render cvars in quality groups and verified they were changed
