### PR TITLE
(Cherry-Pick) Fixed comparison of file paths with '.' using the AZ Path API (#16674)

### DIFF
--- a/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
@@ -193,7 +193,10 @@ namespace UnitTest
             AZStd::tuple<AZStd::string_view, AZStd::string_view>("test/foo", "test/foo"),
             AZStd::tuple<AZStd::string_view, AZStd::string_view>("test/foo", "test\\foo"),
             AZStd::tuple<AZStd::string_view, AZStd::string_view>("test////foo", "test///foo"),
-            AZStd::tuple<AZStd::string_view, AZStd::string_view>("test/bar/baz//foo", "test/bar/baz\\\\\\foo")
+            AZStd::tuple<AZStd::string_view, AZStd::string_view>("test/bar/baz//foo", "test/bar/baz\\\\\\foo"),
+            AZStd::tuple<AZStd::string_view, AZStd::string_view>("/home/foo/ros_ws/install/foo_robot/./meshes/bar.dae", "/home/foo/ros_ws/install/foo_robot/meshes/bar.dae"),
+            AZStd::tuple<AZStd::string_view, AZStd::string_view>("/./boo/far/./faz", "/boo/./././././far/././faz"),
+            AZStd::tuple<AZStd::string_view, AZStd::string_view>("test/foo/.", "test/foo")
         ));
 
     TEST_F(PathFixture, ComparisonOperators_Succeeds)


### PR DESCRIPTION
## What does this PR do?

This is a cherry pick of commit 183d594453d712e4d9991f96e502bd0f3e847faa
Windows Paths such as `C:/foo/bar/./baz` now correctly compare equal to `C:/foo/bar/baz` and POSIX paths such as `/baz/bar/./foo` now compare equal to `/baz/bar/foo`


## How was this PR tested?

Added Unit Test scenarios to verify the modifications to CompareRelative function were able to compare paths which references a directory using "./" succeeded.

Also verified existing Path UnitTest succeeds
