### PR TITLE
Creating occlusion request bus and integrating into atom cooling system

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Visibility/OcclusionBus.h>
+
+DECLARE_EBUS_INSTANTIATION(AzFramework::OcclusionRequests);
+
+namespace AzFramework
+{
+    void OcclusionRequests::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<OcclusionRequestBus>("OcclusionRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Visibility")
+                ->Attribute(AZ::Script::Attributes::Module, "visibility")
+                ->Event("ClearOcclusionViewDebugInfo", &OcclusionRequestBus::Events::ClearOcclusionViewDebugInfo)
+                ->Event("CreateOcclusionView", &OcclusionRequestBus::Events::CreateOcclusionView)
+                ->Event("DestroyOcclusionView", &OcclusionRequestBus::Events::DestroyOcclusionView)
+                ->Event("UpdateOcclusionView", &OcclusionRequestBus::Events::UpdateOcclusionView)
+                ->Event("IsEntityVisibleInOcclusionView", &OcclusionRequestBus::Events::IsEntityVisibleInOcclusionView)
+                ->Event("IsAabbVisibleInOcclusionView", &OcclusionRequestBus::Events::IsAabbVisibleInOcclusionView)
+                ;
+        }
+    }
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Aabb.h>
+#include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzFramework/Entity/EntityContextBus.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace AzFramework
+{
+    //! OcclusionRequests is an interface for creating occlusion views and queries. The bus must be connected to an entity context ID for an
+    //! entity context containing objects that contribute to or interact with the occlusion scene.
+    class OcclusionRequests : public AZ::EBusTraits
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        typedef AzFramework::EntityContextId BusIdType;
+        using MutexType = AZStd::mutex;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Clear previously collected debug rendering lines and statistics
+        virtual void ClearOcclusionViewDebugInfo() = 0;
+
+        //! Create an occlusion view using the specified name. After the view is created, the name can be used to look up the view and make
+        //! updates or queries against it. More than one occlusion view can be created at a time and used across threads.
+        virtual bool CreateOcclusionView(const AZ::Name& name) = 0;
+
+        //! Destroy a previously created occlusion view.
+        virtual bool DestroyOcclusionView(const AZ::Name& name) = 0;
+
+        //! Updating the occlusion view to capture occlusion data from the specified camera perspective.
+        virtual bool UpdateOcclusionView(
+            const AZ::Name& name, const AZ::Vector3& cameraWorldPos, const AZ::Matrix4x4& cameraWorldToClip) = 0;
+
+        //! Returns true if the entity is not occluded in the occlusion view. Otherwise, returns false.
+        virtual bool IsEntityVisibleInOcclusionView(const AZ::Name& name, const AZ::EntityId& entityId) const = 0;
+
+        //! Returns true if the AABB is not occluded in the occlusion view. Otherwise, returns false.
+        virtual bool IsAabbVisibleInOcclusionView(const AZ::Name& name, const AZ::Aabb& bounds) const = 0;
+
+    protected:
+        ~OcclusionRequests() = default;
+    };
+
+    using OcclusionRequestBus = AZ::EBus<OcclusionRequests>;
+} // namespace AzFramework
+
+DECLARE_EBUS_EXTERN(AzFramework::OcclusionRequests);

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -473,18 +473,20 @@ set(FILES
     Slice/SliceInstantiationBus.h
     Slice/SliceInstantiationTicket.h
     Slice/SliceInstantiationTicket.cpp
-    Visibility/IVisibilitySystem.h
-    Visibility/OctreeSystemComponent.h
-    Visibility/OctreeSystemComponent.cpp
-    Visibility/BoundsBus.h
     Visibility/BoundsBus.cpp
+    Visibility/BoundsBus.h
     Visibility/EntityBoundsUnionBus.h
-    Visibility/EntityVisibilityBoundsUnionSystem.h
     Visibility/EntityVisibilityBoundsUnionSystem.cpp
-    Visibility/EntityVisibilityQuery.h
+    Visibility/EntityVisibilityBoundsUnionSystem.h
     Visibility/EntityVisibilityQuery.cpp
-    Visibility/VisibilityDebug.h
+    Visibility/EntityVisibilityQuery.h
+    Visibility/IVisibilitySystem.h
+    Visibility/OcclusionBus.cpp
+    Visibility/OcclusionBus.h
+    Visibility/OctreeSystemComponent.cpp
+    Visibility/OctreeSystemComponent.h
     Visibility/VisibilityDebug.cpp
-    Visibility/VisibleGeometryBus.h
+    Visibility/VisibilityDebug.h
     Visibility/VisibleGeometryBus.cpp
+    Visibility/VisibleGeometryBus.h
 )

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -257,10 +257,10 @@ namespace AZ
             void SetOcclusionPlanes(const OcclusionPlaneVector& occlusionPlanes) { m_occlusionPlanes = occlusionPlanes; }
 
             //! Notifies the CullingScene that culling will begin for this frame.
-            void BeginCulling(const AZStd::vector<ViewPtr>& views);
+            void BeginCulling(const Scene& scene, const AZStd::vector<ViewPtr>& views);
 
             //! Notifies the CullingScene that the culling is done for this frame.
-            void EndCulling();
+            void EndCulling(const Scene& scene, const AZStd::vector<ViewPtr>& views);
 
             //! Performs render culling and lod selection for a View, then adds the visible renderpackets to that View.
             //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.
@@ -290,21 +290,18 @@ namespace AZ
             //! Returns the number of cullables that have been added to the CullingScene
             uint32_t GetNumCullables() const;
 
-            CullingDebugContext& GetDebugContext()
-            {
-                return m_debugCtx;
-            }
+            CullingDebugContext& GetDebugContext();
 
             //! Returns the visibility scene
-            const AzFramework::IVisibilityScene* GetVisibilityScene() const { return m_visScene; }
+            const AzFramework::IVisibilityScene* GetVisibilityScene() const;
 
         protected:
             size_t CountObjectsInScene();
 
         private:
-            void BeginCullingTaskGraph(const AZStd::vector<ViewPtr>& views);
-            void BeginCullingJobs(const AZStd::vector<ViewPtr>& views);
-            void ProcessCullablesCommon(const Scene& scene, View& view, AZ::Frustum& frustum, void*& maskedOcclusionCulling);
+            void BeginCullingTaskGraph(const Scene& scene, const AZStd::vector<ViewPtr>& views);
+            void BeginCullingJobs(const Scene& scene, const AZStd::vector<ViewPtr>& views);
+            void ProcessCullablesCommon(const Scene& scene, View& view, AZ::Frustum& frustum);
 
             const Scene* m_parentScene = nullptr;
             AzFramework::IVisibilityScene* m_visScene = nullptr;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -165,9 +165,9 @@ namespace AZ
 
             bool HasOutputForPipelineState(RHI::DrawListTag drawListTag) const;
 
-            AzFramework::IVisibilityScene* GetVisibilityScene() const { return m_visibilityScene; }
+            AzFramework::IVisibilityScene* GetVisibilityScene() const;
 
-            AZ::RPI::CullingScene* GetCullingScene() const { return m_cullingScene; }
+            AZ::RPI::CullingScene* GetCullingScene() const;
 
             RenderPipelinePtr FindRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle, ViewType viewType = ViewType::Default);
 
@@ -186,15 +186,9 @@ namespace AZ
 
             RHI::TagBitRegistry<uint32_t>& GetViewTagBitRegistry();
             
-            RHI::Ptr<RHI::DrawFilterTagRegistry> GetDrawFilterTagRegistry() const
-            {
-                return m_drawFilterTagRegistry;
-            }
+            RHI::Ptr<RHI::DrawFilterTagRegistry> GetDrawFilterTagRegistry() const;
 
-            uint16_t GetActiveRenderPipelines() const
-            {
-                return m_numActiveRenderPipelines;
-            }
+            uint16_t GetActiveRenderPipelines() const;
 
         protected:
             // SceneRequestBus::Handler overrides...

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -158,10 +158,10 @@ namespace AZ
             //! Value returned is 1.0f when an area equal to the viewport height squared is covered. Useful for accurate LOD decisions.
             float CalculateSphereAreaInClipSpace(const AZ::Vector3& sphereWorldPosition, float sphereRadius) const;
 
-            const AZ::Name& GetName() const { return m_name; }
-            const UsageFlags GetUsageFlags() { return m_usageFlags; }
+            const AZ::Name& GetName() const;
+            const UsageFlags GetUsageFlags();
 
-            void SetPassesByDrawList(PassesByDrawList* passes) { m_passesByDrawList = passes; }
+            void SetPassesByDrawList(PassesByDrawList* passes);
 
             //! Update View's SRG values and compile. This should only be called once per frame before execute command lists.
             void UpdateSrg();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -15,15 +15,16 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 
+#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Jobs/Job.h>
+#include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Math/ShapeIntersection.h>
-#include <AzCore/Casting/numeric_cast.h>
-#include <AzCore/std/parallel/lock.h>
-#include <AzCore/Casting/numeric_cast.h>
-#include <AzCore/Jobs/JobFunction.h>
-#include <AzCore/Jobs/Job.h>
 #include <AzCore/Task/TaskGraph.h>
+#include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzFramework/Visibility/OcclusionBus.h>
+
 #include <Atom_RPI_Traits_Platform.h>
 
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
@@ -152,20 +153,57 @@ namespace AZ
             return m_visScene->GetEntryCount();
         }
 
+        CullingDebugContext& CullingScene::GetDebugContext()
+        {
+            return m_debugCtx;
+        }
+
+        const AzFramework::IVisibilityScene* CullingScene::GetVisibilityScene() const
+        {
+            return m_visScene;
+        }
+
+        static AzFramework::EntityContextId GetEntityContextIdForOcclusion(const AZ::RPI::Scene* scene)
+        {
+            auto sceneSystem = AzFramework::SceneSystemInterface::Get();
+            AZ_Assert(sceneSystem, "Attempting to retrieve the entity context ID for a scene before the scene system interface is ready.");
+
+            AzFramework::EntityContextId resultId = AzFramework::EntityContextId::CreateNull();
+            sceneSystem->IterateActiveScenes(
+                [&](const AZStd::shared_ptr<AzFramework::Scene>& azScene)
+                {
+                    AZ::RPI::ScenePtr* rpiScene = azScene->FindSubsystemInScene<AZ::RPI::ScenePtr>();
+                    if (rpiScene && (*rpiScene).get() == scene)
+                    {
+                        AzFramework::EntityContext** entityContext =
+                            azScene->FindSubsystemInScene<AzFramework::EntityContext::SceneStorageType>();
+                        if (entityContext)
+                        {
+                            const AzFramework::EntityContextId contextId = (*entityContext)->GetContextId();
+                            if (AzFramework::OcclusionRequestBus::FindFirstHandler(contextId))
+                            {
+                                resultId = contextId;
+                                return false; // Result found, returning
+                            }
+                        }
+                    }
+
+                    return true; // No match, continuing to search for containing scene.
+                });
+            return resultId;
+        }
 
         struct WorklistData
         {
             CullingDebugContext* m_debugCtx = nullptr;
             const Scene* m_scene = nullptr;
+            AzFramework::EntityContextId m_sceneEntityContextId;
             View* m_view = nullptr;
             Frustum m_frustum;
             Frustum m_cameraFrustum;
             Frustum m_excludeFrustum;
             AZ::Job* m_parentJob = nullptr;
             AZ::TaskGraphEvent* m_taskGraphEvent = nullptr;
-#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-            MaskedOcclusionCulling* m_maskedOcclusionCulling = nullptr;
-#endif
             bool m_hasExcludeFrustum = false;
             bool m_applyCameraFrustumIntersectionTest = false;
 #ifdef AZ_CULL_DEBUG_ENABLED
@@ -186,20 +224,17 @@ namespace AZ
             const Scene& scene,
             View& view,
             Frustum& frustum,
-            [[maybe_unused]] void* maskedOcclusionCulling,
             AZ::Job* parentJob,
             AZ::TaskGraphEvent* taskGraphEvent)
         {
             AZStd::shared_ptr<WorklistData> worklistData = AZStd::make_shared<WorklistData>();
             worklistData->m_debugCtx = &debugCtx;
             worklistData->m_scene = &scene;
+            worklistData->m_sceneEntityContextId = GetEntityContextIdForOcclusion(&scene);
             worklistData->m_view = &view;
             worklistData->m_frustum = frustum;
             worklistData->m_parentJob = parentJob;
             worklistData->m_taskGraphEvent = taskGraphEvent;
-#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-            worklistData->m_maskedOcclusionCulling = static_cast<MaskedOcclusionCulling*>(maskedOcclusionCulling);
-#endif
             return worklistData;
         }
 
@@ -223,13 +258,14 @@ namespace AZ
             AZStd::vector<AzFramework::VisibilityEntry*> m_entries;
         };
 
-#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-        static MaskedOcclusionCulling::CullingResult TestOcclusionCulling(
-                    const AZStd::shared_ptr<WorklistData>& worklistData,
-                    AzFramework::VisibilityEntry* visibleEntry);
-#endif
+        static bool TestOcclusionCulling(const AZStd::shared_ptr<WorklistData>& worklistData, AzFramework::VisibilityEntry* visibleEntry);
 
-        static void ProcessEntrylist(const AZStd::shared_ptr<WorklistData>& worklistData, const AZStd::vector<AzFramework::VisibilityEntry*>& entries, bool parentNodeContainedInFrustum = false, s32 startIdx = 0, s32 endIdx = -1)
+        static void ProcessEntrylist(
+            const AZStd::shared_ptr<WorklistData>& worklistData,
+            const AZStd::vector<AzFramework::VisibilityEntry*>& entries,
+            bool parentNodeContainedInFrustum = false,
+            s32 startIdx = 0,
+            s32 endIdx = -1)
         {
 #ifdef AZ_CULL_DEBUG_ENABLED
             // These variable are only used for the gathering of debug information.
@@ -271,9 +307,7 @@ namespace AZ
                         continue;
                     }
 
-#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-                    if (TestOcclusionCulling(worklistData, visibleEntry) == MaskedOcclusionCulling::CullingResult::VISIBLE)
-#endif
+                    if (TestOcclusionCulling(worklistData, visibleEntry))
                     {
                         // There are ways to write this without [[maybe_unused]], but they are brittle.
                         // For example, using #else could cause a bug where the function's parameter
@@ -422,16 +456,8 @@ namespace AZ
             }
         }
 
-#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-        static MaskedOcclusionCulling::CullingResult TestOcclusionCulling(
-            const AZStd::shared_ptr<WorklistData>& worklistData,
-            AzFramework::VisibilityEntry* visibleEntry)
+        static bool TestOcclusionCulling(const AZStd::shared_ptr<WorklistData>& worklistData, AzFramework::VisibilityEntry* visibleEntry)
         {
-            if (!worklistData->m_maskedOcclusionCulling)
-            {
-                return MaskedOcclusionCulling::CullingResult::VISIBLE;
-            }
-
 #ifdef AZ_CULL_PROFILE_VERBOSE
             AZ_PROFILE_SCOPE(RPI, "TestOcclusionCulling");
 #endif
@@ -439,7 +465,28 @@ namespace AZ
             if (visibleEntry->m_boundingVolume.Contains(worklistData->m_view->GetCameraTransform().GetTranslation()))
             {
                 // camera is inside bounding volume
-                return MaskedOcclusionCulling::CullingResult::VISIBLE;
+                return true;
+            }
+
+            // Perform occlusion tests using OcclusionRequestBus if it is connected to the entity context ID for this scene.
+            // TODO MaskedOcclusionCulling needs to be migrated to a gem and adapted to use OcclusionRequestBus
+            if (!worklistData->m_sceneEntityContextId.IsNull())
+            {
+                bool result = true;
+                AzFramework::OcclusionRequestBus::EventResult(
+                    result,
+                    worklistData->m_sceneEntityContextId,
+                    &AzFramework::OcclusionRequestBus::Events::IsAabbVisibleInOcclusionView,
+                    worklistData->m_view->GetName(),
+                    visibleEntry->m_boundingVolume);
+                return result;
+            }
+
+#if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
+            MaskedOcclusionCulling* maskedOcclusionCulling = worklistData->m_view->GetMaskedOcclusionCulling();
+            if (!maskedOcclusionCulling)
+            {
+                return true;
             }
 
             const Vector3& minBound = visibleEntry->m_boundingVolume.GetMin();
@@ -467,9 +514,8 @@ namespace AZ
                 minDepth = AZStd::min(minDepth, corners[index].GetW());
                 if (minDepth < 0.00000001f)
                 {
-                    return MaskedOcclusionCulling::CullingResult::VISIBLE;
+                    return true;
                 }
-
 
                 // convert to NDC
                 corners[index] /= corners[index].GetW();
@@ -481,15 +527,15 @@ namespace AZ
             }
 
             // test against the occlusion buffer, which contains only the manually placed occlusion planes
-            return worklistData->m_maskedOcclusionCulling->TestRect(ndcMinX, ndcMinY, ndcMaxX, ndcMaxY, minDepth);
-        }
+            return maskedOcclusionCulling->TestRect(ndcMinX, ndcMinY, ndcMaxX, ndcMaxY, minDepth) ==
+                MaskedOcclusionCulling::CullingResult::VISIBLE;
 #endif
+        }
 
         void CullingScene::ProcessCullablesCommon(
-            const Scene& scene [[maybe_unused]],
+            const Scene& scene,
             View& view,
-            AZ::Frustum& frustum [[maybe_unused]],
-            void*& maskedOcclusionCulling [[maybe_unused]])
+            AZ::Frustum& frustum [[maybe_unused]])
         {
             AZ_PROFILE_SCOPE(RPI, "CullingScene::ProcessCullablesCommon() - %s", view.GetName().GetCStr());
 
@@ -519,10 +565,22 @@ namespace AZ
                 cullStats.m_cameraViewToWorld = view.GetViewToWorldMatrix();
             }
 #endif //AZ_CULL_DEBUG_ENABLED
+
+            // If connected, update the occlusion views for this scene and view combination.
+            if (const auto& entityContextId = GetEntityContextIdForOcclusion(&scene); !entityContextId.IsNull())
+            {
+                AzFramework::OcclusionRequestBus::Event(
+                    entityContextId,
+                    &AzFramework::OcclusionRequestBus::Events::UpdateOcclusionView,
+                    view.GetName(),
+                    view.GetCameraTransform().GetTranslation(),
+                    view.GetWorldToClipMatrix());
+            }
+
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
             // setup occlusion culling, if necessary
-            maskedOcclusionCulling = m_occlusionPlanes.empty() ? nullptr : view.GetMaskedOcclusionCulling();
-            if (maskedOcclusionCulling)
+            MaskedOcclusionCulling* maskedOcclusionCulling = view.GetMaskedOcclusionCulling();
+            if (maskedOcclusionCulling && !m_occlusionPlanes.empty())
             {
                 // frustum cull occlusion planes
                 using VisibleOcclusionPlane = AZStd::pair<OcclusionPlane, float>;
@@ -563,7 +621,7 @@ namespace AZ
                     static uint32_t indices[6] = { 0, 1, 2, 2, 3, 0 };
 
                     // render into the occlusion buffer, specifying BACKFACE_NONE so it functions as a double-sided occluder
-                    static_cast<MaskedOcclusionCulling*>(maskedOcclusionCulling)->RenderTriangles(verts, indices, 2, nullptr, MaskedOcclusionCulling::BACKFACE_NONE);
+                    maskedOcclusionCulling->RenderTriangles(verts, indices, 2, nullptr, MaskedOcclusionCulling::BACKFACE_NONE);
                 }
             }
 #endif
@@ -578,12 +636,11 @@ namespace AZ
             const Matrix4x4& worldToClip = view.GetWorldToClipMatrix();
             AZ::Frustum frustum = Frustum::CreateFromMatrixColumnMajor(worldToClip);
 
-            void* maskedOcclusionCulling = nullptr;
-            ProcessCullablesCommon(scene, view, frustum, maskedOcclusionCulling);
+            ProcessCullablesCommon(scene, view, frustum);
 
             AZStd::shared_ptr<WorkListType> worklist = AZStd::make_shared<WorkListType>();
             worklist->Init();
-            AZStd::shared_ptr<WorklistData> worklistData = MakeWorklistData(m_debugCtx, scene, view, frustum, maskedOcclusionCulling, parentJob, taskGraphEvent);
+            AZStd::shared_ptr<WorklistData> worklistData = MakeWorklistData(m_debugCtx, scene, view, frustum, parentJob, taskGraphEvent);
             static const AZ::TaskDescriptor descriptor{ "AZ::RPI::ProcessWorklist", "Graphics" };
 
             if (const Matrix4x4* worldToClipExclude = view.GetWorldToClipExcludeMatrix())
@@ -721,8 +778,7 @@ namespace AZ
             const Matrix4x4& worldToClip = view.GetWorldToClipMatrix();
             AZ::Frustum frustum = Frustum::CreateFromMatrixColumnMajor(worldToClip);
 
-            void* maskedOcclusionCulling = nullptr;
-            ProcessCullablesCommon(scene, view, frustum, maskedOcclusionCulling);
+            ProcessCullablesCommon(scene, view, frustum);
 
             // Note 1: Cannot do unique_ptr here because compilation error (auto-deletes function from lambda which the job code complains about) 
             // Note 2: Having this be a pointer (even a shared pointer) is faster than just having this live on the stack like:
@@ -731,7 +787,7 @@ namespace AZ
             // increases the runtime for this function, which runs on a single thread and spawns other jobs).
             AZStd::shared_ptr<EntryListType> entryList = AZStd::make_shared<EntryListType>();
             entryList->m_entries.reserve(r_numEntriesPerCullingJob);
-            AZStd::shared_ptr<WorklistData> worklistData = MakeWorklistData(m_debugCtx, scene, view, frustum, maskedOcclusionCulling, parentJob, nullptr);
+            AZStd::shared_ptr<WorklistData> worklistData = MakeWorklistData(m_debugCtx, scene, view, frustum, parentJob, nullptr);
 
             if (const Matrix4x4* worldToClipExclude = view.GetWorldToClipExcludeMatrix())
             {
@@ -914,18 +970,22 @@ namespace AZ
             m_visScene = nullptr;
         }
 
-        void CullingScene::BeginCullingTaskGraph(const AZStd::vector<ViewPtr>& views)
+        void CullingScene::BeginCullingTaskGraph(const Scene& scene, const AZStd::vector<ViewPtr>& views)
         {
             AZ::TaskGraph taskGraph{ "RPI::Culling" };
-            AZ::TaskDescriptor beginCullingDescriptor{"RPI_CullingScene_BeginCullingView", "Graphics"};
+            AZ::TaskDescriptor beginCullingDescriptor{ "RPI_CullingScene_BeginCullingView", "Graphics" };
+
+            const auto& entityContextId = GetEntityContextIdForOcclusion(&scene);
             for (auto& view : views)
             {
                 taskGraph.AddTask(
                     beginCullingDescriptor,
-                    [&view]()
+                    [&]()
                     {
                         AZ_PROFILE_SCOPE(RPI, "CullingScene: BeginCullingTaskGraph");
                         view->BeginCulling();
+                        AzFramework::OcclusionRequestBus::Event(
+                            entityContextId, &AzFramework::OcclusionRequestBus::Events::CreateOcclusionView, view->GetName());
                     });
             }
 
@@ -937,16 +997,19 @@ namespace AZ
             }
         }
 
-        void CullingScene::BeginCullingJobs(const AZStd::vector<ViewPtr>& views)
+        void CullingScene::BeginCullingJobs(const Scene& scene, const AZStd::vector<ViewPtr>& views)
         {
             AZ::JobCompletion beginCullingCompletion;
 
+            const auto& entityContextId = GetEntityContextIdForOcclusion(&scene);
             for (auto& view : views)
             {
-                const auto cullingLambda = [&view]()
+                const auto cullingLambda = [&]()
                 {
                     AZ_PROFILE_SCOPE(RPI, "CullingScene: BeginCullingJob");
                     view->BeginCulling();
+                    AzFramework::OcclusionRequestBus::Event(
+                        entityContextId, &AzFramework::OcclusionRequestBus::Events::CreateOcclusionView, view->GetName());
                 };
 
                 AZ::Job* cullingJob = AZ::CreateJobFunction(AZStd::move(cullingLambda), true, nullptr);
@@ -957,7 +1020,7 @@ namespace AZ
             beginCullingCompletion.StartAndWaitForCompletion();
         }
 
-        void CullingScene::BeginCulling(const AZStd::vector<ViewPtr>& views)
+        void CullingScene::BeginCulling(const Scene& scene, const AZStd::vector<ViewPtr>& views)
         {
             AZ_PROFILE_SCOPE(RPI, "CullingScene: BeginCulling");
             m_cullDataConcurrencyCheck.soft_lock();
@@ -967,17 +1030,24 @@ namespace AZ
 
             m_taskGraphActive = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
 
-            if(views.size() == 1) // avoid job overhead when only 1 job
+            // Remove any debug artifacts from the previous occlusion culling session.
+            const auto& entityContextId = GetEntityContextIdForOcclusion(&scene);
+            AzFramework::OcclusionRequestBus::Event(
+                entityContextId, &AzFramework::OcclusionRequestBus::Events::ClearOcclusionViewDebugInfo);
+
+            if (views.size() == 1) // avoid job overhead when only 1 job
             {
                 views[0]->BeginCulling();
+                AzFramework::OcclusionRequestBus::Event(
+                    entityContextId, &AzFramework::OcclusionRequestBus::Events::CreateOcclusionView, views[0]->GetName());
             }
             else if (m_taskGraphActive && m_taskGraphActive->IsTaskGraphActive())
             {
-                BeginCullingTaskGraph(views);
+                BeginCullingTaskGraph(scene, views);
             }
             else
             {
-                BeginCullingJobs(views);
+                BeginCullingJobs(scene, views);
             }
 
 #ifdef AZ_CULL_DEBUG_ENABLED
@@ -1016,9 +1086,19 @@ namespace AZ
 #endif
         }
 
-        void CullingScene::EndCulling()
+        void CullingScene::EndCulling(const Scene& scene, const AZStd::vector<ViewPtr>& views)
         {
             m_cullDataConcurrencyCheck.soft_unlock();
+
+            // When culling has completed, destroyed all of the occlusion views.
+            if (const auto& entityContextId = GetEntityContextIdForOcclusion(&scene); !entityContextId.IsNull())
+            {
+                for (auto& view : views)
+                {
+                    AzFramework::OcclusionRequestBus::Event(
+                        entityContextId, &AzFramework::OcclusionRequestBus::Events::DestroyOcclusionView, view->GetName());
+                }
+            }
         }
 
         size_t CullingScene::CountObjectsInScene()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -594,6 +594,21 @@ namespace AZ
             return  -0.25f * cotHalfFovYSq * AZ::Constants::Pi * radiusSq * sqrt(fabsf((distanceSq - radiusSq)/radiusSqSubDepthSq))/radiusSqSubDepthSq;
         }
 
+        const AZ::Name& View::GetName() const
+        {
+            return m_name;
+        }
+
+        const View::UsageFlags View::GetUsageFlags()
+        {
+            return m_usageFlags;
+        }
+
+        void View::SetPassesByDrawList(PassesByDrawList* passes)
+        {
+            m_passesByDrawList = passes;
+        }
+
         void View::UpdateSrg()
         {
             if (m_shaderResourceGroup)

--- a/Gems/Atom/RPI/Code/Tests/System/CullingTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/CullingTests.cpp
@@ -66,7 +66,7 @@ namespace UnitTest
 
         void Cull(TestCameraList& views)
         {
-            m_cullingScene->BeginCulling(views);
+            m_cullingScene->BeginCulling(*m_testScene, views);
 
             // Create and submit work to the culling scene in a similar style as RPI::Scene::PrepareRender
             static const TaskDescriptor processCullablesDescriptor{ "RPI::Scene::ProcessCullables", "Graphics" };
@@ -90,7 +90,7 @@ namespace UnitTest
 
             processCullablesTG.Submit(&processCullablesTGEvent);
             processCullablesTGEvent.Wait();
-            m_cullingScene->EndCulling();
+            m_cullingScene->EndCulling(*m_testScene);
 
             for (ViewPtr& viewPtr : views)
             {


### PR DESCRIPTION
## What does this PR do?

Creating occlusion request bus as interface to support alternate occlusion calling implementations. The interface supports creating occlusion views of scene data that can be used to make occlusion queries for entities and bounding boxes. An implementation should supports requests in parallel to each occlusion view.

Calls to the occlusion request bus have been integrated into the atom culling system. If no active system implements the occlusion request bus then the atom culling system will fallback to masked occlusion culling. The masked occlusion culling system and supporting code will need to be moved to its own gem that implements the interface.

Some references, parameters, and variables relating to masked occlusion culling have been removed except for where explicitly required to maintain functionality.

## How was this PR tested?

The occlusion request bus related code compiles but does not perform any actions, other than searching for an entity context connected to the bus, without an implementation.
Masked occlusion culling continues to function with the changes integrated.