### PR TITLE
Set stabilization checklist to trigger only on opened PR

### DIFF
--- a/.github/workflows/stabilization-pr-checklist.yaml
+++ b/.github/workflows/stabilization-pr-checklist.yaml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened, reopened]
     branches:
     - stabilization/**
     

--- a/.github/workflows/stabilization-pr-checklist.yaml
+++ b/.github/workflows/stabilization-pr-checklist.yaml
@@ -1,3 +1,5 @@
+name: Add stabilization PR checklist
+
 on:
   pull_request:
     types: [opened, reopened]


### PR DESCRIPTION
## What does this PR do?

Minor fix to the stabilization checklist automation to only trigger when the PR is first opened or reopened. Current behavior will trigger a comment after every commit to the PR.

## How was this PR tested?

Tested in a fork of the repo
