### PR TITLE
Optimization - change VirtualTypes set to unordered_set

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.inl
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.inl
@@ -32,7 +32,7 @@ namespace AZ
                     auto view = Containers::Views::MakeFilterView(contentStorage, Containers::DerivedTypeFilter<T>());
                     for (auto it = view.begin(); it != view.end(); ++it)
                     {
-                        AZStd::set<Crc32> types;
+                        Events::GraphMetaInfo::VirtualTypesSet types;
                         Events::GraphMetaInfoBus::Broadcast(
                             &Events::GraphMetaInfoBus::Events::GetVirtualTypes,
                             types,

--- a/Code/Tools/SceneAPI/SceneCore/Events/GraphMetaInfoBus.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/GraphMetaInfoBus.h
@@ -38,7 +38,9 @@ namespace AZ
             {
             public:
                 static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
-                
+
+                using VirtualTypesSet = AZStd::unordered_set<Crc32>;
+
                 inline static Crc32 GetIgnoreVirtualType()
                 {
                     static Crc32 s_ignoreVirtualType = AZ_CRC("Ignore", 0x0d88d6e2);
@@ -58,12 +60,12 @@ namespace AZ
                 // Provides a list of string CRCs that indicate the virtual type the given node can act as.
                 //      Virtual types are none custom types that are different interpretations of existing types based on
                 //      their name or attributes.
-                SCENE_CORE_API virtual void GetVirtualTypes([[maybe_unused]] AZStd::set<Crc32>& types, 
+                SCENE_CORE_API virtual void GetVirtualTypes([[maybe_unused]] VirtualTypesSet& types, 
                                                             [[maybe_unused]] const Containers::Scene& scene,
                                                             [[maybe_unused]] Containers::SceneGraph::NodeIndex node) {}
 
                 // Provides a list of string CRCs that indicate all available virtual types.
-                SCENE_CORE_API virtual void GetAllVirtualTypes([[maybe_unused]] AZStd::set<Crc32>& types) {}
+                SCENE_CORE_API virtual void GetAllVirtualTypes([[maybe_unused]] VirtualTypesSet& types) {}
 
                 // Converts the virtual type hashed name into a readable name.
                 SCENE_CORE_API virtual void GetVirtualTypeName([[maybe_unused]] AZStd::string& name, [[maybe_unused]] Crc32 type) {}

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsMeshGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsMeshGroup.cpp
@@ -80,7 +80,7 @@ namespace AZ
                 auto filteredView = Containers::Views::MakeFilterView(keyValueView, Containers::DerivedTypeFilter<DataTypes::IMeshData>());
                 for (auto it = filteredView.begin(); it != filteredView.end(); ++it)
                 {
-                    AZStd::set<Crc32> types;
+                    Events::GraphMetaInfo::VirtualTypesSet types;
                     auto keyValueIterator = it.GetBaseIterator();
                     Containers::SceneGraph::NodeIndex index = graph.ConvertToNodeIndex(keyValueIterator.GetFirstIterator());
                     EBUS_EVENT(Events::GraphMetaInfoBus, GetVirtualTypes, types, scene, index);

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkeletonGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkeletonGroup.cpp
@@ -125,7 +125,7 @@ namespace AZ
 
                     // Check if this is a virtual type. There are no known virtual types supported by skeletons so this skeleton
                     //      pretends to be something that's not understood by this behavior, so skip it.
-                    AZStd::set<Crc32> virtualTypes;
+                    Events::GraphMetaInfo::VirtualTypesSet virtualTypes;
                     Events::GraphMetaInfoBus::Broadcast(&Events::GraphMetaInfoBus::Events::GetVirtualTypes, virtualTypes, 
                         scene, graph.ConvertToNodeIndex(it.GetFirstIterator()));
                     if (!virtualTypes.empty())

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkinGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkinGroup.cpp
@@ -103,7 +103,7 @@ namespace AZ
                 }
             }
 
-            void SkinGroup::GetVirtualTypes(AZStd::set<Crc32>& types, const Containers::Scene& scene,
+            void SkinGroup::GetVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types, const Containers::Scene& scene,
                 Containers::SceneGraph::NodeIndex node)
             {
                 if (types.find(s_skinVirtualType) != types.end())
@@ -129,7 +129,7 @@ namespace AZ
                 }
             }
 
-            void SkinGroup::GetAllVirtualTypes(AZStd::set<Crc32>& types)
+            void SkinGroup::GetAllVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types)
             {
                 if (types.find(s_skinVirtualType) == types.end())
                 {

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BlendShapeRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BlendShapeRuleBehavior.cpp
@@ -88,7 +88,7 @@ namespace AZ
                 auto filteredView = Containers::Views::MakeFilterView(keyValueView, Containers::DerivedTypeFilter<DataTypes::IBlendShapeData>());
                 for (auto it = filteredView.begin(); it != filteredView.end(); ++it)
                 {
-                    AZStd::set<Crc32> types;
+                    Events::GraphMetaInfo::VirtualTypesSet types;
                     auto keyValueIterator = it.GetBaseIterator();
                     Containers::SceneGraph::NodeIndex index = graph.ConvertToNodeIndex(keyValueIterator.GetFirstIterator());
                     EBUS_EVENT(Events::GraphMetaInfoBus, GetVirtualTypes, types, scene, index);

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/LodRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/LodRuleBehavior.cpp
@@ -122,7 +122,7 @@ namespace AZ
                 auto filteredView = Containers::Views::MakeFilterView(keyValueView, Containers::DerivedTypeFilter<DataTypes::IMeshData>());
                 for (auto it = filteredView.begin(); it != filteredView.end(); ++it)
                 {
-                    AZStd::set<Crc32> types;
+                    Events::GraphMetaInfo::VirtualTypesSet types;
                     auto keyValueIterator = it.GetBaseIterator();
                     Containers::SceneGraph::NodeIndex index = graph.ConvertToNodeIndex(keyValueIterator.GetFirstIterator());
                     EBUS_EVENT(Events::GraphMetaInfoBus, GetVirtualTypes, types, scene, index);
@@ -207,7 +207,7 @@ namespace AZ
                 else if (type == AZ_CRC("LODMesh5", 0xcc875c95)) { name = "LODMesh5"; }
             }
 
-            void LodRuleBehavior::GetAllVirtualTypes(AZStd::set<Crc32>& types)
+            void LodRuleBehavior::GetAllVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types)
             {
                 AZStd::copy(s_lodVirtualTypeKeys.begin(), s_lodVirtualTypeKeys.end(), AZStd::inserter(types, types.begin()));
             }

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/LodRuleBehavior.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/LodRuleBehavior.h
@@ -49,7 +49,7 @@ namespace AZ
                     RequestingApplication requester) override;
 
                 SCENE_DATA_API void GetVirtualTypeName(AZStd::string& name, Crc32 type) override;
-                SCENE_DATA_API void GetAllVirtualTypes(AZStd::set<Crc32>& types) override;
+                SCENE_DATA_API void GetAllVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types) override;
                 SCENE_DATA_API void GetPolicyName(AZStd::string& result) const override
                 {
                     result = "LodRuleBehavior";

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/SkinGroup.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/SkinGroup.h
@@ -42,9 +42,9 @@ namespace AZ
                 Events::ProcessingResult UpdateManifest(Containers::Scene& scene, ManifestAction action,
                     RequestingApplication requester) override;
 
-                void GetVirtualTypes(AZStd::set<Crc32>& types, const Containers::Scene& scene,
+                void GetVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types, const Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex node) override;
-                void GetAllVirtualTypes(AZStd::set<Crc32>& types) override;
+                void GetAllVirtualTypes(Events::GraphMetaInfo::VirtualTypesSet& types) override;
                 void GetVirtualTypeName(AZStd::string& name, Crc32 type) override;
                 void GetPolicyName(AZStd::string& result) const override
                 {

--- a/Code/Tools/SceneAPI/SceneData/Tests/GraphData/RulesTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/GraphData/RulesTests.cpp
@@ -8,6 +8,7 @@
 
 #include <AzTest/AzTest.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneCore/Events/GraphMetaInfoBus.h>
 #include <SceneAPI/SceneData/GraphData/MeshData.h>
 #include <SceneAPI/SceneData/Behaviors/LodRuleBehavior.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
@@ -33,7 +34,10 @@ namespace AZ
                 BusDisconnect();
             }
 
-            void GetVirtualTypes(AZStd::set<Crc32>& types, const SceneAPI::Containers::Scene&, SceneAPI::Containers::SceneGraph::NodeIndex) override
+            void GetVirtualTypes(
+                SceneAPI::Events::GraphMetaInfo::VirtualTypesSet& types,
+                const SceneAPI::Containers::Scene&,
+                SceneAPI::Containers::SceneGraph::NodeIndex) override
             {
                 // Indicate this node is a LOD1 type
                 types.emplace(AZ_CRC_CE("LODMesh1"));

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.cpp
@@ -245,7 +245,7 @@ namespace AZ
                     }
 
                     // Check if the object is one of the registered virtual types.
-                    AZStd::set<Crc32> virtualTypes;
+                    Events::GraphMetaInfo::VirtualTypesSet virtualTypes;
                     Events::GraphMetaInfoBus::Broadcast(&Events::GraphMetaInfo::GetVirtualTypes, virtualTypes, *root->GetScene(), index);
                     for (Crc32 name : virtualTypes)
                     {
@@ -313,7 +313,7 @@ namespace AZ
                         }
                         
                         // Check if the object is one of the registered virtual types.
-                        AZStd::set<Crc32> virtualTypes;
+                        Events::GraphMetaInfo::VirtualTypesSet virtualTypes;
                         Events::GraphMetaInfoBus::Broadcast(&Events::GraphMetaInfo::GetVirtualTypes, virtualTypes, *root->GetScene(), index);
                         for (Crc32 name : virtualTypes)
                         {

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.cpp
@@ -229,7 +229,7 @@ namespace AZ
 
                 if (!m_filterVirtualTypes.empty())
                 {
-                    AZStd::set<Crc32> virtualTypes;
+                    Events::GraphMetaInfo::VirtualTypesSet virtualTypes;
                     EBUS_EVENT(Events::GraphMetaInfoBus, GetVirtualTypes, virtualTypes, m_scene, index);
 
                     for (Crc32 name : virtualTypes)

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
@@ -49,7 +49,7 @@ namespace AZ::RPI
         {
             const Containers::SceneGraph::NodeIndex blendShapeNodeIndex = sceneGraph.ConvertToNodeIndex(it.GetBaseIterator().GetBaseIterator().GetHierarchyIterator());
 
-            AZStd::set<AZ::Crc32> types;
+            Events::GraphMetaInfo::VirtualTypesSet types;
             Events::GraphMetaInfoBus::Broadcast(&Events::GraphMetaInfo::GetVirtualTypes, types, scene, blendShapeNodeIndex);
             if (!types.contains(Events::GraphMetaInfo::GetIgnoreVirtualType()))
             {

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MorphTargetRule.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MorphTargetRule.cpp
@@ -83,7 +83,7 @@ namespace EMotionFX
                 auto filteredView = AZ::SceneAPI::Containers::Views::MakeFilterView(keyValueView, AZ::SceneAPI::Containers::DerivedTypeFilter<AZ::SceneAPI::DataTypes::IBlendShapeData>());
                 for (auto it = filteredView.begin(); it != filteredView.end(); ++it)
                 {
-                    AZStd::set<AZ::Crc32> types;
+                    AZ::SceneAPI::Events::GraphMetaInfo::VirtualTypesSet types;
                     auto keyValueIterator = it.GetBaseIterator();
                     AZ::SceneAPI::Containers::SceneGraph::NodeIndex index = graph.ConvertToNodeIndex(keyValueIterator.GetFirstIterator());
                     AZ::SceneAPI::Events::GraphMetaInfoBus::Broadcast(
@@ -167,7 +167,7 @@ namespace EMotionFX
                 auto filteredView = AZ::SceneAPI::Containers::Views::MakeFilterView(keyValueView, AZ::SceneAPI::Containers::DerivedTypeFilter<AZ::SceneAPI::DataTypes::IBlendShapeData>());
                 for (auto it = filteredView.begin(); it != filteredView.end(); ++it)
                 {
-                    AZStd::set<AZ::Crc32> types;
+                    AZStd::unordered_set<AZ::Crc32> types;
                     auto keyValueIterator = it.GetBaseIterator();
                     AZ::SceneAPI::Containers::SceneGraph::NodeIndex index = graph.ConvertToNodeIndex(keyValueIterator.GetFirstIterator());
                     AZ::SceneAPI::Events::GraphMetaInfoBus::Broadcast(

--- a/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
@@ -109,7 +109,7 @@ namespace PhysX
             {
                 AZ::SceneAPI::Containers::SceneGraph::NodeIndex nodeIndex = graph.ConvertToNodeIndex(iter.GetBaseIterator());
 
-                AZStd::set<AZ::Crc32> types;
+                AZ::SceneAPI::Events::GraphMetaInfo::VirtualTypesSet types;
                 AZ::SceneAPI::Events::GraphMetaInfoBus::Broadcast(&AZ::SceneAPI::Events::GraphMetaInfoBus::Events::GetVirtualTypes, types, scene, nodeIndex);
 
                 if (types.count(AZ_CRC_CE("PhysicsMesh")) == 1)

--- a/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.cpp
@@ -25,7 +25,9 @@ namespace AZ
             SceneAPI::Events::GraphMetaInfoBus::Handler::BusDisconnect();
         }
 
-        void SoftNameBehavior::GetVirtualTypes(AZStd::set<Crc32>& types, const SceneAPI::Containers::Scene& scene,
+        void SoftNameBehavior::GetVirtualTypes(
+            SceneAPI::Events::GraphMetaInfo::VirtualTypesSet& types,
+            const SceneAPI::Containers::Scene& scene,
             SceneAPI::Containers::SceneGraph::NodeIndex node)
         {
             const AZStd::vector<AZStd::unique_ptr<SoftNameSetting>>* softNames = nullptr;
@@ -57,7 +59,7 @@ namespace AZ
             }
         }
 
-        void SoftNameBehavior::GetAllVirtualTypes(AZStd::set<Crc32>& types)
+        void SoftNameBehavior::GetAllVirtualTypes(AZStd::unordered_set<Crc32>& types)
         {
             // Add types that aren't handled by one specific behavior and have a more global utility.
             if (types.find(AZ_CRC("Ignore", 0x0d88d6e2)) == types.end())

--- a/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.cpp
@@ -59,7 +59,7 @@ namespace AZ
             }
         }
 
-        void SoftNameBehavior::GetAllVirtualTypes(AZStd::unordered_set<Crc32>& types)
+        void SoftNameBehavior::GetAllVirtualTypes(SceneAPI::Events::GraphMetaInfo::VirtualTypesSet& types)
         {
             // Add types that aren't handled by one specific behavior and have a more global utility.
             if (types.find(AZ_CRC("Ignore", 0x0d88d6e2)) == types.end())

--- a/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.h
+++ b/Gems/SceneProcessing/Code/Source/Config/Components/SoftNameBehavior.h
@@ -27,10 +27,12 @@ namespace AZ
             void Activate() override;
             void Deactivate() override;
 
-            void GetVirtualTypes(AZStd::set<Crc32>& types, const SceneAPI::Containers::Scene& scene,
+            void GetVirtualTypes(
+                SceneAPI::Events::GraphMetaInfo::VirtualTypesSet& types,
+                const SceneAPI::Containers::Scene& scene,
                 SceneAPI::Containers::SceneGraph::NodeIndex node) override;
             void GetVirtualTypeName(AZStd::string& name, Crc32 type) override;
-            void GetAllVirtualTypes(AZStd::set<Crc32>& types) override;
+            void GetAllVirtualTypes(SceneAPI::Events::GraphMetaInfo::VirtualTypesSet& types) override;
 
             static void Reflect(ReflectContext* context);
         };

--- a/Gems/SceneProcessing/Code/Source/Config/SettingsObjects/SoftNameSetting.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/SettingsObjects/SoftNameSetting.cpp
@@ -69,7 +69,7 @@ namespace AZ
         {
             using namespace SceneAPI::Events;
 
-            AZStd::set<Crc32> virtualTypes;
+            AZStd::unordered_set<Crc32> virtualTypes;
             GraphMetaInfoBus::Broadcast(&GraphMetaInfoBus::Events::GetAllVirtualTypes, virtualTypes);
 
             AZStd::vector<AZStd::string> result;

--- a/Gems/SceneProcessing/Code/Source/Config/SettingsObjects/SoftNameSetting.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/SettingsObjects/SoftNameSetting.cpp
@@ -69,7 +69,7 @@ namespace AZ
         {
             using namespace SceneAPI::Events;
 
-            AZStd::unordered_set<Crc32> virtualTypes;
+            GraphMetaInfo::VirtualTypesSet virtualTypes;
             GraphMetaInfoBus::Broadcast(&GraphMetaInfoBus::Events::GetAllVirtualTypes, virtualTypes);
 
             AZStd::vector<AZStd::string> result;


### PR DESCRIPTION
## What does this PR do?

This is a small optimization that changes the VirtualTypes set to an unordered_set. For a test file with ~1500 meshes, this reduces the FBX Settings page refresh time from ~250 seconds to ~220 seconds. It has a negligible effect on files with a small number of meshes.

## How was this PR tested?

Used PIX to profile before/after timings with this change.
