### PR TITLE
Material Canvas: Create new material instance in viewport after changes

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasViewportContent.cpp
@@ -235,7 +235,16 @@ namespace MaterialCanvas
             }
         }
 
+        // When material canvas generates assets, material input property values are assigned as default values in the material type instead
+        // of overridden values in the material. The generated material asset is empty except for a single field referencing the material
+        // type. Because the material asset never changes, it won't be reprocessed by the AP or treated as a unique asset in the asset
+        // system. We force the viewport to create a unique material instance every time a change needs to be reflected in material canvas.
+        AZ::Render::MaterialAssignment materialAssignment;
+        materialAssignment.m_materialAsset.Create(assetId);
+        materialAssignment.m_materialInstanceMustBeUnique = true;
+        AZ::Render::MaterialAssignmentMap materialAssignmentMap;
+        materialAssignmentMap.emplace(AZ::Render::DefaultMaterialAssignmentId, materialAssignment);
         AZ::Render::MaterialComponentRequestBus::Event(
-            GetObjectEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialAssetIdOnDefaultSlot, assetId);
+            GetObjectEntityId(), &AZ::Render::MaterialComponentRequestBus::Events::SetMaterialMap, materialAssignmentMap);
     }
 } // namespace MaterialCanvas

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialAssignment.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialAssignment.h
@@ -58,6 +58,7 @@ namespace AZ
             MaterialPropertyOverrideMap m_propertyOverrides;
             RPI::MaterialModelUvOverrideMap m_matModUvOverrides;
             bool m_materialInstancePreCreated = false;
+            bool m_materialInstanceMustBeUnique = false;
         };
 
         using MaterialAssignmentMap = AZStd::unordered_map<MaterialAssignmentId, MaterialAssignment>;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -105,14 +105,16 @@ namespace AZ
 
             if (m_materialAsset.GetId().IsValid() && m_materialAsset.IsReady())
             {
-                m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_materialAsset) : RPI::Material::Create(m_materialAsset);
+                const bool createUniqueInstance = m_materialInstanceMustBeUnique || !m_propertyOverrides.empty();
+                m_materialInstance = createUniqueInstance ? RPI::Material::Create(m_materialAsset) : RPI::Material::FindOrCreate(m_materialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
                 return;
             }
 
             if (m_defaultMaterialAsset.GetId().IsValid() && m_defaultMaterialAsset.IsReady())
             {
-                m_materialInstance = m_propertyOverrides.empty() ? RPI::Material::FindOrCreate(m_defaultMaterialAsset) : RPI::Material::Create(m_defaultMaterialAsset);
+                const bool createUniqueInstance = m_materialInstanceMustBeUnique || !m_propertyOverrides.empty();
+                m_materialInstance = createUniqueInstance ? RPI::Material::Create(m_defaultMaterialAsset) : RPI::Material::FindOrCreate(m_defaultMaterialAsset);
                 AZ_Error("MaterialAssignment", m_materialInstance, "Material instance not initialized");
                 return;
             }


### PR DESCRIPTION
## What does this PR do?

This change updates the material assignment class with a flag to force it to create a new material instance regardless of property overrides. The material canvas viewport uses this flag to guarantee the most recent version of the material asset and instance are reflected in the viewport.

Relates to https://github.com/o3de/o3de/issues/16034
Relates to https://github.com/o3de/o3de/issues/16735
Relates to https://github.com/o3de/o3de/issues/14772

## How was this PR tested?

Tested in conjunction with other changes from incoming from a larger change. Builds. Runs. MC viewport material updates with every graph change.