### PR TITLE
Fixes a linux clang-15 compile error

### DIFF
--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -806,7 +806,6 @@ void CXConsole::DumpCVars(ICVarDumpSink* pCallback, unsigned int nFlagsFilter)
 //////////////////////////////////////////////////////////////////////////
 ICVar* CXConsole::GetCVar(const char* sName)
 {
-    assert(this);
     assert(sName);
 
     if (con_debug)


### PR DESCRIPTION
It is not valid to assert(this) and leads to a clang-15 error in warnings-as-error mode.

```XConsole.cpp:809:10: error: 'this' pointer cannot be null in
well-defined C++ code; pointer may be assumed to always convert to true
[-Werror,-Wundefined-bool-conversion]```

## How was this PR tested?

Compiling on linux clang-15.