### PR TITLE
Updated the AZ Console to output the inputs to console commands which are not CVars

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -484,9 +484,23 @@ namespace AZ
                     result = true;
                     if ((silentMode == ConsoleSilentMode::NotSilent) && (curr->GetFlags() & ConsoleFunctorFlags::IsInvisible) != ConsoleFunctorFlags::IsInvisible)
                     {
+                        // First use the ConsoleFunctorBase::GetValue function
+                        // to retrieve the value of the type of the first template parameter to the ConsoleFunctor class template
+                        // This is populated for non-void types and is set for Console Variables(CVars) and Console Commands
+                        // which are member functions
+                        // See `ConsoleFunctor<_TYPE, _REPLICATES_VALUE>::GetValueAsString`
                         CVarFixedString inputStr;
-                        AZ::StringFunc::Join(inputStr, inputs, ' ');
-                        AZLOG_INFO("> %s : %s", curr->GetName(), inputStr.empty() ? "<empty>" : inputStr.c_str());
+                        if (GetValueResult getCVarValue = curr->GetValue(inputStr);
+                            getCVarValue != GetValueResult::Success)
+                        {
+                            // In this case the ConsoleFunctorBase pointer references a `ConsoleFunctor<void, _REPLICATES_VALUE>` object
+                            // which has no type associated with it.
+                            // This is used for Console Commands which are free functions
+                            // The `ConsoleFunctor<void, _REPLICATES_VALUE>::GetValueAsString` returns NotImplemented
+                            // Instead the input arguments to the console command will be logged
+                            AZ::StringFunc::Join(inputStr, inputs, ' ');
+                        }
+                        AZLOG_INFO("> %s : %s", curr->GetName(), inputStr.empty() ? "<no-args>" : inputStr.c_str());
                     }
                     flags = curr->GetFlags();
                 }

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -484,9 +484,9 @@ namespace AZ
                     result = true;
                     if ((silentMode == ConsoleSilentMode::NotSilent) && (curr->GetFlags() & ConsoleFunctorFlags::IsInvisible) != ConsoleFunctorFlags::IsInvisible)
                     {
-                        CVarFixedString value;
-                        curr->GetValue(value);
-                        AZLOG_INFO("> %s : %s", curr->GetName(), value.empty() ? "<empty>" : value.c_str());
+                        CVarFixedString inputStr;
+                        AZ::StringFunc::Join(inputStr, inputs, ' ');
+                        AZLOG_INFO("> %s : %s", curr->GetName(), inputStr.empty() ? "<empty>" : inputStr.c_str());
                     }
                     flags = curr->GetFlags();
                 }


### PR DESCRIPTION
Any console command registered with the AZ_CONSOLEFREEFUNC macro would previous attempt to log its "value" out to the console window using the data type associated with the command and because a free function isn't associated with a class type, it would output "<empty>".

So commands such as "LoadLevel" would always log "LoadLevel : <empty>" and not the name of the level

fixes #16775 

## How was this PR tested?

Verified the `LoadLevel` command in the AutomatedTesting project logged the level name when specified.

Verified the `sys_PakPriority` CVAR logged it's current value when no inputs are supplied.

![image](https://github.com/o3de/o3de/assets/56135373/f631b372-0d2e-414a-bf2e-f631a63f1849)

