### PR TITLE
Avoid QAction::eventFilter: Ambiguous shortcut overload error

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1923,6 +1923,12 @@ namespace ScriptCanvasEditor
         connect(ui->action_AlignLeft, &QAction::triggered, this, &MainWindow::OnAlignLeft);
         connect(ui->action_AlignRight, &QAction::triggered, this, &MainWindow::OnAlignRight);
 
+        // Prevents QAction::eventFilter: Ambiguous shortcut overload
+        ui->action_AlignTop->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignBottom->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignLeft->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignRight->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
         ui->action_ZoomIn->setShortcuts({ QKeySequence(Qt::CTRL + Qt::Key_Plus),
                                           QKeySequence(Qt::CTRL + Qt::Key_Equal)
                                         });


### PR DESCRIPTION
## What does this PR do?

Solves problem with ambiguous shortcuts when aligning ScriptCanvas nodes

## How was this PR tested?

Verified that alignment shortcuts worked in the Script Canvas editor