### PR TITLE
Misc scene-related bugfixes and optimizations

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
@@ -27,6 +27,12 @@ namespace AZ
                 EXPECT_FALSE(matcher.MatchesPattern("string_with_something_else"));
             }
 
+            TEST(PatternMatcherTest, MatchesPattern_CaseInsensitiveMatchingNameWithPostFix_ReturnsTrue)
+            {
+                PatternMatcher matcher("_PoStFiX", PatternMatcher::MatchApproach::PostFix);
+                EXPECT_TRUE(matcher.MatchesPattern("string_with_postfix"));
+            }
+
             TEST(PatternMatcherTest, MatchesPattern_NonMatchingNameWithPostFixAndEarlyOutForSmallerTestThanPattern_ReturnsFalse)
             {
                 PatternMatcher matcher("_postfix", PatternMatcher::MatchApproach::PostFix);
@@ -45,6 +51,12 @@ namespace AZ
                 EXPECT_FALSE(matcher.MatchesPattern("string_with_something_else"));
             }
 
+            TEST(PatternMatcherTest, MatchesPattern_CaseInsensitiveMatchingNameWithPreFix_ReturnsTrue)
+            {
+                PatternMatcher matcher("PrEFiX_", PatternMatcher::MatchApproach::PreFix);
+                EXPECT_TRUE(matcher.MatchesPattern("prefix_for_string"));
+            }
+
             TEST(PatternMatcherTest, MatchesPattern_MatchingNameWithRegex_ReturnsTrue)
             {
                 PatternMatcher matcher("^.{4}$", PatternMatcher::MatchApproach::Regex);
@@ -56,6 +68,23 @@ namespace AZ
                 PatternMatcher matcher("^.{4}$", PatternMatcher::MatchApproach::Regex);
                 EXPECT_FALSE(matcher.MatchesPattern("string_to_long_for_regex"));
             }
+
+            TEST(PatternMatcherTest, MatchesPattern_MatchingPrefixInArrayOfPatterns_ReturnsTrue)
+            {
+                AZStd::array<AZStd::string_view, 3> patterns = { "postfix", "xxx", "prefix_" };
+
+                PatternMatcher matcher(patterns, PatternMatcher::MatchApproach::PreFix);
+                EXPECT_TRUE(matcher.MatchesPattern("prefix_for_string"));
+            }
+
+            TEST(PatternMatcherTest, MatchesPattern_NonMatchingPrefixInArrayOfPatterns_ReturnsFalse)
+            {
+                AZStd::array<AZStd::string_view, 2> patterns = { "postfix", "xxx" };
+
+                PatternMatcher matcher(patterns, PatternMatcher::MatchApproach::PreFix);
+                EXPECT_FALSE(matcher.MatchesPattern("prefix_for_string"));
+            }
+
         } // SceneCore
     } // SceneAPI
 } // AZ

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
@@ -79,7 +79,7 @@ namespace AZ
 
             TEST(PatternMatcherTest, MatchesPattern_NonMatchingPrefixInArrayOfPatterns_ReturnsFalse)
             {
-                AZStd::array<AZStd::string_view, 2> patterns = { "postfix", "xxx" };
+                constexpr auto patterns = AZStd::to_array<AZStd::string_view>({ "postfix", "xxx" });
 
                 PatternMatcher matcher(patterns, PatternMatcher::MatchApproach::PreFix);
                 EXPECT_FALSE(matcher.MatchesPattern("prefix_for_string"));

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/PatternMatcherTests.cpp
@@ -71,7 +71,7 @@ namespace AZ
 
             TEST(PatternMatcherTest, MatchesPattern_MatchingPrefixInArrayOfPatterns_ReturnsTrue)
             {
-                AZStd::array<AZStd::string_view, 3> patterns = { "postfix", "xxx", "prefix_" };
+                constexpr auto patterns = AZStd::to_array<AZStd::string_view>({ "postfix", "xxx", "prefix_" });
 
                 PatternMatcher matcher(patterns, PatternMatcher::MatchApproach::PreFix);
                 EXPECT_TRUE(matcher.MatchesPattern("prefix_for_string"));

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
@@ -190,7 +190,8 @@ namespace AZ
 
             const AZStd::string& PatternMatcher::GetPattern() const
             {
-                return m_patterns[0];
+                const static AZStd::string emptyString{};
+                return !m_patterns.empty() ? m_patterns.front() : emptyString;
             }
 
             PatternMatcher::MatchApproach PatternMatcher::GetMatchApproach() const

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
@@ -37,7 +37,7 @@ namespace AZ
             {
             }
 
-            PatternMatcher::PatternMatcher(AZStd::span<AZStd::string_view> patterns, MatchApproach matcher)
+            PatternMatcher::PatternMatcher(const AZStd::span<const AZStd::string_view> patterns, MatchApproach matcher)
                 : m_matcher(matcher)
             {
                 m_patterns.reserve(patterns.size());

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.cpp
@@ -20,42 +20,58 @@ namespace AZ
         namespace SceneCore
         {
             PatternMatcher::PatternMatcher(const char* pattern, MatchApproach matcher)
-                : m_pattern(pattern)
+                : m_patterns({ AZStd::string(pattern) })
                 , m_matcher(matcher)
             {
             }
 
             PatternMatcher::PatternMatcher(const AZStd::string& pattern, MatchApproach matcher)
-                : m_pattern(pattern)
+                : m_patterns({ pattern })
                 , m_matcher(matcher)
             {
             }
 
             PatternMatcher::PatternMatcher(AZStd::string&& pattern, MatchApproach matcher)
-                : m_pattern(AZStd::move(pattern))
+                : m_patterns({ AZStd::move(pattern) })
                 , m_matcher(matcher)
             {
             }
 
+            PatternMatcher::PatternMatcher(AZStd::span<AZStd::string_view> patterns, MatchApproach matcher)
+                : m_matcher(matcher)
+            {
+                m_patterns.reserve(patterns.size());
+                for (auto& pattern : patterns)
+                {
+                    m_patterns.emplace_back(pattern);
+                }
+            }
+
+            PatternMatcher::PatternMatcher(const PatternMatcher& rhs)
+                : m_patterns(rhs.m_patterns)
+                , m_matcher(rhs.m_matcher)
+            {
+            }
+
             PatternMatcher::PatternMatcher(PatternMatcher&& rhs)
-                : m_pattern(AZStd::move(rhs.m_pattern))
+                : m_patterns(AZStd::move(rhs.m_patterns))
                 , m_matcher(rhs.m_matcher)
             {
             }
 
             PatternMatcher& PatternMatcher::operator=(const PatternMatcher& rhs)
             {
-                m_pattern = rhs.m_pattern;
+                m_patterns = rhs.m_patterns;
                 m_matcher = rhs.m_matcher;
-                m_regexMatcher.reset();
+                m_regexMatchers.clear();
                 return *this;
             }
 
             PatternMatcher& PatternMatcher::operator=(PatternMatcher&& rhs)
             {
-                m_pattern = AZStd::move(rhs.m_pattern);
+                m_patterns = AZStd::move(rhs.m_patterns);
                 m_matcher = rhs.m_matcher;
-                m_regexMatcher.reset();
+                m_regexMatchers.clear();
                 return *this;
             }
 
@@ -106,36 +122,65 @@ namespace AZ
                     return false;
                 }
 
-                m_pattern = patternValue.GetString();
+                m_patterns = { patternValue.GetString() };
 
                 return true;
             }
 
             bool PatternMatcher::MatchesPattern(const char* name, size_t nameLength) const
             {
+                return MatchesPattern(AZStd::string_view(name, nameLength));
+            }
+
+            bool PatternMatcher::MatchesPattern(AZStd::string_view name) const
+            {
+                constexpr bool caseSensitive = false;
+
                 switch (m_matcher)
                 {
                 case MatchApproach::PreFix:
-                    return AzFramework::StringFunc::Equal(name, m_pattern.c_str(), false, m_pattern.size());
-                case MatchApproach::PostFix:
-                {
-                    if (m_pattern.size() > nameLength)
+                    for (const auto& pattern : m_patterns)
                     {
-                        return false;
+                        // Perform a case-insensitive prefix match.
+                        if (AZ::StringFunc::StartsWith(name, pattern, caseSensitive))
+                        {
+                            return true;
+                        }
                     }
-                    size_t offset = nameLength - m_pattern.size();
-                    return AzFramework::StringFunc::Equal(name + offset, m_pattern.c_str());
-                }
+                    return false;
+                case MatchApproach::PostFix:
+                    for (const auto& pattern : m_patterns)
+                    {
+                        // Perform a case-insensitive postfix match.
+                        if (AZ::StringFunc::EndsWith(name, pattern, caseSensitive))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
                 case MatchApproach::Regex:
                 {
-                    // Because PatternMatcher can get default constructed and serialized into directly, there's no good place
-                    // to initialize the regex matcher on construction, so we'll lazily initialize it here on first use.
-                    if (m_regexMatcher == nullptr)
+                    for (size_t index = 0; index < m_patterns.size(); index++)
                     {
-                        m_regexMatcher = AZStd::make_unique<AZStd::regex>(m_pattern, AZStd::regex::extended);
+                        // Because PatternMatcher can get default constructed and serialized into directly, there's no good place
+                        // to initialize the regex matchers on construction, so we'll lazily initialize it here on first use.
+
+                        if (m_regexMatchers.empty())
+                        {
+                            m_regexMatchers.resize(m_patterns.size());
+                        }
+
+                        if (m_regexMatchers[index] == nullptr)
+                        {
+                            m_regexMatchers[index] = AZStd::make_unique<AZStd::regex>(m_patterns[index], AZStd::regex::extended);
+                        }
+                        AZStd::cmatch match;
+                        if (AZStd::regex_match(name.begin(), name.end(), match, *(m_regexMatchers[index])))
+                        {
+                            return true;
+                        }
                     }
-                    AZStd::smatch match;
-                    return AZStd::regex_match(name, match, *m_regexMatcher);
+                    return false;
                 }
                 default:
                     AZ_Assert(false, "Unknown option '%i' for pattern matcher.", m_matcher);
@@ -143,14 +188,9 @@ namespace AZ
                 }
             }
 
-            bool PatternMatcher::MatchesPattern(const AZStd::string& name) const
-            {
-                return MatchesPattern(name.c_str(), name.length());
-            }
-
             const AZStd::string& PatternMatcher::GetPattern() const
             {
-                return m_pattern;
+                return m_patterns[0];
             }
 
             PatternMatcher::MatchApproach PatternMatcher::GetMatchApproach() const
@@ -164,8 +204,8 @@ namespace AZ
                 if (serializeContext)
                 {
                     serializeContext->Class<PatternMatcher>()
-                        ->Version(1)
-                        ->Field("pattern", &PatternMatcher::m_pattern)
+                        ->Version(2)
+                        ->Field("patterns", &PatternMatcher::m_patterns)
                         ->Field("matcher", &PatternMatcher::m_matcher);
 
                     EditContext* editContext = serializeContext->GetEditContext();
@@ -174,7 +214,7 @@ namespace AZ
                         editContext->Class<PatternMatcher>("Pattern matcher", "")
                             ->ClassElement(Edit::ClassElements::EditorData, "")
                             ->Attribute(Edit::Attributes::AutoExpand, true)
-                            ->DataElement(Edit::UIHandlers::Default, &PatternMatcher::m_pattern, "Pattern", "The pattern the matcher will check against.")
+                            ->DataElement(Edit::UIHandlers::Default, &PatternMatcher::m_patterns, "Patterns", "The patterns the matcher will check against.")
                             ->DataElement(Edit::UIHandlers::ComboBox, &PatternMatcher::m_matcher, "Matcher", "The used approach for matching.")
                                 ->EnumAttribute(MatchApproach::PreFix, "PreFix")
                                 ->EnumAttribute(MatchApproach::PostFix, "PostFix")

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
@@ -9,6 +9,7 @@
  */
 
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/JSON/document.h>
 #include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
@@ -47,7 +48,7 @@ namespace AZ
                 SCENE_CORE_API PatternMatcher(const PatternMatcher& rhs) = default;
                 SCENE_CORE_API PatternMatcher(PatternMatcher&& rhs);
 
-                SCENE_CORE_API PatternMatcher& operator=(const PatternMatcher& rhs) = default;
+                SCENE_CORE_API PatternMatcher& operator=(const PatternMatcher& rhs);
                 SCENE_CORE_API PatternMatcher& operator=(PatternMatcher&& rhs);
 
                 SCENE_CORE_API bool LoadFromJson(rapidjson::Document::ConstMemberIterator member);
@@ -62,6 +63,7 @@ namespace AZ
             private:
                 AZStd::string m_pattern;
                 MatchApproach m_matcher = MatchApproach::PostFix;
+                mutable AZStd::unique_ptr<AZStd::regex> m_regexMatcher;
             };
         } // SceneCore
     } // SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
@@ -45,7 +45,8 @@ namespace AZ
                 SCENE_CORE_API PatternMatcher(const char* pattern, MatchApproach matcher);
                 SCENE_CORE_API PatternMatcher(const AZStd::string& pattern, MatchApproach matcher);
                 SCENE_CORE_API PatternMatcher(AZStd::string&& pattern, MatchApproach matcher);
-                SCENE_CORE_API PatternMatcher(const PatternMatcher& rhs) = default;
+                SCENE_CORE_API PatternMatcher(AZStd::span<AZStd::string_view> patterns, MatchApproach matcher);
+                SCENE_CORE_API PatternMatcher(const PatternMatcher& rhs);
                 SCENE_CORE_API PatternMatcher(PatternMatcher&& rhs);
 
                 SCENE_CORE_API PatternMatcher& operator=(const PatternMatcher& rhs);
@@ -54,16 +55,16 @@ namespace AZ
                 SCENE_CORE_API bool LoadFromJson(rapidjson::Document::ConstMemberIterator member);
 
                 SCENE_CORE_API bool MatchesPattern(const char* name, size_t nameLength) const;
-                SCENE_CORE_API bool MatchesPattern(const AZStd::string& name) const;
+                SCENE_CORE_API bool MatchesPattern(AZStd::string_view name) const;
 
                 SCENE_CORE_API const AZStd::string& GetPattern() const;
                 SCENE_CORE_API MatchApproach GetMatchApproach() const;
 
                 static void Reflect(AZ::ReflectContext* context);
             private:
-                AZStd::string m_pattern;
+                AZStd::vector<AZStd::string> m_patterns;
                 MatchApproach m_matcher = MatchApproach::PostFix;
-                mutable AZStd::unique_ptr<AZStd::regex> m_regexMatcher;
+                mutable AZStd::vector<AZStd::unique_ptr<AZStd::regex>> m_regexMatchers;
             };
         } // SceneCore
     } // SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/PatternMatcher.h
@@ -45,7 +45,7 @@ namespace AZ
                 SCENE_CORE_API PatternMatcher(const char* pattern, MatchApproach matcher);
                 SCENE_CORE_API PatternMatcher(const AZStd::string& pattern, MatchApproach matcher);
                 SCENE_CORE_API PatternMatcher(AZStd::string&& pattern, MatchApproach matcher);
-                SCENE_CORE_API PatternMatcher(AZStd::span<AZStd::string_view> patterns, MatchApproach matcher);
+                SCENE_CORE_API PatternMatcher(const AZStd::span<const AZStd::string_view> patterns, MatchApproach matcher);
                 SCENE_CORE_API PatternMatcher(const PatternMatcher& rhs);
                 SCENE_CORE_API PatternMatcher(PatternMatcher&& rhs);
 

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.cpp
@@ -136,8 +136,7 @@ namespace AZ
 
             void NodeListSelectionWidget::BuildList(const Containers::SceneGraph& graph)
             {
-                EntrySet entries;
-                QStringList comboBoxEntries;
+                QStringList entries;
 
                 auto view = Containers::Views::MakePairView(graph.GetNameStorage(), graph.GetContentStorage());
                 for (auto it = view.begin(); it != view.end(); ++it)
@@ -161,12 +160,13 @@ namespace AZ
                         }
                     }
 
-                    AddEntry(it->first, entries, comboBoxEntries);
+                    AddEntry(entries, it->first);
                 }
 
-                if (!comboBoxEntries.empty())
+                if (!entries.empty())
                 {
-                    addItems(comboBoxEntries);
+                    entries.removeDuplicates();
+                    addItems(entries);
                 }
             }
 
@@ -186,26 +186,17 @@ namespace AZ
                 }
             }
 
-            void NodeListSelectionWidget::AddEntry(
-                const Containers::SceneGraph::Name& name, EntrySet& entries, QStringList& comboListEntries)
+            void NodeListSelectionWidget::AddEntry(QStringList& comboListEntries, const Containers::SceneGraph::Name& name)
             {
                 if (m_useShortNames)
                 {
                     const char* shortName = name.GetName();
-                    if (entries.find(shortName) == entries.end())
-                    {
-                        entries.insert(shortName);
-                        comboListEntries.append(QString(shortName));
-                    }
+                    comboListEntries.append(QString(shortName));
                 }
                 else
                 {
                     const char* pathName = name.GetPath();
-                    if (entries.find(pathName) == entries.end())
-                    {
-                        entries.insert(pathName);
-                        comboListEntries.append(QString(pathName));
-                    }
+                    comboListEntries.append(QString(pathName));
                 }
             }
 

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.cpp
@@ -137,6 +137,7 @@ namespace AZ
             void NodeListSelectionWidget::BuildList(const Containers::SceneGraph& graph)
             {
                 EntrySet entries;
+                QStringList comboBoxEntries;
 
                 auto view = Containers::Views::MakePairView(graph.GetNameStorage(), graph.GetContentStorage());
                 for (auto it = view.begin(); it != view.end(); ++it)
@@ -160,7 +161,12 @@ namespace AZ
                         }
                     }
 
-                    AddEntry(entries, it->first);
+                    AddEntry(it->first, entries, comboBoxEntries);
+                }
+
+                if (!comboBoxEntries.empty())
+                {
+                    addItems(comboBoxEntries);
                 }
             }
 
@@ -180,7 +186,8 @@ namespace AZ
                 }
             }
 
-            void NodeListSelectionWidget::AddEntry(EntrySet& entries, const Containers::SceneGraph::Name& name)
+            void NodeListSelectionWidget::AddEntry(
+                const Containers::SceneGraph::Name& name, EntrySet& entries, QStringList& comboListEntries)
             {
                 if (m_useShortNames)
                 {
@@ -188,7 +195,7 @@ namespace AZ
                     if (entries.find(shortName) == entries.end())
                     {
                         entries.insert(shortName);
-                        addItem(shortName);
+                        comboListEntries.append(QString(shortName));
                     }
                 }
                 else
@@ -197,7 +204,7 @@ namespace AZ
                     if (entries.find(pathName) == entries.end())
                     {
                         entries.insert(pathName);
-                        addItem(pathName);
+                        comboListEntries.append(QString(pathName));
                     }
                 }
             }

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.h
@@ -70,7 +70,7 @@ namespace AZ
 
                 void BuildList(const Containers::SceneGraph& graph);
                 bool IsCorrectType(const DataTypes::IGraphObject& object) const;
-                void AddEntry(EntrySet& entries, const Containers::SceneGraph::Name& name);
+                void AddEntry(const Containers::SceneGraph::Name& name, EntrySet& entries, QStringList& comboListEntries);
                 void SetSelection();
                 void AddDisabledOption();
 

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeListSelectionWidget.h
@@ -64,13 +64,11 @@ namespace AZ
                 void OnTextChange(const QString& text);
 
             protected:
-                using EntrySet = AZStd::unordered_set<AZStd::string>;
-
                 void showEvent(QShowEvent* event) override;
 
                 void BuildList(const Containers::SceneGraph& graph);
                 bool IsCorrectType(const DataTypes::IGraphObject& object) const;
-                void AddEntry(const Containers::SceneGraph::Name& name, EntrySet& entries, QStringList& comboListEntries);
+                void AddEntry(QStringList& comboListEntries, const Containers::SceneGraph::Name& name);
                 void SetSelection();
                 void AddDisabledOption();
 

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.cpp
@@ -114,12 +114,16 @@ namespace AZ
 
                 UpdateAddButtonStatus();
 
-                QTimer::singleShot(0, this,
-                    [this]()
-                    {
-                        ScrollToBottom();
-                    }
-                );
+                // Guard against adding lots of ScrollToBottom calls in the case where we're performing bulk adds in a single frame.
+                if (!m_scrollToBottomQueued)
+                {
+                    m_scrollToBottomQueued = true;
+                    QTimer::singleShot(0, this,
+                        [this]()
+                        {
+                            ScrollToBottom();
+                        });
+                }
 
                 return true;
             }
@@ -251,6 +255,8 @@ namespace AZ
 
             void ManifestWidgetPage::ScrollToBottom()
             {
+                m_scrollToBottomQueued = false;
+
                 QScrollArea* propertyGridScrollArea = m_propertyEditor->findChild<QScrollArea*>();
                 if (propertyGridScrollArea)
                 {

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.h
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidgetPage.h
@@ -115,6 +115,7 @@ namespace AZ
                 size_t m_capSize;
                 QString m_helpUrl;
                 QMenu* m_editMenu;
+                bool m_scrollToBottomQueued = false;
             };
         } // namespace UI
     } // namespace SceneAPI

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -150,7 +150,9 @@ namespace AZ
             //! List of object SRGs used by meshes in this model 
             AZStd::vector<Data::Instance<RPI::ShaderResourceGroup>> m_objectSrgList;
             MeshFeatureProcessorInterface::ObjectSrgCreatedEvent m_objectSrgCreatedEvent;
-            AZStd::unique_ptr<MeshLoader> m_meshLoader;
+            // MeshLoader is a shared pointer because it can queue a reference to itself on the SystemTickBus. The reference
+            // needs to stay alive until the queued function is executed.
+            AZStd::shared_ptr<MeshLoader> m_meshLoader;
             RPI::Scene* m_scene = nullptr;
             RHI::DrawItemSortKey m_sortKey = 0;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -172,8 +172,6 @@ namespace AZ
                 m_systemInputAssemblyBufferPoolId = assetIdOutcome.GetValue();
             }
 
-            m_createdSubId.clear();
-
             m_modelName = context.m_group.GetName();
 
             const auto& scene = context.m_scene;

--- a/Gems/SceneProcessing/Registry/SoftNameSettings.setreg
+++ b/Gems/SceneProcessing/Registry/SoftNameSettings.setreg
@@ -2,69 +2,69 @@
     "O3DE": {
         "AssetProcessor": {
             "SceneBuilder": {
-                "NodeSoftNameSettings": [
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Ll][Oo][Dd]_?1(_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "LODMesh1",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Ll][Oo][Dd]_?2(_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "LODMesh2",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Ll][Oo][Dd]_?3(_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "LODMesh3",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Ll][Oo][Dd]_?4(_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "LODMesh4",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Ll][Oo][Dd]_?5(_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "LODMesh5",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Pp][Hh][Yy][Ss](_optimized)?$",
-                            "matcher": 2
-                        },
-                        "virtualType": "PhysicsMesh",
-                        "includeChildren": true
-                    },
-                    {
-                        "pattern": {
-                            "pattern": "^.*_[Pp][Hh][Yy][Ss](_optimized)?$",
-                            "matcher": 1
-                        },
-                        "virtualType": "Ignore",
-                        "includeChildren": false
-                    }
-                ],
+              "NodeSoftNameSettings": [
+                {
+                  "pattern": {
+                    "patterns": [ "_lod_1", "_lod_1_optimized", "_lod1", "_lod1_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "LODMesh1",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "_lod_2", "_lod_2_optimized", "_lod2", "_lod2_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "LODMesh2",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "_lod_3", "_lod_3_optimized", "_lod3", "_lod3_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "LODMesh3",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "_lod_4", "_lod_4_optimized", "_lod4", "_lod4_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "LODMesh4",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "_lod_5", "_lod_5_optimized", "_lod5", "_lod5_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "LODMesh5",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "_phys", "_phys_optimized" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "PhysicsMesh",
+                  "includeChildren": true
+                },
+                {
+                  "pattern": {
+                    "patterns": [ "^.*_[Pp][Hh][Yy][Ss](_optimized)?$" ],
+                    "matcher": 1
+                  },
+                  "virtualType": "Ignore",
+                  "includeChildren": false
+                }
+              ],
                 "FileSoftNameSettings": [
                     {
                         "pattern": {
-                            "pattern": "_anim",
-                            "matcher": 1
+                          "patterns": [ "_anim" ],
+                          "matcher": 1
                         },
                         "virtualType": "Ignore",
                         "inclusiveList": false,


### PR DESCRIPTION
## What does this PR do?

This is a set of bugfixes and optimizations that I discovered while trying to test FBX Settings for a file with a lot of submeshes:
* Optimization (PatternMatcher.cpp): changed Scene's PatternMatcher to only create the regex pattern matcher once on first use. This changed the time to display the LECT.fbx FBX Settings (which contains 27 submeshes) from 3.5 seconds to 2.99 seconds. The savings scale by the number of submeshes and the number of regex patterns.
* Optimization (NodeListSelectionWidget.cpp): changed the method of populating the widget's combobox list. The previous method worked fine for a few entries, but seemed to get exponentially worse as the number of entries went up. The new version seems to have a consistently negligible performance cost.
* Optimization (ManifestWidgetPage.cpp): changed ManifestWidgetPage to avoid redundant ScrollToBottom() queueing. This changed the time to display the LECT.fbx FBX Settings (which contains 27 submeshes) from 2.99 seconds to 2.05 seconds. The savings scale by the number of submeshes.
* Optimization (PatternMatcher.cpp): changed PatternMatcher to contain an array of patterns, and changed the soft name patterns to use an array of Postfix matches instead of a regex. This changed the time to display the LECT.fbx FBX Settings (which contains 27 submeshes) from 2.05 seconds to 1.86 seconds.
* Bugfix (MeshFeatureProcessor.cpp): Asset Browser thumbnail rendering would intermittently assert and crash due to a MeshLoader instance that went invalid in a queued lambda between queueing and execution. This was fixed by making the instance a shared_ptr.
* Bugfix (ModelAssetBuilderComponent.cpp): the sub ID list shouldn't be cleared between mesh groups, or else it won't accurately catch collisions. This causes sub ID collisions to get significantly earlier in the export process, causing the AP failure to get reported anywhere from seconds to minutes sooner.

## How was this PR tested?

* Used PIX to capture timings for each of the optimizations
* Verified for the bugfixes that the suspected problem cases were actually occurring with temporary asserts, then implemented the solutions, then verified that the solutions worked through multiple Editor runs and testing known-broken FBX files.
* Created a few new unit tests for PatternMatcher.