### PR TITLE
Introduce multi-device items

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/CopyItem.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+
+namespace AZ::RHI
+{
+    //! A structure used to define a MultiDeviceCopyItem, copying from a MultiDeviceBuffer to a MultiDeviceBuffer
+    struct MultiDeviceCopyBufferDescriptor
+    {
+        MultiDeviceCopyBufferDescriptor() = default;
+
+        //! Returns the device-specific CopyBufferDescriptor for the given index
+        CopyBufferDescriptor GetDeviceCopyBufferDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_mdSourceBuffer, "Not initialized with source MultiDeviceBuffer\n");
+            AZ_Assert(m_mdDestinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+            return CopyBufferDescriptor{ m_mdSourceBuffer ? m_mdSourceBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                         m_sourceOffset,
+                                         m_mdDestinationBuffer ? m_mdDestinationBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                         m_destinationOffset,
+                                         m_size };
+        }
+
+        const MultiDeviceBuffer* m_mdSourceBuffer = nullptr;
+        uint32_t m_sourceOffset = 0;
+        const MultiDeviceBuffer* m_mdDestinationBuffer = nullptr;
+        uint32_t m_destinationOffset = 0;
+        uint32_t m_size = 0;
+    };
+
+    //! A structure used to define a MultiDeviceCopyItem, copying from a MultiDeviceImage to a MultiDeviceImage
+    struct MultiDeviceCopyImageDescriptor
+    {
+        MultiDeviceCopyImageDescriptor() = default;
+
+        //! Returns the device-specific CopyImageDescriptor for the given index
+        CopyImageDescriptor GetDeviceCopyImageDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_mdSourceImage, "Not initialized with source MultiDeviceImage\n");
+            AZ_Assert(m_mdDestinationImage, "Not initialized with destination MultiDeviceImage\n");
+
+            return CopyImageDescriptor{ m_mdSourceImage ? m_mdSourceImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                        m_sourceSubresource,
+                                        m_sourceOrigin,
+                                        m_sourceSize,
+                                        m_mdDestinationImage ? m_mdDestinationImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                        m_destinationSubresource,
+                                        m_destinationOrigin };
+        }
+
+        const MultiDeviceImage* m_mdSourceImage = nullptr;
+        ImageSubresource m_sourceSubresource;
+        Origin m_sourceOrigin;
+        Size m_sourceSize;
+        const MultiDeviceImage* m_mdDestinationImage = nullptr;
+        ImageSubresource m_destinationSubresource;
+        Origin m_destinationOrigin;
+    };
+
+    //! A structure used to define a MultiDeviceCopyItem, copying from a MultiDeviceBuffer to a MultiDeviceImage
+    struct MultiDeviceCopyBufferToImageDescriptor
+    {
+        MultiDeviceCopyBufferToImageDescriptor() = default;
+
+        //! Returns the device-specific CopyBufferToImageDescriptor for the given index
+        CopyBufferToImageDescriptor GetDeviceCopyBufferToImageDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_mdSourceBuffer, "Not initialized with source MultiDeviceBuffer\n");
+            AZ_Assert(m_mdDestinationImage, "Not initialized with destination MultiDeviceImage\n");
+
+            return CopyBufferToImageDescriptor{ m_mdSourceBuffer ? m_mdSourceBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                                m_sourceOffset,
+                                                m_sourceBytesPerRow,
+                                                m_sourceBytesPerImage,
+                                                m_sourceSize,
+                                                m_mdDestinationImage ? m_mdDestinationImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                                m_destinationSubresource,
+                                                m_destinationOrigin };
+        }
+
+        const MultiDeviceBuffer* m_mdSourceBuffer = nullptr;
+        uint32_t m_sourceOffset = 0;
+        uint32_t m_sourceBytesPerRow = 0;
+        uint32_t m_sourceBytesPerImage = 0;
+        Size m_sourceSize;
+        const MultiDeviceImage* m_mdDestinationImage = nullptr;
+        ImageSubresource m_destinationSubresource;
+        Origin m_destinationOrigin;
+    };
+
+    //! A structure used to define a MultiDeviceCopyItem, copying from a MultiDeviceImage to a MultiDeviceBuffer
+    struct MultiDeviceCopyImageToBufferDescriptor
+    {
+        MultiDeviceCopyImageToBufferDescriptor() = default;
+
+        //! Returns the device-specific CopyImageToBufferDescriptor for the given index
+        CopyImageToBufferDescriptor GetDeviceCopyImageToBufferDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_mdSourceImage, "Not initialized with source MultiDeviceImage\n");
+            AZ_Assert(m_mdDestinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+            return CopyImageToBufferDescriptor{ m_mdSourceImage ? m_mdSourceImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                                m_sourceSubresource,
+                                                m_sourceOrigin,
+                                                m_sourceSize,
+                                                m_mdDestinationBuffer ? m_mdDestinationBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                                m_destinationOffset,
+                                                m_destinationBytesPerRow,
+                                                m_destinationBytesPerImage,
+                                                m_destinationFormat };
+        }
+
+        const MultiDeviceImage* m_mdSourceImage = nullptr;
+        ImageSubresource m_sourceSubresource;
+        Origin m_sourceOrigin;
+        Size m_sourceSize;
+        const MultiDeviceBuffer* m_mdDestinationBuffer = nullptr;
+        uint32_t m_destinationOffset = 0;
+        uint32_t m_destinationBytesPerRow = 0;
+        uint32_t m_destinationBytesPerImage = 0;
+        //! The destination format is usually same as m_mdSourceImage's format. When source image contains more than one aspect,
+        //! the format should be compatiable with the aspect of the source image's subresource
+        Format m_destinationFormat;
+    };
+
+    //! A structure used to define a MultiDeviceCopyItem, copying from a MultiDeviceQueryPool to a MultiDeviceBuffer
+    struct MultiDeviceCopyQueryToBufferDescriptor
+    {
+        MultiDeviceCopyQueryToBufferDescriptor() = default;
+
+        //! Returns the device-specific CopyQueryToBufferDescriptor for the given index
+        CopyQueryToBufferDescriptor GetDeviceCopyQueryToBufferDescriptor(int deviceIndex) const
+        {
+            AZ_Assert(m_mdSourceQueryPool, "Not initialized with source MultiDeviceQueryPool\n");
+            AZ_Assert(m_mdDestinationBuffer, "Not initialized with destination MultiDeviceBuffer\n");
+
+            return CopyQueryToBufferDescriptor{ m_mdSourceQueryPool ? m_mdSourceQueryPool->GetDeviceQueryPool(deviceIndex).get() : nullptr,
+                                                m_firstQuery,
+                                                m_queryCount,
+                                                m_mdDestinationBuffer ? m_mdDestinationBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                                                m_destinationOffset,
+                                                m_destinationStride };
+        }
+
+        const MultiDeviceQueryPool* m_mdSourceQueryPool = nullptr;
+        QueryHandle m_firstQuery = QueryHandle(0);
+        uint32_t m_queryCount = 0;
+        const MultiDeviceBuffer* m_mdDestinationBuffer = nullptr;
+        uint32_t m_destinationOffset = 0;
+        uint32_t m_destinationStride = 0;
+    };
+
+    struct MultiDeviceCopyItem
+    {
+        MultiDeviceCopyItem()
+            : m_type{ CopyItemType::Buffer }
+            , m_mdBuffer{}
+        {
+        }
+
+        MultiDeviceCopyItem(
+            const MultiDeviceCopyBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
+            : m_type{ CopyItemType::Buffer }
+            , m_mdBuffer{ descriptor }
+            , m_deviceMask{ mask }
+        {
+        }
+
+        MultiDeviceCopyItem(
+            const MultiDeviceCopyImageDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
+            : m_type{ CopyItemType::Image }
+            , m_mdImage{ descriptor }
+            , m_deviceMask{ mask }
+        {
+        }
+
+        MultiDeviceCopyItem(
+            const MultiDeviceCopyBufferToImageDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
+            : m_type{ CopyItemType::BufferToImage }
+            , m_mdBufferToImage{ descriptor }
+            , m_deviceMask{ mask }
+        {
+        }
+
+        MultiDeviceCopyItem(
+            const MultiDeviceCopyImageToBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
+            : m_type{ CopyItemType::ImageToBuffer }
+            , m_mdImageToBuffer{ descriptor }
+            , m_deviceMask{ mask }
+        {
+        }
+
+        MultiDeviceCopyItem(
+            const MultiDeviceCopyQueryToBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
+            : m_type{ CopyItemType::QueryToBuffer }
+            , m_mdQueryToBuffer{ descriptor }
+            , m_deviceMask{ mask }
+        {
+        }
+
+        //! Returns the device-specific CopyItem for the given index
+        CopyItem GetDeviceCopyItem(int deviceIndex) const
+        {
+            switch (m_type)
+            {
+            case CopyItemType::Buffer:
+                return CopyItem(m_mdBuffer.GetDeviceCopyBufferDescriptor(deviceIndex));
+            case CopyItemType::Image:
+                return CopyItem(m_mdImage.GetDeviceCopyImageDescriptor(deviceIndex));
+            case CopyItemType::BufferToImage:
+                return CopyItem(m_mdBufferToImage.GetDeviceCopyBufferToImageDescriptor(deviceIndex));
+            case CopyItemType::ImageToBuffer:
+                return CopyItem(m_mdImageToBuffer.GetDeviceCopyImageToBufferDescriptor(deviceIndex));
+            case CopyItemType::QueryToBuffer:
+                return CopyItem(m_mdQueryToBuffer.GetDeviceCopyQueryToBufferDescriptor(deviceIndex));
+            default:
+                return CopyItem();
+            }
+        }
+
+        CopyItemType m_type;
+        union {
+            MultiDeviceCopyBufferDescriptor m_mdBuffer;
+            MultiDeviceCopyImageDescriptor m_mdImage;
+            MultiDeviceCopyBufferToImageDescriptor m_mdBufferToImage;
+            MultiDeviceCopyImageToBufferDescriptor m_mdImageToBuffer;
+            MultiDeviceCopyQueryToBufferDescriptor m_mdQueryToBuffer;
+        };
+        //! A DeviceMask to denote on which devices an operation should take place
+        RHI::MultiDevice::DeviceMask m_deviceMask;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceCopyItem.h
@@ -230,7 +230,8 @@ namespace AZ::RHI
         }
 
         CopyItemType m_type;
-        union {
+        union
+        {
             MultiDeviceCopyBufferDescriptor m_mdBuffer;
             MultiDeviceCopyImageDescriptor m_mdImage;
             MultiDeviceCopyBufferToImageDescriptor m_mdBufferToImage;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/DispatchItem.h>
+#include <Atom/RHI/MultiDeviceIndirectArguments.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ::RHI
+{
+    //! Arguments used when submitting an indirect dispatch call into a CommandList.
+    //! The indirect dispatch arguments are the same ones as the indirect draw ones.
+    using MultiDeviceDispatchIndirect = MultiDeviceIndirectArguments;
+
+    //! Encapsulates the arguments that are specific to a type of dispatch.
+    //! It uses a union to be able to store all possible arguments.
+    struct MultiDeviceDispatchArguments
+    {
+        AZ_TYPE_INFO(MultiDeviceDispatchArguments, "0A354A63-D2C5-4C59-B3E0-0800FA7FBA63");
+
+        MultiDeviceDispatchArguments()
+            : MultiDeviceDispatchArguments(DispatchDirect{})
+        {
+        }
+
+        MultiDeviceDispatchArguments(const DispatchDirect& direct)
+            : m_type{ DispatchType::Direct }
+            , m_direct{ direct }
+        {
+        }
+
+        MultiDeviceDispatchArguments(const MultiDeviceDispatchIndirect& indirect)
+            : m_type{ DispatchType::Indirect }
+            , m_mdIndirect{ indirect }
+        {
+        }
+
+        //! Returns the device-specific DispatchArguments for the given index
+        DispatchArguments GetDeviceDispatchArguments(int deviceIndex) const
+        {
+            switch (m_type)
+            {
+            case DispatchType::Direct:
+                return DispatchArguments(m_direct);
+            case DispatchType::Indirect:
+                return DispatchArguments(m_mdIndirect.GetDeviceIndirectArguments(deviceIndex));
+            default:
+                return DispatchArguments();
+            }
+        }
+
+        DispatchType m_type;
+        union {
+            //! Arguments for a direct dispatch.
+            DispatchDirect m_direct;
+            //! Arguments for an indirect dispatch.
+            MultiDeviceDispatchIndirect m_mdIndirect;
+        };
+    };
+
+    //! Encapsulates all the necessary information for doing a dispatch call.
+    //! This includes all common arguments for the different dispatch type, plus
+    //! arguments that are specific to a type.
+    class MultiDeviceDispatchItem
+    {
+    public:
+        MultiDeviceDispatchItem(MultiDevice::DeviceMask deviceMask)
+            : m_deviceMask{ deviceMask }
+        {
+            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceDispatchItems.emplace(deviceIndex, DispatchItem{});
+                }
+            }
+        }
+
+        //! Returns the device-specific DispatchItem for the given index
+        const DispatchItem& GetDeviceDispatchItem(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceDispatchItem",
+                m_deviceDispatchItems.find(deviceIndex) != m_deviceDispatchItems.end(),
+                "No DeviceDispatchItem found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceDispatchItems.at(deviceIndex);
+        }
+
+        //! Arguments specific to a dispatch type.
+        void SetArguments(const MultiDeviceDispatchArguments& arguments)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_arguments = arguments.GetDeviceDispatchArguments(deviceIndex);
+            }
+        }
+
+        //! The number of inline constants in each array.
+        void SetRootConstantSize(uint8_t rootConstantSize)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_rootConstantSize = rootConstantSize;
+            }
+        }
+
+        void SetPipelineState(const MultiDevicePipelineState* pipelineState)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+        }
+
+        //! Array of shader resource groups to bind (count must match m_shaderResourceGroupCount).
+        void SetShaderResourceGroups(
+            const AZStd::span<const MultiDeviceShaderResourceGroup*> shaderResourceGroups, uint8_t shaderResourceGroupCount)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_shaderResourceGroupCount = shaderResourceGroupCount;
+                for (int i = 0; i < dispatchItem.m_shaderResourceGroupCount; ++i)
+                {
+                    dispatchItem.m_shaderResourceGroups[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+                }
+            }
+        }
+
+        //! Unique SRG, not shared within the draw packet. This is usually a per-draw SRG, populated with the shader variant fallback
+        //! key
+        void SetUniqueShaderResourceGroup(const MultiDeviceShaderResourceGroup* uniqueShaderResourceGroup)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
+            }
+        }
+
+        //! Inline constants data.
+        void SetRootConstants(const uint8_t* rootConstants)
+        {
+            for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
+            {
+                dispatchItem.m_rootConstants = rootConstants;
+            }
+        }
+
+    private:
+        //! A DeviceMask denoting on which devices a device-specific DispatchItem should be generated
+        MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+        //! A map of all device-specific DispatchItem, indexed by the device index
+        AZStd::unordered_map<int, DispatchItem> m_deviceDispatchItems;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -81,7 +81,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
                 {
                     m_deviceDispatchItems.emplace(deviceIndex, DispatchItem{});
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/DispatchRaysItem.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ::RHI
+{
+    class MultiDeviceRayTracingPipelineState;
+    class MultiDeviceRayTracingShaderTable;
+    class MultiDeviceShaderResourceGroup;
+    class ImageView;
+    class BufferView;
+
+    //! Encapsulates all the necessary information for doing a ray tracing dispatch call.
+    class MultiDeviceDispatchRaysItem
+    {
+    public:
+        MultiDeviceDispatchRaysItem(MultiDevice::DeviceMask deviceMask)
+            : m_deviceMask{ deviceMask }
+        {
+            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceDispatchRaysItems.emplace(deviceIndex, DispatchRaysItem{});
+                }
+            }
+        }
+
+        //! Returns the device-specific DispatchRaysItem for the given index
+        const DispatchRaysItem& GetDeviceDispatchRaysItem(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceDispatchItem",
+                m_deviceDispatchRaysItems.find(deviceIndex) != m_deviceDispatchRaysItems.end(),
+                "No DeviceDispatchItem found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceDispatchRaysItems.at(deviceIndex);
+        }
+
+        //! The number of rays to cast
+        void SetDimensions(uint32_t width, uint32_t height, uint32_t depth)
+        {
+            for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+            {
+                dispatchRaysItem.m_width = width;
+                dispatchRaysItem.m_height = height;
+                dispatchRaysItem.m_depth = depth;
+            }
+        }
+
+        //! Ray tracing pipeline state
+        void SetRayTracingPipelineState(const MultiDeviceRayTracingPipelineState* rayTracingPipelineState)
+        {
+            for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+            {
+                dispatchRaysItem.m_rayTracingPipelineState = rayTracingPipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+        }
+
+        //! Ray tracing shader table
+        void SetRayTracingShaderTable(const MultiDeviceRayTracingShaderTable* rayTracingShaderTable)
+        {
+            for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+            {
+                dispatchRaysItem.m_rayTracingShaderTable = rayTracingShaderTable->GetDeviceRayTracingShaderTable(deviceIndex).get();
+            }
+        }
+
+        //! Shader Resource Groups
+        void SetShaderResourceGroups(const MultiDeviceShaderResourceGroup* const* shaderResourceGroups, uint32_t shaderResourceGroupCount)
+        {
+            for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+            {
+                dispatchRaysItem.m_shaderResourceGroupCount = shaderResourceGroupCount;
+
+                auto [it, insertOK]{ m_deviceShaderResourceGroups.emplace(
+                    deviceIndex, AZStd::vector<ShaderResourceGroup*>(shaderResourceGroupCount)) };
+
+                auto& [index, deviceShaderResourceGroup]{ *it };
+
+                for (int i = 0; i < shaderResourceGroupCount; ++i)
+                {
+                    deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+                }
+
+                dispatchRaysItem.m_shaderResourceGroups = deviceShaderResourceGroup.data();
+            }
+        }
+
+        //! Global shader pipeline state
+        void SetPipelineState(const MultiDevicePipelineState* globalPipelineState)
+        {
+            for (auto& [deviceIndex, dispatchRaysItem] : m_deviceDispatchRaysItems)
+            {
+                dispatchRaysItem.m_globalPipelineState = globalPipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+        }
+
+    private:
+        //! A DeviceMask denoting on which devices a device-specific DispatchRaysItem should be generated
+        MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+        //! A map of all device-specific DispatchRaysItem, indexed by the device index
+        AZStd::unordered_map<int, DispatchRaysItem> m_deviceDispatchRaysItems;
+        //! A map of all device-specific ShaderResourceGroups, indexed by the device index
+        AZStd::unordered_map<int, AZStd::vector<ShaderResourceGroup*>> m_deviceShaderResourceGroups;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
@@ -35,7 +35,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
                 {
                     m_deviceDispatchRaysItems.emplace(deviceIndex, DispatchRaysItem{});
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceIndirectArguments.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferView.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <AzCore/std/containers/array.h>
+
+namespace AZ::RHI
+{
+    struct Scissor;
+    struct Viewport;
+    struct DefaultNamespaceType;
+    // Forward declaration to
+    template<typename T, typename NamespaceType>
+    struct Handle;
+
+    using MultiDeviceDrawIndirect = MultiDeviceIndirectArguments;
+
+    //! A structure used to define the type of draw that should happen, directly passed on to the device-specific DrawItems in
+    //! MultiDeviceDrawItem::SetArguments
+    struct MultiDeviceDrawArguments
+    {
+        AZ_TYPE_INFO(MultiDeviceDrawArguments, "B8127BDE-513E-4D5C-98C2-027BA1DE9E6E");
+
+        MultiDeviceDrawArguments()
+            : MultiDeviceDrawArguments(DrawIndexed{})
+        {
+        }
+
+        MultiDeviceDrawArguments(const DrawIndexed& indexed)
+            : m_type{ DrawType::Indexed }
+            , m_indexed{ indexed }
+        {
+        }
+
+        MultiDeviceDrawArguments(const DrawLinear& linear)
+            : m_type{ DrawType::Linear }
+            , m_linear{ linear }
+        {
+        }
+
+        MultiDeviceDrawArguments(const MultiDeviceDrawIndirect& indirect)
+            : m_type{ DrawType::Indirect }
+            , m_mdIndirect{ indirect }
+        {
+        }
+
+        //! Returns the device-specific DrawArguments for the given index
+        DrawArguments GetDeviceDrawArguments(int deviceIndex) const
+        {
+            switch (m_type)
+            {
+            case DrawType::Indexed:
+                return DrawArguments(m_indexed);
+            case DrawType::Linear:
+                return DrawArguments(m_linear);
+            case DrawType::Indirect:
+                return DrawArguments(m_mdIndirect.GetDeviceIndirectArguments(deviceIndex));
+            default:
+                return DrawArguments();
+            }
+        }
+
+        DrawType m_type;
+        union {
+            DrawIndexed m_indexed;
+            DrawLinear m_linear;
+            MultiDeviceDrawIndirect m_mdIndirect;
+        };
+    };
+
+    class MultiDeviceDrawItem
+    {
+    public:
+        MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask)
+            : m_deviceMask{ deviceMask }
+        {
+            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceDrawItems.emplace(deviceIndex, DrawItem{});
+                }
+            }
+        }
+
+        //! Returns the device-specific DrawItem for the given index
+        const DrawItem& GetDeviceDrawItem(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceDrawItem",
+                m_deviceDrawItems.find(deviceIndex) != m_deviceDrawItems.end(),
+                "No DeviceDrawItem found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceDrawItems.at(deviceIndex);
+        }
+
+        void SetArguments(const MultiDeviceDrawArguments& arguments)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_arguments = arguments.GetDeviceDrawArguments(deviceIndex);
+            }
+        }
+
+        void SetStencilRef(uint8_t stencilRef)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_stencilRef = stencilRef;
+            }
+        }
+
+        void SetPipelineState(const MultiDevicePipelineState* pipelineState)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
+            }
+        }
+
+        //! The index buffer used when drawing with an indexed draw call.
+        void SetIndexBufferView(const MultiDeviceIndexBufferView* indexBufferView)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                m_deviceIndexBufferView.emplace(deviceIndex, indexBufferView->GetDeviceIndexBufferView(deviceIndex));
+            }
+
+            // Done extra so memory is not moved around any more during map resize
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_indexBufferView = &m_deviceIndexBufferView[deviceIndex];
+            }
+        }
+
+        //! Array of stream buffers to bind (count must match m_streamBufferViewCount).
+        void SetStreamBufferViews(const MultiDeviceStreamBufferView* streamBufferViews, uint32_t streamBufferViewCount)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(streamBufferViewCount);
+
+                auto [it, insertOK]{ m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::vector<StreamBufferView>{}) };
+
+                auto& [index, deviceStreamBufferView]{ *it };
+
+                for (auto i = 0u; i < streamBufferViewCount; ++i)
+                {
+                    deviceStreamBufferView.emplace_back(streamBufferViews[i].GetDeviceStreamBufferView(deviceIndex));
+                }
+
+                drawItem.m_streamBufferViews = deviceStreamBufferView.data();
+            }
+        }
+
+        //! Shader Resource Groups
+        void SetShaderResourceGroups(const MultiDeviceShaderResourceGroup* const* shaderResourceGroups, uint32_t shaderResourceGroupCount)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(shaderResourceGroupCount);
+
+                auto [it, insertOK]{ m_deviceShaderResourceGroups.emplace(
+                    deviceIndex, AZStd::vector<ShaderResourceGroup*>(shaderResourceGroupCount)) };
+
+                auto& [index, deviceShaderResourceGroup]{ *it };
+
+                for (auto i = 0u; i < shaderResourceGroupCount; ++i)
+                {
+                    deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
+                }
+
+                drawItem.m_shaderResourceGroups = deviceShaderResourceGroup.data();
+            }
+        }
+
+        //! Unique SRG, not shared within the draw packet. This is usually a per-draw SRG, populated with the shader variant fallback
+        //! key
+        void SetUniqueShaderResourceGroup(const MultiDeviceShaderResourceGroup* uniqueShaderResourceGroup)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
+            }
+        }
+
+        //! Array of root constants to bind (count must match m_rootConstantSize).
+        void SetRootConstants(const uint8_t* rootConstants, uint8_t rootConstantSize)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_rootConstantSize = rootConstantSize;
+                drawItem.m_rootConstants = rootConstants;
+            }
+        }
+
+        //! List of scissors to be applied to this draw item only. Scissor will be restore to the previous state
+        //! after the MultiDeviceDrawItem has been processed.
+        void SetScissors(const Scissor* scissors, uint8_t scissorsCount)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_scissorsCount = scissorsCount;
+                drawItem.m_scissors = scissors;
+            }
+        }
+
+        //! List of viewports to be applied to this draw item only. Viewports will be restore to the previous state
+        //! after the MultiDeviceDrawItem has been processed.
+        void SetViewports(const Viewport* viewports, uint8_t viewportCount)
+        {
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            {
+                drawItem.m_viewportsCount = viewportCount;
+                drawItem.m_viewports = viewports;
+            }
+        }
+
+    private:
+        MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+        //! A map of all device-specific DrawItems, indexed by the device index
+        AZStd::unordered_map<int, DrawItem> m_deviceDrawItems;
+        //! A map of all device-specific IndexBufferViews, indexed by the device index
+        AZStd::unordered_map<int, IndexBufferView> m_deviceIndexBufferView;
+        //! A map of all device-specific StreamBufferViews, indexed by the device index
+        AZStd::unordered_map<int, AZStd::vector<StreamBufferView>> m_deviceStreamBufferViews;
+        //! A map of all device-specific ShaderResourceGroups, indexed by the device index
+        AZStd::unordered_map<int, AZStd::vector<ShaderResourceGroup*>> m_deviceShaderResourceGroups;
+    };
+
+    struct MultiDeviceDrawItemProperties
+    {
+        MultiDeviceDrawItemProperties() = default;
+
+        MultiDeviceDrawItemProperties(
+            const MultiDeviceDrawItem* item, DrawItemSortKey sortKey = 0, DrawFilterMask filterMask = DrawFilterMaskDefaultValue)
+            : m_mdItem{ item }
+            , m_sortKey{ sortKey }
+            , m_drawFilterMask{ filterMask }
+        {
+        }
+
+        bool operator==(const MultiDeviceDrawItemProperties& rhs) const
+        {
+            return m_mdItem == rhs.m_mdItem && m_sortKey == rhs.m_sortKey && m_depth == rhs.m_depth &&
+                m_drawFilterMask == rhs.m_drawFilterMask;
+        }
+
+        bool operator!=(const MultiDeviceDrawItemProperties& rhs) const
+        {
+            return !(*this == rhs);
+        }
+
+        bool operator<(const MultiDeviceDrawItemProperties& rhs) const
+        {
+            return m_sortKey < rhs.m_sortKey;
+        }
+
+        //! Returns the device-specific DrawItemProperties for the given index
+        DrawItemProperties GetDeviceDrawItemProperties(int deviceIndex) const
+        {
+            AZ_Assert(m_mdItem, "Not initialized with MultiDeviceDrawItem\n");
+
+            DrawItemProperties result{ nullptr, m_sortKey, m_drawFilterMask };
+            result.m_item = &m_mdItem->GetDeviceDrawItem(deviceIndex);
+            result.m_depth = m_depth;
+            return result;
+        }
+
+        //! A pointer to the draw item
+        const MultiDeviceDrawItem* m_mdItem = nullptr;
+        //! A sorting key of this draw item which is used for sorting draw items in DrawList
+        //! Check RHI::SortDrawList() function for detail
+        DrawItemSortKey m_sortKey = 0;
+        //! A depth value this draw item which is used for sorting draw items in DrawList
+        //! Check RHI::SortDrawList() function for detail
+        float m_depth = 0.0f;
+        //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
+        DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
+    };
+
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -237,10 +237,16 @@ namespace AZ::RHI
         //! A map of all device-specific DrawItems, indexed by the device index
         AZStd::unordered_map<int, DrawItem> m_deviceDrawItems;
         //! A map of all device-specific IndexBufferViews, indexed by the device index
+        //! This additional cache is needed since device-specific IndexBufferViews are returned as objects
+        //! and the device-specific DrawItem holds a pointer to it.
         AZStd::unordered_map<int, IndexBufferView> m_deviceIndexBufferView;
         //! A map of all device-specific StreamBufferViews, indexed by the device index
+        //! This additional cache is needed since device-specific StreamBufferViews are returned as objects
+        //! and the device-specific DrawItem holds a pointer to it.
         AZStd::unordered_map<int, AZStd::vector<StreamBufferView>> m_deviceStreamBufferViews;
         //! A map of all device-specific ShaderResourceGroups, indexed by the device index
+        //! This additional cache is needed since device-specific ShaderResourceGroups are provided as a ShaderResourceGroup**,
+        //! which are then locally cached in a vector (per device) and the device-specific DrawItem holds a pointer to this vector's data.
         AZStd::unordered_map<int, AZStd::vector<ShaderResourceGroup*>> m_deviceShaderResourceGroups;
     };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -91,7 +91,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
                 {
                     m_deviceDrawItems.emplace(deviceIndex, DrawItem{});
                 }
@@ -210,7 +210,7 @@ namespace AZ::RHI
             }
         }
 
-        //! List of scissors to be applied to this draw item only. Scissor will be restore to the previous state
+        //! List of scissors to be applied to this draw item only. Scissor will be restored to the previous state
         //! after the MultiDeviceDrawItem has been processed.
         void SetScissors(const Scissor* scissors, uint8_t scissorsCount)
         {
@@ -221,7 +221,7 @@ namespace AZ::RHI
             }
         }
 
-        //! List of viewports to be applied to this draw item only. Viewports will be restore to the previous state
+        //! List of viewports to be applied to this draw item only. Viewports will be restored to the previous state
         //! after the MultiDeviceDrawItem has been processed.
         void SetViewports(const Viewport* viewports, uint8_t viewportCount)
         {
@@ -277,10 +277,7 @@ namespace AZ::RHI
         {
             AZ_Assert(m_mdItem, "Not initialized with MultiDeviceDrawItem\n");
 
-            DrawItemProperties result{ nullptr, m_sortKey, m_drawFilterMask };
-            result.m_item = &m_mdItem->GetDeviceDrawItem(deviceIndex);
-            result.m_depth = m_depth;
-            return result;
+            return { &m_mdItem->GetDeviceDrawItem(deviceIndex), m_sortKey, m_depth, m_drawFilterMask };
         }
 
         //! A pointer to the draw item

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -41,10 +41,13 @@ set(FILES
     Include/Atom/RHI/CommandListValidator.h
     Include/Atom/RHI/CommandListStates.h
     Include/Atom/RHI/CopyItem.h
+    Include/Atom/RHI/MultiDeviceCopyItem.h
     Include/Atom/RHI/ConstantsData.h
     Include/Atom/RHI/DispatchItem.h
+    Include/Atom/RHI/MultiDeviceDispatchItem.h
     Include/Atom/RHI/DrawFilterTagRegistry.h
     Include/Atom/RHI/DrawItem.h
+    Include/Atom/RHI/MultiDeviceDrawItem.h
     Include/Atom/RHI/DrawList.h
     Include/Atom/RHI/DrawListTagRegistry.h
     Include/Atom/RHI/DrawListContext.h
@@ -235,6 +238,7 @@ set(FILES
     Include/Atom/RHI/RayTracingShaderTable.h
     Include/Atom/RHI/RayTracingBufferPools.h
     Include/Atom/RHI/DispatchRaysItem.h
+    Include/Atom/RHI/MultiDeviceDispatchRaysItem.h
     Source/RHI/RayTracingAccelerationStructure.cpp
     Source/RHI/RayTracingPipelineState.cpp
     Source/RHI/RayTracingShaderTable.cpp


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, in particular:
- `MultiDeviceCopyItem`
- `MultiDeviceDispatchItem`
- `MultiDeviceDispatchRaysItem`
- `MultiDeviceDrawItems`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources|[#16262](https://github.com/o3de/o3de/pull/16262)|merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)| merged |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591)| merged |
|Indirect*|[#16681](https://github.com/o3de/o3de/pull/16681)|open|
| SRGs|[#16680](https://github.com/o3de/o3de/pull/16680) | merged |
| TransientAttachmentPool | [#16712](https://github.com/o3de/o3de/pull/16712) | open |
|RayTracing Resources| [#16767](https://github.com/o3de/o3de/pull/16767) |open|
| Items | this PR | open |

