### PR TITLE
Fix implicit conversion from array to span

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/span.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/span.h
@@ -112,9 +112,9 @@ namespace AZStd
         template<size_t N, class = enable_if_t<extent == dynamic_extent || N == Extent>>
         constexpr span(type_identity_t<element_type> (&arr)[N]) noexcept;
 
-        template <class U, size_t N, class = enable_if_t<extent == dynamic_extent || N == Extent>>
+        template <class U, size_t N, class = enable_if_t<(extent == dynamic_extent || N == Extent) && is_convertible_v<U, T>>>
         constexpr span(array<U, N>& data) noexcept;
-        template <class U, size_t N, class = enable_if_t<extent == dynamic_extent || N == Extent>>
+        template <class U, size_t N, class = enable_if_t<(extent == dynamic_extent || N == Extent) && is_convertible_v<U, T>>>
         constexpr span(const array<U, N>& data) noexcept;
 
         template <class R, class = enable_if_t<ranges::contiguous_range<R> &&


### PR DESCRIPTION
## What does this PR do?

This PR fixes the message `Call to <function name> is ambiguous` when an `AZStd::array` is passed as a parameter to a function which accepts different types of `AZStd::span`, like this:
```
void A(AZStd::span<int> a) {  }
void A(AZStd::span<AZStd::string> a) {  }
....
AZStd::array<int, 3> b;
A(b);
```
This code change is similar to what is done eg. in the current standard library of MSVC.

## How was this PR tested?

No other tests than compiling the engine successfully
