### PR TITLE
Introduce multi-device buffer/image views

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -42,7 +42,7 @@ namespace AZ::RHI
         //! Returns the buffer frame attachment if the buffer is currently attached.
         const BufferFrameAttachment* GetFrameAttachment() const;
 
-        Ptr<MultiDeviceBufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor);
+        Ptr<MultiDeviceBufferView> BuildBufferView(const BufferViewDescriptor& bufferViewDescriptor);
 
         //! Get the hash associated with the MultiDeviceBuffer
         const HashValue64 GetHash() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -8,14 +8,16 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/BufferDescriptor.h>
-#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferView.h>
 #include <Atom/RHI/MultiDeviceResource.h>
 
 namespace AZ::RHI
 {
     class BufferFrameAttachment;
     struct BufferViewDescriptor;
+    class MultiDeviceBufferView;
 
     //! A MultiDeviceBuffer holds all Buffers across multiple devices.
     //! The buffer descriptor will be shared across all the buffers.
@@ -40,6 +42,8 @@ namespace AZ::RHI
         //! Returns the buffer frame attachment if the buffer is currently attached.
         const BufferFrameAttachment* GetFrameAttachment() const;
 
+        Ptr<MultiDeviceBufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor);
+
         //! Get the hash associated with the MultiDeviceBuffer
         const HashValue64 GetHash() const;
 
@@ -56,5 +60,42 @@ namespace AZ::RHI
 
         //! The RHI descriptor for this MultiDeviceBuffer.
         BufferDescriptor m_descriptor;
+    };
+
+    //! A MultiDeviceBufferView is a light-weight representation of a view onto a multi-device buffer.
+    //! It holds a raw pointer to a multi-device buffer as well as a BufferViewDescriptor object.
+    //! Using both, single-device BufferViews can be retrieved.
+    class MultiDeviceBufferView : public Object
+    {
+    public:
+        AZ_RTTI(MultiDeviceBufferView, "{CD764967-6AC1-4B9D-9573-498FA61F8F84}", Object);
+        virtual ~MultiDeviceBufferView() = default;
+
+        MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor)
+            : m_buffer{ buffer }
+            , m_descriptor{ descriptor }
+        {
+        }
+
+        //! Given a device index, return the corresponding BufferView for the selected device
+        const RHI::Ptr<RHI::BufferView> GetDeviceBufferView(int deviceIndex) const;
+
+        //! Return the contained multi-device buffer
+        const RHI::MultiDeviceBuffer* GetBuffer() const
+        {
+            return m_buffer;
+        }
+
+        //! Return the contained BufferViewDescriptor
+        const BufferViewDescriptor& GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+    private:
+        //! A raw pointer to a multi-device buffer
+        const RHI::MultiDeviceBuffer* m_buffer;
+        //! The corresponding BufferViewDescriptor for this view.
+        BufferViewDescriptor m_descriptor;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -10,6 +10,7 @@
 #include <Atom/RHI.Reflect/ImageSubresource.h>
 #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
 #include <Atom/RHI/Image.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/MultiDeviceResource.h>
 
 namespace AZ::RHI
@@ -64,7 +65,7 @@ namespace AZ::RHI
         //!      number of array slices).
         //!  @param totalSizeInBytes
         //!      [Optional] If specified, will be filled with the total size necessary to contain all subresources.
-        void GetSubresourceLayout(MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags) const;
+        void GetSubresourceLayout(MultiDeviceImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags = ImageAspectFlags::All) const;
 
         //! Returns the set of queue classes that are supported for usage as an attachment on the frame scheduler.
         //! Effectively, for a scope of a specific hardware class to use the image as an attachment, the queue must
@@ -75,6 +76,13 @@ namespace AZ::RHI
         //! is imported into the frame scheduler (which is reset every frame). This value will be null for non-attachment
         //! images.
         const ImageFrameAttachment* GetFrameAttachment() const;
+
+        //! Returns the most detailed mip level currently resident in memory on any device, where a value of 0
+        //! is the highest detailed mip.
+        uint32_t GetResidentMipLevel() const;
+
+        //! Returns whether the image has sub-resources which can be evicted from or streamed into the device memory
+        bool IsStreamable() const;
 
         //! Returns the aspects that are included in the image.
         ImageAspectFlags GetAspectFlags() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/ImageSubresource.h>
+#include <Atom/RHI.Reflect/ImageViewDescriptor.h>
 #include <Atom/RHI/Image.h>
 #include <Atom/RHI/MultiDeviceResource.h>
 
@@ -16,6 +17,7 @@ namespace AZ::RHI
     class ImageFrameAttachment;
     class MultiDeviceShaderResourceGroup;
     class ImageView;
+    class MultiDeviceImageView;
     struct ImageViewDescriptor;
 
     //! MultiDeviceImage represents a collection of MultiDeviceImage Subresources, where each subresource comprises a one to three
@@ -46,6 +48,9 @@ namespace AZ::RHI
         //! Returns the image descriptor used to initialize the image. If the image is uninitialized, the contents
         //! are considered undefined.
         const ImageDescriptor& GetDescriptor() const;
+
+        //! Returns the multi-device ImageView
+        Ptr<MultiDeviceImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor);
 
         //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
         //! this data represents how to store the image in a buffer resource. Naturally, if the image contents
@@ -95,5 +100,42 @@ namespace AZ::RHI
 
         //! Aspects supported by the image
         ImageAspectFlags m_aspectFlags = ImageAspectFlags::None;
+    };
+
+    //! A MultiDeviceImageView is a light-weight representation of a view onto a multi-device image.
+    //! It holds a raw pointer to a multi-device image as well as an ImageViewDescriptor.
+    //! Using both, single-device ImageViews can be retrieved.
+    class MultiDeviceImageView : public Object
+    {
+    public:
+        AZ_RTTI(MultiDeviceImageView, "{C837818B-2A4D-49F2-A37E-349494A9C9B7}", Object);
+        virtual ~MultiDeviceImageView() = default;
+
+        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor)
+            : m_image{ image }
+            , m_descriptor{ descriptor }
+        {
+        }
+
+        //! Given a device index, return the corresponding ImageView for the selected device
+        const RHI::Ptr<RHI::ImageView> GetDeviceImageView(int deviceIndex) const;
+
+        //! Return the contained multi-device image
+        const RHI::MultiDeviceImage* GetImage() const
+        {
+            return m_image;
+        }
+
+        //! Return the contained ImageViewDescriptor
+        const ImageViewDescriptor& GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+    private:
+        //! A raw pointer to a multi-device image
+        const RHI::MultiDeviceImage* m_image;
+        //! The corresponding ImageViewDescriptor for this view.
+        ImageViewDescriptor m_descriptor;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -51,7 +51,7 @@ namespace AZ::RHI
         const ImageDescriptor& GetDescriptor() const;
 
         //! Returns the multi-device ImageView
-        Ptr<MultiDeviceImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor);
+        Ptr<MultiDeviceImageView> BuildImageView(const ImageViewDescriptor& imageViewDescriptor);
 
         //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
         //! this data represents how to store the image in a buffer resource. Naturally, if the image contents

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
@@ -11,6 +11,7 @@
 #include <Atom/RHI/MultiDeviceObject.h>
 #include <Atom/RHI/PipelineLibrary.h>
 
+#include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI.Reflect/PipelineLibraryData.h>
 
 namespace AZ::RHI
@@ -22,6 +23,19 @@ namespace AZ::RHI
     //! MultiDevicePipelineLibrary
     struct MultiDevicePipelineLibraryDescriptor
     {
+        void Init(MultiDevice::DeviceMask deviceMask, const PipelineLibraryDescriptor& descriptor)
+        {
+            int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+            for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                {
+                    m_devicePipelineLibraryDescriptors[deviceIndex] = descriptor;
+                }
+            }
+        }
+
         //! Returns the device-specific PipelineLibraryDescriptor for the given index
         inline PipelineLibraryDescriptor GetDevicePipelineLibraryDescriptor(int deviceIndex) const
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
 
             for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                if (CheckBit(AZStd::to_underlying(deviceMask), deviceIndex))
                 {
                     m_devicePipelineLibraryDescriptors[deviceIndex] = descriptor;
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDevicePipelineLibrary.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
 
             for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if (CheckBit(AZStd::to_underlying(deviceMask), deviceIndex))
+                if (CheckBit(AZStd::to_underlying(deviceMask), static_cast<u8>(deviceIndex)))
                 {
                     m_devicePipelineLibraryDescriptors[deviceIndex] = descriptor;
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -37,10 +37,6 @@ namespace AZ::RHI
     //! NOTE [SRG Constants]: The ConstantsData class is used for efficiently setting/getting the constants values of the SRG.
     class MultiDeviceShaderResourceGroupData
     {
-        //! Local abstraction for multi-device views to images and buffers, consisting of an image/buffer and a corresponding descriptor
-        using MultiDeviceBufferView = AZStd::pair<const MultiDeviceBuffer*, BufferViewDescriptor>;
-        using MultiDeviceImageView = AZStd::pair<const MultiDeviceImage*, ImageViewDescriptor>;
-
     public:
         //! By default creates an empty data structure. Must be initialized before use.
         MultiDeviceShaderResourceGroupData() = default;
@@ -274,8 +270,8 @@ namespace AZ::RHI
             return false;
         }
 
-        const ImageViewDescriptor& imageViewDescriptor = imageView->second;
-        const MultiDeviceImage& image = *(imageView->first);
+        const ImageViewDescriptor& imageViewDescriptor = imageView->GetDescriptor();
+        const MultiDeviceImage& image = *(imageView->GetImage());
         const ImageDescriptor& imageDescriptor = image.GetDescriptor();
         const ImageFrameAttachment* frameAttachment = image.GetFrameAttachment();
 
@@ -440,8 +436,8 @@ namespace AZ::RHI
         }
 
         const TShaderInputDescriptor& shaderInputBuffer = GetLayout()->GetShaderInput(inputIndex);
-        const BufferViewDescriptor& bufferViewDescriptor = bufferView->second;
-        const MultiDeviceBuffer& buffer = *(bufferView->first);
+        const BufferViewDescriptor& bufferViewDescriptor = bufferView->GetDescriptor();
+        const MultiDeviceBuffer& buffer = *(bufferView->GetBuffer());
         const BufferDescriptor& bufferDescriptor = buffer.GetDescriptor();
         const BufferFrameAttachment* frameAttachment = buffer.GetFrameAttachment();
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -51,6 +51,25 @@ namespace AZ
 
             const StreamingImagePoolDescriptor& GetDescriptor() const override final;
 
+            //! Set a callback function that is called when the pool is out of memory for new allocations
+            //! User could provide such a callback function which releases some resources from the pool
+            //! If some resources are released, the function may return true.
+            //! If nothing is released, the function should return false.
+            using LowMemoryCallback = StreamingImagePool::LowMemoryCallback;
+            void SetLowMemoryCallback(LowMemoryCallback callback);
+
+            //! Set memory budget for all device pools
+            //! Return true if the pool was set to new memory budget successfully
+            bool SetMemoryBudget(size_t newBudget);
+
+            //! Returns the maximum memory used by one of its pools for a specific heap type.
+            const HeapMemoryUsage& GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const;
+
+            //! Return if it supports tiled image feature
+            bool SupportTiledImage() const;
+
+            void Shutdown() override final;
+
         private:
             using MultiDeviceImagePoolBase::InitImage;
             using MultiDeviceResourcePool::Init;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -62,7 +62,8 @@ namespace AZ
             //! Return true if the pool was set to new memory budget successfully
             bool SetMemoryBudget(size_t newBudget);
 
-            //! Returns the maximum memory used by one of its pools for a specific heap type.
+            //! Iterates through all device-specific image pools and returns the HeapMemoryUsage
+            //! from the pool with the maximum memory budget.
             const HeapMemoryUsage& GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const;
 
             //! Return if it supports tiled image feature

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -31,7 +31,7 @@ namespace AZ::RHI
         return static_cast<const BufferFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
     }
 
-    Ptr<MultiDeviceBufferView> MultiDeviceBuffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor)
+    Ptr<MultiDeviceBufferView> MultiDeviceBuffer::BuildBufferView(const BufferViewDescriptor& bufferViewDescriptor)
     {
         return aznew MultiDeviceBufferView{ this, bufferViewDescriptor };
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -31,6 +31,11 @@ namespace AZ::RHI
         return static_cast<const BufferFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
     }
 
+    Ptr<MultiDeviceBufferView> MultiDeviceBuffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor)
+    {
+        return aznew MultiDeviceBufferView{ this, bufferViewDescriptor };
+    }
+
     const HashValue64 MultiDeviceBuffer::GetHash() const
     {
         HashValue64 hash = HashValue64{ 0 };
@@ -54,5 +59,11 @@ namespace AZ::RHI
         {
             deviceBuffer->InvalidateViews();
         });
+    }
+
+    //! Given a device index, return the corresponding BufferView for the selected device
+    const RHI::Ptr<RHI::BufferView> MultiDeviceBufferView::GetDeviceBufferView(int deviceIndex) const
+    {
+        return m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -43,7 +43,7 @@ namespace AZ::RHI
         return static_cast<const ImageFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
     }
 
-    Ptr<MultiDeviceImageView> MultiDeviceImage::GetImageView(const ImageViewDescriptor& imageViewDescriptor)
+    Ptr<MultiDeviceImageView> MultiDeviceImage::BuildImageView(const ImageViewDescriptor& imageViewDescriptor)
     {
         return aznew MultiDeviceImageView{ this, imageViewDescriptor };
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -48,6 +48,26 @@ namespace AZ::RHI
         return aznew MultiDeviceImageView{ this, imageViewDescriptor };
     }
 
+    uint32_t MultiDeviceImage::GetResidentMipLevel() const
+    {
+        auto minLevel{AZStd::numeric_limits<uint32_t>::max()};
+        IterateObjects<Image>([&minLevel]([[maybe_unused]] auto deviceIndex, auto deviceImage)
+        {
+            minLevel = AZStd::min(minLevel, deviceImage->GetResidentMipLevel());
+        });
+        return minLevel;
+    }
+
+    bool MultiDeviceImage::IsStreamable() const
+    {
+        bool isStreamable{true};
+        IterateObjects<Image>([&isStreamable]([[maybe_unused]] auto deviceIndex, auto deviceImage)
+        {
+            isStreamable &= deviceImage->IsStreamable();
+        });
+        return isStreamable;
+    }
+
     ImageAspectFlags MultiDeviceImage::GetAspectFlags() const
     {
         return m_aspectFlags;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -43,6 +43,11 @@ namespace AZ::RHI
         return static_cast<const ImageFrameAttachment*>(MultiDeviceResource::GetFrameAttachment());
     }
 
+    Ptr<MultiDeviceImageView> MultiDeviceImage::GetImageView(const ImageViewDescriptor& imageViewDescriptor)
+    {
+        return aznew MultiDeviceImageView{ this, imageViewDescriptor };
+    }
+
     ImageAspectFlags MultiDeviceImage::GetAspectFlags() const
     {
         return m_aspectFlags;
@@ -73,5 +78,11 @@ namespace AZ::RHI
         {
             deviceImage->InvalidateViews();
         });
+    }
+
+    //! Given a device index, return the corresponding BufferView for the selected device
+    const RHI::Ptr<RHI::ImageView> MultiDeviceImageView::GetDeviceImageView(int deviceIndex) const
+    {
+        return m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -136,8 +136,7 @@ namespace AZ::RHI
 
                 for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
                 {
-                    auto [image, imageViewDescriptor]{ *imageViews[imageIndex] };
-                    deviceImageViews[imageIndex] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                    deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetImageViewArray(inputIndex, deviceImageViews, arrayIndex);
@@ -166,8 +165,7 @@ namespace AZ::RHI
 
                 for (int i = 0; i < imageViews.size(); ++i)
                 {
-                    auto [image, imageViewDescriptor]{ *imageViews[i] };
-                    deviceImageViews[i] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                    deviceImageViews[i] = imageViews[i]->GetDeviceImageView(deviceIndex).get();
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetImageViewUnboundedArray(inputIndex, deviceImageViews);
@@ -214,8 +212,7 @@ namespace AZ::RHI
 
                 for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
                 {
-                    auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
-                    deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetBufferViewArray(inputIndex, deviceBufferViews, arrayIndex);
@@ -243,8 +240,7 @@ namespace AZ::RHI
 
                 for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
                 {
-                    auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
-                    deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetBufferViewUnboundedArray(inputIndex, deviceBufferViews);
@@ -372,15 +368,12 @@ namespace AZ::RHI
 
             for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
             {
-                auto [image, imageViewDescriptor]{ *imageViews[imageIndex] };
-                deviceImageViews[imageIndex] = image->GetDeviceImage(deviceIndex)->GetImageView(imageViewDescriptor).get();
+                deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
             }
-
-            auto [buffer, bufferViewDescriptor]{ *indirectResourceBufferView };
 
             deviceShaderResourceGroupData.SetBindlessViews(
                 indirectResourceBufferIndex,
-                buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get(),
+                indirectResourceBufferView->GetDeviceBufferView(deviceIndex).get(),
                 deviceImageViews,
                 outIndices,
                 isViewReadOnly,
@@ -404,15 +397,12 @@ namespace AZ::RHI
 
             for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
             {
-                auto [buffer, bufferViewDescriptor]{ *bufferViews[bufferIndex] };
-                deviceBufferViews[bufferIndex] = buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get();
+                deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
             }
-
-            auto [buffer, bufferViewDescriptor]{ *indirectResourceBufferView };
 
             deviceShaderResourceGroupData.SetBindlessViews(
                 indirectResourceBufferIndex,
-                buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(bufferViewDescriptor).get(),
+                indirectResourceBufferView->GetDeviceBufferView(deviceIndex).get(),
                 deviceBufferViews,
                 outIndices,
                 isViewReadOnly,


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, in particular:
- `MultiDeviceBufferView`
- `MultiDeviceImageView`

As mentioned in [RFC120](https://github.com/o3de/sig-graphics-audio/issues/120), we do not want full multi-device versions (i.e. inheriting from a multi-device version of `ResourceView`) of `BufferView` and `ImageView`, since the memory management is quite involved and resources store references to their views.
Our goal is to just use a light-weight combination of resource (referenced by a raw pointer) and descriptor, as this does not change the API too much (views are passed around as `RHI::Ptr`s frequently, precluding the use of a simple `AZStd::pair`), hence a class inheriting from `Object` that just provides the accessor API is introduced.

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Planned PRs
This commit is one in a series of PRs to come:

| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources|[#16262](https://github.com/o3de/o3de/pull/16262)|merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)| merged |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591)| merged |
|Indirect*|[#16681](https://github.com/o3de/o3de/pull/16681)|merged|
| SRGs|[#16680](https://github.com/o3de/o3de/pull/16680) | merged |
| TransientAttachmentPool | [#16712](https://github.com/o3de/o3de/pull/16712) | open |
|RayTracing Resources| [#16767](https://github.com/o3de/o3de/pull/16767) |open|
| Items | [#16768](https://github.com/o3de/o3de/pull/16768) | open |
| Views | this PR | open |

