### PR TITLE
Adding const to shape and bounds buses

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Render/GeometryIntersectionBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Render/GeometryIntersectionBus.h
@@ -67,7 +67,7 @@ namespace AzFramework
             using BusIdType = EntityIdAndContext;
 
             // Intersection against this render geometry
-            virtual RayResult RenderGeometryIntersect(const RayRequest& ray) = 0;
+            virtual RayResult RenderGeometryIntersect(const RayRequest& ray) const = 0;
 
         private:
             inline static void OnConnect(const EntityIdAndContext& entityAndContext);

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
@@ -34,13 +34,13 @@ namespace AzFramework
         //! @note It is preferred to use CalculateEntityWorldBoundsUnion in the general case as
         //! more than one component may be providing a bound. It isn't guaranteed which bound
         //! will be returned by a single call to GetWorldBounds.
-        virtual AZ::Aabb GetWorldBounds() = 0;
+        virtual AZ::Aabb GetWorldBounds() const = 0;
 
         //! Returns an axis aligned bounding box in local space.
         //! @note It is preferred to use CalculateEntityLocalBoundsUnion in the general case as
         //! more than one component may be providing a bound. It isn't guaranteed which bound
         //! will be returned by a single call to GetLocalBounds.
-        virtual AZ::Aabb GetLocalBounds() = 0;
+        virtual AZ::Aabb GetLocalBounds() const = 0;
 
     protected:
         ~BoundsRequests() = default;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/BoundInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/BoundInterface.h
@@ -86,7 +86,7 @@ namespace AzToolsFramework
             //! @param rayDir The direction of the ray to test with.
             //! @param[out] rayIntersectionDistance The distance of the intersecting point closest to the ray origin.
             //! @return Boolean indicating whether there is a least one intersecting point between this bound shape and the ray.
-            virtual bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) = 0;
+            virtual bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const = 0;
 
             virtual void SetShapeData(const BoundRequestShapeBase& shapeData) = 0;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/Manipulators/ManipulatorBounds.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/Manipulators/ManipulatorBounds.cpp
@@ -90,7 +90,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundSphere::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             float vecRayIntersectionDistance;
             if (AZ::Intersect::IntersectRaySphere(rayOrigin, rayDirection, m_center, m_radius, vecRayIntersectionDistance) > 0)
@@ -112,7 +112,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundBox::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             return AZ::Intersect::IntersectRayBox(
                        rayOrigin, rayDirection, m_center, m_axis1, m_axis2, m_axis3, m_halfExtents.GetX(), m_halfExtents.GetY(),
@@ -132,7 +132,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundCylinder::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             float t1 = std::numeric_limits<float>::max();
             float t2 = std::numeric_limits<float>::max();
@@ -157,7 +157,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundCone::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             float t = std::numeric_limits<float>::max();
             if (IntersectRayCone(rayOrigin, rayDirection, m_apexPosition, m_dir, m_height, m_radius, t))
@@ -181,7 +181,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundQuad::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             return AZ::Intersect::IntersectRayQuad(
                        rayOrigin, rayDirection, m_corner1, m_corner2, m_corner3, m_corner4, rayIntersectionDistance) > 0;
@@ -199,7 +199,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundTorus::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             return IntersectHollowCylinder(
                 rayOrigin, rayDirection, m_center, m_axis, m_minorRadius, m_majorRadius, rayIntersectionDistance);
@@ -217,7 +217,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundLineSegment::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             const float rayLength = 1000.0f;
             AZ::Vector3 closestPosRay, closestPosLineSegment;
@@ -250,7 +250,7 @@ namespace AzToolsFramework
         }
 
         bool ManipulatorBoundSpline::IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
         {
             if (const AZStd::shared_ptr<const AZ::Spline> spline = m_spline.lock())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/Manipulators/ManipulatorBounds.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Picking/Manipulators/ManipulatorBounds.h
@@ -54,7 +54,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_center = AZ::Vector3::CreateZero();
@@ -72,7 +72,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_center = AZ::Vector3::CreateZero();
@@ -93,7 +93,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_base = AZ::Vector3::CreateZero(); //!< The center of the circle at the base of the cylinder.
@@ -113,7 +113,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_apexPosition = AZ::Vector3::CreateZero();
@@ -136,7 +136,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_corner1 = AZ::Vector3::CreateZero();
@@ -156,7 +156,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             // Approximate a torus as a thin cylinder. A ray intersects a torus when the ray and the torus'
@@ -179,7 +179,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZ::Vector3 m_worldStart = AZ::Vector3::CreateZero();
@@ -198,7 +198,7 @@ namespace AzToolsFramework
             {
             }
 
-            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) override;
+            bool IntersectRay(const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDir, float& rayIntersectionDistance) const override;
             void SetShapeData(const BoundRequestShapeBase& shapeData) override;
 
             AZStd::weak_ptr<const AZ::Spline> m_spline;

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
@@ -53,14 +53,14 @@ namespace UnitTest
         AzFramework::BoundsRequestBus::Handler::BusDisconnect();
     }
 
-    AZ::Aabb BoundsTestComponent::GetWorldBounds()
+    AZ::Aabb BoundsTestComponent::GetWorldBounds() const
     {
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
         return GetLocalBounds().GetTransformedAabb(worldFromLocal);
     }
 
-    AZ::Aabb BoundsTestComponent::GetLocalBounds()
+    AZ::Aabb BoundsTestComponent::GetLocalBounds() const
     {
         return m_localBounds;
     }

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
@@ -90,7 +90,7 @@ namespace UnitTest
     }
 
     AzFramework::RenderGeometry::RayResult RenderGeometryIntersectionTestComponent::RenderGeometryIntersect(
-        const AzFramework::RenderGeometry::RayRequest& ray)
+        const AzFramework::RenderGeometry::RayRequest& ray) const
     {
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
@@ -40,8 +40,8 @@ namespace UnitTest
         bool SupportsEditorRayIntersect() override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         AZ::Aabb m_localBounds; //!< Local bounds that can be modified for certain tests (defaults to unit cube).
     };

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
@@ -60,6 +60,6 @@ namespace UnitTest
         void Deactivate() override;
 
         // IntersectionRequestBus overrides ...
-        AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) override;
+        AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) const override;
     };
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Visibility/EditorVisibilityTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Visibility/EditorVisibilityTests.cpp
@@ -187,7 +187,7 @@ namespace UnitTest
         TestBoundComponent() = default;
 
         // BoundsRequestBus overrides
-        AZ::Aabb GetWorldBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
         AZ::Aabb GetLocalBounds() const override;
 
         void ChangeBounds(const AZ::Aabb& localAabb);

--- a/Code/Framework/AzToolsFramework/Tests/Visibility/EditorVisibilityTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Visibility/EditorVisibilityTests.cpp
@@ -188,7 +188,7 @@ namespace UnitTest
 
         // BoundsRequestBus overrides
         AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetLocalBounds() const override;
 
         void ChangeBounds(const AZ::Aabb& localAabb);
 
@@ -221,14 +221,14 @@ namespace UnitTest
         AzFramework::BoundsRequestBus::Handler::BusDisconnect();
     }
 
-    AZ::Aabb TestBoundComponent::GetWorldBounds()
+    AZ::Aabb TestBoundComponent::GetWorldBounds() const
     {
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
         return m_localAabb.GetTransformedAabb(worldFromLocal);
     }
 
-    AZ::Aabb TestBoundComponent::GetLocalBounds()
+    AZ::Aabb TestBoundComponent::GetLocalBounds() const
     {
         return m_localAabb;
     }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h
@@ -92,10 +92,10 @@ namespace AZ
             virtual bool GetExcludeFromReflectionCubeMaps() const = 0;
 
             //! Returns the axis-aligned bounding box for the model at its world position.
-            virtual AZ::Aabb GetWorldBounds() = 0;
+            virtual AZ::Aabb GetWorldBounds() const = 0;
 
             //! Returns the axis-aligned bounding box in model space.
-            virtual AZ::Aabb GetLocalBounds() = 0;
+            virtual AZ::Aabb GetLocalBounds() const = 0;
         };
         using MeshComponentRequestBus = EBus<MeshComponentRequests>;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -410,14 +410,14 @@ namespace AZ
             return true;
         }
 
-        AZ::Aabb EditorAreaLightComponent::GetWorldBounds()
+        AZ::Aabb EditorAreaLightComponent::GetWorldBounds() const
         {
             Transform transform = Transform::CreateIdentity();
             TransformBus::EventResult(transform, GetEntityId(), &TransformBus::Events::GetWorldTM);
             return GetLocalBounds().GetTransformedAabb(transform);
         }
 
-        AZ::Aabb EditorAreaLightComponent::GetLocalBounds()
+        AZ::Aabb EditorAreaLightComponent::GetLocalBounds() const
         {
             return m_controller.GetLocalVisualizationBounds();
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.h
@@ -37,8 +37,8 @@ namespace AZ
             void Deactivate() override;
 
             // BoundsRequestBus overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
         private:
             // AzFramework::EntityDebugDisplayEventBus::Handler overrides...

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.cpp
@@ -176,7 +176,7 @@ namespace AZ
             return hitResult;
         }
 
-        AZ::Aabb EditorDecalComponent::GetWorldBounds()
+        AZ::Aabb EditorDecalComponent::GetWorldBounds() const
         {
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
@@ -184,7 +184,7 @@ namespace AZ
             return GetLocalBounds().GetTransformedAabb(transform);
         }
 
-        AZ::Aabb EditorDecalComponent::GetLocalBounds()
+        AZ::Aabb EditorDecalComponent::GetLocalBounds() const
         {
             AZ::Aabb bbox = AZ::Aabb::CreateNull();
             bbox.AddPoint(AZ::Vector3(-1, -1, 0));

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.h
@@ -51,8 +51,8 @@ namespace AZ
             AZ::Aabb GetEditorSelectionBoundsViewport(const AzFramework::ViewportInfo& viewportInfo) override;
 
             // BoundsRequestBus overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
         private:
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -702,8 +702,18 @@ namespace AZ
         }
 
         void MeshComponentController::GetVisibleGeometry(
-            [[maybe_unused]] const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
+            const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
         {
+            // Only include data for this entity if it is within bounds. This could possibly be done per sub mesh.
+            if (bounds.IsValid())
+            {
+                const AZ::Aabb worldBounds = GetWorldBounds();
+                if (worldBounds.IsValid() && !worldBounds.Overlaps(bounds))
+                {
+                    return;
+                }
+            }
+
             // Attempt to copy the triangle list geometry data out of the model asset into the visible geometry structure
             const auto& modelAsset = GetModelAsset();
             if (!modelAsset.IsReady() || modelAsset->GetLodAssets().empty())

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -677,7 +677,7 @@ namespace AZ
             return false;
         }
 
-        Aabb MeshComponentController::GetWorldBounds()
+        Aabb MeshComponentController::GetWorldBounds() const
         {
             if (const AZ::Aabb localBounds = GetLocalBounds(); localBounds.IsValid())
             {
@@ -687,7 +687,7 @@ namespace AZ
             return AZ::Aabb::CreateNull();
         }
 
-        Aabb MeshComponentController::GetLocalBounds()
+        Aabb MeshComponentController::GetLocalBounds() const
         {
             if (m_meshHandle.IsValid() && m_meshFeatureProcessor)
             {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -790,7 +790,7 @@ namespace AZ
         }
 
         AzFramework::RenderGeometry::RayResult MeshComponentController::RenderGeometryIntersect(
-            const AzFramework::RenderGeometry::RayRequest& ray)
+            const AzFramework::RenderGeometry::RayRequest& ray) const
         {
             AzFramework::RenderGeometry::RayResult result;
             if (const Data::Instance<RPI::Model> model = GetModel())

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -141,7 +141,7 @@ namespace AZ
             void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
             // IntersectionRequestBus overrides ...
-            AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) override;
+            AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) const override;
 
             // TransformNotificationBus::Handler overrides ...
             void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -134,8 +134,8 @@ namespace AZ
             bool GetExcludeFromReflectionCubeMaps() const override;
 
             // AzFramework::BoundsRequestBus::Handler overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
             // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
             void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
@@ -317,12 +317,12 @@ namespace AZ
             return m_shapeBus ? m_shapeBus->GetEncompassingAabb() : AZ::Aabb();
         }
 
-        AZ::Aabb ReflectionProbeComponentController::GetWorldBounds()
+        AZ::Aabb ReflectionProbeComponentController::GetWorldBounds() const
         {
             return GetAabb();
         }
 
-        AZ::Aabb ReflectionProbeComponentController::GetLocalBounds()
+        AZ::Aabb ReflectionProbeComponentController::GetLocalBounds() const
         {
             if (!m_shapeBus)
             {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.h
@@ -90,8 +90,8 @@ namespace AZ
             void UpdateCubeMap();
 
             // BoundsRequestBus overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
             void RegisterInnerExtentsChangedHandler(AZ::Event<bool>::Handler& handler);
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -107,12 +107,12 @@ namespace AZ::Render
         AZ::Interface<AzFramework::IEntityBoundsUnion>::Get()->RefreshEntityLocalBoundsUnion(m_entityId);
     }
 
-    AZ::Aabb AtomActorInstance::GetWorldBounds()
+    AZ::Aabb AtomActorInstance::GetWorldBounds() const
     {
         return m_worldAABB;
     }
 
-    AZ::Aabb AtomActorInstance::GetLocalBounds()
+    AZ::Aabb AtomActorInstance::GetLocalBounds() const
     {
         return m_localAABB;
     }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -96,8 +96,8 @@ namespace AZ
             void SetIsVisible(bool isVisible) override;
 
             // BoundsRequestBus overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
             AtomActor* GetRenderActor() const;
 

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -712,7 +712,7 @@ namespace EMotionFX
             return GetWorldBounds();
         }
 
-        AZ::Aabb EditorActorComponent::GetWorldBounds()
+        AZ::Aabb EditorActorComponent::GetWorldBounds() const
         {
             if (m_renderActorInstance)
             {
@@ -722,7 +722,7 @@ namespace EMotionFX
             return AZ::Aabb::CreateNull();
         }
 
-        AZ::Aabb EditorActorComponent::GetLocalBounds()
+        AZ::Aabb EditorActorComponent::GetLocalBounds() const
         {
             if (m_renderActorInstance)
             {

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -85,8 +85,8 @@ namespace EMotionFX
             void OnAssetUnloaded(AZ::Data::AssetId assetId, AZ::Data::AssetType assetType) override;
 
             // BoundsRequestBus overrides ...
-            AZ::Aabb GetWorldBounds() override;
-            AZ::Aabb GetLocalBounds() override;
+            AZ::Aabb GetWorldBounds() const override;
+            AZ::Aabb GetLocalBounds() const override;
 
             // AzFramework::EntityDebugDisplayEventBus overrides ...
             void DisplayEntityViewport(

--- a/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
+++ b/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
@@ -62,7 +62,7 @@ namespace UnitTest
     {
     public:
         AZ::Entity m_entity;
-        int m_count = 0;
+        mutable int m_count = 0;
 
         MockShape()
         {
@@ -74,14 +74,14 @@ namespace UnitTest
             LmbrCentral::ShapeComponentRequestsBus::Handler::BusDisconnect();
         }
 
-        AZ::Crc32 GetShapeType() override
+        AZ::Crc32 GetShapeType() const override
         {
             ++m_count;
             return AZ_CRC("TestShape", 0x856ca50c);
         }
 
         AZ::Aabb m_aabb = AZ::Aabb::CreateNull();
-        AZ::Aabb GetEncompassingAabb() override
+        AZ::Aabb GetEncompassingAabb() const override
         {
             ++m_count;
             return m_aabb;
@@ -89,7 +89,7 @@ namespace UnitTest
 
         AZ::Transform m_localTransform = AZ::Transform::CreateIdentity();
         AZ::Aabb m_localBounds = AZ::Aabb::CreateNull();
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override
         {
             ++m_count;
             transform = m_localTransform;
@@ -97,21 +97,21 @@ namespace UnitTest
         }
 
         bool m_pointInside = true;
-        bool IsPointInside([[maybe_unused]] const AZ::Vector3& point) override
+        bool IsPointInside([[maybe_unused]] const AZ::Vector3& point) const override
         {
             ++m_count;
             return m_pointInside;
         }
 
         float m_distanceSquaredFromPoint = 0.0f;
-        float DistanceSquaredFromPoint([[maybe_unused]] const AZ::Vector3& point) override
+        float DistanceSquaredFromPoint([[maybe_unused]] const AZ::Vector3& point) const override
         {
             ++m_count;
             return m_distanceSquaredFromPoint;
         }
 
         AZ::Vector3 m_randomPointInside = AZ::Vector3::CreateZero();
-        AZ::Vector3 GenerateRandomPointInside([[maybe_unused]] AZ::RandomDistributionType randomDistribution) override
+        AZ::Vector3 GenerateRandomPointInside([[maybe_unused]] AZ::RandomDistributionType randomDistribution) const override
         {
             ++m_count;
             return m_randomPointInside;
@@ -119,7 +119,9 @@ namespace UnitTest
 
         bool m_intersectRay = false;
         bool IntersectRay(
-            [[maybe_unused]] const AZ::Vector3& src, [[maybe_unused]] const AZ::Vector3& dir, [[maybe_unused]] float& distance) override
+            [[maybe_unused]] const AZ::Vector3& src,
+            [[maybe_unused]] const AZ::Vector3& dir,
+            [[maybe_unused]] float& distance) const override
         {
             ++m_count;
             return m_intersectRay;

--- a/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
+++ b/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
@@ -32,7 +32,7 @@ namespace UnitTest
         MOCK_METHOD0(GetBoxConfiguration, LmbrCentral::BoxShapeConfig());
         MOCK_CONST_METHOD0(GetBoxDimensions, AZ::Vector3());
         MOCK_METHOD1(SetBoxDimensions, void(const AZ::Vector3& newDimensions));
-        MOCK_METHOD0(IsTypeAxisAligned, bool());
+        MOCK_CONST_METHOD0(IsTypeAxisAligned, bool());
     };
 
     class MockShapeComponentRequests
@@ -49,13 +49,13 @@ namespace UnitTest
             LmbrCentral::ShapeComponentRequestsBus::Handler::BusDisconnect();
         }
 
-        MOCK_METHOD0(GetShapeType, AZ::Crc32());
-        MOCK_METHOD0(GetEncompassingAabb, AZ::Aabb());
-        MOCK_METHOD2(GetTransformAndLocalBounds, void(AZ::Transform& transform, AZ::Aabb& bounds));
-        MOCK_METHOD1(IsPointInside, bool(const AZ::Vector3& point));
-        MOCK_METHOD1(DistanceSquaredFromPoint, float(const AZ::Vector3& point));
-        MOCK_METHOD1(GenerateRandomPointInside, AZ::Vector3(AZ::RandomDistributionType randomDistribution));
-        MOCK_METHOD3(IntersectRay, bool(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance));
+        MOCK_CONST_METHOD0(GetShapeType, AZ::Crc32());
+        MOCK_CONST_METHOD0(GetEncompassingAabb, AZ::Aabb());
+        MOCK_CONST_METHOD2(GetTransformAndLocalBounds, void(AZ::Transform& transform, AZ::Aabb& bounds));
+        MOCK_CONST_METHOD1(IsPointInside, bool(const AZ::Vector3& point));
+        MOCK_CONST_METHOD1(DistanceSquaredFromPoint, float(const AZ::Vector3& point));
+        MOCK_CONST_METHOD1(GenerateRandomPointInside, AZ::Vector3(AZ::RandomDistributionType randomDistribution));
+        MOCK_CONST_METHOD3(IntersectRay, bool(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance));
     };
 
     class MockShape : public LmbrCentral::ShapeComponentRequestsBus::Handler

--- a/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
+++ b/Gems/LmbrCentral/Code/Mocks/LmbrCentral/Shape/MockShapes.h
@@ -29,7 +29,7 @@ namespace UnitTest
             LmbrCentral::BoxShapeComponentRequestsBus::Handler::BusDisconnect();
         }
 
-        MOCK_METHOD0(GetBoxConfiguration, LmbrCentral::BoxShapeConfig());
+        MOCK_CONST_METHOD0(GetBoxConfiguration, const LmbrCentral::BoxShapeConfig&());
         MOCK_CONST_METHOD0(GetBoxDimensions, AZ::Vector3());
         MOCK_METHOD1(SetBoxDimensions, void(const AZ::Vector3& newDimensions));
         MOCK_CONST_METHOD0(IsTypeAxisAligned, bool());

--- a/Gems/LmbrCentral/Code/Source/Shape/AxisAlignedBoxShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/AxisAlignedBoxShape.cpp
@@ -57,7 +57,7 @@ namespace LmbrCentral
         BoxShape::OnTransformChanged(local, worldNoRotation);
     }
 
-    bool AxisAlignedBoxShape::IsTypeAxisAligned()
+    bool AxisAlignedBoxShape::IsTypeAxisAligned() const
     {
         return true;
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/AxisAlignedBoxShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/AxisAlignedBoxShape.h
@@ -42,6 +42,6 @@ namespace LmbrCentral
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
         // BoxShapeComponentRequestBus::Handler overrides ...
-        bool IsTypeAxisAligned() override;
+        bool IsTypeAxisAligned() const override;
     };
 } // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.cpp
@@ -131,12 +131,12 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    bool BoxShape::IsTypeAxisAligned()
+    bool BoxShape::IsTypeAxisAligned() const
     {
         return false;
     }
 
-    AZ::Aabb BoxShape::GetEncompassingAabb()
+    AZ::Aabb BoxShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -144,7 +144,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_aabb;
     }
 
-    void BoxShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void BoxShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         const AZ::Vector3 extent(m_boxShapeConfig.m_dimensions * m_currentNonUniformScale * 0.5f);
         const AZ::Vector3 scaledOffset(m_boxShapeConfig.m_translationOffset * m_currentNonUniformScale);
@@ -152,7 +152,7 @@ namespace LmbrCentral
         transform = m_currentTransform;
     }
 
-    bool BoxShape::IsPointInside(const AZ::Vector3& point)
+    bool BoxShape::IsPointInside(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -165,7 +165,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_obb.Contains(point);
     }
 
-    float BoxShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float BoxShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -178,7 +178,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_obb.GetDistanceSq(point);
     }
 
-    bool BoxShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool BoxShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -203,7 +203,7 @@ namespace LmbrCentral
         return intersection;
     }
 
-    AZ::Vector3 BoxShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution)
+    AZ::Vector3 BoxShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_boxShapeConfig, &m_mutex, m_currentNonUniformScale);

--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.h
@@ -43,13 +43,13 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponentRequestsBus::Handler
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("Box", 0x08a9483a); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("Box", 0x08a9483a); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
         AZ::Vector3 GetTranslationOffset() const override;
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
@@ -57,7 +57,7 @@ namespace LmbrCentral
         BoxShapeConfig GetBoxConfiguration() override { return m_boxShapeConfig; }
         AZ::Vector3 GetBoxDimensions() const override { return m_boxShapeConfig.m_dimensions; }
         void SetBoxDimensions(const AZ::Vector3& dimensions) override;
-        bool IsTypeAxisAligned() override;
+        bool IsTypeAxisAligned() const override;
 
         // AZ::TransformNotificationBus::Handler
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
@@ -92,7 +92,7 @@ namespace LmbrCentral
             bool m_axisAligned = true; ///< Indicates whether the box is axis or object aligned.
         };
 
-        BoxIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable BoxIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform; ///< Caches the current transform for the entity on which this component lives.
         AZ::EntityId m_entityId; ///< Id of the entity the box shape is attached to.
         AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; ///< Responds to changes in non-uniform scale.

--- a/Gems/LmbrCentral/Code/Source/Shape/BoxShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/BoxShape.h
@@ -54,7 +54,7 @@ namespace LmbrCentral
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
         // BoxShapeComponentRequestBus::Handler
-        BoxShapeConfig GetBoxConfiguration() override { return m_boxShapeConfig; }
+       const BoxShapeConfig& GetBoxConfiguration() const override { return m_boxShapeConfig; }
         AZ::Vector3 GetBoxDimensions() const override { return m_boxShapeConfig.m_dimensions; }
         void SetBoxDimensions(const AZ::Vector3& dimensions) override;
         bool IsTypeAxisAligned() const override;
@@ -65,7 +65,6 @@ namespace LmbrCentral
         void OnNonUniformScaleChanged(const AZ::Vector3& scale);
         const AZ::Vector3& GetCurrentNonUniformScale() const { return m_currentNonUniformScale; }
 
-        const BoxShapeConfig& GetBoxConfiguration() const { return m_boxShapeConfig; }
         void SetBoxConfiguration(const BoxShapeConfig& boxShapeConfig) { m_boxShapeConfig = boxShapeConfig; }
         const AZ::Transform& GetCurrentTransform() const { return m_currentTransform; }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
@@ -105,19 +105,19 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    float CapsuleShape::GetHeight()
+    float CapsuleShape::GetHeight() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_capsuleShapeConfig.m_height;
     }
 
-    float CapsuleShape::GetRadius()
+    float CapsuleShape::GetRadius() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_capsuleShapeConfig.m_radius;
     }
 
-    CapsuleInternalEndPoints CapsuleShape::GetCapsulePoints()
+    CapsuleInternalEndPoints CapsuleShape::GetCapsulePoints() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.cpp
@@ -125,7 +125,7 @@ namespace LmbrCentral
         return { m_intersectionDataCache.m_basePlaneCenterPoint, m_intersectionDataCache.m_topPlaneCenterPoint };
     }
 
-    AZ::Aabb CapsuleShape::GetEncompassingAabb()
+    AZ::Aabb CapsuleShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
@@ -138,7 +138,7 @@ namespace LmbrCentral
         return baseAabb;
     }
 
-    void CapsuleShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void CapsuleShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         float halfHeight = AZ::GetMax(m_capsuleShapeConfig.m_height * 0.5f, m_capsuleShapeConfig.m_radius);
         const AZ::Vector3 extent(m_capsuleShapeConfig.m_radius, m_capsuleShapeConfig.m_radius, halfHeight);
@@ -147,7 +147,7 @@ namespace LmbrCentral
         transform = m_currentTransform;
     }
 
-    bool CapsuleShape::IsPointInside(const AZ::Vector3& point)
+    bool CapsuleShape::IsPointInside(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
@@ -178,7 +178,7 @@ namespace LmbrCentral
             m_intersectionDataCache.m_internalHeight * m_intersectionDataCache.m_internalHeight, radiusSquared, point);
     }
 
-    float CapsuleShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float CapsuleShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);
@@ -194,7 +194,7 @@ namespace LmbrCentral
         return clampedDistance * clampedDistance;
     }
 
-    bool CapsuleShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool CapsuleShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_capsuleShapeConfig, &m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.h
@@ -34,12 +34,12 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponentRequestsBus::Handler
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("Capsule", 0xc268a183); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("Capsule", 0xc268a183); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
         AZ::Vector3 GetTranslationOffset() const override;
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
@@ -82,7 +82,7 @@ namespace LmbrCentral
         };
 
         CapsuleShapeConfig m_capsuleShapeConfig; ///< Underlying capsule configuration.
-        CapsuleIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable CapsuleIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform; ///< Caches the current World transform.
         AZ::EntityId m_entityId; ///< Id of the entity the shape is attached to.
         mutable AZStd::shared_mutex m_mutex; ///< Mutex to allow multiple readers but single writer for efficient thread safety

--- a/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CapsuleShape.h
@@ -44,17 +44,16 @@ namespace LmbrCentral
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
         // CapsuleShapeComponentRequestsBus::Handler
-        CapsuleShapeConfig GetCapsuleConfiguration() override { return m_capsuleShapeConfig; }
+        const CapsuleShapeConfig& GetCapsuleConfiguration() const override { return m_capsuleShapeConfig; }
         void SetHeight(float height) override;
         void SetRadius(float radius) override;
-        CapsuleInternalEndPoints GetCapsulePoints() override;
-        float GetHeight() override;
-        float GetRadius() override;
+        CapsuleInternalEndPoints GetCapsulePoints() const override;
+        float GetHeight() const override;
+        float GetRadius() const override;
 
         // AZ::TransformNotificationBus::Handler
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
-        const CapsuleShapeConfig& GetCapsuleConfiguration() const { return m_capsuleShapeConfig; }
         void SetCapsuleConfiguration(const CapsuleShapeConfig& capsuleShapeConfig) { m_capsuleShapeConfig = capsuleShapeConfig; }
         const AZ::Transform& GetCurrentTransform() const { return m_currentTransform; }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.cpp
@@ -66,7 +66,7 @@ namespace LmbrCentral
 
     //////////////////////////////////////////////////////////////////////////
 
-    AZ::Aabb CompoundShapeComponent::GetEncompassingAabb()
+    AZ::Aabb CompoundShapeComponent::GetEncompassingAabb() const
     {
         AZ::Aabb finalAabb = AZ::Aabb::CreateNull();
 
@@ -82,7 +82,7 @@ namespace LmbrCentral
         return finalAabb;
     }
 
-    void CompoundShapeComponent::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void CompoundShapeComponent::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         transform = AZ::Transform::CreateIdentity();
         bounds = AZ::Aabb::CreateNull();
@@ -117,7 +117,7 @@ namespace LmbrCentral
         }
     }
 
-    bool CompoundShapeComponent::IsPointInside(const AZ::Vector3& point)
+    bool CompoundShapeComponent::IsPointInside(const AZ::Vector3& point) const
     {
         bool result = false;
         for (AZ::EntityId childEntity : m_configuration.GetChildEntities())
@@ -131,7 +131,7 @@ namespace LmbrCentral
         return result;
     }
 
-    float CompoundShapeComponent::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float CompoundShapeComponent::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         float smallestDistanceSquared = FLT_MAX;
         for (AZ::EntityId childEntity : m_configuration.GetChildEntities())
@@ -147,7 +147,7 @@ namespace LmbrCentral
         return smallestDistanceSquared;
     }
 
-    bool CompoundShapeComponent::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool CompoundShapeComponent::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         bool intersection = false;
         for (AZ::EntityId childEntity : m_configuration.GetChildEntities())

--- a/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.h
@@ -49,7 +49,7 @@ namespace LmbrCentral
         bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
         
         // CompoundShapeComponentRequestsBus::Handler implementation
-        CompoundShapeConfiguration GetCompoundShapeConfiguration() override
+        const CompoundShapeConfiguration& GetCompoundShapeConfiguration() const override
         {
             return m_configuration;
         }

--- a/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CompoundShapeComponent.h
@@ -37,16 +37,16 @@ namespace LmbrCentral
         void Deactivate() override;
         
         // ShapeComponent::Handler implementation
-        AZ::Crc32 GetShapeType() override
+        AZ::Crc32 GetShapeType() const override
         {
             return AZ::Crc32("Compound");
         }
 
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
         
         // CompoundShapeComponentRequestsBus::Handler implementation
         CompoundShapeConfiguration GetCompoundShapeConfiguration() override

--- a/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
@@ -84,13 +84,13 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::TransformChanged);
     }
 
-    float CylinderShape::GetHeight()
+    float CylinderShape::GetHeight() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_cylinderShapeConfig.m_height;
     }
 
-    float CylinderShape::GetRadius()
+    float CylinderShape::GetRadius() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_cylinderShapeConfig.m_radius;

--- a/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.cpp
@@ -126,7 +126,7 @@ namespace LmbrCentral
     }
 
     // reference: http://www.iquilezles.org/www/articles/diskbbox/diskbbox.htm
-    AZ::Aabb CylinderShape::GetEncompassingAabb()
+    AZ::Aabb CylinderShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
@@ -150,7 +150,7 @@ namespace LmbrCentral
         }
     }
 
-    void CylinderShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void CylinderShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         AZStd::shared_lock lock(m_mutex);
         const AZ::Vector3 extent(m_cylinderShapeConfig.m_radius, m_cylinderShapeConfig.m_radius, m_cylinderShapeConfig.m_height * 0.5f);
@@ -158,7 +158,7 @@ namespace LmbrCentral
         transform = m_currentTransform;
     }
 
-    AZ::Vector3 CylinderShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution)
+    AZ::Vector3 CylinderShape::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
@@ -237,7 +237,7 @@ namespace LmbrCentral
         return m_currentTransform.TransformPoint(localRandomPoint);
     }
 
-    bool CylinderShape::IsPointInside(const AZ::Vector3& point)
+    bool CylinderShape::IsPointInside(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
@@ -250,7 +250,7 @@ namespace LmbrCentral
             point);
     }
 
-    float CylinderShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float CylinderShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);
@@ -266,7 +266,7 @@ namespace LmbrCentral
             m_intersectionDataCache.m_radius);
     }
 
-    bool CylinderShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool CylinderShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_cylinderShapeConfig, &m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.h
@@ -43,13 +43,13 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponentRequestsBus::Handler
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("Cylinder", 0x9b045bea); }
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("Cylinder", 0x9b045bea); }
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // CylinderShapeComponentRequestsBus::Handler
         CylinderShapeConfig GetCylinderConfiguration() override { return m_cylinderShapeConfig; }
@@ -88,7 +88,7 @@ namespace LmbrCentral
         };
 
         CylinderShapeConfig m_cylinderShapeConfig; ///< Underlying cylinder configuration.
-        CylinderIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable CylinderIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform; ///< Caches the current World transform.
         AZ::EntityId m_entityId; ///< The Id of the entity the shape is attached to.
         mutable AZStd::shared_mutex m_mutex; ///< Mutex to allow multiple readers but single writer for efficient thread safety

--- a/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/CylinderShape.h
@@ -52,16 +52,15 @@ namespace LmbrCentral
         bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // CylinderShapeComponentRequestsBus::Handler
-        CylinderShapeConfig GetCylinderConfiguration() override { return m_cylinderShapeConfig; }
+        const CylinderShapeConfig& GetCylinderConfiguration() const override { return m_cylinderShapeConfig; }
         void SetHeight(float height) override;
         void SetRadius(float radius) override;
-        float GetHeight() override;
-        float GetRadius() override;
+        float GetHeight() const override;
+        float GetRadius() const override;
 
         // AZ::TransformNotificationBus::Handler
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
-        const CylinderShapeConfig& GetCylinderConfiguration() const { return m_cylinderShapeConfig; }
         void SetCylinderConfiguration(const CylinderShapeConfig& cylinderShapeConfig) { m_cylinderShapeConfig = cylinderShapeConfig; }
         const AZ::Transform& GetCurrentTransform() const { return m_currentTransform; }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
@@ -79,7 +79,7 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::TransformChanged);
     }
 
-    DiskShapeConfig DiskShape::GetDiskConfiguration()
+    const DiskShapeConfig& DiskShape::GetDiskConfiguration() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_diskShapeConfig;
@@ -97,13 +97,13 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    float DiskShape::GetRadius()
+    float DiskShape::GetRadius() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_diskShapeConfig.m_radius;
     }
 
-    const AZ::Vector3& DiskShape::GetNormal()
+    const AZ::Vector3& DiskShape::GetNormal() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
@@ -178,12 +178,6 @@ namespace LmbrCentral
         m_position = currentTransform.GetTranslation();
         m_normal = currentTransform.GetBasisZ().GetNormalized();
         m_radius = configuration.m_radius * currentTransform.GetUniformScale();
-    }
-
-    const DiskShapeConfig& DiskShape::GetDiskConfiguration() const
-    {
-        AZStd::shared_lock lock(m_mutex);
-        return m_diskShapeConfig;
     }
 
     void DiskShape::SetDiskConfiguration(const DiskShapeConfig& diskShapeConfig)

--- a/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/DiskShape.cpp
@@ -111,7 +111,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_normal;
     }
 
-    AZ::Aabb DiskShape::GetEncompassingAabb()
+    AZ::Aabb DiskShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
@@ -127,7 +127,7 @@ namespace LmbrCentral
         return AZ::Aabb::CreateCenterHalfExtents(m_currentTransform.GetTranslation(), halfsize);
     }
 
-    void DiskShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void DiskShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         AZStd::shared_lock lock(m_mutex);
         const float radius = m_diskShapeConfig.m_radius;
@@ -135,12 +135,12 @@ namespace LmbrCentral
         transform = m_currentTransform;
     }
 
-    bool DiskShape::IsPointInside([[maybe_unused]] const AZ::Vector3& point)
+    bool DiskShape::IsPointInside([[maybe_unused]] const AZ::Vector3& point) const
     {
         return false; // 2D object cannot have points that are strictly inside in 3d space.
     }
 
-    float DiskShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float DiskShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);
@@ -162,7 +162,7 @@ namespace LmbrCentral
         return closestPoint.GetDistanceSq(point);
     }
 
-    bool DiskShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool DiskShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_diskShapeConfig, &m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/DiskShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/DiskShape.h
@@ -39,12 +39,12 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponentRequestsBus
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("DiskShape", 0x8c83427c); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point)  override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("DiskShape", 0x8c83427c); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const  override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // DiskShapeComponentRequestBus
         DiskShapeConfig GetDiskConfiguration() override;
@@ -81,7 +81,7 @@ namespace LmbrCentral
         };
 
         DiskShapeConfig m_diskShapeConfig; ///< Underlying disk configuration.
-        DiskIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable DiskIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform; ///< Caches the current world transform.
         AZ::EntityId m_entityId; ///< The Id of the entity the shape is attached to.
         mutable AZStd::shared_mutex m_mutex; ///< Mutex to allow multiple readers but single writer for efficient thread safety

--- a/Gems/LmbrCentral/Code/Source/Shape/DiskShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/DiskShape.h
@@ -47,15 +47,14 @@ namespace LmbrCentral
         bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // DiskShapeComponentRequestBus
-        DiskShapeConfig GetDiskConfiguration() override;
+        const DiskShapeConfig& GetDiskConfiguration() const override;
         void SetRadius(float radius) override;
-        float GetRadius() override;
-        const AZ::Vector3& GetNormal() override;
+        float GetRadius() const override;
+        const AZ::Vector3& GetNormal() const override;
 
         // AZ::TransformNotificationBus
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
-        const DiskShapeConfig& GetDiskConfiguration() const;
         void SetDiskConfiguration(const DiskShapeConfig& diskShapeConfig);
         const AZ::Transform& GetCurrentTransform() const;
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.cpp
@@ -190,7 +190,7 @@ namespace LmbrCentral
         return AZ::Quaternion::CreateIdentity();
     }
 
-    AZ::Aabb EditorAxisAlignedBoxShapeComponent::GetLocalBounds()
+    AZ::Aabb EditorAxisAlignedBoxShapeComponent::GetLocalBounds() const
     {
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::Aabb aabb = AZ::Aabb::CreateNull();

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorAxisAlignedBoxShapeComponent.h
@@ -37,7 +37,7 @@ namespace LmbrCentral
         void Deactivate() override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetLocalBounds() const override;
 
     protected:
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
@@ -217,14 +217,14 @@ namespace LmbrCentral
         }
     }
 
-    AZ::Aabb EditorBaseShapeComponent::GetWorldBounds()
+    AZ::Aabb EditorBaseShapeComponent::GetWorldBounds() const
     {
         AZ::Aabb aabb = AZ::Aabb::CreateNull();
         ShapeComponentRequestsBus::EventResult(aabb, GetEntityId(), &ShapeComponentRequests::GetEncompassingAabb);
         return aabb;
     }
 
-    AZ::Aabb EditorBaseShapeComponent::GetLocalBounds()
+    AZ::Aabb EditorBaseShapeComponent::GetLocalBounds() const
     {
         AZ::Transform unused;
         AZ::Aabb resultBounds = AZ::Aabb::CreateNull();

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.h
@@ -51,8 +51,8 @@ namespace LmbrCentral
         bool GetShapeColorIsEditable() override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         // ShapeComponentNotificationsBus overrides ...
         void OnShapeChanged(ShapeChangeReasons changeReason) override;

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorCompoundShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorCompoundShapeComponent.cpp
@@ -94,7 +94,7 @@ namespace LmbrCentral
         CompoundShapeComponentHierarchyRequestsBus::Handler::BusDisconnect();
     }
 
-    bool EditorCompoundShapeComponent::HasChildId(const AZ::EntityId& entityId)
+    bool EditorCompoundShapeComponent::HasChildId(const AZ::EntityId& entityId) const
     {
         for (const AZ::EntityId& childEntityId : m_configuration.GetChildEntities())
         {

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorCompoundShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorCompoundShapeComponent.h
@@ -43,13 +43,13 @@ namespace LmbrCentral
 
     private:
         // CompoundShapeComponentRequestsBus::Handler
-        CompoundShapeConfiguration GetCompoundShapeConfiguration() override
+        const CompoundShapeConfiguration& GetCompoundShapeConfiguration() const override
         {
             return m_configuration;
         }
 
         // CompoundShapeComponentHierarchyRequestsBus::Handler
-        bool HasChildId(const AZ::EntityId& entityId) override;
+        bool HasChildId(const AZ::EntityId& entityId) const override;
 
         bool ValidateChildIds() override;
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.cpp
@@ -475,14 +475,14 @@ namespace LmbrCentral
         return m_splineCommon.m_spline->m_vertexContainer.Empty();
     }
 
-    AZ::Aabb EditorSplineComponent::GetWorldBounds()
+    AZ::Aabb EditorSplineComponent::GetWorldBounds() const
     {
         AZ::Aabb aabb = AZ::Aabb::CreateNull();
         m_splineCommon.m_spline->GetAabb(aabb, m_cachedUniformScaleTransform);
         return aabb;
     }
 
-    AZ::Aabb EditorSplineComponent::GetLocalBounds()
+    AZ::Aabb EditorSplineComponent::GetLocalBounds() const
     {
         AZ::Aabb aabb = AZ::Aabb::CreateNull();
         m_splineCommon.m_spline->GetAabb(aabb, AZ::Transform::CreateIdentity());

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.h
@@ -46,8 +46,8 @@ namespace LmbrCentral
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
     private:
         AZ_DISABLE_COPY_MOVE(EditorSplineComponent)

--- a/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.cpp
@@ -365,7 +365,7 @@ namespace LmbrCentral
         m_intersectionDataCache.InvalidateCache(InvalidateShapeCacheReason::ShapeChange);
     }
 
-    AZ::Aabb PolygonPrismShape::GetEncompassingAabb()
+    AZ::Aabb PolygonPrismShape::GetEncompassingAabb() const
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
         m_intersectionDataCache.UpdateIntersectionParams(
@@ -374,7 +374,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_aabb;
     }
 
-    void PolygonPrismShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void PolygonPrismShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
         bounds = PolygonPrismUtil::CalculateAabb(*m_polygonPrism, AZ::Transform::Identity());
@@ -384,7 +384,7 @@ namespace LmbrCentral
     /// Return if the point is inside of the polygon prism volume or not.
     /// Use 'Crossings Test' to determine if point lies in or out of the polygon.
     /// @param point Position in world space to test against.
-    bool PolygonPrismShape::IsPointInside(const AZ::Vector3& point)
+    bool PolygonPrismShape::IsPointInside(const AZ::Vector3& point) const
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
         m_intersectionDataCache.UpdateIntersectionParams(
@@ -400,7 +400,7 @@ namespace LmbrCentral
         return PolygonPrismUtil::IsPointInside(*m_polygonPrism, point, m_currentTransform);
     }
 
-    float PolygonPrismShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float PolygonPrismShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
         m_intersectionDataCache.UpdateIntersectionParams(
@@ -409,7 +409,7 @@ namespace LmbrCentral
         return PolygonPrismUtil::DistanceSquaredFromPoint(*m_polygonPrism, point, m_currentTransform);
     }
 
-    bool PolygonPrismShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool PolygonPrismShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         PolygonPrismSharedLockGuard lock(m_mutex, m_uniqueLockThreadId);
         m_intersectionDataCache.UpdateIntersectionParams(

--- a/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/PolygonPrismShape.h
@@ -58,12 +58,12 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponent::Handler
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("PolygonPrism", 0xd6b50036); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("PolygonPrism", 0xd6b50036); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // PolygonShapeShapeComponentRequestBus::Handler
         AZ::PolygonPrismPtr GetPolygonPrism() override;
@@ -181,7 +181,7 @@ namespace LmbrCentral
         };
 
         AZ::PolygonPrismPtr m_polygonPrism; ///< Reference to the underlying polygon prism data.
-        PolygonPrismIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable PolygonPrismIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform = AZ::Transform::CreateIdentity(); ///< Caches the current transform for this shape.
         AZ::EntityId m_entityId; ///< Id of the entity the box shape is attached to.
         AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; ///< Responds to changes in non-uniform scale.

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
@@ -152,7 +152,7 @@ namespace LmbrCentral
         return m_intersectionDataCache.m_quaternion;
     }
 
-    AZ::Aabb QuadShape::GetEncompassingAabb()
+    AZ::Aabb QuadShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         AZ::Aabb aabb = AZ::Aabb::CreateNull();
@@ -166,7 +166,7 @@ namespace LmbrCentral
         return aabb;
     }
 
-    void QuadShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void QuadShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         AZStd::shared_lock lock(m_mutex);
         bounds = AZ::Aabb::CreateCenterHalfExtents(
@@ -176,12 +176,12 @@ namespace LmbrCentral
         transform = m_currentTransform;
     }
 
-    bool QuadShape::IsPointInside([[maybe_unused]] const AZ::Vector3& point)
+    bool QuadShape::IsPointInside([[maybe_unused]] const AZ::Vector3& point) const
     {
         return false; // 2D object cannot have points that are strictly inside in 3d space.
     }
 
-    float QuadShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float QuadShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -200,7 +200,7 @@ namespace LmbrCentral
         return xDist * xDist + yDist * yDist + zDist * zDist;
     }
 
-    bool QuadShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool QuadShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         auto corners = m_quadShapeConfig.GetCorners();

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
@@ -102,7 +102,7 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    QuadShapeConfig QuadShape::GetQuadConfiguration()
+    const QuadShapeConfig& QuadShape::GetQuadConfiguration() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_quadShapeConfig;
@@ -120,7 +120,7 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    float QuadShape::GetQuadWidth()
+    float QuadShape::GetQuadWidth() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_quadShapeConfig.m_width;
@@ -138,13 +138,13 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    float QuadShape::GetQuadHeight()
+    float QuadShape::GetQuadHeight() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_quadShapeConfig.m_height;
     }
 
-    const AZ::Quaternion& QuadShape::GetQuadOrientation()
+    const AZ::Quaternion& QuadShape::GetQuadOrientation() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_quadShapeConfig, &m_mutex, m_currentNonUniformScale);
@@ -224,11 +224,6 @@ namespace LmbrCentral
         m_quaternion = currentTransform.GetRotation();
         m_scaledWidth = configuration.m_width * currentTransform.GetUniformScale() * currentNonUniformScale.GetX();
         m_scaledHeight = configuration.m_height * currentTransform.GetUniformScale() * currentNonUniformScale.GetY();
-    }
-
-    const QuadShapeConfig& QuadShape::GetQuadConfiguration() const
-    {
-        return m_quadShapeConfig;
     }
 
     void QuadShape::SetQuadConfiguration(const QuadShapeConfig& QuadShapeConfig)

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.h
@@ -42,12 +42,12 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         //! ShapeComponentRequestsBus overrides...
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("QuadShape", 0x40d75e14); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point)  override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("QuadShape", 0x40d75e14); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const  override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         //! QuadShapeComponentRequestBus overrides...
         QuadShapeConfig GetQuadConfiguration() override;
@@ -92,7 +92,7 @@ namespace LmbrCentral
         };
 
         QuadShapeConfig m_quadShapeConfig; //! Underlying quad configuration.
-        QuadIntersectionDataCache m_intersectionDataCache; //! Caches transient intersection data.
+        mutable QuadIntersectionDataCache m_intersectionDataCache; //! Caches transient intersection data.
         AZ::Transform m_currentTransform; //! Caches the current world transform.
         AZ::EntityId m_entityId; //! The Id of the entity the shape is attached to.
         AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; ///< Responds to changes in non-uniform scale.

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.h
@@ -50,12 +50,12 @@ namespace LmbrCentral
         bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         //! QuadShapeComponentRequestBus overrides...
-        QuadShapeConfig GetQuadConfiguration() override;
+        const QuadShapeConfig& GetQuadConfiguration() const override;
         void SetQuadWidth(float width) override;
-        float GetQuadWidth() override;
+        float GetQuadWidth() const override;
         void SetQuadHeight(float height) override;
-        float GetQuadHeight() override;
-        const AZ::Quaternion& GetQuadOrientation() override;
+        float GetQuadHeight() const override;
+        const AZ::Quaternion& GetQuadOrientation() const override;
 
         //! AZ::TransformNotificationBus overrides...
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
@@ -63,7 +63,6 @@ namespace LmbrCentral
         void OnNonUniformScaleChanged(const AZ::Vector3& scale);
         const AZ::Vector3& GetCurrentNonUniformScale() const { return m_currentNonUniformScale; }
 
-        const QuadShapeConfig& GetQuadConfiguration() const;
         void SetQuadConfiguration(const QuadShapeConfig& quadShapeConfig);
         const AZ::Transform& GetCurrentTransform() const;
 

--- a/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.cpp
@@ -197,7 +197,7 @@ namespace LmbrCentral
         }
     }
 
-    AZ::Crc32 ReferenceShapeComponent::GetShapeType()
+    AZ::Crc32 ReferenceShapeComponent::GetShapeType() const
     {
         AZ::Crc32 result = {};
 
@@ -210,7 +210,7 @@ namespace LmbrCentral
         return result;
     }
 
-    AZ::Aabb ReferenceShapeComponent::GetEncompassingAabb()
+    AZ::Aabb ReferenceShapeComponent::GetEncompassingAabb() const
     {
         AZ::Aabb result = AZ::Aabb::CreateNull();
 
@@ -223,7 +223,7 @@ namespace LmbrCentral
         return result;
     }
 
-    void ReferenceShapeComponent::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void ReferenceShapeComponent::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         transform = AZ::Transform::CreateIdentity();
         bounds = AZ::Aabb::CreateNull();
@@ -235,7 +235,7 @@ namespace LmbrCentral
         }
     }
 
-    bool ReferenceShapeComponent::IsPointInside(const AZ::Vector3& point)
+    bool ReferenceShapeComponent::IsPointInside(const AZ::Vector3& point) const
     {
         bool result = false;
 
@@ -248,7 +248,7 @@ namespace LmbrCentral
         return result;
     }
 
-    float ReferenceShapeComponent::DistanceFromPoint(const AZ::Vector3& point)
+    float ReferenceShapeComponent::DistanceFromPoint(const AZ::Vector3& point) const
     {
         float result = FLT_MAX;
 
@@ -261,7 +261,7 @@ namespace LmbrCentral
         return result;
     }
 
-    float ReferenceShapeComponent::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float ReferenceShapeComponent::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         float result = FLT_MAX;
 
@@ -274,7 +274,7 @@ namespace LmbrCentral
         return result;
     }
 
-    AZ::Vector3 ReferenceShapeComponent::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution)
+    AZ::Vector3 ReferenceShapeComponent::GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const
     {
         AZ::Vector3 result = AZ::Vector3::CreateZero();
 
@@ -287,7 +287,7 @@ namespace LmbrCentral
         return result;
     }
 
-    bool ReferenceShapeComponent::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool ReferenceShapeComponent::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         bool result = false;
 

--- a/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/ReferenceShapeComponent.h
@@ -78,14 +78,14 @@ namespace LmbrCentral
 
         //////////////////////////////////////////////////////////////////////////
         // ShapeComponentRequestsBus
-        AZ::Crc32 GetShapeType() override;
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point) override;
-        float DistanceFromPoint(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override;
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const override;
+        float DistanceFromPoint(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType randomDistribution) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
@@ -96,7 +96,7 @@ namespace LmbrCentral
         return m_sphereShapeConfig.m_radius;
     }
 
-    AZ::Aabb SphereShape::GetEncompassingAabb()
+    AZ::Aabb SphereShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
@@ -104,14 +104,14 @@ namespace LmbrCentral
             m_currentTransform.TransformPoint(m_sphereShapeConfig.m_translationOffset), m_intersectionDataCache.m_radius);
     }
 
-    void SphereShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void SphereShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         AZStd::shared_lock lock(m_mutex);
         bounds = AZ::Aabb::CreateCenterRadius(m_sphereShapeConfig.m_translationOffset, m_sphereShapeConfig.m_radius);
         transform = m_currentTransform;
     }
 
-    bool SphereShape::IsPointInside(const AZ::Vector3& point)
+    bool SphereShape::IsPointInside(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
@@ -120,7 +120,7 @@ namespace LmbrCentral
             m_intersectionDataCache.m_position, m_intersectionDataCache.m_radius * m_intersectionDataCache.m_radius, point);
     }
 
-    float SphereShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float SphereShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);
@@ -131,7 +131,7 @@ namespace LmbrCentral
         return clampedDistance * clampedDistance;
     }
 
-    bool SphereShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool SphereShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         m_intersectionDataCache.UpdateIntersectionParams(m_currentTransform, m_sphereShapeConfig, &m_mutex);

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.cpp
@@ -90,7 +90,7 @@ namespace LmbrCentral
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
     }
 
-    float SphereShape::GetRadius()
+    float SphereShape::GetRadius() const
     {
         AZStd::shared_lock lock(m_mutex);
         return m_sphereShapeConfig.m_radius;

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.h
@@ -39,12 +39,12 @@ namespace LmbrCentral
         void InvalidateCache(InvalidateShapeCacheReason reason);
 
         // ShapeComponentRequestsBus::Handler
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("Sphere", 0x55f96687); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point)  override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("Sphere", 0x55f96687); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const  override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
         AZ::Vector3 GetTranslationOffset() const override;
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
@@ -81,7 +81,7 @@ namespace LmbrCentral
         };
 
         SphereShapeConfig m_sphereShapeConfig; ///< Underlying sphere configuration.
-        SphereIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
+        mutable SphereIntersectionDataCache m_intersectionDataCache; ///< Caches transient intersection data.
         AZ::Transform m_currentTransform; ///< Caches the current world transform.
         AZ::EntityId m_entityId; ///< The Id of the entity the shape is attached to.
         mutable AZStd::shared_mutex m_mutex; ///< Mutex to allow multiple readers but single writer for efficient thread safety

--- a/Gems/LmbrCentral/Code/Source/Shape/SphereShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/SphereShape.h
@@ -49,14 +49,13 @@ namespace LmbrCentral
         void SetTranslationOffset(const AZ::Vector3& translationOffset) override;
 
         // SphereShapeComponentRequestsBus::Handler
-        SphereShapeConfig GetSphereConfiguration() override { return m_sphereShapeConfig; }
+        const SphereShapeConfig& GetSphereConfiguration() const override { return m_sphereShapeConfig; }
         void SetRadius(float radius) override;
-        float GetRadius() override;
+        float GetRadius() const override;
 
         // AZ::TransformNotificationBus::Handler
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
-        const SphereShapeConfig& GetSphereConfiguration() const { return m_sphereShapeConfig; }
         void SetSphereConfiguration(const SphereShapeConfig& sphereShapeConfig) { m_sphereShapeConfig = sphereShapeConfig; }
         const AZ::Transform& GetCurrentTransform() const { return m_currentTransform; }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
@@ -232,7 +232,7 @@ namespace LmbrCentral
         return aabb;
     }
 
-    AZ::Aabb TubeShape::GetEncompassingAabb()
+    AZ::Aabb TubeShape::GetEncompassingAabb() const
     {
         AZStd::shared_lock lock(m_mutex);
         if (m_spline == nullptr)
@@ -246,14 +246,14 @@ namespace LmbrCentral
         return CalculateTubeBounds(*this, worldFromLocalUniformScale);
     }
 
-    void TubeShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds)
+    void TubeShape::GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const
     {
         AZStd::shared_lock lock(m_mutex);
         bounds = CalculateTubeBounds(*this, AZ::Transform::CreateIdentity());
         transform = m_currentTransform;
     }
 
-    bool TubeShape::IsPointInside(const AZ::Vector3& point)
+    bool TubeShape::IsPointInside(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         if (m_spline == nullptr)
@@ -274,7 +274,7 @@ namespace LmbrCentral
         return (m_spline->GetPosition(address) - localPoint).GetLengthSq() < (radiusSq + variableRadiusSq) * scale;
     }
 
-    float TubeShape::DistanceFromPoint(const AZ::Vector3& point)
+    float TubeShape::DistanceFromPoint(const AZ::Vector3& point) const
     {
         AZStd::shared_lock lock(m_mutex);
         AZ::Transform worldFromLocalNormalized = m_currentTransform;
@@ -290,13 +290,13 @@ namespace LmbrCentral
         return AZStd::max(0.0f, (sqrtf(splineQueryResult.m_distanceSq) - (m_radius + variableRadius)) * uniformScale);
     }
 
-    float TubeShape::DistanceSquaredFromPoint(const AZ::Vector3& point)
+    float TubeShape::DistanceSquaredFromPoint(const AZ::Vector3& point) const
     {
         float distance = DistanceFromPoint(point);
         return powf(distance, 2.0f);
     }
 
-    bool TubeShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance)
+    bool TubeShape::IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const
     {
         AZStd::shared_lock lock(m_mutex);
         const auto splineQueryResult = IntersectSpline(m_currentTransform, src, dir, *m_spline);

--- a/Gems/LmbrCentral/Code/Source/Shape/TubeShape.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/TubeShape.h
@@ -39,13 +39,13 @@ namespace LmbrCentral
         void Deactivate();
 
         // ShapeComponentRequestsBus
-        AZ::Crc32 GetShapeType() override { return AZ_CRC("Tube", 0xfd30de9e); }
-        AZ::Aabb GetEncompassingAabb() override;
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override;
-        bool IsPointInside(const AZ::Vector3& point)  override;
-        float DistanceFromPoint(const AZ::Vector3& point) override;
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override;
-        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) override;
+        AZ::Crc32 GetShapeType() const override { return AZ_CRC("Tube", 0xfd30de9e); }
+        AZ::Aabb GetEncompassingAabb() const override;
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override;
+        bool IsPointInside(const AZ::Vector3& point) const  override;
+        float DistanceFromPoint(const AZ::Vector3& point) const override;
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override;
+        bool IntersectRay(const AZ::Vector3& src, const AZ::Vector3& dir, float& distance) const override;
 
         // TubeShapeComponentRequestsBus
         void SetRadius(float radius) override;

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/BoxShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/BoxShapeComponentBus.h
@@ -75,7 +75,7 @@ namespace LmbrCentral
         virtual void SetBoxDimensions(const AZ::Vector3& newDimensions) = 0;
 
         /// Returns true if the object type is axis-aligned box shape, otherwise false (regardless of orientation).
-        virtual bool IsTypeAxisAligned() = 0;
+        virtual bool IsTypeAxisAligned() const = 0;
     };
 
     // Bus to service the Box Shape component event group

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/BoxShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/BoxShapeComponentBus.h
@@ -64,7 +64,7 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual BoxShapeConfig GetBoxConfiguration() = 0;
+        virtual const BoxShapeConfig& GetBoxConfiguration() const = 0;
 
         /// @brief Gets dimensions for the Box Shape
         /// @return Vector3 indicating dimensions along the x,y & z axis

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CapsuleShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CapsuleShapeComponentBus.h
@@ -67,16 +67,16 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual CapsuleShapeConfig GetCapsuleConfiguration() = 0;
+        virtual const CapsuleShapeConfig& GetCapsuleConfiguration() const = 0;
 
         /// @brief Returns the end to end height of the capsule, this includes the cylinder and both caps.
-        virtual float GetHeight() = 0;
+        virtual float GetHeight() const = 0;
 
         /// @brief Returns the radius of the capsule.
-        virtual float GetRadius() = 0;
+        virtual float GetRadius() const = 0;
 
         /// @brief Returns the base and top points of the capsule, corresponding to the center points of the cap spheres.
-        virtual CapsuleInternalEndPoints GetCapsulePoints() = 0;
+        virtual CapsuleInternalEndPoints GetCapsulePoints() const = 0;
 
         /// @brief Sets the end to end height of capsule, this includes the cylinder and both caps.
         /// @param height new height of the capsule.

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CompoundShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CompoundShapeComponentBus.h
@@ -46,7 +46,7 @@ namespace LmbrCentral
     class CompoundShapeComponentRequests : public AZ::ComponentBus
     {
     public:
-        virtual CompoundShapeConfiguration GetCompoundShapeConfiguration() = 0;
+        virtual const CompoundShapeConfiguration& GetCompoundShapeConfiguration() const = 0;
     };
 
     // Bus to service the Compound Shape component event group
@@ -58,7 +58,7 @@ namespace LmbrCentral
     public:
         // This method returns whether or not any entity referenced in the shape component (traversing the enitre reference tree through compound shape components) has a reference to the passed
         // in entity id.  This is needed to detect circular references
-        virtual bool HasChildId(const AZ::EntityId& /*entityId*/) { return false; }
+        virtual bool HasChildId(const AZ::EntityId& /*entityId*/) const { return false; }
 
         virtual bool ValidateChildIds() { return true; }
     };

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CylinderShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/CylinderShapeComponentBus.h
@@ -61,13 +61,13 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual CylinderShapeConfig GetCylinderConfiguration() = 0;
+        virtual const CylinderShapeConfig& GetCylinderConfiguration() const = 0;
 
         /// @brief Returns the end to end height of the cylinder.
-        virtual float GetHeight() = 0;
+        virtual float GetHeight() const = 0;
 
         /// @brief Returns the radius of the cylinder.
-        virtual float GetRadius() = 0;
+        virtual float GetRadius() const = 0;
         
         /// @brief Sets height of the cylinder
         /// @param height new height of the cylinder

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/DiskShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/DiskShapeComponentBus.h
@@ -45,17 +45,17 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual DiskShapeConfig GetDiskConfiguration() = 0;
+        virtual const DiskShapeConfig& GetDiskConfiguration() const = 0;
 
         //! @brief Returns the radius for the disk shape component.
-        virtual float GetRadius() = 0;
+        virtual float GetRadius() const = 0;
 
         //! @brief Sets the radius for the disk shape component.
         //! @param radius new Radius of the disk shape.
         virtual void SetRadius(float radius) = 0;
 
         //! @brief Convenience function that returns the facing normal for the disk determined by the transform component.
-        virtual const AZ::Vector3& GetNormal() = 0;
+        virtual const AZ::Vector3& GetNormal() const = 0;
 
     };
 

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/QuadShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/QuadShapeComponentBus.h
@@ -54,24 +54,24 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual QuadShapeConfig GetQuadConfiguration() = 0;
+        virtual const QuadShapeConfig& GetQuadConfiguration() const = 0;
 
         //! @brief Returns the width for the quad shape component.
-        virtual float GetQuadWidth() = 0;
+        virtual float GetQuadWidth() const = 0;
 
         //! @brief Sets the width for the quad shape component.
         //! @param width New width of the quad shape.
         virtual void SetQuadWidth(float width) = 0;
 
         //! @brief Returns the height for the quad shape component.
-        virtual float GetQuadHeight() = 0;
+        virtual float GetQuadHeight() const = 0;
 
         //! @brief Sets the height for the quad shape component.
         //! @param width New height of the quad shape.
         virtual void SetQuadHeight(float height) = 0;
 
         //! @brief Convenience function that returns the orientation as a quaternion for the quad determined by the transform component.
-        virtual const AZ::Quaternion& GetQuadOrientation() = 0;
+        virtual const AZ::Quaternion& GetQuadOrientation() const = 0;
 
     };
 

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/ShapeComponentBus.h
@@ -128,28 +128,28 @@ namespace LmbrCentral
 
         /// @brief Returns the type of shape that this component holds
         /// @return Crc32 indicating the type of shape
-        virtual AZ::Crc32 GetShapeType() = 0;
+        virtual AZ::Crc32 GetShapeType() const = 0;
 
         /// @brief Returns an AABB that encompasses this entire shape
         /// @return AABB that encompasses the shape
-        virtual AZ::Aabb GetEncompassingAabb() = 0;
+        virtual AZ::Aabb GetEncompassingAabb() const = 0;
 
         /**
         * @brief Returns the local space bounds of a shape and its world transform
         * @param transform AZ::Transform outparam containing the shape transform
         * @param bounds AZ::Aabb outparam containing an untransformed tight fitting bounding box according to the shape parameters
         */
-        virtual void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) = 0;
+        virtual void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const = 0;
 
         /// @brief Checks if a given point is inside a shape or outside it
         /// @param point Vector3 indicating the point to be tested
         /// @return bool indicating whether the point is inside or out
-        virtual bool IsPointInside(const AZ::Vector3& point) = 0;
+        virtual bool IsPointInside(const AZ::Vector3& point) const = 0;
 
         /// @brief Returns the min distance a given point is from the shape
         /// @param point Vector3 indicating point to calculate distance from
         /// @return float indicating distance point is from shape
-        virtual float DistanceFromPoint(const AZ::Vector3& point)
+        virtual float DistanceFromPoint(const AZ::Vector3& point) const
         {
             return sqrtf(DistanceSquaredFromPoint(point));
         }
@@ -157,18 +157,18 @@ namespace LmbrCentral
         /// @brief Returns the min squared distance a given point is from the shape
         /// @param point Vector3 indicating point to calculate square distance from
         /// @return float indicating square distance point is from shape
-        virtual float DistanceSquaredFromPoint(const AZ::Vector3& point) = 0;
+        virtual float DistanceSquaredFromPoint(const AZ::Vector3& point) const = 0;
 
         /// @brief Returns a random position inside the volume.
         /// @param randomDistribution An enum representing the different random distributions to use.
-        virtual AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType /*randomDistribution*/)
+        virtual AZ::Vector3 GenerateRandomPointInside(AZ::RandomDistributionType /*randomDistribution*/) const
         {
             AZ_Warning("ShapeComponentRequests", false, "GenerateRandomPointInside not implemented");
             return AZ::Vector3::CreateZero();
         }
 
         /// @brief Returns if a ray is intersecting the shape.
-        virtual bool IntersectRay(const AZ::Vector3& /*src*/, const AZ::Vector3& /*dir*/, float& /*distance*/)
+        virtual bool IntersectRay(const AZ::Vector3& /*src*/, const AZ::Vector3& /*dir*/, float& /*distance*/) const
         {
             AZ_Warning("ShapeComponentRequests", false, "IntersectRay not implemented");
             return false;

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/SphereShapeComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/SphereShapeComponentBus.h
@@ -55,10 +55,10 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        virtual SphereShapeConfig GetSphereConfiguration() = 0;
+        virtual const SphereShapeConfig& GetSphereConfiguration() const = 0;
 
         /// @brief Returns the radius for the sphere shape component.
-        virtual float GetRadius() = 0;
+        virtual float GetRadius() const = 0;
 
         /// @brief Sets the radius for the sphere shape component.
         /// @param radius new Radius of the sphere shape.

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -1042,12 +1042,12 @@ namespace PhysX
         m_proxyShapeConfiguration.m_cylinder.m_configuration = Utils::CreatePxCookedMeshConfiguration(samplePoints, scale).value();
     }
 
-    AZ::Aabb EditorColliderComponent::GetWorldBounds()
+    AZ::Aabb EditorColliderComponent::GetWorldBounds() const
     {
         return GetAabb();
     }
 
-    AZ::Aabb EditorColliderComponent::GetLocalBounds()
+    AZ::Aabb EditorColliderComponent::GetLocalBounds() const
     {
         AZ::Aabb worldBounds = GetWorldBounds();
         if (worldBounds.IsValid())

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -153,8 +153,8 @@ namespace PhysX
         bool IsDebugDrawDisplayFlagEnabled() const;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         // EditorComponentSelectionRequestsBus overrides ...
         AZ::Aabb GetEditorSelectionBoundsViewport(const AzFramework::ViewportInfo& viewportInfo) override;

--- a/Gems/PhysX/Code/Source/EditorJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorJointComponent.cpp
@@ -118,7 +118,7 @@ namespace PhysX
         return aabb;
     }
 
-    AZ::Aabb EditorJointComponent::GetWorldBounds()
+    AZ::Aabb EditorJointComponent::GetWorldBounds() const
     {
         AZ::Transform worldTM = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldTM, GetEntityId(), &AZ::TransformInterface::GetWorldTM);
@@ -126,7 +126,7 @@ namespace PhysX
         return GetLocalBounds().GetTransformedAabb(worldTM);
     }
 
-    AZ::Aabb EditorJointComponent::GetLocalBounds()
+    AZ::Aabb EditorJointComponent::GetLocalBounds() const
     {
         return AZ::Aabb::CreateFromMinMax(-AZ::Vector3(JointAabbHalfExtent), AZ::Vector3(JointAabbHalfExtent));
     }

--- a/Gems/PhysX/Code/Source/EditorJointComponent.h
+++ b/Gems/PhysX/Code/Source/EditorJointComponent.h
@@ -40,8 +40,8 @@ namespace PhysX
         void Deactivate() override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
     protected:
         // TransformNotificationBus overrides ...

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.cpp
@@ -1111,12 +1111,12 @@ namespace PhysX
         UpdateShapeConfigurationScale();
     }
 
-    AZ::Aabb EditorMeshColliderComponent::GetWorldBounds()
+    AZ::Aabb EditorMeshColliderComponent::GetWorldBounds() const
     {
         return GetAabb();
     }
 
-    AZ::Aabb EditorMeshColliderComponent::GetLocalBounds()
+    AZ::Aabb EditorMeshColliderComponent::GetLocalBounds() const
     {
         AZ::Aabb worldBounds = GetWorldBounds();
         if (worldBounds.IsValid())

--- a/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorMeshColliderComponent.h
@@ -124,8 +124,8 @@ namespace PhysX
         bool IsDebugDrawDisplayFlagEnabled() const;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         // EditorComponentSelectionRequestsBus overrides ...
         AZ::Aabb GetEditorSelectionBoundsViewport(const AzFramework::ViewportInfo& viewportInfo) override;

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -685,12 +685,12 @@ namespace PhysX
         }
     }
 
-    AZ::Aabb EditorRigidBodyComponent::GetWorldBounds()
+    AZ::Aabb EditorRigidBodyComponent::GetWorldBounds() const
     {
         return GetAabb();
     }
 
-    AZ::Aabb EditorRigidBodyComponent::GetLocalBounds()
+    AZ::Aabb EditorRigidBodyComponent::GetLocalBounds() const
     {
         AZ::Aabb worldBounds = GetWorldBounds();
         if (worldBounds.IsValid())

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.h
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.h
@@ -89,8 +89,8 @@ namespace PhysX
         void OnEntityActivated(const AZ::EntityId& entityId) override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         // EditorComponentBase
         void BuildGameEntity(AZ::Entity* gameEntity) override;

--- a/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
@@ -1484,7 +1484,7 @@ namespace PhysX
 
     TEST_P(MassComputeFixture, RigidBody_ComputeMassFlagsCombinationsTwoShapes_MassPropertiesCalculatedAccordingly)
     {
-        const Physics::ShapeType shapeType = GetShapeType() const;
+        const Physics::ShapeType shapeType = GetShapeType();
         const SimulatedShapesMode shapeMode = GetShapesMode();
         const AzPhysics::MassComputeFlags massComputeFlags = GetMassComputeFlags();
         const bool multiShapeTest = IsMultiShapeTest();

--- a/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXSpecificTest.cpp
@@ -1484,7 +1484,7 @@ namespace PhysX
 
     TEST_P(MassComputeFixture, RigidBody_ComputeMassFlagsCombinationsTwoShapes_MassPropertiesCalculatedAccordingly)
     {
-        const Physics::ShapeType shapeType = GetShapeType();
+        const Physics::ShapeType shapeType = GetShapeType() const;
         const SimulatedShapesMode shapeMode = GetShapesMode();
         const AzPhysics::MassComputeFlags massComputeFlags = GetMassComputeFlags();
         const bool multiShapeTest = IsMultiShapeTest();
@@ -1576,7 +1576,7 @@ namespace PhysX
     };
 
     INSTANTIATE_TEST_CASE_P(PhysX, MassComputeFixture, ::testing::Combine(
-        ::testing::ValuesIn({ Physics::ShapeType::Sphere, Physics::ShapeType::Box, Physics::ShapeType::Capsule }), // Values for GetShapeType()
+        ::testing::ValuesIn({ Physics::ShapeType::Sphere, Physics::ShapeType::Box, Physics::ShapeType::Capsule }), // Values for GetShapeType() const
         ::testing::ValuesIn({ SimulatedShapesMode::NONE, SimulatedShapesMode::MIXED, SimulatedShapesMode::ALL }), // Values for GetShapesMode()
         ::testing::ValuesIn(PossibleMassComputeFlags), // Values for GetMassComputeFlags()
         ::testing::Bool(), // Values for IncludeAllShapes()

--- a/Gems/RecastNavigation/Code/Tests/MockInterfaces.h
+++ b/Gems/RecastNavigation/Code/Tests/MockInterfaces.h
@@ -50,10 +50,10 @@ namespace RecastNavigationTests
             return AZ::Aabb::CreateCenterHalfExtents(AZ::Vector3::CreateZero(), AZ::Vector3::CreateOne() * 10);
         }
 
-        MOCK_METHOD0(GetShapeType, AZ::Crc32());
-        MOCK_METHOD2(GetTransformAndLocalBounds, void(AZ::Transform&, AZ::Aabb&));
-        MOCK_METHOD1(IsPointInside, bool(const AZ::Vector3&));
-        MOCK_METHOD1(DistanceSquaredFromPoint, float(const AZ::Vector3&));
+        MOCK_CONST_METHOD0(GetShapeType, AZ::Crc32());
+        MOCK_CONST_METHOD2(GetTransformAndLocalBounds, void(AZ::Transform&, AZ::Aabb&));
+        MOCK_CONST_METHOD1(IsPointInside, bool(const AZ::Vector3&));
+        MOCK_CONST_METHOD1(DistanceSquaredFromPoint, float(const AZ::Vector3&));
     };    
 
     class MockDebug : public AzFramework::DebugDisplayRequestBus::Handler

--- a/Gems/RecastNavigation/Code/Tests/MockInterfaces.h
+++ b/Gems/RecastNavigation/Code/Tests/MockInterfaces.h
@@ -45,7 +45,7 @@ namespace RecastNavigationTests
             LmbrCentral::ShapeComponentRequestsBus::Handler::BusDisconnect();
         }
 
-        AZ::Aabb GetEncompassingAabb() override
+        AZ::Aabb GetEncompassingAabb() const override
         {
             return AZ::Aabb::CreateCenterHalfExtents(AZ::Vector3::CreateZero(), AZ::Vector3::CreateOne() * 10);
         }

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
@@ -66,30 +66,30 @@ namespace UnitTest
 
         AZ::Aabb m_GetLocalBounds = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
         AZ::Transform m_GetTransform = AZ::Transform::CreateIdentity();
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override
         {
             transform = m_GetTransform;
             bounds = m_GetLocalBounds;
         }
 
         AZ::Crc32 m_GetShapeType = AZ_CRC("MockShapeComponentHandler", 0x5189d279);
-        AZ::Crc32 GetShapeType() override
+        AZ::Crc32 GetShapeType() const override
         {
             return m_GetShapeType;
         }
 
         AZ::Aabb m_GetEncompassingAabb = AZ::Aabb::CreateCenterRadius(AZ::Vector3::CreateZero(), 0.5f);
-        AZ::Aabb GetEncompassingAabb() override
+        AZ::Aabb GetEncompassingAabb() const override
         {
             return m_GetEncompassingAabb;
         }
 
-        bool IsPointInside(const AZ::Vector3& point) override
+        bool IsPointInside(const AZ::Vector3& point) const override
         {
             return m_GetEncompassingAabb.Contains(point);
         }
 
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override
         {
             return m_GetEncompassingAabb.GetDistanceSq(point);
         }

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.cpp
@@ -224,7 +224,7 @@ namespace Terrain
         return false;
     }
 
-    AZ::Aabb TerrainWorldDebuggerComponent::GetWorldBounds()
+    AZ::Aabb TerrainWorldDebuggerComponent::GetWorldBounds() const
     {
         AZ::Aabb terrainAabb = AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero());
         AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
@@ -233,7 +233,7 @@ namespace Terrain
         return terrainAabb;
     }
 
-    AZ::Aabb TerrainWorldDebuggerComponent::GetLocalBounds()
+    AZ::Aabb TerrainWorldDebuggerComponent::GetLocalBounds() const
     {
         // This is a level component, so the local bounds will always be the same as the world bounds.
         return GetWorldBounds();

--- a/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldDebuggerComponent.h
@@ -116,8 +116,8 @@ namespace Terrain
 
         //////////////////////////////////////////////////////////////////////////
         // BoundsRequestBus
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         //////////////////////////////////////////////////////////////////////////
         // AzFramework::Terrain::TerrainDataNotificationBus

--- a/Gems/Vegetation/Code/Source/Debugger/DebugComponent.h
+++ b/Gems/Vegetation/Code/Source/Debugger/DebugComponent.h
@@ -117,14 +117,14 @@ namespace Vegetation
 
         //////////////////////////////////////////////////////////////////////////
         // BoundsRequestBus
-        AZ::Aabb GetWorldBounds() override
+        AZ::Aabb GetWorldBounds() const override
         {
             // DisplayEntityViewport relies on the BoundsRequestBus to get the entity bounds to determine when to call debug drawing
             // for that entity.  Since this is a level component that can draw infinitely far in every direction, we return an
             // effectively infinite AABB so that it always draws.
             return AZ::Aabb::CreateFromMinMax(AZ::Vector3(-AZ::Constants::FloatMax), AZ::Vector3(AZ::Constants::FloatMax));
         }
-        AZ::Aabb GetLocalBounds() override
+        AZ::Aabb GetLocalBounds() const override
         {
             // The local and world bounds will be the same for this component.
             return GetWorldBounds();

--- a/Gems/Vegetation/Code/Tests/VegetationMocks.h
+++ b/Gems/Vegetation/Code/Tests/VegetationMocks.h
@@ -203,28 +203,28 @@ namespace UnitTest
         {
         }
 
-        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) override
+        void GetTransformAndLocalBounds(AZ::Transform& transform, AZ::Aabb& bounds) const override
         {
             transform = AZ::Transform::CreateTranslation(m_aabb.GetCenter());
             bounds = m_aabb;
         }
 
-        AZ::Crc32 GetShapeType() override
+        AZ::Crc32 GetShapeType() const override
         {
             return AZ::Crc32();
         }
 
-        AZ::Aabb GetEncompassingAabb() override
+        AZ::Aabb GetEncompassingAabb() const override
         {
             return m_aabb;
         }
 
-        bool IsPointInside(const AZ::Vector3& point) override
+        bool IsPointInside(const AZ::Vector3& point) const override
         {
             return m_aabb.Contains(point);
         }
 
-        float DistanceSquaredFromPoint(const AZ::Vector3& point) override
+        float DistanceSquaredFromPoint(const AZ::Vector3& point) const override
         {
             return m_aabb.GetDistanceSq(point);
         }
@@ -429,13 +429,13 @@ namespace UnitTest
         : public AZ::Render::MeshComponentRequestBus::Handler
     {
         AZ::Aabb m_GetWorldBoundsOutput;
-        AZ::Aabb GetWorldBounds() override
+        AZ::Aabb GetWorldBounds() const override
         {
             return m_GetWorldBoundsOutput;
         }
 
         AZ::Aabb m_GetLocalBoundsOutput;
-        AZ::Aabb GetLocalBounds() override
+        AZ::Aabb GetLocalBounds() const override
         {
             return m_GetLocalBoundsOutput;
         }

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -672,7 +672,7 @@ namespace WhiteBox
         return GetWorldBounds();
     }
 
-    AZ::Aabb EditorWhiteBoxComponent::GetWorldBounds()
+    AZ::Aabb EditorWhiteBoxComponent::GetWorldBounds() const
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
@@ -685,13 +685,13 @@ namespace WhiteBox
         return m_worldAabb.value();
     }
 
-    AZ::Aabb EditorWhiteBoxComponent::GetLocalBounds()
+    AZ::Aabb EditorWhiteBoxComponent::GetLocalBounds() const
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         if (!m_localAabb.has_value())
         {
-            auto& whiteBoxMesh = *GetWhiteBoxMesh();
+            auto& whiteBoxMesh = *const_cast<EditorWhiteBoxComponent*>(this)->GetWhiteBoxMesh();
 
             m_localAabb = CalculateAabb(
                 whiteBoxMesh,

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
@@ -70,8 +70,8 @@ namespace WhiteBox
         bool SupportsEditorRayIntersect() override;
 
         // BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         //! Returns if the component currently has an instance of RenderMeshInterface.
         bool HasRenderMesh() const;
@@ -124,8 +124,8 @@ namespace WhiteBox
         Api::WhiteBoxMeshStream m_whiteBoxData; //!< Serialized White Box mesh data.
         //! Holds a reference to an optional WhiteBoxMeshAsset and manages the lifecycle of adding/removing an asset.
         EditorWhiteBoxMeshAsset* m_editorMeshAsset = nullptr;
-        AZStd::optional<AZ::Aabb> m_worldAabb; //!< Cached world aabb (used for selection/view determination).
-        AZStd::optional<AZ::Aabb> m_localAabb; //!< Cached local aabb (used for center pivot calculation).
+        mutable AZStd::optional<AZ::Aabb> m_worldAabb; //!< Cached world aabb (used for selection/view determination).
+        mutable AZStd::optional<AZ::Aabb> m_localAabb; //!< Cached local aabb (used for center pivot calculation).
         AZStd::optional<Api::Faces> m_faces; //!< Cached faces (triangles of mesh used for intersection/selection).
         WhiteBoxRenderData m_renderData; //!< Cached render data constructed from the White Box mesh source data.
         WhiteBoxMaterial m_material = {

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorBounds.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorBounds.cpp
@@ -64,7 +64,7 @@ namespace WhiteBox
     }
 
     bool ManipulatorBoundPolygon::IntersectRay(
-        const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+        const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
     {
         int64_t intersectedTriangleIndex = 0;
         return IntersectRayPolygon(
@@ -111,7 +111,7 @@ namespace WhiteBox
     }
 
     bool ManipulatorBoundEdge::IntersectRay(
-        const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance)
+        const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const
     {
         return IntersectRayEdge(m_edgeBound, m_edgeBound.m_radius, rayOrigin, rayDirection, rayIntersectionDistance);
     }

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorBounds.h
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorBounds.h
@@ -107,7 +107,7 @@ namespace WhiteBox
         }
 
         bool IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) override;
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const override;
         void SetShapeData(const AzToolsFramework::Picking::BoundRequestShapeBase& shapeData) override;
 
         PolygonBound m_polygonBound;
@@ -145,7 +145,7 @@ namespace WhiteBox
         }
 
         bool IntersectRay(
-            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) override;
+            const AZ::Vector3& rayOrigin, const AZ::Vector3& rayDirection, float& rayIntersectionDistance) const override;
         void SetShapeData(const AzToolsFramework::Picking::BoundRequestShapeBase& shapeData) override;
 
         EdgeBound m_edgeBound;


### PR DESCRIPTION
## What does this PR do?

This change is largely just adding const to shape, bounds, and intersection buses. Prior to this, the functions could not be called directly from other const functions without casting or using the bus.

Updated mesh component get visible geometry function to check world bounds against the incoming bounds.

## How was this PR tested?

Compiled code. There should be no functional changes for other systems.
Tested mesh component visibility changes against local changes.