### PR TITLE
Introduce multi-device TransientAttachmentPool

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
@@ -44,9 +44,6 @@ namespace AZ::RHI
         MultiDeviceTransientAttachmentPool() = default;
         virtual ~MultiDeviceTransientAttachmentPool() = default;
 
-        //! Returns true if a Transient Attachment Pool is needed according to the supplied descriptor.
-        static bool NeedsTransientAttachmentPool(const TransientAttachmentPoolDescriptor& descriptor);
-
         //! Called to initialize the pool.
         ResultCode Init(MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor);
 
@@ -97,12 +94,9 @@ namespace AZ::RHI
         TransientAttachmentPoolCompileFlags GetCompileFlags() const;
 
     private:
-        bool ValidateInitParameters(const TransientAttachmentPoolDescriptor& descriptor) const;
-
         //! Remove the entry related to the provided attachmentId from the cache as it is probably stale now
         void RemoveFromCache(RHI::AttachmentId attachmentId);
 
-        Scope* m_currentScope = nullptr;
         TransientAttachmentPoolDescriptor m_descriptor;
         TransientAttachmentPoolCompileFlags m_compileFlags = TransientAttachmentPoolCompileFlags::None;
 
@@ -112,8 +106,5 @@ namespace AZ::RHI
         //! This map is used to reverse look up resource hash so we can clear them out of m_cache
         //! once they have been replaced with a new resource at a different place in the heap.
         AZStd::unordered_map<AttachmentId, HashValue64> m_reverseLookupHash;
-
-        //! A map of all device-specific TransientAttachmentPools, indexed by the device index
-        AZStd::unordered_map<int, Ptr<TransientAttachmentPool>> m_deviceTransientAttachmentPools;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/AliasedHeapEnums.h>
+#include <Atom/RHI.Reflect/TransientAttachmentStatistics.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceResourcePool.h>
+#include <Atom/RHI/ObjectCache.h>
+#include <Atom/RHI/Scope.h>
+#include <Atom/RHI/TransientAttachmentPool.h>
+
+#include <AzCore/std/optional.h>
+
+namespace AZ::RHI
+{
+    class BufferAttachment;
+    class ImageAttachment;
+    class Scope;
+    class SwapChainAttachment;
+    struct TransientImageDescriptor;
+    struct TransientBufferDescriptor;
+
+    //! The transient attachment pool interface is used by the frame scheduler to compile the
+    //! working set of transient attachments for the frame. Each scope is iterated topologically
+    //! and transient resources are allocated and de-allocated. This is all done from within the
+    //! compile phase. Therefore, an allocation may create a resource, but a de-allocation does not
+    //! destroy resources! All de-allocation does is inform the pool that a resource can
+    //! be re-used within a subsequent scope. The final result of this process is a set of
+    //! image / buffer attachments that are backed by guaranteed memory valid *only* for the scope in
+    //! which they attached.
+    class MultiDeviceTransientAttachmentPool : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceTransientAttachmentPool, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceTransientAttachmentPool, "{7CCD1108-B233-4D37-8A80-65CBB1988B22}");
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(TransientAttachmentPool);
+        MultiDeviceTransientAttachmentPool() = default;
+        virtual ~MultiDeviceTransientAttachmentPool() = default;
+
+        //! Returns true if a Transient Attachment Pool is needed according to the supplied descriptor.
+        static bool NeedsTransientAttachmentPool(const TransientAttachmentPoolDescriptor& descriptor);
+
+        //! Called to initialize the pool.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor);
+
+        //! Called to shutdown the pool.
+        void Shutdown();
+
+        //! This is called at the beginning of the compile phase for the current frame,
+        //! before any allocations occur. The user should clear the backing allocator to
+        //! a fresh state.
+        void Begin(
+            const TransientAttachmentPoolCompileFlags flags = TransientAttachmentPoolCompileFlags::None,
+            const TransientAttachmentStatistics::MemoryUsage* memoryHint = nullptr);
+
+        //! Called when a new scope is being allocated. Scopes are allocated in submission order.
+        void BeginScope(Scope& scopeBase);
+
+        //! Called when an image is being activated for the first time. This class should acquire
+        //! an image from the pool, configured for the provided descriptor. This may involve aliasing
+        //! from a heap, or simple object pooling. Images are held in an internal cache.
+        virtual MultiDeviceImage* ActivateImage(const TransientImageDescriptor& descriptor);
+
+        //! Called when an buffer is being activated for the first time. This class should acquire
+        //! an buffer from the pool, configured for the provided descriptor. This may involve aliasing
+        //! from a heap, or simple object pooling. Buffers are held in an internal cache.
+        virtual MultiDeviceBuffer* ActivateBuffer(const TransientBufferDescriptor& descriptor);
+
+        //! Called when a buffer is being de-allocated from the pool. Called during the last scope the attachment
+        //! is used, after all allocations for that scope have been processed. It will also be removed from the cache.
+        virtual void DeactivateBuffer(const AttachmentId& attachmentId);
+
+        //! Called when a image is being de-allocated from the pool. Called during the last scope the attachment
+        //! is used, after all allocations for that scope have been processed. It will also be removed from the cache.
+        virtual void DeactivateImage(const AttachmentId& attachmentId);
+
+        //! Called when all allocations for the current scope have completed.
+        void EndScope();
+
+        //! Called when the allocations / deallocations have completed for all scopes.
+        void End();
+
+        //! Get statistics for the pool (built during End).
+        AZStd::unordered_map<int, TransientAttachmentStatistics> GetStatistics() const;
+
+        //! Get pool descriptor
+        const TransientAttachmentPoolDescriptor& GetDescriptor() const;
+
+        //! Get the compile flags being used during the allocation of resources.
+        TransientAttachmentPoolCompileFlags GetCompileFlags() const;
+
+    private:
+        bool ValidateInitParameters(const TransientAttachmentPoolDescriptor& descriptor) const;
+
+        //! Remove the entry related to the provided attachmentId from the cache as it is probably stale now
+        void RemoveFromCache(RHI::AttachmentId attachmentId);
+
+        Scope* m_currentScope = nullptr;
+        TransientAttachmentPoolDescriptor m_descriptor;
+        TransientAttachmentPoolCompileFlags m_compileFlags = TransientAttachmentPoolCompileFlags::None;
+
+        //! MultiDeviceImage/Buffers added as attachments to scopes are tracked in an internal cache
+        ObjectCache<MultiDeviceResource> m_cache;
+
+        //! This map is used to reverse look up resource hash so we can clear them out of m_cache
+        //! once they have been replaced with a new resource at a different place in the heap.
+        AZStd::unordered_map<AttachmentId, HashValue64> m_reverseLookupHash;
+
+        //! A map of all device-specific TransientAttachmentPools, indexed by the device index
+        AZStd::unordered_map<int, Ptr<TransientAttachmentPool>> m_deviceTransientAttachmentPools;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
@@ -119,6 +119,8 @@ namespace AZ::RHI
         //! Get the compile flags being used during the allocation of resources.
         TransientAttachmentPoolCompileFlags GetCompileFlags() const;
 
+        static bool ValidateInitParameters(const TransientAttachmentPoolDescriptor& descriptor);
+
     protected:
         // Adds the stats of a list of heaps into the Pool's TransientAttachmentStatistics.
         void CollectHeapStats(AliasedResourceTypeFlags typeMask, AZStd::span<const TransientAttachmentStatistics::Heap> heapStats);
@@ -140,8 +142,6 @@ namespace AZ::RHI
         virtual void ShutdownInternal() = 0;
 
         //////////////////////////////////////////////////////////////////////////
-
-        bool ValidateInitParameters(const TransientAttachmentPoolDescriptor& descriptor) const;
 
         TransientAttachmentPoolDescriptor m_descriptor;
         TransientAttachmentPoolCompileFlags m_compileFlags = TransientAttachmentPoolCompileFlags::None;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -68,7 +68,7 @@ namespace AZ::RHI
         if (IsInitialized())
         {
             IterateObjects<TransientAttachmentPool>(
-                [](auto deviceIndex, auto deviceTransientAttachmentPool)
+                [](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
                 {
                     deviceTransientAttachmentPool->Shutdown();
                 });
@@ -83,7 +83,7 @@ namespace AZ::RHI
         m_compileFlags = compileFlags;
 
         IterateObjects<TransientAttachmentPool>(
-            [&compileFlags, &memoryHint](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [&compileFlags, &memoryHint](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->Begin(compileFlags, memoryHint);
             });
@@ -93,7 +93,7 @@ namespace AZ::RHI
     {
         // TODO: Only call for the correct device as given by the scopeBase
         IterateObjects<TransientAttachmentPool>(
-            [&scopeBase](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [&scopeBase](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->BeginScope(scopeBase);
             });
@@ -103,7 +103,7 @@ namespace AZ::RHI
     {
         // TODO: Only call for the correct device as given by the scopeBase
         IterateObjects<TransientAttachmentPool>(
-            [](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->EndScope();
             });
@@ -112,7 +112,7 @@ namespace AZ::RHI
     void MultiDeviceTransientAttachmentPool::End()
     {
         IterateObjects<TransientAttachmentPool>(
-            [](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->End();
             });
@@ -211,7 +211,7 @@ namespace AZ::RHI
         RemoveFromCache(attachmentId);
 
         IterateObjects<TransientAttachmentPool>(
-            [&attachmentId](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [&attachmentId](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->DeactivateBuffer(attachmentId);
             });
@@ -222,7 +222,7 @@ namespace AZ::RHI
         RemoveFromCache(attachmentId);
 
         IterateObjects<TransientAttachmentPool>(
-            [&attachmentId](auto deviceIndex, auto deviceTransientAttachmentPool)
+            [&attachmentId](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
                 deviceTransientAttachmentPool->DeactivateImage(attachmentId);
             });

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/AliasedAttachmentAllocator.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceTransientAttachmentPool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    bool MultiDeviceTransientAttachmentPool::NeedsTransientAttachmentPool(const TransientAttachmentPoolDescriptor& descriptor)
+    {
+        switch (descriptor.m_heapParameters.m_type)
+        {
+        case HeapAllocationStrategy::Fixed:
+            {
+                // Fixed strategy must declare a budget for at least one type of resource in order to use a transient attachment pool.
+                return descriptor.m_bufferBudgetInBytes != 0 || descriptor.m_imageBudgetInBytes != 0 ||
+                    descriptor.m_renderTargetBudgetInBytes != 0;
+            }
+        // Paging and Memory Hint strategy can work with a 0 budget.
+        case HeapAllocationStrategy::Paging:
+        case HeapAllocationStrategy::MemoryHint:
+            return true;
+        default:
+            AZ_Assert(false, "Invalid heap allocation type %d", descriptor.m_heapParameters.m_type);
+            return false;
+        }
+    }
+
+    ResultCode MultiDeviceTransientAttachmentPool::Init(
+        MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor)
+    {
+        if (Validation::IsEnabled())
+        {
+            if (IsInitialized())
+            {
+                AZ_Error("MultiDeviceTransientAttachmentPool", false, "MultiDeviceTransientAttachmentPool is already initialized!");
+                return ResultCode::InvalidOperation;
+            }
+        }
+
+        if (!ValidateInitParameters(descriptor))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        m_descriptor = descriptor;
+
+        MultiDeviceObject::Init(deviceMask);
+
+        ResultCode resultCode = ResultCode::Success;
+
+        IterateDevices(
+            [this, &descriptor, &resultCode](int deviceIndex)
+            {
+                auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                m_deviceTransientAttachmentPools[deviceIndex] = Factory::Get().CreateTransientAttachmentPool();
+
+                TransientAttachmentPoolDescriptor deviceDescriptor;
+                deviceDescriptor.m_bufferBudgetInBytes = descriptor.m_bufferBudgetInBytes;
+                deviceDescriptor.m_heapParameters = descriptor.m_heapParameters;
+                deviceDescriptor.m_imageBudgetInBytes = descriptor.m_imageBudgetInBytes;
+                deviceDescriptor.m_renderTargetBudgetInBytes = descriptor.m_renderTargetBudgetInBytes;
+
+                resultCode = m_deviceTransientAttachmentPools[deviceIndex]->Init(*device, deviceDescriptor);
+
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific TransientAttachmentPools and set deviceMask to 0
+            m_deviceTransientAttachmentPools.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    void MultiDeviceTransientAttachmentPool::Shutdown()
+    {
+        if (IsInitialized())
+        {
+            for (const auto& [deviceIndex, pool] : m_deviceTransientAttachmentPools)
+            {
+                pool->Shutdown();
+            }
+            m_deviceTransientAttachmentPools.clear();
+            MultiDeviceObject::Shutdown();
+        }
+    }
+
+    void MultiDeviceTransientAttachmentPool::Begin(
+        const TransientAttachmentPoolCompileFlags compileFlags, const TransientAttachmentStatistics::MemoryUsage* memoryHint)
+    {
+        m_compileFlags = compileFlags;
+
+        m_currentScope = nullptr;
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->Begin(compileFlags, memoryHint);
+        }
+    }
+
+    void MultiDeviceTransientAttachmentPool::BeginScope(Scope& scopeBase)
+    {
+        m_currentScope = static_cast<Scope*>(&scopeBase);
+
+        // TODO: Only call for the correct device as given by the scopeBase
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->BeginScope(scopeBase);
+        }
+
+        TransientAttachmentStatistics::Scope scope;
+        scope.m_scopeId = scopeBase.GetId();
+        scope.m_hardwareQueueClass = scopeBase.GetHardwareQueueClass();
+    }
+
+    void MultiDeviceTransientAttachmentPool::EndScope()
+    {
+        m_currentScope = nullptr;
+        // TODO: Only call for the correct device as given by the scopeBase
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->EndScope();
+        }
+    }
+
+    void MultiDeviceTransientAttachmentPool::End()
+    {
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->End();
+        }
+    }
+
+    MultiDeviceImage* MultiDeviceTransientAttachmentPool::ActivateImage(const TransientImageDescriptor& descriptor)
+    {
+        MultiDeviceImage* image{};
+
+        HashValue64 hash = descriptor.GetHash();
+
+        // Check the cache for the image.
+        if (auto attachment = m_cache.Find(static_cast<uint64_t>(hash)))
+        {
+            image = static_cast<MultiDeviceImage*>(attachment);
+        }
+        // image is not in cache. Create a new one at the placed address, and add it to the cache.
+        else
+        {
+            // Remove any existing resource entries from the cache before adding a new one
+            RemoveFromCache(descriptor.m_attachmentId);
+
+            // Ownership is managed by the cache.
+            RHI::Ptr<MultiDeviceImage> imagePtr = aznew MultiDeviceImage();
+            image = imagePtr.get();
+
+            imagePtr->Init(GetDeviceMask());
+
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                imagePtr->m_deviceObjects[deviceIndex] = deviceTransientAttachmentPool->ActivateImage(descriptor);
+                if (imagePtr->GetDeviceImage(deviceIndex))
+                {
+                    imagePtr->SetDescriptor(imagePtr->GetDeviceImage(deviceIndex)->GetDescriptor());
+                }
+            }
+
+            imagePtr->SetName(descriptor.m_attachmentId);
+            m_cache.Insert(static_cast<uint64_t>(hash), AZStd::move(imagePtr));
+            if (!descriptor.m_attachmentId.IsEmpty())
+            {
+                m_reverseLookupHash.emplace(descriptor.m_attachmentId, hash);
+            }
+        }
+
+        return image;
+    }
+
+    MultiDeviceBuffer* MultiDeviceTransientAttachmentPool::ActivateBuffer(const TransientBufferDescriptor& descriptor)
+    {
+        MultiDeviceBuffer* buffer = nullptr;
+
+        HashValue64 hash = descriptor.GetHash();
+
+        // Check the cache for the buffer.
+        if (auto attachment = m_cache.Find(static_cast<uint64_t>(hash)))
+        {
+            buffer = static_cast<MultiDeviceBuffer*>(attachment);
+        }
+        // buffer is not in cache. Create a new one at the placed address, and add it to the cache.
+        else
+        {
+            // Remove any existing resource entries from the cache before adding a new one
+            RemoveFromCache(descriptor.m_attachmentId);
+
+            // Ownership is managed by the cache.
+            RHI::Ptr<MultiDeviceBuffer> bufferPtr = aznew MultiDeviceBuffer();
+            buffer = bufferPtr.get();
+
+            bufferPtr->Init(GetDeviceMask());
+
+            for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+            {
+                bufferPtr->m_deviceObjects[deviceIndex] = deviceTransientAttachmentPool->ActivateBuffer(descriptor);
+                if (bufferPtr->GetDeviceBuffer(deviceIndex))
+                {
+                    bufferPtr->SetDescriptor(bufferPtr->GetDeviceBuffer(deviceIndex)->GetDescriptor());
+                }
+            }
+
+            bufferPtr->SetName(descriptor.m_attachmentId);
+            m_cache.Insert(static_cast<uint64_t>(hash), AZStd::move(bufferPtr));
+            if (!descriptor.m_attachmentId.IsEmpty())
+            {
+                m_reverseLookupHash.emplace(descriptor.m_attachmentId, hash);
+            }
+        }
+
+        return buffer;
+    }
+
+    void MultiDeviceTransientAttachmentPool::DeactivateBuffer(const AttachmentId& attachmentId)
+    {
+        RemoveFromCache(attachmentId);
+
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->DeactivateBuffer(attachmentId);
+        }
+    }
+
+    void MultiDeviceTransientAttachmentPool::DeactivateImage(const AttachmentId& attachmentId)
+    {
+        RemoveFromCache(attachmentId);
+
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            deviceTransientAttachmentPool->DeactivateImage(attachmentId);
+        }
+    }
+
+    AZStd::unordered_map<int, TransientAttachmentStatistics> MultiDeviceTransientAttachmentPool::GetStatistics() const
+    {
+        AZStd::unordered_map<int, TransientAttachmentStatistics> statistics;
+        for (auto& [deviceIndex, deviceTransientAttachmentPool] : m_deviceTransientAttachmentPools)
+        {
+            statistics.insert({ deviceIndex, deviceTransientAttachmentPool->GetStatistics() });
+        }
+        return statistics;
+    }
+
+    const TransientAttachmentPoolDescriptor& MultiDeviceTransientAttachmentPool::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    TransientAttachmentPoolCompileFlags MultiDeviceTransientAttachmentPool::GetCompileFlags() const
+    {
+        return m_compileFlags;
+    }
+
+    bool MultiDeviceTransientAttachmentPool::ValidateInitParameters(
+        [[maybe_unused]] const TransientAttachmentPoolDescriptor& descriptor) const
+    {
+#if defined(AZ_RHI_ENABLE_VALIDATION)
+        switch (descriptor.m_heapParameters.m_type)
+        {
+        case HeapAllocationStrategy::Fixed:
+            {
+                if (descriptor.m_bufferBudgetInBytes == 0 && descriptor.m_imageBudgetInBytes == 0 &&
+                    descriptor.m_renderTargetBudgetInBytes == 0)
+                {
+                    AZ_Assert(false, "Invalid budget for transient attachment pool when using a Fixed allocation strategy");
+                    return false;
+                }
+                break;
+            }
+        case HeapAllocationStrategy::Paging:
+            {
+                const auto& pagingParameters = descriptor.m_heapParameters.m_pagingParameters;
+                if (pagingParameters.m_pageSizeInBytes == 0)
+                {
+                    AZ_Assert(false, "Invalid page size %d when using a Paging allocation strategy", pagingParameters.m_pageSizeInBytes);
+                    return false;
+                }
+
+                if (descriptor.m_bufferBudgetInBytes && pagingParameters.m_pageSizeInBytes > descriptor.m_bufferBudgetInBytes)
+                {
+                    AZ_Assert(
+                        false,
+                        "Page size %d is bigger than budget for buffers %d",
+                        pagingParameters.m_pageSizeInBytes,
+                        descriptor.m_bufferBudgetInBytes);
+                    return false;
+                }
+
+                if (descriptor.m_imageBudgetInBytes && pagingParameters.m_pageSizeInBytes > descriptor.m_imageBudgetInBytes)
+                {
+                    AZ_Assert(
+                        false,
+                        "Page size %d is bigger than budget for images %d",
+                        pagingParameters.m_pageSizeInBytes,
+                        descriptor.m_imageBudgetInBytes);
+                    return false;
+                }
+
+                if (descriptor.m_renderTargetBudgetInBytes && pagingParameters.m_pageSizeInBytes > descriptor.m_renderTargetBudgetInBytes)
+                {
+                    AZ_Assert(
+                        false,
+                        "Page size %d is bigger than budget for rendertargets %d",
+                        pagingParameters.m_pageSizeInBytes,
+                        descriptor.m_renderTargetBudgetInBytes);
+                    return false;
+                }
+
+                if (pagingParameters.m_initialAllocationPercentage && descriptor.m_bufferBudgetInBytes == 0 &&
+                    descriptor.m_imageBudgetInBytes == 0 && descriptor.m_renderTargetBudgetInBytes == 0)
+                {
+                    AZ_Assert(
+                        false,
+                        "Invalid initial allocation percentage (%lf) when using a Paging allocation strategy",
+                        pagingParameters.m_initialAllocationPercentage);
+                    return false;
+                }
+                break;
+            }
+        case HeapAllocationStrategy::MemoryHint:
+            {
+                const auto& memoryHintParameters = descriptor.m_heapParameters.m_usageHintParameters;
+                if (memoryHintParameters.m_heapSizeScaleFactor < 1.0f)
+                {
+                    AZ_Assert(
+                        false,
+                        "Invalid heap size scale factor (%lf) when using a MemoryHint allocation strategy",
+                        memoryHintParameters.m_heapSizeScaleFactor);
+                    return false;
+                }
+
+                if (memoryHintParameters.m_maxHeapWastedPercentage < 0.f || memoryHintParameters.m_maxHeapWastedPercentage > 1.f)
+                {
+                    AZ_Assert(
+                        false,
+                        "Invalid max heap wasted percentage (%lf) when using a MemoryHint allocation strategy",
+                        memoryHintParameters.m_maxHeapWastedPercentage);
+                    return false;
+                }
+
+                if ((memoryHintParameters.m_heapSizeScaleFactor - 1.0f) >= memoryHintParameters.m_maxHeapWastedPercentage)
+                {
+                    AZ_Assert(
+                        false,
+                        "Heap scale factor (%lf) is bugger than max wasted percentage (%lf) when using a MemoryHint allocation "
+                        "strategy",
+                        memoryHintParameters.m_heapSizeScaleFactor,
+                        memoryHintParameters.m_maxHeapWastedPercentage);
+                    return false;
+                }
+                break;
+            }
+        default:
+            AZ_Assert(false, "Invalid heap allocation strategy %d", descriptor.m_heapParameters.m_type);
+            return false;
+        }
+#endif
+        return true;
+    }
+
+    void MultiDeviceTransientAttachmentPool::RemoveFromCache(AttachmentId attachmentId)
+    {
+        auto it = m_reverseLookupHash.find(attachmentId);
+        if (it != m_reverseLookupHash.end())
+        {
+            HashValue64 originalHash = it->second;
+            m_cache.EraseItem(aznumeric_cast<uint64_t>(originalHash));
+            m_reverseLookupHash.erase(it);
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -74,6 +74,8 @@ namespace AZ::RHI
                 });
             m_deviceObjects.clear();
             MultiDeviceObject::Shutdown();
+            m_cache.Clear();
+            m_reverseLookupHash.clear();
         }
     }
 
@@ -208,8 +210,6 @@ namespace AZ::RHI
 
     void MultiDeviceTransientAttachmentPool::DeactivateBuffer(const AttachmentId& attachmentId)
     {
-        RemoveFromCache(attachmentId);
-
         IterateObjects<TransientAttachmentPool>(
             [&attachmentId](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {
@@ -219,8 +219,6 @@ namespace AZ::RHI
 
     void MultiDeviceTransientAttachmentPool::DeactivateImage(const AttachmentId& attachmentId)
     {
-        RemoveFromCache(attachmentId);
-
         IterateObjects<TransientAttachmentPool>(
             [&attachmentId](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
             {

--- a/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -136,7 +136,7 @@ namespace AZ::RHI
         }
     }
 
-    bool TransientAttachmentPool::ValidateInitParameters([[maybe_unused]] const TransientAttachmentPoolDescriptor& descriptor) const
+    bool TransientAttachmentPool::ValidateInitParameters([[maybe_unused]] const TransientAttachmentPoolDescriptor& descriptor)
     {
 #if defined (AZ_RHI_ENABLE_VALIDATION)
         switch (descriptor.m_heapParameters.m_type)

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -221,7 +221,9 @@ set(FILES
     Include/Atom/RHI/TileAllocator.h
     Include/Atom/RHI/TileAllocator.inl
     Include/Atom/RHI/TransientAttachmentPool.h
+    Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
     Source/RHI/TransientAttachmentPool.cpp
+    Source/RHI/MultiDeviceTransientAttachmentPool.cpp
     Include/Atom/RHI/RHIUtils.h
     Source/RHI/RHIUtils.cpp
     Include/Atom/RHI/RayTracingAccelerationStructure.h


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces `TransientAttachmentPool`.

It is important to note that this PR only introduces this resource class but does not call it currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduced into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources|[#16262](https://github.com/o3de/o3de/pull/16262)|merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)| merged |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591)| merged |
|Indirect*|[#16681](https://github.com/o3de/o3de/pull/16681)|open|
| SRGs|[#16680](https://github.com/o3de/o3de/pull/16680) | open |
| TransientAttachmentPool | this PR | open |
| Items | | |
|RayTracing Resources|||

