### PR TITLE
Added transparent flag to visible geometry structure. Auto detecting and setting it in mesh component.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
@@ -20,9 +20,10 @@ namespace AzFramework
         {
             serializeContext->Class<VisibleGeometry>()
                 ->Version(0)
+                ->Field("transform", &VisibleGeometry::m_transform)
                 ->Field("vertices", &VisibleGeometry::m_vertices)
                 ->Field("indices", &VisibleGeometry::m_indices)
-                ;
+                ->Field("transparent", &VisibleGeometry::m_transparent);
 
             serializeContext->Class<VisibleGeometryContainer>()
                 ;
@@ -36,8 +37,10 @@ namespace AzFramework
                 ->Attribute(AZ::Script::Attributes::Module, "visibility")
                 ->Constructor()
                 ->Constructor<const VisibleGeometry&>()
+                ->Property("transform", BehaviorValueProperty(&VisibleGeometry::m_transform))
                 ->Property("vertices", BehaviorValueProperty(&VisibleGeometry::m_vertices))
                 ->Property("indices", BehaviorValueProperty(&VisibleGeometry::m_indices))
+                ->Property("transparent", BehaviorValueProperty(&VisibleGeometry::m_transparent))
                 ;
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
@@ -38,6 +38,9 @@ namespace AzFramework
 
         //! Index list must contain 3 uint32_t per triangle face. Each index references a position in the vertex list.
         AZStd::vector<uint32_t> m_indices;
+
+        //! Flag signifying if the geometry has transparent elements.
+        bool m_transparent = false;
     };
 
     using VisibleGeometryContainer = AZStd::vector<VisibleGeometry>;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -140,6 +140,9 @@ namespace AZ
             // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
             void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
+            bool DoesMaterialUseDrawListTag(
+                const AZ::Data::Instance<AZ::RPI::Material> material, const AZ::RHI::DrawListTag searchDrawListTag) const;
+
             // IntersectionRequestBus overrides ...
             AzFramework::RenderGeometry::RayResult RenderGeometryIntersect(const AzFramework::RenderGeometry::RayRequest& ray) const override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -140,6 +140,8 @@ namespace AZ
             // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
             void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
+            // Searches all shader items referenced by the material for one with a matching draw list tag.
+            // Returns true if a matching tag was found. Otherwise, false.
             bool DoesMaterialUseDrawListTag(
                 const AZ::Data::Instance<AZ::RPI::Material> material, const AZ::RHI::DrawListTag searchDrawListTag) const;
 


### PR DESCRIPTION
## What does this PR do?

Added a transparent flag to the visible geometry structure.
Updated mesh component controller to automatically detect and set the transparent flag on visible geometry based on materials.

## How was this PR tested?

Compiled project and loaded existing levels. None of this code is used actively in the development branch yet. 
Verified behavior in other projects using the visible geometry bus and structure.