### PR TITLE
Disable o3de-extras automated testing for stabilization

### DIFF
--- a/.automatedtesting.json
+++ b/.automatedtesting.json
@@ -12,10 +12,5 @@
     "ENABLE_GEMS": [
     ],
     "REPOS": [
-        {
-            "NAME": "o3de-extras",
-            "URL": "https://github.com/o3de/o3de-extras.git",
-            "BRANCH": "development"
-        }
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ CMakeUserPresets.json
 [Uu]ser/
 FrameCapture/**
 .DS_Store
+.automatedtesting.json
 user*.cfg
 client*.cfg
 server*.cfg


### PR DESCRIPTION
## What does this PR do?

Removes automated tests for o3de-extras from o3de stabilization, as the components for o3de-extras at the development branch are not being tested for the release. Alternatively, we can include the tests but force the AR builds to run at the stabilization branch.

Includes a change to .gitignore to prevent this from being merged back to development.

## How was this PR tested?

Tested in a sandbox Jenkins build
