### PR TITLE
Add render pipeline switching menu in ImGui menu

### DIFF
--- a/AutomatedTesting/Registry/viewport.setreg
+++ b/AutomatedTesting/Registry/viewport.setreg
@@ -1,0 +1,11 @@
+{
+  "O3DE": {
+    "Viewport": {
+      "SwitchableRenderPipelines": [
+        "Passes/LowEndRenderPipeline.azasset",
+        "Passes/MainRenderPipeline.azasset",
+        "Passes/MultiViewRenderPipeline.azasset"
+      ]
+    }
+  }
+}

--- a/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
@@ -136,7 +136,7 @@ namespace AtomImGuiTools
         {
             if (ImGui::BeginMenu("Render Pipelines"))
             {
-                for (auto renderPipelinePath : m_switchableRenderPipelines)
+                for (const auto& renderPipelinePath : m_switchableRenderPipelines)
                 {
                     if (ImGui::MenuItem(renderPipelinePath.c_str()))
                     {

--- a/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
@@ -61,6 +61,14 @@ namespace AtomImGuiTools
 #if defined(IMGUI_ENABLED)
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
         AtomImGuiToolsRequestBus::Handler::BusConnect();
+
+        // load switchable render pipeline paths from setting registry
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        const char* settingName = "/O3DE/Viewport/SwitchableRenderPipelines";
+        if (settingsRegistry)
+        {
+            settingsRegistry->GetObject<AZStd::set<AZStd::string>>(m_switchableRenderPipelines, settingName);
+        }           
 #endif
         CrySystemEventBus::Handler::BusConnect();
     }
@@ -122,6 +130,21 @@ namespace AtomImGuiTools
                 }
             }
             ImGui::EndMenu();
+        }
+
+        if (m_switchableRenderPipelines.size() > 0)
+        {
+            if (ImGui::BeginMenu("Render Pipelines"))
+            {
+                for (auto renderPipelinePath : m_switchableRenderPipelines)
+                {
+                    if (ImGui::MenuItem(renderPipelinePath.c_str()))
+                    {
+                        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("r_renderPipelinePath", { renderPipelinePath });
+                    }
+                }
+                ImGui::EndMenu();
+            }
         }
     }
     

--- a/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.h
@@ -21,6 +21,7 @@
 #include <Atom/Utils/ImGuiMaterialDetails.h>
 #include <Atom/Utils/ImGuiTransientAttachmentProfiler.h>
 #include <AtomLyIntegration/AtomImGuiTools/AtomImGuiToolsBus.h>
+#include <AzCore/std/containers/set.h>
 #include <MaterialShaderDetailsController.h>
 #endif
 
@@ -75,6 +76,9 @@ namespace AtomImGuiTools
         AZ::Render::ImGuiMaterialDetails m_imguiMaterialDetails;
         bool m_showMaterialDetails = false;
         MaterialShaderDetailsController m_materialDetailsController;
+
+        // switchable render pipelines
+        AZStd::set<AZStd::string> m_switchableRenderPipelines;
 #endif
     };
 


### PR DESCRIPTION
## What does this PR do?

This PR added a render pipeline selection menu to ImGui menu so user can switch render pipeline at runtime. 
The render pipeline paths are defined in setting registry "/O3DE/Viewport/SwitchableRenderPipelines". 
A setting registry file is added to AutomatedTesting project. 

![image](https://github.com/o3de/o3de/assets/55564570/031689f6-b538-4956-a2c3-fc466a4a7548)

## How was this PR tested?

Run AutomatedTesting game launcher. Enable ImGui menu. Select Render Pipeline -> LowEndRenderPipeline. The render pipeline was changed to LowEndPipeline ( in debug info text)
