### PR TITLE
Add a check on the `remainingFileLength` before proceeding to attempt…

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -196,7 +196,7 @@ namespace AZ::Settings
                 memmove(configBuffer.begin(), frontIter, readOffset);
             }
 
-            if (remainingFileLength==0)
+            if (remainingFileLength == 0)
             {
                 // There are no more bytes to read, no need to attempt to read from the stream
                 break;

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.cpp
@@ -196,6 +196,11 @@ namespace AZ::Settings
                 memmove(configBuffer.begin(), frontIter, readOffset);
             }
 
+            if (remainingFileLength==0)
+            {
+                // There are no more bytes to read, no need to attempt to read from the stream
+                break;
+            }
             // Read up to minimum of remaining file length or 4K in the configBuffer
             readSize = (AZStd::min)(configBuffer.max_size() - readOffset, remainingFileLength);
             bytesRead = configStream.Read(readSize, configBuffer.data() + readOffset);

--- a/Code/Framework/AzCore/AzCore/Settings/TextParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/TextParser.cpp
@@ -106,6 +106,12 @@ namespace AZ::Settings
                 memmove(textBuffer.begin(), frontIter, readOffset);
             }
 
+            if (remainingFileLength == 0)
+            {
+                // There are no more bytes to read, no need to attempt to read from the stream
+                break;
+            }
+
             // Read up to minimum of remaining file length or 4K in the textBuffer
             readSize = (AZStd::min)(textBuffer.max_size() - readOffset, remainingFileLength);
             bytesRead = textStream.Read(readSize, textBuffer.data() + readOffset);


### PR DESCRIPTION
## What does this PR do?

Fixes an issue discovered on Linux where an error is triggered attempting to read a config file. The `ParseConfigFile` function successully reads the config file to the end, however, even when it knows there are no remaining bytes to read, it still attempts a file read, in which case the size returned is zero, which triggers the error.

## How was this PR tested?

Reproduced steps described in Fixes https://github.com/o3de/o3de/issues/16603 


Fixes https://github.com/o3de/o3de/issues/16603 