### PR TITLE
This change fix a diffuse probe grid bake issue with pc which doesn't support raytracing

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Include/DiffuseProbeGrid/DiffuseProbeGridFeatureProcessorInterface.h
+++ b/Gems/DiffuseProbeGrid/Code/Include/DiffuseProbeGrid/DiffuseProbeGridFeatureProcessorInterface.h
@@ -151,6 +151,7 @@ namespace AZ
             virtual void SetVisualizationShowInactiveProbes(const DiffuseProbeGridHandle& probeGrid, bool visualizationShowInactiveProbes) = 0;
             virtual void SetVisualizationSphereRadius(const DiffuseProbeGridHandle& probeGrid, float visualizationSphereRadius) = 0;
 
+            virtual bool CanBakeTextures() = 0;
             virtual void BakeTextures(
                 const DiffuseProbeGridHandle& probeGrid,
                 DiffuseProbeGridBakeTexturesCallback callback,

--- a/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
@@ -484,12 +484,7 @@ namespace AZ
 
         bool DiffuseProbeGridComponentController::CanBakeTextures()
         {
-            if (!m_featureProcessor)
-            {
-                return false;
-            }
-
-            return m_featureProcessor->CanBakeTextures();
+        return m_featureProcessor && m_featureProcessor->CanBakeTextures();
         }
 
         void DiffuseProbeGridComponentController::BakeTextures(DiffuseProbeGridBakeTexturesCallback callback)

--- a/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
@@ -482,6 +482,16 @@ namespace AZ
             m_featureProcessor->SetVisualizationSphereRadius(m_handle, m_configuration.m_visualizationSphereRadius);
         }
 
+        bool DiffuseProbeGridComponentController::CanBakeTextures()
+        {
+            if (!m_featureProcessor)
+            {
+                return false;
+            }
+
+            return m_featureProcessor->CanBakeTextures();
+        }
+
         void DiffuseProbeGridComponentController::BakeTextures(DiffuseProbeGridBakeTexturesCallback callback)
         {
             if (!m_featureProcessor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.h
@@ -124,6 +124,7 @@ namespace AZ
 
             // Bake the diffuse probe grid textures to assets
             void BakeTextures(DiffuseProbeGridBakeTexturesCallback callback);
+            bool CanBakeTextures();
 
             // Update the baked texture assets from the configuration
             void UpdateBakedTextures();

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -518,6 +518,17 @@ namespace AZ
                 return AZ::Edit::PropertyRefreshLevels::None;
             }
 
+            if (!m_controller.CanBakeTextures())
+            {
+                QMessageBox::information(
+                    QApplication::activeWindow(),
+                    "Diffuse Probe Grid",
+                    "Can't bake the textures. This function may require gpu raytracing support",
+                    QMessageBox::Ok);
+
+                return AZ::Edit::PropertyRefreshLevels::None;
+            }
+
             DiffuseProbeGridComponentConfig& configuration = m_controller.m_configuration;
 
             // retrieve the source image paths from the configuration

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -523,7 +523,7 @@ namespace AZ
                 QMessageBox::information(
                     QApplication::activeWindow(),
                     "Diffuse Probe Grid",
-                    "Can't bake the textures. This function may require gpu raytracing support",
+                    "Can't bake the textures. Diffuse probe calculations require GPU raytracing support",
                     QMessageBox::Ok);
 
                 return AZ::Edit::PropertyRefreshLevels::None;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -464,6 +464,12 @@ namespace AZ
             probeGrid->SetUseDiffuseIbl(useDiffuseIbl);
         }
 
+        bool DiffuseProbeGridFeatureProcessor::CanBakeTextures()
+        {
+            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
+            return device->GetFeatures().m_rayTracing;
+        }
+
         void DiffuseProbeGridFeatureProcessor::BakeTextures(
             const DiffuseProbeGridHandle& probeGrid,
             DiffuseProbeGridBakeTexturesCallback callback,

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
@@ -61,6 +61,7 @@ namespace AZ
             void SetVisualizationShowInactiveProbes(const DiffuseProbeGridHandle& probeGrid, bool visualizationShowInactiveProbes) override;
             void SetVisualizationSphereRadius(const DiffuseProbeGridHandle& probeGrid, float visualizationSphereRadius) override;
 
+            bool CanBakeTextures() override;
             void BakeTextures(
                 const DiffuseProbeGridHandle& probeGrid,
                 DiffuseProbeGridBakeTexturesCallback callback,


### PR DESCRIPTION
## What does this PR do?
Fix issue (https://github.com/o3de/o3de/issues/16720)

The reason is that if the raytracing isn't supported. The `DiffuseProbeGridRenderPass `will return early in its `SetupFrameGraphDependencies `function. And `diffuseProbeGrid->GetTextureReadback().Update(GetName())` would be skipped. The bake function's callback function won't never be called which means the baking was started, baking pass was added, but the baking process won't never finish. 

The function added a CanBakeTextures function to check if the baking is supported and give possible cause. 

## How was this PR tested?

Disable dx12 raytracing support (o3de\Gems\Atom\RHI\DX12\Code\Source\RHI\Device.cpp, ln 254)
set `m_raytracing = false;`
Run Editor with AutomatedTesting project and open Graphics/stanza level. Select Diffuse Probe Grid 1 entity and press the "bake textures" button