### PR TITLE
Fix release mode compile error. Maybe unused variable for error logs,…

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -297,7 +297,7 @@ namespace AZ
             }
 
             RHI::Ptr<RHI::XRDeviceDescriptor> xrDescriptor = m_rhiSystem.GetDevice()->BuildXRDescriptor();
-            auto result = xrRender->CreateDevice(xrDescriptor.get());
+            [[maybe_unused]] auto result = xrRender->CreateDevice(xrDescriptor.get());
             AZ_Error("RPISystem", result == RHI::ResultCode::Success, "Failed to initialize XR device");
             AZ::RHI::XRSessionDescriptor sessionDescriptor;
             result = xrRender->CreateSession(&sessionDescriptor);


### PR DESCRIPTION
Fixes release mode compile error. A variable was only used for error logging, but error logs aren't compiled into release.

Tested:
Compile in release on Linux