### PR TITLE
Prevent QAction::eventFilter: Ambiguous shortcut overload closes #16600

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1923,6 +1923,12 @@ namespace ScriptCanvasEditor
         connect(ui->action_AlignLeft, &QAction::triggered, this, &MainWindow::OnAlignLeft);
         connect(ui->action_AlignRight, &QAction::triggered, this, &MainWindow::OnAlignRight);
 
+        // Prevent QAction::eventFilter: Ambiguous shortcut overload
+        ui->action_AlignTop->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignBottom->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignLeft->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        ui->action_AlignRight->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
         ui->action_ZoomIn->setShortcuts({ QKeySequence(Qt::CTRL + Qt::Key_Plus),
                                           QKeySequence(Qt::CTRL + Qt::Key_Equal)
                                         });


### PR DESCRIPTION
## What does this PR do?

Fixes node alignment shortcuts in Script Canvas

## How was this PR tested?

Verified alignment hotkeys worked in the Script Canvas editor

Closes #16600 