### PR TITLE
Adding lldb python formatter for AZStd string and hash_table classes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /Gems/LmbrCentral/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Gems/Profiler/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Registry/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
+/scripts/lldb/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /scripts/o3de.* @o3de/sig-core-reviewers @o3de/sig-core-maintainers
 /Templates/ @o3de/sig-core-reviewers @o3de/sig-core-maintainers
@@ -56,7 +57,7 @@
 /Code/Framework/AzCore/Tests/TestCatalog.* @o3de/sig-content-maintainers @o3de/sig-content-reviewers
 /Code/Framework/AzFramework/AzFramework/Asset @o3de/sig-content-maintainers @o3de/sig-content-reviewers
 /Code/Framework/AzFramework/Tests/Asset* @o3de/sig-content-maintainers @o3de/sig-content-reviewers
-  
+
 # SIG-Content Viewport ownership area
 /Code/Framework/AzFramework/AzFramework/Viewport/ @o3de/sig-content-maintainers
 /Code/Framework/AzFramework/AzFramework/Visibility/ @o3de/sig-content-maintainers

--- a/scripts/lldb/.lldb/o3destd_lldb.py
+++ b/scripts/lldb/.lldb/o3destd_lldb.py
@@ -40,10 +40,8 @@ def read_string_data(process: lldb.SBProcess, string_type: lldb.SBType, string_a
         encoding = 'utf-8'
     elif element_type == element_type.GetBasicType(lldb.eBasicTypeWChar):
         if element_size == 4:
-            byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
             encoding = 'utf-32'
         elif element_size == 2:
-            byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
             encoding = 'utf-16'
         else:
             return f'<error: wchar_t type size ({element_size}) is not 2 or 4 bytes. string data cannot be decoded>'

--- a/scripts/lldb/.lldb/o3destd_lldb.py
+++ b/scripts/lldb/.lldb/o3destd_lldb.py
@@ -1,0 +1,121 @@
+
+# See the following pages for information on how to write formatters for lldb
+# https://lldb.llvm.org/use/variable.html#finding-formatters-101
+# https://lldb.llvm.org/python_api/lldb.SBValue.html#lldb.SBValue
+# https://github.com/llvm/llvm-project/blob/main/lldb/examples/synthetic/libcxx.py
+import enum
+import lldb
+import lldb.formatters.Logger
+
+def string_summary(valobj: lldb.SBValue, internal_dict):
+    # Uncomment for debug output
+    #lldb.formatters.Logger._lldb_formatters_debug_level = 3
+
+    logger = lldb.formatters.Logger.Logger()
+    logger >> f"{valobj.GetType()} summary"
+
+
+    def element_type_string_summary(valobj: lldb.SBValue):
+        # Grab the SBProcess object which is needed to read a c-string from memory
+        process = valobj.GetProcess()
+
+        compressed_pair_storage = valobj.EvaluateExpression("m_storage")
+        # The first child of the compressed pair is the AZStd::basic_string::storage union
+        storage_inst = compressed_pair_storage.GetChildAtIndex(0)
+        storage_element = storage_inst.GetChildMemberWithName("m_element")
+        short_string_storage = storage_element.GetChildMemberWithName("m_shortData")
+
+        # Stores the result of summary string
+        result_string = ''
+
+        # Check if the Short String optimization is active
+        is_sso_active_member = short_string_storage.EvaluateExpression("m_packed.m_ssoActive")
+        is_sso_active = int(is_sso_active_member.GetValueAsUnsigned())
+        if is_sso_active:
+            # Read the string size and memory address
+            string_size = int(short_string_storage.EvaluateExpression("m_packed.m_size").GetValueAsUnsigned())
+            string_address = short_string_storage.EvaluateExpression(f'm_buffer').AddressOf()
+        else:
+            # Short String optimization is not active
+            try:
+                target = valobj.GetTarget()
+                allocated_string_type = target.FindFirstType('AllocatedStringData')
+                allocated_storage = storage_element.EvaluateExpression("m_allocatedData")
+            except Exception as e:
+                return f'error: {e}'
+
+            string_size = allocated_storage.EvaluateExpression("m_size").GetValueAsUnsigned()
+            string_address = allocated_storage.EvaluateExpression("m_data")
+
+        try:
+            string_type = valobj.GetType()
+            element_type = string_type.GetTemplateArgumentType(0)
+            error = lldb.SBError()
+
+            # SBType.GetBasicType is strange, passing in the enum value of the type
+            # doesn't query the actual type but returns a new SBType
+            # instance represents the basic type
+            # https://lldb.llvm.org/python_api/lldb.SBType.html#lldb.SBType.GetBasicType
+            if element_type == element_type.GetBasicType(lldb.eBasicTypeChar):
+            # Get the byte size of the character type being stored
+                element_size = element_type.GetByteSize()
+                byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                result_string = byte_data.decode('utf-8')
+            elif element_type == element_type.GetBasicType(lldb.eBasicTypeWChar):
+                element_size = element_type.GetByteSize()
+                if element_size == 4:
+                    byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                    result_string = byte_data.decode('utf-32')
+                if element_size == 2:
+                    byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                    result_string = byte_data.decode('utf-16')
+            else:
+                # element type is not handled(not a char or wchar_t)
+                return '"<not handled>"'
+
+            if error.Fail():
+                return f'process read error: {error}'
+        except Exception as e:
+            return f'error: {e}'
+
+        return f'"{result_string}"'
+
+    # Invoke the inner function that iterates through the AZStd::basic_string structure
+    return element_type_string_summary(valobj)
+
+
+class string_synthetic_provider(lldb.SBSyntheticValueProvider):
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+    def num_children(self) -> int:
+        return 1
+
+    def has_children(self) -> bool:
+        return num_children != 0
+
+    def get_child_index(self, name):
+        if name == '0':
+            return 0
+        return -1
+
+    def get_child_at_index(self, index):
+        if index == 0:
+            return 'foo'
+        return None
+
+    def update(self):
+        return True
+
+
+def __lldb_init_module(debugger, dict):
+    # Import the AZStd::basic_string summary
+    debugger.HandleCommand('type summary add -n "AZStd::string" -F o3destd_lldb.string_summary --category o3de')
+    debugger.HandleCommand('type summary add -x "^AZStd::basic_string<.+>$" -F o3destd_lldb.string_summary --category o3de')
+
+    # Import the AZStd::basic_string synthetic children provider
+    # Commented out as we don't need synthetic children to visualize a string
+    # debugger.HandleCommand('type synthetic add "^AZStd::basic_string<.+>$" --python-class o3destd_lldb.string_synthetic_provider --category o3de')
+
+    # Enable the o3de category for formatters
+    debugger.HandleCommand('type category enable o3de')

--- a/scripts/lldb/.lldb/o3destd_lldb.py
+++ b/scripts/lldb/.lldb/o3destd_lldb.py
@@ -1,3 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
 
 # See the following pages for information on how to write formatters for lldb
 # https://lldb.llvm.org/use/variable.html#finding-formatters-101
@@ -7,10 +14,10 @@ import enum
 import lldb
 import lldb.formatters.Logger
 
-def string_summary(valobj: lldb.SBValue, internal_dict):
-    # Uncomment for debug output
-    #lldb.formatters.Logger._lldb_formatters_debug_level = 3
+# Uncomment for debug output
+# lldb.formatters.Logger._lldb_formatters_debug_level = 3
 
+def string_summary(valobj: lldb.SBValue, internal_dict):
     logger = lldb.formatters.Logger.Logger()
     logger >> f"{valobj.GetType()} summary"
 
@@ -19,34 +26,35 @@ def string_summary(valobj: lldb.SBValue, internal_dict):
         # Grab the SBProcess object which is needed to read a c-string from memory
         process = valobj.GetProcess()
 
-        compressed_pair_storage = valobj.EvaluateExpression("m_storage")
+        compressed_pair_storage = valobj.GetChildMemberWithName("m_storage")
         # The first child of the compressed pair is the AZStd::basic_string::storage union
         storage_inst = compressed_pair_storage.GetChildAtIndex(0)
         storage_element = storage_inst.GetChildMemberWithName("m_element")
         short_string_storage = storage_element.GetChildMemberWithName("m_shortData")
 
-        # Stores the result of summary string
-        result_string = ''
-
         # Check if the Short String optimization is active
-        is_sso_active_member = short_string_storage.EvaluateExpression("m_packed.m_ssoActive")
+        is_sso_active_member = short_string_storage.GetChildMemberWithName("m_packed").GetChildMemberWithName("m_ssoActive")
         is_sso_active = int(is_sso_active_member.GetValueAsUnsigned())
         if is_sso_active:
             # Read the string size and memory address
-            string_size = int(short_string_storage.EvaluateExpression("m_packed.m_size").GetValueAsUnsigned())
-            string_address = short_string_storage.EvaluateExpression(f'm_buffer').AddressOf()
+            string_size = int(short_string_storage.GetChildMemberWithName("m_packed").GetChildMemberWithName("m_size").GetValueAsUnsigned())
+            string_address = short_string_storage.GetChildMemberWithName('m_buffer').AddressOf()
         else:
             # Short String optimization is not active
             try:
-                target = valobj.GetTarget()
-                allocated_string_type = target.FindFirstType('AllocatedStringData')
                 allocated_storage = storage_element.EvaluateExpression("m_allocatedData")
             except Exception as e:
                 return f'error: {e}'
 
-            string_size = allocated_storage.EvaluateExpression("m_size").GetValueAsUnsigned()
-            string_address = allocated_storage.EvaluateExpression("m_data")
+            string_size = allocated_storage.GetChildMemberWithName("m_size").GetValueAsUnsigned()
+            string_address = allocated_storage.GetChildMemberWithName("m_data")
 
+        # If the string size is 0, then return an empty string
+        if string_size == 0:
+            return '""'
+
+        # Stores the result of summary string
+        result_string = ''
         try:
             string_type = valobj.GetType()
             element_type = string_type.GetTemplateArgumentType(0)
@@ -83,29 +91,198 @@ def string_summary(valobj: lldb.SBValue, internal_dict):
     # Invoke the inner function that iterates through the AZStd::basic_string structure
     return element_type_string_summary(valobj)
 
+def fixed_string_summary(valobj: lldb.SBValue, internal_dict):
+    logger = lldb.formatters.Logger.Logger()
+    logger >> f"{valobj.GetType()} summary"
 
-class string_synthetic_provider(lldb.SBSyntheticValueProvider):
+    # Grab the SBProcess object which is needed to read a c-string from memory
+    process = valobj.GetProcess()
+
+    string_size = valobj.GetChildMemberWithName("m_size").GetValueAsUnsigned()
+    string_address = valobj.GetChildMemberWithName("m_buffer").AddressOf()
+
+    # If the string size is 0, then return an empty string
+    if string_size == 0:
+        return '""'
+
+    # Stores the result of summary string
+    result_string = ''
+    try:
+        string_type = valobj.GetType()
+        element_type = string_type.GetTemplateArgumentType(0)
+        error = lldb.SBError()
+
+        # SBType.GetBasicType is strange, passing in the enum value of the type
+        # doesn't query the actual type but returns a new SBType
+        # instance represents the basic type
+        # https://lldb.llvm.org/python_api/lldb.SBType.html#lldb.SBType.GetBasicType
+        if element_type == element_type.GetBasicType(lldb.eBasicTypeChar):
+        # Get the byte size of the character type being stored
+            element_size = element_type.GetByteSize()
+            byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+            result_string = byte_data.decode('utf-8')
+        elif element_type == element_type.GetBasicType(lldb.eBasicTypeWChar):
+            element_size = element_type.GetByteSize()
+            if element_size == 4:
+                byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                result_string = byte_data.decode('utf-32')
+            if element_size == 2:
+                byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                result_string = byte_data.decode('utf-16')
+        else:
+            # element type is not handled(not a char or wchar_t)
+            return '"<not handled>"'
+
+        if error.Fail():
+            return f'process read error: {error}'
+    except Exception as e:
+        return f'error: {e}'
+
+    return f'"{result_string}"'
+
+def string_view_summary(valobj: lldb.SBValue, internal_dict):
+    logger = lldb.formatters.Logger.Logger()
+    logger >> f"{valobj.GetType()} summary"
+
+    # Grab the SBProcess object which is needed to read a c-string from memory
+    process = valobj.GetProcess()
+
+    string_size = valobj.GetChildMemberWithName("m_size").GetValueAsUnsigned()
+    string_address = valobj.GetChildMemberWithName("m_begin")
+
+    # If the string size is 0, then return an empty string
+    if string_size == 0:
+        return '""'
+
+    # Stores the result of summary string
+    result_string = ''
+    try:
+        string_type = valobj.GetType()
+        element_type = string_type.GetTemplateArgumentType(0)
+        error = lldb.SBError()
+
+        # SBType.GetBasicType is strange, passing in the enum value of the type
+        # doesn't query the actual type but returns a new SBType
+        # instance represents the basic type
+        # https://lldb.llvm.org/python_api/lldb.SBType.html#lldb.SBType.GetBasicType
+        if element_type == element_type.GetBasicType(lldb.eBasicTypeChar):
+        # Get the byte size of the character type being stored
+            element_size = element_type.GetByteSize()
+            byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+            result_string = byte_data.decode('utf-8')
+        elif element_type == element_type.GetBasicType(lldb.eBasicTypeWChar):
+            element_size = element_type.GetByteSize()
+            if element_size == 4:
+                byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                result_string = byte_data.decode('utf-32')
+            if element_size == 2:
+                byte_data = process.ReadMemory(string_address.GetValueAsUnsigned(), string_size * element_size, error)
+                result_string = byte_data.decode('utf-16')
+        else:
+            # element type is not handled(not a char or wchar_t)
+            return '"<not handled>"'
+
+        if error.Fail():
+            return f'process read error: {error}'
+    except Exception as e:
+        return f'error: {e}'
+
+    return f'"{result_string}"'
+
+
+class hash_table_synthetic_provider(lldb.SBSyntheticValueProvider):
     def __init__(self, valobj, internal_dict):
         self.valobj = valobj
+        self.bucket_count = None
+        self.num_elements = None
+        self.next_element = None
+        self.element_cache = None
+
+        logger = lldb.formatters.Logger.Logger()
+
+        # Get the node type stored within the hash_table list type
+        data_storage = self.valobj.GetChildMemberWithName("m_data")
+        hash_table_list = data_storage.GetChildMemberWithName("m_list")
+        list_type = hash_table_list.GetType()
+        list_type_template_args = list_type.template_arg_array()
+        if len(list_type_template_args) > 0:
+            # The first template argument is the type T of AZStd::list<T>
+            list_element_type = list_type_template_args[0]
+
+            # Grab the SBTarget object in order to query the list node type
+            target = self.valobj.GetTarget()
+
+            # Substitute in type T into the AZStd::Internal::list_node<T> to get list node type
+            # This will be used to cast the AZStd::Internal::list_base_node to actual value type
+            list_node_type_str = f'AZStd::Internal::list_node<{list_element_type.GetName()} >'
+            self.node_type = target.FindFirstType(list_node_type_str)
+            logger >> f'Hash table list node_type is: "{self.node_type.GetName()}"'
 
     def num_children(self) -> int:
-        return 1
+        return self.num_elements if self.num_elements else 0
 
     def has_children(self) -> bool:
-        return num_children != 0
+        return self.num_children() != 0
 
     def get_child_index(self, name):
-        if name == '0':
-            return 0
-        return -1
+        try:
+            return int(name.lstrip("[").rstrip("]"))
+        except:
+            return -1
 
     def get_child_at_index(self, index):
-        if index == 0:
-            return 'foo'
-        return None
+        if index < 0 or index >= self.num_children():
+            return None
+
+        if not self.node_type:
+            logger >> f'Cannot query Hash table element without node_type'
+            return None
+
+        # populate the cache all the previous elements up to the current index
+        while index >= len(self.element_cache):
+            if not self.next_element:
+                logger >> f'Reached the end of the hash_table list. Element at index {index} cannot be found'
+                return None
+
+            # First dereference the AZStd::Internal::list_base_node*
+            # Next cast the AZStd::Internal::list_base_node -> AZtd::Internal::list_node<T>
+            node = self.next_element.CreateValueFromData("list_node", self.next_element.GetData(), self.node_type)
+            self.element_cache.append(node.GetChildMemberWithName("m_value"))
+
+            # Move to the next element in the list
+            self.next_element = self.next_element.GetChildMemberWithName("m_next")
+            if not self.next_element.GetValueAsUnsigned(0):
+                self.next_element = None
+
+
+        # The value has been found so return it
+        value = self.element_cache[index]
+        return self.valobj.CreateValueFromData(f'[{index}]', value.GetData(), value.GetType())
+
 
     def update(self):
-        return True
+        try:
+            logger = lldb.formatters.Logger.Logger()
+            data_storage = self.valobj.GetChildMemberWithName("m_data")
+            hash_table_list = data_storage.GetChildMemberWithName("m_list")
+            self.num_elements = hash_table_list.GetChildMemberWithName("m_numElements").GetValueAsUnsigned()
+            logger >> f'Num elements = {self.num_elements}'
+
+            self.max_load_factor = data_storage.GetChildMemberWithName("m_max_load_factor").GetValueAsUnsigned()
+
+            hash_table_bucket_vector = data_storage.GetChildMemberWithName("m_vector")
+            self.bucket_count = hash_table_bucket_vector.GetChildMemberWithName("m_last").GetValueAsUnsigned() \
+                - hash_table_bucket_vector.GetChildMemberWithName("m_start").GetValueAsUnsigned()
+            logger >> f'Bucket count = {self.bucket_count}'
+
+            # Store off the pointer to the first element in the hash_table list of nodes
+            self.next_element = hash_table_list.GetChildMemberWithName("m_head").GetChildMemberWithName("m_next") \
+                if self.num_elements else None
+
+            # Cache SB Value containing the map value type and the hash value
+            self.element_cache = []
+        except Exception as e:
+            logger >> f'exception: {e}'
 
 
 def __lldb_init_module(debugger, dict):
@@ -113,9 +290,18 @@ def __lldb_init_module(debugger, dict):
     debugger.HandleCommand('type summary add -n "AZStd::string" -F o3destd_lldb.string_summary --category o3de')
     debugger.HandleCommand('type summary add -x "^AZStd::basic_string<.+>$" -F o3destd_lldb.string_summary --category o3de')
 
-    # Import the AZStd::basic_string synthetic children provider
-    # Commented out as we don't need synthetic children to visualize a string
-    # debugger.HandleCommand('type synthetic add "^AZStd::basic_string<.+>$" --python-class o3destd_lldb.string_synthetic_provider --category o3de')
+    # Import the AZStd::basic_fixed_string summary
+    debugger.HandleCommand('type summary add -x "^AZStd::basic_fixed_string<.+>$" -F o3destd_lldb.fixed_string_summary --category o3de')
+
+    # Import the AZStd::basic_string_view summary
+    debugger.HandleCommand('type summary add -x "^AZStd::basic_string_view<.+>$" -F o3destd_lldb.string_view_summary --category o3de')
+
+    # Import the AZStd::hash_table synthetic children providers (unordered_map and unordered_set)
+    debugger.HandleCommand('type synthetic add -x "^AZStd::hash_table<.+>$" --python-class o3destd_lldb.hash_table_synthetic_provider --category o3de')
+    debugger.HandleCommand('type synthetic add -x "^AZStd::unordered_map<.+>$" --python-class o3destd_lldb.hash_table_synthetic_provider --category o3de')
+    debugger.HandleCommand('type synthetic add -x "^AZStd::unordered_set<.+>$" --python-class o3destd_lldb.hash_table_synthetic_provider --category o3de')
+    debugger.HandleCommand('type synthetic add -x "^AZStd::unordered_multimap<.+>$" --python-class o3destd_lldb.hash_table_synthetic_provider --category o3de')
+    debugger.HandleCommand('type synthetic add -x "^AZStd::unordered_multiset<.+>$" --python-class o3destd_lldb.hash_table_synthetic_provider --category o3de')
 
     # Enable the o3de category for formatters
     debugger.HandleCommand('type category enable o3de')

--- a/scripts/lldb/.lldbinit
+++ b/scripts/lldb/.lldbinit
@@ -1,0 +1,5 @@
+# adding a prompt for lldb commands
+settings set prompt "[lldb]$ "
+
+# Import the AZStd library formatters
+command script import ~/.lldb/o3destd_lldb.py

--- a/scripts/lldb/README.md
+++ b/scripts/lldb/README.md
@@ -1,0 +1,47 @@
+# LLDB Formatters for O3DE
+
+This directory structure contains lldb formatter for O3DE.
+
+It contains an `lldb/.lldbinit` file which is used to source the o3de lldb python scripts to allow for a user's environment.
+The other files are python scripts that uses the [LLDB Python api](https://lldb.llvm.org/use/python-reference.html) to add support for O3DE specific container classes.
+
+
+## Implemented formatters
+The following types have implemented formatters and the files where their implementations can be found in
+
+| Types | Formatter Python Script |
+|------|------|
+|AZStd::basic_string<.*>| lldb/.lldb/o3destd_lldb.py|
+
+
+## How to use
+
+In order to use the lldb formatters, they need to be sourced into the lldb debugger.
+This can be done multiple ways
+1. Manually using the lldb script import command
+    *  `command script import <path-to-o3destd-py>`
+1. As part of an `~/.lldbinit` file that is placed in the user's home directory
+    | OS | Path |
+    | --- | --- |
+    | Linux | `/home/<user>` |
+    | MacOS | `/Users/<user>` |
+    | Windows | `C:/Users/<user>` |
+
+For more information on how to source an LLDB settings and commands into the debugger, follow the LLDB man page [Configuration Files](https://lldb.llvm.org/man/lldb.html#configuration-files)
+
+The directory structure containing this readme setup to allow source the lldb commands by copying the contents of the lldb folder into the user's home directory.  
+**NOTE**: The contents of the lldb folder should be copied and not the the folder itself.  
+i.e copy the ".lldbinit" file inside of the "lldb" folder to your home directory `~/` and not "lldb" folder.
+
+### Structure of Home Directory after copying O3DE lldb python formatters
+```
+~/
+    .lldbinit
+    .lldb/
+        o3destd_lldb.py
+```
+
+### Final Notes
+
+* If you as a user already have other custom python formatters for use with lldb, then the lldb `command script import <path-to-o3destd-py>` command can be used to source the O3DE formatters into your lldb instance.
+* On Linux/MacOS the `.lldbinit` file and `.lldb` directory are hidden due to starting with a \<dot>, so in order to view them in a file manager, it's hidden files option must be used. Also if copying from a file manager, the hidden files can't be selected without being visible.

--- a/scripts/lldb/README.md
+++ b/scripts/lldb/README.md
@@ -11,14 +11,16 @@ The following types have implemented formatters and the files where their implem
 
 | Types | Formatter Python Script |
 |------|------|
-|`AZStd::basic_string<.*>`| lldb/.lldb/o3destd_lldb.py|
 |`AZStd::basic_fixed_string<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::basic_string<.*>`| lldb/.lldb/o3destd_lldb.py|
 |`AZStd::basic_string_view<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::fixed_vector<.*>`| lldb/.lldb/o3destd_lldb.py|
 |`AZStd::hash_table<.*>`| lldb/.lldb/o3destd_lldb.py|
-|`AZStd::unordered_set<.*>`| lldb/.lldb/o3destd_lldb.py|
 |`AZStd::unordered_map<.*>`| lldb/.lldb/o3destd_lldb.py|
-|`AZStd::unordered_multiset<.*>`| lldb/.lldb/o3destd_lldb.py|
 |`AZStd::unordered_multimap<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_multiset<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_set<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::vector<.*>`| lldb/.lldb/o3destd_lldb.py|
 
 
 ## How to use

--- a/scripts/lldb/README.md
+++ b/scripts/lldb/README.md
@@ -11,7 +11,14 @@ The following types have implemented formatters and the files where their implem
 
 | Types | Formatter Python Script |
 |------|------|
-|AZStd::basic_string<.*>| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::basic_string<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::basic_fixed_string<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::basic_string_view<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::hash_table<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_set<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_map<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_multiset<.*>`| lldb/.lldb/o3destd_lldb.py|
+|`AZStd::unordered_multimap<.*>`| lldb/.lldb/o3destd_lldb.py|
 
 
 ## How to use


### PR DESCRIPTION
AZStd string classes(`string`, `string_view`, `fixed_string`), hash_table classes(`unordered_map`, `unordered_set`, `unordered_multimap`, `unordered_multiset`), contiguous container classes(`vector`, `fixed_vector`)  can be visualized in the lldb debugger by sourcing in the `o3destd_lldb.py` script into lldb.


## How was this PR tested?

Verified the lldb debugger print the summary for AZStd::string variables to the watch window
![image](https://github.com/o3de/o3de/assets/56135373/dad61dea-7236-45bb-91f6-02ffc747c01a)

