### PR TITLE
Project Manager: Fix Broken workflow when cancelling new project creation

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
@@ -298,6 +298,10 @@ namespace O3DE::ProjectManager
             // it will also handle detailed error messaging
             if(!ProjectUtils::RegisterProject(projectInfo.m_path, this))
             {
+                // Since the project files were created during this workflow, but register project flow was cancelled or errored out,
+                // clean up the created files here.
+                [[maybe_unused]] bool filesDeleted = ProjectUtils::DeleteProjectFiles(projectInfo.m_path, /*force*/ true);
+                AZ_Warning("O3DE", filesDeleted, "Unable to delete invalid new project files at %s", projectInfo.m_path.toUtf8().constData());
                 return;
             }
 


### PR DESCRIPTION
## What does this PR do?
This fixes a situation where the user may opt to cancel a new project creation if they click on 'Create Project' but warnings such as gem dependency issues can opt them to cancel the creation. Even if they press cancel, the new files are created but not added, so the project information (path) on the project creation workflow is no longer valid because the folder now exists.

(Refer to the [GHI](https://github.com/o3de/o3de/issues/16669) for more info)

## How was this PR tested?
Followed steps described in the [GHI](https://github.com/o3de/o3de/issues/16669).

Fixes https://github.com/o3de/o3de/issues/16669 
