### PR TITLE
Fix Linux release build error

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -434,7 +434,7 @@ namespace AZ
 
         void Pass::ProcessConnection(const PassConnection& connection, uint32_t slotTypeMask)
         {
-            auto prefix = [&]() -> AZStd::string
+            [[maybe_unused]] auto prefix = [&]() -> AZStd::string
             {
                 return AZStd::string::format(
                     "Pass::ProcessConnection %s:%s -> %s:%s",
@@ -605,7 +605,7 @@ namespace AZ
             PassAttachmentBinding* inputBinding = FindAttachmentBinding(connection.m_inputSlotName);
             PassAttachmentBinding* outputBinding = FindAttachmentBinding(connection.m_outputSlotName);
 
-            auto prefix = [&]() -> AZStd::string
+            [[maybe_unused]] auto prefix = [&]() -> AZStd::string
             {
                 return AZStd::string::format(
                     "Pass::ProcessFallbackConnection: %s, %s -> %s",


### PR DESCRIPTION
## What does this PR do?

Fixes a release build error on Linux related to 'Unused Variable'  `prefix`. (Prefix is used in the `AZ_RPI_PASS_ERROR` which is def'd out in release builds)


## How was this PR tested?

Built `o3de-multiplayersample` in release build on Linux
