### PR TITLE
Material Canvas: Option to delete previously generated files before creating new ones

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Document/MaterialGraphCompiler.h
@@ -39,6 +39,7 @@ namespace MaterialCanvas
         void BuildDependencyTables();
         void BuildTemplatePathsForCurrentNode(const GraphModel::ConstNodePtr& currentNode);
         bool LoadTemplatesForCurrentNode();
+        void DeleteExistingFilesForCurrentNode();
         void PreprocessTemplatesForCurrentNode();
         void BuildInstructionsForCurrentNode(const GraphModel::ConstNodePtr& currentNode);
         void BuildMaterialSrgForCurrentNode();

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -175,8 +175,8 @@ namespace MaterialCanvas
                   false),
               AtomToolsFramework::CreateSettingsPropertyValue(
                   "/O3DE/Atom/MaterialCanvas/ForceDeleteGeneratedFiles",
-                  "Delete Generated On Compile",
-                  "This option forces the material graph compiler to preemptively delete previously generated files before creating new ones.",
+                  "Delete Files Before Compile",
+                  "This option forces files previously generated from the current graph to be deleted before creating new ones.",
                   false),
               AtomToolsFramework::CreateSettingsPropertyValue(
                   "/O3DE/AtomToolsFramework/GraphCompiler/CompileOnOpen",

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -174,6 +174,11 @@ namespace MaterialCanvas
                   "placed in the user/Registry folder for the current project.",
                   false),
               AtomToolsFramework::CreateSettingsPropertyValue(
+                  "/O3DE/Atom/MaterialCanvas/ForceDeleteGeneratedFiles",
+                  "Delete Generated On Compile",
+                  "This option forces the material graph compiler to preemptively delete previously generated files before creating new ones.",
+                  false),
+              AtomToolsFramework::CreateSettingsPropertyValue(
                   "/O3DE/AtomToolsFramework/GraphCompiler/CompileOnOpen",
                   "Enable Compile On Open",
                   "If enabled, shaders and materials will automatically be generated whenever a material graph is opened.",


### PR DESCRIPTION
## What does this PR do?

This change provides an option to delete files that were previously generated using the current template before creating new ones. The option was useful while debugging and may also be useful if switching between different material output nodes that might use the same file names. The option is disabled by default. These changes are pulled from a larger set.

## How was this PR tested?

Option is disabled by default but tested in material canvas while iterating on material graphs.