### PR TITLE
Fixed reading of `long/unsigned long` Attributes in the AttributeReader on Linux/Android

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
@@ -164,52 +164,52 @@ namespace AZ::Dom
     }
 
     Value::Value(int8_t value)
-        : m_value(static_cast<int64_t>(value))
+        : m_value(static_cast<AZ::s64>(value))
     {
     }
 
     Value::Value(uint8_t value)
-        : m_value(static_cast<uint64_t>(value))
+        : m_value(static_cast<AZ::u64>(value))
     {
     }
 
     Value::Value(int16_t value)
-        : m_value(static_cast<int64_t>(value))
+        : m_value(static_cast<AZ::s64>(value))
     {
     }
 
     Value::Value(uint16_t value)
-        : m_value(static_cast<uint64_t>(value))
+        : m_value(static_cast<AZ::u64>(value))
     {
     }
 
     Value::Value(int32_t value)
-        : m_value(static_cast<int64_t>(value))
+        : m_value(static_cast<AZ::s64>(value))
     {
     }
 
     Value::Value(uint32_t value)
-        : m_value(static_cast<uint64_t>(value))
+        : m_value(static_cast<AZ::u64>(value))
     {
     }
 
     Value::Value(long value)
-        : m_value(static_cast<int64_t>(value))
+        : m_value(static_cast<AZ::s64>(value))
     {
     }
 
     Value::Value(unsigned long value)
-        : m_value(static_cast<uint64_t>(value))
+        : m_value(static_cast<AZ::u64>(value))
     {
     }
 
     Value::Value(long long value)
-        : m_value(static_cast<int64_t>(value))
+        : m_value(static_cast<AZ::s64>(value))
     {
     }
 
     Value::Value(unsigned long long value)
-        : m_value(static_cast<uint64_t>(value))
+        : m_value(static_cast<AZ::u64>(value))
     {
     }
 
@@ -248,10 +248,10 @@ namespace AZ::Dom
             SetString("");
             break;
         case Type::Int64:
-            m_value = int64_t{};
+            m_value = AZ::s64{};
             break;
         case Type::Uint64:
-            m_value = uint64_t{};
+            m_value = AZ::u64{};
             break;
         case Type::Double:
             m_value = double{};
@@ -310,9 +310,9 @@ namespace AZ::Dom
         {
         case GetTypeIndex<AZStd::monostate>():
             return Type::Null;
-        case GetTypeIndex<int64_t>():
+        case GetTypeIndex<AZ::s64>():
             return Type::Int64;
-        case GetTypeIndex<uint64_t>():
+        case GetTypeIndex<AZ::u64>():
             return Type::Uint64;
         case GetTypeIndex<double>():
             return Type::Double;
@@ -383,11 +383,11 @@ namespace AZ::Dom
             [](auto&& value) -> bool
             {
                 using CurrentType = AZStd::decay_t<decltype(value)>;
-                if constexpr (AZStd::is_same_v<CurrentType, int64_t>)
+                if constexpr (AZStd::is_same_v<CurrentType, AZ::s64>)
                 {
                     return true;
                 }
-                else if constexpr (AZStd::is_same_v<CurrentType, uint64_t>)
+                else if constexpr (AZStd::is_same_v<CurrentType, AZ::u64>)
                 {
                     return true;
                 }
@@ -405,12 +405,12 @@ namespace AZ::Dom
 
     bool Value::IsInt() const
     {
-        return AZStd::holds_alternative<int64_t>(m_value);
+        return AZStd::holds_alternative<AZ::s64>(m_value);
     }
 
     bool Value::IsUint() const
     {
-        return AZStd::holds_alternative<uint64_t>(m_value);
+        return AZStd::holds_alternative<AZ::u64>(m_value);
     }
 
     bool Value::IsDouble() const
@@ -926,42 +926,42 @@ namespace AZ::Dom
         return GetNodeInternal();
     }
 
-    int64_t Value::GetInt64() const
+    AZ::s64 Value::GetInt64() const
     {
         switch (m_value.index())
         {
-        case GetTypeIndex<int64_t>():
-            return AZStd::get<int64_t>(m_value);
-        case GetTypeIndex<uint64_t>():
-            return static_cast<int64_t>(AZStd::get<uint64_t>(m_value));
+        case GetTypeIndex<AZ::s64>():
+            return AZStd::get<AZ::s64>(m_value);
+        case GetTypeIndex<AZ::u64>():
+            return static_cast<AZ::s64>(AZStd::get<AZ::u64>(m_value));
         case GetTypeIndex<double>():
-            return static_cast<int64_t>(AZStd::get<double>(m_value));
+            return static_cast<AZ::s64>(AZStd::get<double>(m_value));
         }
         AZ_Assert(false, "AZ::Dom::Value: Called GetInt on a non-numeric type");
         return {};
     }
 
-    void Value::SetInt64(int64_t value)
+    void Value::SetInt64(AZ::s64 value)
     {
         m_value = value;
     }
 
-    uint64_t Value::GetUint64() const
+    AZ::u64 Value::GetUint64() const
     {
         switch (m_value.index())
         {
-        case GetTypeIndex<int64_t>():
-            return static_cast<uint64_t>(AZStd::get<int64_t>(m_value));
-        case GetTypeIndex<uint64_t>():
-            return AZStd::get<uint64_t>(m_value);
+        case GetTypeIndex<AZ::s64>():
+            return static_cast<AZ::u64>(AZStd::get<AZ::s64>(m_value));
+        case GetTypeIndex<AZ::u64>():
+            return AZStd::get<AZ::u64>(m_value);
         case GetTypeIndex<double>():
-            return static_cast<uint64_t>(AZStd::get<double>(m_value));
+            return static_cast<AZ::u64>(AZStd::get<double>(m_value));
         }
         AZ_Assert(false, "AZ::Dom::Value: Called GetInt on a non-numeric type");
         return {};
     }
 
-    void Value::SetUint64(uint64_t value)
+    void Value::SetUint64(AZ::u64 value)
     {
         m_value = value;
     }
@@ -985,10 +985,10 @@ namespace AZ::Dom
     {
         switch (m_value.index())
         {
-        case GetTypeIndex<int64_t>():
-            return static_cast<double>(AZStd::get<int64_t>(m_value));
-        case GetTypeIndex<uint64_t>():
-            return static_cast<double>(AZStd::get<uint64_t>(m_value));
+        case GetTypeIndex<AZ::s64>():
+            return static_cast<double>(AZStd::get<AZ::s64>(m_value));
+        case GetTypeIndex<AZ::u64>():
+            return static_cast<double>(AZStd::get<AZ::u64>(m_value));
         case GetTypeIndex<double>():
             return AZStd::get<double>(m_value);
         }
@@ -1081,11 +1081,11 @@ namespace AZ::Dom
                 {
                     result = visitor.Null();
                 }
-                else if constexpr (AZStd::is_same_v<Alternative, int64_t>)
+                else if constexpr (AZStd::is_same_v<Alternative, AZ::s64>)
                 {
                     result = visitor.Int64(arg);
                 }
-                else if constexpr (AZStd::is_same_v<Alternative, uint64_t>)
+                else if constexpr (AZStd::is_same_v<Alternative, AZ::u64>)
                 {
                     result = visitor.Uint64(arg);
                 }

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.h
@@ -163,13 +163,16 @@ namespace AZ::Dom
         //! The internal storage type for Value.
         //! These types do not correspond one-to-one with the Value's external Type as there may be multiple storage classes
         //! for the same type in some instances, such as string storage.
+        //! The AZ type aliases of `AZ::s64` and `AZ::u64` are being used in lieu of `int64_t` and `uint64_t`
+        //! As those guaranteed to always be `long long` and `unsigned long long` on all platforms, where the C standard type aliases
+        //! are long-based on Linux and Android and long long-based on Windows, Mac and iOS
         using ValueType = AZStd::variant<
             // Null
             AZStd::monostate,
             // Int64
-            int64_t,
+            AZ::s64,
             // Uint64
-            uint64_t,
+            AZ::u64,
             // Double
             double,
             // Bool
@@ -338,12 +341,12 @@ namespace AZ::Dom
         const Node& GetNode() const;
 
         // int API...
-        int64_t GetInt64() const;
-        void SetInt64(int64_t);
+        AZ::s64 GetInt64() const;
+        void SetInt64(AZ::s64);
 
         // uint API...
-        uint64_t GetUint64() const;
-        void SetUint64(uint64_t);
+        AZ::u64 GetUint64() const;
+        void SetUint64(AZ::u64);
 
         // bool API...
         bool GetBool() const;

--- a/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/AttributeReader.h
@@ -48,7 +48,7 @@ namespace AZ
         template<class RetType, class InstType, typename ... Args>
         bool AttributeInvoke(Attribute* attr, InstType&& instance, Args&& ... args)
         {
-            // try a function 
+            // try a function
             if (auto func = azrtti_cast<AttributeFunction<RetType(Args...)>*>(attr); func != nullptr)
             {
                 func->Invoke(AZStd::forward<InstType>(instance), AZStd::forward<Args>(args)...);
@@ -108,6 +108,14 @@ namespace AZ
                         return true;
                     }
                     if (AttributeRead<unsigned int, Args..., DestType>(value, attr, AZStd::forward<InstType>(instance), args...))
+                    {
+                        return true;
+                    }
+                    if (AttributeRead<long, DestType, Args...>(value, attr, AZStd::forward<InstType>(instance), args...))
+                    {
+                        return true;
+                    }
+                    if (AttributeRead<unsigned long, DestType, Args...>(value, attr, AZStd::forward<InstType>(instance), args...))
                     {
                         return true;
                     }

--- a/Code/Framework/AzCore/AzCore/base.h
+++ b/Code/Framework/AzCore/AzCore/base.h
@@ -171,29 +171,27 @@ using std::ptrdiff_t;
 
 namespace AZ
 {
-    typedef int8_t    s8;
-    typedef uint8_t   u8;
-    typedef int16_t   s16;
-    typedef uint16_t  u16;
-    typedef int32_t   s32;
-    typedef uint32_t  u32;
-#   if AZ_TRAIT_COMPILER_INT64_T_IS_LONG // int64_t is long
-    typedef signed long long        s64;
-    typedef unsigned long long      u64;
-#   else
-    typedef int64_t   s64;
-    typedef uint64_t  u64;
-#   endif //
+    using s8 = int8_t;
+    using u8 = uint8_t;
+    using s16 = int16_t;
+    using u16 = uint16_t;
+    using s32 = int32_t;
+    using u32 = uint32_t;
+    // s64 and u64 are always long long and unsigned long long on all platforms
+    // where it is 64-bits
+    // The previous behavior with checking the AZ_TRAIT_COMPILER_INT64_T_IS_LONG define
+    // was exactly the same as it is now.
+    using s64 = signed long long;
+    using u64 = unsigned long long;
 
-
-    typedef struct
+    struct s128
     {
         s64 a, b;
-    } s128;
-    typedef struct
+    };
+    struct u128
     {
         u64 a, b;
-    } u128;
+    };
 
     template<typename T>
     inline T SizeAlignUp(T s, size_t a) { return static_cast<T>((s+(a-1)) & ~(a-1)); }

--- a/Code/Framework/AzCore/Tests/DOM/DomValueBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomValueBenchmarks.cpp
@@ -66,11 +66,11 @@ namespace AZ::Dom::Benchmark
                     {
                         return Type::Null;
                     }
-                    else if constexpr (AZStd::is_same_v<CurrentType, int64_t>)
+                    else if constexpr (AZStd::is_same_v<CurrentType, AZ::s64>)
                     {
                         return Type::Int64;
                     }
-                    else if constexpr (AZStd::is_same_v<CurrentType, uint64_t>)
+                    else if constexpr (AZStd::is_same_v<CurrentType, AZ::u64>)
                     {
                         return Type::Uint64;
                     }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/DepthOfField/DepthOfFieldSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/DepthOfField/DepthOfFieldSettings.cpp
@@ -286,7 +286,7 @@ namespace AZ
 
         void DepthOfFieldSettings::SetQualityLevel(uint32_t qualityLevel)
         {
-            // Clampe quality level to be less than the size of the QualitySet array
+            // Clamp quality level to be less than the size of the QualitySet array
             m_qualityLevel = AZStd::max(qualityLevel, static_cast<uint32_t>(AZStd::size(DepthOfField::QualitySet) - 1));
             m_sampleRadialDivision2 = DepthOfField::QualitySet[m_qualityLevel].sampleRadialDivision2;
             m_sampleRadialDivision4 = DepthOfField::QualitySet[m_qualityLevel].sampleRadialDivision4;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/DepthOfField/DepthOfFieldSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/DepthOfField/DepthOfFieldSettings.cpp
@@ -58,7 +58,7 @@ namespace AZ
             LoadPencilMap();
             m_pencilMapIndex = GetSceneSrg()->FindShaderInputImageIndex(Name("m_dofPencilMap"));
 
-            // Get default 
+            // Get default
             auto viewSrg = GetDefaultViewSrg();
             AZ_Assert(viewSrg, "DepthOfFieldSettings : Failed to get the default render pipeline's default viewSrg.");
 
@@ -259,7 +259,7 @@ namespace AZ
 
         // [GFX TODO][ATOM-3035]This function is temporary and will change with improvement to the draw list tag system
         void DepthOfFieldSettings::UpdateAutoFocusDepth(bool enabled)
-        {            
+        {
             const Name TemplateNameReadBackFocusDepth = Name("DepthOfFieldReadBackFocusDepthTemplate");
             // [GFX TODO][ATOM-4908] multiple camera should be distingushed.
             RPI::PassFilter passFilter = RPI::PassFilter::CreateWithTemplateName(TemplateNameReadBackFocusDepth, GetParentScene());
@@ -286,10 +286,11 @@ namespace AZ
 
         void DepthOfFieldSettings::SetQualityLevel(uint32_t qualityLevel)
         {
-            m_qualityLevel = qualityLevel;
-            m_sampleRadialDivision2 = DepthOfField::QualitySet[qualityLevel].sampleRadialDivision2;
-            m_sampleRadialDivision4 = DepthOfField::QualitySet[qualityLevel].sampleRadialDivision4;
-            m_sampleRadialDivision8 = DepthOfField::QualitySet[qualityLevel].sampleRadialDivision8;
+            // Clampe quality level to be less than the size of the QualitySet array
+            m_qualityLevel = AZStd::max(qualityLevel, static_cast<uint32_t>(AZStd::size(DepthOfField::QualitySet) - 1));
+            m_sampleRadialDivision2 = DepthOfField::QualitySet[m_qualityLevel].sampleRadialDivision2;
+            m_sampleRadialDivision4 = DepthOfField::QualitySet[m_qualityLevel].sampleRadialDivision4;
+            m_sampleRadialDivision8 = DepthOfField::QualitySet[m_qualityLevel].sampleRadialDivision8;
         }
 
         void DepthOfFieldSettings::SetApertureF(float apertureF)


### PR DESCRIPTION
### AttributeReader fixes
The AttributeReader had a feature gap that attempting to read an attribute that was of type `long` and `unsigned long` wasn't possible.

This issue is more apparent on Linux where the DPE stores it's attributes in a Dom::Value where it uses the standard C type aliases  of `int64_t` and `uint64_t`

However, while the standard type aliases are always 64-bits across platforms, they are *NOT* the same underlying type.

So on Windows `int64_t` and `uint64_t` are of type `long long` and `unsigned long long` respectively.

However on Linux and Android `int64_t` and `uint64_t` are of type `long` and `unsigned long long` respectively.

#Depth of field setting fixes
Clamped the setting of the Depth of Field Settings m_qualityLevel to [0, 2)

The DepthOfFieldSettings `m_qualityLevel` value is used to index into an array with 2 elements, however the `DepthOfFieldSettings::SetQualityLevel` function did not validate that the value was < 2, therefore a crash occurs when indexing out of bounds of the array.

fixes #16534 

### Explanation of what caused the crash

The underlying issue that caused the crash is that the [DepthOfFieldSettings::SetQualityLevel](https://github.com/o3de/o3de/blob/development/Gems/Atom/Feature/Common/Code/Source/PostProcess/DepthOfField/DepthOfFieldSettings.cpp#L287-L293) function accepted a qualityLevel integer and used that to index into an array of size 2.

However if the quality level value was >=2, it would index out of bounds of the array and cause a crash.
So the fix for the crash was to make sure to clamp the `m_qualityLevel` value to fit within the bounds of the array.


Now the user facing issue is that the user was able to use the IntSlider in the Editor move the slider values above 1 for the quality level.

The reason for this was that the `Min` and `Max` attribute in the Document Property Editor are stored in `Dom::Value` objects.

Now a Dom::Value stored its integer types under the hood as a `int64_t` and `uint64_t`.

However the AZ::AttributeReader only supported reading from an AZ::s64/AZ::u64 which was always `long long` and `unsigned long long` respectively.
On Linux/Android 64-bit, type instead use `long` and `unsigned long` for the `int64_t` and `uint64_t` type aliases and therefore the AttributeReader would failed

## How was this PR tested?

Validated that moving the Int slider for the "Quality Level" field for the Depth Of Field Component in the Editor only allowed for values of 0 and 1 when the DPE was enabled.
