### PR TITLE
[Linux] Fix linux snap package issues with Project Manager

### DIFF
--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -309,10 +309,11 @@ def get_all_gem_infos(project_path: pathlib.Path or None) -> list:
     # because the project might be using a different engine than the one Project Manager is
     # running out of
 
-    # Attempt to get the engine path from the project path if possible. If not, then default
-    # to attempting to get engine path from the registered '--this-engine' value from the manifest
+    # Attempt to get the engine path from the project path if possible (except when the project path
+    # is a template). If not, then default to attempting to get engine path from the registered 
+    # '--this-engine' value from the manifest
     engine_path = None
-    if project_path:
+    if project_path and utils.find_ancestor_dir_containing_file('template.json', project_path) is None:
         engine_path = manifest.get_project_engine_path(project_path=project_path)
     if not engine_path:
         engine_path = manifest.get_this_engine_path()
@@ -442,16 +443,16 @@ def get_gem_infos_from_all_repos(project_path:pathlib.Path = None, enabled_only:
     if not remote_gem_json_data_list:
         return list()
 
-    # Attempt to get the engine path from the project path if possible. If not, then default
-    # to attempting to get engine path from the registered '--this-engine' value from the manifest
+    # Attempt to get the engine path from the project path if possible (except when the project path
+    # is a template). If not, then default to attempting to get engine path from the registered 
+    # '--this-engine' value from the manifest
     engine_path = None
-    if project_path:
+    if project_path and utils.find_ancestor_dir_containing_file('template.json', project_path) is None:
         engine_path = manifest.get_project_engine_path(project_path=project_path)
     if not engine_path:
         engine_path = manifest.get_this_engine_path()
-
     if not engine_path:
-        logger.error("Failed to get engine path for remote gem compatibility checksi!")
+        logger.error("Failed to get engine path for remote gem compatibility checks")
         return list() 
 
     engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)

--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -308,7 +308,14 @@ def get_all_gem_infos(project_path: pathlib.Path or None) -> list:
     # it's easier to determine which gems are engine gems here rather than in c++
     # because the project might be using a different engine than the one Project Manager is
     # running out of
-    engine_path = manifest.get_project_engine_path(project_path=project_path) if project_path else manifest.get_this_engine_path() 
+
+    # Attempt to get the engine path from the project path if possible. If not, then default
+    # to attempting to get engine path from the registered '--this-engine' value from the manifest
+    engine_path = None
+    if project_path:
+        engine_path = manifest.get_project_engine_path(project_path=project_path)
+    if not engine_path:
+        engine_path = manifest.get_this_engine_path()
     if not engine_path:
         logger.error("Failed to get engine path for gem info retrieval")
         return [] 
@@ -435,9 +442,16 @@ def get_gem_infos_from_all_repos(project_path:pathlib.Path = None, enabled_only:
     if not remote_gem_json_data_list:
         return list()
 
-    engine_path = manifest.get_project_engine_path(project_path=project_path) if project_path else manifest.get_this_engine_path() 
+    # Attempt to get the engine path from the project path if possible. If not, then default
+    # to attempting to get engine path from the registered '--this-engine' value from the manifest
+    engine_path = None
+    if project_path:
+        engine_path = manifest.get_project_engine_path(project_path=project_path)
     if not engine_path:
-        logger.error("Failed to get engine path for remote gem compatibility checks")
+        engine_path = manifest.get_this_engine_path()
+
+    if not engine_path:
+        logger.error("Failed to get engine path for remote gem compatibility checksi!")
         return list() 
 
     engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)


### PR DESCRIPTION
## What does this PR do?

This fixes an issue with the snap package installed SDK and Project Manager where you will get multiple errors showing a gem was "Removed or Unregistered" during the create new project workflow with a remote repo.

**Root Cause**
The root cause is when the project manager downloads a template from a remote repo, its template is stored in `$HOME/O3DE/Templates`, it cannot resolve the engine path because it is trying to get the engine path from the project path. For project templates, we shouldn't care about its engine path because its not an actual project yet (that is a different issue). The logic attempts to resolve the engine path by walking up the path of the template until `engine.json` is found. While this works for templates in the snap installation (because the templates are inside the engine folder), it doesn't work for downloaded templates because $HOME/O3DE/Templates` is outside the engine path.

**Fix**
The fix for now is to instead of attempting to get the engine path from the project if the project is specified or rely on the registered engine path in the manifest, the engine path from the manifest will act as a fallback if if cannot find the engine path from the project.

Fixes https://github.com/o3de/o3de/issues/16660 

## How was this PR tested?
This was tested in a manually expanded snap package. Will test further once the snap package is recreated with this change.

