### PR TITLE
DPE: Fixed edge case for ShowChildrenOnly on parent container elements

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1220,6 +1220,22 @@ namespace AZ::Reflection
                             }
                         }
                     }
+
+                    // Check for edge case where the parent node has a parent container, but is set to ShowChildrenOnly
+                    // which would result in the container element missing the 'Remove' button. This replicates the parent container
+                    // info to its child node instead so that the 'Remove' button can still be shown.
+                    auto parentContainer = Find(group, DescriptorAttributes::ParentContainer, parentNode);
+                    if ((parentNode.m_computedVisibility == PropertyVisibility::ShowChildrenOnly) && parentContainer)
+                    {
+                        nodeData.m_cachedAttributes.push_back({ group, DescriptorAttributes::ParentContainer, *parentContainer });
+
+                        auto parentContainerInstance = Find(group, DescriptorAttributes::ParentContainerInstance, parentNode);
+                        if (parentContainerInstance)
+                        {
+                            nodeData.m_cachedAttributes.push_back(
+                                { group, DescriptorAttributes::ParentContainerInstance, *parentContainerInstance });
+                        }
+                    }
                 }
 
                 if (genericValueCache.ArraySize() > 0)


### PR DESCRIPTION
## What does this PR do?

Fixed #16073 

This fixes an edge-case where container elements have a visibility of `ShowChildrenOnly` so only their children are actually shown. This caused an issue where a remove button to delete that element is expected on the elements, but is missing in this case because the children of that container element didn't have the appropriate parent container info to display that button.

Here it is working now on surface tags (where previously the remove buttons on the elements were missing):
![SurfaceTags_AFTER](https://github.com/o3de/o3de/assets/7519264/17f0ae9a-c6b6-4b3d-88e4-0665667c060f)

## How was this PR tested?

Tested the components mentioned in the bug and verified the remove buttons now show up and work as expected when the DPE is enabled.