### PR TITLE
optimization to reduce valueHashed patches

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -328,11 +328,9 @@ namespace AZ::DocumentPropertyEditor
                 return {};
             }
 
-            const AZStd::any* opaqueValue = &value[EntryValueKey].GetOpaqueValue();
-            auto genericValue = AZStd::any_cast<GenericValueType>(opaqueValue);
-            if (genericValue != nullptr)
+            if (auto genericValueOpt = Dom::Utils::ValueToType<GenericValueType>(value[EntryValueKey]); genericValueOpt.has_value())
             {
-                return GenericValuePair{ *genericValue, AZStd::string(value[EntryDescriptionKey].GetString()) };
+                return GenericValuePair{ genericValueOpt.value(), AZStd::string(value[EntryDescriptionKey].GetString()) };
             }
 
             return {};
@@ -410,27 +408,13 @@ namespace AZ::DocumentPropertyEditor
                     continue;
                 }
 
-                if (!entryDom[EntryValueKey].IsOpaqueValue())
+                if (auto genericValueOpt = Dom::Utils::ValueToType<GenericValueType>(entryDom[EntryValueKey]); genericValueOpt.has_value())
                 {
-                    continue;
-                }
-
-                const AZStd::any* opaqueValue = &entryDom[EntryValueKey].GetOpaqueValue();
-                auto genericValue = AZStd::any_cast<GenericValueType>(opaqueValue);
-                if (opaqueValue->is<GenericValueType>() && genericValue)
-                {
-                    result.emplace_back(AZStd::make_pair(*genericValue, entryDom[EntryDescriptionKey].GetString()));
+                    result.emplace_back(genericValueOpt.value(), entryDom[EntryDescriptionKey].GetString());
                 }
             }
 
-            if (result.empty())
-            {
-                return {};
-            }
-            else
-            {
-                return result;
-            }
+            return !result.empty() ? AZStd::make_optional(AZStd::move(result)) : AZStd::nullopt;
         }
     };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -280,7 +280,16 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value ValueToDom(const GenericValuePair& attribute) const override
         {
             Dom::Value result(Dom::Type::Object);
-            result[EntryValueKey] = Dom::Value::FromOpaqueValue(AZStd::make_any<GenericValueType>(attribute.first));
+            if constexpr (AZStd::is_constructible_v<Dom::Value, GenericValueType>)
+            {
+                // this type is already constructible as a normal Dom::Value, create it as-is
+                result[EntryValueKey] = Dom::Value(attribute.first);
+            }
+            else
+            {
+                // type doesn't fit directly into a Dom::Value, construct it as an opaque value
+                result[EntryValueKey] = Dom::Value::FromOpaqueValue(AZStd::make_any<GenericValueType>(attribute.first));
+            }
             result[EntryDescriptionKey] = Dom::Value(attribute.second, true);
             return result;
         }
@@ -353,7 +362,16 @@ namespace AZ::DocumentPropertyEditor
             for (const auto& entry : attribute)
             {
                 Dom::Value entryDom(Dom::Type::Object);
-                entryDom[EntryValueKey] = Dom::Value::FromOpaqueValue(AZStd::make_any<GenericValueType>(entry.first));
+                if constexpr (AZStd::is_constructible_v<Dom::Value, GenericValueType>)
+                {
+                    // this type is already constructible as a normal Dom::Value, create it as-is
+                    entryDom[EntryValueKey] = Dom::Value(entry.first);
+                }
+                else
+                {
+                    // type doesn't fit directly into a Dom::Value, construct it as an opaque value
+                    entryDom[EntryValueKey] = Dom::Value::FromOpaqueValue(AZStd::make_any<GenericValueType>(entry.first));
+                }
                 entryDom[EntryDescriptionKey] = Dom::Value(entry.second, true);
                 result.ArrayPushBack(AZStd::move(entryDom));
             }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -129,7 +129,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto OnChanged = CallbackAttributeDefinition<void(const Dom::Value&, ValueChangeType)>("OnChanged");
         static constexpr auto Value = AttributeDefinition<AZ::Dom::Value>("Value");
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
-        static constexpr auto ValueHashed = AttributeDefinition<AZ::Uuid>("ValueHashed");
+        static constexpr auto ValueHashed = AttributeDefinition<AZ::u64>("ValueHashed");
         static constexpr auto ParentValue = AttributeDefinition<AZ::Dom::Value>("ParentValue");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -383,7 +383,7 @@ namespace AZ::DocumentPropertyEditor
             {
                 m_builder.Attribute(
                     Nodes::PropertyEditor::ValueHashed,
-                    AZ::Uuid::CreateData(static_cast<AZStd::byte*>(instance), valueSize));
+                    static_cast<AZ::u64>(AZStd::hash<AZ::Uuid>{}((AZ::Uuid::CreateData(static_cast<AZStd::byte*>(instance), valueSize)))));
             }
             m_builder.EndPropertyEditor();
 


### PR DESCRIPTION
## What does this PR do?
- attempts to construct natively handled DOM values where possible, instead of defaulting to opaque types. This allows the values to be diffed correctly and only patch when necessary
- Fix valueHashed to be stored as a u4 to prevent unnecessary shared_ptr diffs/patches

## How was this PR tested?
locally, using the Editor project