### PR TITLE
Added ChangeValidate support to the DPE

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AggregateAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AggregateAdapter.cpp
@@ -998,6 +998,7 @@ namespace AZ::DocumentPropertyEditor
     {
         return { Nodes::PropertyEditor::OnChanged.GetName(),
                  Nodes::PropertyEditor::ChangeNotify.GetName(),
+                 Nodes::PropertyEditor::ChangeValidate.GetName(),
                  Nodes::PropertyEditor::RequestTreeUpdate.GetName(),
                  Nodes::GenericButton::OnActivate.GetName() };
     }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -64,6 +64,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::EnumUnderlyingType);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::InternalEnumValueKey);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeNotify);
+        system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ChangeValidate);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ValueHashed);
         system->RegisterNodeAttribute<PropertyEditor>(PropertyEditor::ParentValue);
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -164,6 +164,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto GenericValueList = GenericValueListAttributeDefinition<GenericValueType>("GenericValueList");
 
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
+        static constexpr auto ChangeValidate = CallbackAttributeDefinition<AZ::Outcome<void, AZStd::string>(void*, const AZ::Uuid&)>("ChangeValidate");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
     };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EntityCompositionRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EntityCompositionRequestBus.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -22,7 +22,8 @@
 
 #include <AzToolsFramework/Entity/EntityTypes.h>
 #include <AzToolsFramework/SourceControl/SourceControlAPI.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+
+#include <QObject>
 
 namespace AZ
 {
@@ -35,6 +36,7 @@ class QApplication;
 class QDockWidget;
 class QMainWindow;
 class QMenu;
+class QString;
 class QWidget;
 
 namespace AzToolsFramework
@@ -58,6 +60,17 @@ namespace AzToolsFramework
 
     //! Return true to accept this type of component.
     using ComponentFilter = AZStd::function<bool(const AZ::SerializeContext::ClassData&)>;
+
+    // when a property is modified, we attempt to retrieve the value that comes out in response to the Property Modification function that you may supply
+    // if you return anything other than Refresh_None, the tree may be queued for update:
+    enum PropertyModificationRefreshLevel : int
+    {
+        Refresh_None,
+        Refresh_Values,
+        Refresh_AttributesAndValues,
+        Refresh_EntireTree,
+        Refresh_EntireTree_NewContent,
+    };
 
     /**
      * Bus owned by the ToolsApplication. Listen for general ToolsApplication events.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Math/IntersectSegment.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -26,6 +26,7 @@
 #include <AzToolsFramework/Manipulators/ManipulatorView.h>
 #include <AzToolsFramework/Manipulators/PlanarManipulator.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/EditorInfoRemover.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/EditorInfoRemover.cpp
@@ -18,6 +18,7 @@
 #include <AzToolsFramework/Prefab/Spawnable/EditorInfoRemover.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/ToolsComponents/EditorOnlyEntityComponentBus.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
 
 namespace AzToolsFramework::Prefab::PrefabConversionUtils
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -54,6 +54,7 @@
 #include <AzToolsFramework/UI/Slice/SlicePushWidget.hxx>
 #include <AzToolsFramework/UI/Slice/SliceRelationshipBus.h>
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/Slice/SliceTransaction.h>
 #include <AzToolsFramework/Undo/UndoSystem.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -36,6 +36,7 @@
 #include <AzToolsFramework/ToolsComponents/TransformComponentSerializer.h>
 #include <AzToolsFramework/ToolsComponents/EditorInspectorComponentBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -44,6 +44,7 @@
 #include <AzToolsFramework/UI/Prefab/ActionManagerIdentifiers/PrefabActionUpdaterIdentifiers.h>
 #include <AzToolsFramework/UI/Prefab/PrefabIntegrationInterface.h>
 #include <AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
@@ -16,6 +16,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include "PropertyEditorAPI_Internals.h"
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h>
+#include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
 
 class QWidget;
 class QCheckBox;
@@ -29,17 +30,6 @@ namespace AZ
 namespace AzToolsFramework
 {
     class InstanceDataNode;
-
-    // when a property is modified, we attempt to retrieve the value that comes out in response to the Property Modification function that you may supply
-    // if you return anything other than Refresh_None, the tree may be queued for update:
-    enum PropertyModificationRefreshLevel : int
-    {
-        Refresh_None,
-        Refresh_Values,
-        Refresh_AttributesAndValues,
-        Refresh_EntireTree,
-        Refresh_EntireTree_NewContent,
-    };
 
     // only ONE property handler is ever created for each kind of property.
     // so do not store state for a particular GUI, inside your property handler.  Your one handler may be responsible for translating

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
@@ -19,6 +19,7 @@
 #include <native/utilities/AssetBuilderInfo.h>
 #include <native/utilities/BuilderManager.h>
 #include <native/utilities/UuidManager.h>
+#include <QtGui/qwindowdefs.h>
 #endif
 
 namespace AzToolsFramework

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
@@ -36,6 +36,11 @@ namespace AZ
     }
 }
 
+namespace AzToolsFramework
+{
+    class PropertyHandlerBase;
+}
+
 namespace EMotionFX
 {
     namespace Integration

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.cpp
@@ -18,6 +18,7 @@
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
 #include <AzFramework/Viewport/CameraState.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <Editor/ColliderComponentMode.h>
 #include <Source/HeightfieldColliderComponent.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -38,6 +38,7 @@
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <ScriptCanvas/Variable/GraphVariable.h>
 
 namespace ScriptCanvasEditor

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -33,6 +33,7 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/Maths/TransformUtils.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <QMessageBox>
 #include <WhiteBox/EditorWhiteBoxColliderBus.h>


### PR DESCRIPTION
## What does this PR do?

Fixes #16454 and #16456 

This PR adds logic to handle the `ChangeValidate` attribute that checks if a new value being set on a property is valid, based on a callback provided when the property is exposed to the EditContext.

The `ChangeValidate` logic itself is relatively small, compared to how many files are in this PR. The reason for all the other files (which I've split into a separate commit) is because adding an include of `AzToolsFramework/API/ToolsApplicationAPI.h` exposed a circular include issue. To resolve this, I had to remove an include and move the `PropertyModificationRefreshLevel` enum. In the fallout, I also had to add some additional includes in places that had been relying on that other include I removed.

Here is an example of the change validate working on two different fields in the Diffuse Grid component.

![DPEChangeValidate](https://github.com/o3de/o3de/assets/7519264/ed304f1f-b02e-4a33-923a-0fb3f9899e44)

## How was this PR tested?

Tested and verified the bugs with their reproduction steps.