### PR TITLE
Fixes codegen for authority->server network properties for client-server code split

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -722,10 +722,18 @@ void {{ ClassName }}::NotifyChanges{{ AutoComponentMacros.GetNetPropertiesSetNam
     }
 {%         endif %}
 {%     else %}
+
+{%         if Property.attrib['ReplicateTo'] == 'Server' %}
+#if AZ_TRAIT_SERVER
+{%         endif %}
     if (replicationRecord.m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.GetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property) }})))
     {
         m_{{ LowerFirst(Property.attrib['Name']) }}Event.Signal(m_{{ LowerFirst(Property.attrib['Name']) }});
     }
+{%         if Property.attrib['ReplicateTo'] == 'Server' %}
+#endif
+{%         endif %}
+
 {%     endif %}
 {% endif %}
 {% endcall %}


### PR DESCRIPTION
## What does this PR do?

Using Multiplayer gem, it is a valid scenario to declare a network property with Authority->Server direction, for example:

```cpp
<NetworkProperty Type="bool" Name="LightServerState" Init="false" ReplicateFrom="Authority" ReplicateTo="Server"
    IsRewindable="false" IsPredictable="false" IsPublic="true" Container="Object" ExposeToEditor="false" 
    ExposeToScript="false"  GenerateEventBindings="true" Description="Current light state"/>
```

This currently results in a compile error. This PR fixes the codegen to correctly build the network code for client and server binaries.

## How was this PR tested?

Tested with a multiplayer gem enabled project.
