### PR TITLE
An option to skip version check for a component in a clients-server handshake

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
@@ -39,7 +39,13 @@ namespace {{ Namespace }}
             componentData.m_versionHash = {{ Component.attrib['Name'] }}::GetVersionHash();
             componentData.m_componentPropertyNameLookupFunction = {{ ComponentBaseName }}::GetNetworkPropertyName;
             componentData.m_componentRpcNameLookupFunction = {{ ComponentBaseName }}::GetRpcName;
-            componentData.m_allocComponentInputFunction = {{ ComponentBaseName }}::AllocateComponentInput;
+            componentData.m_allocComponentInputFunction = {{ ComponentBaseName }}::AllocateComponentInput;            
+{% if ('OmitFromClientServerVersionHandshake' in Component.attrib) %}
+{%     set ComponentSkipsVersioning = Component.attrib['OmitFromClientServerVersionHandshake']|booleanTrue %}
+{%     if ComponentSkipsVersioning %}
+            componentData.m_includeInVersionCheck = false;
+{%     endif %}
+{% endif %}
             {{ ComponentBaseName }}::s_netComponentId = multiplayerComponentRegistry->RegisterMultiplayerComponent(componentData);
 {% if NetworkInputCount > 0 %}
             {{ ComponentName }}NetworkInput::s_netComponentId = {{ ComponentBaseName }}::s_netComponentId;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/MultiplayerComponentRegistry.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/MultiplayerComponentRegistry.h
@@ -28,6 +28,7 @@ namespace Multiplayer
             PropertyNameLookupFunction m_componentPropertyNameLookupFunction;
             RpcNameLookupFunction m_componentRpcNameLookupFunction;
             AllocComponentInputFunction m_allocComponentInputFunction;
+            bool m_includeInVersionCheck = true;
         };
 
         //! Registers a multiplayer component with the multiplayer system.

--- a/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
@@ -15,9 +15,12 @@ namespace Multiplayer
         NetComponentId netComponentId = m_nextNetComponentId++;
         m_componentData[netComponentId] = componentData;
 
-        // add all the component hashes together to create an system-wide hash
-        m_componentVersionHashes[componentData.m_componentName] = componentData.m_versionHash;
-        m_systemVersionHash += componentData.m_versionHash;
+        if (componentData.m_includeInVersionCheck)
+        {
+            // add all the component hashes together to create an system-wide hash
+            m_componentVersionHashes[componentData.m_componentName] = componentData.m_versionHash;
+            m_systemVersionHash += componentData.m_versionHash;
+        }
 
         return netComponentId;
     }


### PR DESCRIPTION
## What does this PR do?

In certain cases a network component might be in a gem that loads on clients but does load on servers.
In such a case, a component version check fails because the server includes the component in the version hash but client doesn't.

This PR adds an option `OmitFromClientServerVersionHandshake` to add a toggle to disable a network component from a version checks between a client and a server.

```xml
<Component
    Name="MyServerOnlyNetworkComponent"
    OverrideController="true"
    OverrideInclude="Source/Components/MyServerOnlyNetworkComponent.h"


    OmitFromClientServerVersionHandshake="true"
```

## How was this PR tested?

On a multiplayer enable project with a server-only components as shown above.
