### PR TITLE
Added support for joints connecting to articulation links

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/RigidBodyBus.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
-#include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
+#include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
 
 namespace AzPhysics
 {
@@ -23,8 +24,7 @@ namespace AzPhysics
 namespace Physics
 {
     //! Requests interface for a rigid body (static or dynamic).
-    class RigidBodyRequests
-        : public AZ::ComponentBus
+    class RigidBodyRequests : public AZ::ComponentBus
     {
     public:
         using MutexType = AZStd::recursive_mutex;
@@ -82,8 +82,7 @@ namespace Physics
     using RigidBodyRequestBus = AZ::EBus<RigidBodyRequests>;
 
     //! Notifications interface for a rigid body (static or dynamic).
-    class RigidBodyNotifications
-        : public AZ::ComponentBus
+    class RigidBodyNotifications : public AZ::ComponentBus
     {
     private:
         template<class Bus>
@@ -108,11 +107,11 @@ namespace Physics
                     if (entityState == AZ::Entity::State::Active)
                     {
                         // Only immediately dispatch if the entity is a RigidBodyRequestBus' handler.
-                        RigidBodyRequestBus::EnumerateHandlersId(
+                        AzPhysics::SimulatedBodyComponentRequestsBus::EnumerateHandlersId(
                             id,
-                            [&handler, id](const RigidBodyRequests* rigidBodyhandler)
+                            [&handler, id](const AzPhysics::SimulatedBodyComponentRequests* simulatedBodyhandler)
                             {
-                                if (rigidBodyhandler->IsPhysicsEnabled())
+                                if (simulatedBodyhandler->IsPhysicsEnabled())
                                 {
                                     handler->OnPhysicsEnabled(id);
                                 }
@@ -144,4 +143,4 @@ namespace Physics
     };
 
     using RigidBodyNotificationBus = AZ::EBus<RigidBodyNotifications>;
-}
+} // namespace Physics

--- a/Gems/PhysX/Code/Editor/EditorJointConfiguration.cpp
+++ b/Gems/PhysX/Code/Editor/EditorJointConfiguration.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
 #include <AzCore/Serialization/EditContext.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <Editor/EditorJointConfiguration.h>
+#include <Source/EditorArticulationLinkComponent.h>
 #include <Source/EditorRigidBodyComponent.h>
 #include <Source/EditorStaticRigidBodyComponent.h>
 
@@ -17,7 +17,7 @@ namespace
 {
     const float LocalRotationMax = 360.0f;
     const float LocalRotationMin = -360.0f;
-}
+} // namespace
 
 namespace PhysX
 {
@@ -49,37 +49,43 @@ namespace PhysX
                 ->Field("Is Soft Limit", &EditorJointLimitConfig::m_isSoftLimit)
                 ->Field("Tolerance", &EditorJointLimitConfig::m_tolerance)
                 ->Field("Damping", &EditorJointLimitConfig::m_damping)
-                ->Field("Stiffness", &EditorJointLimitConfig::m_stiffness)
-                ;
+                ->Field("Stiffness", &EditorJointLimitConfig::m_stiffness);
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<PhysX::EditorJointLimitConfig>(
-                    "Editor Joint Limit Config Base", "Base joint limit parameters.")
+                editContext->Class<PhysX::EditorJointLimitConfig>("Editor Joint Limit Config Base", "Base joint limit parameters.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(0, &PhysX::EditorJointLimitConfig::m_isLimited, "Limit",
-                        "When active, the joint's degrees of freedom are limited.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointLimitConfig::m_isLimited, "Limit", "When active, the joint's degrees of freedom are limited.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorJointLimitConfig::IsInComponentMode)
-                    ->DataElement(0, &PhysX::EditorJointLimitConfig::m_isSoftLimit, "Soft limit",
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointLimitConfig::m_isSoftLimit,
+                        "Soft limit",
                         "When active, motion beyond the joint limit with a spring-like return is allowed.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitConfig::m_isLimited)
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorJointLimitConfig::IsInComponentMode)
-                    ->DataElement(0, &PhysX::EditorJointLimitConfig::m_damping, "Damping",
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointLimitConfig::m_damping,
+                        "Damping",
                         "Dissipation of energy and reduction in spring oscillations when outside the joint limit.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitConfig::IsSoftLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_springMax)
                     ->Attribute(AZ::Edit::Attributes::Min, s_springMin)
-                    ->DataElement(0, &PhysX::EditorJointLimitConfig::m_stiffness, "Stiffness",
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointLimitConfig::m_stiffness,
+                        "Stiffness",
                         "The spring's drive relative to the position of the follower when outside the joint limit.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitConfig::IsSoftLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_springMax)
-                    ->Attribute(AZ::Edit::Attributes::Min, s_springMin)
-                    ;
+                    ->Attribute(AZ::Edit::Attributes::Min, s_springMin);
             }
         }
     }
@@ -102,30 +108,29 @@ namespace PhysX
                 ->Version(1)
                 ->Field("Standard Limit Configuration", &EditorJointLimitPairConfig::m_standardLimitConfig)
                 ->Field("Positive Limit", &EditorJointLimitPairConfig::m_limitPositive)
-                ->Field("Negative Limit", &EditorJointLimitPairConfig::m_limitNegative)
-                ;
+                ->Field("Negative Limit", &EditorJointLimitPairConfig::m_limitNegative);
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<PhysX::EditorJointLimitPairConfig>(
-                    "Angular Limit", "Rotation limitation.")
+                editContext->Class<PhysX::EditorJointLimitPairConfig>("Angular Limit", "Rotation limitation.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(0, &PhysX::EditorJointLimitPairConfig::m_standardLimitConfig
-                        , "Standard limit configuration"
-                        , "Common limit parameters to all joint types.")
-                    ->DataElement(0, &PhysX::EditorJointLimitPairConfig::m_limitPositive, "Positive angular limit",
-                        "Positive rotation angle.")
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointLimitPairConfig::m_standardLimitConfig,
+                        "Standard limit configuration",
+                        "Common limit parameters to all joint types.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointLimitPairConfig::m_limitPositive, "Positive angular limit", "Positive rotation angle.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitPairConfig::IsLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_angleMax)
                     ->Attribute(AZ::Edit::Attributes::Min, s_angleMin)
-                    ->DataElement(0, &PhysX::EditorJointLimitPairConfig::m_limitNegative, "Negative angular limit",
-                        "Negative rotation angle.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointLimitPairConfig::m_limitNegative, "Negative angular limit", "Negative rotation angle.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitPairConfig::IsLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_angleMin)
-                    ->Attribute(AZ::Edit::Attributes::Min, -s_angleMax)
-                    ;
+                    ->Attribute(AZ::Edit::Attributes::Min, -s_angleMax);
             }
         }
     }
@@ -137,12 +142,14 @@ namespace PhysX
 
     JointLimitProperties EditorJointLimitPairConfig::ToGameTimeConfig() const
     {
-        return JointLimitProperties(m_standardLimitConfig.m_isLimited
-            , m_standardLimitConfig.m_isSoftLimit
-            , m_standardLimitConfig.m_damping
-            , m_limitPositive, m_limitNegative
-            , m_standardLimitConfig.m_stiffness
-            , m_standardLimitConfig.m_tolerance);
+        return JointLimitProperties(
+            m_standardLimitConfig.m_isLimited,
+            m_standardLimitConfig.m_isSoftLimit,
+            m_standardLimitConfig.m_damping,
+            m_limitPositive,
+            m_limitNegative,
+            m_standardLimitConfig.m_stiffness,
+            m_standardLimitConfig.m_tolerance);
     }
 
     void EditorJointLimitLinearPairConfig::Reflect(AZ::ReflectContext* context)
@@ -153,8 +160,7 @@ namespace PhysX
                 ->Version(1)
                 ->Field("Standard Limit Configuration", &EditorJointLimitLinearPairConfig::m_standardLimitConfig)
                 ->Field("Lower Limit", &EditorJointLimitLinearPairConfig::m_limitLower)
-                ->Field("Upper Limit", &EditorJointLimitLinearPairConfig::m_limitUpper)
-                ;
+                ->Field("Upper Limit", &EditorJointLimitLinearPairConfig::m_limitUpper);
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
@@ -222,30 +228,29 @@ namespace PhysX
                 ->Version(1)
                 ->Field("Standard Limit Configuration", &EditorJointLimitConeConfig::m_standardLimitConfig)
                 ->Field("Y Axis Limit", &EditorJointLimitConeConfig::m_limitY)
-                ->Field("Z Axis Limit", &EditorJointLimitConeConfig::m_limitZ)
-                ;
+                ->Field("Z Axis Limit", &EditorJointLimitConeConfig::m_limitZ);
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<PhysX::EditorJointLimitConeConfig>(
-                    "Angular Limit", "Rotation limitation.")
+                editContext->Class<PhysX::EditorJointLimitConeConfig>("Angular Limit", "Rotation limitation.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(0, &PhysX::EditorJointLimitConeConfig::m_standardLimitConfig
-                        , "Standard limit configuration"
-                        , "Common limit parameters to all joint types.")
-                    ->DataElement(0, &PhysX::EditorJointLimitConeConfig::m_limitY, "Y axis angular limit",
-                        "Limit for swing angle about Y axis.")
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointLimitConeConfig::m_standardLimitConfig,
+                        "Standard limit configuration",
+                        "Common limit parameters to all joint types.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointLimitConeConfig::m_limitY, "Y axis angular limit", "Limit for swing angle about Y axis.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitConeConfig::IsLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_angleMax)
                     ->Attribute(AZ::Edit::Attributes::Min, s_angleMin)
-                    ->DataElement(0, &PhysX::EditorJointLimitConeConfig::m_limitZ, "Z axis angular limit",
-                        "Limit for swing angle about Z axis.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointLimitConeConfig::m_limitZ, "Z axis angular limit", "Limit for swing angle about Z axis.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointLimitConeConfig::IsLimited)
                     ->Attribute(AZ::Edit::Attributes::Max, s_angleMax)
-                    ->Attribute(AZ::Edit::Attributes::Min, s_angleMin)
-                    ;
+                    ->Attribute(AZ::Edit::Attributes::Min, s_angleMin);
             }
         }
     }
@@ -257,13 +262,14 @@ namespace PhysX
 
     JointLimitProperties EditorJointLimitConeConfig::ToGameTimeConfig() const
     {
-        return JointLimitProperties(m_standardLimitConfig.m_isLimited
-            , m_standardLimitConfig.m_isSoftLimit
-            , m_standardLimitConfig.m_damping
-            , m_limitY
-            , m_limitZ
-            , m_standardLimitConfig.m_stiffness
-            , m_standardLimitConfig.m_tolerance);
+        return JointLimitProperties(
+            m_standardLimitConfig.m_isLimited,
+            m_standardLimitConfig.m_isSoftLimit,
+            m_standardLimitConfig.m_damping,
+            m_limitY,
+            m_limitZ,
+            m_standardLimitConfig.m_stiffness,
+            m_standardLimitConfig.m_tolerance);
     }
 
     void EditorJointConfig::Reflect(AZ::ReflectContext* context)
@@ -282,65 +288,72 @@ namespace PhysX
                 ->Field("Maximum Torque", &EditorJointConfig::m_torqueMax)
                 ->Field("Display Debug", &EditorJointConfig::m_displayJointSetup)
                 ->Field("Select Lead on Snap", &EditorJointConfig::m_selectLeadOnSnap)
-                ->Field("Self Collide", &EditorJointConfig::m_selfCollide)
-                ;
+                ->Field("Self Collide", &EditorJointConfig::m_selfCollide);
 
             serializeContext->Enum<EditorJointConfig::DisplaySetupState>()
                 ->Value("Never", EditorJointConfig::DisplaySetupState::Never)
                 ->Value("Selected", EditorJointConfig::DisplaySetupState::Selected)
-                ->Value("Always", EditorJointConfig::DisplaySetupState::Always)
-                ;
+                ->Value("Always", EditorJointConfig::DisplaySetupState::Always);
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
                 editContext->Enum<EditorJointConfig::DisplaySetupState>("Joint Display Setup State", "Options for displaying joint setup.")
                     ->Value("Never", EditorJointConfig::DisplaySetupState::Never)
                     ->Value("Selected", EditorJointConfig::DisplaySetupState::Selected)
-                    ->Value("Always", EditorJointConfig::DisplaySetupState::Always)
-                    ;
+                    ->Value("Always", EditorJointConfig::DisplaySetupState::Always);
 
-                editContext->Class<PhysX::EditorJointConfig>(
-                    "PhysX Joint Configuration", "")
+                editContext->Class<PhysX::EditorJointConfig>("PhysX Joint Configuration", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_localPosition, "Local Position"
-                        , "Local Position of joint, relative to its entity.")
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_localRotation, "Local Rotation"
-                        , "Local Rotation of joint, relative to its entity.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointConfig::m_localPosition, "Local Position", "Local Position of joint, relative to its entity.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointConfig::m_localRotation, "Local Rotation", "Local Rotation of joint, relative to its entity.")
                     ->Attribute(AZ::Edit::Attributes::Min, LocalRotationMin)
                     ->Attribute(AZ::Edit::Attributes::Max, LocalRotationMax)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_fixJointLocation, "Fix Joint Location"
-                        , "When enabled the joint will remain in the same location when moving the entity.")
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_leadEntity, "Lead Entity"
-                        , "Parent entity associated with joint.")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorJointConfig::OnLeadEntityChanged)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_selfCollide, "Lead-Follower Collide"
-                        , "When active, the lead and follower pair will collide with each other.")
                     ->DataElement(
-                        AZ::Edit::UIHandlers::ComboBox, &PhysX::EditorJointConfig::m_displayJointSetup, "Display Setup in Viewport"
-                        , "Never = Not shown."
+                        0,
+                        &PhysX::EditorJointConfig::m_fixJointLocation,
+                        "Fix Joint Location",
+                        "When enabled the joint will remain in the same location when moving the entity.")
+                    ->DataElement(0, &PhysX::EditorJointConfig::m_leadEntity, "Lead Entity", "Parent entity associated with joint.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorJointConfig::OnLeadEntityChanged)
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointConfig::m_selfCollide,
+                        "Lead-Follower Collide",
+                        "When active, the lead and follower pair will collide with each other.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox,
+                        &PhysX::EditorJointConfig::m_displayJointSetup,
+                        "Display Setup in Viewport",
+                        "Never = Not shown."
                         "Select = Show setup display when entity is selected."
                         "Always = Always show setup display.")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorJointConfig::IsInComponentMode)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_selectLeadOnSnap, "Select Lead on Snap"
-                        , "Select lead entity on snap to position in component mode.")
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_breakable
-                        , "Breakable"
-                        , "Joint is breakable when force or torque exceeds limit.")
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointConfig::m_selectLeadOnSnap,
+                        "Select Lead on Snap",
+                        "Select lead entity on snap to position in component mode.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointConfig::m_breakable, "Breakable", "Joint is breakable when force or torque exceeds limit.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, &EditorJointConfig::IsInComponentMode)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_forceMax,
-                        "Maximum Force", "Amount of force joint can withstand before breakage.")
+                    ->DataElement(
+                        0, &PhysX::EditorJointConfig::m_forceMax, "Maximum Force", "Amount of force joint can withstand before breakage.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointConfig::m_breakable)
                     ->Attribute(AZ::Edit::Attributes::Max, BreakageMax)
                     ->Attribute(AZ::Edit::Attributes::Min, BreakageMin)
-                    ->DataElement(0, &PhysX::EditorJointConfig::m_torqueMax,
-                        "Maximum Torque", "Amount of torque joint can withstand before breakage.")
+                    ->DataElement(
+                        0,
+                        &PhysX::EditorJointConfig::m_torqueMax,
+                        "Maximum Torque",
+                        "Amount of torque joint can withstand before breakage.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &EditorJointConfig::m_breakable)
                     ->Attribute(AZ::Edit::Attributes::Max, BreakageMax)
-                    ->Attribute(AZ::Edit::Attributes::Min, BreakageMin)
-                    ;
+                    ->Attribute(AZ::Edit::Attributes::Min, BreakageMin);
             }
         }
     }
@@ -351,8 +364,7 @@ namespace PhysX
         OnLeadEntityChanged();
 
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-            , AzToolsFramework::Refresh_AttributesAndValues);
+            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
     }
 
     JointGenericProperties EditorJointConfig::ToGenericProperties() const
@@ -374,15 +386,14 @@ namespace PhysX
     {
         return JointComponentConfiguration(
             AZ::Transform::CreateFromQuaternionAndTranslation(
-                AZ::Quaternion::CreateFromEulerAnglesDegrees(m_localRotation),
-                m_localPosition),
+                AZ::Quaternion::CreateFromEulerAnglesDegrees(m_localRotation), m_localPosition),
             m_leadEntity,
             m_followerEntity);
     }
 
     bool EditorJointConfig::ShowSetupDisplay() const
     {
-        switch(m_displayJointSetup)
+        switch (m_displayJointSetup)
         {
         case DisplaySetupState::Always:
             return true;
@@ -410,16 +421,16 @@ namespace PhysX
         }
 
         AZ::Entity* entity = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(entity,
-            &AZ::ComponentApplicationRequests::FindEntity,
-            m_leadEntity);
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, m_leadEntity);
         if (entity)
         {
             [[maybe_unused]] const bool leadEntityHasRigidActor =
                 (entity->FindComponent<PhysX::EditorRigidBodyComponent>() ||
-                 entity->FindComponent<PhysX::EditorStaticRigidBodyComponent>());
+                 entity->FindComponent<PhysX::EditorStaticRigidBodyComponent>() ||
+                 entity->FindComponent<PhysX::EditorArticulationLinkComponent>());
 
-            AZ_Warning("EditorJointComponent",
+            AZ_Warning(
+                "EditorJointComponent",
                 leadEntityHasRigidActor,
                 "Joints require either a dynamic or static rigid body on the lead entity. "
                 "Please add either a static or a dynamic rigid body component to entity %s",
@@ -430,12 +441,12 @@ namespace PhysX
             AZStd::string followerEntityName;
             if (m_followerEntity.IsValid())
             {
-                AZ::ComponentApplicationBus::BroadcastResult(followerEntityName,
-                    &AZ::ComponentApplicationRequests::GetEntityName,
-                    m_followerEntity);
+                AZ::ComponentApplicationBus::BroadcastResult(
+                    followerEntityName, &AZ::ComponentApplicationRequests::GetEntityName, m_followerEntity);
             }
 
-            AZ_Warning("EditorJointComponent",
+            AZ_Warning(
+                "EditorJointComponent",
                 false,
                 "Cannot find instance of lead entity given its entity ID. Please check that joint in entity %s has valid lead entity.",
                 followerEntityName.c_str());

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -12,7 +12,6 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
-#include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Shape.h>
 #include <PhysX/ArticulationJointBus.h>
 #include <PhysX/ArticulationSensorBus.h>
@@ -22,11 +21,13 @@
 #include <Source/Articulation.h>
 #include <Source/Articulation/ArticulationLinkConfiguration.h>
 
+#include <AzFramework/Physics/PhysicsScene.h>
+
 namespace physx
 {
     class PxArticulationReducedCoordinate;
     class PxArticulationJointReducedCoordinate;
-}
+} // namespace physx
 
 namespace PhysX
 {
@@ -37,6 +38,7 @@ namespace PhysX
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
         , public PhysX::ArticulationJointRequestBus::Handler
         , public PhysX::ArticulationSensorRequestBus::Handler
+        , public AzPhysics::SimulatedBodyComponentRequestsBus::Handler
 #endif
     {
     public:
@@ -82,6 +84,16 @@ namespace PhysX
         void SetSensorTransform(AZ::u32 sensorIndex, const AZ::Transform& sensorTransform) override;
         AZ::Vector3 GetForce(AZ::u32 sensorIndex) const override;
         AZ::Vector3 GetTorque(AZ::u32 sensorIndex) const override;
+
+        AzPhysics::SimulatedBody* GetSimulatedBodyConst() const;
+        // SimulatedBodyComponentRequests overrides ...
+        AzPhysics::SimulatedBody* GetSimulatedBody() override;
+        AzPhysics::SimulatedBodyHandle GetSimulatedBodyHandle() const override;
+        void EnablePhysics() override;
+        void DisablePhysics() override;
+        bool IsPhysicsEnabled() const override;
+        AZ::Aabb GetAabb() const override;
+        AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
 #endif
         physx::PxArticulationLink* GetArticulationLink(const AZ::EntityId entityId);
         const AZStd::vector<AZ::u32> GetSensorIndices(const AZ::EntityId entityId);

--- a/Gems/PhysX/Code/Source/JointComponent.h
+++ b/Gems/PhysX/Code/Source/JointComponent.h
@@ -10,12 +10,14 @@
 #include <PxPhysicsAPI.h>
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityBus.h>
 #include <AzCore/Component/EntityId.h>
-#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Component/TickBus.h>
-#include <AzFramework/Physics/RigidBodyBus.h>
+#include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 
+#include <PhysX/ArticulationJointBus.h>
 #include <PhysX/Joint/Configuration/PhysXJointConfiguration.h>
 
 namespace AzPhysics
@@ -33,14 +35,12 @@ namespace PhysX
         static void Reflect(AZ::ReflectContext* context);
 
         JointComponentConfiguration() = default;
-        JointComponentConfiguration(
-            AZ::Transform localTransformFromFollower,
-            AZ::EntityId leadEntity,
-            AZ::EntityId followerEntity);
+        JointComponentConfiguration(AZ::Transform localTransformFromFollower, AZ::EntityId leadEntity, AZ::EntityId followerEntity);
 
         AZ::EntityId m_leadEntity; ///< EntityID for entity containing body that is lead to this joint constraint.
         AZ::EntityId m_followerEntity; ///< EntityID for entity containing body that is follower to this joint constraint.
-        AZ::Transform m_localTransformFromFollower; ///< Joint's location and orientation in the frame (coordinate system) of the follower entity.
+        AZ::Transform
+            m_localTransformFromFollower; ///< Joint's location and orientation in the frame (coordinate system) of the follower entity.
     };
 
     /// Base class for game-time generic joint components.
@@ -54,9 +54,7 @@ namespace PhysX
         static void Reflect(AZ::ReflectContext* context);
 
         JointComponent() = default;
-        JointComponent(
-            const JointComponentConfiguration& configuration,
-            const JointGenericProperties& genericProperties);
+        JointComponent(const JointComponentConfiguration& configuration, const JointGenericProperties& genericProperties);
         JointComponent(
             const JointComponentConfiguration& configuration,
             const JointGenericProperties& genericProperties,
@@ -103,11 +101,11 @@ namespace PhysX
 
         AZ::Transform GetJointLocalPose(const physx::PxRigidActor* actor, const AZ::Transform& jointPose);
 
-        AZ::Transform GetJointTransform(AZ::EntityId entityId,
-            const JointComponentConfiguration& jointConfig);
+        AZ::Transform GetJointTransform(AZ::EntityId entityId, const JointComponentConfiguration& jointConfig);
 
         /// Used on initialization by sub-classes to get native pointers from entity IDs.
-        /// This allows sub-classes to instantiate specific native types. This base class does not need knowledge of any specific joint type.
+        /// This allows sub-classes to instantiate specific native types. This base class does not need knowledge of any specific joint
+        /// type.
         void ObtainLeadFollowerInfo(LeadFollowerInfo& leadFollowerInfo);
 
         /// Issues warnings for invalid scenarios when initializing a joint from entity IDs.


### PR DESCRIPTION
## What does this PR do?

This PR makes it possible to add joints that connect to articulation links.
Before, such joints were impossible, even though they are supported by the PhysX engine.
This PR fixes https://github.com/o3de/o3de/issues/16188.

## How was this PR tested?

Locally, by replacing some articulation links with joints in a prefab.
