### PR TITLE
Update shader and SRG instance ID creation functions

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -43,7 +43,6 @@ namespace AZ
         //! operation is always performed.
         class Material
             : public Data::InstanceData
-            , Data::AssetBus::Handler
             , public ShaderReloadNotificationBus::MultiHandler
         {
             friend class MaterialSystem;
@@ -148,9 +147,6 @@ namespace AZ
             //! Standard init path from asset data.
             static Data::Instance<Material> CreateInternal(MaterialAsset& materialAsset);
             RHI::ResultCode Init(MaterialAsset& materialAsset);
-
-            // AssetBus overrides...
-            void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
 
             ///////////////////////////////////////////////////////////////////
             // ShaderReloadNotificationBus overrides...

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -60,18 +60,19 @@ namespace AZ
             ScopedValue isInitializing(&m_isInitializing, true, false);
 
             // All of these members must be reset if the material can be reinitialized because of the shader reload notification bus
+            m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
             m_shaderResourceGroup = {};
             m_rhiShaderResourceGroup = {};
             m_materialProperties = {};
             m_generalShaderCollection = {};
             m_materialPipelineData = {};
-            m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
+
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
             if (!m_materialAsset.IsReady())
             {
-                // We will call this function again later when the asset is ready.
-                Data::AssetBus::Handler::BusConnect(m_materialAsset.GetId());
-                return RHI::ResultCode::Success;
+                AZ_Error(s_debugTraceName, false, "Material::Init failed because acid is not ready. materialAsset uuid=%s",
+                    materialAsset.GetId().ToFixedString().c_str());
+                return RHI::ResultCode::Fail;
             }
 
             if (!m_materialAsset->InitializeNonSerializedData())
@@ -143,7 +144,6 @@ namespace AZ
 
         Material::~Material()
         {
-            Data::AssetBus::Handler::BusDisconnect();
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
         }
 
@@ -833,14 +833,5 @@ namespace AZ
         {
             return m_materialProperties.GetMaterialPropertiesLayout();
         }
-
-        // AssetBus overrides...
-        void Material::OnAssetReady(Data::Asset<Data::AssetData> asset)
-        {
-            Data::AssetBus::Handler::BusDisconnect();
-            Init(*static_cast<MaterialAsset*>(asset.Get()));
-        }
-        // AssetBus overrides end
-
     } // namespace RPI
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

## What does this PR do?

This change updates these functions to generate unique instance IDs that take the content or the version of the data into account. The asset data pointer is used to make the value more unique, relative to the asset, but could be replaced with some other explicit version value or a hash of the data. Ensuring that the instance ID is unique relative to the version of the data will permit new instances to be created or new versions of the asset with the same asset ID.

Relates to https://github.com/o3de/o3de/issues/16034
Relates to https://github.com/o3de/o3de/issues/16735
Relates to https://github.com/o3de/o3de/issues/14772
Relates to https://github.com/o3de/o3de/issues/15794’

## How was this PR tested?

Tested immaterial canvas in conjunction with other changes from a larger group of changes. This might need additional testing or revision based on recommendations for something potentially more stable than the asset pointer. There should be no negative impact unless some system was expecting a specific instance ID format. With this and other changes, iterating in material canvas no longer produces any asserts and updates assets and instances in the viewport as expected.