### PR TITLE
Atom tools, SMC, MC: Atom tools asset browser support for extension based file filters

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
@@ -62,7 +62,7 @@ namespace AtomToolsFramework
 
         using FileTypeFilterVec = AZStd::vector<FileTypeFilter>;
 
-        //! Set up ext based file filters for the as the browser. The filters can be set using the options menu on the search bar. This is
+        //! Set up ext based file filters for the asset browser. The filters can be set using the options menu on the search bar. This is
         //! intended to be used instead of asset type filters because some tools primarily work with source files that do not have
         //! registered asset type info.
         void SetFileTypeFilters(const FileTypeFilterVec& fileTypeFilters);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h
@@ -11,8 +11,11 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/containers/map.h>
+#include <AzCore/std/string/string.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/Search/Filter.h>
+#include <AzToolsFramework/AssetBrowser/Search/SearchWidget.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QByteArray>
@@ -45,10 +48,32 @@ namespace AtomToolsFramework
         AtomToolsAssetBrowser(QWidget* parent = nullptr);
         ~AtomToolsAssetBrowser();
 
-        void SetFilterState(const AZStd::string& category, const AZStd::string& displayName, bool enabled);
+        //! @return the asset browser top level search widget 
+        AzToolsFramework::AssetBrowser::SearchWidget* GetSearchWidget();
+
+        //! FileTypeFilter contains a set of extensions used to compare and filter file paths add a flag that tells if the filter is
+        //! enabled.
+        struct FileTypeFilter
+        {
+            AZStd::string m_name;
+            AZStd::unordered_set<AZStd::string> m_extensions;
+            bool m_enabled = false;
+        };
+
+        using FileTypeFilterVec = AZStd::vector<FileTypeFilter>;
+
+        //! Set up ext based file filters for the as the browser. The filters can be set using the options menu on the search bar. This is
+        //! intended to be used instead of asset type filters because some tools primarily work with source files that do not have
+        //! registered asset type info.
+        void SetFileTypeFilters(const FileTypeFilterVec& fileTypeFilters);
+
+        //! Register a custom handler for opening different file types.
         void SetOpenHandler(AZStd::function<void(const AZStd::string&)> openHandler);
 
+        //! Select the asset browser entries matching the absolute path.
         void SelectEntries(const AZStd::string& absolutePath);
+
+        //! Open the currently selected asset browser entries using the registered file openers.
         void OpenSelectedEntries();
 
     protected:
@@ -56,6 +81,13 @@ namespace AtomToolsFramework
         void UpdateFilter();
         void UpdatePreview();
         void TogglePreview();
+
+        void InitOptionsMenu();
+        void InitSettingsHandler();
+        void InitSettings();
+        void SaveSettings();
+
+        void UpdateFileTypeFilters();
 
         // AZ::SystemTickBus::Handler
         void OnSystemTick() override;
@@ -71,5 +103,13 @@ namespace AtomToolsFramework
         AZStd::function<void(const AZStd::string&)> m_openHandler;
 
         AZ::SettingsRegistryInterface::NotifyEventHandler m_settingsNotifyEventHandler;
+
+        FileTypeFilterVec m_fileTypeFilters;
+
+        bool m_fileTypeFiltersEnabled = false;
+
+        bool m_showEmptyFolders = false;
+
+        QMenu* m_optionsMenu = nullptr;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -176,38 +176,48 @@ namespace AtomToolsFramework
             switch (entry->GetEntryType())
             {
             case AssetBrowserEntry::AssetEntryType::Folder:
-                if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
                 {
-                    return m_showEmptyFolders;
+                    if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
+                    {
+                        return m_showEmptyFolders;
+                    }
+
+                    // The path is invalid or ignored
+                    return false;
                 }
 
-                return false;
-
             case AssetBrowserEntry::AssetEntryType::Source:
-                if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
                 {
-                    // Filter assets against supported extensions instead of using asset type comparisons
-                    if (m_fileTypeFiltersEnabled)
+                    if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
                     {
-                        for (const auto& fileTypeFilter : m_fileTypeFilters)
+                        // Filter assets against supported extensions instead of using asset type comparisons
+                        if (m_fileTypeFiltersEnabled)
                         {
-                            if (fileTypeFilter.m_enabled)
+                            for (const auto& fileTypeFilter : m_fileTypeFilters)
                             {
-                                for (const auto& extension : fileTypeFilter.m_extensions)
+                                if (fileTypeFilter.m_enabled)
                                 {
-                                    if (AZ::StringFunc::EndsWith(path, extension))
+                                    for (const auto& extension : fileTypeFilter.m_extensions)
                                     {
-                                        return true;
+                                        if (AZ::StringFunc::EndsWith(path, extension))
+                                        {
+                                            return true;
+                                        }
                                     }
                                 }
                             }
-                        }
-                        return false;
-                    }
-                    return true;
-                }
 
-                return false;
+                            // Filters were enabled but no matching filter was found so exclude this entry.
+                            return false;
+                        }
+
+                        // Filters were not enabled so automatically include all entries.
+                        return true;
+                    }
+
+                    // The path is invalid or ignored
+                    return false;
+                }
             }
 
             return false;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetBrowser/AtomToolsAssetBrowser.cpp
@@ -10,6 +10,7 @@
 #include <AtomToolsFramework/AssetBrowser/AtomToolsAssetBrowser.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/std/sort.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzQtComponents/Utilities/DesktopUtilities.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
@@ -41,19 +42,6 @@ namespace AtomToolsFramework
         m_ui->m_searchWidget->Setup(true, true);
         m_ui->m_searchWidget->setMinimumSize(QSize(150, 0));
 
-        // Create pop-up menu to toggle the visibility of the asset browser preview window
-        QMenu* viewOptionsMenu= new QMenu(this);
-        QMenu::connect(viewOptionsMenu, &QMenu::aboutToShow, [this, viewOptionsMenu]() {
-            viewOptionsMenu->clear();
-            QAction* action = viewOptionsMenu->addAction(tr("Show Asset Preview"), this, &AtomToolsAssetBrowser::TogglePreview);
-            action->setCheckable(true);
-            action->setChecked(m_ui->m_previewerFrame->isVisible());
-        });
-
-        m_ui->m_viewOptionButton->setMenu(viewOptionsMenu);
-        m_ui->m_viewOptionButton->setIcon(QIcon(":/Icons/menu.svg"));
-        m_ui->m_viewOptionButton->setPopupMode(QToolButton::InstantPopup);
-
         m_ui->m_splitter->setSizes(QList<int>() << 400 << 200);
         m_ui->m_splitter->setStretchFactor(0, 1);
 
@@ -79,34 +67,54 @@ namespace AtomToolsFramework
         connect(m_ui->m_assetBrowserTreeViewWidget, &AssetBrowserTreeView::selectionChangedSignal, this, &AtomToolsAssetBrowser::UpdatePreview);
         connect(m_ui->m_searchWidget->GetFilter().data(), &AssetBrowserEntryFilter::updatedSignal, m_filterModel, &AssetBrowserFilterModel::filterUpdatedSlot);
 
-        // Monitor for asset browser related settings changes
-        if (auto registry = AZ::SettingsRegistry::Get())
-        {
-            m_settingsNotifyEventHandler = registry->RegisterNotifier(
-                [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
-                {
-                    // Refresh the asset browser model if any of the filter related settings change.
-                    if (AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
-                            "/O3DE/AtomToolsFramework/Application/IgnoreCacheFolder", notifyEventArgs.m_jsonKeyPath) ||
-                        AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
-                            "/O3DE/AtomToolsFramework/Application/IgnoredPathRegexPatterns", notifyEventArgs.m_jsonKeyPath))
-                    {
-                        m_filterModel->filterUpdatedSlot();
-                    }
-                });
-        }
+        InitOptionsMenu();
+        InitSettingsHandler();
+        InitSettings();
     }
 
     AtomToolsAssetBrowser::~AtomToolsAssetBrowser()
     {
+        // Disconnect the event handler before saving settings so that it does not get triggered from the destructor.
+        m_settingsNotifyEventHandler.Disconnect();
+
+        // Rewrite any potentially unsaved settings to the registry.
+        SaveSettings();
+
         // Maintains the tree expansion state between runs
         m_ui->m_assetBrowserTreeViewWidget->SaveState();
         AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void AtomToolsAssetBrowser::SetFilterState(const AZStd::string& category, const AZStd::string& displayName, bool enabled)
+    AzToolsFramework::AssetBrowser::SearchWidget* AtomToolsAssetBrowser::GetSearchWidget()
     {
-        m_ui->m_searchWidget->SetFilterState(category.c_str(), displayName.c_str(), enabled);
+        return m_ui->m_searchWidget;
+    }
+
+    void AtomToolsAssetBrowser::SetFileTypeFilters(const FileTypeFilterVec& fileTypeFilters)
+    {
+        m_fileTypeFilters = fileTypeFilters;
+
+        // Pre sort the file type filters just so that they are organized alphabetically in the menu.
+        AZStd::sort(
+            m_fileTypeFilters.begin(),
+            m_fileTypeFilters.end(),
+            [](const auto& fileTypeFilter1, const auto& fileTypeFilter2)
+            {
+                return fileTypeFilter1.m_name < fileTypeFilter2.m_name;
+            });
+
+        UpdateFileTypeFilters();
+    }
+
+    void AtomToolsAssetBrowser::UpdateFileTypeFilters()
+    {
+        m_fileTypeFiltersEnabled = AZStd::any_of(
+            m_fileTypeFilters.begin(),
+            m_fileTypeFilters.end(),
+            [](const auto& fileTypeFilter)
+            {
+                return fileTypeFilter.m_enabled;
+            });
     }
 
     void AtomToolsAssetBrowser::SetOpenHandler(AZStd::function<void(const AZStd::string&)> openHandler)
@@ -163,20 +171,55 @@ namespace AtomToolsFramework
     {
         using namespace AzToolsFramework::AssetBrowser;
 
-        auto filterFn = [&](const AssetBrowserEntry* entry)
+        auto filterFn = [this](const AssetBrowserEntry* entry)
         {
-            if (entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Source &&
-                entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
+            switch (entry->GetEntryType())
             {
+            case AssetBrowserEntry::AssetEntryType::Folder:
+                if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
+                {
+                    return m_showEmptyFolders;
+                }
+
+                return false;
+
+            case AssetBrowserEntry::AssetEntryType::Source:
+                if (const auto& path = entry->GetFullPath(); !path.empty() && !IsPathIgnored(path))
+                {
+                    // Filter assets against supported extensions instead of using asset type comparisons
+                    if (m_fileTypeFiltersEnabled)
+                    {
+                        for (const auto& fileTypeFilter : m_fileTypeFilters)
+                        {
+                            if (fileTypeFilter.m_enabled)
+                            {
+                                for (const auto& extension : fileTypeFilter.m_extensions)
+                                {
+                                    if (AZ::StringFunc::EndsWith(path, extension))
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                        return false;
+                    }
+                    return true;
+                }
+
                 return false;
             }
 
-            const auto& path = entry->GetFullPath();
-            return !IsPathIgnored(path);
+            return false;
         };
 
+        // The custom filter uses a lambda or function pointer instead of combining complicated filter logic operations. The filter must
+        // propagate down in order to support showing and hiding empty folders.
+        CustomFilter* customFilter = new CustomFilter(filterFn);
+        customFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+
         QSharedPointer<CompositeFilter> finalFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND));
-        finalFilter->AddFilter(FilterConstType(new CustomFilter(filterFn)));
+        finalFilter->AddFilter(FilterConstType(customFilter));
         finalFilter->AddFilter(m_ui->m_searchWidget->GetFilter());
 
         return finalFilter;
@@ -215,6 +258,152 @@ namespace AtomToolsFramework
         {
             m_ui->m_splitter->restoreState(m_browserState);
         }
+    }
+
+    void AtomToolsAssetBrowser::InitOptionsMenu()
+    {
+        // Create pop-up menu to toggle the visibility of the asset browser preview window
+        m_optionsMenu = new QMenu(this);
+        QMenu::connect(
+            m_optionsMenu,
+            &QMenu::aboutToShow,
+            [this]()
+            {
+                // Register action to toggle showing and hiding the asset preview image
+                m_optionsMenu->clear();
+                QAction* action = m_optionsMenu->addAction(tr("Show Asset Preview"), this, &AtomToolsAssetBrowser::TogglePreview);
+                action->setCheckable(true);
+                action->setChecked(m_ui->m_previewerFrame->isVisible());
+
+                // Register action to toggle showing and hiding folders with no visible children
+                m_optionsMenu->addSeparator();
+                QAction* emptyFolderAction = m_optionsMenu->addAction(
+                    tr("Show Empty Folders"),
+                    this,
+                    [this]()
+                    {
+                        m_showEmptyFolders = !m_showEmptyFolders;
+                        m_filterModel->filterUpdatedSlot();
+                    });
+                emptyFolderAction->setCheckable(true);
+                emptyFolderAction->setChecked(m_showEmptyFolders);
+
+                // Register actions to toggle showing and hiding asset browser entries matching supported extensions
+                if (!m_fileTypeFilters.empty())
+                {
+                    m_optionsMenu->addSeparator();
+                    m_optionsMenu->addAction(
+                        tr("Enable All File Filters"),
+                        this,
+                        [this]()
+                        {
+                            for (auto& fileTypeFilter : m_fileTypeFilters)
+                            {
+                                fileTypeFilter.m_enabled = true;
+                            }
+                            UpdateFileTypeFilters();
+                            m_filterModel->filterUpdatedSlot();
+                        });
+
+                    m_optionsMenu->addAction(
+                        tr("Disable All File Filters"),
+                        this,
+                        [this]()
+                        {
+                            for (auto& fileTypeFilter : m_fileTypeFilters)
+                            {
+                                fileTypeFilter.m_enabled = false;
+                            }
+                            UpdateFileTypeFilters();
+                            m_filterModel->filterUpdatedSlot();
+                        });
+                    m_optionsMenu->addSeparator();
+
+                    for (const auto& fileTypeFilter : m_fileTypeFilters)
+                    {
+                        QAction* extensionAction = m_optionsMenu->addAction(
+                            tr("Show %1 Files").arg(fileTypeFilter.m_name.c_str()),
+                            this,
+                            [this, fileTypeFilterName = fileTypeFilter.m_name]()
+                            {
+                                auto fileTypeFilterItr = AZStd::find_if(
+                                    m_fileTypeFilters.begin(),
+                                    m_fileTypeFilters.end(),
+                                    [fileTypeFilterName](const auto& fileTypeFilter)
+                                    {
+                                        return fileTypeFilter.m_name == fileTypeFilterName;
+                                    });
+                                if (fileTypeFilterItr != m_fileTypeFilters.end())
+                                {
+                                    fileTypeFilterItr->m_enabled = !fileTypeFilterItr->m_enabled;
+                                }
+                                UpdateFileTypeFilters();
+                                m_filterModel->filterUpdatedSlot();
+                            });
+                        extensionAction->setCheckable(true);
+                        extensionAction->setChecked(fileTypeFilter.m_enabled);
+                    }
+                }
+            });
+
+        m_ui->m_viewOptionButton->setMenu(m_optionsMenu);
+        m_ui->m_viewOptionButton->setIcon(QIcon(":/Icons/menu.svg"));
+        m_ui->m_viewOptionButton->setPopupMode(QToolButton::InstantPopup);
+    }
+
+    void AtomToolsAssetBrowser::InitSettingsHandler()
+    {
+        // Monitor for asset browser related settings changes
+        if (auto registry = AZ::SettingsRegistry::Get())
+        {
+            m_settingsNotifyEventHandler = registry->RegisterNotifier(
+                [this](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
+                {
+                    // Refresh the asset browser model if any of the filter related settings change.
+                    if (AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
+                            "/O3DE/AtomToolsFramework/Application/IgnoreCacheFolder", notifyEventArgs.m_jsonKeyPath) ||
+                        AZ::SettingsRegistryMergeUtils::IsPathAncestorDescendantOrEqual(
+                            "/O3DE/AtomToolsFramework/Application/IgnoredPathRegexPatterns", notifyEventArgs.m_jsonKeyPath))
+                    {
+                        m_filterModel->filterUpdatedSlot();
+                    }
+                });
+        }
+    }
+
+    void AtomToolsAssetBrowser::InitSettings()
+    {
+        // Restoring enabled state for registered file type filters.
+        const auto& fileTypeFilterStateMap =
+            GetSettingsObject("/O3DE/AtomToolsFramework/AssetBrowser/FileTypeFilterStateMap", AZStd::unordered_map<AZStd::string, bool>{});
+        for (const auto& fileTypeFilterStatePair : fileTypeFilterStateMap)
+        {
+            auto fileTypeFilterItr = AZStd::find_if(
+                m_fileTypeFilters.begin(),
+                m_fileTypeFilters.end(),
+                [fileTypeFilterStatePair](const auto& fileTypeFilter)
+                {
+                    return fileTypeFilter.m_name == fileTypeFilterStatePair.first;
+                });
+            if (fileTypeFilterItr != m_fileTypeFilters.end())
+            {
+                fileTypeFilterItr->m_enabled = fileTypeFilterStatePair.second;
+            }
+        }
+        m_showEmptyFolders = GetSettingsValue("/O3DE/AtomToolsFramework/AssetBrowser/ShowEmptyFolders", false);
+        UpdateFileTypeFilters();
+    }
+
+    void AtomToolsAssetBrowser::SaveSettings()
+    {
+        // Record the enabled state for each of the file type filters
+        AZStd::unordered_map<AZStd::string, bool> fileTypeFilterStateMap;
+        for (const auto& fileTypeFilter : m_fileTypeFilters)
+        {
+            fileTypeFilterStateMap[fileTypeFilter.m_name] = fileTypeFilter.m_enabled;
+        }
+        SetSettingsObject("/O3DE/AtomToolsFramework/AssetBrowser/FileTypeFilterStateMap", fileTypeFilterStateMap);
+        SetSettingsValue("/O3DE/AtomToolsFramework/AssetBrowser/ShowEmptyFolders", m_showEmptyFolders);
     }
 
     void AtomToolsAssetBrowser::OnSystemTick()

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -23,8 +23,21 @@ namespace MaterialCanvas
         , m_graphViewSettingsPtr(graphViewSettingsPtr)
         , m_styleManager(toolId, graphViewSettingsPtr->m_styleManagerPath)
     {
-        m_assetBrowser->SetFilterState("", AZ::RPI::StreamingImageAsset::Group, true);
-        m_assetBrowser->SetFilterState("", AZ::RPI::MaterialAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->ClearTypeFilter();
+        m_assetBrowser->GetSearchWidget()->SetTypeFilterVisible(false);
+        m_assetBrowser->SetFileTypeFilters({
+            { "Material", { "material" }, true },
+            { "Material Graph", { "materialgraph", "materialgraphtemplate" }, true },
+            { "Material Graph Node", { "materialgraphnode", "materialgraphnodetemplate" }, true },
+            { "Material Type", { "materialtype" }, true },
+            { "Material Pipeline", { "materialpipeline" }, true },
+            { "Shader", { "shader" }, true },
+            { "Shader Template", { "shader.template" }, true },
+            { "Shader Variant List", { "shadervariantlist" }, true },
+            { "Image", { "tif", "tiff", "png", "bmp", "jpg", "jpeg", "tga", "gif", "dds", "exr" }, true },
+            { "Lua", { "lua" }, true },
+            { "AZSL", { "azsl", "azsli", "srgi" }, true },
+        });
 
         m_documentInspector = new AtomToolsFramework::AtomToolsDocumentInspector(m_toolId, this);
         m_documentInspector->SetDocumentSettingsPrefix("/O3DE/Atom/MaterialCanvas/DocumentInspector");

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
@@ -18,8 +18,8 @@ namespace MaterialEditor
     MaterialEditorMainWindow::MaterialEditorMainWindow(const AZ::Crc32& toolId, QWidget* parent)
         : Base(toolId, "MaterialEditorMainWindow", parent)
     {
-        m_assetBrowser->SetFilterState("", AZ::RPI::StreamingImageAsset::Group, true);
-        m_assetBrowser->SetFilterState("", AZ::RPI::MaterialAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->SetFilterState("", AZ::RPI::StreamingImageAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->SetFilterState("", AZ::RPI::MaterialAsset::Group, true);
 
         m_documentInspector = new AtomToolsFramework::AtomToolsDocumentInspector(m_toolId, this);
         m_documentInspector->SetDocumentSettingsPrefix("/O3DE/Atom/MaterialEditor/DocumentInspector");

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
@@ -23,8 +23,8 @@ namespace PassCanvas
         , m_graphViewSettingsPtr(graphViewSettingsPtr)
         , m_styleManager(toolId, graphViewSettingsPtr->m_styleManagerPath)
     {
-        m_assetBrowser->SetFilterState("", AZ::RPI::StreamingImageAsset::Group, true);
-        m_assetBrowser->SetFilterState("", AZ::RPI::PassAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->SetFilterState("", AZ::RPI::StreamingImageAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->SetFilterState("", AZ::RPI::PassAsset::Group, true);
 
         m_documentInspector = new AtomToolsFramework::AtomToolsDocumentInspector(m_toolId, this);
         m_documentInspector->SetDocumentSettingsPrefix("/O3DE/Atom/PassCanvas/DocumentInspector");

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -33,7 +33,16 @@ namespace ShaderManagementConsole
     ShaderManagementConsoleWindow::ShaderManagementConsoleWindow(const AZ::Crc32& toolId, QWidget* parent)
         : Base(toolId, "ShaderManagementConsoleWindow",  parent)
     {
-        m_assetBrowser->SetFilterState("", AZ::RPI::ShaderAsset::Group, true);
+        m_assetBrowser->GetSearchWidget()->ClearTypeFilter();
+        m_assetBrowser->GetSearchWidget()->SetTypeFilterVisible(false);
+        m_assetBrowser->SetFileTypeFilters({
+            { "Material", { "material" }, true },
+            { "Material Type", { "materialtype" }, true },
+            { "Shader", { "shader" }, true },
+            { "Shader Template", { "shader.template" }, true },
+            { "Shader Variant List", { "shadervariantlist" }, true },
+            { "AZSL", { "azsl", "azsli", "srgi" }, true },
+        });
 
         m_documentInspector = new AtomToolsFramework::AtomToolsDocumentInspector(m_toolId, this);
         m_documentInspector->SetDocumentSettingsPrefix("/O3DE/Atom/ShaderManagementConsole/DocumentInspector");


### PR DESCRIPTION
## What does this PR do?

SMC, MC, and other tools work primarily with source files that are not directly tied to asset types. This change implements support in the atom tools asset browser for setting up extension based file filters in lieu of the asset group based filters.

## How was this PR tested?

Opened the four tools using this as a browser.
Confirmed that standard asset browser type filters were hidden and disabled.
Confirmed that all file type filters were registered and appeared in the options menu.
Confirmed that individual filters displayed files matching specified extensions.
Confirmed that disabling all filters showed an unfiltered tree of assets.
Confirmed that tools saved settings and shut down correctly.
Confirmed that material canvas files that did not appear in the asset browser previously are now available, selectable, openable.
![image](https://github.com/o3de/o3de/assets/82461473/f124e42d-4c04-4ba7-b491-867ca4f221c5)
