### PR TITLE
Make any failure during export halt the process

### DIFF
--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -70,7 +70,12 @@ def process_command(args: list,
     if len(args) == 0:
         logging.error("function `process_command` must be supplied a non-empty list of arguments")
         return 1
-    return utils.CLICommand(args, cwd, logging.getLogger(), env=env).run()
+
+    # Raise an error if there was any issue running an export command
+    result = utils.CLICommand(args, cwd, logging.getLogger(), env=env).run()
+    if result != 0:
+        raise RuntimeError(f"Error running command: {args}")
+    return result
 
 
 def execute_python_script(target_script_path: pathlib.Path or str, o3de_context: O3DEScriptExportContext = None) -> int:


### PR DESCRIPTION
## What does this PR do?

Fixes #16561 

With this change, if any of the commands processed during the export workflow fail, the export process will be halted. This will alert the user immediately if any of the export commands have an issue so they can investigate.

For example, currently there is a build issue with the game and unified launchers in the MultiplayerSample in release mode. But even though they fail to build, the export process continues on. This results in the game and unified launcher packages missing the game and unified launcher executables.

With this change, the export command will (properly) fail at this section:

```
[INFO] root:   MultiplayerSample.Client.vcxproj -> D:\MultiplayerSample\build\mono\lib\release\MultiplayerSample.Client.lib
[INFO] root:   unity_0_cxx.cxx
[INFO] root: D:/MultiplayerSampleAssets/Gems/O3DEPopcornFXPlugin/Code/Source/Integration/Startup/PopcornFxStartup.cpp(211,121): error C2220: the following warning is treated as an error [D:\MultiplayerSample\build\mono\External\O3DEPopcornFXPlugin-68d3a0d7\Code\PopcornFX.vcxproj]
[INFO] root: D:/MultiplayerSampleAssets/Gems/O3DEPopcornFXPlugin/Code/Source/Integration/Startup/PopcornFxStartup.cpp(211,121): error C2220:                     AZ_Error("PopcornFX", false, "Could not create some of the explicitely affinitized worker-threads."); [D:\MultiplayerSample\build\mono\External\O3DEPopcornFXPlugin-68d3a0d7\Code\PopcornFX.vcxproj]
[INFO] root: D:/MultiplayerSampleAssets/Gems/O3DEPopcornFXPlugin/Code/Source/Integration/Startup/PopcornFxStartup.cpp(211,121): error C2220:                                                                                                                         ^ [D:\MultiplayerSample\build\mono\External\O3DEPopcornFXPlugin-68d3a0d7\Code\PopcornFX.vcxproj]
[INFO] root: D:/MultiplayerSampleAssets/Gems/O3DEPopcornFXPlugin/Code/Source/Integration/Startup/PopcornFxStartup.cpp(211,121): warning C4390: ';': empty controlled statement found; is this the intent? [D:\MultiplayerSample\build\mono\External\O3DEPopcornFXPlugin-68d3a0d7\Code\PopcornFX.vcxproj]
[INFO] root:
[INFO] root: Terminating process 'cmake' with PID(40344)
[INFO] root: process 'cmake' with PID(40344) terminated with exit code 1
[ERROR] o3de.utils: Failed to run script 'D:\github\o3de\scripts\o3de\ExportScripts\export_standalone_monolithic_project_centric.py'. Here is the stacktrace:
Traceback (most recent call last):
  File "D:\github\o3de\scripts\o3de\o3de\utils.py", line 196, in load_and_execute_script
    spec.loader.exec_module(script_module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "D:\github\o3de\scripts\o3de\ExportScripts\export_standalone_monolithic_project_centric.py", line 344, in <module>
    export_standalone_monolithic_project_centric(o3de_context.project_path,
  File "D:\github\o3de\scripts\o3de\ExportScripts\export_standalone_monolithic_project_centric.py", line 257, in export_standalone_monolithic_project_centric
    build_monolithic_code_modules(project_path, project_name, build_config, mono_build_path,
  File "D:\github\o3de\scripts\o3de\ExportScripts\export_standalone_monolithic_project_centric.py", line 85, in build_monolithic_code_modules
    result = process_command(["cmake", "--build", mono_build_path, "--target", f"{project_name}.GameLauncher", "--config", build_config, "--", "/m"])
  File "D:\github\o3de\scripts\o3de\o3de\export_project.py", line 76, in process_command
    raise RuntimeError(f"Error running command: {args}")
RuntimeError: Error running command: ['cmake', '--build', WindowsPath('D:/MultiplayerSample/build/mono'), '--target', 'MultiplayerSample.GameLauncher', '--config', 'release', '--', '/m']
[INFO] o3de: Completed with issues: result 1
```

## How was this PR tested?

Verified export command halts once it encounters an error (e.g. MPS building game/unified launchers). Fixed the MPS launcher build errors locally and re-ran the export command and verified it completes successfully with packages that contain the game/unified launchers.