### PR TITLE
Fixed missing aliases in audio gems for unified launchers

### DIFF
--- a/Gems/AudioEngineWwise/Code/CMakeLists.txt
+++ b/Gems/AudioEngineWwise/Code/CMakeLists.txt
@@ -72,6 +72,7 @@ ly_add_target(
 )
 
 ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS Gem::${gem_name})
 
 ################################################################################
 # Tests

--- a/Gems/AudioSystem/Code/CMakeLists.txt
+++ b/Gems/AudioSystem/Code/CMakeLists.txt
@@ -74,9 +74,11 @@ ly_add_target(
             Gem::${gem_name}.Private.Object
 )
 
-# AudioSystem aliases for Clients (no Servers)
+# AudioSystem aliases for Clients and Unified launchers (no Servers)
 ly_create_alias(NAME ${gem_name}.Clients        NAMESPACE Gem TARGETS Gem::${gem_name})
 ly_create_alias(NAME ${gem_name}.Clients.API    NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Unified        NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Unified.API    NAMESPACE Gem TARGETS Gem::${gem_name}.API)
 
 ################################################################################
 # Tests


### PR DESCRIPTION
## What does this PR do?

This PR adds aliases in our audio gems so that unified launchers can depend on them. Otherwise, audio won't be loaded in the unified launchers (in the case that the game depends on audio).

This is the other half of the fix required to get audio working in the MultiplayerSample unified launcher: https://github.com/o3de/o3de-multiplayersample/pull/462

## How was this PR tested?

Built the MultiplayerSample unified launcher and verified that the audio now works. Also tested the game launcher and verified audio continues to work for it as well.