### PR TITLE
Correcting spelling of "Default" in material component

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
@@ -136,7 +136,7 @@ end
 function FindMaterialAssignmentTest:OnTick(deltaTime, timePoint)
 
     if(nil == self.assignmentIds) then
-        local originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId)
+        local originalAssignments = MaterialComponentRequestBus.Event.GetDefaultMaterialMap(self.entityId)
         if(nil == originalAssignments or #originalAssignments <= 1) then -- There is always 1 entry for the default assignment; a loaded model will have at least 2 assignments
             return
         end

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
@@ -135,7 +135,7 @@ end
 function PropertyValueTest:OnTick(deltaTime, timePoint)
 
     if(nil == self.assignmentIds) then
-        local originalAssignments = MaterialComponentRequestBus.Event.GetDefautMaterialMap(self.entityId)
+        local originalAssignments = MaterialComponentRequestBus.Event.GetDefaultMaterialMap(self.entityId)
         if(nil == originalAssignments or #originalAssignments <= 1) then -- There is always 1 entry for the default assignment; a loaded model will have at least 2 assignments
             return
         end

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.py
@@ -45,7 +45,7 @@ def assetIdToPath(assetId):
 # List all slot ids
 def getIds(entityId):
     print("Get material ids")
-    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetDefautMaterialMap', entityId).keys()
+    return azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetDefaultMaterialMap', entityId).keys()
 
 def printMaterials(entityId):
     materials = azlmbr.render.MaterialComponentRequestBus(azlmbr.bus.Event, 'GetMaterialMap', entityId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialAssignment.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialAssignment.h
@@ -75,7 +75,7 @@ namespace AZ
             const MaterialAssignmentMap& materials, const MaterialAssignmentId& id);
 
         //! Utility function for generating a set of available material assignments in a model
-        MaterialAssignmentMap GetDefautMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
+        MaterialAssignmentMap GetDefaultMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);
 
         //! Get material slot labels from a model
         MaterialAssignmentLabelMap GetMaterialSlotLabelsFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -21,6 +21,12 @@ namespace AZ
             //! Get a map representing the default layout and values for all material assignment slots on the source model or object
             virtual MaterialAssignmentMap GetDefaultMaterialMap() const = 0;
 
+            // O3DE_DEPRECATION_NOTICE(GHI-16783) Function is being replaced by GetDefaultMaterialMap
+            virtual MaterialAssignmentMap GetDefautMaterialMap() const
+            {
+                return GetDefaultMaterialMap();
+            }
+
             //! Search for a material assignment ID matching the lod and label parameters
             //! @param lod Index of the LOD to be searched for the material assignment ID. -1 is used to search the default material and
             //! model material slots.
@@ -215,6 +221,12 @@ namespace AZ
 
             //! Returns the available material slots and default assigned materials
             virtual MaterialAssignmentMap GetDefaultMaterialMap() const = 0;
+
+            // O3DE_DEPRECATION_NOTICE(GHI-16783) Function is being replaced by GetDefaultMaterialMap
+            virtual MaterialAssignmentMap GetDefautMaterialMap() const
+            {
+                return GetDefaultMaterialMap();
+            }
 
             //! Returns a map of UV Overridable UV channel names
             virtual AZStd::unordered_set<AZ::Name> GetModelUvNames() const = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -19,7 +19,7 @@ namespace AZ
         {
         public:
             //! Get a map representing the default layout and values for all material assignment slots on the source model or object
-            virtual MaterialAssignmentMap GetDefautMaterialMap() const = 0;
+            virtual MaterialAssignmentMap GetDefaultMaterialMap() const = 0;
 
             //! Search for a material assignment ID matching the lod and label parameters
             //! @param lod Index of the LOD to be searched for the material assignment ID. -1 is used to search the default material and
@@ -214,7 +214,7 @@ namespace AZ
             virtual MaterialAssignmentLabelMap GetMaterialLabels() const = 0;
 
             //! Returns the available material slots and default assigned materials
-            virtual MaterialAssignmentMap GetDefautMaterialMap() const = 0;
+            virtual MaterialAssignmentMap GetDefaultMaterialMap() const = 0;
 
             //! Returns a map of UV Overridable UV channel names
             virtual AZStd::unordered_set<AZ::Name> GetModelUvNames() const = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -315,7 +315,7 @@ namespace AZ
             // Get the known material assignment slots from the associated model or other source
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
-                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
+                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefaultMaterialMap);
                         
             // Generate the table of editable materials using the source data to define number of groups, elements, and initial values
             for (const auto& materialPair : originalMaterials)
@@ -371,7 +371,7 @@ namespace AZ
         {
             MaterialAssignmentMap originalMaterials;
             MaterialComponentRequestBus::EventResult(
-                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
+                originalMaterials, GetEntityId(), &MaterialComponentRequestBus::Events::GetDefaultMaterialMap);
 
             // Generate a unique set of all material asset IDs that will be used for source data generation
             AZStd::unordered_map<AZ::Data::AssetId, AZStd::string> assetIdToSlotNameMap;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -240,7 +240,7 @@ namespace AZ
             {
                 MaterialAssignmentMap primaryMaterialSlots;
                 MaterialComponentRequestBus::EventResult(
-                    primaryMaterialSlots, primaryEntityId, &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
+                    primaryMaterialSlots, primaryEntityId, &MaterialComponentRequestBus::Events::GetDefaultMaterialMap);
 
                 return AZStd::all_of(
                     secondaryEntityIds.begin(), secondaryEntityIds.end(),
@@ -249,7 +249,7 @@ namespace AZ
                         MaterialAssignmentMap secondaryMaterialSlots;
                         MaterialComponentRequestBus::EventResult(
                             secondaryMaterialSlots, secondaryEntityId,
-                            &MaterialComponentRequestBus::Events::GetDefautMaterialMap);
+                            &MaterialComponentRequestBus::Events::GetDefaultMaterialMap);
 
                         if (primaryMaterialSlots.size() != secondaryMaterialSlots.size())
                         {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -234,7 +234,7 @@ namespace AZ
             return DefaultMaterialAssignment;
         }
 
-        MaterialAssignmentMap GetDefautMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+        MaterialAssignmentMap GetDefaultMaterialMapFromModelAsset(const Data::Asset<AZ::RPI::ModelAsset> modelAsset)
         {
             MaterialAssignmentMap materials;
             materials[DefaultMaterialAssignmentId] = MaterialAssignment();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -36,7 +36,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                     ->Attribute(AZ::Script::Attributes::Category, "render")
                     ->Attribute(AZ::Script::Attributes::Module, "render")
-                    ->Event("GetDefautMaterialMap", &MaterialComponentRequestBus::Events::GetDefautMaterialMap, "GetOriginalMaterialAssignments")
+                    ->Event("GetDefaultMaterialMap", &MaterialComponentRequestBus::Events::GetDefaultMaterialMap, ""GetDefautMaterialMap")
                     ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
                     ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId) // This function is now redundant but cannot be marked deprecated or removed in case it's still referenced in script
                     ->Event("GetDefaultMaterialAssetId", &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId)
@@ -238,7 +238,7 @@ namespace AZ
             ReleaseMaterials();
 
             MaterialConsumerRequestBus::EventResult(
-                m_defaultMaterialMap, m_entityId, &MaterialConsumerRequestBus::Events::GetDefautMaterialMap);
+                m_defaultMaterialMap, m_entityId, &MaterialConsumerRequestBus::Events::GetDefaultMaterialMap);
 
             // Build tables of all referenced materials so that we can load and look up defaults
             for (const auto& [materialAssignmentId, materialAssignment] : m_defaultMaterialMap)
@@ -344,7 +344,7 @@ namespace AZ
             }
         }
 
-        MaterialAssignmentMap MaterialComponentController::GetDefautMaterialMap() const
+        MaterialAssignmentMap MaterialComponentController::GetDefaultMaterialMap() const
         {
             return m_defaultMaterialMap;
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -36,7 +36,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                     ->Attribute(AZ::Script::Attributes::Category, "render")
                     ->Attribute(AZ::Script::Attributes::Module, "render")
-                    ->Event("GetDefaultMaterialMap", &MaterialComponentRequestBus::Events::GetDefaultMaterialMap, ""GetDefautMaterialMap")
+                    ->Event("GetDefaultMaterialMap", &MaterialComponentRequestBus::Events::GetDefaultMaterialMap, "GetDefautMaterialMap")
                     ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
                     ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId) // This function is now redundant but cannot be marked deprecated or removed in case it's still referenced in script
                     ->Event("GetDefaultMaterialAssetId", &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -46,7 +46,7 @@ namespace AZ
             const MaterialComponentConfig& GetConfiguration() const;
 
             //! MaterialComponentRequestBus overrides...
-            MaterialAssignmentMap GetDefautMaterialMap() const override;
+            MaterialAssignmentMap GetDefaultMaterialMap() const override;
             MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
             AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -346,9 +346,9 @@ namespace AZ
             return GetMaterialSlotIdFromModelAsset(GetModelAsset(), lod, label);
         }
 
-        MaterialAssignmentMap MeshComponentController::GetDefautMaterialMap() const
+        MaterialAssignmentMap MeshComponentController::GetDefaultMaterialMap() const
         {
-            return GetDefautMaterialMapFromModelAsset(GetModelAsset());
+            return GetDefaultMaterialMapFromModelAsset(GetModelAsset());
         }
 
         AZStd::unordered_set<AZ::Name> MeshComponentController::GetModelUvNames() const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -150,7 +150,7 @@ namespace AZ
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentLabelMap GetMaterialLabels() const override;
-            MaterialAssignmentMap GetDefautMaterialMap() const override;
+            MaterialAssignmentMap GetDefaultMaterialMap() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 
             // MaterialComponentNotificationBus::Handler overrides ...

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -215,9 +215,9 @@ namespace AZ::Render
         return GetMaterialSlotIdFromModelAsset(GetModelAsset(), lod, label);
     }
 
-    MaterialAssignmentMap AtomActorInstance::GetDefautMaterialMap() const
+    MaterialAssignmentMap AtomActorInstance::GetDefaultMaterialMap() const
     {
-        return GetDefautMaterialMapFromModelAsset(GetModelAsset());
+        return GetDefaultMaterialMapFromModelAsset(GetModelAsset());
     }
 
     AZStd::unordered_set<AZ::Name> AtomActorInstance::GetModelUvNames() const

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -126,7 +126,7 @@ namespace AZ
             MaterialAssignmentId FindMaterialAssignmentId(
                 const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentLabelMap GetMaterialLabels() const override;
-            MaterialAssignmentMap GetDefautMaterialMap() const override;
+            MaterialAssignmentMap GetDefaultMaterialMap() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/MaterialComponentRequestBus.names
@@ -923,17 +923,17 @@
                     ]
                 },
                 {
-                    "base": "GetDefautMaterialMap",
+                    "base": "GetDefaultMaterialMap",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Get Defaut Material Map"
+                        "tooltip": "When signaled, this will invoke Get Default Material Map"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Get Defaut Material Map is invoked"
+                        "tooltip": "Signaled after Get Default Material Map is invoked"
                     },
                     "details": {
-                        "name": "Get Defaut Material Map"
+                        "name": "Get Default Material Map"
                     },
                     "results": [
                         {


### PR DESCRIPTION
## What does this PR do?

Correcting typo where the word default was missing an “L” in some material related functions.
Updated behavior context binding deprecation.

## How was this PR tested?

Building