### PR TITLE
Fix entity selection issue with high DPI setting

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -347,7 +347,7 @@ void EditorViewportWidget::mousePressEvent(QMouseEvent* event)
 AzToolsFramework::ViewportInteraction::MousePick EditorViewportWidget::BuildMousePick(const QPoint& point) const
 {
     AzToolsFramework::ViewportInteraction::MousePick mousePick;
-    mousePick.m_screenCoordinates = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point);
+    mousePick.m_screenCoordinates = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point * devicePixelRatioF());
     const auto [origin, direction] = m_renderViewport->ViewportScreenToWorldRay(mousePick.m_screenCoordinates);
     mousePick.m_rayOrigin = origin;
     mousePick.m_rayDirection = direction;
@@ -1424,7 +1424,8 @@ Vec3 EditorViewportWidget::ViewToWorld(
     AZ_UNUSED(bSkipVegetation);
     AZ_UNUSED(collideWithObject);
 
-    auto ray = m_renderViewport->ViewportScreenToWorldRay(AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(vp));
+    auto ray =
+        m_renderViewport->ViewportScreenToWorldRay(AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(vp * devicePixelRatioF()));
 
     const float maxDistance = 10000.f;
     Vec3 v = AZVec3ToLYVec3(ray.m_direction) * maxDistance;

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -45,7 +45,9 @@ void QtViewport::BuildDragDropContext(
     AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
 {
     context.m_hitLocation = AzToolsFramework::FindClosestPickIntersection(
-        viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), AzToolsFramework::EditorPickRayLength,
+        viewportId,
+        AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point * devicePixelRatioF()),
+        AzToolsFramework::EditorPickRayLength,
         AzToolsFramework::GetDefaultEntityPlacementDistance());
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -150,10 +150,9 @@ namespace AzToolsFramework
         public:
             //! Returns the current camera state for this viewport.
             virtual AzFramework::CameraState GetCameraState() = 0;
-            //! Transforms a point in world space to screen space coordinates in Qt Widget space.
-            //! Multiply by DeviceScalingFactor to get the position in viewport pixel space.
+            //! Transforms a point in world space to screen space coordinates in viewport pixel space
             virtual AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition) = 0;
-            //! Transforms a point from Qt widget screen space to world space based on the given clip space depth.
+            //! Transforms a point in viewport pixel space to world space based on the given clip space depth.
             //! Returns the world space position if successful.
             virtual AZ::Vector3 ViewportScreenToWorld(const AzFramework::ScreenPoint& screenPosition) = 0;
             //! Casts a point in screen space to a ray in world space originating from the viewport camera frustum's near plane.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -82,7 +82,10 @@ namespace AtomToolsFramework
 
         m_viewportInteractionImpl = AZStd::make_unique<ViewportInteractionImpl>(GetDefaultCamera());
         m_viewportInteractionImpl->m_deviceScalingFactorFn = [this] { return aznumeric_cast<float>(devicePixelRatioF()); };
-        m_viewportInteractionImpl->m_screenSizeFn = [this] { return AzFramework::ScreenSize(width(), height()); };
+        m_viewportInteractionImpl->m_screenSizeFn = [this] {
+            AzFramework::WindowSize screenSize = GetClientAreaSize();
+            return AzFramework::ScreenSize(screenSize.m_width, screenSize.m_height);
+        };
         m_viewportInteractionImpl->Connect(newId);
 
         AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Handler::BusConnect(GetId());
@@ -264,7 +267,7 @@ namespace AtomToolsFramework
             eventType == QEvent::Type::MouseMove)
         {
             const auto* mouseEvent = static_cast<const QMouseEvent*>(event);
-            m_mousePosition = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(mouseEvent->pos());
+            m_mousePosition = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(mouseEvent->pos() * devicePixelRatioF());
         }
     }
 
@@ -275,7 +278,7 @@ namespace AtomToolsFramework
 
     void RenderViewportWidget::mouseMoveEvent(QMouseEvent* mouseEvent)
     {
-        m_mousePosition = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(mouseEvent->pos());
+        m_mousePosition = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(mouseEvent->pos() * devicePixelRatioF());
     }
 
     void RenderViewportWidget::SendWindowResizeEvent()
@@ -413,6 +416,7 @@ namespace AtomToolsFramework
 
     AzFramework::WindowSize RenderViewportWidget::GetClientAreaSize() const
     {
+        // The client area size need to be measured in device pixel size. 
         const auto pixelRatio = devicePixelRatioF();
         return AzFramework::WindowSize{aznumeric_cast<uint32_t>(width()*pixelRatio), aznumeric_cast<uint32_t>(height()*pixelRatio)};
     }
@@ -462,6 +466,7 @@ namespace AtomToolsFramework
 
     AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
     {
+        // We want render resolution matches the screen's resolution
         return GetClientAreaSize();
     }
 


### PR DESCRIPTION
## What does this PR do?
This PR is to fix this GHI: https://github.com/o3de/o3de/issues/16494

## How was this PR tested?
 Change Windows DPI to 150%
Tested following functions in O3DE Editor:
- Use mouse to select entity
- Drag mouse to select multiple entities. 
- Drag an procprefab asset to viewport which creates a prefab entity at the position where the mouse was released
- Right click menu and choose Instantiate prefab to create a prefab entity. The entity was created at the center of the screen (expected behavior based on the code)
- Material editor: using mouse to control camera
- Animation editor: using mouse control camera.
