### PR TITLE
Document Property Editor Slider fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/DOM/DomComparison.h>
+#include <AzCore/DOM/DomUtils.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/containers/unordered_set.h>
 
@@ -84,7 +85,7 @@ namespace AZ::Dom
                 const size_t entriesToEnumerate = AZStd::min(beforeSize, afterSize);
                 for (size_t i = 0; i < entriesToEnumerate; ++i)
                 {
-                    if (before[i] != after[i])
+                    if (!Utils::DeepCompareIsEqual(before[i], after[i]))
                     {
                         ++changedValueCount;
                         if (changedValueCount >= params.m_replaceThreshold)

--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
@@ -534,8 +534,11 @@ namespace AZ::Dom::Utils
             // It can't actually compare the data
             // Therefore two opaque values with the same data, but that different are aprt of different objects
             // will always compare unequal. This can result in-efficient behavior such as creating more Dom Patches than necessary
+            AZ::JsonSerializerSettings storeSettings;
+            // Defaults should be kept in the Dom::Value to make sure a complete object is written to the Dom
+            storeSettings.m_keepDefaults = true;
             Value newValue;
-            if (auto storeViaSerializationResult = StoreViaJsonSerialization(valueAddress, nullptr, typeTraits.m_typeId, newValue);
+            if (auto storeViaSerializationResult = StoreViaJsonSerialization(valueAddress, nullptr, typeTraits.m_typeId, newValue, storeSettings);
                 storeViaSerializationResult.GetProcessing() != JsonSerializationResult::Processing::Halted)
             {
                 return newValue;

--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
@@ -144,7 +144,7 @@ namespace AZ::Dom::Utils
         }
         if (settings.m_registrationContext == nullptr)
         {
-            false;
+            return false;
         }
 
         JsonSerializerSettings serializerSettings;

--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
@@ -537,6 +537,12 @@ namespace AZ::Dom::Utils
             AZ::JsonSerializerSettings storeSettings;
             // Defaults should be kept in the Dom::Value to make sure a complete object is written to the Dom
             storeSettings.m_keepDefaults = true;
+
+            // Create a pass no-op issue reporting to skip the DefaultIssueReporter logging AZ_Warnings
+            storeSettings.m_reporting = [](AZStd::string_view, JsonSerializationResult::ResultCode result, AZStd::string_view)
+            {
+                return result;
+            };
             Value newValue;
             if (auto storeViaSerializationResult = StoreViaJsonSerialization(valueAddress, nullptr, typeTraits.m_typeId, newValue, storeSettings);
                 storeViaSerializationResult.GetProcessing() != JsonSerializationResult::Processing::Halted)

--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
@@ -25,7 +25,7 @@ namespace AZ::Dom::Utils
     struct ComparisonParameters
     {
         //! If set, opaque values will only be compared by type and not contents
-        //! This can be useful when comparing opaque values that aren't equal in-memory but shouldn't constitue a
+        //! This can be useful when comparing opaque values that aren't equal in-memory but shouldn't constitute a
         //! comparison failure (e.g. comparing callbacks)
         bool m_treatOpaqueValuesOfSameTypeAsEqual = false;
     };

--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
@@ -236,7 +236,13 @@ namespace AZ::Dom::Utils
 
             // If the Dom::Value can be loaded into the WrapperType using JSON
             // Serialization, then the Value is convertible to the C++ type
-            if (CanLoadViaJsonSerialization(azrtti_typeid<WrapperType>(), value))
+            JsonDeserializerSettings loadSettings;
+            // Create a no-op issue reporter to suppress AZ_Warnings
+            loadSettings.m_reporting = [](AZStd::string_view, JsonSerializationResult::ResultCode result, AZStd::string_view)
+            {
+                return result;
+            };
+            if (CanLoadViaJsonSerialization(azrtti_typeid<WrapperType>(), value, loadSettings))
             {
                 return true;
             }
@@ -343,7 +349,13 @@ namespace AZ::Dom::Utils
                 {
                     // Attempt to deserialize the type into T using JSON Serialization if possible
                     WrapperType typeValue;
-                    if (auto loadViaJsonSerializationResult = LoadViaJsonSerialization(typeValue, value);
+                    // Create a pass no-op issue reporting to skip the DefaultIssueReporter logging AZ_Warnings
+                    JsonDeserializerSettings loadSettings;
+                    loadSettings.m_reporting = [](AZStd::string_view, JsonSerializationResult::ResultCode result, AZStd::string_view)
+                    {
+                        return result;
+                    };
+                    if (auto loadViaJsonSerializationResult = LoadViaJsonSerialization(typeValue, value, loadSettings);
                         loadViaJsonSerializationResult.GetProcessing() != JsonSerializationResult::Processing::Halted)
                     {
                         return typeValue;

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
@@ -417,6 +417,15 @@ namespace AZ
 
 } // namespace AZ
 
+namespace AZ::Edit
+{
+    AZ::TemplateId GetO3deTemplateId(AZ::Adl, AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<EnumConstant>)
+    {
+        return AZ::TemplateId(EnumConstantTypeId);
+    }
+}
+
+
 // pre-instantiate the extremely common ones
 template AZ::EditContext::ClassBuilder* AZ::EditContext::ClassBuilder::Attribute<AZ::Crc32>(const char *, AZ::Crc32);
 template AZ::EditContext::ClassBuilder* AZ::EditContext::ClassBuilder::Attribute<AZ::Crc32>(AZ::Crc32, AZ::Crc32);

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.h
@@ -805,29 +805,38 @@ namespace AZ
     //=========================================================================
     namespace Edit
     {
+        struct EnumConstantBase
+        {
+            // Store using a u64 under the hood so this can be safely cast to any valid enum-range value
+            AZ::u64 m_value{};
+            AZStd::string m_description;
+        };
+
+        constexpr const char* EnumConstantTypeId = "{4CDFEE70-7271-4B27-833B-F8F72AA64C40}";
+
         template <class EnumType>
         struct EnumConstant
+            : EnumConstantBase
         {
-            AZ_TYPE_INFO(EnumConstant, "{4CDFEE70-7271-4B27-833B-F8F72AA64C40}");
+            AZ_TYPE_INFO(EnumConstant, EnumConstantTypeId);
 
-            using UnderlyingType = AZStd::RemoveEnumT<EnumType>;
+            // Bring the base class constructors into scope
+            using EnumConstantBase::EnumConstantBase;
 
-            EnumConstant() {}
             EnumConstant(EnumType first, AZStd::string_view description)
-                : m_value(static_cast<AZ::u64>(first))
-                , m_description(description)
+                : EnumConstantBase{ static_cast<AZ::u64>(first), description }
             {
             }
+            using UnderlyingType = AZStd::RemoveEnumT<EnumType>;
 
             AZStd::pair<UnderlyingType, AZStd::string> operator()() const
             {
                 return { static_cast<UnderlyingType>(m_value), m_description };
             }
-
-            // Store using a u64 under the hood so this can be safely cast to any valid enum-range value
-            AZ::u64 m_value;
-            AZStd::string m_description;
         };
+
+        // Overload to allow querying TypeInfo when specifying the EnumConstant class template
+        AZ::TemplateId GetO3deTemplateId(AZ::Adl, AZ::AzGenericTypeInfo::Internal::TemplateIdentityTypes<EnumConstant>);
 
         // Automatically generate a list of EnumConstant from AzEnumTraits
         template<typename EnumType, typename UnderlyingType = AZStd::underlying_type_t<EnumType>>

--- a/Code/Framework/AzCore/AzCore/Serialization/EnumConstantJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/EnumConstantJsonSerializer.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/EnumConstantJsonSerializer.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/EditContext.h>
+
+namespace AZ::EnumConstantJsonSerializerInternal
+{
+    constexpr const char* ValueField = "value";
+    constexpr const char* DescriptionField = "description";
+} // namespace AZ::EnumConstantSerializerInternal
+
+namespace AZ
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(EnumConstantJsonSerializer, "EnumConstantJsonSerializer", "{A231A314-A4EB-4485-835F-A58A9C3C5F08}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(EnumConstantJsonSerializer, BaseJsonSerializer);
+    AZ_CLASS_ALLOCATOR_IMPL(EnumConstantJsonSerializer, SystemAllocator);
+
+    JsonSerializationResult::Result EnumConstantJsonSerializer::Load(
+        void* outputValue, const Uuid&, const rapidjson::Value& inputValue, JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::ReadField);
+
+        switch (inputValue.GetType())
+        {
+        case rapidjson::kObjectType:
+        {
+            auto enumConstant = reinterpret_cast<Edit::EnumConstantBase*>(outputValue);
+            if (auto valueIt = inputValue.FindMember(EnumConstantJsonSerializerInternal::ValueField); valueIt != inputValue.MemberEnd())
+            {
+                using ValueType = decltype(enumConstant->m_value);
+                result.Combine(ContinueLoading(&enumConstant->m_value, azrtti_typeid<ValueType>(), valueIt->value, context));
+
+                if (result.GetProcessing() != JSR::Processing::Completed)
+                {
+                    result.Combine(context.Report(result, "Failed to read enum value for EnumConstant<EnumType>."));
+                }
+            }
+            if (auto descIt = inputValue.FindMember(EnumConstantJsonSerializerInternal::DescriptionField); descIt != inputValue.MemberEnd())
+            {
+                using DescriptionType = decltype(enumConstant->m_description);
+                result.Combine(ContinueLoading(&enumConstant->m_description, azrtti_typeid<DescriptionType>(), descIt->value, context));
+
+                if (result.GetProcessing() != JSR::Processing::Completed)
+                {
+                    result.Combine(context.Report(result, "Failed to read enum description for EnumConstant<EnumType>."));
+                }
+            }
+
+            return context.Report(
+                result,
+                result.GetOutcome() <= JSR::Outcomes::PartialSkip ? "Successfully loaded data into EnumConstant<EnumType>."
+                                                                     : "Failed to load data into EnumConstant<EnumType>.");
+        }
+        case rapidjson::kArrayType: // fall through
+        case rapidjson::kNullType: // fall through
+        case rapidjson::kStringType: // fall through
+        case rapidjson::kFalseType: // fall through
+        case rapidjson::kTrueType: // fall through
+        case rapidjson::kNumberType:
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::Unsupported,
+                "Unsupported type. EnumConstant<EnumType> can only be read from an object.");
+
+        default:
+            return context.Report(
+                JSR::Tasks::ReadField, JSR::Outcomes::Unknown, "Unknown json type encountered for EnumConstant<EnumType>.");
+        }
+    }
+
+    JsonSerializationResult::Result EnumConstantJsonSerializer::Store(
+        rapidjson::Value& outputValue, const void* inputValue, const void* defaultValue, const Uuid&, JsonSerializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::WriteValue);
+
+        auto enumConstant = reinterpret_cast<const Edit::EnumConstantBase*>(inputValue);
+        auto defaultEnumConstant = reinterpret_cast<const Edit::EnumConstantBase*>(defaultValue);
+
+        if (!outputValue.IsObject())
+        {
+            outputValue.SetObject();
+        }
+
+        using ValueType = decltype(enumConstant->m_value);
+        using DescriptionType = decltype(enumConstant->m_description);
+
+        auto* enumValue = &enumConstant->m_value;
+        auto* defaultEnumValue = defaultEnumConstant != nullptr ? &defaultEnumConstant->m_value : nullptr;
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue, rapidjson::StringRef(EnumConstantJsonSerializerInternal::ValueField), enumValue, defaultEnumValue, azrtti_typeid<ValueType>(), context));
+
+        auto* enumDescription = &enumConstant->m_description;
+        auto* defaultEnumDescription = defaultEnumConstant != nullptr ? &defaultEnumConstant->m_description : nullptr;
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue,
+            rapidjson::StringRef(EnumConstantJsonSerializerInternal::DescriptionField),
+            enumDescription,
+            defaultEnumDescription,
+            azrtti_typeid<DescriptionType>(),
+            context));
+
+        return context.Report(
+            result,
+            result.GetProcessing() == JSR::Processing::Completed ? "EnumConstant<EnumType> stored successfully."
+            : "Failed to store EnumConstant<EnumType>.");
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/EnumConstantJsonSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/EnumConstantJsonSerializer.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AZ
+{
+    //! JSON serializer for EnumConstant<EnumType>
+    //! This is only used for marshaling the EnumConstant to and from a Dom Value
+    //! in-memory. EnumConstant's are an editor only concept and shouldn't be persisted to the filesystem
+    class EnumConstantJsonSerializer : public BaseJsonSerializer
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(EnumConstantJsonSerializer);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        JsonSerializationResult::Result Load(
+            void* outputValue,
+            const Uuid& outputValueTypeId,
+            const rapidjson::Value& inputValue,
+            JsonDeserializerContext& context) override;
+        JsonSerializationResult::Result Store(
+            rapidjson::Value& outputValue,
+            const void* inputValue,
+            const void* defaultValue,
+            const Uuid& valueTypeId,
+            JsonSerializerContext& context) override;
+    };
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerialization.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerialization.h
@@ -34,6 +34,27 @@ namespace AZ
         Greater,
         Error
     };
+
+    //! Represents entries of which reflection context a type is registered
+    //!
+    //! Only one value is returned.
+    //! The values are NOT bitwise-ORed together if the type is registered with multiple context,
+    //! the JsonRegistrationContext is set before the SerializeContext
+    enum class RegisteredReflectionContext
+    {
+        None = 0,
+        JsonRegistrationContext = 1,
+        SerializeContext,
+    };
+    //! structure which stores the result of an operation to query if an AZ::TypeID
+    //! is registered with a reflection context
+    struct RegisteredReflectionContextResult
+    {
+        //! @return true if the type is reflected with any reflection context
+        explicit operator bool() const;
+
+        RegisteredReflectionContext m_reflectContextValue{ RegisteredReflectionContext::None };
+    };
     
     //! Core class to handle serialization to and from json documents.
     //! The Json Serialization works by taking a default constructed object and then apply the information found in the JSON document
@@ -302,6 +323,13 @@ namespace AZ
         //! @param settings Additional settings that control the way the imports are restored.
         static JsonSerializationResult::ResultCode RestoreImports(
             rapidjson::Value& jsonDoc, rapidjson::Document::AllocatorType& allocator, JsonImportSettings& settings);
+
+        //! Returns an result structure indicating if the type is reflected using either the SerializeContext or JsonRegistrationContext
+        //! If the type is reflected in both contexts, then the JsonRegistrationContext is given preference in that case
+        //! @param typeId AZ TypeInfo to query in the SerializeContext or JSON RegistrationContext
+        //! @return result structure which is convertible to bool. If the type is either reflected in SerializeContext or JsonRegistrationContext
+        //! then it converts to true, otherwise the result structure converts to false
+        static RegisteredReflectionContextResult IsTypeSerializable(const AZ::TypeId& typeId, JsonSerializerSettings settings = {});
 
     private:
         JsonSerialization() = delete;

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
@@ -22,6 +22,8 @@
 #include <AzCore/Serialization/Json/TupleSerializer.h>
 #include <AzCore/Serialization/Json/UnorderedSetSerializer.h>
 #include <AzCore/Serialization/Json/UnsupportedTypesSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EnumConstantJsonSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/ConfigurableStack.h>
 #include <AzCore/std/any.h>
@@ -41,6 +43,7 @@
 #include <AzCore/std/smart_ptr/intrusive_ptr.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+
 
 namespace AZ
 {
@@ -110,6 +113,8 @@ namespace AZ
                 ->HandlesType<AZStd::optional>();
             jsonContext->Serializer<JsonBitsetSerializer>()
                 ->HandlesType<AZStd::bitset>();
+            jsonContext->Serializer<EnumConstantJsonSerializer>()
+                ->HandlesType<AZ::Edit::EnumConstant>();
 
             MathReflect(jsonContext);
         }

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -550,6 +550,8 @@ set(FILES
     Serialization/AZStdAnyDataContainer.inl
     Serialization/DynamicSerializableField.cpp
     Serialization/DynamicSerializableField.h
+    Serialization/EnumConstantJsonSerializer.cpp
+    Serialization/EnumConstantJsonSerializer.h
     Serialization/EditContext.cpp
     Serialization/EditContext.h
     Serialization/EditContext.inl

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -424,19 +424,64 @@ namespace AZ::DocumentPropertyEditor
                 attributes,
                 [valuePointer, valueType, this](const Dom::Value& newValue)
                 {
-                    void* marshalledPointer = AZ::Dom::Utils::TryMarshalValueToPointer(newValue, valueType);
-                    rapidjson::Document serializedValue;
-                    JsonSerialization::Store(serializedValue, serializedValue.GetAllocator(), marshalledPointer, nullptr, valueType);
+                    AZ::JsonSerializationResult::ResultCode resultCode(AZ::JsonSerializationResult::Tasks::ReadField);
+                    // marshal this new value into a pointer for use by the Json serializer if a pointer is being stored
+                    if (auto marshalledPointer = AZ::Dom::Utils::TryMarshalValueToPointer(newValue, valueType); marshalledPointer != nullptr)
+                    {
+                        rapidjson::Document buffer;
+                        JsonSerializerSettings serializeSettings;
+                        JsonDeserializerSettings deserializeSettings;
+                        serializeSettings.m_serializeContext = m_serializeContext;
+                        deserializeSettings.m_serializeContext = m_serializeContext;
 
-                    JsonDeserializerSettings deserializeSettings;
-                    deserializeSettings.m_serializeContext = m_serializeContext;
-                    // now deserialize that value into the original location
-                    JsonSerialization::Load(valuePointer, valueType, serializedValue, deserializeSettings);
+                        // serialize the new value to Json, using the original valuePointer as a reference object to generate a minimal
+                        // diff
+                        resultCode = JsonSerialization::Store(
+                            buffer, buffer.GetAllocator(), marshalledPointer, valuePointer, valueType, serializeSettings);
+
+                        if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                        {
+                            AZ_Error(
+                                "ReflectionAdapter",
+                                false,
+                                "Storing new property editor value to JSON for copying to instance has failed with error %s",
+                                resultCode.ToString("").c_str());
+                            return newValue;
+                        }
+
+                        // now deserialize that value into the original location
+                        resultCode = JsonSerialization::Load(valuePointer, valueType, buffer, deserializeSettings);
+                        if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                        {
+                            AZ_Error(
+                                "ReflectionAdapter",
+                                false,
+                                "Loading JSON value containing new property editor into instance has failed with error %s",
+                                resultCode.ToString("").c_str());
+                            return newValue;
+                        }
+
+                    }
+                    else
+                    {
+                        // Otherwise use Json Serialization to copy the Dom Value directly into the valuePointer address
+                        resultCode = AZ::Dom::Utils::LoadViaJsonSerialization(valuePointer, valueType, newValue);
+                        if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                        {
+                            AZ_Error(
+                                "ReflectionAdapter",
+                                false,
+                                "Loading new DOMValue directly into instance has failed with error %s",
+                                resultCode.ToString("").c_str());
+                            return newValue;
+                        }
+                    }
 
                     AZ::Dom::Value newInstancePointerValue;
-                    auto outputWriter = newInstancePointerValue.GetWriteHandler();
-                    auto convertToAzDomResult =
-                        AZ::Dom::Json::VisitRapidJsonValue(serializedValue, *outputWriter, AZ::Dom::Lifetime::Temporary);
+                    AZ::JsonSerializerSettings storeSettings;
+                    // Defaults must be kept to make sure a complete object is written to the Dom::Value
+                    storeSettings.m_keepDefaults = true;
+                    AZ::Dom::Utils::StoreViaJsonSerialization(valuePointer, nullptr, valueType, newInstancePointerValue, storeSettings);
                     return newInstancePointerValue;
                 },
                 false,
@@ -753,12 +798,9 @@ namespace AZ::DocumentPropertyEditor
                 }
 
                 AZ::Dom::Value instancePointerValue = AZ::Dom::Utils::MarshalTypedPointerToValue(access.Get(), access.GetType());
-                bool hashValue = false;
-                const AZ::Name PointerTypeFieldName = AZ::Dom::Utils::PointerTypeFieldName;
-                if (instancePointerValue.IsOpaqueValue() || instancePointerValue.FindMember(PointerTypeFieldName))
-                {
-                    hashValue = true;
-                }
+                // Only hash an opaque value
+                // A value that is not opaque, but is a pointer will have it's members visited in a recursive call to this method
+                const bool hashValue = instancePointerValue.IsOpaqueValue();
 
                 // The IsInspectorOverrideManagementEnabled() check is only temporary until the inspector override management feature set
                 // is fully developed. Since the original utils funtion is in AzToolsFramework and we can't access it from here, we are
@@ -784,41 +826,59 @@ namespace AZ::DocumentPropertyEditor
                     // this needs to write the value back into the reflected object via Json serialization
                     auto StoreValueIntoPointer = [valuePointer = access.Get(), valueType = access.GetType(), this](const Dom::Value& newValue)
                     {
-                        // marshal this new value into a pointer for use by the Json serializer
-                        auto marshalledPointer = AZ::Dom::Utils::TryMarshalValueToPointer(newValue, valueType);
-
-                        rapidjson::Document buffer;
-                        JsonSerializerSettings serializeSettings;
-                        JsonDeserializerSettings deserializeSettings;
-                        serializeSettings.m_serializeContext = m_serializeContext;
-                        deserializeSettings.m_serializeContext = m_serializeContext;
-
-                        // serialize the new value to Json, using the original valuePointer as a reference object to generate a minimal
-                        // diff
-                        AZ::JsonSerializationResult::ResultCode resultCode = JsonSerialization::Store(
-                            buffer, buffer.GetAllocator(), marshalledPointer, valuePointer, valueType, serializeSettings);
-
-                        if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                        AZ::JsonSerializationResult::ResultCode resultCode(AZ::JsonSerializationResult::Tasks::ReadField);
+                        // marshal this new value into a pointer for use by the Json serializer if a pointer is being stored
+                        if (auto marshalledPointer = AZ::Dom::Utils::TryMarshalValueToPointer(newValue, valueType); marshalledPointer != nullptr)
                         {
-                            AZ_Error(
-                                "ReflectionAdapter",
-                                false,
-                                "Storing new property editor value to JSON for copying to instance has failed with error %s",
-                                resultCode.ToString("").c_str());
-                            return newValue;
+                            rapidjson::Document buffer;
+                            JsonSerializerSettings serializeSettings;
+                            JsonDeserializerSettings deserializeSettings;
+                            serializeSettings.m_serializeContext = m_serializeContext;
+                            deserializeSettings.m_serializeContext = m_serializeContext;
+
+                            // serialize the new value to Json, using the original valuePointer as a reference object to generate a minimal
+                            // diff
+                            resultCode = JsonSerialization::Store(
+                                buffer, buffer.GetAllocator(), marshalledPointer, valuePointer, valueType, serializeSettings);
+
+                            if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                            {
+                                AZ_Error(
+                                    "ReflectionAdapter",
+                                    false,
+                                    "Storing new property editor value to JSON for copying to instance has failed with error %s",
+                                    resultCode.ToString("").c_str());
+                                return newValue;
+                            }
+
+                            // now deserialize that value into the original location
+                            resultCode = JsonSerialization::Load(valuePointer, valueType, buffer, deserializeSettings);
+                            if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                            {
+                                AZ_Error(
+                                    "ReflectionAdapter",
+                                    false,
+                                    "Loading JSON value containing new property editor into instance has failed with error %s",
+                                    resultCode.ToString("").c_str());
+                                return newValue;
+                            }
+
+                        }
+                        else
+                        {
+                            // Otherwise use Json Serialization to copy the Dom Value directly into the valuePointer address
+                            resultCode = AZ::Dom::Utils::LoadViaJsonSerialization(valuePointer, valueType, newValue);
+                            if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                            {
+                                AZ_Error(
+                                    "ReflectionAdapter",
+                                    false,
+                                    "Loading new DOMValue directly into instance has failed with error %s",
+                                    resultCode.ToString("").c_str());
+                                return newValue;
+                            }
                         }
 
-                        // now deserialize that value into the original location
-                        resultCode = JsonSerialization::Load(valuePointer, valueType, buffer, deserializeSettings);
-                        if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
-                        {
-                            AZ_Error(
-                                "ReflectionAdapter",
-                                false,
-                                "Loading JSON value containing new property editor into instance has failed with error %s",
-                                resultCode.ToString("").c_str());
-                            return newValue;
-                        }
 
                         // NB: the returned value for serialized pointer values is instancePointerValue, but since this is passed by
                         // pointer, it will not actually detect a changed dom value. Since we are already writing directly to the DOM

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -357,45 +357,7 @@ namespace AzToolsFramework
             auto value = AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Value.ExtractFromDomNode(node);
             if (value.has_value())
             {
-                if (!Prefab::IsInspectorOverrideManagementEnabled())
-                {
-                    m_proxyValue = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()).value_or(m_proxyValue);
-                }
-                else
-                {
-                    // Assign a custom reporting callback to ignore unregistered types
-                    AZ::JsonDeserializerSettings settings;
-                    AZStd::string scratchBuffer;
-                    settings.m_reporting = [&scratchBuffer](
-                        AZStd::string_view message, AZ::JsonSerializationResult::ResultCode result, AZStd::string_view path) -> auto
-                    {
-                        // Unregistered types are acceptable and do not require a warning
-                        if (result.GetTask() != AZ::JsonSerializationResult::Tasks::RetrieveInfo ||
-                            result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::Unknown)
-                        {
-                            // Default Json serialization issue reporting
-                            if (result.GetProcessing() != AZ::JsonSerializationResult::Processing::Completed)
-                            {
-                                scratchBuffer.append(message.begin(), message.end());
-                                scratchBuffer.append("\n    Reason: ");
-                                result.AppendToString(scratchBuffer, path);
-                                scratchBuffer.append(".");
-                                AZ_Warning("JSON Serialization", false, "%s", scratchBuffer.c_str());
-
-                                scratchBuffer.clear();
-                            }
-                        }
-
-                        return result;
-                    };
-
-                    AZ::JsonSerializationResult::ResultCode loadResult =
-                        AZ::Dom::Utils::LoadViaJsonSerialization(m_proxyValue, value.value(), settings);
-                    if (loadResult.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
-                    {
-                        m_proxyValue = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()).value_or(m_proxyValue);
-                    }
-                }
+                m_proxyValue = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()).value_or(m_proxyValue);
             }
 
             AZ::SerializeContext* serializeContext = nullptr;


### PR DESCRIPTION
## What does this PR do?

The Dom `GenerateHierarchicalDeltaPatch` function has been updated to perform a Deep Comparison of Dom Contents being compared. This allows Dom Values that are value equal, but not pointer equal to compare equivalent.
Such as in the case when two Dom Values which stores a label with the same string value of "Exposure" is compared to each other

The Dom::Utils `MarshalOpaqueValue` function has been updated to marshal a C++ object to a Dom Value using JSON Serialization which results in a Dom Object instead of an opaque value

The Dom::Utils `ValueToType` function was updated to use Json Serialization to convert a Dom::Value back into a C++ object when the C++ type supports SerializeContext or JsonRegistrationContext reflection

The EditContext `EnumConstant` class has had a Json Serializer added to it, to allow it to be stored in the Dom as Dom Object instead of an Opaque Value. 

The above changes allows the Dom Deep Comparison logic to perform a piecewise comparison of each object field for differences instead of needing to compare opaque values memory addresses for equality.

These changes reduces the number of diffs generated by the Dom.

The ReflectionAdapter VisitObjectBegin function has been updated to no longer store `ValueHashed` property for a type that is a pointer, but is JSON serializable. These types are can be stored as a Dom Object.

The ReflectionAdapter `VisitObjectBegin` function `StoreValueIntoPointer` lambda has modified to account for when a Dom Object is visited in addition to it's current logic of assuming the Dom Value is storing a pointer type.

Json Serialization is used to deserialize the Dom::Value into bound value address when using the DocumentPropertyEditor visitor API

The AssetJsonSerializer was updated to correctly return a failure result when an "assetId" field from from the Json object being deserialized is missing.
This change prevents an the Dom Utils logic that converts a `Dom::Value` to a C++ `AZ::Data::Asset<AZ::Data::AssetData>`  from incorrectly returning that the conversion was successful when the `Dom::Value` is not storing a Dom Object to an `AZ::Data::Asset<AZ::Data::AssetData>`.
(The failure case here is the `Dom::Value` is storing a pointer to an `AZ::Data::Asset<MaterialAsset>`, where it needs to go through the `TryMarshalValueToPointer` function to correctly convert the Dom::Value to an Asset type)

fixes #16742 

## How was this PR tested?

Verified that both the Exposure and Bake Exposure sliders on the Editor Reflection Probe Component acted in consistent manner.

Also verified that Asset references on Components, were able to be set and removed to make sure there are no regressions in that logic.
