### PR TITLE
Fix segmentation fault for Project Manager on first build

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -145,8 +145,12 @@ namespace O3DE::ProjectManager
             logStream << configOutput;
             logStream.flush();
 
-            // Show last line of output
-            UpdateProgress(configOutput.split('\n', Qt::SkipEmptyParts).last());
+            // Show last line of output if any
+            auto configOutputLines = configOutput.split('\n', Qt::SkipEmptyParts);
+            if (configOutputLines.length()>0)
+            {
+                UpdateProgress(configOutputLines.last());
+            }
 
             if (QThread::currentThread()->isInterruptionRequested())
             {

--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -147,7 +147,7 @@ namespace O3DE::ProjectManager
 
             // Show last line of output if any
             auto configOutputLines = configOutput.split('\n', Qt::SkipEmptyParts);
-            if (configOutputLines.length()>0)
+            if (configOutputLines.length() > 0)
             {
                 UpdateProgress(configOutputLines.last());
             }


### PR DESCRIPTION
## What does this PR do?
When Project Manager builds a project for the first time, or if there are errors during the configure process, it will abruptly close with a segmentation fault. This address the issue by protecting against the root cause of the crash (described below)

**Root Cause**
The project manager uses `QProcress->realAllStandardOutput()` to report the last line from the stdout pipe while waiting for the process to complete. However, its possible that an error that occurs during this process is only coming through stderr, and stdout is flushed out already. This causes the following line:
```
            // Show last line of output
            UpdateProgress(configOutput.split('\n', Qt::SkipEmptyParts).last());
```
To crash with
```
 thread #22, name = 'QThread', stop reason = signal SIGABRT
  * frame #0: 0x00007ffff3496a7c libc.so.6`__GI___pthread_kill at pthread_kill.c:44:76
    frame #1: 0x00007ffff3496a30 libc.so.6`__GI___pthread_kill [inlined] __pthread_kill_internal(signo=6, threadid=140736816297536) at pthread_kill.c:78:10
    frame #2: 0x00007ffff3496a30 libc.so.6`__GI___pthread_kill(threadid=140736816297536, signo=6) at pthread_kill.c:89:10
    frame #3: 0x00007ffff3442476 libc.so.6`__GI_raise(sig=6) at raise.c:26:13
    frame #4: 0x00007ffff34287f3 libc.so.6`__GI_abort at abort.c:79:7
    frame #5: 0x00007ffff3c95999 libQt5Core.so.5`QMessageLogger::fatal(char const*, ...) const [inlined] qt_message_fatal((null)=QtFatalMsg, context=<unavailable>, message=<unavailable>) at qlogging.cpp:1914:15
    frame #6: 0x00007ffff3c95994 libQt5Core.so.5`QMessageLogger::fatal(this=<unavailable>, msg=<unavailable>) const at qlogging.cpp:893:21
    frame #7: 0x00007ffff3c94d53 libQt5Core.so.5`qt_assert(assertion=<unavailable>, file=<unavailable>, line=<unavailable>) at qglobal.cpp:3358:46
    frame #8: 0x00005555583e776b o3de`QList<QString>::last(this=0x00007fffd7f12270) at qlist.h:364:17
    frame #9: 0x00005555583af6da o3de`O3DE::ProjectManager::ProjectBuilderWorker::BuildProjectForPlatform(this=0x000055555e3d4df0) at ProjectBuilderWorker.cpp:149:73
```
According to the [Qt documentation for QList](https://doc.qt.io/qt-6/qlist.html#last-1):
```
Returns a reference to the last item in the list. This function assumes that the list isn't empty.
```

## How was this PR tested?
Followed repro steps in described in the [GHI](https://github.com/o3de/o3de/issues/16686).


Fixes https://github.com/o3de/o3de/issues/16686 
