### PR TITLE
Fixes issues when unregistering a view

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -385,7 +385,6 @@ namespace AZ
 
         void RenderPipeline::SetPersistentView(const PipelineViewTag& viewTag, ViewPtr view)
         {
-            AZ_Assert(view, "Persistent View for ViewTag [%s] is invalid.", viewTag.GetCStr());
             // If a view is registered for multiple viewTags, it gets only the PassesByDrawList of whatever
             // DrawList it was registered last, which will cause a crash during SortDrawList later. So we check
             // here if the view is already registered with another viewTag.
@@ -424,9 +423,14 @@ namespace AZ
                 if (view)
                 {
                     view->OnAddToRenderPipeline();
+                    pipelineViews.m_views[0] = view;
+                    m_persistentViewsByViewTag[view.get()] = viewTag;
                 }
-                pipelineViews.m_views[0] = view;
-                m_persistentViewsByViewTag[view.get()] = viewTag;
+                else { // view == nullptr
+                    // we are removing the view, so we have to set the type to Unknown or the engine assumes m_views[0] is valid
+                    pipelineViews.m_views.clear();
+                    pipelineViews.m_type = PipelineViewType::Unknown;
+                }
 
                 if (previousView)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -228,6 +228,9 @@ namespace AZ
             // Use a new list for building pipeline views since we may need information from the previous list in m_views in the process
             PipelineViewMap newViewsByTag;
 
+            // re-register only views where the view-tag still exists after rebuilding.
+            m_persistentViewsByViewTag.clear();
+
             for (const auto& tag : viewTags)
             {
                 PipelineViews pipelineViews;
@@ -240,6 +243,16 @@ namespace AZ
                     {
                         pipelineViews.m_views.clear();
                     }
+                    else if (pipelineViews.m_type == PipelineViewType::Persistent)
+                    {
+                        for (auto& view : pipelineViews.m_views)
+                        {
+                            if (view)
+                            {
+                                m_persistentViewsByViewTag[view.get()] = pipelineViews.m_viewTag;
+                            }
+                        }
+                    }
                 }
                 else
                 {
@@ -251,6 +264,9 @@ namespace AZ
             }
 
             m_pipelineViewsByTag = AZStd::move(newViewsByTag);
+
+            // transient views are re-registered every frame anyway
+            m_transientViewsByViewTag.clear();
         }
 
         void RenderPipeline::CollectDrawListMaskForViews(PipelineViews& views)


### PR DESCRIPTION
## What does this PR do?

Follow-up to [PR !15823](https://github.com/o3de/o3de/pull/15823)

Fixes some issues that came up in an environment with multiple views:
- Unregistering a view no longer deletes the view-tag from `m_pipelineViewsByTag`, allowing immediate re-registration of a view for that view-tag
- Don't clear the vector of views in `m_pipelineViewsByTag`, since the engine assumes entries for persistent views in the  have always one viewPtr in the array, and only check for validity, but not existence
- Rebuild the `m_persistentViewsByViewTag` when the pipeline changed, since otherwise invalid view-pointers would stick arround when the game-mode is started from the editor  

