### PR TITLE
Fix DPE resizing on Linux

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -59,6 +59,14 @@ AZ_POP_DISABLE_WARNING
 
 AZ_CVAR_EXTERNED(bool, ed_enableDPE);
 
+AZ_CVAR(
+    bool,
+    ed_enableDPEAssetEditor,
+    false,
+    nullptr,
+    AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
+    "If set, enables experimental Document Property Editor for the AssetEditor");
+
 namespace AzToolsFramework
 {
     namespace AssetEditor
@@ -159,8 +167,17 @@ namespace AzToolsFramework
             setObjectName("AssetEditorTab");
 
             QWidget* propertyEditor = nullptr;
-            // TODO: Re-enable the DPE in the Asset Editor
-            //m_useDPE = DocumentPropertyEditor::ShouldReplaceRPE();
+
+            // use the DPE version of the AssetEditor if both ed_enableDPE and ed_enableDPEAssetEditor are enabled
+            m_useDPE = DocumentPropertyEditor::ShouldReplaceRPE();
+            if (m_useDPE)
+            {
+                if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+                {
+                    console->GetCvarValue("ed_enableDPEAssetEditor", m_useDPE);
+                }
+            }
+
             if (!m_useDPE)
             {
                 m_propertyEditor = new ReflectedPropertyEditor(this);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1326,6 +1326,7 @@ namespace AzToolsFramework
         {
             // only save our expander state if our expanse/collapse was user-driven
             dpe->SetSavedExpanderStateForRow(BuildDomPath(), isExpanded);
+            dpe->updateGeometry();
             dpe->ExpanderChangedByUser();
         }
     }
@@ -1701,6 +1702,7 @@ namespace AzToolsFramework
             }
         }
         m_layout->addStretch();
+        updateGeometry();
         emit RequestSizeUpdate();
     }
 
@@ -1726,7 +1728,11 @@ namespace AzToolsFramework
             {
                 HandleReset();
             }
-            emit RequestSizeUpdate();
+            else
+            {
+                updateGeometry();
+                emit RequestSizeUpdate();
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR do?
Ensures that the DPE requests size updates when handling DOM changes or expander changes, even on Linux.
fixes #14863 

## How was this PR tested?
locally in the Editor project, for both Windows and Linux
