### PR TITLE
Fix DAE import scale

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -86,8 +86,6 @@ namespace AZ
                 | static_cast<unsigned long>(aiProcess_GenBoundingBoxes) // Generate bounding boxes
                 | aiProcess_GenNormals); //Generate normals for meshes
 
-            CalculateAABBandVertices(m_assImpScene, m_aabb, m_vertices);
-
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
             // Reset abort behavior for anything else that may call abort.
             std::signal(SIGABRT, previous_handler);
@@ -101,6 +99,8 @@ namespace AZ
                 AZ_TracePrintf(SceneAPI::Utilities::ErrorWindow, "Failed to import Asset Importer Scene. Error returned: %s", m_importer->GetErrorString());
                 return false;
             }
+
+            CalculateAABBandVertices(m_assImpScene, m_aabb, m_vertices);
 
             return true;
         }

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -49,6 +49,13 @@ namespace AZ
                  * This applies to an FBX format in which the default unit is a centimeter. */
                 m_unitSizeInMeters = m_unitSizeInMeters * .01f;
             }
+            else
+            {
+                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
+                auto rootTransform = 
+                    AssImpSDKWrapper::AssImpTypeConverter::ToTransform(assImpScene->GetAssImpScene()->mRootNode->mTransformation);
+                m_unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
+            }
 
             AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpScene->GetUpVectorAndSign();
 


### PR DESCRIPTION
## What does this PR do?

Any DAE files that have a scale set in it were importing at 1:1 size with the scale setting ignored. This is because the DAE importer in AssImp stores the scale in the root node transform matrix (see https://github.com/assimp/assimp/blob/master/code/AssetLib/Collada/ColladaLoader.cpp#L175-L182 ). The O3DE SceneSystem code was only looking for the scale in the metadata fields, which are set by FBX.

This change extracts the scale from the root transform to use for scaling the input.

Eventually, this should get investigated further to see why the root transform isn't being used directly as a part of node transformation and import. It's possible that more information should be getting extracted and used from this transform.

## How was this PR tested?
Imported the attached DAE file.
[apartment.zip](https://github.com/o3de/o3de/files/12489416/apartment.zip)

This file used to get imported at ~39x the correct size, because it has a scale of 0.0254 meters. Additionally, changing the scale file in the DAE had no impact. With the change in the PR, the model comes in at the appropriate scale, and changing the scale in the DAE changes the imported size.