### PR TITLE
Fix for atom tools not launching with all gems enabled

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
+++ b/Gems/Atom/Tools/MaterialCanvas/Registry/gem_autoload.materialcanvas.setreg
@@ -34,6 +34,19 @@
                     }
                 }
             },
+            "VirtualGamepad": {
+                "Targets": {
+                    "VirtualGamepad": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Clients": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine": {

--- a/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
+++ b/Gems/Atom/Tools/MaterialEditor/Registry/gem_autoload.materialeditor.setreg
@@ -34,6 +34,19 @@
                     }
                 }
             },
+            "VirtualGamepad": {
+                "Targets": {
+                    "VirtualGamepad": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Clients": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine": {

--- a/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
+++ b/Gems/Atom/Tools/PassCanvas/Registry/gem_autoload.passcanvas.setreg
@@ -34,6 +34,19 @@
                     }
                 }
             },
+            "VirtualGamepad": {
+                "Targets": {
+                    "VirtualGamepad": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Clients": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine": {

--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -34,6 +34,19 @@
                     }
                 }
             },
+            "VirtualGamepad": {
+                "Targets": {
+                    "VirtualGamepad": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Clients": {
+                        "AutoLoad": false
+                    },
+                    "VirtualGamepad.Tools": {
+                        "AutoLoad": false
+                    }
+                }
+            },
             "LyShine": {
                 "Targets": {
                     "LyShine": {

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/bootstrap.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/bootstrap.py
@@ -160,9 +160,6 @@ from PySide2 import QtGui
 from PySide2.QtCore import Slot, QObject, QUrl
 from shiboken2 import wrapInstance, getCppPointer
 
-# import additional O3DE QtForPython Gem modules
-import az_qt_helpers
-
 # additional DCCsi imports that utilize PySide2
 from DccScriptingInterface.Editor.Scripts.ui import start_service
 from DccScriptingInterface.Editor.Scripts.ui import hook_register_action_sampleui
@@ -346,6 +343,8 @@ def click_action_dccsi_about():
     """Open DCCsi About Dialog"""
     _LOGGER.debug(f'Clicked: click_action_dccsi_about')
 
+    # import additional O3DE QtForPython Gem modules
+    import az_qt_helpers
     EDITOR_MAIN_WINDOW = az_qt_helpers.get_editor_main_window()
 
     about_dialog = DccsiAbout(EDITOR_MAIN_WINDOW)

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/ui.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/ui.py
@@ -45,7 +45,6 @@ import DccScriptingInterface.azpy.shared.ui.samples
 from DccScriptingInterface.azpy.shared.ui.samples import SampleUI
 
 # O3DE imports
-import az_qt_helpers
 import azlmbr
 import azlmbr.bus
 import azlmbr.paths
@@ -65,6 +64,8 @@ def click_action_sampleui():
     """
     _LOGGER.debug(f'Clicked: click_action_sampleui')
 
+    # import additional O3DE QtForPython Gem modules
+    import az_qt_helpers
     ui = SampleUI(parent=az_qt_helpers.get_editor_main_window(),
                   title='Dccsi: SampleUI')
     ui.show()


### PR DESCRIPTION
## What does this PR do?

All of the atom tools that run independently of the main editor have registry settings to disable specific gems within those tools. This is done to speed up launch times and reduce memory utilization by not loading or activating systems that will never be used within those tools. Occasionally, a new gem is added or activated that may depend on one of the disabled gem modules. In this case, the virtual game pad was activated by the game project and relied upon ly shine, which is disabled by those tools. So the virtual game pad was added to the disabled list. Alternatively, the auto load or disabled gem registry settings files can be completely removed to let all of the project runtime dependencies load in the tools. I attempted this but certain gems, like script canvas, will still need to be disabled because it fires several errors and warnings outside of the main editor while, I assume, trying to load graph data.

Resolves https://github.com/o3de/o3de/issues/16795

## How was this PR tested?

Enabled all of the stock gems on automated testing project to reproduce the error.
Virtual game pad proved to be the problem, as shown in the provided logs.
Disabling virtual game pad resolved that specific issue.
This revealed other issues like DCC script interface bootstrap attempting to import modules and run scripts that will only operate in the main editor.
Updated those Python files by moving the import lines.
There is already code in the DCC script interface bootstrap to exit if the host application is material editor, material canvas, etc.