### PR TITLE
Fixed UIElement change notify

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -585,12 +585,16 @@ namespace AzToolsFramework
             if (newValueSet)
             {
                 PropertyEditor::OnChanged.InvokeOnDomNode(m_domNode, newValue, changeType);
+            }
 
-                // Only trigger the ChangeNotify in response to PropertyEditorGUIMessages::RequestWrite
-                if (changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit)
-                {
-                    OnRequestPropertyNotify();
-                }
+            // Only trigger the ChangeNotify in response to PropertyEditorGUIMessages::RequestWrite.
+            // Also, we trigger this regardless of newValueSet, because of cases like a UIElement
+            // with no backing data element where there will be no value getting set but we still
+            // need to trigger the change notify in case the user has some logic that needs to
+            // be executed.
+            if (changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit)
+            {
+                OnRequestPropertyNotify();
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16703 

There is logic that detects if a new value was set based on the `OnValueChanged` event so that we don't invoke the `OnChanged` unless a value has been set, which was also gating if the `ChangeNotify` should be triggered. However, there are cases where a value won't be set but we do want to still trigger the `ChangeNotify`, such as in the Cloth component with the "Simulate in editor" checkbox, which is a pure `UIElement` with no backing data element and only a change notify trigger to make the cloth be simulated/stop simulation. In this case, there will be no value set, but we still want the `ChangeNotify` to trigger.

![SimulateInEditor_WORKING](https://github.com/o3de/o3de/assets/7519264/b3a5e29e-8690-4593-a7df-ed270a7e4800)

## How was this PR tested?

Tested the "Simluate in editor" checkbox with both DPE enabled and disabled and verified cloth correctly simluates in both scenarios.