### PR TITLE
Make sure the bindless Srg is bound to the correct slot for Raytracing Passes with DX12

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -399,14 +399,23 @@ namespace AZ
             }
 
             // set the bindless descriptor table if required by the shader
+            const auto& device = static_cast<Device&>(GetDevice());
             for (uint32_t bindingIndex = 0; bindingIndex < globalPipelineLayout->GetRootParameterBindingCount(); ++bindingIndex)
             {
-                RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(bindingIndex);
-                if (binding.m_bindlessTable.IsValid())
+                const size_t srgSlot = globalPipelineLayout->GetSlotByIndex(bindingIndex);
+                if (srgSlot == device.GetBindlessSrgSlot())
                 {
-                    GetCommandList()->SetComputeRootDescriptorTable(
-                        binding.m_bindlessTable.GetIndex(), m_descriptorContext->GetBindlessGpuPlatformHandle());
-                    break;
+                    RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(bindingIndex);
+                    if (binding.m_bindlessTable.IsValid())
+                    {
+                        GetCommandList()->SetComputeRootDescriptorTable(
+                            binding.m_bindlessTable.GetIndex(), m_descriptorContext->GetBindlessGpuPlatformHandle());
+                        break;
+                    }
+                    else
+                    {
+                        AZ_Assert(false, "The ShaderResourceGroup using the Bindless SRG Slot doesn't have bindless arrays.");
+                    }
                 }
             }
 


### PR DESCRIPTION
## What does this PR do?

For raytracing passes with DX12, if a SRG other than the bindless SRG contains bindless arrays, the bindless SRG was potentially bound to the wrong SRG slot, thereby overwriting the bound SRG, and also effectively not binding the bindless SRG.

## How was this PR tested?

Windows and DX12
