### PR TITLE
Fixed Debug Rendering component group visibility issue

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RenderDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RenderDebugEditorComponent.cpp
@@ -65,6 +65,7 @@ namespace AZ::Render
                     // Lighting
                     ->ClassElement(Edit::ClassElements::Group, "Lighting")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::ComboBox, &RenderDebugComponentConfig::m_renderDebugLightingType,
                         "Lighting Type", "Controls whether diffuse or specular lighting is displayed.")
@@ -119,6 +120,7 @@ namespace AZ::Render
                     // Base Color Override
                     ->ClassElement(Edit::ClassElements::Group, "Base Color")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::CheckBox, &RenderDebugComponentConfig::m_overrideBaseColor,
                         "Override Base Color", "Whether to override base color values on materials in the scene.")
@@ -132,6 +134,7 @@ namespace AZ::Render
                     //  Roughness Override
                     ->ClassElement(Edit::ClassElements::Group, "Roughness")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::CheckBox, &RenderDebugComponentConfig::m_overrideRoughness,
                         "Override Roughness", "Whether to override roughness values on materials in the scene.")
@@ -148,6 +151,7 @@ namespace AZ::Render
                     // Metallic Override
                     ->ClassElement(Edit::ClassElements::Group, "Metallic")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::CheckBox, &RenderDebugComponentConfig::m_overrideMetallic,
                         "Override Metallic", "Whether to override roughness values on materials in the scene.")
@@ -164,6 +168,7 @@ namespace AZ::Render
                     // Normal Maps
                     ->ClassElement(Edit::ClassElements::Group, "Normals")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::CheckBox, &RenderDebugComponentConfig::m_enableNormalMaps,
                         "Enable Normal Maps", "Whether to use normal maps in rendering.")
@@ -178,6 +183,7 @@ namespace AZ::Render
                     // Please use these only for local debugging purposes and DO NOT leave their usage in when submitting code
                     ->ClassElement(Edit::ClassElements::Group, "Custom Debug Variables")
                         ->Attribute(Edit::Attributes::AutoExpand, false)
+                        ->Attribute(Edit::Attributes::Visibility, &RenderDebugComponentConfig::GetEnabled)
 
                     ->DataElement(Edit::UIHandlers::CheckBox, &RenderDebugComponentConfig::m_customDebugOption01,
                         "Custom Option 01", "Custom variables are accessible from the Scene SRG for shader authors to use directly in their azsl code"


### PR DESCRIPTION
## What does this PR do?

Fixes #16060 

This fixes an issue with empty groups being shown in the `Debug Rendering` component if `Enable Render Debugging` is disabled in DPE mode. This is due to an old hack in the RPE where since it didn't support visibility attributes on groups, it would recursively look through all children and if they are all hidden then it would hide the group as well. The DPE actually does support visibility attributes on groups, so you can just put a single visibility attribute on the group instead of having to put one on each element.

We have a backlog item to go and remove the hack extraneous visibility attributes once the DPE is enabled by default:
https://github.com/o3de/o3de/issues/16462

Here is the result of the groups being hidden properly now in the DPE (previously the groups would all be shown but empty):
![DebugRendering_AFTER](https://github.com/o3de/o3de/assets/7519264/3b02e5c3-94c1-4f6b-ba36-da00aa11d6c7)

## How was this PR tested?

Tested the `Debug Rendering` component and verified the applicable groups/elements are shown/hidden as expected.