### PR TITLE
Fixed prefab overrides not working with DPE enabled

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -319,7 +319,14 @@ namespace AZ::Reflection
                     path.append("/");
                     path.append(AZStd::string::format("%zu", parentData.m_childElementIndex));
                 }
-                else if (nodeData.m_classElement)
+                // If we have a class element, we skip appending to the SerializedPath if its a base class
+                // because base class information is ignored by the JSON serializer in JsonSerializer::StoreWithClassElement.
+                // The name for these look like "BaseClass1", "BaseClass2", etc... are defined in c_serializeBaseClassStrings
+                // and won't be present once serialized so if we don't ignore them then certain logic that attempts to
+                // match against the SerializedPath won't be accurate.
+                else if (
+                    nodeData.m_classElement &&
+                    ((nodeData.m_classElement->m_flags & AZ::SerializeContext::ClassElement::FLG_BASE_CLASS) == 0))
                 {
                     AZStd::string_view elementName = nodeData.m_classElement->m_name;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16788 and #16790

Fixes issue with prefab overrides not working through the DPE. The main change is just removing the CreateAndEdit/ApplyComponentOverridePatch methods that weren't creating the patches properly and creating extra undo/redo nodes. Instead, I just let the prefab public handler create the patches and undo/redo nodes, which is the same logic flow if you have DPE enabled but Outliner overrides enabled but not Inspector overrides. This change does keep the logic to make sure the override label(s) get updated properly in the inspector.

![PrefabOverrides](https://github.com/o3de/o3de/assets/7519264/a054a30b-a0fd-4766-a4a5-66e661d1f9cf)

## How was this PR tested?

Tested the repro steps as well as ad-hoc testing.