### PR TITLE
Introduce multi-device buffer resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -15,17 +15,22 @@ namespace AZ::RHI
     class Fence;
 
     //! A structure used as an argument to BufferPool::InitBuffer.
-    struct BufferInitRequest
+    template <typename BufferClass>
+    struct BufferInitRequestTemplate
     {
-        BufferInitRequest() = default;
+        BufferInitRequestTemplate() = default;
 
-        BufferInitRequest(
-            Buffer& buffer,
+        BufferInitRequestTemplate(
+            BufferClass& buffer,
             const BufferDescriptor& descriptor,
-            const void* initialData = nullptr);
+            const void* initialData = nullptr)
+            : m_buffer{&buffer}
+            , m_descriptor{descriptor}
+            , m_initialData{initialData}
+            {}
 
         /// The buffer to initialize. The buffer must be in an uninitialized state.
-        Buffer* m_buffer = nullptr;
+        BufferClass* m_buffer = nullptr;
 
         /// The descriptor used to initialize the buffer.
         BufferDescriptor m_descriptor;
@@ -35,14 +40,19 @@ namespace AZ::RHI
     };
 
     //! A structure used as an argument to BufferPool::MapBuffer.
-    struct BufferMapRequest
+    template <typename BufferClass>
+    struct BufferMapRequestTemplate
     {
-        BufferMapRequest() = default;
+        BufferMapRequestTemplate() = default;
 
-        BufferMapRequest(Buffer& buffer, size_t byteOffset, size_t byteCount);
+        BufferMapRequestTemplate(BufferClass& buffer, size_t byteOffset, size_t byteCount)
+            : m_buffer{&buffer}
+            , m_byteOffset{byteOffset}
+            , m_byteCount{byteCount}
+            {}
 
         /// The buffer instance to map for CPU access.
-        Buffer* m_buffer = nullptr;
+        BufferClass* m_buffer = nullptr;
 
         /// The number of bytes offset from the base of the buffer to map for access.
         size_t m_byteOffset = 0;
@@ -58,13 +68,14 @@ namespace AZ::RHI
     };
 
     //! A structure used as an argument to BufferPool::StreamBuffer.
-    struct BufferStreamRequest
+    template <typename BufferClass, typename FenceClass>
+    struct BufferStreamRequestTemplate
     {
         /// A fence to signal on completion of the upload operation.
-        Fence* m_fenceToSignal = nullptr;
+        FenceClass* m_fenceToSignal = nullptr;
 
         /// The buffer instance to stream up to.
-        Buffer* m_buffer = nullptr;
+        BufferClass* m_buffer = nullptr;
 
         /// The number of bytes offset from the base of the buffer to start the upload.
         size_t m_byteOffset = 0;
@@ -77,6 +88,10 @@ namespace AZ::RHI
         /// is invoked).
         const void* m_sourceData = nullptr;
     };
+
+    using BufferInitRequest = BufferInitRequestTemplate<Buffer>;
+    using BufferMapRequest = BufferMapRequestTemplate<Buffer>;
+    using BufferStreamRequest = BufferStreamRequestTemplate<Buffer, Fence>;
 
     //! Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
     //! contains properties defining memory characteristics of buffer pools. All buffers created on a pool

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/BufferDescriptor.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+
+namespace AZ::RHI
+{
+    class BufferFrameAttachment;
+    struct BufferViewDescriptor;
+
+    //! A MultiDeviceBuffer holds all Buffers across multiple devices.
+    //! The buffer descriptor will be shared across all the buffers.
+    //! The user manages the lifecycle of a MultiDeviceBuffer through a MultiDeviceBufferPool
+    class MultiDeviceBuffer : public MultiDeviceResource
+    {
+        using Base = MultiDeviceResource;
+        friend class MultiDeviceBufferPoolBase;
+        friend class MultiDeviceBufferPool;
+        friend class MultiDeviceRayTracingTlas;
+        friend class MultiDeviceTransientAttachmentPool;
+
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceBuffer, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceBuffer, "{8B8A544D-7819-4677-9C47-943B821DE619}", MultiDeviceResource);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(Buffer);
+        MultiDeviceBuffer() = default;
+        virtual ~MultiDeviceBuffer() = default;
+
+        const BufferDescriptor& GetDescriptor() const;
+
+        //! Returns the buffer frame attachment if the buffer is currently attached.
+        const BufferFrameAttachment* GetFrameAttachment() const;
+
+        //! Get the hash associated with the MultiDeviceBuffer
+        const HashValue64 GetHash() const;
+
+        //! Shuts down the resource by detaching it from its parent pool.
+        void Shutdown() override final;
+
+        void InvalidateViews() override final;
+
+    protected:
+        void SetDescriptor(const BufferDescriptor& descriptor);
+
+    private:
+        void Invalidate();
+
+        //! The RHI descriptor for this MultiDeviceBuffer.
+        BufferDescriptor m_descriptor;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RHI.Reflect/BufferDescriptor.h>
 #include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/MultiDeviceResource.h>
 
 namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/BufferPoolDescriptor.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPoolBase.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceFence;
+
+    //! A structure used as an argument to MultiDeviceBufferPool::InitBuffer.
+    struct MultiDeviceBufferInitRequest
+    {
+        MultiDeviceBufferInitRequest() = default;
+
+        MultiDeviceBufferInitRequest(MultiDeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData = nullptr);
+
+        //! The buffer to initialize. The buffer must be in an uninitialized state.
+        MultiDeviceBuffer* m_buffer = nullptr;
+
+        //! The descriptor used to initialize the buffer.
+        BufferDescriptor m_descriptor;
+
+        //! [Optional] Initial data used to initialize the buffer.
+        const void* m_initialData = nullptr;
+    };
+
+    //! A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
+    struct MultiDeviceBufferMapRequest
+    {
+        MultiDeviceBufferMapRequest() = default;
+
+        MultiDeviceBufferMapRequest(MultiDeviceBuffer& buffer, size_t byteOffset, size_t byteCount);
+
+        //! The buffer instance to map for CPU access.
+        MultiDeviceBuffer* m_buffer = nullptr;
+
+        //! The number of bytes offset from the base of the buffer to map for access.
+        size_t m_byteOffset = 0;
+
+        //! The number of bytes beginning from the offset to map for access.
+        size_t m_byteCount = 0;
+    };
+
+    //! A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
+    struct MultiDeviceBufferMapResponse
+    {
+        //! Will hold the mapped data for each device selected in the MultiDeviceBuffer
+        AZStd::vector<void*> m_data;
+    };
+
+    //! A structure used as an argument to MultiDeviceBufferPool::StreamBuffer.
+    struct MultiDeviceBufferStreamRequest
+    {
+        //! A fence to signal on completion of the upload operation.
+        MultiDeviceFence* m_fenceToSignal = nullptr;
+
+        //! The buffer instance to stream up to.
+        MultiDeviceBuffer* m_buffer = nullptr;
+
+        //! The number of bytes offset from the base of the buffer to start the upload.
+        size_t m_byteOffset = 0;
+
+        //! The number of bytes to upload beginning from m_byteOffset.
+        size_t m_byteCount = 0;
+
+        //! A pointer to the source data to upload. The source data must remain valid
+        //! for the duration of the upload operation (i.e. until m_callbackFunction
+        //! is invoked).
+        const void* m_sourceData = nullptr;
+    };
+
+    //! Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
+    //! contains properties defining memory characteristics of buffer pools. All buffers created on a pool
+    //! share the same backing heap and buffer bind flags.
+    class MultiDeviceBufferPool : public MultiDeviceBufferPoolBase
+    {
+        friend class MultiDeviceRayTracingBufferPools;
+
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceBufferPool, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceBufferPool, "{547F1577-0AA3-4F0D-9656-8905DE5E9E8A}", MultiDeviceBufferPoolBase)
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(BufferPool);
+        MultiDeviceBufferPool() = default;
+        virtual ~MultiDeviceBufferPool() override = default;
+
+        //! Initializes the buffer pool with a provided descriptor. The pool must be in an uninitialized
+        //! state, or this call will fail. To re-use an existing pool, you must first call Shutdown
+        //! before calling Init again.
+        //!
+        //!  @param descriptor The descriptor containing properties used to initialize the pool.
+        //!  @return A result code denoting the status of the call. If successful, the pool is considered
+        //!      initialized and is able to service buffer requests. If failure, the pool remains uninitialized.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor);
+
+        //! Initializes a buffer instance created from this pool. The buffer must be in an uninitialized
+        //! state, or the call will fail. To re-use an existing buffer instance, first call Shutdown
+        //! on the buffer prior to calling InitBuffer on the pool.
+        //!
+        //!  @param request The request used to initialize a buffer instance.
+        //!  @return A result code denoting the status of the call. If successful, the buffer is considered
+        //!      initialized and 'registered' with the pool. If the pool fails to secure an allocation for the
+        //!      buffer, it remain in a shutdown state. If the initial data upload fails, the buffer will be
+        //!      initialized, but will remain empty and the call will return ResultCode::OutOfMemory. Checking
+        //!      this amounts to seeing if buffer.IsInitialized() is true.
+        ResultCode InitBuffer(const MultiDeviceBufferInitRequest& request);
+
+        //! NOTE: Only applicable to 'Host' pools. Device pools will fail with ResultCode::InvalidOperation.
+        //!
+        //! Instructs the pool to allocate a new backing allocation for the buffer. This enables the user to
+        //! ignore tracking hazards between the CPU and GPU timelines. Call this method if the entire buffer contents
+        //! are being overwritten for a new frame.
+        //!
+        //! The user may instead do hazard tracking manually by not overwriting regions in-flight on the GPU. To ensure
+        //! that a region has flushed through the GPU, either use Fences to track when a Scope has completed, or rely
+        //! on RHI::Limits::Device::FrameCountMax (for example, by N-buffering the data in a round-robin
+        //! fashion).
+        //!
+        //! If the new allocation is small enough to be page-allocated, the buffer's debug name will be lost.
+        //! If the allocation is large enough to create a new buffer object, it will call SetName() with
+        //! the old name.
+        //!
+        //!  @param buffer The buffer whose backing allocation to orphan. The buffer must be registered and
+        //!      initialized with this pool.
+        //!  @return On success, the buffer is considered to have a new backing allocation. On failure, the existing
+        //!      buffer allocation remains intact.
+        ResultCode OrphanBuffer(MultiDeviceBuffer& buffer);
+
+        //! Maps a buffer region for CPU access. The type of access (read or write) is dictated by the type of
+        //! buffer pool. Host pools with host read access may read from the buffer--the contents of which
+        //! are written by the GPU. All other modes only expose write-only access by the CPU.
+        //!
+        //! Is it safe to nest Map operations if the regions are disjoint. Calling Map is reference counted, so calling
+        //! Unmap is required for each Map call. Map operations will block the frame scheduler from recording staging
+        //! operations to the command lists. To avoid this, unmap all buffer regions before the frame execution phase.
+        //!
+        //!  @param request The map request structure holding properties for the map operation.
+        //!  @param response The map response structure holding the mapped data pointer (if successful), or null.
+        //!  @return Returns a result code specifying whether the call succeeded, or a failure code specifying
+        //!      why the call failed.
+        ResultCode MapBuffer(const MultiDeviceBufferMapRequest& request, MultiDeviceBufferMapResponse& response);
+
+        //! Unmaps a buffer for CPU access. The mapped data pointer is considered invalid after this call and
+        //! should not be accessed. This call unmaps the data region and unblocks the GPU for access.
+        void UnmapBuffer(MultiDeviceBuffer& buffer);
+
+        //! Asynchronously streams buffer data up to the GPU. The operation is decoupled from the frame scheduler.
+        //! It is not valid to use the buffer while the upload is running. The provided fence is signaled when the
+        //! upload completes.
+        ResultCode StreamBuffer(const MultiDeviceBufferStreamRequest& request);
+
+        //! Returns the buffer descriptor used to initialize the buffer pool. Descriptor contents
+        //! are undefined for uninitialized pools.
+        const BufferPoolDescriptor& GetDescriptor() const override final;
+
+        //! Shuts down the pool. This method will shutdown all resources associated with the pool.
+        void Shutdown() override final;
+
+    private:
+        using MultiDeviceBufferPoolBase::InitBuffer;
+        using MultiDeviceResourcePool::Init;
+
+        //! Validates that the map operation succeeded by printing a warning otherwise. Increments
+        //! the map reference counts for the buffer and the pool.
+        void ValidateBufferMap(MultiDeviceBuffer& buffer, bool isDataValid);
+
+        bool ValidateNotDeviceLevel() const;
+
+        bool ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const;
+        bool ValidateInitRequest(const MultiDeviceBufferInitRequest& initRequest) const;
+        bool ValidateIsHostHeap() const;
+        bool ValidateMapRequest(const MultiDeviceBufferMapRequest& request) const;
+
+        BufferPoolDescriptor m_descriptor;
+
+        //! A map of all device-specific BufferPools, indexed by the device index
+        AZStd::unordered_map<int, Ptr<BufferPool>> m_deviceBufferPools;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -16,40 +16,6 @@ namespace AZ::RHI
 {
     class MultiDeviceFence;
 
-    //! A structure used as an argument to MultiDeviceBufferPool::InitBuffer.
-    struct MultiDeviceBufferInitRequest
-    {
-        MultiDeviceBufferInitRequest() = default;
-
-        MultiDeviceBufferInitRequest(MultiDeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData = nullptr);
-
-        //! The buffer to initialize. The buffer must be in an uninitialized state.
-        MultiDeviceBuffer* m_buffer = nullptr;
-
-        //! The descriptor used to initialize the buffer.
-        BufferDescriptor m_descriptor;
-
-        //! [Optional] Initial data used to initialize the buffer.
-        const void* m_initialData = nullptr;
-    };
-
-    //! A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
-    struct MultiDeviceBufferMapRequest
-    {
-        MultiDeviceBufferMapRequest() = default;
-
-        MultiDeviceBufferMapRequest(MultiDeviceBuffer& buffer, size_t byteOffset, size_t byteCount);
-
-        //! The buffer instance to map for CPU access.
-        MultiDeviceBuffer* m_buffer = nullptr;
-
-        //! The number of bytes offset from the base of the buffer to map for access.
-        size_t m_byteOffset = 0;
-
-        //! The number of bytes beginning from the offset to map for access.
-        size_t m_byteCount = 0;
-    };
-
     //! A structure used as an argument to MultiDeviceBufferPool::MapBuffer.
     struct MultiDeviceBufferMapResponse
     {
@@ -57,26 +23,9 @@ namespace AZ::RHI
         AZStd::vector<void*> m_data;
     };
 
-    //! A structure used as an argument to MultiDeviceBufferPool::StreamBuffer.
-    struct MultiDeviceBufferStreamRequest
-    {
-        //! A fence to signal on completion of the upload operation.
-        MultiDeviceFence* m_fenceToSignal = nullptr;
-
-        //! The buffer instance to stream up to.
-        MultiDeviceBuffer* m_buffer = nullptr;
-
-        //! The number of bytes offset from the base of the buffer to start the upload.
-        size_t m_byteOffset = 0;
-
-        //! The number of bytes to upload beginning from m_byteOffset.
-        size_t m_byteCount = 0;
-
-        //! A pointer to the source data to upload. The source data must remain valid
-        //! for the duration of the upload operation (i.e. until m_callbackFunction
-        //! is invoked).
-        const void* m_sourceData = nullptr;
-    };
+    using MultiDeviceBufferInitRequest = BufferInitRequestTemplate<MultiDeviceBuffer>;
+    using MultiDeviceBufferMapRequest = BufferMapRequestTemplate<MultiDeviceBuffer>;
+    using MultiDeviceBufferStreamRequest = BufferStreamRequestTemplate<MultiDeviceBuffer, MultiDeviceFence>;
 
     //! Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
     //! contains properties defining memory characteristics of buffer pools. All buffers created on a pool
@@ -180,8 +129,5 @@ namespace AZ::RHI
         bool ValidateMapRequest(const MultiDeviceBufferMapRequest& request) const;
 
         BufferPoolDescriptor m_descriptor;
-
-        //! A map of all device-specific BufferPools, indexed by the device index
-        AZStd::unordered_map<int, Ptr<BufferPool>> m_deviceBufferPools;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPoolBase.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+
+namespace AZ::RHI
+{
+    //! A simple base class for buffer pools. This mainly exists so that various
+    //! buffer pool implementations can have some type safety separate from other
+    //! resource pool types.
+    class MultiDeviceBufferPoolBase : public MultiDeviceResourcePool
+    {
+    public:
+        AZ_RTTI(MultiDeviceBufferPoolBase, "{08EC3384-CC9F-4F04-B87E-0BB9D23F7CB0}", MultiDeviceResourcePool);
+        virtual ~MultiDeviceBufferPoolBase() override = default;
+
+    protected:
+        MultiDeviceBufferPoolBase() = default;
+
+        ResultCode InitBuffer(MultiDeviceBuffer* buffer, const BufferDescriptor& descriptor, PlatformMethod platformInitResourceMethod);
+
+    private:
+        using MultiDeviceResourcePool::InitResource;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndexBufferView.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/IndexBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceBuffer;
+
+    uint32_t GetIndexFormatSize(IndexFormat indexFormat);
+
+    //! A multi-device class representing a view onto a MultiDeviceBuffer holding indices, distinct from
+    //! actual view classes (like BufferView), there is no representation on the API level.
+    //! Its device-specific buffers are provided to the RHI back-end at draw time.
+    class alignas(8) MultiDeviceIndexBufferView
+    {
+    public:
+        MultiDeviceIndexBufferView() = default;
+
+        MultiDeviceIndexBufferView(const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, IndexFormat format);
+
+        //! Returns the device-specific IndexBufferView for the given index
+        IndexBufferView GetDeviceIndexBufferView(int deviceIndex) const;
+
+        //! Returns the hash of the view. This hash is precomputed at creation time.
+        HashValue64 GetHash() const;
+
+        //! Returns the buffer associated with the data in the view.
+        const MultiDeviceBuffer* GetBuffer() const;
+
+        //! Returns the byte offset into the buffer returned by GetBuffer
+        uint32_t GetByteOffset() const;
+
+        //! Returns the number of bytes in the view.
+        uint32_t GetByteCount() const;
+
+        //! Returns the format of each index in the view.
+        IndexFormat GetIndexFormat() const;
+
+    private:
+        HashValue64 m_hash = HashValue64{ 0 };
+        const MultiDeviceBuffer* m_mdBuffer = nullptr;
+        uint32_t m_byteOffset = 0;
+        uint32_t m_byteCount = 0;
+        IndexFormat m_format = IndexFormat::Uint32;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
@@ -80,7 +80,9 @@ namespace AZ::RHI
         ConstPtr<PipelineLibraryData> GetSerializedData(int deviceIndex = RHI::MultiDevice::DefaultDeviceIndex) const
         {
             if (m_deviceObjects.contains(deviceIndex))
+            {
                 return GetDevicePipelineLibrary(deviceIndex)->GetSerializedData();
+            }
             else
             {
                 AZ_Error(

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/StreamBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+#include <AzCore/std/containers/span.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceBuffer;
+    class InputStreamLayout;
+
+    //! Provides a view into a multi-device buffer, to be used as vertex stream. The content of the view is a contiguous
+    //! list of input vertex data. Its device-specific buffer is provided to the RHI back-end at draw time for a given device.
+    class alignas(8) MultiDeviceStreamBufferView
+    {
+    public:
+        MultiDeviceStreamBufferView() = default;
+
+        MultiDeviceStreamBufferView(const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, uint32_t byteStride);
+
+        //! Returns the device-specific StreamBufferView for the given index
+        StreamBufferView GetDeviceStreamBufferView(int deviceIndex) const
+        {
+            AZ_Assert(m_mdBuffer, "No MultiDeviceBuffer available\n");
+
+            return StreamBufferView(*m_mdBuffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_byteStride);
+        }
+
+        //! Returns the hash of the view. This hash is precomputed at creation time.
+        HashValue64 GetHash() const;
+
+        //! Returns the buffer associated with the view.
+        const MultiDeviceBuffer* GetBuffer() const;
+
+        //! Returns the byte offset into the buffer.
+        uint32_t GetByteOffset() const;
+
+        //! Returns the number of bytes in the view.
+        uint32_t GetByteCount() const;
+
+        //! Returns the distance in bytes between consecutive vertex entries in the buffer.
+        //! This must match the stride value in StreamBufferDescriptor.
+        uint32_t GetByteStride() const;
+
+    private:
+        HashValue64 m_hash = HashValue64{ 0 };
+        const MultiDeviceBuffer* m_mdBuffer = nullptr;
+        uint32_t m_byteOffset = 0;
+        uint32_t m_byteCount = 0;
+        uint32_t m_byteStride = 0;
+    };
+
+    //! Utility function for checking that the set of StreamBufferViews aligns with the InputStreamLayout
+    bool ValidateStreamBufferViews(
+        const InputStreamLayout& inputStreamLayout, AZStd::span<const MultiDeviceStreamBufferView> streamBufferViews);
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -10,24 +10,6 @@
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
 namespace AZ::RHI
 {
-    BufferInitRequest::BufferInitRequest(
-        Buffer& buffer,
-        const BufferDescriptor& descriptor,
-        const void* initialData)
-        : m_buffer{&buffer}
-        , m_descriptor{descriptor}
-        , m_initialData{initialData}
-    {}
-
-    BufferMapRequest::BufferMapRequest(
-        Buffer& buffer,
-        size_t byteOffset,
-        size_t byteCount)
-        : m_buffer{&buffer}
-        , m_byteOffset{byteOffset}
-        , m_byteCount{byteCount}
-    {}
-
     bool BufferPool::ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const
     {
         if (Validation::IsEnabled())

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/BufferFrameAttachment.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+
+namespace AZ::RHI
+{
+    void MultiDeviceBuffer::SetDescriptor(const BufferDescriptor& descriptor)
+    {
+        m_descriptor = descriptor;
+    }
+
+    void MultiDeviceBuffer::Invalidate()
+    {
+        m_deviceObjects.clear();
+    }
+
+    const RHI::BufferDescriptor& MultiDeviceBuffer::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    const BufferFrameAttachment* MultiDeviceBuffer::GetFrameAttachment() const
+    {
+        return static_cast<const BufferFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
+    }
+
+    const HashValue64 MultiDeviceBuffer::GetHash() const
+    {
+        HashValue64 hash = HashValue64{ 0 };
+        hash = m_descriptor.GetHash();
+        return hash;
+    }
+
+    void MultiDeviceBuffer::Shutdown()
+    {
+        IterateObjects<Buffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
+        {
+            deviceBuffer->Shutdown();
+        });
+
+        MultiDeviceResource::Shutdown();
+    }
+
+    void MultiDeviceBuffer::InvalidateViews()
+    {
+        IterateObjects<Buffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
+        {
+            deviceBuffer->InvalidateViews();
+        });
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceFence.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceBufferInitRequest::MultiDeviceBufferInitRequest(
+        MultiDeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData)
+        : m_buffer{ &buffer }
+        , m_descriptor{ descriptor }
+        , m_initialData{ initialData }
+    {
+    }
+
+    MultiDeviceBufferMapRequest::MultiDeviceBufferMapRequest(MultiDeviceBuffer& buffer, size_t byteOffset, size_t byteCount)
+        : m_buffer{ &buffer }
+        , m_byteOffset{ byteOffset }
+        , m_byteCount{ byteCount }
+    {
+    }
+
+    bool MultiDeviceBufferPool::ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (descriptor.m_heapMemoryLevel == RHI::HeapMemoryLevel::Device &&
+                descriptor.m_hostMemoryAccess == RHI::HostMemoryAccess::Read)
+            {
+                AZ_Error(
+                    "MultiDeviceBufferPool",
+                    false,
+                    "When HeapMemoryLevel::Device is specified, m_hostMemoryAccess must be HostMemoryAccess::Write.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool MultiDeviceBufferPool::ValidateInitRequest(const MultiDeviceBufferInitRequest& initRequest) const
+    {
+        if (Validation::IsEnabled())
+        {
+            const BufferPoolDescriptor& poolDescriptor = GetDescriptor();
+
+            // Bind flags of the buffer must match the pool bind flags.
+            if (initRequest.m_descriptor.m_bindFlags != poolDescriptor.m_bindFlags)
+            {
+                AZ_Error(
+                    "MultiDeviceBufferPool",
+                    false,
+                    "MultiDeviceBuffer bind flags don't match pool bind flags in pool '%s'",
+                    GetName().GetCStr());
+                return false;
+            }
+
+            // Initial data is not allowed for read-only heaps.
+            if (initRequest.m_initialData && poolDescriptor.m_hostMemoryAccess == HostMemoryAccess::Read)
+            {
+                AZ_Error("MultiDeviceBufferPool", false, "Initial data is not allowed with read-only pools.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool MultiDeviceBufferPool::ValidateIsHostHeap() const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (GetDescriptor().m_heapMemoryLevel != HeapMemoryLevel::Host)
+            {
+                AZ_Error("MultiDeviceBufferPool", false, "This operation is only permitted for pools on the Host heap.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool MultiDeviceBufferPool::ValidateMapRequest(const MultiDeviceBufferMapRequest& request) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!request.m_buffer)
+            {
+                AZ_Error("MultiDeviceBufferPool", false, "Trying to map a null buffer.");
+                return false;
+            }
+
+            if (request.m_byteCount == 0)
+            {
+                AZ_Warning(
+                    "MultiDeviceBufferPool", false, "Trying to map zero bytes from buffer '%s'.", request.m_buffer->GetName().GetCStr());
+                return false;
+            }
+
+            if (request.m_byteOffset + request.m_byteCount > request.m_buffer->GetDescriptor().m_byteCount)
+            {
+                AZ_Error(
+                    "MultiDeviceBufferPool",
+                    false,
+                    "Unable to map buffer '%s', overrunning the size of the buffer.",
+                    request.m_buffer->GetName().GetCStr());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    ResultCode MultiDeviceBufferPool::Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor)
+    {
+        return MultiDeviceResourcePool::Init(
+            deviceMask,
+            [this, &descriptor]()
+            {
+                if (!ValidatePoolDescriptor(descriptor))
+                {
+                    return ResultCode::InvalidArgument;
+                }
+
+                // Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                // for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                // possibility that users will get garbage values from GetDescriptor().
+                m_descriptor = descriptor;
+
+                ResultCode result = ResultCode::Success;
+
+                IterateDevices(
+                    [this, &descriptor, &result](int deviceIndex)
+                    {
+                        auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                        m_deviceBufferPools[deviceIndex] = Factory::Get().CreateBufferPool();
+                        result = m_deviceBufferPools[deviceIndex]->Init(*device, descriptor);
+
+                        return result == ResultCode::Success;
+                    });
+
+                if (result != ResultCode::Success)
+                {
+                    // Reset already initialized device-specific BufferPools and set deviceMask to 0
+                    m_deviceBufferPools.clear();
+                    MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+                }
+
+                return result;
+            });
+    }
+
+    ResultCode MultiDeviceBufferPool::InitBuffer(const MultiDeviceBufferInitRequest& initRequest)
+    {
+        AZ_PROFILE_FUNCTION(RHI);
+
+        if (!ValidateInitRequest(initRequest))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        ResultCode resultCode = InitBuffer(
+            initRequest.m_buffer,
+            initRequest.m_descriptor,
+            [this, &initRequest]()
+            {
+                return IterateObjects<BufferPool>([&initRequest](auto deviceIndex, auto deviceBufferPool)
+                {
+                    if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
+                    {
+                        initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
+                    }
+
+                    BufferInitRequest bufferInitRequest(
+                        *initRequest.m_buffer->GetDeviceBuffer(deviceIndex), initRequest.m_descriptor, initRequest.m_initialData);
+                    return deviceBufferPool->InitBuffer(bufferInitRequest);
+                });
+            });
+
+        if (resultCode == ResultCode::Success && initRequest.m_initialData)
+        {
+            MultiDeviceBufferMapRequest mapRequest;
+            mapRequest.m_buffer = initRequest.m_buffer;
+            mapRequest.m_byteCount = initRequest.m_descriptor.m_byteCount;
+            mapRequest.m_byteOffset = 0;
+
+            MultiDeviceBufferMapResponse mapResponse;
+            resultCode = MapBuffer(mapRequest, mapResponse);
+            if (resultCode == ResultCode::Success)
+            {
+                for (auto data : mapResponse.m_data)
+                {
+                    if (data)
+                    {
+                        memcpy(data, initRequest.m_initialData, initRequest.m_descriptor.m_byteCount);
+                    }
+                }
+
+                UnmapBuffer(*initRequest.m_buffer);
+            }
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceBufferPool::OrphanBuffer(MultiDeviceBuffer& buffer)
+    {
+        if (!ValidateIsInitialized() || !ValidateIsHostHeap() || !ValidateNotDeviceLevel())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsRegistered(&buffer))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        AZ_PROFILE_SCOPE(RHI, "MultiDeviceBufferPool::OrphanBuffer");
+
+        buffer.Invalidate();
+        buffer.Init(GetDeviceMask());
+
+        return ResultCode::Success;
+    }
+
+    ResultCode MultiDeviceBufferPool::MapBuffer(const MultiDeviceBufferMapRequest& request, MultiDeviceBufferMapResponse& response)
+    {
+        AZ_PROFILE_FUNCTION(RHI);
+
+        if (!ValidateIsInitialized() || !ValidateNotDeviceLevel())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsRegistered(request.m_buffer))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        if (!ValidateMapRequest(request))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        BufferMapRequest deviceMapRequest{};
+        deviceMapRequest.m_byteCount = request.m_byteCount;
+        deviceMapRequest.m_byteOffset = request.m_byteOffset;
+
+        BufferMapResponse deviceMapResponse{};
+
+        ResultCode resultCode = IterateObjects<BufferPool>([&](auto deviceIndex, auto deviceBufferPool)
+        {
+            deviceMapRequest.m_buffer = request.m_buffer->GetDeviceBuffer(deviceIndex).get();
+            auto resultCode = deviceBufferPool->MapBuffer(deviceMapRequest, deviceMapResponse);
+
+            if (resultCode != ResultCode::Success)
+            {
+                AZ_Error(
+                    "MultiDeviceBufferPool",
+                    false,
+                    "Unable to map buffer '%s'.",
+                    request.m_buffer->GetName().GetCStr());
+            }
+            else
+            {
+                response.m_data.push_back(deviceMapResponse.m_data);
+            }
+
+            return resultCode;
+        });
+
+        ValidateBufferMap(*request.m_buffer, !response.m_data.empty());
+        return resultCode;
+    }
+
+    void MultiDeviceBufferPool::UnmapBuffer(MultiDeviceBuffer& buffer)
+    {
+        if (ValidateIsInitialized() && ValidateNotDeviceLevel() && ValidateIsRegistered(&buffer))
+        {
+            IterateObjects<BufferPool>([&buffer](auto deviceIndex, auto deviceBufferPool)
+            {
+                deviceBufferPool->UnmapBuffer(*buffer.GetDeviceBuffer(deviceIndex));
+            });
+        }
+    }
+
+    ResultCode MultiDeviceBufferPool::StreamBuffer(const MultiDeviceBufferStreamRequest& request)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsRegistered(request.m_buffer))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        return IterateObjects<BufferPool>([&request](auto deviceIndex, auto deviceBufferPool)
+        {
+            auto* buffer = request.m_buffer->GetDeviceBuffer(deviceIndex).get();
+
+            BufferStreamRequest bufferStreamRequest{ request.m_fenceToSignal ? request.m_fenceToSignal->GetDeviceFence(deviceIndex).get()
+                                                                             : nullptr,
+                                                     buffer,
+                                                     request.m_byteOffset,
+                                                     request.m_byteCount,
+                                                     request.m_sourceData };
+
+            return deviceBufferPool->StreamBuffer(bufferStreamRequest);
+        });
+    }
+
+    const BufferPoolDescriptor& MultiDeviceBufferPool::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    void MultiDeviceBufferPool::ValidateBufferMap([[maybe_unused]] MultiDeviceBuffer& buffer, bool isDataValid)
+    {
+        if (Validation::IsEnabled())
+        {
+            // No need for validation for a null rhi
+            if (!isDataValid)
+            {
+                AZ_Error("MultiDeviceBufferPool", false, "Failed to map buffer '%s'.", buffer.GetName().GetCStr());
+            }
+        }
+    }
+
+    bool MultiDeviceBufferPool::ValidateNotDeviceLevel() const
+    {
+        return GetDescriptor().m_heapMemoryLevel != HeapMemoryLevel::Device;
+    }
+
+    void MultiDeviceBufferPool::Shutdown()
+    {
+        IterateObjects<BufferPool>([](auto deviceIndex, auto deviceBufferPool)
+        {
+            deviceBufferPool->Shutdown();
+        });
+        MultiDeviceResourcePool::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPoolBase.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPoolBase.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceBufferPoolBase.h>
+
+namespace AZ::RHI
+{
+    ResultCode MultiDeviceBufferPoolBase::InitBuffer(
+        MultiDeviceBuffer* buffer, const BufferDescriptor& descriptor, PlatformMethod platformInitResourceMethod)
+    {
+        // The descriptor is assigned regardless of whether initialization succeeds. Descriptors are considered
+        // undefined for uninitialized resources. This makes the buffer descriptor well defined at initialization
+        // time rather than leftover data from the previous usage.
+        buffer->SetDescriptor(descriptor);
+
+        return MultiDeviceResourcePool::InitResource(buffer, platformInitResourceMethod);
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndexBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndexBufferView.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <AzCore/Utils/TypeHash.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceIndexBufferView::MultiDeviceIndexBufferView(
+        const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, IndexFormat format)
+        : m_mdBuffer{ &buffer }
+        , m_byteOffset{ byteOffset }
+        , m_byteCount{ byteCount }
+        , m_format{ format }
+    {
+        m_hash = TypeHash64(*this);
+    }
+
+    IndexBufferView MultiDeviceIndexBufferView::GetDeviceIndexBufferView(int deviceIndex) const
+    {
+        AZ_Assert(m_mdBuffer, "No MultiDeviceBuffer available\n");
+
+        return IndexBufferView(*m_mdBuffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_format);
+    }
+
+    AZ::HashValue64 MultiDeviceIndexBufferView::GetHash() const
+    {
+        return m_hash;
+    }
+
+    const MultiDeviceBuffer* MultiDeviceIndexBufferView::GetBuffer() const
+    {
+        return m_mdBuffer;
+    }
+
+    uint32_t MultiDeviceIndexBufferView::GetByteOffset() const
+    {
+        return m_byteOffset;
+    }
+
+    uint32_t MultiDeviceIndexBufferView::GetByteCount() const
+    {
+        return m_byteCount;
+    }
+
+    IndexFormat MultiDeviceIndexBufferView::GetIndexFormat() const
+    {
+        return m_format;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/InputStreamLayout.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceStreamBufferView::MultiDeviceStreamBufferView(
+        const MultiDeviceBuffer& buffer, uint32_t byteOffset, uint32_t byteCount, uint32_t byteStride)
+        : m_mdBuffer{ &buffer }
+        , m_byteOffset{ byteOffset }
+        , m_byteCount{ byteCount }
+        , m_byteStride{ byteStride }
+    {
+        size_t seed = 0;
+        AZStd::hash_combine(seed, m_mdBuffer);
+        AZStd::hash_combine(seed, m_byteOffset);
+        AZStd::hash_combine(seed, m_byteCount);
+        AZStd::hash_combine(seed, m_byteStride);
+        m_hash = static_cast<HashValue64>(seed);
+    }
+
+    HashValue64 MultiDeviceStreamBufferView::GetHash() const
+    {
+        return m_hash;
+    }
+
+    const MultiDeviceBuffer* MultiDeviceStreamBufferView::GetBuffer() const
+    {
+        return m_mdBuffer;
+    }
+
+    uint32_t MultiDeviceStreamBufferView::GetByteOffset() const
+    {
+        return m_byteOffset;
+    }
+
+    uint32_t MultiDeviceStreamBufferView::GetByteCount() const
+    {
+        return m_byteCount;
+    }
+
+    uint32_t MultiDeviceStreamBufferView::GetByteStride() const
+    {
+        return m_byteStride;
+    }
+
+    bool ValidateStreamBufferViews(
+        const RHI::InputStreamLayout& inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView> streamBufferViews)
+    {
+        bool ok = true;
+
+        if (Validation::IsEnabled())
+        {
+            if (!inputStreamLayout.IsFinalized())
+            {
+                AZ_Error("InputStreamLayout", false, "InputStreamLayout is not finalized.");
+                ok = false;
+            }
+
+            if (inputStreamLayout.GetStreamBuffers().size() != streamBufferViews.size())
+            {
+                AZ_Error(
+                    "InputStreamLayout",
+                    false,
+                    "InputStreamLayout references %d stream buffers but %d StreamBufferViews were provided.",
+                    inputStreamLayout.GetStreamBuffers().size(),
+                    streamBufferViews.size());
+                ok = false;
+            }
+
+            for (int i = 0; i < inputStreamLayout.GetStreamBuffers().size() && i < streamBufferViews.size(); ++i)
+            {
+                auto& bufferDescriptor = inputStreamLayout.GetStreamBuffers()[i];
+                auto& bufferView = streamBufferViews[i];
+
+                // It can be valid to have a null buffer if this stream is not actually used by the shader, which can be the case for
+                // streams marked optional.
+                if (bufferView.GetBuffer() == nullptr)
+                {
+                    continue;
+                }
+
+                if (bufferDescriptor.m_byteStride != bufferView.GetByteStride())
+                {
+                    AZ_Error(
+                        "InputStreamLayout",
+                        false,
+                        "InputStreamLayout's buffer[%d] has stride=%d but MultiDeviceStreamBufferView[%d] has stride=%d.",
+                        i,
+                        bufferDescriptor.m_byteStride,
+                        i,
+                        bufferView.GetByteStride());
+                    ok = false;
+                }
+            }
+        }
+
+        return ok;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <AzCore/Debug/Timer.h>
+#include <AzCore/std/parallel/conditional_variable.h>
+#include <Tests/Device.h>
+
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/ResourceInvalidateBus.h>
+
+#include <Tests/Buffer.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceBufferTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceBufferTests()
+            : MultiDeviceRHITestFixture()
+        {
+        }
+
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceBufferTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceBuffer> noopBuffer;
+        noopBuffer = aznew RHI::MultiDeviceBuffer;
+    }
+
+    TEST_F(MultiDeviceBufferTests, TestAll)
+    {
+        RHI::Ptr<RHI::MultiDeviceBuffer> bufferA;
+        bufferA = aznew RHI::MultiDeviceBuffer;
+
+        bufferA->SetName(Name("BufferA"));
+        AZ_TEST_ASSERT(bufferA->GetName().GetStringView() == "BufferA");
+        AZ_TEST_ASSERT(bufferA->use_count() == 1);
+
+        {
+            RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPool;
+            bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+
+            AZ_TEST_ASSERT(bufferPool->use_count() == 1);
+
+            RHI::Ptr<RHI::MultiDeviceBuffer> bufferB;
+            bufferB = aznew RHI::MultiDeviceBuffer;
+            AZ_TEST_ASSERT(bufferB->use_count() == 1);
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+            bufferPool->Init(DeviceMask, bufferPoolDesc);
+
+            AZStd::vector<uint8_t> testData(32);
+            for (uint32_t i = 0; i < 32; ++i)
+            {
+                testData[i] = (uint8_t)i * 2;
+            }
+
+            AZ_TEST_ASSERT(bufferA->IsInitialized() == false);
+            AZ_TEST_ASSERT(bufferB->IsInitialized() == false);
+
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = bufferA.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 32);
+            initRequest.m_initialData = testData.data();
+            bufferPool->InitBuffer(initRequest);
+
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                RHI::Ptr<RHI::BufferView> bufferView;
+                bufferView = bufferA->GetDeviceBuffer(deviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, 32));
+
+                AZ_TEST_ASSERT(bufferView->IsInitialized());
+                ASSERT_FALSE(bufferView->IsStale());
+                AZ_TEST_ASSERT(bufferView->IsFullView());
+                AZ_TEST_ASSERT(bufferA->GetDeviceBuffer(deviceIndex)->use_count() == 2);
+            }
+
+            // MDBuffer still only used once
+            AZ_TEST_ASSERT(bufferA->use_count() == 1);
+            AZ_TEST_ASSERT(bufferA->IsInitialized());
+
+            initRequest.m_buffer = bufferB.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 16);
+            initRequest.m_initialData = testData.data() + 16;
+            bufferPool->InitBuffer(initRequest);
+
+            AZ_TEST_ASSERT(bufferB->IsInitialized());
+
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                const auto& bufferAData{static_cast<Buffer*>(bufferA->GetDeviceBuffer(deviceIndex).get())->GetData()};
+                AZ_TEST_ASSERT(AZStd::equal(testData.begin(), testData.end(), bufferAData.begin()));
+
+                const auto& bufferBData{static_cast<Buffer*>(bufferB->GetDeviceBuffer(deviceIndex).get())->GetData()};
+                AZ_TEST_ASSERT(AZStd::equal(testData.begin() + 16, testData.end(), bufferBData.begin()));
+            }
+
+            AZ_TEST_ASSERT(bufferA->GetPool() == bufferPool.get());
+            AZ_TEST_ASSERT(bufferB->GetPool() == bufferPool.get());
+            AZ_TEST_ASSERT(bufferPool->GetResourceCount() == 2);
+
+            {
+                uint32_t bufferIndex = 0;
+
+                const RHI::MultiDeviceBuffer* buffers[] =
+                {
+                    bufferA.get(),
+                    bufferB.get()
+                };
+
+                bufferPool->ForEach<RHI::MultiDeviceBuffer>([&bufferIndex, &buffers]([[maybe_unused]] RHI::MultiDeviceBuffer& buffer)
+                {
+                    AZ_UNUSED(buffers); // Prevent unused warning in release builds
+                    AZ_Assert(buffers[bufferIndex] == &buffer, "buffers don't match");
+                    bufferIndex++;
+                });
+            }
+
+            bufferB->Shutdown();
+            AZ_TEST_ASSERT(bufferB->GetPool() == nullptr);
+
+            RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPoolB;
+            bufferPoolB = aznew AZ::RHI::MultiDeviceBufferPool;
+            bufferPoolB->Init(DeviceMask, bufferPoolDesc);
+
+            initRequest.m_buffer = bufferB.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 16);
+            initRequest.m_initialData = testData.data() + 16;
+            bufferPoolB->InitBuffer(initRequest);
+            AZ_TEST_ASSERT(bufferB->GetPool() == bufferPoolB.get());
+
+            //Since we are switching bufferpools for bufferB it adds a refcount and invalidates the views.
+            //We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            bufferPoolB->Shutdown();
+            AZ_TEST_ASSERT(bufferPoolB->GetResourceCount() == 0);
+        }
+
+        AZ_TEST_ASSERT(bufferA->GetPool() == nullptr);
+        AZ_TEST_ASSERT(bufferA->use_count() == 1);
+    }
+
+    TEST_F(MultiDeviceBufferTests, TestViews)
+    {
+        AZStd::vector<RHI::Ptr<RHI::BufferView>> bufferViewsA(DeviceCount);
+
+        {
+            RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool;
+            bufferPool = aznew RHI::MultiDeviceBufferPool;
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+            bufferPool->Init(DeviceMask, bufferPoolDesc);
+
+            RHI::Ptr<RHI::MultiDeviceBuffer> buffer;
+            buffer = aznew RHI::MultiDeviceBuffer;
+
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = buffer.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 32);
+            bufferPool->InitBuffer(initRequest);
+
+            // Should report initialized and not stale.
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                bufferViewsA[deviceIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, 32));
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Should report as still initialized and also stale.
+            buffer->Shutdown();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale());
+            }
+
+            // Should *still* report as stale since resource invalidation events are queued.
+            bufferPool->InitBuffer(initRequest);
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex) 
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale()); 
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Explicit invalidation should mark it stale.
+            buffer->InvalidateViews();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsInitialized());
+                AZ_TEST_ASSERT(bufferViewsA[deviceIndex]->IsStale() == false);
+            }
+
+            // Create an uninitialized bufferview and let it go out of scope
+            RHI::Ptr<RHI::BufferView> uninitializedBufferViewPtr = RHI::Factory::Get().CreateBufferView();
+        }
+    }
+
+
+    struct MultiDeviceBufferAndViewBindFlags
+    {
+        RHI::BufferBindFlags bufferBindFlags;
+        RHI::BufferBindFlags viewBindFlags;
+    };
+
+    class MultiDeviceBufferBindFlagTests
+        : public MultiDeviceBufferTests
+        , public ::testing::WithParamInterface <MultiDeviceBufferAndViewBindFlags>
+    {
+    public:
+        void SetUp() override
+        {
+            MultiDeviceBufferTests::SetUp();
+
+            // Create a pool and buffer with the buffer bind flags from the parameterized test
+            m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = GetParam().bufferBindFlags;
+            m_bufferPool->Init(DeviceMask, bufferPoolDesc);
+
+            m_buffer = aznew RHI::MultiDeviceBuffer;
+            RHI::MultiDeviceBufferInitRequest initRequest;
+            initRequest.m_buffer = m_buffer.get();
+            initRequest.m_descriptor = RHI::BufferDescriptor(GetParam().bufferBindFlags, 32);
+            m_bufferPool->InitBuffer(initRequest);
+        }
+    
+        void TearDown() override
+        {
+            m_bufferPool.reset();
+            m_buffer.reset();
+            m_bufferView.reset();
+            MultiDeviceBufferTests::TearDown();
+        }
+
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_buffer;
+        RHI::Ptr<RHI::BufferView> m_bufferView;
+    };
+
+    TEST_P(MultiDeviceBufferBindFlagTests, InitView_ViewIsCreated)
+    {
+        RHI::BufferViewDescriptor bufferViewDescriptor;
+        bufferViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            m_bufferView = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor);
+            EXPECT_EQ(m_bufferView.get()!=nullptr, true);
+        }
+    }
+
+    // This test fixture is the same as MultiDeviceBufferBindFlagTests, but exists separately so that
+    // we can instantiate different test cases that are expected to fail
+    class MultiDeviceBufferBindFlagFailureCases
+        : public MultiDeviceBufferBindFlagTests
+    {
+
+    };
+
+    TEST_P(MultiDeviceBufferBindFlagFailureCases, InitView_ViewIsNotCreated)
+    {
+        RHI::BufferViewDescriptor bufferViewDescriptor;
+        bufferViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            m_bufferView = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor);
+            EXPECT_EQ(m_bufferView.get()==nullptr, true);
+        }
+    }
+
+        // These combinations should result in a successful creation of the buffer view
+    std::vector<MultiDeviceBufferAndViewBindFlags> GenerateCompatibleMultiDeviceBufferBindFlagCombinations()
+    {
+        std::vector<MultiDeviceBufferAndViewBindFlags> testCases;
+        MultiDeviceBufferAndViewBindFlags flags;
+
+        // When the buffer bind flags are equal to or a superset of the buffer view bind flags, the view is compatible with the buffer
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::Constant;
+        testCases.push_back(flags); 
+        
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        // When the buffer view bind flags are None, they have no effect and should work with any bind flag used by the buffer
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::None;
+        testCases.push_back(flags);
+
+        return testCases;
+    };
+
+    // These combinations should fail during BufferView::Init
+    std::vector<MultiDeviceBufferAndViewBindFlags> GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()
+    {
+        std::vector<MultiDeviceBufferAndViewBindFlags> testCases;
+        MultiDeviceBufferAndViewBindFlags flags;
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::Constant;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.bufferBindFlags = RHI::BufferBindFlags::None;
+        flags.viewBindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        return testCases;
+    }
+
+    std::string MultiDeviceBufferBindFlagsToString(RHI::BufferBindFlags bindFlags)
+    {
+        switch (bindFlags)
+        {
+        case RHI::BufferBindFlags::None:
+            return "None";
+        case RHI::BufferBindFlags::Constant:
+            return "Constant";
+        case RHI::BufferBindFlags::ShaderRead:
+            return "ShaderRead";
+        case RHI::BufferBindFlags::ShaderWrite:
+            return "ShaderWrite";
+        case RHI::BufferBindFlags::ShaderReadWrite:
+            return "ShaderReadWrite";
+        default:
+            AZ_Assert(false, "No string conversion was created for this bind flag setting.")
+            break;
+        }
+
+        return "";
+    }
+
+    std::string GenerateMultiDeviceBufferBindFlagTestCaseName(const ::testing::TestParamInfo<MultiDeviceBufferAndViewBindFlags>& info)
+    {
+        return MultiDeviceBufferBindFlagsToString(info.param.bufferBindFlags) + "BufferWith" + MultiDeviceBufferBindFlagsToString(info.param.viewBindFlags) + "BufferView";
+    }
+
+    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+
+    enum class MultiDeviceParallelGetBufferViewTestCases
+    {
+        Get,
+        GetAndDeferRemoval,
+        GetCreateAndDeferRemoval
+    };
+
+    enum class MultiDeviceParallelGetBufferViewCurrentAction
+    {
+        Get,
+        Create,
+        DeferredRemoval
+    };
+
+    MultiDeviceParallelGetBufferViewCurrentAction ParallelBufferViewGetCurrentAction(const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        switch (testCase)
+        {
+        case MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval:
+            switch (rand() % 2)
+            {
+            case 0:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+            case 1:
+                return MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval;
+            }
+        case MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval:
+            switch (rand() % 3)
+            {
+            case 0:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+            case 1:
+                return MultiDeviceParallelGetBufferViewCurrentAction::Create;
+            case 2:
+                return MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval;
+            }
+        case MultiDeviceParallelGetBufferViewTestCases::Get:
+        default:
+            return MultiDeviceParallelGetBufferViewCurrentAction::Get;
+        }
+    }
+
+    void ParallelGetBufferViewHelper(
+        const size_t& threadCountMax,
+        const uint32_t& bufferViewCount,
+        const uint32_t& iterations,
+        const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        // printf("Testing threads=%zu assetIds=%zu ... ", threadCountMax, assetIdCount);
+
+        AZ::Debug::Timer timer;
+        timer.Stamp();
+
+        // Create the buffer
+        constexpr uint32_t viewSize = 32;
+        constexpr uint32_t maxBufferViewCount = 100;
+        constexpr uint32_t bufferSize = viewSize * maxBufferViewCount;
+            
+        AZ_Assert(
+            maxBufferViewCount >= bufferViewCount,
+            "This test uses offsets/sizes to create unique BufferViewDescriptors. Ensure the buffer size is large enough to handle the "
+            "number of unique buffer views.");
+
+        RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool;
+        bufferPool = aznew AZ::RHI::MultiDeviceBufferPool;
+
+        RHI::BufferPoolDescriptor bufferPoolDesc;
+        bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
+        bufferPool->Init(DeviceMask, bufferPoolDesc);
+
+        RHI::Ptr<RHI::MultiDeviceBuffer> buffer;
+        buffer = aznew RHI::MultiDeviceBuffer;
+
+        RHI::MultiDeviceBufferInitRequest initRequest;
+        initRequest.m_buffer = buffer.get();
+        initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, bufferSize);
+        bufferPool->InitBuffer(initRequest);
+
+        AZStd::vector<RHI::BufferViewDescriptor> viewDescriptors;
+        viewDescriptors.reserve(bufferViewCount);
+        for (uint32_t i = 0; i < bufferViewCount; ++i)
+        {
+            viewDescriptors.push_back(RHI::BufferViewDescriptor::CreateRaw(i * viewSize, viewSize));
+        }
+
+        AZStd::vector<AZStd::vector<RHI::Ptr<RHI::BufferView>>> referenceTable(bufferViewCount);
+
+        AZStd::vector<AZStd::thread> threads;
+        AZStd::mutex mutex;
+        AZStd::mutex referenceTableMutex;
+        AZStd::atomic<int> threadCount((int)threadCountMax);
+        AZStd::condition_variable cv;
+
+        for (size_t i = 0; i < threadCountMax; ++i)
+        {
+            threads.emplace_back(
+                [&threadCount, &cv, &buffer, &viewDescriptors, &referenceTable, &iterations, &testCase, &referenceTableMutex]()
+                {
+                    bool deferRemoval = testCase == MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval ||
+                        testCase == MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval;
+
+                    for (uint32_t i = 0; i < iterations; ++i) // queue up a bunch of work
+                    {
+                        // Pick a random buffer view from a random device to deal with
+                        const size_t index = rand() % viewDescriptors.size();
+                        const int deviceIndex = rand() % DeviceCount;
+                        const RHI::BufferViewDescriptor& viewDescriptor = viewDescriptors[index];
+
+                        MultiDeviceParallelGetBufferViewCurrentAction currentAction = ParallelBufferViewGetCurrentAction(testCase);
+
+                        if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Get ||
+                            currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Create)
+                        {
+                            RHI::Ptr<RHI::BufferView> ptr = nullptr;
+                            if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Get)
+                            {
+                                ptr = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(viewDescriptor);
+                                EXPECT_EQ(ptr->GetDescriptor(), viewDescriptor);
+                            }
+                            else if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::Create)
+                            {
+                                ptr = RHI::Factory::Get().CreateBufferView();
+                                // Only initialize half of the created references to validated
+                                // that uninitialized views are also threadsafe
+                                if (rand() % 2)
+                                {
+                                    RHI::ResultCode resultCode = ptr->Init(static_cast<const Buffer&>(*buffer->GetDeviceBuffer(deviceIndex)), viewDescriptor);
+                                    EXPECT_EQ(resultCode, RHI::ResultCode::Success);
+                                    EXPECT_EQ(ptr->GetDescriptor(), viewDescriptor);
+                                }
+                            }
+
+                            // Validate the new reference
+                            EXPECT_NE(ptr, nullptr);
+
+                            if (deferRemoval)
+                            {
+                                // If this test case includes deferring the removal,
+                                // keep a reference to the instance alive so it can be removed later
+                                referenceTableMutex.lock();
+                                referenceTable[index].push_back(ptr);
+                                referenceTableMutex.unlock();
+                            }
+                        }
+                        else if (currentAction == MultiDeviceParallelGetBufferViewCurrentAction::DeferredRemoval)
+                        {
+                            // Drop the refcount to zero so the instance will be released
+                            referenceTableMutex.lock();
+                            referenceTable[index].clear();
+                            referenceTableMutex.unlock();
+                        }
+                    }
+
+                    threadCount--;
+                    cv.notify_one();
+                });
+        }
+
+        bool timedOut = false;
+
+        // Used to detect a deadlock.  If we wait for more than 10 seconds, it's likely a deadlock has occurred
+        while (threadCount > 0 && !timedOut)
+        {
+            AZStd::unique_lock<AZStd::mutex> lock(mutex);
+            timedOut =
+                (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::steady_clock::now() + AZStd::chrono::seconds(1)));
+        }
+
+        EXPECT_TRUE(threadCount == 0) << "One or more threads appear to be deadlocked at " << timer.GetDeltaTimeInSeconds()
+                                      << " seconds";
+
+        for (auto& thread : threads)
+        {
+            thread.join();
+        }
+
+        // printf("Took %f seconds\n", timer.GetDeltaTimeInSeconds());
+    }
+
+    void ParallelGetBufferViewTest(const MultiDeviceParallelGetBufferViewTestCases& testCase)
+    {
+        // This is the original test scenario from when InstanceDatabase was first implemented
+        //                           threads, bufferViews,  seconds
+        ParallelGetBufferViewHelper(8, 100, 5, testCase);
+
+        // This value is checked in as 1 so this test doesn't take too much time, but can be increased locally to soak the test.
+        const size_t attempts = 1;
+
+        for (size_t i = 0; i < attempts; ++i)
+        {
+            // printf("Attempt %zu of %zu... \n", i, attempts);
+
+            // The idea behind this series of tests is that there are two threads sharing one bufferView, and both threads try to
+            // create or release that view at the same time.
+            const uint32_t iterations = 1000;
+            //                           threads, AssetIds, iterations
+            ParallelGetBufferViewHelper(2, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 1, iterations, testCase);
+            // printf("Attempt %zu of %zu... \n", i, attempts);
+
+            // Here we try a bunch of different threadCount:bufferViewCount ratios to be thorough
+            //                           threads, views, iterations
+            ParallelGetBufferViewHelper(2, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 2, iterations, testCase);
+            ParallelGetBufferViewHelper(4, 4, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 1, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 2, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 3, iterations, testCase);
+            ParallelGetBufferViewHelper(8, 4, iterations, testCase);
+        }
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_Get)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::Get);
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_GetAndDeferRemoval)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::GetAndDeferRemoval);
+    }
+
+    TEST_F(MultiDeviceBufferTests, DISABLED_ParallelGetBufferViewTests_GetCreateAndDeferRemoval)
+    {
+        ParallelGetBufferViewTest(MultiDeviceParallelGetBufferViewTestCases::GetCreateAndDeferRemoval);
+    }
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
@@ -91,7 +91,7 @@ namespace UnitTest
                 AZ_TEST_ASSERT(bufferView->IsInitialized());
                 ASSERT_FALSE(bufferView->IsStale());
                 AZ_TEST_ASSERT(bufferView->IsFullView());
-                AZ_TEST_ASSERT(bufferA->GetDeviceBuffer(deviceIndex)->use_count() == 2);
+                AZ_TEST_ASSERT(bufferA->GetDeviceBuffer(deviceIndex)->use_count() == 3);
             }
 
             // MDBuffer still only used once

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -16,17 +16,27 @@ set(FILES
     Source/RHI/LinearAllocator.cpp
     Source/RHI/PoolAllocator.cpp
     Include/Atom/RHI/Buffer.h
+    Include/Atom/RHI/MultiDeviceBuffer.h
     Include/Atom/RHI/BufferView.h
     Include/Atom/RHI/IndexBufferView.h
+    Include/Atom/RHI/MultiDeviceIndexBufferView.h
     Include/Atom/RHI/StreamBufferView.h
+    Include/Atom/RHI/MultiDeviceStreamBufferView.h
     Source/RHI/Buffer.cpp
+    Source/RHI/MultiDeviceBuffer.cpp
     Source/RHI/BufferView.cpp
     Source/RHI/IndexBufferView.cpp
+    Source/RHI/MultiDeviceIndexBufferView.cpp
     Source/RHI/StreamBufferView.cpp
+    Source/RHI/MultiDeviceStreamBufferView.cpp
     Include/Atom/RHI/BufferPool.h
+    Include/Atom/RHI/MultiDeviceBufferPool.h
     Include/Atom/RHI/BufferPoolBase.h
+    Include/Atom/RHI/MultiDeviceBufferPoolBase.h
     Source/RHI/BufferPool.cpp
+    Source/RHI/MultiDeviceBufferPool.cpp
     Source/RHI/BufferPoolBase.cpp
+    Source/RHI/MultiDeviceBufferPoolBase.cpp
     Include/Atom/RHI/CommandList.h
     Include/Atom/RHI/CommandListValidator.h
     Include/Atom/RHI/CommandListStates.h

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -54,6 +54,7 @@ set(FILES
     Tests/IntervalMapTests.cpp
     Tests/MultiDevicePipelineStateTests.cpp
     Tests/MultiDeviceQueryTests.cpp
+    Tests/MultiDeviceBufferTests.cpp
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/AsyncWorkQueue.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/DeviceObject.h>
 #include <Atom/RHI/StreamingImagePool.h>
 #include <AzCore/std/containers/span.h>
@@ -18,11 +19,6 @@
 
 namespace AZ
 {
-    namespace RHI
-    {
-        struct BufferStreamRequest;
-    }
-
     namespace Metal
     {
         class Device;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/Fence.h>
 #include <Atom/RHI/StreamingImagePool.h>
 #include <AzCore/std/parallel/mutex.h>
@@ -22,7 +23,6 @@ namespace AZ
 {
     namespace RHI
     {
-        struct BufferStreamRequest;
         struct StreamingImageExpandRequest;
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, including:

- `MultiDeviceBuffer`
- `MultiDeviceBufferPoolBase`
- `MultiDeviceBufferPool`
- `MultiDeviceIndexBufferView`
- `MultiDeviceStreamBufferView`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources| [#16262](https://github.com/o3de/o3de/pull/16262) | merged|
| Buffers | this PR | open |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591) | open |
|Indirect*|||
| Items | | |
| SRGs| | |
|RayTracing Resources|||


## How was this PR tested?

This PR also introduces a new testset, which adapts the tests from `BufferTests` for multiple devices in:
- `MultiDeviceBufferTests`
