### PR TITLE
DX12: Fix binding of Bindless for multiple scopes in a group

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -244,8 +244,8 @@ namespace AZ
                 // A queue of tile mappings to execute on the command queue at submission time (prior to executing the command list).
                 TileMapRequestList m_tileMapRequests;
 
-                // Signal that the global bindless heap is bound
-                bool m_bindBindlessHeap = false;
+                // Signal that the global bindless heap is bound to the index
+                int m_bindlessHeapLastIndex = -1;
 
                 // The currently bound shading rate image
                 const ImageView* m_shadingRateImage = nullptr;
@@ -387,7 +387,7 @@ namespace AZ
                 if (srgSlot == device.GetBindlessSrgSlot() && shaderResourceGroup == nullptr)
                 {
                     // Skip in case the global static heap is already bound
-                    if (m_state.m_bindBindlessHeap)
+                    if (m_state.m_bindlessHeapLastIndex == binding.m_bindlessTable.GetIndex())
                     {
                         continue;
                     }
@@ -411,7 +411,7 @@ namespace AZ
                         AZ_Assert(false, "Invalid PipelineType");
                         break;
                     }
-                    m_state.m_bindBindlessHeap = true;
+                    m_state.m_bindlessHeapLastIndex = binding.m_bindlessTable.GetIndex();
                     continue;
                 }
                 


### PR DESCRIPTION
## What does this PR do?

In the DX12 CommandList::CommitShaderResources: Check if the Bindless descriptor table was bound to the expected index, not just if it was already bound.
We had a problem that the Bindless SRG was not bound for a custom pass. Checking if it was bound to the expected index, and setting if it it was not, solved the problem.

I think what happens is this: There is a single `CommandList` in the `FrameGraphExecuteGroup` that's used for all scopes in the group.
When one of the scopes uses the Bindless SRG it sets it as a descriptor table in the DX12 CommandList. The index is defined in the PipelineLayout of the scope.
When another scopes also needs the Bindless SRG it's possible (likely?) that it uses another index for the Bindless SRG as the one before.
This means that the DescriptorTable might be overwritten by a different SRG, that uses the index of the last Bindless SRG.

## How was this PR tested?

Windows and DX12
