### PR TITLE
Fixing warning as error caused by unused variable

### DIFF
--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -271,7 +271,7 @@ namespace PhysX
 
     void setInboundJointDriveParams(
         physx::PxArticulationJointReducedCoordinate* inboundJoint,
-        physx::PxArticulationAxis articulationAxis,
+        [[maybe_unused]] physx::PxArticulationAxis articulationAxis,
         const ArticulationJointMotorProperties& motorProperties)
     {
         physx::PxArticulationDrive drive;


### PR DESCRIPTION
## What does this PR do?

Resolves a warning as error created by an unused variable

## How was this PR tested?

Compiled without warnings or errors