### PR TITLE
ComputePass Shader Reload Callback

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -46,6 +46,12 @@ namespace AZ
             //! Return the shader
             Data::Instance<Shader> GetShader() const;
 
+            // When the compute shader is reloaded, this callback will be called. Subclasses of ComputePass
+            // should override OnShaderReloadedInternal() instead. By default  OnShaderReloadedInternal() will simply call
+            // the callback.
+            using ComputeShaderReloadedCallback = AZStd::function<void(ComputePass* computePass)>;
+            void SetComputeShaderReloadedCallback(ComputeShaderReloadedCallback callback);
+
         protected:
             ComputePass(const PassDescriptor& descriptor, AZ::Name supervariant = AZ::Name(""));
 
@@ -81,6 +87,11 @@ namespace AZ
             void LoadShader(AZ::Name supervariant = AZ::Name(""));
             PassDescriptor m_passDescriptor;
 
+            // At the end of LoadShader(), this function is called. By default it executes
+            // the callback function. This gives an opportunity to subclasses and owners of compute passes
+            // to call SetTargetThreadCounts(), update shader constants, etc.
+            virtual void OnShaderReloadedInternal();
+            ComputeShaderReloadedCallback m_shaderReloadedCallback = nullptr;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -143,6 +143,8 @@ namespace AZ
 
             m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
 
+            OnShaderReloadedInternal();
+
             ShaderReloadNotificationBus::Handler::BusDisconnect();
             ShaderReloadNotificationBus::Handler::BusConnect(passData->m_shaderReference.m_assetId);
         }
@@ -240,6 +242,19 @@ namespace AZ
         void ComputePass::OnShaderVariantReinitialized(const ShaderVariant&)
         {
             LoadShader();
+        }
+
+        void ComputePass::SetComputeShaderReloadedCallback(ComputeShaderReloadedCallback callback)
+        {
+            m_shaderReloadedCallback = callback;
+        }
+
+        void ComputePass::OnShaderReloadedInternal()
+        {
+            if (m_shaderReloadedCallback)
+            {
+                m_shaderReloadedCallback(this);
+            }
         }
 
     }   // namespace RPI


### PR DESCRIPTION
## What does this PR do?

Added the ability for subclasses and owners of a ComputePass to be notified when the compute shader is reloaded from disk. This was necessary to add because the Pass SRG is recreated and the owners or subclasses would not be aware that the shader constants require update.

Thanks to this new callback the shader constants can be refreshed/updated by owners of a compute pass or subclass of a compute pass.

## How was this PR tested?

It was tested in the Volumetric Cloudscape Gem which has several compute shaders that required this callback
when the compute shader is reloaded from Disk.
