### PR TITLE
Buffer-related resources

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -48,7 +48,7 @@ namespace AZ
             //! Set the buffer views and vertex count on the given SRG
             void SetBufferViewsOnShaderResourceGroup(const Data::Instance<RPI::ShaderResourceGroup>& perInstanceSRG);
         private:
-            RHI::Ptr<RHI::SingleDeviceBufferView> m_vertexDeltaBufferView;
+            RHI::Ptr<RHI::MultiDeviceBufferView> m_vertexDeltaBufferView;
             Data::Instance<RPI::Buffer> m_vertexDeltaBuffer;
         };
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/TransformService/TransformServiceFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/TransformService/TransformServiceFeatureProcessor.h
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
 #include <Atom/RHI/SingleDeviceBufferView.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
@@ -38,8 +38,6 @@ namespace AZ
             // create an AuxGeomDrawQueue object for this scene and register it with the AuxGeomSystemComponent
             m_sceneDrawQueue = RPI::AuxGeomDrawPtr(aznew AuxGeomDrawQueue);
 
-            RHI::RHISystemInterface* rhiSystem = RHI::RHISystemInterface::Get();
-
             // initialize the dynamic primitive processor
             m_dynamicPrimitiveProcessor = AZStd::make_unique<DynamicPrimitiveProcessor>();
             if (!m_dynamicPrimitiveProcessor->Initialize(scene))
@@ -50,7 +48,7 @@ namespace AZ
 
             // initialize the fixed shape processor
             m_fixedShapeProcessor = AZStd::make_unique<FixedShapeProcessor>();
-            if (!m_fixedShapeProcessor->Initialize(*rhiSystem->GetDevice(), scene))
+            if (!m_fixedShapeProcessor->Initialize(RHI::MultiDevice::AllDevices, scene))
             {
                 AZ_Error(s_featureProcessorName, false, "Failed to init AuxGeom FixedShapeProcessor");
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceIndexBufferView.h>
 #include <Atom/RHI/SingleDeviceStreamBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -48,15 +48,15 @@ namespace AZ
             }
         }
 
-        bool FixedShapeProcessor::Initialize(AZ::RHI::Device& rhiDevice, const AZ::RPI::Scene* scene)
+        bool FixedShapeProcessor::Initialize(RHI::MultiDevice::DeviceMask deviceMask, const AZ::RPI::Scene* scene)
         {
             RHI::BufferPoolDescriptor desc;
             desc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             desc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
 
-            m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_bufferPool = aznew RHI::MultiDeviceBufferPool;
             m_bufferPool->SetName(Name("AuxGeomFixedShapeBufferPool"));
-            RHI::ResultCode resultCode = m_bufferPool->Init(rhiDevice, desc);
+            RHI::ResultCode resultCode = m_bufferPool->Init(deviceMask, desc);
 
             if (resultCode != RHI::ResultCode::Success)
             {
@@ -1225,10 +1225,10 @@ namespace AZ
         {
             AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Fail;
 
-            AZ::RHI::SingleDeviceBufferInitRequest request;
+            AZ::RHI::MultiDeviceBufferInitRequest request;
 
             // setup m_pointIndexBuffer
-            objectBuffers.m_pointIndexBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+            objectBuffers.m_pointIndexBuffer = aznew RHI::MultiDeviceBuffer;
             const auto pointIndexDataSize = static_cast<uint32_t>(meshData.m_pointIndices.size() * sizeof(uint16_t));
 
             request.m_buffer = objectBuffers.m_pointIndexBuffer.get();
@@ -1243,7 +1243,7 @@ namespace AZ
             }
 
             // setup m_lineIndexBuffer
-            objectBuffers.m_lineIndexBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+            objectBuffers.m_lineIndexBuffer = aznew RHI::MultiDeviceBuffer;
             const auto lineIndexDataSize = static_cast<uint32_t>(meshData.m_lineIndices.size() * sizeof(uint16_t));
 
             request.m_buffer = objectBuffers.m_lineIndexBuffer.get();
@@ -1258,7 +1258,7 @@ namespace AZ
             }
 
             // setup m_triangleIndexBuffer
-            objectBuffers.m_triangleIndexBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+            objectBuffers.m_triangleIndexBuffer = aznew RHI::MultiDeviceBuffer;
             const auto triangleIndexDataSize = static_cast<uint32_t>(meshData.m_triangleIndices.size() * sizeof(uint16_t));
             request.m_buffer = objectBuffers.m_triangleIndexBuffer.get();
             request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, triangleIndexDataSize };
@@ -1272,7 +1272,7 @@ namespace AZ
             }
 
             // setup m_positionBuffer
-            objectBuffers.m_positionBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+            objectBuffers.m_positionBuffer = aznew RHI::MultiDeviceBuffer;
             const auto positionDataSize = static_cast<uint32_t>(meshData.m_positions.size() * sizeof(AuxGeomPosition));
 
             request.m_buffer = objectBuffers.m_positionBuffer.get();
@@ -1286,7 +1286,7 @@ namespace AZ
             }
 
             // setup m_normalBuffer
-            objectBuffers.m_normalBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+            objectBuffers.m_normalBuffer = aznew RHI::MultiDeviceBuffer;
             const auto normalDataSize = static_cast<uint32_t>(meshData.m_normals.size() * sizeof(AuxGeomNormal));
 
             request.m_buffer = objectBuffers.m_normalBuffer.get();
@@ -1303,7 +1303,7 @@ namespace AZ
             objectBuffers.m_pointIndexCount = static_cast<uint32_t>(meshData.m_pointIndices.size());
             AZ::RHI::SingleDeviceIndexBufferView pointIndexBufferView =
             {
-                *objectBuffers.m_pointIndexBuffer,
+                *objectBuffers.m_pointIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 static_cast<uint32_t>(objectBuffers.m_pointIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1314,7 +1314,7 @@ namespace AZ
             objectBuffers.m_lineIndexCount = static_cast<uint32_t>(meshData.m_lineIndices.size());
             AZ::RHI::SingleDeviceIndexBufferView lineIndexBufferView =
             {
-                *objectBuffers.m_lineIndexBuffer,
+                *objectBuffers.m_lineIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 static_cast<uint32_t>(objectBuffers.m_lineIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1325,7 +1325,7 @@ namespace AZ
             objectBuffers.m_triangleIndexCount = static_cast<uint32_t>(meshData.m_triangleIndices.size());
             AZ::RHI::SingleDeviceIndexBufferView triangleIndexBufferView =
             {
-                *objectBuffers.m_triangleIndexBuffer,
+                *objectBuffers.m_triangleIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 static_cast<uint32_t>(objectBuffers.m_triangleIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1338,7 +1338,7 @@ namespace AZ
 
             AZ::RHI::SingleDeviceStreamBufferView positionBufferView =
             {
-                *objectBuffers.m_positionBuffer,
+                *objectBuffers.m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 positionCount * positionSize,
                 positionSize,
@@ -1350,7 +1350,7 @@ namespace AZ
 
             AZ::RHI::SingleDeviceStreamBufferView normalBufferView =
             {
-                *objectBuffers.m_normalBuffer,
+                *objectBuffers.m_normalBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 normalCount * normalSize,
                 normalSize,

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceIndexBufferView.h>
 #include <Atom/RHI/SingleDeviceStreamBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
@@ -62,7 +62,7 @@ namespace AZ
             ~FixedShapeProcessor() = default;
 
             //! Initialize the FixedShapeProcessor and all its buffers, shaders, stream layouts etc
-            bool Initialize(AZ::RHI::Device& rhiDevice, const AZ::RPI::Scene* scene);
+            bool Initialize(RHI::MultiDevice::DeviceMask deviceMask, const AZ::RPI::Scene* scene);
 
             //! Releases the FixedShapeProcessor and all buffers
             void Release();
@@ -88,19 +88,19 @@ namespace AZ
             struct ObjectBuffers
             {
                 uint32_t m_pointIndexCount;
-                AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_pointIndexBuffer;
+                AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_pointIndexBuffer;
                 AZ::RHI::SingleDeviceIndexBufferView m_pointIndexBufferView;
 
                 uint32_t m_lineIndexCount;
-                AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_lineIndexBuffer;
+                AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_lineIndexBuffer;
                 AZ::RHI::SingleDeviceIndexBufferView m_lineIndexBufferView;
 
                 uint32_t m_triangleIndexCount;
-                AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_triangleIndexBuffer;
+                AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_triangleIndexBuffer;
                 AZ::RHI::SingleDeviceIndexBufferView m_triangleIndexBufferView;
 
-                AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_positionBuffer;
-                AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_normalBuffer;
+                AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
+                AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_normalBuffer;
                 StreamBufferViewsForAllStreams m_streamBufferViews;
                 StreamBufferViewsForAllStreams m_streamBufferViewsWithNormals;
             };
@@ -214,7 +214,7 @@ namespace AZ
         private: // data
 
             //! The buffer pool that manages the index and vertex buffers for each shape
-            RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
+            RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
 
             //! The descriptor for drawing an object of each draw style using predefined streams
             RHI::InputStreamLayout m_objectStreamLayout[DrawStyle_Count];

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -536,7 +536,7 @@ namespace AZ
             desc.m_bufferData = instanceData;
             m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
             m_instanceBufferView = RHI::SingleDeviceStreamBufferView(
-                *m_instanceBuffer->GetRHIBuffer(),
+                *m_instanceBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 aznumeric_cast<uint32_t>(desc.m_byteCount),
                 aznumeric_cast<uint32_t>(desc.m_elementSize));

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2169,19 +2169,24 @@ namespace AZ
                 // note that the element count is the size of the entire buffer, even though this mesh may only
                 // occupy a portion of the vertex buffer.  This is necessary since we are accessing it using
                 // a ByteAddressBuffer in the raytracing shaders and passing the byte offset to the shader in a constant buffer.
-                uint32_t positionBufferByteCount = static_cast<uint32_t>(const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetDescriptor().m_byteCount);
+                uint32_t positionBufferByteCount = static_cast<uint32_t>(
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor positionBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, positionBufferByteCount);
 
-                uint32_t normalBufferByteCount = static_cast<uint32_t>(const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetDescriptor().m_byteCount);
+                uint32_t normalBufferByteCount = static_cast<uint32_t>(
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor normalBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, normalBufferByteCount);
 
-                uint32_t tangentBufferByteCount = static_cast<uint32_t>(const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetDescriptor().m_byteCount);
+                uint32_t tangentBufferByteCount = static_cast<uint32_t>(
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor tangentBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, tangentBufferByteCount);
 
-                uint32_t bitangentBufferByteCount = static_cast<uint32_t>(const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetDescriptor().m_byteCount);
+                uint32_t bitangentBufferByteCount = static_cast<uint32_t>(
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor bitangentBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, bitangentBufferByteCount);
 
-                uint32_t uvBufferByteCount = static_cast<uint32_t>(const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetDescriptor().m_byteCount);
+                uint32_t uvBufferByteCount = static_cast<uint32_t>(
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor uvBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, uvBufferByteCount);
 
                 const RHI::SingleDeviceIndexBufferView& indexBufferView = mesh.m_indexBufferView;
@@ -2197,18 +2202,21 @@ namespace AZ
                 RayTracingFeatureProcessor::SubMesh subMesh;
                 subMesh.m_positionFormat = PositionStreamFormat;
                 subMesh.m_positionVertexBufferView = streamBufferViews[0];
-                subMesh.m_positionShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetBufferView(positionBufferDescriptor);
+                subMesh.m_positionShaderBufferView =
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetBufferView(positionBufferDescriptor);
 
                 subMesh.m_normalFormat = NormalStreamFormat;
                 subMesh.m_normalVertexBufferView = streamBufferViews[1];
-                subMesh.m_normalShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetBufferView(normalBufferDescriptor);
+                subMesh.m_normalShaderBufferView =
+                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetBufferView(normalBufferDescriptor);
 
                 if (tangentBufferByteCount > 0)
                 {
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::Tangent;
                     subMesh.m_tangentFormat = TangentStreamFormat;
                     subMesh.m_tangentVertexBufferView = streamBufferViews[2];
-                    subMesh.m_tangentShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetBufferView(tangentBufferDescriptor);
+                    subMesh.m_tangentShaderBufferView =
+                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetBufferView(tangentBufferDescriptor);
                 }
 
                 if (bitangentBufferByteCount > 0)
@@ -2216,7 +2224,8 @@ namespace AZ
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::Bitangent;
                     subMesh.m_bitangentFormat = BitangentStreamFormat;
                     subMesh.m_bitangentVertexBufferView = streamBufferViews[3];
-                    subMesh.m_bitangentShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetBufferView(bitangentBufferDescriptor);
+                    subMesh.m_bitangentShaderBufferView =
+                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetBufferView(bitangentBufferDescriptor);
                 }
 
                 if (uvBufferByteCount > 0)
@@ -2224,11 +2233,13 @@ namespace AZ
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::UV;
                     subMesh.m_uvFormat = UVStreamFormat;
                     subMesh.m_uvVertexBufferView = streamBufferViews[4];
-                    subMesh.m_uvShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetBufferView(uvBufferDescriptor);
+                    subMesh.m_uvShaderBufferView =
+                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetBufferView(uvBufferDescriptor);
                 }
 
                 subMesh.m_indexBufferView = mesh.m_indexBufferView;
-                subMesh.m_indexShaderBufferView = const_cast<RHI::SingleDeviceBuffer*>(mesh.m_indexBufferView.GetBuffer())->GetBufferView(indexBufferDescriptor);
+                subMesh.m_indexShaderBufferView =
+                    const_cast<RHI::SingleDeviceBuffer*>(mesh.m_indexBufferView.GetBuffer())->GetBufferView(indexBufferDescriptor);
 
                 // add material data
                 if (material)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.h
@@ -49,7 +49,7 @@ namespace AZ
             void ApplySettingsTo(ExposureControlSettings* target, float alpha) const;
 
             void UpdateBuffer();
-            const RHI::SingleDeviceBufferView* GetBufferView() const { return m_buffer->GetBufferView(); }
+            const RHI::MultiDeviceBufferView* GetBufferView() const { return m_buffer->GetBufferView(); }
             
             // Generate all getters and override setters.
             // Declare non-override setters, which will be defined in the .cpp

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -448,12 +448,14 @@ namespace AZ
         {
             if (m_offsetBuffer)
             {
-                m_shaderResourceGroup->SetBufferView(m_offsetsInputIndex, m_offsetBuffer->GetBufferView());
+                m_shaderResourceGroup->SetBufferView(
+                    m_offsetsInputIndex, m_offsetBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
 
             if (m_weightBuffer)
             {
-                m_shaderResourceGroup->SetBufferView(m_weightsInputIndex, m_weightBuffer->GetBufferView());
+                m_shaderResourceGroup->SetBufferView(
+                    m_weightsInputIndex, m_weightBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
 
             SetTargetThreadCounts(m_sourceImageWidth, m_sourceImageHeight, 1);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
@@ -41,8 +41,8 @@ namespace AZ
                 auto buf = m_readbackBuffer->Map(m_copyDescriptor.m_size, 0);
                 if (buf.size())
                 {
-                    //? TODO: Take first here?
-                    memcpy(&depth, buf[0], sizeof(depth));
+                    AZ_Assert(RHI::CheckBitsAny(m_readbackBuffer->GetRHIBuffer()->GetDeviceMask(), RHI::MultiDevice::DefaultDevice), "DepthOfFieldFocusDepthToCpuPass currently only supports the default device.");
+                    memcpy(&depth, buf[RHI::MultiDevice::DefaultDeviceIndex], sizeof(depth));
                     m_readbackBuffer->Unmap();
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
@@ -39,7 +39,7 @@ namespace AZ
             if (m_readbackBuffer)
             {
                 auto buf = m_readbackBuffer->Map(m_copyDescriptor.m_size, 0);
-                if (buf.size())
+                if (buf[RHI::MultiDevice::DefaultDeviceIndex] != nullptr)
                 {
                     AZ_Assert(RHI::CheckBitsAny(m_readbackBuffer->GetRHIBuffer()->GetDeviceMask(), RHI::MultiDevice::DefaultDevice), "DepthOfFieldFocusDepthToCpuPass currently only supports the default device.");
                     memcpy(&depth, buf[RHI::MultiDevice::DefaultDeviceIndex], sizeof(depth));

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
@@ -38,10 +38,11 @@ namespace AZ
             float depth = 0.0f;
             if (m_readbackBuffer)
             {
-                void* buf = m_readbackBuffer->Map(m_copyDescriptor.m_size, 0);
-                if (buf)
+                auto buf = m_readbackBuffer->Map(m_copyDescriptor.m_size, 0);
+                if (buf.size())
                 {
-                    memcpy(&depth, buf, sizeof(depth));
+                    //? TODO: Take first here?
+                    memcpy(&depth, buf[0], sizeof(depth));
                     m_readbackBuffer->Unmap();
                 }
             }
@@ -67,9 +68,9 @@ namespace AZ
                 desc.m_bufferData = nullptr;
                 m_readbackBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
 
-                m_copyDescriptor.m_sourceBuffer = m_bufferRef->GetRHIBuffer();
+                m_copyDescriptor.m_mdSourceBuffer = m_bufferRef->GetRHIBuffer();
                 m_copyDescriptor.m_sourceOffset = 0;
-                m_copyDescriptor.m_destinationBuffer = m_readbackBuffer->GetRHIBuffer();
+                m_copyDescriptor.m_mdDestinationBuffer = m_readbackBuffer->GetRHIBuffer();
                 m_copyDescriptor.m_destinationOffset = 0;
                 m_copyDescriptor.m_size = sizeof(float);
 
@@ -97,7 +98,7 @@ namespace AZ
 
         void DepthOfFieldCopyFocusDepthToCpuPass::BuildCommandList(const RHI::FrameGraphExecuteContext& context)
         {
-            context.GetCommandList()->Submit(m_copyDescriptor);
+            context.GetCommandList()->Submit(m_copyDescriptor.GetDeviceCopyBufferDescriptor(RHI::MultiDevice::DefaultDeviceIndex));
         }
 
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceCopyItem.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
@@ -49,7 +49,7 @@ namespace AZ
 
             RPI::Ptr<RPI::Buffer> m_bufferRef;
             Data::Instance<RPI::Buffer> m_readbackBuffer;
-            RHI::SingleDeviceCopyBufferDescriptor m_copyDescriptor;
+            RHI::MultiDeviceCopyBufferDescriptor m_copyDescriptor;
             bool m_needsInitialize = true;
         };
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
@@ -42,7 +42,8 @@ namespace AZ
             AZ_Assert(m_shaderResourceGroup != nullptr, "%s has a null shader resource group when calling Compile.", GetPathName().GetCStr());
 
             m_shaderResourceGroup->SetConstant(m_autoFocusScreenPositionIndex, m_autoFocusScreenPosition);
-            m_shaderResourceGroup->SetBufferView(m_autoFocusDataBufferIndex, m_bufferRef->GetBufferView());
+            m_shaderResourceGroup->SetBufferView(
+                m_autoFocusDataBufferIndex, m_bufferRef->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             BindPassSrg(context, m_shaderResourceGroup);
             m_shaderResourceGroup->Compile();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
@@ -116,7 +116,7 @@ namespace AZ
                         if (settings)
                         {
                             settings->UpdateBuffer();
-                            view->GetShaderResourceGroup()->SetBufferView(m_exposureControlBufferInputIndex, settings->GetBufferView());
+                            view->GetShaderResourceGroup()->SetBufferView(m_exposureControlBufferInputIndex, settings->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
                         }
                     }
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -689,7 +689,9 @@ namespace AZ
             // directional lights
             const auto directionalLightFP = GetParentScene()->GetFeatureProcessor<DirectionalLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_directionalLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, directionalLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                directionalLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_directionalLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, directionalLightFP->GetLightCount());
@@ -697,7 +699,9 @@ namespace AZ
             // simple point lights
             const auto simplePointLightFP = GetParentScene()->GetFeatureProcessor<SimplePointLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_simplePointLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, simplePointLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                simplePointLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_simplePointLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, simplePointLightFP->GetLightCount());
@@ -705,7 +709,9 @@ namespace AZ
             // simple spot lights
             const auto simpleSpotLightFP = GetParentScene()->GetFeatureProcessor<SimpleSpotLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_simpleSpotLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, simpleSpotLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                simpleSpotLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_simpleSpotLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, simpleSpotLightFP->GetLightCount());
@@ -713,7 +719,9 @@ namespace AZ
             // point lights (sphere)
             const auto pointLightFP = GetParentScene()->GetFeatureProcessor<PointLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_pointLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, pointLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                pointLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_pointLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, pointLightFP->GetLightCount());
@@ -721,7 +729,9 @@ namespace AZ
             // disk lights
             const auto diskLightFP = GetParentScene()->GetFeatureProcessor<DiskLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_diskLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, diskLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                diskLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_diskLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, diskLightFP->GetLightCount());
@@ -729,7 +739,9 @@ namespace AZ
             // capsule lights
             const auto capsuleLightFP = GetParentScene()->GetFeatureProcessor<CapsuleLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_capsuleLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, capsuleLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                capsuleLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_capsuleLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, capsuleLightFP->GetLightCount());
@@ -737,7 +749,9 @@ namespace AZ
             // quad lights
             const auto quadLightFP = GetParentScene()->GetFeatureProcessor<QuadLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_quadLights"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, quadLightFP->GetLightBuffer()->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                quadLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_quadLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, quadLightFP->GetLightCount());
@@ -757,10 +771,20 @@ namespace AZ
             }
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_meshInfo"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_meshInfoGpuBuffer[m_currentMeshInfoFrameIndex]->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                m_meshInfoGpuBuffer[m_currentMeshInfoFrameIndex]
+                    ->GetBufferView()
+                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
+                    .get());
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_meshBufferIndices"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_meshBufferIndicesGpuBuffer[m_currentIndexListFrameIndex]->GetBufferView());
+            m_rayTracingSceneSrg->SetBufferView(
+                bufferIndex,
+                m_meshBufferIndicesGpuBuffer[m_currentIndexListFrameIndex]
+                    ->GetBufferView()
+                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
+                    .get());
 
 #if !USE_BINDLESS_SRG
             RHI::ShaderInputBufferUnboundedArrayIndex bufferUnboundedArrayIndex = srgLayout->FindShaderInputBufferUnboundedArrayIndex(AZ::Name("m_meshBuffers"));
@@ -775,10 +799,20 @@ namespace AZ
             RHI::ShaderInputBufferIndex bufferIndex;
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_materialInfo"));
-            m_rayTracingMaterialSrg->SetBufferView(bufferIndex, m_materialInfoGpuBuffer[m_currentMaterialInfoFrameIndex]->GetBufferView());
+            m_rayTracingMaterialSrg->SetBufferView(
+                bufferIndex,
+                m_materialInfoGpuBuffer[m_currentMaterialInfoFrameIndex]
+                    ->GetBufferView()
+                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
+                    .get());
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_materialTextureIndices"));
-            m_rayTracingMaterialSrg->SetBufferView(bufferIndex, m_materialTextureIndicesGpuBuffer[m_currentIndexListFrameIndex]->GetBufferView());
+            m_rayTracingMaterialSrg->SetBufferView(
+                bufferIndex,
+                m_materialTextureIndicesGpuBuffer[m_currentIndexListFrameIndex]
+                    ->GetBufferView()
+                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
+                    .get());
 
 #if !USE_BINDLESS_SRG
             RHI::ShaderInputImageUnboundedArrayIndex textureUnboundedArrayIndex = srgLayout->FindShaderInputImageUnboundedArrayIndex(AZ::Name("m_materialTextures"));

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.h
@@ -129,14 +129,14 @@ namespace AZ
             };
 
             // buffer pool for the vertex and index buffers
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_bufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
 
             // box mesh rendering buffers
             // note that the position and index views are stored in ReflectionRenderData
             AZStd::vector<Position> m_boxPositions;
             AZStd::vector<uint16_t> m_boxIndices;
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_boxPositionBuffer;
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_boxIndexBuffer;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_boxPositionBuffer;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_boxIndexBuffer;
             RHI::InputStreamLayout m_boxStreamLayout;
 
             // contains the rendering data needed by reflection probes

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
@@ -89,7 +89,8 @@ namespace AZ
 
             if (m_buffer)
             {
-                m_sceneSrg->SetBufferView(m_physicalSkyBufferIndex, m_buffer->GetBufferView());
+                m_sceneSrg->SetBufferView(
+                    m_physicalSkyBufferIndex, m_buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 
 #include <Atom/RPI.Public/Buffer/Buffer.h>

--- a/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
@@ -133,9 +133,15 @@ namespace AZ
 
         void TransformServiceFeatureProcessor::UpdateSceneSrg(RPI::ShaderResourceGroup *sceneSrg)
         {
-            sceneSrg->SetBufferView(m_objectToWorldBufferIndex, m_objectToWorldBuffer->GetBufferView());
-            sceneSrg->SetBufferView(m_objectToWorldInverseTransposeBufferIndex, m_objectToWorldInverseTransposeBuffer->GetBufferView());
-            sceneSrg->SetBufferView(m_objectToWorldHistoryBufferIndex, m_objectToWorldHistoryBuffer->GetBufferView());
+            sceneSrg->SetBufferView(
+                m_objectToWorldBufferIndex,
+                m_objectToWorldBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            sceneSrg->SetBufferView(
+                m_objectToWorldInverseTransposeBufferIndex,
+                m_objectToWorldInverseTransposeBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            sceneSrg->SetBufferView(
+                m_objectToWorldHistoryBufferIndex,
+                m_objectToWorldHistoryBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
         }
 
         void TransformServiceFeatureProcessor::OnBeginPrepareRender()

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <Atom/Feature/Utils/GpuBufferHandler.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RPI.Public/Buffer/BufferSystemInterface.h>
 #include <Atom/Utils/Utils.h>
@@ -90,7 +90,7 @@ namespace AZ
         {
             if (m_bufferIndex.IsValid())
             {
-                srg->SetBufferView(m_bufferIndex, m_buffer->GetBufferView());
+                srg->SetBufferView(m_bufferIndex, m_buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
             if (m_elementCountIndex.IsValid())
             {

--- a/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
@@ -10,7 +10,6 @@
 #include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RHI/SingleDeviceShaderResourceGroupPool.h>
 #include <Atom/RHI/SingleDeviceResourcePool.h>
-#include <Atom/RHI/SingleDeviceBufferPoolBase.h>
 #include <Atom/RHI/SingleDeviceImagePoolBase.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
 #include <Atom/RHI/ResourceView.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -194,7 +194,7 @@ namespace AZ::RHI
     {
         AZ_PROFILE_FUNCTION(RHI);
 
-        if (!ValidateIsInitialized() || !ValidateNotDeviceLevel())
+        if (!ValidateIsInitialized())
         {
             return ResultCode::InvalidOperation;
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -8,7 +8,6 @@
 #include <Atom/RHI/Scope.h>
 #include <Atom/RHI/ResourcePoolDatabase.h>
 #include <Atom/RHI/SingleDeviceImagePoolBase.h>
-#include <Atom/RHI/SingleDeviceBufferPoolBase.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
 namespace AZ::RHI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -65,6 +65,8 @@ namespace AZ
             //! This function is only used for buffer created in host such as dynamic buffer which content is rewritten every frame
             bool OrphanAndUpdateData(const void* sourceData, uint64_t sourceDataSizeInBytes);
 
+            //! Maps all buffers in the underlying multi-device buffer and returns a vector
+            //! with mapped addresses, one per device.
             AZStd::vector<void*> Map(size_t byteCount, uint64_t byteOffset);
             void Unmap();
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -8,10 +8,9 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceBufferView.h>
-#include <Atom/RHI/SingleDeviceFence.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceFence.h>
 
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/Base.h>
@@ -48,11 +47,11 @@ namespace AZ
             //! Blocks until a streaming upload has completed (if one is currently in flight).
             void WaitForUpload();
 
-            RHI::SingleDeviceBuffer* GetRHIBuffer();
+            RHI::MultiDeviceBuffer* GetRHIBuffer();
 
-            const RHI::SingleDeviceBuffer* GetRHIBuffer() const;
+            const RHI::MultiDeviceBuffer* GetRHIBuffer() const;
 
-            const RHI::SingleDeviceBufferView* GetBufferView() const;
+            const RHI::MultiDeviceBufferView* GetBufferView() const;
 
             //! Update buffer's content with sourceData at an offset of bufferByteOffset
             bool UpdateData(const void* sourceData, uint64_t sourceDataSizeInBytes, uint64_t bufferByteOffset = 0);
@@ -66,7 +65,7 @@ namespace AZ
             //! This function is only used for buffer created in host such as dynamic buffer which content is rewritten every frame
             bool OrphanAndUpdateData(const void* sourceData, uint64_t sourceDataSizeInBytes);
 
-            void* Map(size_t byteCount, uint64_t byteOffset);
+            AZStd::vector<void*> Map(size_t byteCount, uint64_t byteOffset);
             void Unmap();
 
             //! Get attachment id if this buffer is used as scope attachment
@@ -94,9 +93,9 @@ namespace AZ
             RHI::ResultCode Init(BufferAsset& bufferAsset);
             void InitBufferView();
 
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_rhiBuffer;
-            RHI::Ptr<RHI::SingleDeviceBufferView> m_bufferView;
-            RHI::SingleDeviceBufferPool* m_rhiBufferPool = nullptr;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_rhiBuffer;
+            RHI::Ptr<RHI::MultiDeviceBufferView> m_bufferView;
+            RHI::MultiDeviceBufferPool* m_rhiBufferPool = nullptr;
 
             Data::Instance<BufferPool> m_bufferPool;
 
@@ -104,7 +103,7 @@ namespace AZ
             Data::Asset<BufferAsset> m_bufferAsset;
 
             // Tracks the streaming upload of the buffer.
-            RHI::Ptr<RHI::SingleDeviceFence> m_streamFence;
+            RHI::Ptr<RHI::MultiDeviceFence> m_streamFence;
             AZStd::mutex m_pendingUploadMutex;
 
             RHI::BufferViewDescriptor m_bufferViewDescriptor;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <AtomCore/Instance/InstanceData.h>
 
@@ -37,18 +37,18 @@ namespace AZ
 
             ~BufferPool() = default;
 
-            RHI::SingleDeviceBufferPool* GetRHIPool();
+            RHI::MultiDeviceBufferPool* GetRHIPool();
 
-            const RHI::SingleDeviceBufferPool* GetRHIPool() const;
+            const RHI::MultiDeviceBufferPool* GetRHIPool() const;
 
         private:
             BufferPool() = default;
 
             // Standard asset creation path.
-            static Data::Instance<BufferPool> CreateInternal(RHI::Device& device, ResourcePoolAsset& poolAsset);
-            RHI::ResultCode Init(RHI::Device& device, ResourcePoolAsset& poolAsset);
+            static Data::Instance<BufferPool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
+            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
 
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_pool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_pool;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystem.h
@@ -29,18 +29,18 @@ namespace AZ
             static void GetAssetHandlers(AssetHandlerPtrList& assetHandlers);
 
             // BufferSystemInterface overrides...
-            RHI::Ptr<RHI::SingleDeviceBufferPool> GetCommonBufferPool(CommonBufferPoolType poolType) override;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> GetCommonBufferPool(CommonBufferPoolType poolType) override;
             Data::Instance<Buffer> CreateBufferFromCommonPool(const CommonBufferDescriptor& descriptor) override;
             Data::Instance<Buffer> FindCommonBuffer(AZStd::string_view uniqueBufferName) override;
 
-            void Init();
+            void Init(RHI::MultiDevice::DeviceMask deviceMask);
             void Shutdown();
 
         protected:
             bool CreateCommonBufferPool(CommonBufferPoolType poolType);
 
         private:
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_commonPools[static_cast<uint8_t>(CommonBufferPoolType::Count)];
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_commonPools[static_cast<uint8_t>(CommonBufferPoolType::Count)];
 
             bool m_initialized = false;
         };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystemInterface.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI.Reflect/Format.h>
 
@@ -72,7 +72,7 @@ namespace AZ
             }
 
             //! Get default buffer pool provided by RPI
-            virtual RHI::Ptr<RHI::SingleDeviceBufferPool> GetCommonBufferPool(CommonBufferPoolType poolType) = 0;
+            virtual RHI::Ptr<RHI::MultiDeviceBufferPool> GetCommonBufferPool(CommonBufferPoolType poolType) = 0;
 
             //! Create buffer from common buffer pool
             virtual Data::Instance<Buffer> CreateBufferFromCommonPool(const CommonBufferDescriptor& descriptor) = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceCopyItem.h>
 #include <Atom/RHI/SingleDeviceDispatchItem.h>
 #include <Atom/RHI/ScopeProducer.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
@@ -9,7 +9,6 @@
 
 #include <AtomCore/Instance/Instance.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceCopyItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -294,12 +294,21 @@ namespace AZ
 
             if (auto buf = Map(sourceDataSize, bufferByteOffset); buf.size())
             {
+                auto partialResult{false};
                 for (auto index{ 0u }; index < buf.size(); ++index)
                 {
-                    memcpy(buf[index], sourceData, sourceDataSize);
+                    if(buf[index] != nullptr)
+                    {
+                        memcpy(buf[index], sourceData, sourceDataSize);
+                        partialResult = true;
+                    }
                 }
-                Unmap();
-                return true;
+
+                if(partialResult)
+                {
+                    Unmap();
+                }
+                return partialResult;
             }
 
             return false;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -9,9 +9,8 @@
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceFence.h>
-#include <Atom/RHI/SingleDeviceBufferView.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceFence.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RPI.Public/Buffer/BufferPool.h>
 #include <Atom/RPI.Public/Buffer/BufferSystemInterface.h>
@@ -42,8 +41,7 @@ namespace AZ
              * pointer around at all times, and then only initialize the buffer view once.
              */
 
-            auto& factory = RHI::Factory::Get();
-            m_rhiBuffer = factory.CreateBuffer();
+            m_rhiBuffer = aznew RHI::MultiDeviceBuffer;
             AZ_Assert(m_rhiBuffer, "Failed to acquire an buffer instance from the RHI. Is the RHI initialized?");
         }
 
@@ -52,17 +50,17 @@ namespace AZ
             WaitForUpload();
         }
 
-        RHI::SingleDeviceBuffer* Buffer::GetRHIBuffer()
+        RHI::MultiDeviceBuffer* Buffer::GetRHIBuffer()
         {
             return m_rhiBuffer.get();
         }
 
-        const RHI::SingleDeviceBuffer* Buffer::GetRHIBuffer() const
+        const RHI::MultiDeviceBuffer* Buffer::GetRHIBuffer() const
         {
             return m_rhiBuffer.get();
         }
 
-        const RHI::SingleDeviceBufferView* Buffer::GetBufferView() const
+        const RHI::MultiDeviceBufferView* Buffer::GetBufferView() const
         {
             if (m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::InputAssembly ||
                 m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::DynamicInputAssembly)
@@ -125,7 +123,7 @@ namespace AZ
 
             bool initWithData = (bufferAsset.GetBuffer().size() > 0 && bufferAsset.GetBuffer().size() <= MinStreamSize);
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_rhiBuffer.get();
             request.m_descriptor = bufferAsset.GetBufferDescriptor();
             request.m_initialData = initWithData ? bufferAsset.GetBuffer().data() : nullptr;
@@ -139,15 +137,16 @@ namespace AZ
                 if (bufferAsset.GetBuffer().size() > 0 && !initWithData)
                 {
                     AZ_PROFILE_SCOPE(RPI, "Stream Upload");
-                    m_streamFence = RHI::Factory::Get().CreateFence();
+                    m_streamFence = aznew RHI::MultiDeviceFence;
                     if (m_streamFence)
                     {
-                        m_streamFence->Init(m_rhiBufferPool->GetDevice(), RHI::FenceState::Reset);
+                        //? TODO: What should be done here?
+                        m_streamFence->Init(m_rhiBufferPool->GetDeviceMask(), RHI::FenceState::Reset);
                     }
 
                     RHI::BufferDescriptor bufferDescriptor = bufferAsset.GetBufferDescriptor();
 
-                    RHI::SingleDeviceBufferStreamRequest request2;
+                    RHI::MultiDeviceBufferStreamRequest request2;
                     request2.m_buffer = m_rhiBuffer.get();
                     request2.m_fenceToSignal = m_streamFence.get();
                     request2.m_byteCount = bufferDescriptor.m_byteCount;
@@ -181,11 +180,11 @@ namespace AZ
         void Buffer::Resize(uint64_t bufferSize)
         {
             RHI::BufferDescriptor desc = m_rhiBuffer->GetDescriptor();            
-            m_rhiBuffer = RHI::Factory::Get().CreateBuffer();
+            m_rhiBuffer = aznew RHI::MultiDeviceBuffer;
             AZ_Assert(m_rhiBuffer, "Failed to acquire an buffer instance from the RHI. Is the RHI initialized?");
             
             desc.m_byteCount = bufferSize;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_rhiBuffer.get();
             request.m_descriptor = desc;
 
@@ -209,8 +208,8 @@ namespace AZ
             {
                 return;
             }
-               
-            m_bufferView = m_rhiBuffer->GetBufferView(m_bufferViewDescriptor);
+
+            m_bufferView = aznew RHI::MultiDeviceBufferView{ m_rhiBuffer.get(), m_bufferViewDescriptor };
 
             if(!m_bufferView.get())
             {
@@ -218,20 +217,20 @@ namespace AZ
             }
         }
 
-        void* Buffer::Map(size_t byteCount, uint64_t byteOffset)
+        AZStd::vector<void*> Buffer::Map(size_t byteCount, uint64_t byteOffset)
         {
             if (byteOffset + byteCount > m_rhiBuffer->GetDescriptor().m_byteCount)
             {
                 AZ_Error("Buffer", false, "Map out of range");
-                return nullptr;
+                return {};
             }
 
-            RHI::SingleDeviceBufferMapRequest request;
+            RHI::MultiDeviceBufferMapRequest request;
             request.m_buffer = m_rhiBuffer.get();
             request.m_byteCount = byteCount;
             request.m_byteOffset = byteOffset;
 
-            RHI::SingleDeviceBufferMapResponse response;
+            RHI::MultiDeviceBufferMapResponse response;
             RHI::ResultCode result = m_rhiBufferPool->MapBuffer(request, response);
 
             if (result == RHI::ResultCode::Success)
@@ -241,7 +240,7 @@ namespace AZ
             else
             {
                 AZ_Error("RPI::Buffer", false, "Failed to update RHI buffer. Error code: %d", result);
-                return nullptr;
+                return {};
             }
         }
 
@@ -286,7 +285,7 @@ namespace AZ
 
             return UpdateData(sourceData, sourceDataSize, 0);
         }
-        
+
         bool Buffer::UpdateData(const void* sourceData, uint64_t sourceDataSize, uint64_t bufferByteOffset)
         {
             if (sourceDataSize == 0)
@@ -294,9 +293,12 @@ namespace AZ
                 return true;
             }
 
-            if (void* buf = Map(sourceDataSize, bufferByteOffset))
+            if (auto buf = Map(sourceDataSize, bufferByteOffset); buf.size())
             {
-                memcpy(buf, sourceData, sourceDataSize);
+                for (auto index{ 0u }; index < buf.size(); ++index)
+                {
+                    memcpy(buf[index], sourceData, sourceDataSize);
+                }
                 Unmap();
                 return true;
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -140,7 +140,6 @@ namespace AZ
                     m_streamFence = aznew RHI::MultiDeviceFence;
                     if (m_streamFence)
                     {
-                        //? TODO: What should be done here?
                         m_streamFence->Init(m_rhiBufferPool->GetDeviceMask(), RHI::FenceState::Reset);
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferPool.cpp
@@ -11,7 +11,7 @@
 #include <Atom/RPI.Reflect/ResourcePoolAsset.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <Atom/RHI.Reflect/BufferPoolDescriptor.h>
 
@@ -28,10 +28,10 @@ namespace AZ
                 resourcePoolAsset);
         }
 
-        Data::Instance<BufferPool> BufferPool::CreateInternal(RHI::Device& device, ResourcePoolAsset& poolAsset)
+        Data::Instance<BufferPool> BufferPool::CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
         {
             Data::Instance<BufferPool> bufferPool = aznew BufferPool();
-            RHI::ResultCode resultCode = bufferPool->Init(device, poolAsset);
+            RHI::ResultCode resultCode = bufferPool->Init(deviceMask, poolAsset);
             if (resultCode == RHI::ResultCode::Success)
             {
                 return bufferPool;
@@ -40,12 +40,12 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode BufferPool::Init(RHI::Device& device, ResourcePoolAsset& poolAsset)
+        RHI::ResultCode BufferPool::Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
         {
-            RHI::Ptr<RHI::SingleDeviceBufferPool> bufferPool = RHI::Factory::Get().CreateBufferPool();
+            RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool = aznew RHI::MultiDeviceBufferPool;
             if (!bufferPool)
             {
-                AZ_Error("RPI::BufferPool", false, "Failed to create RHI::SingleDeviceBufferPool");
+                AZ_Error("RPI::BufferPool", false, "Failed to create RHI::MultiDeviceBufferPool");
                 return RHI::ResultCode::Fail;
             }
 
@@ -57,7 +57,7 @@ namespace AZ
             }
 
             bufferPool->SetName(AZ::Name{ poolAsset.GetPoolName() });
-            RHI::ResultCode resultCode = bufferPool->Init(device, *desc);
+            RHI::ResultCode resultCode = bufferPool->Init(deviceMask, *desc);
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_pool = bufferPool;
@@ -66,12 +66,12 @@ namespace AZ
             return resultCode;
         }
 
-        const RHI::SingleDeviceBufferPool* BufferPool::GetRHIPool() const
+        const RHI::MultiDeviceBufferPool* BufferPool::GetRHIPool() const
         {
             return m_pool.get();
         }
 
-        RHI::SingleDeviceBufferPool* BufferPool::GetRHIPool()
+        RHI::MultiDeviceBufferPool* BufferPool::GetRHIPool()
         {
             return m_pool.get();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
@@ -38,7 +38,7 @@ namespace AZ
             }
             
             m_ringBufferSize = ringBufferSize;
-            m_ringBufferStartAddress = m_ringBuffer->Map(m_ringBufferSize, 0);
+            m_ringBufferStartAddress = m_ringBuffer->Map(m_ringBufferSize, 0)[0]; //? TODO take the first
             
             m_currentPosition = 0;
             m_endPositionLimit = 0;
@@ -132,7 +132,7 @@ namespace AZ
         RHI::SingleDeviceIndexBufferView DynamicBufferAllocator::GetIndexBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, RHI::IndexFormat format)
         {
             return RHI::SingleDeviceIndexBufferView(
-                *m_ringBuffer->GetRHIBuffer(),
+                *m_ringBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 GetBufferAddressOffset(dynamicBuffer),
                 dynamicBuffer->m_size,
                 format
@@ -142,7 +142,7 @@ namespace AZ
         RHI::SingleDeviceStreamBufferView DynamicBufferAllocator::GetStreamBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, uint32_t strideByteCount)
         {
             return RHI::SingleDeviceStreamBufferView(
-                *m_ringBuffer->GetRHIBuffer(),
+                *m_ringBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 GetBufferAddressOffset(dynamicBuffer),
                 dynamicBuffer->m_size,
                 strideByteCount

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
@@ -38,7 +38,9 @@ namespace AZ
             }
             
             m_ringBufferSize = ringBufferSize;
-            m_ringBufferStartAddress = m_ringBuffer->Map(m_ringBufferSize, 0)[0]; //? TODO take the first
+
+            AZ_Assert(RHI::CheckBitsAny(m_ringBuffer->GetRHIBuffer()->GetDeviceMask(), RHI::MultiDevice::DefaultDevice), "DynamicBufferAllocator currently only supports the default device.");
+            m_ringBufferStartAddress = m_ringBuffer->Map(m_ringBufferSize, 0)[RHI::MultiDevice::DefaultDeviceIndex];
             
             m_currentPosition = 0;
             m_endPositionLimit = 0;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -83,7 +83,7 @@ namespace AZ
                     }
 
                     meshInstance.m_indexBufferView = RHI::SingleDeviceIndexBufferView(
-                        *indexBuffer->GetRHIBuffer(),
+                        *indexBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(),
                         bufferViewDescriptor.m_elementOffset * bufferViewDescriptor.m_elementSize,
                         bufferViewDescriptor.m_elementCount * bufferViewDescriptor.m_elementSize,
                         indexFormat);
@@ -328,7 +328,7 @@ namespace AZ
                         // Note, don't use iter->m_semantic as it can be a UV name matching.
                         layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, iter->m_format);
 
-                        RHI::SingleDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
+                        RHI::SingleDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
                         streamBufferViewsOut.push_back(bufferView);
                     }
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -580,7 +580,8 @@ namespace AZ
                 auto bufferSize = readbackBufferCurrent->GetBufferSize();
                 readbackItem.m_dataBuffer = AZStd::make_shared<AZStd::vector<uint8_t>>();
 
-                void* buf = readbackBufferCurrent->Map(bufferSize, 0)[0]; //? Take element 0 here
+                AZ_Assert(RHI::CheckBitsAny(readbackBufferCurrent->GetRHIBuffer()->GetDeviceMask(), RHI::MultiDevice::DefaultDevice), "AttachmentReadback currently only supports the default device for now as long as passes have no device index yet.");
+                void* buf = readbackBufferCurrent->Map(bufferSize, 0)[RHI::MultiDevice::DefaultDeviceIndex];
                 if (buf)
                 {
                     if (m_attachmentType == RHI::AttachmentType::Buffer)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -379,7 +379,7 @@ namespace AZ
                 // copy buffer
                 RHI::SingleDeviceCopyBufferDescriptor copyBuffer;
                 copyBuffer.m_sourceBuffer = buffer;
-                copyBuffer.m_destinationBuffer = m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
+                copyBuffer.m_destinationBuffer = m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
                 copyBuffer.m_size = aznumeric_cast<uint32_t>(desc.m_byteCount);
 
                 m_readbackItems[0].m_copyItem = copyBuffer;
@@ -437,7 +437,7 @@ namespace AZ
                     copyImageToBuffer.m_destinationOffset = 0;
                     copyImageToBuffer.m_destinationBytesPerRow = imageSubresourceLayouts[mipSlice].m_bytesPerRow;
                     copyImageToBuffer.m_destinationBytesPerImage = imageSubresourceLayouts[mipSlice].m_bytesPerImage;
-                    copyImageToBuffer.m_destinationBuffer = readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
+                    copyImageToBuffer.m_destinationBuffer = readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
                     copyImageToBuffer.m_destinationFormat = m_imageDescriptor.m_format;
 
                     readbackItem.m_mipInfo.m_slice = mipSlice;
@@ -580,7 +580,7 @@ namespace AZ
                 auto bufferSize = readbackBufferCurrent->GetBufferSize();
                 readbackItem.m_dataBuffer = AZStd::make_shared<AZStd::vector<uint8_t>>();
 
-                void* buf = readbackBufferCurrent->Map(bufferSize, 0);
+                void* buf = readbackBufferCurrent->Map(bufferSize, 0)[0]; //? Take element 0 here
                 if (buf)
                 {
                     if (m_attachmentType == RHI::AttachmentType::Buffer)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -948,11 +948,11 @@ namespace AZ
                         Buffer* buffer = static_cast<Buffer*>(attachment->m_importedResource.get());
                         if (currentAttachment == nullptr)
                         {
-                            attachmentDatabase.ImportBuffer(attachmentId, buffer->GetRHIBuffer());
+                            attachmentDatabase.ImportBuffer(attachmentId, buffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get());
                         }
                         else
                         {
-                            AZ_Assert(currentAttachment->GetResource() == buffer->GetRHIBuffer(),
+                            AZ_Assert(currentAttachment->GetResource() == buffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(),
                                 "Importing buffer attachment named \"%s\" but a different attachment with the "
                                 "same name already exists in the database.\n", attachmentId.GetCStr());
                         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -434,7 +434,7 @@ namespace AZ
 
             m_rhiSystem.Init(bindlessSrgLayout);
             m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
-            m_bufferSystem.Init();
+            m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
             m_dynamicDraw.Init(m_descriptor.m_dynamicDrawSystemDescriptor);
 
             m_passSystem.InitPassTemplates();
@@ -464,7 +464,7 @@ namespace AZ
             //Init rhi/image/buffer systems to match InitializeSystemAssets
             m_rhiSystem.Init();
             m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
-            m_bufferSystem.Init();
+            m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
 
             // Assets aren't actually available or needed for tests, but the m_systemAssetsInitialized flag still needs to be flipped.
             m_systemAssetsInitialized = true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -518,9 +518,10 @@ namespace AZ
 
         bool ShaderResourceGroup::SetBuffer(RHI::ShaderInputBufferIndex inputIndex, const Data::Instance<Buffer>& buffer, uint32_t arrayIndex)
         {
-            const RHI::SingleDeviceBufferView* bufferView = buffer ? buffer->GetBufferView() : nullptr;
+            const auto bufferView =
+                buffer ? buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex) : nullptr;
 
-            if (m_data.SetBufferView(inputIndex, bufferView, arrayIndex))
+            if (m_data.SetBufferView(inputIndex, bufferView.get(), arrayIndex))
             {
                 const RHI::Interval interval = m_layout->GetGroupInterval(inputIndex);
 

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
@@ -109,9 +109,9 @@ namespace UnitTest
             m_longBuffer = Buffer::FindOrCreate(m_longBufferAsset);
 
             m_threeBuffers = { m_shortBuffer, m_mediumBuffer, m_longBuffer };
-            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
-            m_bufferViewB = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
-            m_bufferViewC = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
+            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6)); //? Convert together with SRG later
+            m_bufferViewB = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
+            m_bufferViewC = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
 
             m_threeBufferViews = { m_bufferViewA.get(), m_bufferViewB.get(), m_bufferViewC.get() };
         }
@@ -189,8 +189,8 @@ namespace UnitTest
         EXPECT_EQ(m_mediumBuffer, m_testSrg->GetBuffer(m_indexOfBufferB));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_shortBuffer->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferA, 0));
-        EXPECT_EQ(m_mediumBuffer->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferB, 0));
+        EXPECT_EQ(m_shortBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferA, 0));
+        EXPECT_EQ(m_mediumBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferB, 0));
 
         // Test changing back to null...
 
@@ -214,9 +214,9 @@ namespace UnitTest
         EXPECT_EQ(m_longBuffer, m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_shortBuffer->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_mediumBuffer->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_longBuffer->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_shortBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_mediumBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_longBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
 
         // Test changing back to null...
 
@@ -242,9 +242,9 @@ namespace UnitTest
         EXPECT_EQ(m_threeBuffers[0], m_testSrg->GetBuffer(m_indexOfBufferArray, 0));
         EXPECT_EQ(m_threeBuffers[1], m_testSrg->GetBuffer(m_indexOfBufferArray, 1));
         EXPECT_EQ(m_threeBuffers[2], m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
-        EXPECT_EQ(m_threeBuffers[0]->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_threeBuffers[1]->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_threeBuffers[2]->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_threeBuffers[0]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_threeBuffers[1]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_threeBuffers[2]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
 
         // Test replacing just two buffers including changing one buffer back to null...
 
@@ -297,8 +297,8 @@ namespace UnitTest
         EXPECT_EQ(twoBuffers[0], m_testSrg->GetBuffer(m_indexOfBufferArray, 1));
         EXPECT_EQ(twoBuffers[1], m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
         EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(twoBuffers[0]->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(twoBuffers[1]->GetBufferView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(twoBuffers[0]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(twoBuffers[1]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
     }
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetBufferArrayAtOffset_ValidationFailure)

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
@@ -109,7 +109,7 @@ namespace UnitTest
             m_longBuffer = Buffer::FindOrCreate(m_longBufferAsset);
 
             m_threeBuffers = { m_shortBuffer, m_mediumBuffer, m_longBuffer };
-            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6)); //? Convert together with SRG later
+            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
             m_bufferViewB = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
             m_bufferViewC = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
 

--- a/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
@@ -104,7 +104,7 @@ namespace AZ
                     return false;
                 }
 
-                if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()))
+                if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
                 {
                     AZ_Error(warningHeader, false, "Failed to bind buffer view for [%s]", bufferDesc.m_bufferName.GetCStr());
                     return false;

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
@@ -139,8 +139,8 @@ namespace AZ
                 //! This indirectly forces the sync to be applied to all 'sub-buffers' used by each of the
                 //!  HairObjects / HairDispatches and therefore allows us to change their data in the shader
                 //!  between passes.
-                AZStd::vector<Data::Instance<RHI::SingleDeviceBufferView>> m_dynamicBuffersViews;   // RW used for the Compute
-                AZStd::vector<Data::Instance<RHI::SingleDeviceBufferView>> m_readBuffersViews;      // Read only used for the Raster fill
+                AZStd::vector<Data::Instance<RHI::MultiDeviceBufferView>> m_dynamicBuffersViews;   // RW used for the Compute
+                AZStd::vector<Data::Instance<RHI::MultiDeviceBufferView>> m_readBuffersViews;      // Read only used for the Raster fill
 
                 //! The following vector is required in order to keep the allocators 'alive' or
                 //!  else they are cleared from the buffer via the reference mechanism.
@@ -380,7 +380,7 @@ namespace AZ
                 Data::Instance<RPI::ShaderResourceGroup> m_hairRenderSrg;   
  
                 //! Index buffer for the render pass via draw calls - naming was kept
-                Data::Instance<RHI::SingleDeviceBuffer> m_indexBuffer;
+                Data::Instance<RHI::MultiDeviceBuffer> m_indexBuffer;
                 RHI::SingleDeviceIndexBufferView m_indexBufferView;
                 //-------------------------------------------------------------------
 

--- a/Gems/AtomTressFX/Code/Rendering/SharedBuffer.h
+++ b/Gems/AtomTressFX/Code/Rendering/SharedBuffer.h
@@ -13,7 +13,6 @@
 
 #include <Atom/RHI/FreeListAllocator.h>
 #include <Atom/RHI.Reflect/Format.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -54,13 +54,13 @@ namespace AZ
             m_visualizationTlas = AZ::RHI::SingleDeviceRayTracingTlas::CreateRHIRayTracingTlas();
 
             // create the grid data buffer
-            m_gridDataBuffer = RHI::Factory::Get().CreateBuffer();
+            m_gridDataBuffer = aznew RHI::MultiDeviceBuffer;
 
             RHI::BufferDescriptor descriptor;
             descriptor.m_byteCount = DiffuseProbeGridRenderData::GridDataBufferSize;
             descriptor.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_gridDataBuffer.get();
             request.m_descriptor = descriptor;
             [[maybe_unused]] RHI::ResultCode result = m_renderData->m_bufferPool->InitBuffer(request);
@@ -483,8 +483,8 @@ namespace AZ
             uint32_t packed2 = GetNumRaysPerProbe().m_rayCount | (DefaultNumIrradianceTexels << 16) | (DefaultNumDistanceTexels << 24);
             uint32_t packed3 = 0;
             uint32_t packed4 = (m_scrolling << 16) | (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20); // scrolling, rayFormat, irradianceFormat, relocation, classification
-        
-            m_prepareSrg->SetBufferView(m_renderData->m_prepareSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+
+            m_prepareSrg->SetBufferView(m_renderData->m_prepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgGridDataInitializedNameIndex, m_gridDataInitialized);
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridOriginNameIndex, m_transform.GetTranslation());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridProbeHysteresisNameIndex, m_probeHysteresis);
@@ -516,7 +516,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_rayTraceSrg.get(), "Failed to create RayTrace shader resource group");
             }
 
-            m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
             m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
             m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
@@ -538,7 +538,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendIrradianceSrg.get(), "Failed to create BlendIrradiance shader resource group");
             }
 
-            m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
             m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
             m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
@@ -554,7 +554,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendDistanceSrg.get(), "Failed to create BlendDistance shader resource group");
             }
 
-            m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
             m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
             m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
@@ -623,7 +623,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_relocationSrg.get(), "Failed to create Relocation shader resource group");
             }
 
-            m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
             m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
@@ -638,7 +638,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_classificationSrg.get(), "Failed to create Classification shader resource group");
             }
 
-            m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
             m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
@@ -658,7 +658,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_renderObjectSrg.get(), "Failed to create render shader resource group");
             }
 
-            m_renderObjectSrg->SetBufferView(m_renderData->m_renderSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_renderObjectSrg->SetBufferView(m_renderData->m_renderSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
 
             AZ::Matrix3x4 modelToWorld = AZ::Matrix3x4::CreateFromTransform(m_transform) * AZ::Matrix3x4::CreateScale(m_renderExtents);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgModelToWorldNameIndex, modelToWorld);
@@ -692,7 +692,7 @@ namespace AZ
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, tlasInstancesBufferByteCount / RayTracingTlasInstanceElementSize, RayTracingTlasInstanceElementSize);
             m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->GetBufferView(bufferViewDescriptor).get());
 
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationPrepareSrg->SetConstant(m_renderData->m_visualizationPrepareSrgProbeSphereRadiusNameIndex, m_visualizationSphereRadius);
         }
@@ -709,7 +709,7 @@ namespace AZ
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
             m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
 
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
@@ -725,7 +725,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_querySrg.get(), "Failed to create Query shader resource group");
             }
 
-            m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
             m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
             m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
@@ -31,7 +31,7 @@ namespace AZ
             static const uint32_t GridDataBufferSize = 112;
 
             RHI::Ptr<RHI::SingleDeviceImagePool> m_imagePool;          
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_bufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
 
             AZStd::array<RHI::SingleDeviceStreamBufferView, 1> m_boxPositionBufferView;
             RHI::SingleDeviceIndexBufferView m_boxIndexBufferView;
@@ -277,7 +277,7 @@ namespace AZ
             const RHI::Ptr<RHI::SingleDeviceImage> GetIrradianceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_irradianceImage[m_currentImageIndex] : m_bakedIrradianceImage->GetRHIImage(); }
             const RHI::Ptr<RHI::SingleDeviceImage> GetDistanceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_distanceImage[m_currentImageIndex] : m_bakedDistanceImage->GetRHIImage(); }
             const RHI::Ptr<RHI::SingleDeviceImage> GetProbeDataImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_probeDataImage[m_currentImageIndex] : m_bakedProbeDataImage->GetRHIImage(); }
-            const RHI::Ptr<RHI::SingleDeviceBuffer> GetGridDataBuffer() { return m_gridDataBuffer; }
+            const RHI::Ptr<RHI::MultiDeviceBuffer> GetGridDataBuffer() { return m_gridDataBuffer; }
 
             const AZStd::string& GetBakedIrradianceRelativePath() const { return m_bakedIrradianceRelativePath; }
             const AZStd::string& GetBakedDistanceRelativePath() const { return m_bakedDistanceRelativePath; }
@@ -401,7 +401,7 @@ namespace AZ
             DiffuseProbeGridMode m_mode = DiffuseProbeGridMode::RealTime;
 
             // grid data buffer
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_gridDataBuffer;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_gridDataBuffer;
             bool m_gridDataInitialized = false;
 
             // real-time textures

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
@@ -172,14 +172,14 @@ namespace AZ
             };
 
             // buffer pool for the vertex and index buffers
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_bufferPool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
 
             // box mesh rendering buffers
             // note that the position and index views are stored in DiffuseProbeGridRenderData
             AZStd::vector<Position> m_boxPositions;
             AZStd::vector<uint16_t> m_boxIndices;
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_boxPositionBuffer;
-            RHI::Ptr<RHI::SingleDeviceBuffer> m_boxIndexBuffer;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_boxPositionBuffer;
+            RHI::Ptr<RHI::MultiDeviceBuffer> m_boxIndexBuffer;
             RHI::InputStreamLayout m_boxStreamLayout;
 
             // contains the rendering data needed by probe grids

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
@@ -110,7 +110,7 @@ namespace AZ
             {
                 // grid data buffer
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(diffuseProbeGrid->GetGridDataBufferAttachmentId(), diffuseProbeGrid->GetGridDataBuffer());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(diffuseProbeGrid->GetGridDataBufferAttachmentId(), diffuseProbeGrid->GetGridDataBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import grid data buffer");
 
                     RHI::BufferScopeAttachmentDescriptor desc;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
@@ -144,11 +144,11 @@ namespace AZ
             // query buffer
             {
                 RHI::AttachmentId attachmentId = diffuseProbeGridFeatureProcessor->GetQueryBufferAttachmentId();
-                RHI::Ptr<RHI::SingleDeviceBuffer> buffer = diffuseProbeGridFeatureProcessor->GetQueryBuffer()->GetRHIBuffer();
+                RHI::Ptr<RHI::MultiDeviceBuffer> buffer = diffuseProbeGridFeatureProcessor->GetQueryBuffer()->GetRHIBuffer();
 
                 if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, buffer);
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, buffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import query buffer");
                 }
 
@@ -226,9 +226,9 @@ namespace AZ
 
                 // bind query buffer
                 RHI::ShaderInputBufferIndex bufferIndex = m_srgLayout->FindShaderInputBufferIndex(AZ::Name("m_irradianceQueries"));
-                RHI::Ptr<RHI::SingleDeviceBuffer> buffer = diffuseProbeGridFeatureProcessor->GetQueryBuffer()->GetRHIBuffer();
+                RHI::Ptr<RHI::MultiDeviceBuffer> buffer = diffuseProbeGridFeatureProcessor->GetQueryBuffer()->GetRHIBuffer();
                 RHI::BufferViewDescriptor bufferViewDescriptor = diffuseProbeGridFeatureProcessor->GetQueryBufferViewDescriptor();
-                diffuseProbeGrid->GetQuerySrg()->SetBufferView(bufferIndex, buffer->GetBufferView(bufferViewDescriptor).get());
+                diffuseProbeGrid->GetQuerySrg()->SetBufferView(bufferIndex, buffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(bufferViewDescriptor).get());
 
                 // bind output UAV
                 bufferIndex = m_srgLayout->FindShaderInputBufferIndex(AZ::Name("m_output"));

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
@@ -172,7 +172,7 @@ namespace AZ
             // The attachment itself is created for the PerPass shared buffer.
             viewDescriptor.m_ignoreFrameAttachmentValidation = true;
 
-            RHI::SingleDeviceBuffer* rhiBuffer = Meshlets::SharedBufferInterface::Get()->GetBuffer()->GetRHIBuffer();
+            RHI::MultiDeviceBuffer* rhiBuffer = Meshlets::SharedBufferInterface::Get()->GetBuffer()->GetRHIBuffer();
             Data::Instance<RHI::SingleDeviceBufferView> bufferView = RHI::Factory::Get().CreateBufferView();
             RHI::ResultCode resultCode = bufferView->Init(*rhiBuffer, viewDescriptor);
 

--- a/Gems/Meshlets/Code/Source/Meshlets/SharedBuffer.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/SharedBuffer.h
@@ -13,7 +13,6 @@
 
 #include <Atom/RHI/FreeListAllocator.h>
 #include <Atom/RHI.Reflect/Format.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -92,7 +92,8 @@ namespace NvCloth
         const uint64_t byteCount = aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementCount) * aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementSize);
         const uint64_t byteOffset = aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementOffset) * aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementSize);
 
-        m_buffer = static_cast<T*>(m_rpiBuffer->Map(byteCount, byteOffset)[0]); //? Do we want to convert this?
+        AZ_Assert(AZ::RHI::CheckBitsAny(m_rpiBuffer->GetRHIBuffer()->GetDeviceMask(), AZ::RHI::MultiDevice::DefaultDevice), "ClothComponentMesh currently only supports the default device.");
+        m_buffer = static_cast<T*>(m_rpiBuffer->Map(byteCount, byteOffset)[AZ::RHI::MultiDevice::DefaultDeviceIndex]);
     }
 
     template<typename T>

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -92,7 +92,7 @@ namespace NvCloth
         const uint64_t byteCount = aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementCount) * aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementSize);
         const uint64_t byteOffset = aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementOffset) * aznumeric_cast<uint64_t>(bufferViewDescriptor.m_elementSize);
 
-        m_buffer = static_cast<T*>(m_rpiBuffer->Map(byteCount, byteOffset));
+        m_buffer = static_cast<T*>(m_rpiBuffer->Map(byteCount, byteOffset)[0]); //? Do we want to convert this?
     }
 
     template<typename T>

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
@@ -166,7 +166,7 @@ namespace AZ::Render
             m_starsVertexBuffer->UpdateData(m_starsMeshData.data(), bufferSize);
         }
 
-        m_meshStreamBufferViews[0] = RHI::SingleDeviceStreamBufferView(*m_starsVertexBuffer->GetRHIBuffer(), 0, bufferSize, elementSize);
+        m_meshStreamBufferViews[0] = RHI::SingleDeviceStreamBufferView(*m_starsVertexBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, bufferSize, elementSize);
 
         UpdateDrawPacket();
     }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -284,7 +284,7 @@ namespace Terrain
     {
         return
         {
-            *buffer->GetRHIBuffer(),
+            *buffer->GetRHIBuffer()->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
             offset,
             aznumeric_cast<uint32_t>(buffer->GetBufferSize()),
             buffer->GetBufferViewDescriptor().m_elementSize
@@ -365,21 +365,21 @@ namespace Terrain
         rtSector.m_normalsBuffer = CreateRayTracingMeshBufferInstance(AZ::RHI::Format::R32G32B32_FLOAT, m_gridVerts2D, nullptr, positionName.c_str());
 
         // setup the stream and shader buffer views
-        AZ::RHI::SingleDeviceBuffer& rhiPositionsBuffer = *rtSector.m_positionsBuffer->GetRHIBuffer();
+        AZ::RHI::MultiDeviceBuffer& rhiPositionsBuffer = *rtSector.m_positionsBuffer->GetRHIBuffer();
         uint32_t positionsBufferByteCount = aznumeric_cast<uint32_t>(rhiPositionsBuffer.GetDescriptor().m_byteCount);
         AZ::RHI::Format positionsBufferFormat = rtSector.m_positionsBuffer->GetBufferViewDescriptor().m_elementFormat;
         uint32_t positionsBufferElementSize = AZ::RHI::GetFormatSize(positionsBufferFormat);
-        AZ::RHI::SingleDeviceStreamBufferView positionsVertexBufferView(rhiPositionsBuffer, 0, positionsBufferByteCount, positionsBufferElementSize);
+        AZ::RHI::SingleDeviceStreamBufferView positionsVertexBufferView(*rhiPositionsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), 0, positionsBufferByteCount, positionsBufferElementSize);
         AZ::RHI::BufferViewDescriptor positionsBufferDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, positionsBufferByteCount);
 
-        AZ::RHI::SingleDeviceBuffer& rhiNormalsBuffer = *rtSector.m_normalsBuffer->GetRHIBuffer();
+        AZ::RHI::MultiDeviceBuffer& rhiNormalsBuffer = *rtSector.m_normalsBuffer->GetRHIBuffer();
         uint32_t normalsBufferByteCount = aznumeric_cast<uint32_t>(rhiNormalsBuffer.GetDescriptor().m_byteCount);
         AZ::RHI::Format normalsBufferFormat = rtSector.m_normalsBuffer->GetBufferViewDescriptor().m_elementFormat;
         uint32_t normalsBufferElementSize = AZ::RHI::GetFormatSize(normalsBufferFormat);
-        AZ::RHI::SingleDeviceStreamBufferView normalsVertexBufferView(rhiNormalsBuffer, 0, normalsBufferByteCount, normalsBufferElementSize);
+        AZ::RHI::SingleDeviceStreamBufferView normalsVertexBufferView(*rhiNormalsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), 0, normalsBufferByteCount, normalsBufferElementSize);
         AZ::RHI::BufferViewDescriptor normalsBufferDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, normalsBufferByteCount);
 
-        AZ::RHI::SingleDeviceBuffer& rhiIndexBuffer = *m_rtIndexBuffer->GetRHIBuffer();
+        AZ::RHI::MultiDeviceBuffer& rhiIndexBuffer = *m_rtIndexBuffer->GetRHIBuffer();
         AZ::RHI::IndexFormat indexBufferFormat = AZ::RHI::IndexFormat::Uint32;
 
         uint32_t totalIndexBufferByteCount = aznumeric_cast<uint32_t>(rhiIndexBuffer.GetDescriptor().m_byteCount);
@@ -394,11 +394,11 @@ namespace Terrain
 
             subMesh.m_positionFormat = positionsBufferFormat;
             subMesh.m_positionVertexBufferView = positionsVertexBufferView;
-            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.GetBufferView(positionsBufferDescriptor);
+            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(positionsBufferDescriptor);
             subMesh.m_normalFormat = normalsBufferFormat;
             subMesh.m_normalVertexBufferView = normalsVertexBufferView;
-            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.GetBufferView(normalsBufferDescriptor);
-            subMesh.m_indexBufferView = AZ::RHI::SingleDeviceIndexBufferView(rhiIndexBuffer, indexBufferByteOffset, indexBufferByteCount, indexBufferFormat);
+            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(normalsBufferDescriptor);
+            subMesh.m_indexBufferView = AZ::RHI::SingleDeviceIndexBufferView(*rhiIndexBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), indexBufferByteOffset, indexBufferByteCount, indexBufferFormat);
             subMesh.m_baseColor = AZ::Color::CreateFromVector3(AZ::Vector3(0.18f));
 
             AZ::RHI::BufferViewDescriptor indexBufferDescriptor;
@@ -407,7 +407,7 @@ namespace Terrain
             indexBufferDescriptor.m_elementSize = indexElementSize;
             indexBufferDescriptor.m_elementFormat = AZ::RHI::Format::R32_UINT;
 
-            subMesh.m_indexShaderBufferView = rhiIndexBuffer.GetBufferView(indexBufferDescriptor);
+            subMesh.m_indexShaderBufferView = rhiIndexBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(indexBufferDescriptor);
 
             meshGroup.m_mesh.m_assetId = AZ::Data::AssetId(meshGroup.m_id);
             float xyScale = (m_gridSize * m_sampleSpacing) * (1 << lodLevel);
@@ -452,7 +452,7 @@ namespace Terrain
         // Create all the sectors with uninitialized SRGs. The SRGs will be updated later by CheckLodGridsForUpdate().
         m_indexBufferView =
         {
-            *m_indexBuffer->GetRHIBuffer(),
+            *m_indexBuffer->GetRHIBuffer()->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
             0,
             aznumeric_cast<uint32_t>(m_indexBuffer->GetBufferSize()),
             AZ::RHI::IndexFormat::Uint16


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

This specific PR transitions RPI::Buffer to use MultiDeviceBuffer. It is not a small change and thus this is one of the bigger PRs in this set of PRs to come.

## How was this PR tested?

`Gem::Atom_RPI.Tests.main`
