### PR TITLE
Use select instead of tertiary operator for vectors, required for a dxc update.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/LinearSrgb_To_Srgb.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/LinearSrgb_To_Srgb.azsli
@@ -11,5 +11,5 @@
 real3 LinearSrgb_To_Srgb(real3 color)
 {
     // Copied from CryFx's ToAccurateSRGB()
-    return (color.xyz < 0.0031308) ? 12.92 * color.xyz : 1.055 * pow(color.xyz, 1.0 / 2.4) - real3(0.055, 0.055, 0.055);
+    return select((color.xyz < 0.0031308), 12.92 * color.xyz, 1.055 * pow(color.xyz, 1.0 / 2.4) - real3(0.055, 0.055, 0.055));
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/Srgb_To_LinearSrgb.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/GeneratedTransforms/Srgb_To_LinearSrgb.azsli
@@ -11,5 +11,5 @@
 real3 Srgb_To_LinearSrgb(real3 color)
 {
     // Copied from CryFx's ToAccurateLinear()
-    return (color.xyz < 0.04045) ? color.xyz / 12.92h : pow((color.xyz + real3(0.055, 0.055, 0.055)) / real3(1.055, 1.055, 1.055), 2.4);
+    return select((color.xyz < 0.04045), color.xyz / 12.92h, pow((color.xyz + real3(0.055, 0.055, 0.055)) / real3(1.055, 1.055, 1.055), 2.4));
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Aces.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Aces.azsli
@@ -790,7 +790,7 @@ float3 OutputDeviceTransform(const float3 oces, OutputTransformParameters otPara
         // LDR mode, clamp 0/1 and encode with given gamma value for the OETF
         linearCV = clamp(linearCV, 0., 1.);
 
-        outputCV = outputCV > 0.0f ? pow(linearCV, 1.0f / otParams.gamma) : 0.0f;
+        outputCV = select(outputCV > 0.0f, pow(linearCV, 1.0f / otParams.gamma), 0.0f);
     }
 
     return outputCV;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/PostProcessUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/PostProcessUtil.azsli
@@ -19,23 +19,23 @@
 
 float3 LinearToSRGB(float3 col)
 {
-    return (col.xyz < 0.0031308) ? 12.92 * col.xyz : 1.055 * pow(abs(col.xyz), 1.0 / 2.4) - float3( 0.055, 0.055, 0.055 );
+    return select((col.xyz < 0.0031308), 12.92 * col.xyz, 1.055 * pow(abs(col.xyz), 1.0 / 2.4) - float3( 0.055, 0.055, 0.055 )) ;
 }
 
 float3 SRGBToLinear(float3 col)
 {
-    return (col.xyz < 0.04045) ? col.xyz / 12.92 : pow (abs((col.xyz + float3(0.055, 0.055, 0.055)) / float3(1.055, 1.055, 1.055)), 2.4);
+    return select((col.xyz < 0.04045), col.xyz / 12.92, pow (abs((col.xyz + float3(0.055, 0.055, 0.055)) / float3(1.055, 1.055, 1.055)), 2.4));
 }
 
 /* AZSL doesn't support function overload for the moment.
 half3 LinearToSRGB(half3 col)
 {
-    return (col < 0.0031308h) ? 12.92h * col : 1.055h * pow(abs(col), 1.0h / 2.4h) - half3(0.055h, 0.055h, 0.055h);
+    return select((col < 0.0031308h), 12.92h * col, 1.055h * pow(abs(col), 1.0h / 2.4h) - half3(0.055h, 0.055h, 0.055h));
 }
 
 half3 SRGBToLinear(half3 col)
 {
-    return (col.xyz < 0.04045h) ? col.xyz / 12.92h : pow (abs((col.xyz + half3(0.055h, 0.055h, 0.055h)) / half3(1.055h, 1.055h, 1.055h)), 2.4h);
+    return select((col.xyz < 0.04045h), col.xyz / 12.92h, pow (abs((col.xyz + half3(0.055h, 0.055h, 0.055h)) / half3(1.055h, 1.055h, 1.055h)), 2.4h));
 }
 */
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.azsl
@@ -47,7 +47,7 @@ float4 SampleAverageValidColors(float2 tex0, float2 tex1, float2 tex2, float2 te
     float4 dofFactors = float4(color0.a, color1.a, color2.a, color3.a);
     float4 blends = ConvertBlendsFloat4(dofFactors , PassSrg::m_blendFactor);
     // 0.25 is 1 / pixel number.
-    float4 masks = blends > 0.0f ? 0.25f : 0.0f;
+    float4 masks = select(blends > 0.0f, 0.25f, 0.0f);
     float weight = dot(masks, (float4)1.0f);
 
     float4 color = (float4)0;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
@@ -75,7 +75,7 @@ bool TraceRayScreenSpace(float3 rayStartVS, float3 rayDirectionVS, uint2 dimensi
     float3 Q1 = rayEndVS * k1;
 
     // if the line is degenerate, make it cover at least one pixel
-    P1 += DistanceSqr(P0, P1) < EPSILON ? float2(0.01f, 0.01f) : 0.0f;
+    P1 += select(DistanceSqr(P0, P1) < EPSILON, float2(0.01f, 0.01f), 0.0f);
 
     // store all of the start variables in a single float4
     float4 PQK = float4(P0, Q0.z, k0);

--- a/Gems/AtomLyIntegration/ImguiAtom/Assets/Shaders/ImGuiAtom/ImGuiAtom.azsl
+++ b/Gems/AtomLyIntegration/ImguiAtom/Assets/Shaders/ImGuiAtom/ImGuiAtom.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup ObjectSrg : SRG_PerObject
 
 float3 SRGBToLinear( float3 x )
 {
-    return x < 0.04045f ? x / 12.92f : pow( (abs(x) + 0.055f) / 1.055f, 2.4f );
+    return select(x < 0.04045f, x / 12.92f, pow( (abs(x) + 0.055f) / 1.055f, 2.4f ));
 
     // NOTE: abs on x quiets FXC warning "X3571: pow(f, e) will not work for negative f, 
     // use abs(f) or conditionally handle negative values if you expect them".


### PR DESCRIPTION
This conforms to HLSL 2021, see:

https://github.com/microsoft/DirectXShaderCompiler/wiki/HLSL-2021#logical-operation-short-circuiting-for-scalars

## What does this PR do?

This will be needed in the future when using newer versions of dxc.

## How was this PR tested?

Ran the asset processor with a simple test project to see if everything still compiles.
