### PR TITLE
SMC: Allow access to generated shaders and materials in intermediate assets folder

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/Search/Filter.h>
 
@@ -68,5 +69,7 @@ namespace AtomToolsFramework
         QByteArray m_browserState;
 
         AZStd::function<void(const AZStd::string&)> m_openHandler;
+
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_settingsNotifyEventHandler;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -293,8 +293,11 @@ namespace AtomToolsFramework
     //! Collect a set of file paths from all project safe folders matching an extension
     AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingExtension(const AZStd::string& extension);
 
-    //! Return a list of all asset safe folders except for those underneath the cache folder, usually intermediate asset folders.
-    AZStd::vector<AZStd::string> GetNonCacheSourceFolders();
+    //! Returns true if settings are configured to ignore the input path
+    bool IsPathIgnored(const AZStd::string& path);
+
+    //! Returns a list of all asset safe folders except for those set to be ignored, cache and intermediate asset folders.
+    AZStd::vector<AZStd::string> GetSupportedSourceFolders();
 
     //! Add menu actions for scripts specified in the settings registry
     //! @param menu The menu where the actions will be inserted

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -154,7 +154,7 @@ namespace AtomToolsFramework
             }
 
             const auto& path = entry->GetFullPath();
-            return !AZ::StringFunc::Contains(path, "cache");
+            return !IsPathIgnored(path);
         };
 
         QSharedPointer<CompositeFilter> finalFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -9,6 +9,7 @@
 #include <AssetBrowser/ui_AtomToolsAssetBrowser.h>
 #include <AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h>
 #include <AtomToolsFramework/Util/Util.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzQtComponents/Utilities/DesktopUtilities.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
@@ -77,6 +78,23 @@ namespace AtomToolsFramework
         connect(m_ui->m_assetBrowserTreeViewWidget, &AssetBrowserTreeView::activated, this, &AtomToolsAssetBrowser::OpenSelectedEntries);
         connect(m_ui->m_assetBrowserTreeViewWidget, &AssetBrowserTreeView::selectionChangedSignal, this, &AtomToolsAssetBrowser::UpdatePreview);
         connect(m_ui->m_searchWidget->GetFilter().data(), &AssetBrowserEntryFilter::updatedSignal, m_filterModel, &AssetBrowserFilterModel::filterUpdatedSlot);
+
+        // Monitor for asset browser related settings changes
+        if (auto registry = AZ::SettingsRegistry::Get())
+        {
+            m_settingsNotifyEventHandler = registry->RegisterNotifier(
+                [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
+                {
+                    // Refresh the asset browser model if any of the filter related settings change.
+                    if (AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
+                            "/O3DE/AtomToolsFramework/Application/IgnoreCacheFolder", notifyEventArgs.m_jsonKeyPath) ||
+                        AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
+                            "/O3DE/AtomToolsFramework/Application/IgnoredPathRegexPatterns", notifyEventArgs.m_jsonKeyPath))
+                    {
+                        m_filterModel->filterUpdatedSlot();
+                    }
+                });
+        }
     }
 
     AtomToolsAssetBrowser::~AtomToolsAssetBrowser()

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -361,7 +361,7 @@ namespace AtomToolsFramework
             }
 
             const auto& path = entry->GetFullPath();
-            return !AZ::StringFunc::Contains(path, "cache") &&
+            return !IsPathIgnored(path) &&
                 AZStd::any_of(
                     supportedExtensions.begin(),
                     supportedExtensions.end(),
@@ -445,7 +445,7 @@ namespace AtomToolsFramework
     {
         const auto& fullPath = GetPathWithoutAlias(path);
         const AZ::IO::FixedMaxPath assetPath = AZ::IO::PathView(fullPath).LexicallyNormal();
-        for (const auto& assetFolder : GetNonCacheSourceFolders())
+        for (const auto& assetFolder : GetSupportedSourceFolders())
         {
             // Check if the path is relative to the asset folder
             if (assetPath.IsRelativeTo(AZ::IO::PathView(assetFolder)))
@@ -664,7 +664,7 @@ namespace AtomToolsFramework
     void VisitFilesInFolder(
         const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse)
     {
-        if (!visitorFn || AZ::StringFunc::Contains(folder, "cache"))
+        if (!visitorFn || IsPathIgnored(folder))
         {
             return;
         }
@@ -703,20 +703,18 @@ namespace AtomToolsFramework
 
     void VisitFilesInScanFolders(const AZStd::function<bool(const AZStd::string&)> visitorFn)
     {
-        if (!visitorFn)
+        if (visitorFn)
         {
-            return;
-        }
-
-        for (const AZStd::string& scanFolder : GetNonCacheSourceFolders())
-        {
-            VisitFilesInFolder(scanFolder, visitorFn, true);
+            for (const AZStd::string& scanFolder : GetSupportedSourceFolders())
+            {
+                VisitFilesInFolder(scanFolder, visitorFn, true);
+            }
         }
     }
 
     AZStd::vector<AZStd::string> GetPathsInSourceFoldersMatchingFilter(const AZStd::function<bool(const AZStd::string&)> filterFn)
     {
-        const auto& scanFolders = GetNonCacheSourceFolders();
+        const auto& scanFolders = GetSupportedSourceFolders();
 
         AZStd::vector<AZStd::string> results;
         results.reserve(scanFolders.size());
@@ -761,7 +759,19 @@ namespace AtomToolsFramework
             });
     }
 
-    AZStd::vector<AZStd::string> GetNonCacheSourceFolders()
+    bool IsPathIgnored(const AZStd::string& path)
+    {
+        for (const auto& pattern : GetSettingsObject("/O3DE/Atom/Tools/IgnoredPathPatterns", AZStd::vector<AZStd::string>{}))
+        {
+            if (AZ::StringFunc::Contains(path, pattern))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    AZStd::vector<AZStd::string> GetSupportedSourceFolders()
     {
         AZStd::vector<AZStd::string> scanFolders;
         scanFolders.reserve(100);
@@ -769,7 +779,7 @@ namespace AtomToolsFramework
         AzToolsFramework::AssetSystemRequestBus::Broadcast(
             &AzToolsFramework::AssetSystem::AssetSystemRequest::GetAssetSafeFolders, scanFolders);
 
-        AZStd::erase_if(scanFolders, [](const AZStd::string& path){ return AZ::StringFunc::Contains(path, "cache"); });
+        AZStd::erase_if(scanFolders, [](const AZStd::string& path){ return IsPathIgnored(path); });
         return scanFolders;
     }
 
@@ -864,7 +874,8 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetPathWithoutAlias", GetPathWithoutAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithAlias", GetPathWithAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingExtension", GetPathsInSourceFoldersMatchingExtension, nullptr, ""));
-            addUtilFunc(behaviorContext->Method("GetNonCacheSourceFolders", GetNonCacheSourceFolders, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("IsPathIgnored", IsPathIgnored, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetSupportedSourceFolders", GetSupportedSourceFolders, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSettingsValue_bool", GetSettingsValue<bool>, nullptr, ""));
             addUtilFunc(behaviorContext->Method("SetSettingsValue_bool", SetSettingsValue<bool>, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSettingsValue_s64", GetSettingsValue<AZ::s64>, nullptr, ""));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -299,6 +299,12 @@ namespace AtomToolsFramework
                   "Enable source control for the application if it is available",
                   false),
               CreateSettingsPropertyValue(
+                  "/O3DE/AtomToolsFramework/Application/IgnoreCacheFolder",
+                  "Ignore Files In Cache Folder",
+                  "This toggles whether or not files located in the cache folder appear in the asset browser, file selection dialogs, and "
+                  "during file enumeration. Changing this setting may require restarting the application to take effect in some areas.",
+                  true),
+              CreateSettingsPropertyValue(
                   "/O3DE/AtomToolsFramework/Application/UpdateIntervalWhenActive",
                   "Update Interval When Active",
                   "Minimum delay between ticks (in milliseconds) when the application has focus",

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/paths.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/paths.materialcanvas.setreg
@@ -1,8 +1,8 @@
 {
     "O3DE": {
-        "Atom": {
-            "Tools": {
-                "IgnoredPathPatterns": [ "cache" ]
+        "AtomToolsFramework": {
+            "Application": {
+                "IgnoreCacheFolder": true
             }
         }
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Registry/paths.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/paths.materialcanvas.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Atom": {
+            "Tools": {
+                "IgnoredPathPatterns": [ "cache" ]
+            }
+        }
+    }
+}

--- a/Gems/Atom/Tools/MaterialEditor/Registry/paths.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/paths.materialeditor.setreg
@@ -1,8 +1,8 @@
 {
     "O3DE": {
-        "Atom": {
-            "Tools": {
-                "IgnoredPathPatterns": [ "cache" ]
+        "AtomToolsFramework": {
+            "Application": {
+                "IgnoreCacheFolder": true
             }
         }
     }

--- a/Gems/Atom/Tools/MaterialEditor/Registry/paths.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/paths.materialeditor.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Atom": {
+            "Tools": {
+                "IgnoredPathPatterns": [ "cache" ]
+            }
+        }
+    }
+}

--- a/Gems/Atom/Tools/PassCanvas/Registry/paths.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/paths.passcanvas.setreg
@@ -1,8 +1,8 @@
 {
     "O3DE": {
-        "Atom": {
-            "Tools": {
-                "IgnoredPathPatterns": [ "cache" ]
+        "AtomToolsFramework": {
+            "Application": {
+                "IgnoreCacheFolder": true
             }
         }
     }

--- a/Gems/Atom/Tools/PassCanvas/Registry/paths.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/paths.passcanvas.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Atom": {
+            "Tools": {
+                "IgnoredPathPatterns": [ "cache" ]
+            }
+        }
+    }
+}

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/paths.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/paths.shadermanagementconsole.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Atom": {
+            "Tools": {
+                "IgnoredPathPatterns": []
+            }
+        }
+    }
+}

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/paths.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/paths.shadermanagementconsole.setreg
@@ -1,8 +1,8 @@
 {
     "O3DE": {
-        "Atom": {
-            "Tools": {
-                "IgnoredPathPatterns": []
+        "AtomToolsFramework": {
+            "Application": {
+                "IgnoreCacheFolder": false
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Replaced explicit checks for ignoring the cache folder with configurable settings so that SMC could access generated shaders and materials

## How was this PR tested?

Built and tested material editor, material canvas, and shader management console to see that each respected the filter settings.