### PR TITLE
Introduce multi-device ray tracing resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/RayTracingAccelerationStructure.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceRayTracingBufferPools;
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Bottom Level Acceleration Structure (BLAS)
+
+    //! MultiDeviceRayTracingGeometry
+    //!
+    //! The geometry entry contains the vertex and index buffers associated with geometry in the
+    //! scene.  Each MultiDeviceRayTracingBlas contains a list of these entries.
+    struct MultiDeviceRayTracingGeometry
+    {
+        RHI::Format m_vertexFormat = RHI::Format::Unknown;
+        RHI::MultiDeviceStreamBufferView m_mdVertexBuffer;
+        RHI::MultiDeviceIndexBufferView m_mdIndexBuffer;
+        // [GFX TODO][ATOM-4989] Add DXR BLAS Transform Buffer
+    };
+    using MultiDeviceRayTracingGeometryVector = AZStd::vector<MultiDeviceRayTracingGeometry>;
+
+    //! MultiDeviceRayTracingBlasDescriptor
+    //!
+    //! The Build() operation in the descriptor allows the BLAS to be initialized
+    //! using the following pattern:
+    //!
+    //! RHI::MultiDeviceRayTracingBlasDescriptor descriptor;
+    //! descriptor.Build()
+    //!    ->Geometry()
+    //!        ->VertexFormat(RHI::Format::R32G32B32_FLOAT)
+    //!        ->VertexBuffer(vertexBufferView)
+    //!        ->IndexBuffer(indexBufferView)
+    //!    ;
+    class MultiDeviceRayTracingBlasDescriptor final
+    {
+    public:
+        MultiDeviceRayTracingBlasDescriptor() = default;
+        ~MultiDeviceRayTracingBlasDescriptor() = default;
+
+        //! Returns the device-specific RayTracingBlasDescriptor for the given index
+        RayTracingBlasDescriptor GetDeviceRayTracingBlasDescriptor(int deviceIndex) const;
+
+        //! Accessors
+        const MultiDeviceRayTracingGeometryVector& GetGeometries() const
+        {
+            return m_mdGeometries;
+        }
+        MultiDeviceRayTracingGeometryVector& GetGeometries()
+        {
+            return m_mdGeometries;
+        }
+
+        //! Build operations
+        MultiDeviceRayTracingBlasDescriptor* Build();
+        MultiDeviceRayTracingBlasDescriptor* Geometry();
+        MultiDeviceRayTracingBlasDescriptor* VertexBuffer(const RHI::MultiDeviceStreamBufferView& vertexBuffer);
+        MultiDeviceRayTracingBlasDescriptor* VertexFormat(RHI::Format vertexFormat);
+        MultiDeviceRayTracingBlasDescriptor* IndexBuffer(const RHI::MultiDeviceIndexBufferView& indexBuffer);
+
+    private:
+        MultiDeviceRayTracingGeometryVector m_mdGeometries;
+        MultiDeviceRayTracingGeometry* m_mdBuildContext = nullptr;
+    };
+
+    //! MultiDeviceRayTracingBlas
+    //!
+    //! A MultiDeviceRayTracingBlas is created from the information in the MultiDeviceRayTracingBlasDescriptor.
+    class MultiDeviceRayTracingBlas : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingBlas, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceRayTracingBlas, "{D17E050F-ECC2-4C20-A073-F43008F2D168}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingBlas);
+        MultiDeviceRayTracingBlas() = default;
+        virtual ~MultiDeviceRayTracingBlas() = default;
+
+        //! Creates the internal BLAS buffers from the descriptor
+        ResultCode CreateBuffers(
+            MultiDevice::DeviceMask deviceMask,
+            const MultiDeviceRayTracingBlasDescriptor* descriptor,
+            const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+        //! Returns true if the MultiDeviceRayTracingBlas has been initialized
+        bool IsValid() const;
+
+    private:
+        MultiDeviceRayTracingBlasDescriptor m_mdDescriptor;
+    };
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Top Level Acceleration Structure (TLAS)
+
+    //! MultiDeviceRayTracingTlasInstance
+    //!
+    //! Each TLAS instance entry refers to a MultiDeviceRayTracingBlas, and can contain a transform which
+    //! will be applied to all of the geometry entries in the Blas.  It also contains a hitGroupIndex
+    //! which is used to index into the MultiDeviceRayTracingShaderTable to determine the hit shader when a
+    //! ray hits any geometry in the instance.
+    struct MultiDeviceRayTracingTlasInstance
+    {
+        uint32_t m_instanceID = 0;
+        uint32_t m_hitGroupIndex = 0;
+        AZ::Transform m_transform = AZ::Transform::CreateIdentity();
+        AZ::Vector3 m_nonUniformScale = AZ::Vector3::CreateOne();
+        bool m_transparent = false;
+        RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_mdBlas;
+    };
+    using MultiDeviceRayTracingTlasInstanceVector = AZStd::vector<MultiDeviceRayTracingTlasInstance>;
+
+    //! MultiDeviceRayTracingTlasDescriptor
+    //!
+    //! The Build() operation in the descriptor allows the TLAS to be initialized
+    //! using the following pattern:
+    //!
+    //! RHI::MultiDeviceRayTracingTlasDescriptor descriptor;
+    //! descriptor.Build()
+    //!     ->Instance()
+    //!         ->InstanceID(0)
+    //!         ->HitGroupIndex(0)
+    //!         ->Blas(blas1)
+    //!         ->Transform(transform1)
+    //!     ->Instance()
+    //!         ->InstanceID(1)
+    //!         ->HitGroupIndex(1)
+    //!         ->Blas(blas2)
+    //!         ->Transform(transform2)
+    //!     ;
+    class MultiDeviceRayTracingTlasDescriptor final
+    {
+    public:
+        MultiDeviceRayTracingTlasDescriptor() = default;
+        ~MultiDeviceRayTracingTlasDescriptor() = default;
+
+        //! Returns the device-specific RayTracingTlasDescriptor for the given index
+        RayTracingTlasDescriptor GetDeviceRayTracingTlasDescriptor(int deviceIndex) const;
+
+        //! Accessors
+        const MultiDeviceRayTracingTlasInstanceVector& GetInstances() const
+        {
+            return m_mdInstances;
+        }
+        MultiDeviceRayTracingTlasInstanceVector& GetInstances()
+        {
+            return m_mdInstances;
+        }
+
+        const RHI::Ptr<RHI::MultiDeviceBuffer>& GetInstancesBuffer() const
+        {
+            return m_mdInstancesBuffer;
+        }
+        RHI::Ptr<RHI::MultiDeviceBuffer>& GetInstancesBuffer()
+        {
+            return m_mdInstancesBuffer;
+        }
+
+        uint32_t GetNumInstancesInBuffer() const
+        {
+            return m_numInstancesInBuffer;
+        }
+
+        //! Build operations
+        MultiDeviceRayTracingTlasDescriptor* Build();
+        MultiDeviceRayTracingTlasDescriptor* Instance();
+        MultiDeviceRayTracingTlasDescriptor* InstanceID(uint32_t instanceID);
+        MultiDeviceRayTracingTlasDescriptor* HitGroupIndex(uint32_t hitGroupIndex);
+        MultiDeviceRayTracingTlasDescriptor* Transform(const AZ::Transform& transform);
+        MultiDeviceRayTracingTlasDescriptor* NonUniformScale(const AZ::Vector3& nonUniformScale);
+        MultiDeviceRayTracingTlasDescriptor* Transparent(bool transparent);
+        MultiDeviceRayTracingTlasDescriptor* Blas(RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& blas);
+        MultiDeviceRayTracingTlasDescriptor* InstancesBuffer(RHI::Ptr<RHI::MultiDeviceBuffer>& tlasInstances);
+        MultiDeviceRayTracingTlasDescriptor* NumInstances(uint32_t numInstancesInBuffer);
+
+    private:
+        MultiDeviceRayTracingTlasInstanceVector m_mdInstances;
+        MultiDeviceRayTracingTlasInstance* m_mdBuildContext = nullptr;
+
+        //! externally created Instances buffer, cannot be combined with other Instances
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_mdInstancesBuffer;
+        uint32_t m_numInstancesInBuffer;
+    };
+
+    //! MultiDeviceRayTracingTlas
+    //!
+    //! A MultiDeviceRayTracingTlas is created from the information in the MultiDeviceRayTracingTlasDescriptor.
+    class MultiDeviceRayTracingTlas : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingTlas, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceRayTracingTlas, "{A2B0F8F1-D0B5-4D90-8AFA-CEF543D20E34}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingTlas);
+        MultiDeviceRayTracingTlas() = default;
+        virtual ~MultiDeviceRayTracingTlas() = default;
+
+        //! Creates the internal TLAS buffers from the descriptor
+        ResultCode CreateBuffers(
+            MultiDevice::DeviceMask deviceMask,
+            const MultiDeviceRayTracingTlasDescriptor* descriptor,
+            const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+        //! Returns the TLAS RHI buffer
+        const RHI::Ptr<RHI::MultiDeviceBuffer> GetTlasBuffer() const;
+        const RHI::Ptr<RHI::MultiDeviceBuffer> GetTlasInstancesBuffer() const;
+
+    private:
+        MultiDeviceRayTracingTlasDescriptor m_mdDescriptor;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -31,7 +31,6 @@ namespace AZ::RHI
         RHI::Format m_vertexFormat = RHI::Format::Unknown;
         RHI::MultiDeviceStreamBufferView m_mdVertexBuffer;
         RHI::MultiDeviceIndexBufferView m_mdIndexBuffer;
-        // [GFX TODO][ATOM-4989] Add DXR BLAS Transform Buffer
     };
     using MultiDeviceRayTracingGeometryVector = AZStd::vector<MultiDeviceRayTracingGeometry>;
 
@@ -192,7 +191,7 @@ namespace AZ::RHI
 
         //! externally created Instances buffer, cannot be combined with other Instances
         RHI::Ptr<RHI::MultiDeviceBuffer> m_mdInstancesBuffer;
-        uint32_t m_numInstancesInBuffer;
+        uint32_t m_numInstancesInBuffer = 0;
     };
 
     //! MultiDeviceRayTracingTlas

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/RayTracingBufferPools.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceBufferPool;
+
+    //! MultiDeviceRayTracingBufferPools
+    //!
+    //! This class encapsulates all of the MultiDeviceBufferPools needed for ray tracing, freeing the application
+    //! from setting up and managing the buffers pools individually.
+    //!
+    class MultiDeviceRayTracingBufferPools : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingBufferPools, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceRayTracingBufferPools, "{59397661-F5A5-44DE-9B1D-E6F5BC32DC51}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingBufferPools);
+        MultiDeviceRayTracingBufferPools() = default;
+        virtual ~MultiDeviceRayTracingBufferPools() = default;
+
+        //! Accessors
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetShaderTableBufferPool() const;
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetScratchBufferPool() const;
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetBlasBufferPool() const;
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetTlasInstancesBufferPool() const;
+        const RHI::Ptr<RHI::MultiDeviceBufferPool>& GetTlasBufferPool() const;
+
+        //! Initializes the multi-device BufferPools as well as all device-specific RayTracingBufferPools
+        void Init(MultiDevice::DeviceMask deviceMask);
+
+    private:
+        bool m_initialized = false;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_mdShaderTableBufferPool;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_mdScratchBufferPool;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_mdBlasBufferPool;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_mdTlasInstancesBufferPool;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_mdTlasBufferPool;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/RayTracingPipelineState.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+namespace AZ::RHI
+{
+    //! MultiDeviceRayTracingPipelineStateDescriptor
+    //!
+    //! The Build() operation in the descriptor allows the pipeline state to be initialized
+    //! using the following pattern:
+    //!
+    //! RHI::MultiDeviceRayTracingPipelineStateDescriptor descriptor;
+    //! descriptor.Build()
+    //!     ->ShaderLibrary(shaderDescriptor)
+    //!         ->RayGenerationShaderName(AZ::Name("RayGenerationShader"))
+    //!     ->ShaderLibrary(missShaderDescriptor)
+    //!         ->MissShaderName(AZ::Name("MissShader"))
+    //!     ->ShaderLibrary(closestHitShader1Descriptor)
+    //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader1"))
+    //!     ->ShaderLibrary(closestHitShader2Descriptor)
+    //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader2"))
+    //!     ->HitGroup(AZ::Name("HitGroup1"))
+    //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader1"))
+    //!     ->HitGroup(AZ::Name("HitGroup2"))
+    //!         ->ClosestHitShaderName(AZ::Name("ClosestHitShader2"))
+    //!     ;
+    //!
+    class MultiDeviceRayTracingPipelineStateDescriptor final
+    {
+    public:
+        MultiDeviceRayTracingPipelineStateDescriptor() = default;
+        ~MultiDeviceRayTracingPipelineStateDescriptor() = default;
+
+        //! Returns the device-specific RayTracingPipelineStateDescriptor for the given index
+        RayTracingPipelineStateDescriptor GetDeviceRayTracingPipelineStateDescriptor(int deviceIndex) const;
+
+        //! Accessors
+        const RayTracingConfiguration& GetConfiguration() const
+        {
+            return m_descriptor.GetConfiguration();
+        }
+        RayTracingConfiguration& GetConfiguration()
+        {
+            return m_descriptor.GetConfiguration();
+        }
+
+        const RHI::MultiDevicePipelineState* GetPipelineState() const
+        {
+            return m_mdPipelineState;
+        }
+
+        const RayTracingShaderLibraryVector& GetShaderLibraries() const
+        {
+            return m_descriptor.GetShaderLibraries();
+        }
+        RayTracingShaderLibraryVector& GetShaderLibraries()
+        {
+            return m_descriptor.GetShaderLibraries();
+        }
+
+        const RayTracingHitGroupVector& GetHitGroups() const
+        {
+            return m_descriptor.GetHitGroups();
+        }
+        RayTracingHitGroupVector& GetHitGroups()
+        {
+            return m_descriptor.GetHitGroups();
+        }
+
+        //! Build operations
+        MultiDeviceRayTracingPipelineStateDescriptor* Build();
+        MultiDeviceRayTracingPipelineStateDescriptor* MaxPayloadSize(uint32_t maxPayloadSize);
+        MultiDeviceRayTracingPipelineStateDescriptor* MaxAttributeSize(uint32_t maxAttributeSize);
+        MultiDeviceRayTracingPipelineStateDescriptor* MaxRecursionDepth(uint32_t maxRecursionDepth);
+        MultiDeviceRayTracingPipelineStateDescriptor* PipelineState(const RHI::MultiDevicePipelineState* pipelineState);
+        MultiDeviceRayTracingPipelineStateDescriptor* ShaderLibrary(RHI::PipelineStateDescriptorForRayTracing& descriptor);
+
+        MultiDeviceRayTracingPipelineStateDescriptor* RayGenerationShaderName(const AZ::Name& name);
+        MultiDeviceRayTracingPipelineStateDescriptor* MissShaderName(const AZ::Name& name);
+        MultiDeviceRayTracingPipelineStateDescriptor* ClosestHitShaderName(const AZ::Name& closestHitShaderName);
+        MultiDeviceRayTracingPipelineStateDescriptor* AnyHitShaderName(const AZ::Name& anyHitShaderName);
+
+        MultiDeviceRayTracingPipelineStateDescriptor* HitGroup(const AZ::Name& name);
+
+    private:
+        const RHI::MultiDevicePipelineState* m_mdPipelineState = nullptr;
+        RayTracingPipelineStateDescriptor m_descriptor;
+    };
+
+    //! Defines the shaders, hit groups, and other parameters required for ray tracing operations across multiple devices.
+    class MultiDeviceRayTracingPipelineState : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingPipelineState, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceRayTracingPipelineState, "{22F609DF-C889-4278-9580-3D2A99E78857}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingPipelineState);
+        MultiDeviceRayTracingPipelineState() = default;
+
+        virtual ~MultiDeviceRayTracingPipelineState() = default;
+
+        const MultiDeviceRayTracingPipelineStateDescriptor& GetDescriptor() const
+        {
+            return m_mdDescriptor;
+        }
+
+        //! Initialize all device-specific RayTracingPipelineStates
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingPipelineStateDescriptor& descriptor);
+
+    private:
+        //! explicit shutdown is not allowed for this type
+        void Shutdown() override final;
+
+        MultiDeviceRayTracingPipelineStateDescriptor m_mdDescriptor;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/DeviceObject.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/RayTracingShaderTable.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceRayTracingBufferPools;
+    class MultiDeviceShaderResourceGroup;
+
+    //! Specifies the shader and any local root signature parameters that make up a record in the shader table
+    struct MultiDeviceRayTracingShaderTableRecord
+    {
+        //! name of the shader as described in the pipeline state
+        AZ::Name m_shaderExportName;
+
+        //! shader resource group for this shader record
+        const RHI::MultiDeviceShaderResourceGroup* m_mdShaderResourceGroup;
+
+        static const uint32_t InvalidKey = static_cast<uint32_t>(-1);
+
+        //! key that can be used to identify this record
+        uint32_t m_key = InvalidKey;
+    };
+    using MultiDeviceRayTracingShaderTableRecordList = AZStd::list<MultiDeviceRayTracingShaderTableRecord>;
+
+    //! MultiDeviceRayTracingShaderTableDescriptor
+    //!
+    //! The Build() operation in the descriptor allows the shader table to be initialized
+    //! using the following pattern:
+    //!
+    //! RHI::MultiDeviceRayTracingShaderTableDescriptor descriptor;
+    //! descriptor.Build(AZ::Name("RayTracingExampleShaderTable"), m_mdRayTracingPipelineState)
+    //!     ->RayGenerationRecord(AZ::Name("RayGenerationShader"))
+    //!     ->MissRecord(AZ::Name("MissShader"))
+    //!         ->ShaderResourceGroup(missSrg)
+    //!     ->HitGroupRecord(AZ::Name("HitGroup1"))
+    //!         ->ShaderResourceGroup(hitGroupSrg1)
+    //!     ->HitGroupRecord(AZ::Name("HitGroup2"))
+    //!         ->ShaderResourceGroup(hitGroupSrg2)
+    //!     ;
+    //!
+    class MultiDeviceRayTracingShaderTableDescriptor
+    {
+    public:
+        MultiDeviceRayTracingShaderTableDescriptor() = default;
+        ~MultiDeviceRayTracingShaderTableDescriptor() = default;
+
+        //! Returns the device-specific RayTracingShaderTableDescriptor for the given index
+        AZStd::shared_ptr<RayTracingShaderTableDescriptor> GetDeviceRayTracingShaderTableDescriptor(int deviceIndex);
+
+        //! Accessors
+        const RHI::Ptr<MultiDeviceRayTracingPipelineState>& GetPipelineState() const
+        {
+            return m_mdRayTracingPipelineState;
+        }
+
+        const MultiDeviceRayTracingShaderTableRecordList& GetRayGenerationRecord() const
+        {
+            return m_mdRayGenerationRecord;
+        }
+        MultiDeviceRayTracingShaderTableRecordList& GetRayGenerationRecord()
+        {
+            return m_mdRayGenerationRecord;
+        }
+
+        const MultiDeviceRayTracingShaderTableRecordList& GetMissRecords() const
+        {
+            return m_mdMissRecords;
+        }
+        MultiDeviceRayTracingShaderTableRecordList& GetMissRecords()
+        {
+            return m_mdMissRecords;
+        }
+
+        const MultiDeviceRayTracingShaderTableRecordList& GetHitGroupRecords() const
+        {
+            return m_mdHitGroupRecords;
+        }
+        MultiDeviceRayTracingShaderTableRecordList& GetHitGroupRecords()
+        {
+            return m_mdHitGroupRecords;
+        }
+
+        void RemoveHitGroupRecords(uint32_t key);
+
+        //! build operations
+        MultiDeviceRayTracingShaderTableDescriptor* Build(
+            const AZ::Name& name, RHI::Ptr<MultiDeviceRayTracingPipelineState>& rayTracingPipelineState);
+        MultiDeviceRayTracingShaderTableDescriptor* RayGenerationRecord(const AZ::Name& name);
+        MultiDeviceRayTracingShaderTableDescriptor* MissRecord(const AZ::Name& name);
+        MultiDeviceRayTracingShaderTableDescriptor* HitGroupRecord(
+            const AZ::Name& name, uint32_t key = MultiDeviceRayTracingShaderTableRecord::InvalidKey);
+        MultiDeviceRayTracingShaderTableDescriptor* ShaderResourceGroup(const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup);
+
+    private:
+        AZ::Name m_name;
+        RHI::Ptr<MultiDeviceRayTracingPipelineState> m_mdRayTracingPipelineState;
+        //! limited to one record, but stored as a list to simplify processing
+        MultiDeviceRayTracingShaderTableRecordList m_mdRayGenerationRecord;
+        MultiDeviceRayTracingShaderTableRecordList m_mdMissRecords;
+        MultiDeviceRayTracingShaderTableRecordList m_mdHitGroupRecords;
+
+        MultiDeviceRayTracingShaderTableRecord* m_mdBuildContext = nullptr;
+    };
+
+    //! Shader Table
+    //! Specifies the ray generation, miss, and hit shaders used during the ray tracing process
+    class MultiDeviceRayTracingShaderTable : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceRayTracingShaderTable, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceRayTracingShaderTable, "{B448997B-A8E6-446E-A333-EFD92B486D9B}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingShaderTable);
+        MultiDeviceRayTracingShaderTable() = default;
+        virtual ~MultiDeviceRayTracingShaderTable() = default;
+
+        //! Initialize all device-specific RayTracingShaderTables
+        void Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingBufferPools& rayTracingBufferPools);
+
+        //! Queues this MultiDeviceRayTracingShaderTable to be built by the FrameScheduler.
+        //! Note that the descriptor must be heap allocated, preferably using make_shared.
+        void Build(const AZStd::shared_ptr<MultiDeviceRayTracingShaderTableDescriptor> descriptor);
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -203,7 +203,7 @@ namespace AZ::RHI
         }
 
         IterateObjects<RayTracingBlas>(
-            [](auto deviceIndex, auto deviceRayTracingBlas)
+            [](auto /*deviceIndex*/, auto deviceRayTracingBlas)
             {
                 if (!deviceRayTracingBlas->IsValid())
                 {

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    RayTracingBlasDescriptor MultiDeviceRayTracingBlasDescriptor::GetDeviceRayTracingBlasDescriptor(int deviceIndex) const
+    {
+        RayTracingBlasDescriptor descriptor;
+
+        for (const auto& geometry : m_mdGeometries)
+        {
+            descriptor.Geometry()
+                ->VertexFormat(geometry.m_vertexFormat)
+                ->VertexBuffer(geometry.m_mdVertexBuffer.GetDeviceStreamBufferView(deviceIndex))
+                ->IndexBuffer(geometry.m_mdIndexBuffer.GetDeviceIndexBufferView(deviceIndex));
+        }
+
+        return descriptor;
+    }
+
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::Build()
+    {
+        return this;
+    }
+
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::Geometry()
+    {
+        m_mdGeometries.emplace_back();
+        m_mdBuildContext = &m_mdGeometries.back();
+        return this;
+    }
+
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::VertexBuffer(
+        const RHI::MultiDeviceStreamBufferView& vertexBuffer)
+    {
+        AZ_Assert(m_mdBuildContext, "VertexBuffer property can only be added to a Geometry entry");
+        m_mdBuildContext->m_mdVertexBuffer = vertexBuffer;
+        return this;
+    }
+
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::VertexFormat(RHI::Format vertexFormat)
+    {
+        AZ_Assert(m_mdBuildContext, "VertexFormat property can only be added to a Geometry entry");
+        m_mdBuildContext->m_vertexFormat = vertexFormat;
+        return this;
+    }
+
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::IndexBuffer(
+        const RHI::MultiDeviceIndexBufferView& indexBuffer)
+    {
+        AZ_Assert(m_mdBuildContext, "IndexBuffer property can only be added to a Geometry entry");
+        m_mdBuildContext->m_mdIndexBuffer = indexBuffer;
+        return this;
+    }
+
+    RayTracingTlasDescriptor MultiDeviceRayTracingTlasDescriptor::GetDeviceRayTracingTlasDescriptor(int deviceIndex) const
+    {
+        AZ_Assert(m_mdInstancesBuffer, "No MultiDeviceBuffer available!\n");
+
+        RayTracingTlasDescriptor descriptor;
+
+        for (const auto& instance : m_mdInstances)
+        {
+            descriptor.Instance()
+                ->InstanceID(instance.m_instanceID)
+                ->HitGroupIndex(instance.m_hitGroupIndex)
+                ->Transform(instance.m_transform)
+                ->NonUniformScale(instance.m_nonUniformScale)
+                ->Transparent(instance.m_transparent)
+                ->Blas(instance.m_mdBlas->GetDeviceRayTracingBlas(deviceIndex));
+        }
+
+        if (m_mdInstancesBuffer)
+        {
+            descriptor.InstancesBuffer(m_mdInstancesBuffer->GetDeviceBuffer(deviceIndex))->NumInstances(m_numInstancesInBuffer);
+        }
+
+        return descriptor;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Build()
+    {
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Instance()
+    {
+        AZ_Assert(m_mdInstancesBuffer == nullptr, "Instance cannot be combined with an instances buffer");
+        m_mdInstances.emplace_back();
+        m_mdBuildContext = &m_mdInstances.back();
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstanceID(uint32_t instanceID)
+    {
+        AZ_Assert(m_mdBuildContext, "InstanceID property can only be added to an Instance entry");
+        m_mdBuildContext->m_instanceID = instanceID;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::HitGroupIndex(uint32_t hitGroupIndex)
+    {
+        AZ_Assert(m_mdBuildContext, "HitGroupIndex property can only be added to an Instance entry");
+        m_mdBuildContext->m_hitGroupIndex = hitGroupIndex;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Transform(const AZ::Transform& transform)
+    {
+        AZ_Assert(m_mdBuildContext, "Transform property can only be added to an Instance entry");
+        m_mdBuildContext->m_transform = transform;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::NonUniformScale(const AZ::Vector3& nonUniformScale)
+    {
+        AZ_Assert(m_mdBuildContext, "NonUniformSCale property can only be added to an Instance entry");
+        m_mdBuildContext->m_nonUniformScale = nonUniformScale;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Transparent(bool transparent)
+    {
+        AZ_Assert(m_mdBuildContext, "Transparent property can only be added to a Geometry entry");
+        m_mdBuildContext->m_transparent = transparent;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::Blas(RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& blas)
+    {
+        AZ_Assert(m_mdBuildContext, "Blas property can only be added to an Instance entry");
+        m_mdBuildContext->m_mdBlas = blas;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstancesBuffer(
+        RHI::Ptr<RHI::MultiDeviceBuffer>& instancesBuffer)
+    {
+        AZ_Assert(!m_mdBuildContext, "InstancesBuffer property can only be added to the top level");
+        AZ_Assert(m_mdInstances.size() == 0, "InstancesBuffer cannot exist with instance entries");
+        m_mdInstancesBuffer = instancesBuffer;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::NumInstances(uint32_t numInstancesInBuffer)
+    {
+        AZ_Assert(m_mdInstancesBuffer.get(), "NumInstances property can only be added to the InstancesBuffer entry");
+        m_numInstancesInBuffer = numInstancesInBuffer;
+        return this;
+    }
+
+    ResultCode MultiDeviceRayTracingBlas::CreateBuffers(
+        MultiDevice::DeviceMask deviceMask,
+        const MultiDeviceRayTracingBlasDescriptor* descriptor,
+        const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
+    {
+        m_mdDescriptor = *descriptor;
+        ResultCode resultCode{ ResultCode::Success };
+
+        MultiDeviceObject::Init(deviceMask);
+
+        IterateDevices(
+            [this, &resultCode, &descriptor, &rayTracingBufferPools](auto deviceIndex)
+            {
+                auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBlas();
+
+                auto deviceDescriptor{ descriptor->GetDeviceRayTracingBlasDescriptor(deviceIndex) };
+
+                resultCode = GetDeviceRayTracingBlas(deviceIndex)
+                                 ->CreateBuffers(
+                                     *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
+
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific RayTracingBlas and set deviceMask to 0
+            m_deviceObjects.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    bool MultiDeviceRayTracingBlas::IsValid() const
+    {
+        if (m_deviceObjects.empty())
+        {
+            return false;
+        }
+
+        IterateObjects<RayTracingBlas>(
+            [](auto deviceIndex, auto deviceRayTracingBlas)
+            {
+                if (!deviceRayTracingBlas->IsValid())
+                {
+                    return false;
+                }
+                return true;
+            });
+        return true;
+    }
+
+    ResultCode MultiDeviceRayTracingTlas::CreateBuffers(
+        MultiDevice::DeviceMask deviceMask,
+        const MultiDeviceRayTracingTlasDescriptor* descriptor,
+        const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
+    {
+        m_mdDescriptor = *descriptor;
+        ResultCode resultCode{ ResultCode::Success };
+
+        MultiDeviceObject::Init(deviceMask);
+
+        IterateObjects<RayTracingTlas>(
+            [this, &resultCode, &descriptor, &rayTracingBufferPools](int deviceIndex, auto deviceRayTracingTlas)
+            {
+                auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingTlas();
+
+                auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
+
+                resultCode = deviceRayTracingTlas->CreateBuffers(
+                    *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
+
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific RayTracingTlas and set deviceMask to 0
+            m_deviceObjects.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasBuffer() const
+    {
+        if (m_deviceObjects.empty())
+        {
+            return nullptr;
+        }
+
+        auto tlasBuffer = aznew RHI::MultiDeviceBuffer;
+        tlasBuffer->Init(GetDeviceMask());
+
+        IterateObjects<RayTracingTlas>(
+            [&tlasBuffer](int deviceIndex, auto deviceRayTracingTlas)
+            {
+                tlasBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
+
+                if (!tlasBuffer->m_deviceObjects[deviceIndex])
+                {
+                    tlasBuffer = nullptr;
+                    return false;
+                }
+
+                tlasBuffer->SetDescriptor(tlasBuffer->GetDeviceBuffer(deviceIndex)->GetDescriptor());
+                return true;
+            });
+
+        return tlasBuffer;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasInstancesBuffer() const
+    {
+        if (m_deviceObjects.empty())
+        {
+            return nullptr;
+        }
+
+        auto tlasInstancesBuffer = aznew RHI::MultiDeviceBuffer;
+        tlasInstancesBuffer->Init(GetDeviceMask());
+
+        IterateObjects<RayTracingTlas>(
+            [&tlasInstancesBuffer](int deviceIndex, auto deviceRayTracingTlas)
+            {
+                tlasInstancesBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
+
+                if (!tlasInstancesBuffer->m_deviceObjects[deviceIndex])
+                {
+                    tlasInstancesBuffer = nullptr;
+                    return false;
+                }
+
+                tlasInstancesBuffer->SetDescriptor(tlasInstancesBuffer->GetDeviceBuffer(deviceIndex)->GetDescriptor());
+                return true;
+            });
+        return tlasInstancesBuffer;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingBufferPools.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingBufferPools.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetShaderTableBufferPool() const
+    {
+        AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+        return m_mdShaderTableBufferPool;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetScratchBufferPool() const
+    {
+        AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+        return m_mdScratchBufferPool;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetBlasBufferPool() const
+    {
+        AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+        return m_mdBlasBufferPool;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetTlasInstancesBufferPool() const
+    {
+        AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+        return m_mdTlasInstancesBufferPool;
+    }
+
+    const RHI::Ptr<RHI::MultiDeviceBufferPool>& MultiDeviceRayTracingBufferPools::GetTlasBufferPool() const
+    {
+        AZ_Assert(m_initialized, "MultiDeviceRayTracingBufferPools was not initialized");
+        return m_mdTlasBufferPool;
+    }
+
+    void MultiDeviceRayTracingBufferPools::Init(MultiDevice::DeviceMask deviceMask)
+    {
+        if (m_initialized)
+        {
+            return;
+        }
+
+        MultiDeviceObject::Init(deviceMask);
+
+        // Initialize device ray tracing buffer pools
+        IterateDevices(
+            [this](int deviceIndex)
+            {
+                RHI::Ptr<RHI::Device> device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBufferPools();
+                GetDeviceRayTracingBufferPools(deviceIndex)->Init(device);
+                return true;
+            });
+
+        m_mdShaderTableBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_mdShaderTableBufferPool->Init(
+            deviceMask,
+            [this]()
+            {
+                IterateObjects<RayTracingBufferPools>(
+                    [this]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
+                    {
+                        m_mdShaderTableBufferPool->m_deviceObjects[deviceIndex] = deviceBufferPool->GetShaderTableBufferPool().get();
+                        m_mdShaderTableBufferPool->m_descriptor = deviceBufferPool->GetShaderTableBufferPool()->GetDescriptor();
+                    });
+                return ResultCode::Success;
+            });
+
+        m_mdScratchBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_mdScratchBufferPool->Init(
+            deviceMask,
+            [this]()
+            {
+                IterateObjects<RayTracingBufferPools>(
+                    [this]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
+                    {
+                        m_mdScratchBufferPool->m_deviceObjects[deviceIndex] = deviceBufferPool->GetScratchBufferPool().get();
+                        m_mdScratchBufferPool->m_descriptor = deviceBufferPool->GetScratchBufferPool()->GetDescriptor();
+                    });
+                return ResultCode::Success;
+            });
+
+        m_mdBlasBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_mdBlasBufferPool->Init(
+            deviceMask,
+            [this]()
+            {
+                IterateObjects<RayTracingBufferPools>(
+                    [this]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
+                    {
+                        m_mdBlasBufferPool->m_deviceObjects[deviceIndex] = deviceBufferPool->GetBlasBufferPool().get();
+                        m_mdBlasBufferPool->m_descriptor = deviceBufferPool->GetBlasBufferPool()->GetDescriptor();
+                    });
+                return ResultCode::Success;
+            });
+
+        m_mdTlasInstancesBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_mdTlasInstancesBufferPool->Init(
+            deviceMask,
+            [this]()
+            {
+                IterateObjects<RayTracingBufferPools>(
+                    [this]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
+                    {
+                        m_mdTlasInstancesBufferPool->m_deviceObjects[deviceIndex] = deviceBufferPool->GetTlasInstancesBufferPool().get();
+                        m_mdTlasInstancesBufferPool->m_descriptor = deviceBufferPool->GetTlasInstancesBufferPool()->GetDescriptor();
+                    });
+                return ResultCode::Success;
+            });
+
+        m_mdTlasBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_mdTlasBufferPool->Init(
+            deviceMask,
+            [this]()
+            {
+                IterateObjects<RayTracingBufferPools>(
+                    [this]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
+                    {
+                        m_mdTlasBufferPool->m_deviceObjects[deviceIndex] = deviceBufferPool->GetTlasBufferPool().get();
+                        m_mdTlasBufferPool->m_descriptor = deviceBufferPool->GetTlasBufferPool()->GetDescriptor();
+                    });
+                return ResultCode::Success;
+            });
+
+        m_initialized = true;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    RayTracingPipelineStateDescriptor MultiDeviceRayTracingPipelineStateDescriptor::GetDeviceRayTracingPipelineStateDescriptor(
+        int deviceIndex) const
+    {
+        AZ_Assert(m_mdPipelineState, "No MultiDevicePipelineState available\n");
+
+        RayTracingPipelineStateDescriptor descriptor{ m_descriptor };
+
+        if (m_mdPipelineState)
+        {
+            descriptor.PipelineState(m_mdPipelineState->GetDevicePipelineState(deviceIndex).get());
+        }
+
+        return descriptor;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::Build()
+    {
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxPayloadSize(uint32_t maxPayloadSize)
+    {
+        m_descriptor.MaxPayloadSize(maxPayloadSize);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxAttributeSize(uint32_t maxAttributeSize)
+    {
+        m_descriptor.MaxAttributeSize(maxAttributeSize);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MaxRecursionDepth(
+        uint32_t maxRecursionDepth)
+    {
+        m_descriptor.MaxRecursionDepth(maxRecursionDepth);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::PipelineState(
+        const RHI::MultiDevicePipelineState* pipelineState)
+    {
+        m_mdPipelineState = pipelineState;
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::ShaderLibrary(
+        RHI::PipelineStateDescriptorForRayTracing& descriptor)
+    {
+        m_descriptor.ShaderLibrary(descriptor);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::RayGenerationShaderName(
+        const AZ::Name& name)
+    {
+        m_descriptor.RayGenerationShaderName(name);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::MissShaderName(const AZ::Name& name)
+    {
+        m_descriptor.MissShaderName(name);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::ClosestHitShaderName(
+        const AZ::Name& closestHitShaderName)
+    {
+        m_descriptor.ClosestHitShaderName(closestHitShaderName);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::AnyHitShaderName(
+        const AZ::Name& anyHitShaderName)
+    {
+        m_descriptor.AnyHitShaderName(anyHitShaderName);
+        return this;
+    }
+
+    MultiDeviceRayTracingPipelineStateDescriptor* MultiDeviceRayTracingPipelineStateDescriptor::HitGroup(const AZ::Name& hitGroupName)
+    {
+        m_descriptor.HitGroup(hitGroupName);
+        return this;
+    }
+
+    ResultCode MultiDeviceRayTracingPipelineState::Init(
+        MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingPipelineStateDescriptor& descriptor)
+    {
+        m_mdDescriptor = descriptor;
+
+        MultiDeviceObject::Init(deviceMask);
+
+        ResultCode resultCode{ ResultCode::Success };
+
+        IterateDevices(
+            [this, &resultCode](int deviceIndex)
+            {
+                auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingPipelineState();
+
+                auto descriptor{ m_mdDescriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
+                resultCode = GetDeviceRayTracingPipelineState(deviceIndex)->Init(*device, &descriptor);
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific RayTracingPipelineState and set deviceMask to 0
+            m_deviceObjects.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    void MultiDeviceRayTracingPipelineState::Shutdown()
+    {
+        MultiDeviceObject::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingShaderTable.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace AZ::RHI
+{
+    AZStd::shared_ptr<RayTracingShaderTableDescriptor> MultiDeviceRayTracingShaderTableDescriptor::GetDeviceRayTracingShaderTableDescriptor(
+        int deviceIndex)
+    {
+        AZ_Assert(m_mdRayTracingPipelineState, "No MultiDeviceRayTracingPipelineState available\n");
+
+        AZStd::shared_ptr<RayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RayTracingShaderTableDescriptor>();
+
+        if (m_mdRayTracingPipelineState)
+        {
+            descriptor->Build(m_name, m_mdRayTracingPipelineState->GetDeviceRayTracingPipelineState(deviceIndex));
+        }
+
+        for (const auto& rayGenerationRecord : m_mdRayGenerationRecord)
+        {
+            descriptor->RayGenerationRecord(rayGenerationRecord.m_shaderExportName);
+            if (rayGenerationRecord.m_mdShaderResourceGroup)
+            {
+                descriptor->ShaderResourceGroup(
+                    rayGenerationRecord.m_mdShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+        }
+
+        for (const auto& missRecord : m_mdMissRecords)
+        {
+            descriptor->MissRecord(missRecord.m_shaderExportName);
+            if (missRecord.m_mdShaderResourceGroup)
+            {
+                descriptor->ShaderResourceGroup(missRecord.m_mdShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+        }
+
+        for (const auto& hitGroupRecord : m_mdHitGroupRecords)
+        {
+            descriptor->HitGroupRecord(hitGroupRecord.m_shaderExportName, hitGroupRecord.m_key);
+            if (hitGroupRecord.m_mdShaderResourceGroup)
+            {
+                descriptor->ShaderResourceGroup(hitGroupRecord.m_mdShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+        }
+
+        return descriptor;
+    }
+
+    void MultiDeviceRayTracingShaderTableDescriptor::RemoveHitGroupRecords(uint32_t key)
+    {
+        for (MultiDeviceRayTracingShaderTableRecordList::iterator itHitGroup = m_mdHitGroupRecords.begin();
+             itHitGroup != m_mdHitGroupRecords.end();
+             ++itHitGroup)
+        {
+            MultiDeviceRayTracingShaderTableRecord& record = *itHitGroup;
+            if (record.m_key == key)
+            {
+                m_mdHitGroupRecords.erase(itHitGroup);
+            }
+        }
+    }
+
+    MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::Build(
+        const AZ::Name& name, RHI::Ptr<MultiDeviceRayTracingPipelineState>& rayTracingPipelineState)
+    {
+        m_name = name;
+        m_mdRayTracingPipelineState = rayTracingPipelineState;
+        return this;
+    }
+
+    MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::RayGenerationRecord(const AZ::Name& name)
+    {
+        AZ_Assert(m_mdRayGenerationRecord.empty(), "Ray generation record already added");
+        m_mdRayGenerationRecord.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name });
+        m_mdBuildContext = &m_mdRayGenerationRecord.back();
+        return this;
+    }
+
+    MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::MissRecord(const AZ::Name& name)
+    {
+        m_mdMissRecords.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name });
+        m_mdBuildContext = &m_mdMissRecords.back();
+        return this;
+    }
+
+    MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::HitGroupRecord(
+        const AZ::Name& name, uint32_t key /* = MultiDeviceRayTracingShaderTableRecord::InvalidKey */)
+    {
+        m_mdHitGroupRecords.emplace_back(MultiDeviceRayTracingShaderTableRecord{ name, nullptr, key });
+        m_mdBuildContext = &m_mdHitGroupRecords.back();
+        return this;
+    }
+
+    MultiDeviceRayTracingShaderTableDescriptor* MultiDeviceRayTracingShaderTableDescriptor::ShaderResourceGroup(
+        const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup)
+    {
+        AZ_Assert(m_mdBuildContext, "MultiDeviceShaderResourceGroup can only be added to a shader table record");
+        AZ_Assert(m_mdBuildContext->m_mdShaderResourceGroup == nullptr, "Records can only have one MultiDeviceShaderResourceGroup");
+        m_mdBuildContext->m_mdShaderResourceGroup = shaderResourceGroup;
+        return this;
+    }
+
+    void MultiDeviceRayTracingShaderTable::Init(MultiDevice::DeviceMask deviceMask, const MultiDeviceRayTracingBufferPools& bufferPools)
+    {
+        MultiDeviceObject::Init(deviceMask);
+
+        IterateDevices(
+            [this, &bufferPools](auto deviceIndex)
+            {
+                auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingShaderTable();
+
+                auto deviceBufferPool{ bufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get() };
+
+                GetDeviceRayTracingShaderTable(deviceIndex)->Init(*device, *deviceBufferPool);
+
+                return true;
+            });
+    }
+
+    void MultiDeviceRayTracingShaderTable::Build(const AZStd::shared_ptr<MultiDeviceRayTracingShaderTableDescriptor> descriptor)
+    {
+        IterateObjects<RayTracingShaderTable>(
+            [&descriptor](auto deviceIndex, auto deviceRayTracingShaderTable)
+            {
+                deviceRayTracingShaderTable->Build(descriptor->GetDeviceRayTracingShaderTableDescriptor(deviceIndex));
+            });
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -231,14 +231,22 @@ set(FILES
     Include/Atom/RHI/RHIUtils.h
     Source/RHI/RHIUtils.cpp
     Include/Atom/RHI/RayTracingAccelerationStructure.h
+    Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
     Include/Atom/RHI/RayTracingPipelineState.h
+    Include/Atom/RHI/MultiDeviceRayTracingPipelineState.h
     Include/Atom/RHI/RayTracingShaderTable.h
+    Include/Atom/RHI/MultiDeviceRayTracingShaderTable.h
     Include/Atom/RHI/RayTracingBufferPools.h
+    Include/Atom/RHI/MultiDeviceRayTracingBufferPools.h
     Include/Atom/RHI/DispatchRaysItem.h
     Source/RHI/RayTracingAccelerationStructure.cpp
+    Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
     Source/RHI/RayTracingPipelineState.cpp
+    Source/RHI/MultiDeviceRayTracingPipelineState.cpp
     Source/RHI/RayTracingShaderTable.cpp
+    Source/RHI/MultiDeviceRayTracingShaderTable.cpp
     Source/RHI/RayTracingBufferPools.cpp
+    Source/RHI/MultiDeviceRayTracingBufferPools.cpp
     Include/Atom/RHI/interval_map.h
     Include/Atom/RHI/ImageProperty.h
     Include/Atom/RHI/BufferProperty.h


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, in particular:
- `MultiDeviceRayTracingShaderTable`
- `MultiDeviceRayTracingPipelineState`
- `MultiDeviceRayTracingBufferPools`
- `MultiDeviceRayTracingBlas`
- `MultiDeviceRayTracingTlas`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources|[#16262](https://github.com/o3de/o3de/pull/16262)|merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)| merged |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591)| merged |
|Indirect*|[#16681](https://github.com/o3de/o3de/pull/16681)|open|
| SRGs|[#16680](https://github.com/o3de/o3de/pull/16680) | merged |
| TransientAttachmentPool | [#16712](https://github.com/o3de/o3de/pull/16712) | open |
|RayTracing Resources|this PR|open|
| Items | | |


