### PR TITLE
Change PR checklist GHA event type

### DIFF
--- a/.github/workflows/stabilization-pr-checklist.yaml
+++ b/.github/workflows/stabilization-pr-checklist.yaml
@@ -1,7 +1,7 @@
 name: Add stabilization PR checklist
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
     branches:
     - stabilization/**


### PR DESCRIPTION
## What does this PR do?

Another fix to allow Github Actions to trigger on PRs from a fork. Github recently changed this behavior for security reasons, this event type (pull_request_target) reverts to the i[ntended behavior](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)

## How was this PR tested?

Tested in a fork, with a PR from another fork
