### PR TITLE
Fix bad python sys.path temporary logic

### DIFF
--- a/scripts/o3de/o3de/cmake.py
+++ b/scripts/o3de/o3de/cmake.py
@@ -18,9 +18,12 @@ import pathlib
 import string
 import sys
 
+# add the scripts/o3de directory to the front of the sys.path temporarily to import 
+# some o3de python modules
 sys.path.insert(0, os.path.dirname(pathlib.Path(__file__).parent))
 from o3de import manifest, utils, compatibility
-sys.path.pop()
+# Remove the temporarily added path
+sys.path = sys.path[1:]
 
 logger = logging.getLogger('o3de.cmake')
 logging.basicConfig(format=utils.LOG_FORMAT)


### PR DESCRIPTION
## What does this PR do?

Originally code was added to insert the o3de script path to resolve an error that came up while testing the export project script. However, the logic to remove the temporary path is bad, popping off the tail even though the path was inserted in the front.

## How was this PR tested?

Generated a project locally, no python errors
