### PR TITLE
Fix LY_3RDPARTY_PATH environment variable query being wrong

### DIFF
--- a/cmake/3rdParty.cmake
+++ b/cmake/3rdParty.cmake
@@ -30,7 +30,7 @@ function(get_default_third_party_folder output_third_party_path)
     
     # 1. Highest priority, cache variable, that will override the value of any of the cases below
     # 2. if defined in an env variable, take it from there
-    if($ENV{LY_3RDPARTY_PATH})
+    if(DEFINED ENV{LY_3RDPARTY_PATH})
         set(${output_third_party_path} $ENV{LY_3RDPARTY_PATH} PARENT_SCOPE)
         return()
     endif()


### PR DESCRIPTION
## What does this PR do?

The query for the environment variable `LY_3RDPARTY_PATH` in 3rdParty.cmake is wrong, since it does not correctly detect if a system environment variable with this name exists.
This PR changes this to the syntax as suggested by https://cmake.org/cmake/help/latest/variable/ENV.html , which is also the syntax used in other CMake scripts in the engine.

## How was this PR tested?

After defining the LY_3RDPARTY_PATH-Variable in the Windows dialog "Environment Variables", it was picked up by the engine (eg. cmake output "-- Using package ..."), which was not the case before.
