### PR TITLE
Material Canvas: Updating material graph shaders to not optimize out material SRG

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
@@ -62,6 +62,9 @@ option bool o_normal_override_enabled = false;
 
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 {
+    // m_placeHolder keeps MaterialSrg from being compiled out, causing SRG mismatches while assets are processing when iterating on graphs
+    bool m_placeHolder;
+
     // O3DE_GENERATED_MATERIAL_SRG_BEGIN
     // O3DE_GENERATED_MATERIAL_SRG_END
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -38,6 +38,9 @@ Surface EvaluateSurface_MaterialGraphName(
     const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
 
+    // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
+    const bool placeHolder = MaterialSrg::m_placeHolder;
+
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor
     real3 inNormal = normalWS;
     real3 inBaseColor = {1.0, 1.0, 1.0};

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -44,6 +44,9 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     const float3 O3DE_MC_BITANGENT_WS = bitangentWS;
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
 
+    // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
+    const bool placeHolder = MaterialSrg::m_placeHolder;
+
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
     // O3DE_GENERATED_INSTRUCTIONS_END

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
@@ -71,6 +71,9 @@ option bool o_clearCoat_normal_override_enabled = false;
 
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 {
+    // m_placeHolder keeps MaterialSrg from being compiled out, causing SRG mismatches while assets are processing when iterating on graphs
+    bool m_placeHolder;
+
     // O3DE_GENERATED_MATERIAL_SRG_BEGIN
     // O3DE_GENERATED_MATERIAL_SRG_END
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -40,6 +40,9 @@ Surface EvaluateSurface_MaterialGraphName(
     const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
 
+    // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
+    const bool placeHolder = MaterialSrg::m_placeHolder;
+
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
     real3 inNormal = normalWS;
     real3 inBaseColor = {1.0, 1.0, 1.0};

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
@@ -44,6 +44,9 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     const float3 O3DE_MC_BITANGENT_WS = bitangentWS;
     #define O3DE_MC_UV(index) (index == 0 ? uv0 : uv1);
 
+    // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
+    const bool placeHolder = MaterialSrg::m_placeHolder;
+
     // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inPositionOffset
     float3 inPositionOffset = {0.0, 0.0, 0.0};
     // O3DE_GENERATED_INSTRUCTIONS_END


### PR DESCRIPTION
## What does this PR do?

This change updates the material graph template material SRGs to include a placeholder variable. Including and referencing this variable ensures that the material SRG always exists across all shaders that might use it. This initial resolved one assert that triggered when adding or removing material inputs from a material graph, consequently adding or removing variables from the material SRG and corresponding connections in the material type. As the AP processes the material and shader changes, the runtime may receive individual shader updates with inconsistent SRG data until everything is fully compiled and synchronized.

This change may be reverted after subsequent changes that may also address the issue.

Relates to https://github.com/o3de/o3de/issues/16034
Relates to https://github.com/o3de/o3de/issues/16735
Relates to https://github.com/o3de/o3de/issues/14772

## How was this PR tested?

Tested in conjunction with other incoming changes to prevent the following asserts while iterating on shaders and materials.

```
==================================================================
2023-09-15T10:29:10{0000000000009988}[        System]     Trace::Assert
 D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI/CommandList.h(290): (39304) 'bool __cdecl AZ::DX12::CommandList::CommitShaderResources<AZ::RHI::PipelineStateType::Draw,struct AZ::RHI::DrawItem>(const struct AZ::RHI::DrawItem &)'
2023-09-15T10:29:10{0000000000009980}[        System]     
==================================================================
2023-09-15T10:29:10{0000000000009988}[        System]     Pipeline layout is null.
2023-09-15T10:29:10{0000000000009980}[        System]     Trace::Assert
 D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI/CommandList.h(441): (39296) 'bool __cdecl AZ::DX12::CommandList::CommitShaderResources<AZ::RHI::PipelineStateType::Draw,struct AZ::RHI::DrawItem>(const struct AZ::RHI::DrawItem &)'
2023-09-15T10:29:10{0000000000009988}[        System]     ------------------------------------------------
2023-09-15T10:29:10{0000000000009980}[        System]     The DrawItem being submitted doesn't provide an SRG for slot '2', which the shader is expecting. If this slot is for a Pass, View or Scene SRG, this likely means the pass didn't collect it (for the view SRG, check if your pass provides a PipelineViewTag). The SRGs currently provided by the DrawItem are: Slot #0 = 'ShadowCatcher_DrawSrg', Slot #1 = 'ShadowCatcher_ObjectSrg', Slot #5 = 'SceneAndViewSrgs_ViewSrg', Slot #6 = 'SceneAndViewSrgs_SceneSrg'
2023-09-15T10:29:10{0000000000009980}[        System]     ------------------------------------------------
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI\CommandList.h (291) : AZ::DX12::CommandList::CommitShaderResources<0,AZ::RHI::DrawItem>
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI\CommandList.cpp (557) : AZ::DX12::CommandList::Submit
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RasterPass.cpp (245) : AZ::RPI::RasterPass::SubmitDrawItems
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RasterPass.cpp (266) : AZ::RPI::RasterPass::BuildCommandListInternal
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI\CommandList.h (443) : AZ::DX12::CommandList::CommitShaderResources<0,AZ::RHI::DrawItem>
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RenderPass.cpp (223) : AZ::RPI::RenderPass::BuildCommandList
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RHI\DX12\Code\Source\RHI\CommandList.cpp (557) : AZ::DX12::CommandList::Submit
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RHI\Code\Source\RHI\FrameScheduler.cpp (506) : AZ::RHI::FrameScheduler::ExecuteContextInternal
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RasterPass.cpp (245) : AZ::RPI::RasterPass::SubmitDrawItems
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Gems\Atom\RHI\Code\Source\RHI\FrameScheduler.cpp (533) : AZ::RHI::FrameScheduler::ExecuteGroupInternal
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RasterPass.cpp (266) : AZ::RPI::RasterPass::BuildCommandListInternal
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\Jobs\Internal\JobManagerBase.cpp (31) : AZ::Internal::JobManagerBase::Process
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RPI\Code\Source\RPI.Public\Pass\RenderPass.cpp (223) : AZ::RPI::RenderPass::BuildCommandList
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\Jobs\Internal\JobManagerWorkStealing.cpp (421) : AZ::Internal::JobManagerWorkStealing::ProcessJobsInternal
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RHI\Code\Source\RHI\FrameScheduler.cpp (506) : AZ::RHI::FrameScheduler::ExecuteContextInternal
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\std\parallel\thread.h (193) : AZStd::Internal::thread_info_impl<`AZStd::thread::thread<`AZ::Internal::JobManagerWorkStealing::CreateWorkerThreads'::`4'::<lambda_1> >'::`2'::<lambda_1> >::execute
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Gems\Atom\RHI\Code\Source\RHI\FrameScheduler.cpp (533) : AZ::RHI::FrameScheduler::ExecuteGroupInternal
2023-09-15T10:29:10{0000000000009988}[        System]     D:\projects\o3de\Code\Framework\AzCore\Platform\Common\WinAPI\AzCore\std\parallel\internal\thread_WinAPI.cpp (38) : AZStd::Internal::thread_run_function
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\Jobs\Internal\JobManagerBase.cpp (31) : AZ::Internal::JobManagerBase::Process
2023-09-15T10:29:10{0000000000009988}[        System]     00007FF89E906C0C (ucrtbase) : recalloc
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\Jobs\Internal\JobManagerWorkStealing.cpp (421) : AZ::Internal::JobManagerWorkStealing::ProcessJobsInternal
2023-09-15T10:29:10{0000000000009988}[        System]     00007FF8A01355A0 (KERNEL32) : BaseThreadInitThunk
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Code\Framework\AzCore\AzCore\std\parallel\thread.h (193) : AZStd::Internal::thread_info_impl<`AZStd::thread::thread<`AZ::Internal::JobManagerWorkStealing::CreateWorkerThreads'::`4'::<lambda_1> >'::`2'::<lambda_1> >::execute
2023-09-15T10:29:10{0000000000009988}[        System]     00007FF8A13A485B (ntdll) : RtlUserThreadStart
2023-09-15T10:29:10{0000000000009980}[        System]     D:\projects\o3de\Code\Framework\AzCore\Platform\Common\WinAPI\AzCore\std\parallel\internal\thread_WinAPI.cpp (38) : AZStd::Internal::thread_run_function
2023-09-15T10:29:10{0000000000009988}[        System]     ==================================================================
```