### PR TITLE
Fixed an issue that AP only have one job running when process fbx and material files.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -158,7 +158,7 @@ namespace AZ
                         false,
                         0);
                 }
-                else if (materialTypeForamt == MaterialTypeSourceData::Format::Abstract)
+                else if (materialTypeFormat == MaterialTypeSourceData::Format::Abstract)
                 {
                     const AZStd::string intermediateMaterialTypePath =
                         MaterialUtils::PredictIntermediateMaterialTypeSourcePath(request.m_sourceFile, materialTypePath);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -132,8 +132,8 @@ namespace AZ
             // the child material. See https://github.com/o3de/o3de/issues/13766
             if (!materialTypePath.empty())
             {
-                // Load the material type data to find the exact material type format.
-                // This is required to get an accurate dependency
+                // We usually won't load file during CreateJob since we want to keep the function fast. 
+                // But here we have to load the material type data to find the exact material type format so we could create an accurate source dependency.
                 AZStd::string resolvedMaterialPath = AssetUtils::ResolvePathReference(request.m_sourceFile.c_str(), materialTypePath.c_str());
 
                 MaterialTypeSourceData::Format materialTypeForamt = MaterialTypeSourceData::Format::Invalid;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -142,7 +142,7 @@ namespace AZ
 
                 if (materialTypeSourceData.IsSuccess())
                 {
-                    materialTypeForamt = materialTypeSourceData.GetValue().GetFormat();
+                    materialTypeFormat = materialTypeSourceData.GetValue().GetFormat();
                 }
 
                 // If the material uses the "Direct" format, then there will need to be a dependency on that file.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -11,6 +11,7 @@
 #include <Material/MaterialBuilderUtils.h>
 
 #include <Atom/RPI.Edit/Material/MaterialUtils.h>
+#include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Edit/Common/JsonUtils.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AssetBuilderSDK/SerializationDependencies.h>
@@ -133,9 +134,11 @@ namespace AZ
             {
                 // Load the material type data to find the exact material type format.
                 // This is required to get an accurate dependency
+                AZStd::string resolvedMaterialPath = AssetUtils::ResolvePathReference(request.m_sourceFile.c_str(), materialTypePath.c_str());
+
                 MaterialTypeSourceData::Format materialTypeForamt = MaterialTypeSourceData::Format::Invalid;
                 MaterialUtils::ImportedJsonFiles importedJsonFiles;
-                auto materialTypeSourceData = MaterialUtils::LoadMaterialTypeSourceData(materialTypePath, nullptr, &importedJsonFiles);
+                auto materialTypeSourceData = MaterialUtils::LoadMaterialTypeSourceData(resolvedMaterialPath, nullptr, &importedJsonFiles);
 
                 if (materialTypeSourceData.IsSuccess())
                 {
@@ -148,7 +151,7 @@ namespace AZ
                 {
                     MaterialBuilderUtils::AddPossibleDependencies(
                         request.m_sourceFile,
-                        materialTypePath,
+                        resolvedMaterialPath,
                         MaterialTypeBuilder::FinalStageJobKey,
                         outputJobDescriptor.m_jobDependencyList,
                         response.m_sourceFileDependencyList,

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -147,7 +147,7 @@ namespace AZ
 
                 // If the material uses the "Direct" format, then there will need to be a dependency on that file.
                 // If it uses the "Abstract" format, then there will be an intermediate .materialtype and there needs to be a dependency on that file instead.
-                if (materialTypeForamt == MaterialTypeSourceData::Format::Direct)
+                if (materialTypeFormat == MaterialTypeSourceData::Format::Direct)
                 {
                     MaterialBuilderUtils::AddPossibleDependencies(
                         request.m_sourceFile,

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -136,7 +136,7 @@ namespace AZ
                 // But here we have to load the material type data to find the exact material type format so we could create an accurate source dependency.
                 AZStd::string resolvedMaterialPath = AssetUtils::ResolvePathReference(request.m_sourceFile.c_str(), materialTypePath.c_str());
 
-                MaterialTypeSourceData::Format materialTypeForamt = MaterialTypeSourceData::Format::Invalid;
+                MaterialTypeSourceData::Format materialTypeFormat = MaterialTypeSourceData::Format::Invalid;
                 MaterialUtils::ImportedJsonFiles importedJsonFiles;
                 auto materialTypeSourceData = MaterialUtils::LoadMaterialTypeSourceData(resolvedMaterialPath, nullptr, &importedJsonFiles);
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
@@ -59,6 +59,9 @@ namespace AZ::RPI::MaterialBuilderUtils
                     }
 
                     jobDependencies.push_back(jobDependency);
+
+                    // If the file was found, there is no need to add other possible path for the same dependency file.
+                    return;
                 }
                 else
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -2465,7 +2465,7 @@ namespace AZ
             constexpr AZ::u32 ResourcePoolDefaultSubId = 0;
 
             AssetBuilderSDK::JobDependency jobDependency;
-            jobDependency.m_jobKey = "Model Asset Builder (Default Vertex Buffer Pool)";
+            jobDependency.m_jobKey = "Atom Resource Pool";
             jobDependency.m_sourceFile = defaultVertexBufferPoolSource;
             jobDependency.m_platformIdentifier = platformIdentifier;
             jobDependency.m_productSubIds.push_back(ResourcePoolDefaultSubId);


### PR DESCRIPTION
## What does this PR do?
This PR fixes the issue that AP won't process fbx and material assets in parallel. This issue is related to this change https://github.com/o3de/o3de/pull/14862
The reason the issue happened because the change made from that PR 
1. If all the pending jobs left have missing source job dependencies.
2. The AP would only bring one job from the pending jobs to process. 
3. If there is one job in process, the other pending jobs would wait. 
Since the PR was used to address an intermediate asset issue, we can't revert it unless we have other solution for that issue.

The fix we have in this PR to address the problem is to have accurate source dependencies for both fbx and material files so they won't go down that route. 

For fbx file, the missing source dependency was caused by wrong job key for resource pool asset. 
For material file, the missing source dependencies have two causes
1. Inaccurate job key for abstract materialtype file
2. redundant image dependencies.  

## How was this PR tested?
Tested with AutomatedTesting project, clear cache then run AP for the project. The AP has more than one jobs when processing fbx files or materials files. Tested on both windows and linux.
