### PR TITLE
Remove developer preview title from Shortcuts and Bootstrapper WiX templates

### DIFF
--- a/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
+++ b/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
@@ -5,7 +5,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
 
-    <Bundle Name="$(var.CPACK_PACKAGE_NAME) [Developer Preview]"
+    <Bundle Name="$(var.CPACK_PACKAGE_NAME)"
         Version="$(var.CPACK_PACKAGE_VERSION)"
         Manufacturer="$(var.CPACK_PACKAGE_VENDOR)"
         UpgradeCode="$(var.CPACK_BOOTSTRAP_UPGRADE_GUID)"

--- a/cmake/Platform/Windows/Packaging/Shortcuts.wxs
+++ b/cmake/Platform/Windows/Packaging/Shortcuts.wxs
@@ -7,7 +7,7 @@
 
         <DirectoryRef Id="TARGETDIR">
             <Directory Id="ProgramMenuFolder">
-                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME) [Developer Preview]">
+                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME)">
                     <Directory Id="VersionedApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_VERSION)"/>
                 </Directory>
             </Directory>


### PR DESCRIPTION
## What does this PR do?

Changes the WiX windows templates to remove the `[Developer Preview]` title in dialog boxes and in add/remove programs. Addresses https://github.com/o3de/o3de/issues/15872. This will impact the next release cycle if we don't want this message in the installed release version

## How was this PR tested?
Will be testing this in a branch build
