### PR TITLE
Fix splash screen on Linux

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -359,6 +359,7 @@ CCryEditApp::CCryEditApp()
     m_sPreviewFile[0] = 0;
 
     AzFramework::AssetSystemInfoBus::Handler::BusConnect();
+    AzFramework::AssetSystemStatusBus::Handler::BusConnect();
 
     m_disableIdleProcessingCounter = 0;
     EditorIdleProcessingBus::Handler::BusConnect();
@@ -368,6 +369,7 @@ CCryEditApp::CCryEditApp()
 CCryEditApp::~CCryEditApp()
 {
     EditorIdleProcessingBus::Handler::BusDisconnect();
+    AzFramework::AssetSystemStatusBus::Handler::BusDisconnect();
     AzFramework::AssetSystemInfoBus::Handler::BusDisconnect();
     s_currentInstance = nullptr;
 }
@@ -792,6 +794,11 @@ QString FormatRichTextCopyrightNotice()
     QString copyrightString = QObject::tr("Copyright %1 Contributors to the Open 3D Engine Project");
 
     return copyrightString.arg(copyrightHtmlSymbol);
+}
+
+void CCryEditApp::AssetSystemWaiting()
+{
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -88,6 +88,7 @@ class SANDBOX_API CCryEditApp
     : public QObject
     , protected AzFramework::AssetSystemInfoBus::Handler
     , protected EditorIdleProcessingBus::Handler
+    , protected AzFramework::AssetSystemStatusBus::Handler
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
@@ -229,6 +230,10 @@ public:
 protected:
     // ------- AzFramework::AssetSystemInfoBus::Handler ------
     void OnError(AzFramework::AssetSystem::AssetSystemErrors error) override;
+    // -------------------------------------------
+
+    // ------- AzFramework::AssetSystemStatusBus::Handler ------
+    void AssetSystemWaiting() override;
     // -------------------------------------------
 
 private:

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemBus.h
@@ -325,6 +325,8 @@ namespace AzFramework
             virtual void AssetSystemAvailable() {}
             //! Notifies listeners Asset System turns not available
             virtual void AssetSystemUnavailable() {}
+            //! Notifies listeners Asset System is still waiting
+            virtual void AssetSystemWaiting() {}
         };
 
     } // namespace AssetSystem

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -713,6 +713,8 @@ namespace AzFramework
             {
                 AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
 
+                AssetSystemStatusBus::Broadcast(&AssetSystemStatusBus::Events::AssetSystemWaiting);
+
                 if (!ConnectedWithAssetProcessor())
                 {
                     //If we are here than it means we were connected but have lost connection with AP


### PR DESCRIPTION
## What does this PR do?
On Linux, the editor splash screen does not draw until all the assets are complete. So the user will have an outline of what the splash screen would be but not show any useful information. The root cause of the problem is that during the loop that is waiting for Asset Processor to be 'ready', there is a bus call to pump idle messages:

```
AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
```
On Linux, the handler for this handles Xcb events, but it does not pass the events to Qt. 
```
    void XcbApplication::PumpSystemEventLoopUntilEmpty()
    {
        if (xcb_connection_t* xcbConnection = m_xcbConnectionManager->GetXcbConnection())
        {
            while (auto event = XcbStdFreePtr<xcb_generic_event_t>{xcb_poll_for_event(xcbConnection)})
            {
                XcbEventHandlerBus::Broadcast(&XcbEventHandlerBus::Events::HandleXcbEvent, event.get());
            }
        }
    }
```
The events are instead passed to the XcbApplication handler, which is primarily intended to handle messages for the game clients, not the Qt editor. 

In order to fix this, we are adding an additional event to the `AssetSystemStatus` bus called `AssetSystemWaiting()`, to provide an additional means to process any queued events. 

## How was this PR tested?
Launched the Editor on Linux



https://github.com/o3de/o3de/assets/82231385/17463ab8-b17a-4539-a8b9-2a3f370684fe




Fixes https://github.com/o3de/o3de/issues/14223 