### PR TITLE
Fix for nullptr crash on default pipeline dereference in native VR

### DIFF
--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -220,8 +220,11 @@ namespace AZ::Render
             viewportContext->GetViewportSize().m_height,
             multisampleState.m_samples > 1 ? AZStd::string::format("MSAA %dx", multisampleState.m_samples).c_str() : "NoMSAA"
         ));
-                
-        DrawLine(AZStd::string::format("Render pipeline: %s", viewportContext->GetCurrentPipeline()->GetId().GetCStr()));
+
+        if(viewportContext->GetCurrentPipeline())   // avoid VR crash on nullptr
+        {
+            DrawLine(AZStd::string::format("Render pipeline: %s", viewportContext->GetCurrentPipeline()->GetId().GetCStr()));
+        }
     }
 
     void AtomViewportDisplayInfoSystemComponent::DrawCameraInfo()


### PR DESCRIPTION
One line crash fix for native android VR (tested with Quest 2)
GetCurrentPipeline() returns the pipeline at idx 0 of the m_currentPipelines array, which in VR is nullptr.
Dunno how important it is to draw the renderpipeline ID in VR?