### PR TITLE
Fixes a bunch of linux compile errors for clang15

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
@@ -90,7 +90,7 @@ namespace AZ
 
                 eventTracker.WriteEventInfo(this, CTGEvent::Deallocated, "CTG::Release parent=false");
 
-                azdestroy(this);
+                delete this;
             }
 
             return remaining;

--- a/Code/Framework/AzFramework/Tests/Scene.cpp
+++ b/Code/Framework/AzFramework/Tests/Scene.cpp
@@ -204,7 +204,8 @@ namespace SceneUnitTest
         size_t index = 0;
         m_sceneSystem->IterateActiveScenes([&index, &scenes](const AZStd::shared_ptr<Scene>& scene)
             {
-                EXPECT_EQ(scenes[index++], scene);
+                AZStd::shared_ptr<Scene> newscene = scenes[index++];
+                EXPECT_EQ(newscene, scene);
                 return true;
             });
     }
@@ -237,7 +238,8 @@ namespace SceneUnitTest
         index = 0;
         m_sceneSystem->IterateZombieScenes([&index, &scenes](Scene& scene)
             {
-                EXPECT_EQ(scenes[index++].get(), &scene);
+                AZStd::shared_ptr<Scene> zombieScene = scenes[index++];
+                EXPECT_EQ(zombieScene.get(), &scene);
                 return true;
             });
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/FIR-Filter.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/FIR-Filter.cpp
@@ -21,7 +21,10 @@
 #define mallocAligned(sze)  _aligned_malloc(sze, 16)
 #define freeAligned(ptr)      _aligned_free(ptr)
 
+AZ_PUSH_DISABLE_WARNING_CLANG("-Wunused-value")
+AZ_PUSH_DISABLE_WARNING_CLANG("-Wtautological-compare")
 AZ_PUSH_DISABLE_WARNING_GCC("-Wunused-value")
+
 
 /* ####################################################################################################################
  */
@@ -1283,3 +1286,5 @@ namespace ImageProcessingAtom
 }
 
 AZ_POP_DISABLE_WARNING_GCC
+AZ_POP_DISABLE_WARNING_CLANG
+AZ_POP_DISABLE_WARNING_CLANG

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -162,7 +162,8 @@ namespace AZ
 
             for (auto& mipChain : m_mipChains)
             {
-                AZ_Assert(mipChain.m_mipOffset >= mipChain.m_mipOffset, "unexpected mipoffset");
+                // Assert that the offset does not become negative after subtraction:
+                AZ_Assert(mipChain.m_mipOffset >= mipmapShift, "unexpected mipoffset");
                 mipChain.m_mipOffset -= mipmapShift;
             }
 


### PR DESCRIPTION
These errors occur on clang15 which is standard for ubuntu 23.xx

Most of them are related to macros that expand to a tautology, or a no-op, which clang15 is better at detecting.

## What does this PR do?
These are just compile fixes for errors generated by the compiler.  They should not change behavior.

## How was this PR tested?
Just compilation and basic run tests.
