### PR TITLE
Add support to pad skinned mesh buffers to respect needed alignment

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
@@ -136,6 +136,7 @@ namespace AZ
 
         void Device::EndFrameInternal()
         {
+            m_bindlessArgumentBuffer.GarbageCollect();
             m_argumentBufferConstantsAllocator.GarbageCollect();
             m_argumentBufferAllocator.GarbageCollect();
             m_commandQueueContext.End();

--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -23,54 +23,25 @@ if(PAL_TRAIT_ATOM_RHI_VULKAN_TARGETS_ALREADY_DEFINED)
     return() # Vulkan targets already defined in PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
 endif()
 
-if(NOT PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED)
 
-    # Create stub modules. Once we support gem loading configuration, we can remove this stubbed targets
-    ly_add_target(
-        NAME Atom_RHI_Vulkan.Private ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
-        NAMESPACE Gem
-        FILES_CMAKE
-            atom_rhi_vulkan_stub_module.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Source
-        BUILD_DEPENDENCIES
-            PRIVATE
-                AZ::AzCore
-                Gem::Atom_RHI.Reflect
-    )
-
-    if(PAL_TRAIT_BUILD_HOST_TOOLS)
-        ly_add_target(
-            NAME Atom_RHI_Vulkan.Builders GEM_MODULE
-
-            NAMESPACE Gem
-            FILES_CMAKE
-                ${pal_source_dir}/platform_builders_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-                ${pal_include_dir}/platform_builders_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-                atom_rhi_vulkan_reflect_common_files.cmake
-                atom_rhi_vulkan_builders_common_files.cmake
-            INCLUDE_DIRECTORIES
-                PRIVATE
-                    Include
-                    ${pal_include_dir}
-                    Source
-                    ${pal_source_dir}
-
-            BUILD_DEPENDENCIES
-                PRIVATE
-                    AZ::AzCore
-                    AZ::AssetBuilderSDK
-                    Gem::Atom_RHI.Edit
-                    Gem::Atom_RHI.Reflect
-                    Gem::Atom_RHI_Vulkan.Glad.Static
-
-        )
-    endif()
-
-    return() # Do not create the rest of the targets
-
-endif()
+ly_add_target(
+    NAME Atom_RHI_Vulkan.Glad.Static STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        atom_rhi_vulkan_glad_files.cmake
+        ${pal_include_dir}/platform_glad_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+        ${pal_source_dir}/platform_glad_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include
+            Include/Atom/RHI.Loader/Glad
+            ${pal_include_dir}
+    BUILD_DEPENDENCIES
+        PRIVATE
+            AZ::AzCore
+        PUBLIC
+            3rdParty::glad_vulkan
+)
 
 ly_add_target(
     NAME Atom_RHI_Vulkan.Reflect STATIC
@@ -91,6 +62,73 @@ ly_add_target(
             Gem::Atom_RHI.Reflect
             Gem::Atom_RHI_Vulkan.Glad.Static
 )
+
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_add_target(
+        NAME Atom_RHI_Vulkan.Builders.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            atom_rhi_vulkan_builders_common_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+                ${pal_source_dir}
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::AzCore
+                AZ::AssetBuilderSDK
+                Gem::Atom_RHI.Reflect
+                Gem::Atom_RHI_Vulkan.Reflect
+    )
+
+    ly_add_target(
+        NAME Atom_RHI_Vulkan.Builders GEM_MODULE
+
+        NAMESPACE Gem
+        FILES_CMAKE
+            ${pal_source_dir}/platform_builders_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+                ${pal_source_dir}
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::AzCore
+                Gem::Atom_RHI.Reflect
+                Gem::Atom_RHI.Public
+                Gem::Atom_RHI_Vulkan.Reflect
+                Gem::Atom_RHI_Vulkan.Builders.Static
+                Gem::Atom_RHI.Edit
+        )
+
+endif()
+
+if(NOT PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED)
+
+    # Create stub modules. Once we support gem loading configuration, we can remove this stubbed targets
+    ly_add_target(
+        NAME Atom_RHI_Vulkan.Private ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+        NAMESPACE Gem
+        FILES_CMAKE
+            atom_rhi_vulkan_stub_module.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::AzCore
+                Gem::Atom_RHI.Reflect
+    )
+
+    return() # Do not create the rest of the targets
+
+endif()
+
+
 
 ly_add_target(
     NAME Atom_RHI_Vulkan.Private.Static STATIC
@@ -140,66 +178,3 @@ ly_add_target(
             ${VULKAN_VALIDATION_LAYER}
 )
 
-ly_add_target(
-    NAME Atom_RHI_Vulkan.Glad.Static STATIC
-    NAMESPACE Gem
-    FILES_CMAKE
-        atom_rhi_vulkan_glad_files.cmake
-        ${pal_include_dir}/platform_glad_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-        ${pal_source_dir}/platform_glad_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-    INCLUDE_DIRECTORIES
-        PUBLIC
-            Include
-            Include/Atom/RHI.Loader/Glad
-            ${pal_include_dir}
-    BUILD_DEPENDENCIES
-        PRIVATE
-            AZ::AzCore
-        PUBLIC
-            3rdParty::glad_vulkan
-)
-
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
-
-    ly_add_target(
-        NAME Atom_RHI_Vulkan.Builders.Static STATIC
-        NAMESPACE Gem
-        FILES_CMAKE
-            atom_rhi_vulkan_builders_common_files.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Source
-                ${pal_source_dir}
-            PUBLIC
-                Include
-        BUILD_DEPENDENCIES
-            PRIVATE
-                AZ::AzCore
-                AZ::AssetBuilderSDK
-                Gem::Atom_RHI.Reflect
-                Gem::Atom_RHI_Vulkan.Reflect
-    )
-
-    ly_add_target(
-        NAME Atom_RHI_Vulkan.Builders GEM_MODULE
-
-        NAMESPACE Gem
-        FILES_CMAKE
-            ${pal_source_dir}/platform_builders_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Source
-                ${pal_source_dir}
-            PUBLIC
-                Include
-        BUILD_DEPENDENCIES
-            PRIVATE
-                AZ::AzCore
-                Gem::Atom_RHI.Reflect
-                Gem::Atom_RHI.Public
-                Gem::Atom_RHI_Vulkan.Reflect
-                Gem::Atom_RHI_Vulkan.Builders.Static
-                Gem::Atom_RHI.Edit
-    )
-
-endif()

--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -109,20 +109,8 @@ endif()
 
 if(NOT PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED)
 
-    # Create stub modules. Once we support gem loading configuration, we can remove this stubbed targets
-    ly_add_target(
-        NAME Atom_RHI_Vulkan.Private ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
-        NAMESPACE Gem
-        FILES_CMAKE
-            atom_rhi_vulkan_stub_module.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Source
-        BUILD_DEPENDENCIES
-            PRIVATE
-                AZ::AzCore
-                Gem::Atom_RHI.Reflect
-    )
+    # Create alias for Atom RHI Vulkan private Gem Module
+    ly_create_alias(NAME Atom_RHI_Vulkan.Private NAMESPACE Gem)
 
     return() # Do not create the rest of the targets
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
@@ -157,16 +157,7 @@ namespace AZ
                 "Aligned count should be equal or greater as we are aligning up. Aligned value %i BufferSize %i",
                 alignedCount,
                 streamBuffer.size());
-            size_t alignmentCountDelta = alignedCount - streamBuffer.size();
-
-            // Pad the buffer in order to respect the alignment
-            if (alignmentCountDelta > 0)
-            {
-                for (int i = 0; i < alignmentCountDelta; i++)
-                {
-                    streamBuffer.emplace_back(static_cast<T>(0));
-                }
-            }
+            streamBuffer.resize(alignedCount, static_cast<T>(0));
         }
     } //namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
@@ -162,8 +162,6 @@ namespace AZ
             // Pad the buffer in order to respect the alignment
             if (alignmentCountDelta > 0)
             {
-                //AZStd::vector<T> extraIds(alignmentCountDelta, 0);
-                //streamBuffer.insert(streamBuffer.end(), extraIds.begin(), extraIds.end());
                 for (int i = 0; i < alignmentCountDelta; i++)
                 {
                     streamBuffer.emplace_back(static_cast<T>(0));

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
@@ -14,6 +14,47 @@ namespace AZ
 {
     namespace RPI
     {
+        namespace 
+        {
+            const uint32_t PositionFloatsPerVert = 3;
+            const uint32_t NormalFloatsPerVert = 3;
+            const uint32_t UVFloatsPerVert = 2;
+            const uint32_t ColorFloatsPerVert = 4;
+            const uint32_t TangentFloatsPerVert = 4; // The 4th channel is used to indicate handedness of the bitangent, either 1 or -1.
+            const uint32_t BitangentFloatsPerVert = 3;
+
+            const AZ::RHI::Format IndicesFormat = AZ::RHI::Format::R32_UINT;
+            const AZ::RHI::Format PositionFormat = AZ::RHI::Format::R32G32B32_FLOAT;
+            const AZ::RHI::Format NormalFormat = AZ::RHI::Format::R32G32B32_FLOAT;
+            const AZ::RHI::Format UVFormat = AZ::RHI::Format::R32G32_FLOAT;
+            const AZ::RHI::Format ColorFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
+            const AZ::RHI::Format BitangentFormat = AZ::RHI::Format::R32G32B32_FLOAT;
+            // The 4th channel is used to indicate handedness of the bitangent, either 1 or -1.
+            const AZ::RHI::Format TangentFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
+            const AZ::RHI::Format SkinIndicesFormat = AZ::RHI::Format::R16_UINT; // Single-component, 16-bit int per weight
+            const AZ::RHI::Format SkinWeightFormat = AZ::RHI::Format::R32_FLOAT; // Single-component, 32-bit floating point per weight
+
+            const char* ShaderSemanticName_SkinJointIndices = "SKIN_JOINTINDICES";
+            const char* ShaderSemanticName_SkinWeights = "SKIN_WEIGHTS";
+
+            // Morph targets
+            const char* ShaderSemanticName_MorphTargetDeltas = "MORPHTARGET_VERTEXDELTAS";
+
+            // Cloth data
+            const char* const ShaderSemanticName_ClothData = "CLOTH_DATA";
+            const uint32_t ClothDataFloatsPerVert = 4;
+            const AZ::RHI::Format ClothDataFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
+
+            // We align all the skinned mesh related stream buffers to 192 bytes for various reasons.
+            // Metal has a restriction where each typed buffer needs to start at 64 byte boundary.
+            // At the same time a lot of our stream buffer views are RGB or RGBA so they need to be 12 and
+            // 16 byte aligned or all the element count/element offset logic will break. Changing stream buffer
+            // views to R32 is also an option but it will break vertex shaders where they expect RGB views for IA buffers (for example t-pose for
+            // skinned mesh). In order to satisfy 64/16/12 byte alignment we align all buffers to 192. This way we can meet metal's
+            // restriction as well as maintain RGB/RGBA stream buffer views.
+            const uint32_t SkinnedMeshBufferAlignment = 192;
+        }
+
         //! ModelAssetHelpers is a collection of helper methods for generating or manipulating model assets.
         class ModelAssetHelpers
         {
@@ -27,6 +68,14 @@ namespace AZ
             //! This model won't have a material on it so it requires a separate Material component to be displayable.
             //! @param modelAsset An empty modelAsset that will get filled in with unit X data.
             static void CreateUnitX(ModelAsset* modelAsset);
+
+
+            template<typename T>
+            static size_t GetAlignedCount(size_t vertexCount, AZ::RHI::Format bufferFormat, uint32_t alignment);
+
+            template<typename T>
+            static void AlignStreamBuffer(
+                AZStd::vector<T>& streamBuffer, size_t vertexCount, AZ::RHI::Format bufferFormat, uint32_t alignment);
 
         private:
             //! Create a BufferAsset from the given data buffer.
@@ -55,5 +104,39 @@ namespace AZ
                 AZStd::span<const float> bitangents,
                 AZStd::span<const float> uvs);
         };
+
+        template<typename T>
+        size_t ModelAssetHelpers::GetAlignedCount(size_t vertexCount, AZ::RHI::Format bufferFormat, uint32_t alignment)
+        {
+            //Calculate vertex data in bytes
+            size_t vertexDataInBytes = vertexCount * RHI::GetFormatSize(bufferFormat);
+
+            //Align up the appropriate alignment. Alignment can be non-power of two.
+            size_t alignedVertexDataInBytes = RHI::AlignUpNPOT(vertexDataInBytes, alignment);
+
+            //Calculate the aligned element count
+            size_t alignedVertexCount = alignedVertexDataInBytes / sizeof(T);
+            return alignedVertexCount;
+        }
+
+        template<typename T>
+        void ModelAssetHelpers::AlignStreamBuffer(
+            AZStd::vector<T>& streamBuffer, size_t vertexCount, AZ::RHI::Format bufferFormat, uint32_t alignment)
+        {
+            size_t alignedCount = GetAlignedCount<T>(vertexCount, bufferFormat, alignment);
+            AZ_Assert(
+                alignedCount >= streamBuffer.size(),
+                "Aligned count should be equal or greater as we are aligning up. Aligned value %i BufferSize %i",
+                alignedCount,
+                streamBuffer.size());
+            size_t alignmentCountDelta = alignedCount - streamBuffer.size();
+
+            // Pad the buffer in order to respect the alignment
+            if (alignmentCountDelta > 0)
+            {
+                AZStd::vector<T> extraIds(alignmentCountDelta, 0);
+                streamBuffer.insert(streamBuffer.end(), extraIds.begin(), extraIds.end());
+            }
+        }
     } //namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
@@ -149,6 +149,10 @@ namespace AZ
             const AZ::Aabb& GetAabb() const;
 
             Data::Asset<BufferAsset> GetIndexBufferAsset() const { return m_indexBuffer; }
+
+            //! A helper method for returning a specific buffer asset view related to mesh associated with mesh index.
+            const BufferAssetView* GetSemanticBufferAssetView(const AZ::Name& semantic, uint32_t meshIndex = 0) const;
+
         private:
             // AssetData overrides...
             bool HandleAutoReload() override

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -1509,7 +1509,7 @@ namespace AZ
                 uint32_t meshVertexCount = meshPositionsFloatCount / PositionFloatsPerVert;
                 if (hasSkinData)
                 {
-                    // Skinned buffers are padded so true vertex count is cached a part of the mesh and used here.
+                    // Skinned buffers are padded so true vertex count is cached as part of the mesh and used here.
                     meshVertexCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount);
                 }
 
@@ -1602,7 +1602,7 @@ namespace AZ
                     const size_t totalVertexInfluences = mesh.m_influencesPerVertex * mesh.m_vertexCount;
                     AZ_Assert(
                         mesh.m_skinJointIndices.size() >= totalVertexInfluences && mesh.m_skinWeights.size() >= totalVertexInfluences,
-                        "Number of allocated skin influence joint indices (%d) and the number of weights (%d) should be above (%d)  .",
+                        "Number of allocated skin influence joint indices (%zu) and the number of weights (%zu) should be above (%zu)  .",
                         mesh.m_skinJointIndices.size(),
                         mesh.m_skinWeights.size(),
                         totalVertexInfluences);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -86,7 +86,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<ModelAssetBuilderComponent, SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(42);  // Fix vertex welding
+                    ->Version(36);  // Pad Skinning mesh buffers to respect appropriate alignment
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -86,7 +86,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<ModelAssetBuilderComponent, SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(36);  // Pad Skinning mesh buffers to respect appropriate alignment
+                    ->Version(38);  // Pad Skinning mesh buffers to respect appropriate alignment
             }
         }
 
@@ -1284,7 +1284,7 @@ namespace AZ
             size_t expectedVertexCount,
             const AZStd::vector<T>& bufferData,
             AZ::RHI::Format format,
-            const char* streamName,
+            [[maybe_unused]] const char* streamName,
             bool isAligned /*= false*/) const
         {
             size_t actualVertexCount = (bufferData.size() * sizeof(T)) / RHI::GetFormatSize(format);
@@ -1599,7 +1599,7 @@ namespace AZ
                             mesh.m_name.GetCStr());
                     }
 
-                    const size_t totalVertexInfluences = mesh.m_influencesPerVertex * mesh.m_vertexCount;
+                    [[maybe_unused]] const size_t totalVertexInfluences = mesh.m_influencesPerVertex * mesh.m_vertexCount;
                     AZ_Assert(
                         mesh.m_skinJointIndices.size() >= totalVertexInfluences && mesh.m_skinWeights.size() >= totalVertexInfluences,
                         "Number of allocated skin influence joint indices (%zu) and the number of weights (%zu) should be above (%zu)  .",

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -25,6 +25,7 @@
 #include <Atom/RPI.Reflect/Model/MorphTargetDelta.h>
 #include <Atom/RPI.Reflect/Model/SkinJointIdPadding.h>
 #include <Atom/RPI.Reflect/Model/SkinMetaAssetCreator.h>
+#include <Atom/RPI.Reflect/Model/ModelAssetHelpers.h>
 
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
@@ -61,36 +62,6 @@ static constexpr AZStd::string_view MismatchedVertexLayoutsAreErrorsKey{ "/O3DE/
   */
 #define AZ_RPI_MESHES_SHARE_COMMON_BUFFERS
 
-namespace
-{
-    const AZ::RHI::Format IndicesFormat = AZ::RHI::Format::R32_UINT;
-
-    const uint32_t PositionFloatsPerVert = 3;
-    const uint32_t NormalFloatsPerVert   = 3;
-    const uint32_t UVFloatsPerVert       = 2;
-    const uint32_t ColorFloatsPerVert    = 4;
-    const uint32_t TangentFloatsPerVert  = 4; // The 4th channel is used to indicate handedness of the bitangent, either 1 or -1.
-    const uint32_t BitangentFloatsPerVert = 3; 
-    
-    const AZ::RHI::Format PositionFormat = AZ::RHI::Format::R32G32B32_FLOAT;
-    const AZ::RHI::Format NormalFormat   = AZ::RHI::Format::R32G32B32_FLOAT;
-    const AZ::RHI::Format UVFormat       = AZ::RHI::Format::R32G32_FLOAT;
-    const AZ::RHI::Format ColorFormat    = AZ::RHI::Format::R32G32B32A32_FLOAT;
-    const AZ::RHI::Format TangentFormat = AZ::RHI::Format::R32G32B32A32_FLOAT; // The 4th channel is used to indicate handedness of the bitangent, either 1 or -1.
-    const AZ::RHI::Format BitangentFormat = AZ::RHI::Format::R32G32B32_FLOAT;
-
-    const char* ShaderSemanticName_SkinJointIndices = "SKIN_JOINTINDICES";
-    const char* ShaderSemanticName_SkinWeights = "SKIN_WEIGHTS";
-    const AZ::RHI::Format SkinWeightFormat = AZ::RHI::Format::R32_FLOAT; // Single-component, 32-bit floating point per weight
-
-    // Morph targets
-    const char* ShaderSemanticName_MorphTargetDeltas = "MORPHTARGET_VERTEXDELTAS";
-
-    // Cloth data
-    const char* const ShaderSemanticName_ClothData = "CLOTH_DATA";
-    const uint32_t ClothDataFloatsPerVert = 4;
-    const AZ::RHI::Format ClothDataFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
-}
 
 namespace AZ
 {
@@ -115,7 +86,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<ModelAssetBuilderComponent, SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(35);  // Fix vertex welding
+                    ->Version(42);  // Fix vertex welding
             }
         }
 
@@ -385,7 +356,7 @@ namespace AZ
             
             ModelAssetCreator modelAssetCreator;
             modelAssetCreator.Begin(modelAssetId);
-
+            modelAssetCreator.SetName(modelAssetName);
             AZStd::shared_ptr<const SceneAPI::DataTypes::ITagRule> tagRule = context.m_group.GetRuleContainerConst().FindFirstByType<SceneAPI::DataTypes::ITagRule>();
             if (tagRule)
             {
@@ -492,7 +463,7 @@ namespace AZ
                             return AZ::SceneAPI::Events::ProcessingResult::Failure;
                         }
 
-                        if (!CreateMesh(meshView, indexBuffer, streamBuffers, lodAssetCreator, context.m_materialsByUid))
+                        if (!CreateMesh(meshView, indexBuffer, streamBuffers, modelAssetCreator, lodAssetCreator, context.m_materialsByUid))
                         {
                             return AZ::SceneAPI::Events::ProcessingResult::Failure;
                         }
@@ -762,7 +733,12 @@ namespace AZ
                     AZStd::vector<AZ::Name>& colorNames = productMesh.m_colorCustomNames;
                     AZStd::vector<float>& clothData = productMesh.m_clothData;
 
+                    AZStd::vector<uint16_t>& skinJointIndices = productMesh.m_skinJointIndices;
+                    AZStd::vector<float>& skinWeights = productMesh.m_skinWeights;
+
                     const size_t vertexCount = oldToNewIndices.size();
+                    productMesh.m_vertexCount = vertexCount;
+
                     positions.reserve(vertexCount * PositionFloatsPerVert);
                     normals.reserve(vertexCount * NormalFloatsPerVert);
 
@@ -851,7 +827,7 @@ namespace AZ
                             sourceMesh, oldToNewIndices, warnedExcessOfSkinInfluences);
 
                         const uint32_t totalInfluences = productMesh.m_influencesPerVertex * aznumeric_cast<uint32_t>(vertexCount);
-                        productMesh.m_skinJointIndices.reserve(totalInfluences + CalculateJointIdPaddingCount(totalInfluences));
+                        productMesh.m_skinJointIndices.reserve(totalInfluences);
                         productMesh.m_skinWeights.reserve(totalInfluences);
                     }
 
@@ -959,6 +935,23 @@ namespace AZ
                         }
                     }// for each vertex in old to new indices
 
+                    // Align all the stream buffers to ensure they all padded to SkinnedMeshBufferAlignment byte boundary.
+                    // This is done to ensure that we can respect Metal's requirement of having typed buffers aligned to 64.
+                    // We also need to align to 16 and 12 byte boundary in order to respect RGB32 and RGBA32 buffer views.
+                    if (hasSkinData)
+                    {
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(positions, vertexCount, PositionFormat, SkinnedMeshBufferAlignment);
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(normals, vertexCount, NormalFormat, SkinnedMeshBufferAlignment);
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(tangents, vertexCount, TangentFormat, SkinnedMeshBufferAlignment);
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(bitangents, vertexCount, BitangentFormat, SkinnedMeshBufferAlignment);
+                        
+                        const size_t totalVertexInfluences = productMesh.m_influencesPerVertex * vertexCount;
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(
+                            skinJointIndices, totalVertexInfluences, SkinIndicesFormat, SkinnedMeshBufferAlignment);
+                        RPI::ModelAssetHelpers::AlignStreamBuffer(
+                            skinWeights, totalVertexInfluences, SkinWeightFormat, SkinnedMeshBufferAlignment);
+                    }
+
                     // A morph target that only influenced one source mesh might be split over multiple product meshes
                     // if the source mesh had multiple materials and was split up.
                     // So here, we need to know the start and end indices of the current product mesh within the original source
@@ -992,12 +985,16 @@ namespace AZ
                     // of total elements. Pad buffers with missing data to make them align with positions and normals
                     if (productMesh.m_tangents.empty())
                     {
-                        productMesh.m_tangents.resize(vertexCount * TangentFloatsPerVert, 1.0f);
+                        size_t alignedVertexCount =
+                            RPI::ModelAssetHelpers::GetAlignedCount<float>(vertexCount, TangentFormat, SkinnedMeshBufferAlignment);
+                        productMesh.m_tangents.resize(alignedVertexCount, 1.0f);
                         AZ_Warning(s_builderName, false, "Mesh '%s' is missing tangents and no defaults were generated. Skinned meshes require tangents. Dummy tangents will be inserted, which may result in rendering artifacts.", productMesh.m_name.GetCStr());
                     }
                     if (productMesh.m_bitangents.empty())
                     {
-                        productMesh.m_bitangents.resize(vertexCount * BitangentFloatsPerVert, 1.0f);
+                        size_t alignedVertexCount =
+                            RPI::ModelAssetHelpers::GetAlignedCount<float>(vertexCount, BitangentFormat, SkinnedMeshBufferAlignment);
+                        productMesh.m_bitangents.resize(alignedVertexCount, 1.0f);
                         AZ_Warning(s_builderName, false, "Mesh '%s' is missing bitangents and no defaults were generated. Skinned meshes require bitangents. Dummy bitangents will be inserted, which may result in rendering artifacts.", productMesh.m_name.GetCStr());
                     }
                 }
@@ -1283,12 +1280,28 @@ namespace AZ
         }
 
         template<typename T>
-        bool ModelAssetBuilderComponent::ValidateStreamSize([[maybe_unused]] size_t expectedVertexCount, [[maybe_unused]] const AZStd::vector<T>& bufferData, [[maybe_unused]] AZ::RHI::Format format, [[maybe_unused]] const char* streamName) const
+        bool ModelAssetBuilderComponent::ValidateStreamSize(
+            size_t expectedVertexCount,
+            const AZStd::vector<T>& bufferData,
+            AZ::RHI::Format format,
+            const char* streamName,
+            bool isAligned /*= false*/) const
         {
             size_t actualVertexCount = (bufferData.size() * sizeof(T)) / RHI::GetFormatSize(format);
             bool vertexCountMatchesExpected = expectedVertexCount == actualVertexCount;
+
+            //If the buffer is aligned it will have padded data so need to account for that. 
+            if (isAligned)
+            {
+                size_t expectedPaddedVertexCountInT =
+                    RPI::ModelAssetHelpers::GetAlignedCount<T>(expectedVertexCount, format, SkinnedMeshBufferAlignment);
+                size_t expectedPaddedVertexCount = expectedPaddedVertexCountInT / RHI::GetFormatComponentCount(format);
+                vertexCountMatchesExpected = expectedPaddedVertexCount == actualVertexCount;
+            }
+
             AZ_Error(
-                s_builderName, vertexCountMatchesExpected,
+                s_builderName,
+                vertexCountMatchesExpected,
                 "VertexStream '%s' does not match the expected vertex count. This typically means multiple sub-meshes have mis-matched "
                 "vertex stream layouts (such as one having more uv sets than the other) but are assigned the same material in the dcc tool "
                 "so they were merged.",
@@ -1299,41 +1312,54 @@ namespace AZ
         bool ModelAssetBuilderComponent::ValidateStreamAlignment(const ProductMeshContent& mesh) const
         {
             bool success = true;
-            size_t expectedVertexCount = mesh.m_positions.size() * sizeof(mesh.m_positions[0]) / RHI::GetFormatSize(PositionFormat);
+            const bool hasSkinData = !mesh.m_skinJointIndices.empty() && !mesh.m_skinWeights.empty();
+            if (!mesh.m_positions.empty())
+            {
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_positions, PositionFormat, "POSITION", hasSkinData);
+            }
             if (!mesh.m_normals.empty())
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_normals, NormalFormat, "NORMAL");
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_normals, NormalFormat, "NORMAL", hasSkinData);
             }
             if (!mesh.m_tangents.empty())
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_tangents, TangentFormat, "TANGENT");
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_tangents, TangentFormat, "TANGENT", hasSkinData);
             }
             if (!mesh.m_bitangents.empty())
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_bitangents, BitangentFormat, "BITANGENT");
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_bitangents, BitangentFormat, "BITANGENT", hasSkinData);
             }
+
             for (size_t i = 0; i < mesh.m_uvSets.size(); ++i)
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_uvSets[i], UVFormat, mesh.m_uvCustomNames[i].GetCStr());
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_uvSets[i], UVFormat, mesh.m_uvCustomNames[i].GetCStr());
             }
             for (size_t i = 0; i < mesh.m_colorSets.size(); ++i)
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_colorSets[i], ColorFormat, mesh.m_colorCustomNames[i].GetCStr());
+                success &=
+                    ValidateStreamSize(mesh.m_vertexCount, mesh.m_colorSets[i], ColorFormat, mesh.m_colorCustomNames[i].GetCStr());
             }
             if (!mesh.m_clothData.empty())
             {
-                success &= ValidateStreamSize(expectedVertexCount, mesh.m_clothData, ClothDataFormat, ShaderSemanticName_ClothData);
+                success &= ValidateStreamSize(mesh.m_vertexCount, mesh.m_clothData, ClothDataFormat, ShaderSemanticName_ClothData);
             }
             if (!mesh.m_skinJointIndices.empty())
             {
                 success &= ValidateStreamSize(
-                    expectedVertexCount * mesh.m_influencesPerVertex, mesh.m_skinJointIndices, AZ::RHI::Format::R16_UINT,
-                    ShaderSemanticName_SkinJointIndices);
+                    mesh.m_vertexCount * mesh.m_influencesPerVertex,
+                    mesh.m_skinJointIndices,
+                    AZ::RHI::Format::R16_UINT,
+                    ShaderSemanticName_SkinJointIndices,
+                    hasSkinData);  
             }
             if (!mesh.m_skinWeights.empty())
             {
                 success &= ValidateStreamSize(
-                    expectedVertexCount * mesh.m_influencesPerVertex, mesh.m_skinWeights, SkinWeightFormat, ShaderSemanticName_SkinWeights);
+                    mesh.m_vertexCount * mesh.m_influencesPerVertex,
+                    mesh.m_skinWeights,
+                    SkinWeightFormat,
+                    ShaderSemanticName_SkinWeights,
+                    hasSkinData);
             }
 
             return success;
@@ -1350,6 +1376,13 @@ namespace AZ
 
             auto meshPositionCount = meshPositionsFloatCount / PositionFloatsPerVert;
             auto meshNormalsCount = meshNormalsFloatCount / NormalFloatsPerVert;
+            const bool hasSkinData = !mesh.m_skinJointIndices.empty() && !mesh.m_skinWeights.empty();
+            if (hasSkinData)
+            {
+                // Skinned buffers are padded so true vertex count is cached a part of the mesh and used here.
+                meshPositionCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount);
+                meshNormalsCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount);
+            }
 
             meshView.m_indexView = RHI::BufferViewDescriptor::CreateTyped(0, meshIndexCount, IndicesFormat);
             meshView.m_positionView = RHI::BufferViewDescriptor::CreateTyped(0, meshPositionCount, PositionFormat);
@@ -1397,11 +1430,10 @@ namespace AZ
 
             if (!mesh.m_skinJointIndices.empty() && !mesh.m_skinWeights.empty())
             {
-                const size_t numSkinInfluences = mesh.m_skinWeights.size();
-
-                uint32_t jointIndicesSizeInBytes = static_cast<uint32_t>(numSkinInfluences * sizeof(uint16_t));
+                const size_t numSkinInfluences = meshPositionCount * mesh.m_influencesPerVertex;
+                const uint32_t jointIndicesSizeInBytes = static_cast<uint32_t>(numSkinInfluences * sizeof(uint16_t));
                 meshView.m_skinJointIndicesView = RHI::BufferViewDescriptor::CreateRaw(0, jointIndicesSizeInBytes);
-                meshView.m_skinWeightsView = RHI::BufferViewDescriptor::CreateTyped(0, static_cast<uint32_t>(numSkinInfluences), SkinWeightFormat);
+                meshView.m_skinWeightsView = RHI::BufferViewDescriptor::CreateTyped(0, aznumeric_cast<uint32_t>(numSkinInfluences),SkinWeightFormat);
             }
 
             if (!mesh.m_morphTargetVertexData.empty())
@@ -1473,7 +1505,13 @@ namespace AZ
                 meshView.m_indexView = RHI::BufferViewDescriptor::CreateTyped(static_cast<uint32_t>(lodBufferInfo.m_indexCount), meshIndexCount, IndicesFormat);
                 lodBufferInfo.m_indexCount += meshIndexCount;
 
-                const uint32_t meshVertexCount = meshPositionsFloatCount / PositionFloatsPerVert;
+                const bool hasSkinData = !mesh.m_skinJointIndices.empty() && !mesh.m_skinWeights.empty();
+                uint32_t meshVertexCount = meshPositionsFloatCount / PositionFloatsPerVert;
+                if (hasSkinData)
+                {
+                    // Skinned buffers are padded so true vertex count is cached a part of the mesh and used here.
+                    meshVertexCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount);
+                }
 
                 if (!mesh.m_positions.empty())
                 {
@@ -1560,24 +1598,21 @@ namespace AZ
                             "name %s is skinned, but previous meshes were not skinned.",
                             mesh.m_name.GetCStr());
                     }
-                    AZ_Assert(mesh.m_skinJointIndices.size() == mesh.m_skinWeights.size(),
-                        "Number of skin influence joint indices (%d) should match the number of weights (%d).",
-                        mesh.m_skinJointIndices.size(), mesh.m_skinWeights.size());
+
+                    const size_t totalVertexInfluences = mesh.m_influencesPerVertex * mesh.m_vertexCount;
+                    AZ_Assert(
+                        mesh.m_skinJointIndices.size() >= totalVertexInfluences && mesh.m_skinWeights.size() >= totalVertexInfluences,
+                        "Number of allocated skin influence joint indices (%d) and the number of weights (%d) should be above (%d)  .",
+                        mesh.m_skinJointIndices.size(),
+                        mesh.m_skinWeights.size(),
+                        totalVertexInfluences);
 
                     AZ_Assert(mesh.m_skinWeights.size() % mesh.m_influencesPerVertex == 0,
                         "The number of skin influences per vertex (%d) is not a multiple of the total number of skinning weights (%d). This means that not every vertex has exactly (%d) skinning weights and invalidates the data.",
                         mesh.m_skinWeights.size(), mesh.m_influencesPerVertex, mesh.m_influencesPerVertex);
 
                     uint32_t prevJointIdCount = aznumeric_cast<uint32_t>(lodBufferInfo.m_jointIdsCount);
-                    uint32_t newJointIdCount = aznumeric_cast<uint32_t>(mesh.m_skinJointIndices.size());
-
-                    // Pad the joint id buffer if it ends too soon, so the next view can start aligned
-                    uint32_t extraIdCount = CalculateJointIdPaddingCount(newJointIdCount);
-
-                    // Pad the buffer
-                    AZStd::vector<uint16_t> extraIds(extraIdCount, 0);
-                    mesh.m_skinJointIndices.insert(
-                        mesh.m_skinJointIndices.end(), extraIds.begin(), extraIds.end());
+                    uint32_t newJointIdCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount * mesh.m_influencesPerVertex);
 
                     AZ_Assert(prevJointIdCount * sizeof(uint16_t) % 16 == 0, "Failed to align the joint id offset along a 16-byte boundary");
 
@@ -1586,14 +1621,12 @@ namespace AZ
                         /*byteOffset=*/prevJointIdCount * sizeof(uint16_t),
                         /*byteCount*/ newJointIdCount * sizeof(uint16_t));
 
-                    // For the purpose of tracking the size of the buffer, include the padding
-                    lodBufferInfo.m_jointIdsCount += (newJointIdCount + extraIdCount);
-
+                    lodBufferInfo.m_jointIdsCount += aznumeric_cast<uint32_t>(mesh.m_skinJointIndices.size());
                     // Weights are more straightforward, just add any new weights
                     const uint32_t prevJointWeightCount = aznumeric_cast<uint32_t>(lodBufferInfo.m_jointWeightsCount);
-                    const uint32_t newJointWeightCount = aznumeric_cast<uint32_t>(mesh.m_skinWeights.size());
-                    meshView.m_skinWeightsView = RHI::BufferViewDescriptor::CreateTyped(/*elementOffset=*/prevJointWeightCount, newJointWeightCount, SkinWeightFormat);
-                    lodBufferInfo.m_jointWeightsCount += newJointWeightCount;
+                    const uint32_t newJointWeightCount = aznumeric_cast<uint32_t>(mesh.m_vertexCount * mesh.m_influencesPerVertex);
+                    meshView.m_skinWeightsView = RHI::BufferViewDescriptor::CreateTyped(prevJointWeightCount, newJointWeightCount, SkinWeightFormat);
+                    lodBufferInfo.m_jointWeightsCount += aznumeric_cast<uint32_t>(mesh.m_skinWeights.size());
                 }
                 else if (lodBufferInfo.m_jointIdsCount > 0)
                 {
@@ -1664,6 +1697,7 @@ namespace AZ
                     {
                         colorSetCounts[i] += mesh.m_colorSets[i].size();
                     }
+                    mergedMesh.m_vertexCount += mesh.m_vertexCount;
                 }
 
                 mergedMesh.m_indices.reserve(indexCount);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
@@ -122,6 +122,8 @@ namespace AZ
 
                 MaterialUid m_materialUid;
                 uint32_t m_influencesPerVertex = 0;
+                size_t m_vertexCount = 0;
+                
 
                 bool CanBeMerged() const
                 {
@@ -282,7 +284,12 @@ namespace AZ
 
             //! Checks to see if a data buffer is the expected size
             template<typename T>
-            bool ValidateStreamSize(size_t expectedVertexCount, const AZStd::vector<T>& bufferData, AZ::RHI::Format format, const char* streamName) const;
+            bool ValidateStreamSize(
+                size_t expectedVertexCount,
+                const AZStd::vector<T>& bufferData,
+                AZ::RHI::Format format,
+                const char* streamName,
+                bool isAligned = false) const;
 
             //! Checks to see if the vertex count for each stream within a mesh is the same
             bool ValidateStreamAlignment(const ProductMeshContent& mesh) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
@@ -121,6 +121,12 @@ namespace AZ
             return m_aabb;
         }
         
+        const BufferAssetView* ModelLodAsset::GetSemanticBufferAssetView(const AZ::Name& semantic, uint32_t meshIndex) const
+        {
+            AZ_Assert(meshIndex < m_meshes.size(), "Mesh index out of range");
+            return m_meshes[meshIndex].GetSemanticBufferAssetView(semantic);
+        }
+        
         const BufferAssetView* ModelLodAsset::Mesh::GetSemanticBufferAssetView(const AZ::Name& semantic) const
         {
             const AZStd::span<const ModelLodAsset::Mesh::StreamBufferInfo>& streamBufferList = GetStreamBufferInfoList();

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -104,7 +104,7 @@ namespace AZ
                     }
                 }
 
-                //Pad the blend weigth and index buffers in order for it to respect alignment of RPI::SkinnedMeshBufferAlignment
+                //Pad the blend weight and index buffers in order for it to respect alignment of RPI::SkinnedMeshBufferAlignment
                 //as that is the expected behavior of the source asset
                 RPI::ModelAssetHelpers::AlignStreamBuffer<float>(
                     blendWeightBufferData, blendWeightBufferData.size(), RPI::SkinWeightFormat, RPI::SkinnedMeshBufferAlignment);

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -23,6 +23,7 @@
 #include <Atom/RPI.Reflect/ResourcePoolAssetCreator.h>
 #include <Atom/RPI.Reflect/Buffer/BufferAssetCreator.h>
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <Atom/RPI.Reflect/Model/ModelAssetHelpers.h>
 #include <Atom/RPI.Reflect/Model/ModelAssetCreator.h>
 #include <Atom/RPI.Reflect/Model/ModelLodAssetCreator.h>
 #include <Atom/RPI.Public/Model/Model.h>
@@ -103,13 +104,15 @@ namespace AZ
                     }
                 }
 
-                while (blendIndexBufferData.size() % 4 != 0)
-                {
-                    // Pad with some extra data so the the offset to each mesh view is 16 byte aligned
-                    // which is required for raw views. These don't need corresponding weights, because
-                    // they will be ignored, and just serve as padding between different meshes
-                    blendIndexBufferData.push_back(0);
-                }
+                //Pad the blend weigth and index buffers in order for it to respect alignment of RPI::SkinnedMeshBufferAlignment
+                //as that is the expected behavior of the source asset
+                RPI::ModelAssetHelpers::AlignStreamBuffer<float>(
+                    blendWeightBufferData, blendWeightBufferData.size(), RPI::SkinWeightFormat, RPI::SkinnedMeshBufferAlignment);
+
+                //We dont use RPI::SkinIndicesFormat as blendIndexBufferData contains uint32_t instead of uint16_t
+                RHI::Format blendIndexFormat = RHI::Format::R32_FLOAT;
+                RPI::ModelAssetHelpers::AlignStreamBuffer<uint32_t>(
+                    blendIndexBufferData, blendIndexBufferData.size(), blendIndexFormat, RPI::SkinnedMeshBufferAlignment);
             }
         }
 
@@ -197,20 +200,20 @@ namespace AZ
             for (uint32_t lodIndex = 0; lodIndex < numLODs; ++lodIndex)
             {
                 // Create a single LOD
-                const SkinnedMeshInputLod& skinnedMeshLod = skinnedMeshInputBuffers->GetLod(lodIndex);
-
                 Data::Asset<RPI::ModelLodAsset> modelLodAsset = modelAsset->GetLodAssets()[lodIndex];
 
                 // Clear out the vector for re-mapped joint data that will be populated by values from EMotionFX
                 blendIndexBufferData.clear();
                 blendWeightBufferData.clear();
 
-                // Reserve enough memory for the default/common case. This is a temporary vector, so over-allocating isn't going to be wasteful
-                // Under-allocating won't be the end of the world, just a minor one-time re-allocation when the vector runs out of space.
-                // To know exactly what we need in advance would require iterating over all the vertices twice, which isn't worth it.
-                constexpr uint32_t defaultMaxInfluencesPerVertex = 4;
-                blendIndexBufferData.reserve(skinnedMeshLod.GetVertexCount() * defaultMaxInfluencesPerVertex / 2);
-                blendWeightBufferData.reserve(skinnedMeshLod.GetVertexCount() * defaultMaxInfluencesPerVertex);
+                const RPI::BufferAssetView* indicesBuffAssetView =
+                    modelLodAsset->GetSemanticBufferAssetView(Name(RPI::ShaderSemanticName_SkinJointIndices));
+                const RPI::BufferAssetView* weightsBuffAssetView =
+                    modelLodAsset->GetSemanticBufferAssetView(Name(RPI::ShaderSemanticName_SkinWeights));
+
+                // Reserve enough memory for the default/common case. Use the element count from the main source buffer
+                blendIndexBufferData.reserve(indicesBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
+                blendWeightBufferData.reserve(weightsBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
 
                 // Now iterate over the actual data and populate the data for the per-actor buffers
                 uint32_t vertexBufferOffset = 0;


### PR DESCRIPTION
## What does this PR do?

- Add support to pad skinned mesh buffers in order for them to respect RPI::SkinnedMeshBufferAlignment. This helps ensure we are able to respect alignment restrictions across all backends.
- In this case SkinnedMeshBufferAlignment is set to be 192 in order for it to respect  
     - Metal has a restriction where each typed buffer needs to start at 64 byte boundary.
     - At the same time a lot of our stream buffer views are RGB or RGBA so they need to be 12 and 16 byte aligned or all the element count/element offset logic will break.
- Removed Mac specific Vulkan builder and just have support for one builder across all platforms as we will want Mac to be able to process Vulkan related shaders too
- Fix ios crash related to Bindless allocator running out of space.
 
Related ASV PR - https://github.com/o3de/o3de-atom-sampleviewer/pull/635
## How was this PR tested?

Tested with Ybot on PC (dx12/Vk), Mac and ios. 

![IMG_1921](https://github.com/o3de/o3de/assets/47460854/ba89596d-631e-4b14-8f13-64f6b5502bdc)
