### PR TITLE
Fixed logic error in visibility for LOD Configuration group

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -106,7 +106,7 @@ namespace AZ
 
         bool MeshComponentConfig::ShowLodConfig()
         {
-            return LodTypeIsScreenCoverage() && LodTypeIsSpecificLOD();
+            return LodTypeIsScreenCoverage() || LodTypeIsSpecificLOD();
         }
 
         AZStd::vector<AZStd::pair<RPI::Cullable::LodOverride, AZStd::string>> MeshComponentConfig::GetLodOverrideValues()


### PR DESCRIPTION
## What does this PR do?

Fixes #16487 

This fixes a logic error that was preventing the `LOD Configuration` group from being shown on the `Mesh` component based on what the current LOD Type is set to. The reflection code used a `ShowLodConfig` method for the `Visibility` attribute on the group, but the RPE doesn't actually use the `Visibility` attribute for groups, and instead relies on the individual children elements to be shown/hidden, which is why this logic error was never caught.

The `LOD Configuration` group now shows up properly and shows the correct children based on the LOD Type as can be seen below:

![FixedMeshLODConfigurationGroup](https://github.com/o3de/o3de/assets/7519264/fba983f5-b221-4270-a8e5-72e0692a639b)

## How was this PR tested?

Tested the `Mesh` component and verified the `LOD Configuration` group appears with the proper children based on the LOD Type with both DPE enabled and disabled.