### PR TITLE
Fix missing support for multi-collider articulation links

### DIFF
--- a/Gems/PhysX/Code/Source/Articulation.cpp
+++ b/Gems/PhysX/Code/Source/Articulation.cpp
@@ -23,9 +23,9 @@ namespace PhysX
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ArticulationLinkData>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("LinkConfiguration", &ArticulationLinkData::m_articulationLinkConfiguration)
-                ->Field("ShapeColliderPair", &ArticulationLinkData::m_shapeColliderConfiguration)
+                ->Field("ShapeColliderPairList", &ArticulationLinkData::m_shapeColliderConfigurationList)
                 ->Field("LocalTransform", &ArticulationLinkData::m_localTransform)
                 ->Field("JointLeadLocalFrame", &ArticulationLinkData::m_jointLeadLocalFrame)
                 ->Field("JointFollowerLocalFrame", &ArticulationLinkData::m_jointFollowerLocalFrame)
@@ -62,50 +62,44 @@ namespace PhysX
 
     void ArticulationLink::AddCollisionShape(const ArticulationLinkData& thisLinkData)
     {
-        const Physics::ColliderConfiguration* colliderConfiguration = thisLinkData.m_shapeColliderConfiguration.first.get();
-        const Physics::ShapeConfiguration* shapeConfiguration = thisLinkData.m_shapeColliderConfiguration.second.get();
-
-        if (shapeConfiguration && colliderConfiguration)
+        m_physicsShapes.clear();
+        for (auto &[colliderConfiguration, shapeConfiguration]: thisLinkData.m_shapeColliderConfigurationList)
         {
-            if (shapeConfiguration->GetShapeType() == Physics::ShapeType::PhysicsAsset)
+            if (shapeConfiguration && colliderConfiguration)
             {
-                const auto* physicsAssetShapeConfiguration =
-                    static_cast<const Physics::PhysicsAssetShapeConfiguration*>(shapeConfiguration);
-                if (!physicsAssetShapeConfiguration->m_asset.IsReady())
+                if (shapeConfiguration->GetShapeType() == Physics::ShapeType::PhysicsAsset)
                 {
-                    const_cast<Physics::PhysicsAssetShapeConfiguration*>(physicsAssetShapeConfiguration)->m_asset.BlockUntilLoadComplete();
+                    const auto* physicsAssetShapeConfiguration =
+                        static_cast<const Physics::PhysicsAssetShapeConfiguration*>(shapeConfiguration.get());
+                    if (!physicsAssetShapeConfiguration->m_asset.IsReady())
+                    {
+                        const_cast<Physics::PhysicsAssetShapeConfiguration*>(physicsAssetShapeConfiguration)->m_asset.BlockUntilLoadComplete();
+                    }
+
+                    const bool hasNonUniformScale = !Physics::Utils::HasUniformScale(physicsAssetShapeConfiguration->m_assetScale) ||
+                        (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
+                    AZStd::vector<AZStd::shared_ptr<Physics::Shape>> assetShapes;
+                    Utils::CreateShapesFromAsset(
+                        *physicsAssetShapeConfiguration,
+                        *colliderConfiguration,
+                        hasNonUniformScale,
+                        physicsAssetShapeConfiguration->m_subdivisionLevel,
+                        assetShapes);
+                    AZStd::copy(assetShapes.begin(), assetShapes.end(), AZStd::back_inserter(m_physicsShapes));
                 }
-
-                const bool hasNonUniformScale = !Physics::Utils::HasUniformScale(physicsAssetShapeConfiguration->m_assetScale) ||
-                    (AZ::NonUniformScaleRequestBus::FindFirstHandler(GetEntityId()) != nullptr);
-                AZStd::vector<AZStd::shared_ptr<Physics::Shape>> assetShapes;
-                Utils::CreateShapesFromAsset(
-                    *physicsAssetShapeConfiguration,
-                    *colliderConfiguration,
-                    hasNonUniformScale,
-                    physicsAssetShapeConfiguration->m_subdivisionLevel,
-                    assetShapes);
-
-                if (!assetShapes.empty())
+                else
                 {
-                    m_physicsShape = assetShapes[0];
-                    AZ_Warning(
-                        "PhysX",
-                        assetShapes.size() == 1,
-                        "Articulation %s has a link with physics mesh with more than 1 shape",
-                        m_pxLink->getName());
+                    m_physicsShapes.push_back(AZ::Interface<Physics::System>::Get()->CreateShape(*colliderConfiguration, *shapeConfiguration));
                 }
-            }
-            else
-            {
-                m_physicsShape =
-                    AZ::Interface<Physics::System>::Get()->CreateShape(*colliderConfiguration, *shapeConfiguration);
             }
         }
-
-        if (m_physicsShape)
+        AZ_Printf("PhysX", "ArticulationLink::AddCollisionShape: %zu shapes added to link %s\n", m_physicsShapes.size(), m_pxLink->getName());
+        for (const auto& shapePtr : m_physicsShapes)
         {
-            m_pxLink->attachShape(*static_cast<physx::PxShape*>(m_physicsShape->GetNativePointer()));
+            if (shapePtr && shapePtr->GetNativePointer())
+            {
+                m_pxLink->attachShape(*static_cast<physx::PxShape*>(shapePtr->GetNativePointer()));
+            }
         }
     }
 

--- a/Gems/PhysX/Code/Source/Articulation.h
+++ b/Gems/PhysX/Code/Source/Articulation.h
@@ -46,8 +46,8 @@ namespace PhysX
         //! This data comes from Articulation Link Component in the Editor.
         ArticulationLinkConfiguration m_articulationLinkConfiguration;
 
-        //! Data related to the collision shape for this link. 
-        AzPhysics::ShapeColliderPair m_shapeColliderConfiguration;
+        //! Data related to the collision shapes for this link.
+        AzPhysics::ShapeColliderPairList m_shapeColliderConfigurationList;
 
         //! Cached local transform of this link relative to its parent.
         //! This is needed because at the time of constructing the articulation
@@ -95,7 +95,7 @@ namespace PhysX
         physx::PxArticulationLink* m_pxLink = nullptr;
 
         ActorData m_actorData;
-        AZStd::shared_ptr<Physics::Shape> m_physicsShape;
+        AZStd::vector<AZStd::shared_ptr<Physics::Shape>> m_physicsShapes;
     };
 
     ArticulationLink* CreateArticulationLink(const ArticulationLinkConfiguration* articulationConfig);

--- a/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
@@ -33,21 +33,15 @@ namespace PhysX
         linkData->m_localTransform = transformComponent->GetLocalTM();
 
         const auto& components = entity->GetComponents();
-        auto baseColliderComponentIt = AZStd::find_if(
-            components.begin(),
-            components.end(),
-            [](AZ::Component* component)
-            {
-                return azdynamic_cast<BaseColliderComponent*>(component) != nullptr;
-            });
-
-        if (baseColliderComponentIt != components.end())
+        for (const auto& component : components)
         {
-            auto* baseColliderComponent = azdynamic_cast<BaseColliderComponent*>(*baseColliderComponentIt);
-            AzPhysics::ShapeColliderPairList shapeColliderPairList = baseColliderComponent->GetShapeConfigurations();
-            AZ_Assert(!shapeColliderPairList.empty(), "Collider component with no shape configurations");
-
-            linkData->m_shapeColliderConfiguration = shapeColliderPairList[0];
+            if (auto* baseColliderComponent = azdynamic_cast<BaseColliderComponent*>(component))
+            {
+                AzPhysics::ShapeColliderPairList shapeColliderPairList = baseColliderComponent->GetShapeConfigurations();
+                AZ_Assert(!shapeColliderPairList.empty(), "Collider component with no shape configurations");
+                linkData->m_shapeColliderConfigurationList.insert(
+                    linkData->m_shapeColliderConfigurationList.end(), shapeColliderPairList.begin(), shapeColliderPairList.end());
+            }
         }
 
         auto* articulationLinkComponent = entity->FindComponent<ArticulationLinkComponent>();


### PR DESCRIPTION
## What does this PR do?

The old behavior is to support only one collider per articulation link, which is not true.
This PR addresses an issue with articulation in: https://github.com/o3de/o3de/issues/16711

## How was this PR tested?
Manual test against this URDF imported with URDF/SDF importer with PhysX debug gem.
[urdf.zip](https://github.com/o3de/o3de/files/12609194/urdf.zip)

Before:
![Screenshot from 2023-09-14 15-23-50](https://github.com/o3de/o3de/assets/3209244/0a30ea0d-6f8e-431b-875f-f789df821b55)

After:
![Screenshot from 2023-09-14 15-18-07](https://github.com/o3de/o3de/assets/3209244/4307ac87-c3b8-4784-ab86-f757ec781449)

