### PR TITLE
Added SerializeContext reflection for the SettingsRegistryScriptProxy

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1631,12 +1631,7 @@ namespace AZ
         Name::Reflect(context);
         // reflect path
         IO::PathReflect(context);
-
-        // reflect the SettingsRegistryInterface, SettignsRegistryImpl and the global Settings Registry
-        // instance (AZ::SettingsRegistry::Get()) into the Behavior Context
-        if (auto behaviorContext{ azrtti_cast<AZ::BehaviorContext*>(context) }; behaviorContext != nullptr)
-        {
-            AZ::SettingsRegistryScriptUtils::ReflectSettingsRegistryToBehaviorContext(*behaviorContext);
-        }
+        // reflect the SettingsRegistryInterface and SettingsRegistryImpl
+        AZ::SettingsRegistryScriptUtils::ReflectSettingsRegistry(context);
     }
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Settings/SettingsRegistryScriptUtils.h>
@@ -391,5 +392,17 @@ namespace AZ::SettingsRegistryScriptUtils
         Internal::ReflectSettingsRegistryCreateMethod(behaviorContext);
         // Reflect SettingsRegistryInterface Format enum
         Internal::ReflectSettingsRegistryMergeFormatEnum(behaviorContext);
+    }
+
+    void ReflectSettingsRegistry(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext{ azrtti_cast<AZ::SerializeContext*>(context) }; serializeContext != nullptr)
+        {
+            serializeContext->Class<Internal::SettingsRegistryScriptProxy>();
+        }
+        if (auto behaviorContext{ azrtti_cast<AZ::BehaviorContext*>(context) }; behaviorContext != nullptr)
+        {
+            AZ::SettingsRegistryScriptUtils::ReflectSettingsRegistryToBehaviorContext(*behaviorContext);
+        }
     }
 }

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.h
@@ -22,6 +22,7 @@ namespace AZ::SettingsRegistryScriptUtils
     //! Furthermore reflects a global property that wraps the AZ::SettingsRegistry Interface<T> instance to provide access
     //! to the global settings registry
     void ReflectSettingsRegistryToBehaviorContext(AZ::BehaviorContext& behaviorContext);
+    void ReflectSettingsRegistry(AZ::ReflectContext* reflectContext);
 }
 
 namespace AZ::SettingsRegistryScriptUtils::Internal


### PR DESCRIPTION
The SettingsRegistryScriptProxy is a proxy class which exposes access to the Settings Registry in a more user friendly way to scripters.

Because it is available in ScriptCanvas and is a data slot of a script canvas node, it needs to be reflected in order to store the type of the data slot into the a .scriptcanvas file.

## How was this PR tested?

Built the SettingsRegistryScriptProxy code successfully
