### PR TITLE
Fixed change notify usage in the White Box component

### DIFF
--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -115,7 +115,7 @@ namespace WhiteBox
     }
 
     // callback for when the default shape field is changed
-    void EditorWhiteBoxComponent::OnDefaultShapeChange()
+    AZ::Crc32 EditorWhiteBoxComponent::OnDefaultShapeChange()
     {
         const AZStd::string entityIdStr = AZStd::string::format("%llu", static_cast<AZ::u64>(GetEntityId()));
         const AZStd::string componentIdStr = AZStd::string::format("%llu", GetId());
@@ -136,6 +136,8 @@ namespace WhiteBox
         EditorWhiteBoxComponentNotificationBus::Event(
             AZ::EntityComponentIdPair(GetEntityId(), GetId()),
             &EditorWhiteBoxComponentNotificationBus::Events::OnDefaultShapeTypeChanged, m_defaultShape);
+
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 
     bool EditorWhiteBoxVersionConverter(
@@ -211,14 +213,12 @@ namespace WhiteBox
                     ->EnumAttribute(DefaultShapeType::Sphere, "Sphere")
                     ->EnumAttribute(DefaultShapeType::Asset, "Mesh Asset")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorWhiteBoxComponent::OnDefaultShapeChange)
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ_CRC_CE("RefreshEntireTree"))
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &EditorWhiteBoxComponent::m_editorMeshAsset, "Editor Mesh Asset",
                         "Editor Mesh Asset")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorWhiteBoxComponent::AssetVisibility)
                     ->UIElement(AZ::Edit::UIHandlers::Button, "Save as asset", "Save as asset")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorWhiteBoxComponent::SaveAsAsset)
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ_CRC_CE("RefreshEntireTree"))
                     ->Attribute(AZ::Edit::Attributes::ButtonText, "Save As ...")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &EditorWhiteBoxComponent::m_material, "White Box Material",
@@ -572,7 +572,7 @@ namespace WhiteBox
         return WhiteBoxSaveResult{relativePath, AZStd::string(absoluteSaveFilePathCstr)};
     }
 
-    void EditorWhiteBoxComponent::SaveAsAsset()
+    AZ::Crc32 EditorWhiteBoxComponent::SaveAsAsset()
     {
         // let the user select final location of the saved asset
         const auto absoluteSavePathFn = [](const AZStd::string& initialAbsolutePath)
@@ -621,7 +621,7 @@ namespace WhiteBox
         // user pressed cancel
         if (!saveResult.has_value())
         {
-            return;
+            return AZ::Edit::PropertyRefreshLevels::None;
         }
 
         const char* const absoluteSaveFilePath = saveResult.value().m_absoluteFilePath.c_str();
@@ -657,6 +657,8 @@ namespace WhiteBox
                 RequestEditSourceControl(absoluteSaveFilePath);
             }
         }
+
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 
     template<typename TransformFn>

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
@@ -108,8 +108,8 @@ namespace WhiteBox
         void RebuildRenderMesh();
         void RebuildPhysicsMesh();
         void ExportToFile();
-        void SaveAsAsset();
-        void OnDefaultShapeChange();
+        AZ::Crc32 SaveAsAsset();
+        AZ::Crc32 OnDefaultShapeChange();
         void OnMaterialChange();
         AZ::Crc32 AssetVisibility() const;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16693 

In the White Box component, the "Mesh Asset" field wasn't being shown when changing the "Default Shape" to "Mesh Asset". This is because a property refresh was required, but the White Box component was using multiple change notifies for that single data element. The DPE only supports a single change notify on a data element (it does, however, properly support multiple change notifies up its parent hierarchy). This component used multiple change notifies to have one trigger a custom method, and then the second to trigger the property refresh. But this can actually be accomplished in a single method by returning the property refresh level.

I've updated the White Box component to use a single change notify and it now works. I've also added a backlog story to investigate if we should add the support to the DPE to register multiple ChangeNotify attributes on a single data element here:

https://github.com/o3de/o3de/issues/16727

Here is a gif of it working properly now:
![WhiteBoxComponent_WORKING](https://github.com/o3de/o3de/assets/7519264/e23a4af3-dd61-4bd6-af96-a6bd6c7125ae)

## How was this PR tested?

Tested the White Box component with the DPE enabled and disabled and verified the mesh asset field is properly shown/hidden as expected based on the default shape.