### PR TITLE
Increment engine major version post stabilization

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.1.0",


### PR DESCRIPTION
## What does this PR do?

Increment the engine major version to prevent there being any engine version overlap between development and stabilization from this point on.

Related RFC https://github.com/o3de/sig-core/issues/44

## How was this PR tested?

n/a this does not change any functionality
