### PR TITLE
Cherry-pick to fix crash when closing Script Canvas

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
@@ -34,9 +34,7 @@ namespace ScriptCanvas
 
         void Logger::ClearLog()
         {
-#if defined(SC_EXECUTION_TRACE_ENABLED) 
             m_logAsset.GetData().Clear();
-#endif
         }
 
         void Logger::ClearLogExecutionOverride()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
@@ -68,8 +68,8 @@ namespace ScriptCanvas
             {
 #if defined(SC_EXECUTION_TRACE_ENABLED) 
                 SCRIPT_CANVAS_DEBUGGER_TRACE_CLIENT("Logging: %s", loggableEvent.ToString().data());
-                m_logAsset.GetData().m_events.emplace_back(loggableEvent.Duplicate());
 #endif
+                m_logAsset.GetData().m_events.emplace_back(loggableEvent.Duplicate());
             }
 
         private:
@@ -78,9 +78,7 @@ namespace ScriptCanvas
             bool m_logExecutionOverrideEnabled = false;
             bool m_logExecutionOverride = false;
 
-#if defined(SC_EXECUTION_TRACE_ENABLED) 
             ExecutionLogAsset m_logAsset;
-#endif
             ScriptCanvas::Debugger::Target m_target;
         };
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #16449 

This fixes the crash when closing the Script Canvas tool. This fix has been cherry-picked from here: https://github.com/BytesOfPiDev/o3de/commit/52da522b11862e83089d7caacf5988cb3823dffc

## How was this PR tested?

Closed the Script Canvas tool and verified the Editor no longer crashes.