### PR TITLE
Initial visible geometry bus with mesh component controller bindings

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -71,6 +71,7 @@
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
 #include <AzFramework/Visibility/BoundsBus.h>
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
 #include <AzFramework/Viewport/ViewportBus.h>
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 
@@ -326,6 +327,8 @@ namespace AzFramework
         AzFramework::ScreenGeometryReflect(context);
         AzFramework::RemoteStorageDriveConfig::Reflect(context);
         AzFramework::PaintBrushSettings::Reflect(context);
+        AzFramework::VisibleGeometry::Reflect(context);
+        AzFramework::VisibleGeometryRequests::Reflect(context);
 
         Physics::ReflectionUtils::ReflectPhysicsApi(context);
         AzFramework::SurfaceData::SurfaceTagWeight::Reflect(context);

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
@@ -31,6 +31,13 @@ namespace AzFramework
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->Class<VisibleGeometry>("VisibleGeometry")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Visibility")
+                ->Attribute(AZ::Script::Attributes::Module, "visibility")
+                ->Constructor()
+                ->Constructor<const VisibleGeometry&>()
+                ->Property("vertices", BehaviorValueProperty(&VisibleGeometry::m_vertices))
+                ->Property("indices", BehaviorValueProperty(&VisibleGeometry::m_indices))
                 ;
         }
     }
@@ -40,6 +47,9 @@ namespace AzFramework
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->EBus<VisibleGeometryRequestBus>("VisibleGeometryRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Visibility")
+                ->Attribute(AZ::Script::Attributes::Module, "visibility")
                 ->Event("GetVisibleGeometry", &VisibleGeometryRequestBus::Events::GetVisibleGeometry)
                 ;
         }

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AzFramework::VisibleGeometryRequests);
+
+namespace AzFramework
+{
+    void VisibleGeometry::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<VisibleGeometry>()
+                ->Version(0)
+                ->Field("vertices", &VisibleGeometry::m_vertices)
+                ->Field("indices", &VisibleGeometry::m_indices)
+                ;
+
+            serializeContext->Class<VisibleGeometryContainer>()
+                ;
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<VisibleGeometry>("VisibleGeometry")
+                ;
+        }
+    }
+
+    void VisibleGeometryRequests::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<VisibleGeometryRequestBus>("VisibleGeometryRequestBus")
+                ->Event("GetVisibleGeometry", &VisibleGeometryRequestBus::Events::GetVisibleGeometry)
+                ;
+        }
+    }
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
@@ -21,7 +21,7 @@ namespace AZ
 
 namespace AzFramework
 {
-    //! Structure containing vertices and indices for an indexed triangle list
+    //! VisibleGeometry describes details about visible geometry surfaces stored as generic indexed triangle lists
     struct VisibleGeometry
     {
         AZ_TYPE_INFO(VisibleGeometry, "{4B011208-B105-4BC1-A4F3-FD5C44785D71}");
@@ -36,13 +36,13 @@ namespace AzFramework
 
     using VisibleGeometryContainer = AZStd::vector<VisibleGeometry>;
 
-    //! Interface for components to provide generic geometric data for occlusion culling and other purposes
+    //! Interface for components to provide generic geometric data, potentially for occlusion culling and other systems
     class VisibleGeometryRequests : public AZ::ComponentBus
     {
     public:
         static void Reflect(AZ::ReflectContext* context);
 
-        //! Returns a container of visible geometry vertices and indices
+        //! Returns a container of visible geometry
         virtual void GetVisibleGeometry(VisibleGeometryContainer& geometryContainer) const = 0;
 
     protected:

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace AzFramework
+{
+    //! Structure containing vertices and indices for an indexed triangle list
+    struct VisibleGeometry
+    {
+        AZ_TYPE_INFO(VisibleGeometry, "{4B011208-B105-4BC1-A4F3-FD5C44785D71}");
+        AZ_CLASS_ALLOCATOR(VisibleGeometry, AZ::SystemAllocator);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::Matrix4x4 m_transform;
+        AZStd::vector<float> m_vertices;
+        AZStd::vector<uint32_t> m_indices;
+    };
+
+    using VisibleGeometryContainer = AZStd::vector<VisibleGeometry>;
+
+    //! Interface for components to provide generic geometric data for occlusion culling and other purposes
+    class VisibleGeometryRequests : public AZ::ComponentBus
+    {
+    public:
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Returns a container of visible geometry vertices and indices
+        virtual void GetVisibleGeometry(VisibleGeometryContainer& geometryContainer) const = 0;
+
+    protected:
+        ~VisibleGeometryRequests() = default;
+    };
+
+    using VisibleGeometryRequestBus = AZ::EBus<VisibleGeometryRequests>;
+} // namespace AzFramework
+
+DECLARE_EBUS_EXTERN(AzFramework::VisibleGeometryRequests);

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/containers/vector.h>
@@ -21,7 +22,7 @@ namespace AZ
 
 namespace AzFramework
 {
-    //! VisibleGeometry describes details about visible geometry surfaces stored as generic indexed triangle lists
+    //! VisibleGeometry describes visible geometry surfaces stored as generic indexed triangle lists
     struct VisibleGeometry
     {
         AZ_TYPE_INFO(VisibleGeometry, "{4B011208-B105-4BC1-A4F3-FD5C44785D71}");
@@ -29,8 +30,13 @@ namespace AzFramework
 
         static void Reflect(AZ::ReflectContext* context);
 
+        //! Local to world matrix transforming vertices into world space. 
         AZ::Matrix4x4 m_transform;
+
+        //! Vertex list must contain 3 floats, XYZ, per vertex.
         AZStd::vector<float> m_vertices;
+
+        //! Index list must contain 3 uint32_t per triangle face. Each index references a position in the vertex list.
         AZStd::vector<uint32_t> m_indices;
     };
 
@@ -42,8 +48,13 @@ namespace AzFramework
     public:
         static void Reflect(AZ::ReflectContext* context);
 
-        //! Returns a container of visible geometry
-        virtual void GetVisibleGeometry(VisibleGeometryContainer& geometryContainer) const = 0;
+        //! This function should be implemented by components to add VisibleGeometry items to the VisibleGeometryContainer.
+        //! @param bounds is a bounding volume in world space used for sampling geometric data. If bounds is invalid it should be ignored.
+        //! @param geometryContainer is a container of all of the geometry added by the connected entity. It is passed by reference to give
+        //! multiple components on an entity an opportunity to add their geometry. It is the caller's responsibility to manage and clear the
+        //! container between calls. The container should not be cleared within the function, which might destroy a prior components
+        //! contribution.
+        virtual void GetVisibleGeometry(const AZ::Aabb& bounds, VisibleGeometryContainer& geometryContainer) const = 0;
 
     protected:
         ~VisibleGeometryRequests() = default;

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -478,11 +478,13 @@ set(FILES
     Visibility/OctreeSystemComponent.cpp
     Visibility/BoundsBus.h
     Visibility/BoundsBus.cpp
-    Visibility/VisibilityDebug.h
-    Visibility/VisibilityDebug.cpp
     Visibility/EntityBoundsUnionBus.h
     Visibility/EntityVisibilityBoundsUnionSystem.h
     Visibility/EntityVisibilityBoundsUnionSystem.cpp
     Visibility/EntityVisibilityQuery.h
     Visibility/EntityVisibilityQuery.cpp
+    Visibility/VisibilityDebug.h
+    Visibility/VisibilityDebug.cpp
+    Visibility/VisibleGeometryBus.h
+    Visibility/VisibleGeometryBus.cpp
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -765,11 +765,24 @@ namespace AZ
                 AzFramework::VisibleGeometry visibleGeometry;
                 visibleGeometry.m_transform = AZ::Matrix4x4::CreateFromTransform(m_transformInterface->GetWorldTM());
 
-                // This resize and copy assumes the stride between elements is 0.
+                // Reserve space for indices and copy data, assuming stride between elements is 0.
                 visibleGeometry.m_indices.resize_no_construct(indexBufferViewDesc.m_elementCount);
+
+                AZ_Assert(
+                    (sizeof(visibleGeometry.m_indices[0]) * visibleGeometry.m_indices.size()) >=
+                    (indexBufferViewDesc.m_elementSize * indexBufferViewDesc.m_elementCount),
+                    "Index buffer size exceeds memory allocated for visible geometry indices.");
+
                 memcpy(&visibleGeometry.m_indices[0], indexPtr, indexBufferViewDesc.m_elementCount * indexBufferViewDesc.m_elementSize);
 
+                // Reserve space for vertices and copy data, assuming stride between elements is 0.
                 visibleGeometry.m_vertices.resize_no_construct(positionBufferViewDesc.m_elementCount * ElementsPerVertex);
+
+                AZ_Assert(
+                    (sizeof(visibleGeometry.m_vertices[0]) * visibleGeometry.m_vertices.size()) >=
+                    (positionBufferViewDesc.m_elementSize * positionBufferViewDesc.m_elementCount),
+                    "Position buffer size exceeds memory allocated for visible geometry vertices.");
+
                 memcpy(&visibleGeometry.m_vertices[0], positionPtr, positionBufferViewDesc.m_elementCount * positionBufferViewDesc.m_elementSize);
 
                 geometryContainer.emplace_back(AZStd::move(visibleGeometry));

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -22,6 +22,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Render/GeometryIntersectionBus.h>
 #include <AzFramework/Visibility/BoundsBus.h>
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
 
 namespace AZ
 {
@@ -60,6 +61,7 @@ namespace AZ
             , private MeshHandleStateRequestBus::Handler
             , private AtomImGuiTools::AtomImGuiMeshCallbackBus::Handler
             , public AzFramework::BoundsRequestBus::Handler
+            , public AzFramework::VisibleGeometryRequestBus::Handler
             , public AzFramework::RenderGeometry::IntersectionRequestBus::Handler
             , private TransformNotificationBus::Handler
             , private MaterialConsumerRequestBus::Handler
@@ -131,9 +133,12 @@ namespace AZ
             void SetExcludeFromReflectionCubeMaps(bool excludeFromReflectionCubeMaps) override;
             bool GetExcludeFromReflectionCubeMaps() const override;
 
-            // BoundsRequestBus and MeshComponentRequestBus overrides ...
+            // AzFramework::BoundsRequestBus::Handler overrides ...
             AZ::Aabb GetWorldBounds() override;
             AZ::Aabb GetLocalBounds() override;
+
+            // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
+            void GetVisibleGeometry(AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
             // IntersectionRequestBus overrides ...
             AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -138,7 +138,7 @@ namespace AZ
             AZ::Aabb GetLocalBounds() override;
 
             // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
-            void GetVisibleGeometry(AzFramework::VisibleGeometryContainer& geometryContainer) const override;
+            void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
             // IntersectionRequestBus overrides ...
             AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) override;


### PR DESCRIPTION
## What does this PR do?

This change adds a bus and simple data structure to mine geometric data from visible or renderable components, like the mesh and shape components, without requiring access to or knowledge of the renderer or related assets. It has potential use cases for gathering and exporting scene geometry, occlusion culling, rendering debug information, and potential gameplay applications. The visible geometry data structure may be extended with additional members or flags that further described the type of geometry.

## How was this PR tested?

Added implementation for mesh component controller that builds and produces a dump of triangulated data.
Tests that compare against the expected geometry could be added for shapes and other components as implementations come online.