### PR TITLE
Introduce multi-device image resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -11,6 +11,8 @@
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
 
+#include <AzCore/std/containers/unordered_map.h>
+
 namespace AZ::RHI
 {
     struct ImageViewDescriptor;
@@ -125,6 +127,29 @@ namespace AZ::RHI
         uint32_t m_offset = 0;
     };
 
+    struct MultiDeviceImageSubresourceLayout
+    {
+        AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        MultiDeviceImageSubresourceLayout() = default;
+
+        ImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
+        {
+            return m_deviceImageSubresourceLayout[deviceIndex];
+        }
+
+        const ImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex) const
+        {
+            AZ_Assert(
+                m_deviceImageSubresourceLayout.find(deviceIndex) != m_deviceImageSubresourceLayout.end(),
+                "No ImageSubresourceLayout found for device index %d\n",
+                deviceIndex);
+            return m_deviceImageSubresourceLayout.at(deviceIndex);
+        }
+
+        AZStd::unordered_map<int, ImageSubresourceLayout> m_deviceImageSubresourceLayout;
+    };
 
     //! This family of helper function provide a standard subresource layout suitable for
     //! the source of a copy from system memory to a destination RHI staging buffer. The results are

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
@@ -15,17 +15,22 @@
 namespace AZ::RHI
 {
     //! @brief The data structure used to initialize an RHI::Image on an RHI::ImagePool.
-    struct ImageInitRequest
+    template <typename ImageClass>
+    struct ImageInitRequestTemplate
     {
-        ImageInitRequest() = default;
+        ImageInitRequestTemplate() = default;
 
-        ImageInitRequest(
-            Image& image,
+        ImageInitRequestTemplate(
+            ImageClass& image,
             const ImageDescriptor& descriptor,
-            const ClearValue* optimizedClearValue = nullptr);
+            const ClearValue* optimizedClearValue = nullptr)
+            : m_image{&image}
+            , m_descriptor{descriptor}
+            , m_optimizedClearValue{optimizedClearValue}
+        {}
 
         /// The image to initialize.
-        Image* m_image = nullptr;
+        ImageClass* m_image = nullptr;
 
         /// The descriptor used to initialize the image.
         ImageDescriptor m_descriptor;
@@ -37,12 +42,13 @@ namespace AZ::RHI
     };
 
     //!@brief The data structure used to update contents of an RHI::Image on an RHI::ImagePool.
-    struct ImageUpdateRequest
+    template <typename ImageClass, typename ImageSubresourceLayoutClass>
+    struct ImageUpdateRequestTemplate
     {
-        ImageUpdateRequest() = default;
+        ImageUpdateRequestTemplate() = default;
 
         /// A pointer to an initialized image, whose contents will be updated.
-        Image* m_image = nullptr;
+        ImageClass* m_image = nullptr;
 
         /// The image subresource to update.
         ImageSubresource m_imageSubresource;
@@ -54,8 +60,11 @@ namespace AZ::RHI
         const void* m_sourceData = nullptr;
 
         /// The source sub-resource layout.
-        ImageSubresourceLayout m_sourceSubresourceLayout;
+        ImageSubresourceLayoutClass m_sourceSubresourceLayout;
     };
+
+    using ImageInitRequest = ImageInitRequestTemplate<Image>;
+    using ImageUpdateRequest = ImageUpdateRequestTemplate<Image, ImageSubresourceLayout>;
 
     //! ImagePool is a pool of images that will be bound as attachments to the frame scheduler.
     //! As a result, they are intended to be produced and consumed by the GPU. Persistent Color / Depth Stencil / Image

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ImageSubresource.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/MultiDeviceResource.h>
+
+namespace AZ::RHI
+{
+    class ImageFrameAttachment;
+    class MultiDeviceShaderResourceGroup;
+    class ImageView;
+    struct ImageViewDescriptor;
+
+    //! MultiDeviceImage represents a collection of MultiDeviceImage Subresources, where each subresource comprises a one to three
+    //! dimensional grid of pixels. Images are divided into an array of mip-map chains. A mip map chain is
+    //! a list of subresources, progressively halved on each axis, down to a 1x1 pixel base image. If an array is used,
+    //! each array 'slice' is its own mip chain. All mip chains in an array share the same size.
+    //!
+    //! Subresources are organized by a linear indexing scheme: mipSliceOffset + arraySliceOffset * arraySize. The total
+    //! number of subresources is equal to mipLevels * arraySize. All subresources share the same pixel format.
+    //!
+    //! @see ImageView on how to interpret contents of an image.
+    class MultiDeviceImage : public MultiDeviceResource
+    {
+        friend class MultiDeviceImagePoolBase;
+        friend class MultiDeviceImagePool;
+        friend class MultiDeviceTransientAttachmentPool;
+        friend class MultiDeviceStreamingImagePool;
+
+        using Base = MultiDeviceResource;
+
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceImage, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceImage, "{39FFE66C-805A-41AD-9092-91327D51F64B}", MultiDeviceResource);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(Image);
+        MultiDeviceImage() = default;
+        virtual ~MultiDeviceImage() = default;
+
+        //! Returns the image descriptor used to initialize the image. If the image is uninitialized, the contents
+        //! are considered undefined.
+        const ImageDescriptor& GetDescriptor() const;
+
+        //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
+        //! this data represents how to store the image in a buffer resource. Naturally, if the image contents
+        //! are swizzled in device memory, the layouts will differ from the actual physical memory footprint. Use this data
+        //! to facilitate transfers between buffers and images.
+        //!
+        //!  @param subresourceRange The range of subresources in the image to consider when computing subresource layouts.
+        //!  @param subresourceLayouts
+        //!      [Optional] If specified, fills the provided array with computed subresource layout results. The size of the
+        //!      array must be at least the number of subresources specified in the subresource range (number of mip slices *
+        //!      number of array slices).
+        //!  @param totalSizeInBytes
+        //!      [Optional] If specified, will be filled with the total size necessary to contain all subresources.
+        void GetSubresourceLayout(MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags) const;
+
+        //! Returns the set of queue classes that are supported for usage as an attachment on the frame scheduler.
+        //! Effectively, for a scope of a specific hardware class to use the image as an attachment, the queue must
+        //! be present in this mask. This does not apply to non-attachment images on the Compute / Graphics queue.
+        HardwareQueueClassMask GetSupportedQueueMask() const;
+
+        //! Returns the image frame attachment if the image is currently attached. This is assigned when the image
+        //! is imported into the frame scheduler (which is reset every frame). This value will be null for non-attachment
+        //! images.
+        const ImageFrameAttachment* GetFrameAttachment() const;
+
+        //! Returns the aspects that are included in the image.
+        ImageAspectFlags GetAspectFlags() const;
+
+        //! Get the hash associated with the passed image descriptor
+        const HashValue64 GetHash() const;
+
+        //! Shuts down the resource by detaching it from its parent pool.
+        void Shutdown() override final;
+
+        //! Invalidate all device-specific views by setting off events on all corresponding ResourceInvalidateBusses
+        void InvalidateViews() override final;
+
+    protected:
+        virtual void SetDescriptor(const ImageDescriptor& descriptor);
+
+    private:
+        //! The RHI descriptor for this image.
+        ImageDescriptor m_descriptor;
+
+        //! the set of supported queue classes for this resource.
+        HardwareQueueClassMask m_supportedQueueMask = HardwareQueueClassMask::All;
+
+        //! Aspects supported by the image
+        ImageAspectFlags m_aspectFlags = ImageAspectFlags::None;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePool.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/ClearValue.h>
+#include <Atom/RHI.Reflect/ImagePoolDescriptor.h>
+#include <Atom/RHI/ImagePool.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+
+namespace AZ::RHI
+{
+    using MultiDeviceImageInitRequest = ImageInitRequestTemplate<MultiDeviceImage>;
+    using MultiDeviceImageUpdateRequest = ImageUpdateRequestTemplate<MultiDeviceImage, MultiDeviceImageSubresourceLayout>;
+
+    //! MultiDeviceImagePool is a pool of images that will be bound as attachments to the frame scheduler.
+    //! As a result, they are intended to be produced and consumed by the GPU. Persistent Color / Depth Stencil / Image
+    //! attachments should be created from this pool. This pool is not designed for intra-frame aliasing.
+    //! If transient images are required, they can be created from the frame scheduler itself.
+    class MultiDeviceImagePool : public MultiDeviceImagePoolBase
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceImagePool, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceImagePool, "{11D804D0-8332-490B-8A3E-BE279FCEFB8E}", MultiDeviceImagePoolBase);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(ImagePool);
+        MultiDeviceImagePool() = default;
+        virtual ~MultiDeviceImagePool() = default;
+
+        //! Initializes the pool. The pool must be initialized before images can be registered with it.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor);
+
+        //! Initializes an image onto the pool. The pool provides backing GPU resources to the image.
+        ResultCode InitImage(const MultiDeviceImageInitRequest& request);
+
+        //! Updates image content from the CPU.
+        ResultCode UpdateImageContents(const MultiDeviceImageUpdateRequest& request);
+
+        //! Returns the descriptor used to initialize the pool.
+        const ImagePoolDescriptor& GetDescriptor() const override final;
+
+        void Shutdown() override final;
+
+    private:
+        using MultiDeviceImagePoolBase::InitImage;
+        using MultiDeviceResourcePool::Init;
+
+        bool ValidateUpdateRequest(const MultiDeviceImageUpdateRequest& updateRequest) const;
+
+        ImagePoolDescriptor m_descriptor;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImagePoolBase.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+
+namespace AZ::RHI
+{
+    //! A simple base class for multi-device image pools. This mainly exists so that various
+    //! image pool implementations can have some type safety separate from other
+    //! resource pool types.
+    class MultiDeviceImagePoolBase : public MultiDeviceResourcePool
+    {
+    public:
+        AZ_RTTI(MultiDeviceImagePoolBase, "{CAC2167A-D65A-493F-A450-FDE2B1A883B1}", MultiDeviceResourcePool);
+        virtual ~MultiDeviceImagePoolBase() override = default;
+
+    protected:
+        MultiDeviceImagePoolBase() = default;
+
+        ResultCode InitImage(MultiDeviceImage* image, const ImageDescriptor& descriptor, PlatformMethod platformInitResourceMethod);
+
+    private:
+        using MultiDeviceResourcePool::InitResource;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/StreamingImagePoolDescriptor.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+#include <Atom/RHI/StreamingImagePool.h>
+
+#include <AzCore/std/containers/span.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        using CompleteCallback = AZStd::function<void()>;
+
+        using MultiDeviceStreamingImageInitRequest = StreamingImageInitRequestTemplate<MultiDeviceImage>;
+        using MultiDeviceStreamingImageExpandRequest = StreamingImageExpandRequestTemplate<MultiDeviceImage>;
+
+        class MultiDeviceStreamingImagePool : public MultiDeviceImagePoolBase
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(MultiDeviceStreamingImagePool, AZ::SystemAllocator, 0);
+            AZ_RTTI(MultiDeviceStreamingImagePool, "{466B4368-79D6-4363-91DE-3D0001159F7C}", MultiDeviceImagePoolBase);
+            AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(StreamingImagePool);
+            MultiDeviceStreamingImagePool() = default;
+            virtual ~MultiDeviceStreamingImagePool() = default;
+
+            //! Initializes the pool. The pool must be initialized before images can be registered with it.
+            ResultCode Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor);
+
+            //! Initializes the backing resources of an image.
+            ResultCode InitImage(const MultiDeviceStreamingImageInitRequest& request);
+
+            //! Expands a streaming image with new mip chain data. The expansion can be performed
+            //! asynchronously or synchronously depends on @m_waitForUpload in @MultiDeviceStreamingImageExpandRequest.
+            //! Upon completion, the views will be invalidated and map to the newly
+            //! streamed mip levels.
+            ResultCode ExpandImage(const MultiDeviceStreamingImageExpandRequest& request);
+
+            //! Trims a streaming image down to (and including) the target mip level. This occurs
+            //! immediately. The newly evicted mip levels are no longer accessible by image views
+            //! and the contents are considered undefined.
+            ResultCode TrimImage(MultiDeviceImage& image, uint32_t targetMipLevel);
+
+            const StreamingImagePoolDescriptor& GetDescriptor() const override final;
+
+        private:
+            using MultiDeviceImagePoolBase::InitImage;
+            using MultiDeviceResourcePool::Init;
+
+            bool ValidateInitRequest(const MultiDeviceStreamingImageInitRequest& initRequest) const;
+            bool ValidateExpandRequest(const MultiDeviceStreamingImageExpandRequest& expandRequest) const;
+
+            StreamingImagePoolDescriptor m_descriptor;
+
+            //! Frame mutex prevents image update requests from overlapping with frame.
+            AZStd::shared_mutex m_frameMutex;
+        };
+    } // namespace RHI
+} // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -37,17 +37,22 @@ namespace AZ::RHI
     using CompleteCallback = AZStd::function<void()>;
 
     //! A structure used as an argument to StreamingImagePool::InitImage.
-    struct StreamingImageInitRequest
+    template <typename ImageClass>
+    struct StreamingImageInitRequestTemplate
     {
-        StreamingImageInitRequest() = default;
+        StreamingImageInitRequestTemplate() = default;
 
-        StreamingImageInitRequest(
-            Image& image,
+        StreamingImageInitRequestTemplate(
+            ImageClass& image,
             const ImageDescriptor& descriptor,
-            AZStd::span<const StreamingImageMipSlice> tailMipSlices);
+            AZStd::span<const StreamingImageMipSlice> tailMipSlices)
+            : m_image{&image}
+            , m_descriptor{descriptor}
+            , m_tailMipSlices{tailMipSlices}
+        {}
 
         /// The image to initialize.
-        Image* m_image = nullptr;
+        ImageClass* m_image = nullptr;
 
         /// The descriptor used to to initialize the image.
         ImageDescriptor m_descriptor;
@@ -59,12 +64,13 @@ namespace AZ::RHI
     };
 
     //! A structure used as an argument to StreamingImagePool::ExpandImage.
-    struct StreamingImageExpandRequest
+    template <typename ImageClass>
+    struct StreamingImageExpandRequestTemplate
     {
-        StreamingImageExpandRequest() = default;
+        StreamingImageExpandRequestTemplate() = default;
 
         /// The image with which to expand its mip chain.
-        Image* m_image = nullptr;
+        ImageClass* m_image = nullptr;
 
         //! A list of image mip slices used to expand the contents. The data *must*
         //! remain valid for the duration of the upload (until m_completeCallback
@@ -77,6 +83,9 @@ namespace AZ::RHI
         /// A function to call when the upload is complete. It will be called instantly if m_waitForUpload was set to true.
         CompleteCallback m_completeCallback;
     };
+
+    using StreamingImageInitRequest = StreamingImageInitRequestTemplate<Image>;
+    using StreamingImageExpandRequest = StreamingImageExpandRequestTemplate<Image>;
 
     class StreamingImagePool
         : public ImagePoolBase

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -9,15 +9,6 @@
 
 namespace AZ::RHI
 {
-    ImageInitRequest::ImageInitRequest(
-        Image& image,
-        const ImageDescriptor& descriptor,
-        const ClearValue* optimizedClearValue)
-        : m_image{&image}
-        , m_descriptor{descriptor}
-        , m_optimizedClearValue{optimizedClearValue}
-    {}
-
     ResultCode ImagePool::Init(Device& device, const ImagePoolDescriptor& descriptor)
     {
         return ResourcePool::Init(

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+
+namespace AZ::RHI
+{
+    void MultiDeviceImage::SetDescriptor(const ImageDescriptor& descriptor)
+    {
+        m_descriptor = descriptor;
+        m_aspectFlags = GetImageAspectFlags(descriptor.m_format);
+    }
+
+    const ImageDescriptor& MultiDeviceImage::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    void MultiDeviceImage::GetSubresourceLayout(MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags) const
+    {
+        ImageSubresourceRange subresourceRange;
+        subresourceRange.m_mipSliceMin = 0;
+        subresourceRange.m_mipSliceMax = 0;
+        subresourceRange.m_arraySliceMin = 0;
+        subresourceRange.m_arraySliceMax = 0;
+        subresourceRange.m_aspectFlags = aspectFlags;
+
+        IterateObjects<Image>([&subresourceRange, &subresourceLayout](auto deviceIndex, auto deviceImage)
+        {
+            deviceImage->GetSubresourceLayouts(subresourceRange, &subresourceLayout.GetDeviceImageSubresource(deviceIndex), nullptr);
+        });
+    }
+
+    const ImageFrameAttachment* MultiDeviceImage::GetFrameAttachment() const
+    {
+        return static_cast<const ImageFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
+    }
+
+    ImageAspectFlags MultiDeviceImage::GetAspectFlags() const
+    {
+        return m_aspectFlags;
+    }
+
+    const HashValue64 MultiDeviceImage::GetHash() const
+    {
+        HashValue64 hash = HashValue64{ 0 };
+        hash = m_descriptor.GetHash();
+        hash = TypeHash64(m_supportedQueueMask, hash);
+        hash = TypeHash64(m_aspectFlags, hash);
+        return hash;
+    }
+
+    void MultiDeviceImage::Shutdown()
+    {
+        IterateObjects<Image>([]([[maybe_unused]] auto deviceIndex, auto deviceImage)
+        {
+            deviceImage->Shutdown();
+        });
+
+        MultiDeviceResource::Shutdown();
+    }
+
+    void MultiDeviceImage::InvalidateViews()
+    {
+        IterateObjects<Image>([]([[maybe_unused]] auto deviceIndex, auto deviceImage)
+        {
+            deviceImage->InvalidateViews();
+        });
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePool.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceImagePool.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    ResultCode MultiDeviceImagePool::Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor)
+    {
+        return MultiDeviceResourcePool::Init(
+            deviceMask,
+            [this, &descriptor]()
+            {
+                // Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                // for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                // possibility that users will get garbage values from GetDescriptor().
+                m_descriptor = descriptor;
+
+                IterateDevices(
+                    [this, &descriptor](int deviceIndex)
+                    {
+                        auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                        m_deviceObjects[deviceIndex] = Factory::Get().CreateImagePool();
+                        GetDeviceImagePool(deviceIndex)->Init(*device, descriptor);
+
+                        return true;
+                    });
+
+                return ResultCode::Success;
+            });
+    }
+
+    bool MultiDeviceImagePool::ValidateUpdateRequest(const MultiDeviceImageUpdateRequest& updateRequest) const
+    {
+        if (Validation::IsEnabled())
+        {
+            const ImageDescriptor& imageDescriptor = updateRequest.m_image->GetDescriptor();
+            if (updateRequest.m_imageSubresource.m_mipSlice >= imageDescriptor.m_mipLevels ||
+                updateRequest.m_imageSubresource.m_arraySlice >= imageDescriptor.m_arraySize)
+            {
+                AZ_Error(
+                    "MultiDeviceImagePool",
+                    false,
+                    "Updating subresource (array: %d, mip: %d), but the image dimensions are (arraySize: %d, mipLevels: %d)",
+                    updateRequest.m_imageSubresource.m_mipSlice,
+                    updateRequest.m_imageSubresource.m_arraySlice,
+                    imageDescriptor.m_arraySize,
+                    imageDescriptor.m_mipLevels);
+                return false;
+            }
+        }
+
+        AZ_UNUSED(updateRequest);
+        return true;
+    }
+
+    ResultCode MultiDeviceImagePool::InitImage(const MultiDeviceImageInitRequest& initRequest)
+    {
+        return MultiDeviceImagePoolBase::InitImage(
+            initRequest.m_image,
+            initRequest.m_descriptor,
+            [this, &initRequest]()
+            {
+                ResultCode result = IterateObjects<ImagePool>([&initRequest](auto deviceIndex, auto deviceImagePool)
+                {
+                    if (!initRequest.m_image->m_deviceObjects.contains(deviceIndex))
+                    {
+                        initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
+                    }
+
+                    ImageInitRequest imageInitRequest(
+                        *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_optimizedClearValue);
+                    return deviceImagePool->InitImage(imageInitRequest);
+                });
+
+                if (result != ResultCode::Success)
+                {
+                    // Reset already initialized device-specific ImagePools and set deviceMask to 0
+                    m_deviceObjects.clear();
+                    MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+                }
+
+                return result;
+            });
+    }
+
+    ResultCode MultiDeviceImagePool::UpdateImageContents(const MultiDeviceImageUpdateRequest& request)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsRegistered(request.m_image))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        if (!ValidateUpdateRequest(request))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        return IterateObjects<ImagePool>([&request](auto deviceIndex, auto deviceImagePool)
+        {
+            ImageUpdateRequest imageUpdateRequest;
+
+            imageUpdateRequest.m_image = request.m_image->GetDeviceImage(deviceIndex).get();
+            imageUpdateRequest.m_imageSubresource = request.m_imageSubresource;
+            imageUpdateRequest.m_imageSubresourcePixelOffset = request.m_imageSubresourcePixelOffset;
+            imageUpdateRequest.m_sourceData = request.m_sourceData;
+            imageUpdateRequest.m_sourceSubresourceLayout = request.m_sourceSubresourceLayout.GetDeviceImageSubresource(deviceIndex);
+
+            return deviceImagePool->UpdateImageContents(imageUpdateRequest);
+        });
+    }
+
+    const ImagePoolDescriptor& MultiDeviceImagePool::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    void MultiDeviceImagePool::Shutdown()
+    {
+        IterateObjects<ImagePool>([]([[maybe_unused]] auto deviceIndex, auto deviceImagePool)
+        {
+            deviceImagePool->Shutdown();
+        });
+
+        MultiDeviceResourcePool::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePoolBase.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImagePoolBase.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+
+namespace AZ::RHI
+{
+    ResultCode MultiDeviceImagePoolBase::InitImage(
+        MultiDeviceImage* image, const ImageDescriptor& descriptor, PlatformMethod platformInitResourceMethod)
+    {
+        // The descriptor is assigned regardless of whether initialization succeeds. Descriptors are considered
+        // undefined for uninitialized resources. This makes the image descriptor well defined at initialization
+        // time rather than leftover data from the previous usage.
+        image->SetDescriptor(descriptor);
+
+        return MultiDeviceResourcePool::InitResource(image, platformInitResourceMethod);
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/MultiDeviceStreamingImagePool.h>
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/std/parallel/atomic.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace AZ::RHI
+{
+    bool MultiDeviceStreamingImagePool::ValidateInitRequest(const MultiDeviceStreamingImageInitRequest& initRequest) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (initRequest.m_tailMipSlices.empty())
+            {
+                AZ_Error(
+                    "MultiDeviceStreamingImagePool",
+                    false,
+                    "No tail mip slices were provided. You must provide at least one tail mip slice.");
+                return false;
+            }
+
+            if (initRequest.m_tailMipSlices.size() > initRequest.m_descriptor.m_mipLevels)
+            {
+                AZ_Error("MultiDeviceStreamingImagePool", false, "Tail mip array exceeds the number of mip levels in the image.");
+                return false;
+            }
+
+            // Streaming images are only allowed to update via the CPU.
+            if (CheckBitsAny(
+                    initRequest.m_descriptor.m_bindFlags,
+                    ImageBindFlags::Color | ImageBindFlags::DepthStencil | ImageBindFlags::ShaderWrite))
+            {
+                AZ_Error("MultiDeviceStreamingImagePool", false, "Streaming images may only contain read-only bind flags.");
+                return false;
+            }
+        }
+
+        AZ_UNUSED(initRequest);
+        return true;
+    }
+
+    bool MultiDeviceStreamingImagePool::ValidateExpandRequest(const MultiDeviceStreamingImageExpandRequest& expandRequest) const
+    {
+        if (Validation::IsEnabled())
+        {
+            if (!ValidateIsRegistered(expandRequest.m_image))
+            {
+                return false;
+            }
+        }
+
+        AZ_UNUSED(expandRequest);
+        return true;
+    }
+
+    ResultCode MultiDeviceStreamingImagePool::Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor)
+    {
+        AZ_PROFILE_FUNCTION(RHI);
+
+        return MultiDeviceResourcePool::Init(
+            deviceMask,
+            [this, &descriptor]()
+            {
+                // Assign the descriptor prior to initialization. Technically, the descriptor is undefined
+                // for uninitialized pools, so it's okay if initialization fails. Doing this removes the
+                // possibility that users will get garbage values from GetDescriptor().
+                m_descriptor = descriptor;
+
+                ResultCode result = ResultCode::Success;
+
+                IterateDevices(
+                    [this, &descriptor, &result](int deviceIndex)
+                    {
+                        auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                        m_deviceObjects[deviceIndex] = Factory::Get().CreateStreamingImagePool();
+                        result = GetDeviceStreamingImagePool(deviceIndex)->Init(*device, descriptor);
+
+                        return result == ResultCode::Success;
+                    });
+
+                if (result != ResultCode::Success)
+                {
+                    // Reset already initialized device-specific StreamingImagePool and set deviceMask to 0
+                    m_deviceObjects.clear();
+                    MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+                }
+
+                return ResultCode::Success;
+            });
+    }
+
+    ResultCode MultiDeviceStreamingImagePool::InitImage(const MultiDeviceStreamingImageInitRequest& initRequest)
+    {
+        AZ_PROFILE_FUNCTION(RHI);
+
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateInitRequest(initRequest))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        ResultCode resultCode = MultiDeviceImagePoolBase::InitImage(
+            initRequest.m_image,
+            initRequest.m_descriptor,
+            [this, &initRequest]()
+            {
+                return IterateObjects<StreamingImagePool>([&initRequest](auto deviceIndex, auto deviceStreamingImagePool)
+                {
+                    initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
+                    StreamingImageInitRequest streamingImageInitRequest(
+                        *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);
+                    return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
+                });
+            });
+
+        AZ_Warning("MultiDeviceStreamingImagePool", resultCode == ResultCode::Success, "Failed to initialize image.");
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceStreamingImagePool::ExpandImage(const MultiDeviceStreamingImageExpandRequest& request)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateExpandRequest(request))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        auto expandCount = AZStd::make_shared<AZStd::atomic_int>(static_cast<int>(m_deviceObjects.size()));
+
+        auto completeCallback = [expandCount, request]()
+        {
+            if (--*expandCount == 0)
+            {
+                request.m_completeCallback();
+            }
+        };
+
+        return IterateObjects<StreamingImagePool>([&request, &completeCallback](auto deviceIndex, auto deviceStreamingImagePool)
+        {
+            StreamingImageExpandRequest expandRequest;
+
+            expandRequest.m_image = request.m_image->GetDeviceImage(deviceIndex).get();
+            expandRequest.m_mipSlices = request.m_mipSlices;
+            expandRequest.m_waitForUpload = request.m_waitForUpload;
+            expandRequest.m_completeCallback = completeCallback;
+
+            return deviceStreamingImagePool->ExpandImage(expandRequest);
+        });
+    }
+
+    ResultCode MultiDeviceStreamingImagePool::TrimImage(MultiDeviceImage& image, uint32_t targetMipLevel)
+    {
+        if (!ValidateIsInitialized())
+        {
+            return ResultCode::InvalidOperation;
+        }
+
+        if (!ValidateIsRegistered(&image))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        ResultCode resultCode = IterateObjects<StreamingImagePool>([&image, targetMipLevel](auto deviceIndex, auto deviceStreamingImagePool)
+        {
+            return deviceStreamingImagePool->TrimImage(*image.GetDeviceImage(deviceIndex), targetMipLevel);
+        });
+
+        if (resultCode == ResultCode::Success)
+        {
+            // If initialization succeeded, assign the new resident mip level. Invalidate resource views
+            // so that they no longer reference trimmed mip levels.
+            image.InvalidateViews();
+        }
+
+        return resultCode;
+    }
+
+    const StreamingImagePoolDescriptor& MultiDeviceStreamingImagePool::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -9,15 +9,6 @@
 
 namespace AZ::RHI
 {
-    StreamingImageInitRequest::StreamingImageInitRequest(
-        Image& image,
-        const ImageDescriptor& descriptor,
-        AZStd::span<const StreamingImageMipSlice> tailMipSlices)
-        : m_image{&image}
-        , m_descriptor{descriptor}
-        , m_tailMipSlices{tailMipSlices}
-    {}
-        
     bool StreamingImagePool::ValidateInitRequest(const StreamingImageInitRequest& initRequest) const
     {
         if (Validation::IsEnabled())

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+#include <Atom/RHI/MultiDeviceImagePool.h>
+#include <Atom/RHI/ResourceInvalidateBus.h>
+#include <Tests/Device.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    class MultiDeviceImageTests : public MultiDeviceRHITestFixture
+    {
+    public:
+        MultiDeviceImageTests()
+            : MultiDeviceRHITestFixture()
+        {}
+
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+    };
+
+    TEST_F(MultiDeviceImageTests, TestNoop)
+    {
+        RHI::Ptr<RHI::MultiDeviceImage> noopImage;
+        noopImage = aznew RHI::MultiDeviceImage;
+    }
+
+    TEST_F(MultiDeviceImageTests, TestAll)
+    {
+        RHI::Ptr<RHI::MultiDeviceImage> imageA;
+        imageA = aznew RHI::MultiDeviceImage;
+        imageA->SetName(Name("ImageA"));
+
+        ASSERT_TRUE(imageA->GetName().GetStringView() == "ImageA");
+        ASSERT_TRUE(imageA->use_count() == 1);
+
+        {
+            RHI::Ptr<RHI::MultiDeviceImage> imageB;
+            imageB = aznew RHI::MultiDeviceImage;
+
+            ASSERT_TRUE(imageB->use_count() == 1);
+
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePool;
+            imagePool = aznew RHI::MultiDeviceImagePool;
+
+            ASSERT_TRUE(imagePool->use_count() == 1);
+
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
+            imagePool->Init(DeviceMask, imagePoolDesc);
+
+            ASSERT_TRUE(imageA->IsInitialized() == false);
+            ASSERT_TRUE(imageB->IsInitialized() == false);
+
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = imageA.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 16, 16, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+            ASSERT_TRUE(imageA->use_count() == 1);
+
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex) 
+            {
+                RHI::Ptr<RHI::ImageView> imageView;
+                imageView = imageA->GetDeviceImage(deviceIndex)->GetImageView(RHI::ImageViewDescriptor(RHI::Format::R8G8B8A8_UINT));
+                AZ_TEST_ASSERT(imageView->IsStale() == false);
+                ASSERT_TRUE(imageView->IsInitialized());
+                ASSERT_TRUE(imageA->GetDeviceImage(deviceIndex)->use_count() == 3);
+            }
+
+            ASSERT_TRUE(imageA->use_count() == 1);
+            ASSERT_TRUE(imageA->IsInitialized());
+
+            initRequest.m_image = imageB.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 8, 8, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+
+            ASSERT_TRUE(imageB->IsInitialized());
+
+            ASSERT_TRUE(imageA->GetPool() == imagePool.get());
+            ASSERT_TRUE(imageB->GetPool() == imagePool.get());
+            ASSERT_TRUE(imagePool->GetResourceCount() == 2);
+
+            {
+                uint32_t imageIndex = 0;
+
+                const RHI::MultiDeviceImage* images[] =
+                {
+                    imageA.get(),
+                    imageB.get()
+                };
+
+                imagePool->ForEach<RHI::MultiDeviceImage>([&imageIndex, &images]([[maybe_unused]] const RHI::MultiDeviceImage& image)
+                {
+                    AZ_UNUSED(images); // Prevent unused warning in release builds
+                    AZ_Assert(images[imageIndex] == &image, "images don't match");
+                    imageIndex++;
+                });
+            }
+
+            imageB->Shutdown();
+            ASSERT_TRUE(imageB->GetPool() == nullptr);
+
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePoolB;
+            imagePoolB = aznew RHI::MultiDeviceImagePool;
+            imagePoolB->Init(DeviceMask, imagePoolDesc);
+
+            initRequest.m_image = imageB.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 8, 8, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePoolB->InitImage(initRequest);
+            ASSERT_TRUE(imageB->GetPool() == imagePoolB.get());
+
+            //Since we are switching imagePools for imageB it adds a refcount and invalidates the views.
+            //We need this to ensure the views are fully invalidated in order to release the refcount and avoid a leak.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
+            imagePoolB->Shutdown();
+            ASSERT_TRUE(imagePoolB->GetResourceCount() == 0);
+        }
+
+        ASSERT_TRUE(imageA->GetPool() == nullptr);
+        ASSERT_TRUE(imageA->use_count() == 1);
+    }
+
+    TEST_F(MultiDeviceImageTests, TestViews)
+    {
+        RHI::Ptr<RHI::ImageView> imageViewA;
+        
+        {
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePool;
+            imagePool = aznew RHI::MultiDeviceImagePool;
+
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
+            imagePool->Init(DeviceMask, imagePoolDesc);
+
+            RHI::Ptr<RHI::MultiDeviceImage> image;
+            image = aznew RHI::MultiDeviceImage;
+
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = image.get();
+            initRequest.m_descriptor = RHI::ImageDescriptor::Create2DArray(RHI::ImageBindFlags::Color, 8, 8, 2, RHI::Format::R8G8B8A8_UNORM_SRGB);
+            imagePool->InitImage(initRequest);
+
+            // Should report initialized and not stale.
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(RHI::ImageViewDescriptor{});
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+                AZ_TEST_ASSERT(imageViewA->IsFullView());
+            }
+
+            // Should report as still initialized and also stale.
+            image->Shutdown();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+            
+
+            // Should *still* report as stale since resource invalidation events are queued.
+            imagePool->InitImage(initRequest);
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Explicit invalidation should mark it stale.
+            image->InvalidateViews();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsStale());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+            }
+
+            // This should re-initialize the views.
+            RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Test re-initialization.
+            RHI::ImageViewDescriptor imageViewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 0, 0, 0);
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDesc);
+                AZ_TEST_ASSERT(imageViewA->IsFullView() == false);
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+
+            // Test re-initialization.
+            imageViewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 0, 0, 1);
+            for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+            {
+                imageViewA = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDesc);
+                AZ_TEST_ASSERT(imageViewA->IsFullView());
+                AZ_TEST_ASSERT(imageViewA->IsInitialized());
+                AZ_TEST_ASSERT(imageViewA->IsStale() == false);
+            }
+        }
+
+        // The parent image was shut down. This should report as being stale.
+        AZ_TEST_ASSERT(imageViewA->IsStale());
+    }
+
+    struct MultiDeviceImageAndViewBindFlags
+    {
+        RHI::ImageBindFlags imageBindFlags;
+        RHI::ImageBindFlags viewBindFlags;
+    };
+
+    class MultiDeviceImageBindFlagTests
+        : public MultiDeviceImageTests
+        , public ::testing::WithParamInterface <MultiDeviceImageAndViewBindFlags>
+    {
+    public:
+        void SetUp() override
+        {
+            MultiDeviceImageTests::SetUp();
+
+            // Create a pool and image with the image bind flags from the parameterized test
+            m_imagePool = aznew RHI::MultiDeviceImagePool;
+            RHI::ImagePoolDescriptor imagePoolDesc;
+            imagePoolDesc.m_bindFlags = GetParam().imageBindFlags;
+            m_imagePool->Init(DeviceMask, imagePoolDesc);
+
+            RHI::ImageDescriptor imageDescriptor;
+            imageDescriptor.m_bindFlags = GetParam().imageBindFlags;
+
+            m_image = aznew RHI::MultiDeviceImage;
+            RHI::MultiDeviceImageInitRequest initRequest;
+            initRequest.m_image = m_image.get();
+            initRequest.m_descriptor = imageDescriptor;
+            m_imagePool->InitImage(initRequest);
+        }
+
+        void TearDown() override
+        {
+            m_imagePool.reset();
+            m_image.reset();
+            m_imageView.reset();
+            
+            MultiDeviceImageTests::TearDown();
+        }
+
+        RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
+        RHI::Ptr<RHI::MultiDeviceImage> m_image;
+        RHI::Ptr<RHI::ImageView> m_imageView;
+    };
+
+    TEST_P(MultiDeviceImageBindFlagTests, InitView_ViewIsCreated)
+    {
+        RHI::ImageViewDescriptor imageViewDescriptor;
+        imageViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            m_imageView = m_image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor);
+            EXPECT_EQ(m_imageView.get()!=nullptr, true);
+        }
+    }
+
+
+    // This test fixture is the same as MultiDeviceImageBindFlagTests, but exists separately so that
+    // we can instantiate different test cases that are expected to fail
+    class MultiDeviceImageBindFlagFailureCases
+        : public MultiDeviceImageBindFlagTests
+    {
+
+    };
+
+    TEST_P(MultiDeviceImageBindFlagFailureCases, InitView_ViewIsNotCreated)
+    {
+        RHI::ImageViewDescriptor imageViewDescriptor;
+        imageViewDescriptor.m_overrideBindFlags = GetParam().viewBindFlags;
+        for(auto deviceIndex{0}; deviceIndex < DeviceCount; ++deviceIndex)
+        {
+            m_imageView = m_image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor);
+            EXPECT_EQ(m_imageView.get()==nullptr, true);
+        }
+    }
+
+    // These combinations should result in a successful creation of the image view
+    std::vector<MultiDeviceImageAndViewBindFlags> GenerateCompatibleMultiDeviceImageBindFlagCombinations()
+    {
+        std::vector<MultiDeviceImageAndViewBindFlags> testCases;
+        MultiDeviceImageAndViewBindFlags flags;
+
+        // When the image bind flags are equal to or a superset of the image view bind flags, the view is compatible with the image
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::Color;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        // When the image view bind flags are None, they have no effect and should work with any bind flag used by the image
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::None;
+        testCases.push_back(flags);
+
+        return testCases;
+    };
+
+    // These combinations should fail during ImageView::Init
+    std::vector<MultiDeviceImageAndViewBindFlags> GenerateIncompatibleMultiDeviceImageBindFlagCombinations()
+    {
+        std::vector<MultiDeviceImageAndViewBindFlags> testCases;
+        MultiDeviceImageAndViewBindFlags flags;
+
+        flags.imageBindFlags = RHI::ImageBindFlags::Color;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderRead;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderRead;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderWrite;
+        testCases.push_back(flags);
+
+        flags.imageBindFlags = RHI::ImageBindFlags::None;
+        flags.viewBindFlags = RHI::ImageBindFlags::ShaderReadWrite;
+        testCases.push_back(flags);
+
+        return testCases;
+    }
+
+    std::string MultiDeviceImageBindFlagsToString(RHI::ImageBindFlags bindFlags)
+    {
+        switch (bindFlags)
+        {
+        case RHI::ImageBindFlags::None:
+            return "None";
+        case RHI::ImageBindFlags::Color:
+            return "Color";
+        case RHI::ImageBindFlags::ShaderRead:
+            return "ShaderRead";
+        case RHI::ImageBindFlags::ShaderWrite:
+            return "ShaderWrite";
+        case RHI::ImageBindFlags::ShaderReadWrite:
+            return "ShaderReadWrite";
+        default:
+            AZ_Assert(false, "No string conversion was created for this bind flag setting.");
+        }
+
+        return "";
+    }
+
+    std::string GenerateMultiDeviceImageBindFlagTestCaseName(const ::testing::TestParamInfo<MultiDeviceImageAndViewBindFlags>& info)
+    {
+        return MultiDeviceImageBindFlagsToString(info.param.imageBindFlags) + "ImageWith" + MultiDeviceImageBindFlagsToString(info.param.viewBindFlags) + "ImageView";
+    }
+
+    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+}

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -107,15 +107,23 @@ set(FILES
     Include/Atom/RHI/FrameScheduler.h
     Source/RHI/FrameScheduler.cpp
     Include/Atom/RHI/Image.h
+    Include/Atom/RHI/MultiDeviceImage.h
     Include/Atom/RHI/ImageView.h
     Source/RHI/Image.cpp
+    Source/RHI/MultiDeviceImage.cpp
     Source/RHI/ImageView.cpp
     Include/Atom/RHI/ImagePool.h
+    Include/Atom/RHI/MultiDeviceImagePool.h
     Include/Atom/RHI/ImagePoolBase.h
+    Include/Atom/RHI/MultiDeviceImagePoolBase.h
     Include/Atom/RHI/StreamingImagePool.h
+    Include/Atom/RHI/MultiDeviceStreamingImagePool.h
     Source/RHI/ImagePool.cpp
+    Source/RHI/MultiDeviceImagePool.cpp
     Source/RHI/ImagePoolBase.cpp
+    Source/RHI/MultiDeviceImagePoolBase.cpp
     Source/RHI/StreamingImagePool.cpp
+    Source/RHI/MultiDeviceStreamingImagePool.cpp
     Include/Atom/RHI/IndirectBufferSignature.h
     Include/Atom/RHI/IndirectBufferView.h
     Include/Atom/RHI/IndirectBufferWriter.h

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -55,6 +55,7 @@ set(FILES
     Tests/MultiDevicePipelineStateTests.cpp
     Tests/MultiDeviceQueryTests.cpp
     Tests/MultiDeviceBufferTests.cpp
+    Tests/MultiDeviceImageTests.cpp
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.h
@@ -21,11 +21,6 @@
 
 namespace AZ
 {
-    namespace RHI
-    {
-        struct StreamingImageExpandRequest;
-    }
-
     namespace Vulkan
     {
         class Buffer;


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, including:

- `MultiDeviceImage`
- `MultiDeviceImagePoolBase`
- `MultiDeviceImagePool`
- `MultiDeviceStreamingImagePool`
- `MultiDeviceSwapChain`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources| [#16262](https://github.com/o3de/o3de/pull/16262) | merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)  | open |
| Images | this PR | open |
|Indirect*|||
| Items | | |
| SRGs| | |
|RayTracing Resources|||


## How was this PR tested?

This PR also introduces a new testset, which adapts the tests from `ImageTests` for multiple devices in:
- `MultiDeviceImageTests`
