### PR TITLE
[Vulkan] Fix crash when resizing the window

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -106,6 +106,9 @@ namespace AZ
             // create the ray tracing pipeline state object
             m_rayTracingPipelineState = RHI::Factory::Get().CreateRayTracingPipelineState();
             m_rayTracingPipelineState->Init(*device.get(), &descriptor);
+
+            // Since the ray tracing pipeline state changed, we need to rebuilt the shader table
+            m_rayTracingRevision = 0;
         }
 
         bool DiffuseProbeGridRayTracingPass::IsEnabled() const


### PR DESCRIPTION
## What does this PR do?

Fix crash when using a diffuse grid component and resizing the window on Vulkan
Fixes #16369

## How was this PR tested?

Run AutomatedTesting's level Graphics/Sponza.prefab on Vulkan and resized the 3d viewport.
