### PR TITLE
Fix morph target asset loading to handle new 'model.fbx.azmodel' naming

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
@@ -1269,12 +1269,19 @@ namespace EMotionFX
 
     AZ::Data::AssetId Actor::ConstructMorphTargetMetaAssetId(const AZ::Data::AssetId& meshAssetId)
     {
+        // Get the full mesh asset path (ex: 'objects/model.fbx.azmodel')
         AZStd::string meshAssetPath;
         AZ::Data::AssetCatalogRequestBus::BroadcastResult(meshAssetPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, meshAssetId);
+
+        // Get just the filename, stripping off the path and the extension (ex: 'model.fbx')
         AZStd::string meshAssetFileName;
         AzFramework::StringFunc::Path::GetFileName(meshAssetPath.c_str(), meshAssetFileName);
 
-        return AZ::RPI::MorphTargetMetaAsset::ConstructAssetId(meshAssetId, meshAssetFileName);
+        // Strip off the source extension as well, to bring us down to the base asset name (ex: 'model')
+        AZStd::string baseMeshAssetFileName;
+        AzFramework::StringFunc::Path::GetFileName(meshAssetFileName.c_str(), baseMeshAssetFileName);
+
+        return AZ::RPI::MorphTargetMetaAsset::ConstructAssetId(meshAssetId, baseMeshAssetFileName);
     }
 
     bool Actor::DoesMorphTargetMetaAssetExist(const AZ::Data::AssetId& meshAssetId)


### PR DESCRIPTION
## What does this PR do?

Fixed #16650 . The problem was that when Atom model product assets were renamed from 'model.azmodel' to 'model.fbx.azmodel', the Atom model and EMFX skin asset subid calculations were fixed to account for the name change, but the EMFX morph target asset subid calculation was missed. 

This PR applies the same fix to the morph target asset ID calculation that was applied to the skin asset ID calculation a few lines above it in the file.

## How was this PR tested?

Ran through the steps in #16650 and verified that the morph targets now show up.