### PR TITLE
Add logic to prevent duplicate product outputs for the same file

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -105,17 +105,9 @@ namespace AZ
                 AZ_Assert(!id.IsNull(), "Provided guid is not valid");
                 AZ_Assert(!lod.has_value() || lod < 16, "Lod value has to be between 0 and 15 or disabled.");
 
-                ExportProduct exportProduct(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags);
-                auto iter = m_products.find(exportProduct);
-                if (iter != m_products.end())
-                {
-                    return *iter;
-                }
-                else
-                {
-                    auto insertion = m_products.insert(AZStd::move(exportProduct));
-                    return *insertion.first;
-                }
+                // Either insert the new export product if it's the first time this product is being produced,
+                // or else silently fail the insert if it's a duplicate and return the previously-inserted product.
+                return m_products.insert(ExportProduct(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags).first;
             }
 
             const AZStd::unordered_set<ExportProduct>& ExportProductList::GetProducts() const

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -107,7 +107,7 @@ namespace AZ
 
                 // Either insert the new export product if it's the first time this product is being produced,
                 // or else silently fail the insert if it's a duplicate and return the previously-inserted product.
-                return m_products.insert(ExportProduct(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags).first;
+                return *m_products.insert(ExportProduct(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags)).first;
             }
 
             const AZStd::unordered_set<ExportProduct>& ExportProductList::GetProducts() const

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -106,6 +106,14 @@ namespace AZ
                 AZ_Assert(!lod.has_value() || lod < 16, "Lod value has to be between 0 and 15 or disabled.");
 
                 size_t index = m_products.size();
+                auto FindProduct = [productFilename = AZ::IO::PathView(filename)](const ExportProduct& exportProduct)
+                {
+                    return AZ::IO::PathView(exportProduct.m_filename) == productFilename;
+                };
+                if (auto productIt = AZStd::find_if(m_products.begin(), m_products.end(), FindProduct); productIt != m_products.end())
+                {
+                    return *productIt;
+                }
                 m_products.emplace_back(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags);
                 return m_products[index];
             }

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -105,20 +105,20 @@ namespace AZ
                 AZ_Assert(!id.IsNull(), "Provided guid is not valid");
                 AZ_Assert(!lod.has_value() || lod < 16, "Lod value has to be between 0 and 15 or disabled.");
 
-                size_t index = m_products.size();
-                auto FindProduct = [productFilename = AZ::IO::PathView(filename)](const ExportProduct& exportProduct)
+                ExportProduct exportProduct(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags);
+                auto iter = m_products.find(exportProduct);
+                if (iter != m_products.end())
                 {
-                    return AZ::IO::PathView(exportProduct.m_filename) == productFilename;
-                };
-                if (auto productIt = AZStd::find_if(m_products.begin(), m_products.end(), FindProduct); productIt != m_products.end())
-                {
-                    return *productIt;
+                    return *iter;
                 }
-                m_products.emplace_back(AZStd::move(filename), id, assetType, lod, subId, dependencyFlags);
-                return m_products[index];
+                else
+                {
+                    auto insertion = m_products.insert(AZStd::move(exportProduct));
+                    return *insertion.first;
+                }
             }
 
-            const AZStd::vector<ExportProduct>& ExportProductList::GetProducts() const
+            const AZStd::unordered_set<ExportProduct>& ExportProductList::GetProducts() const
             {
                 return m_products;
             }

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
@@ -11,6 +11,8 @@
 #include <AzCore/base.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Uuid.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/std/containers/unordered_set.h>
 #include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
 
 namespace AZ
@@ -53,6 +55,17 @@ namespace AZ
                 AZStd::vector<AZStd::string> m_legacyPathDependencies;
                 //! In the case of CGFs, we will have LOD export products that are dependencies of the base LOD
                 AZStd::vector<ExportProduct> m_productDependencies;
+
+                [[nodiscard]] explicit constexpr operator size_t() const
+                {
+                    size_t path_hash = AZ::IO::hash_value(AZ::IO::PathView(m_filename));
+                    return path_hash;
+                }
+
+                bool operator==(const ExportProduct& other) const
+                {
+                    return AZ::IO::PathView(m_filename) == AZ::IO::PathView(other.m_filename);
+                }
             };
 
             class ExportProductList
@@ -65,12 +78,12 @@ namespace AZ
                 SCENE_CORE_API ExportProduct& AddProduct(AZStd::string&& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,
                     Data::ProductDependencyInfo::ProductDependencyFlags dependencyFlags = Data::ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad));
 
-                SCENE_CORE_API const AZStd::vector<ExportProduct>& GetProducts() const;
+                SCENE_CORE_API const AZStd::unordered_set<ExportProduct>& GetProducts() const;
 
                 SCENE_CORE_API void AddDependencyToProduct(const AZStd::string& productName, ExportProduct& dependency);
 
             private:
-                AZStd::vector<ExportProduct> m_products;
+                AZStd::unordered_set<ExportProduct> m_products;
             };
         } // namespace Events
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
@@ -58,8 +58,7 @@ namespace AZ
 
                 [[nodiscard]] explicit constexpr operator size_t() const
                 {
-                    size_t path_hash = AZ::IO::hash_value(AZ::IO::PathView(m_filename));
-                    return path_hash;
+                    return AZ::IO::hash_value(AZ::IO::PathView(m_filename));
                 }
 
                 bool operator==(const ExportProduct& other) const

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -736,7 +736,7 @@ namespace AZ::SceneAPI::Containers
         ExpectExecute("productList = exportProductList:GetProducts()");
         ExpectExecute("TestExpectEquals(productList:GetSize(), 2)");
         ExpectExecute("exportProductList:AddDependencyToProduct(exportProduct.filename, exportProductDep)");
-        ExpectExecute("TestExpectEquals(productList:Front().productDependencies:GetSize(), 1)");
+        ExpectExecute("TestExpectEquals(exportProduct.productDependencies:GetSize(), 1)");
     }
 
     TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_Fetch_GetsValue)

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/RCExt/Actor/ActorGroupExporter.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/RCExt/Actor/ActorGroupExporter.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/containers/unordered_set.h>
 #include <EMotionFX/Source/Actor.h>
 #include <EMotionFX/Source/ActorManager.h>
 #include <EMotionFX/Source/Importer/Importer.h>
@@ -172,7 +173,7 @@ namespace EMotionFX
         AZStd::optional<AZ::Data::AssetId> ActorGroupExporter::GetMeshAssetId(const ActorGroupExportContext& context) const
         {
             AZ::Data::AssetType atomModelAssetType = azrtti_typeid<AZ::RPI::ModelAsset>();
-            const AZStd::vector<AZ::SceneAPI::Events::ExportProduct>& products = context.m_products.GetProducts();
+            const AZStd::unordered_set<AZ::SceneAPI::Events::ExportProduct>& products = context.m_products.GetProducts();
 
             // Gather the asset ids from the exported mesh groups (Atom model assets).
             AZStd::vector<AZ::SceneAPI::Events::ExportProduct> atomModelAssets;
@@ -199,7 +200,7 @@ namespace EMotionFX
         AZStd::optional<AZ::SceneAPI::Events::ExportProduct> ActorGroupExporter::GetFirstProductByType(
             const ActorGroupExportContext& context, AZ::Data::AssetType type)
         {
-            const AZStd::vector<AZ::SceneAPI::Events::ExportProduct>& products = context.m_products.GetProducts();
+            const AZStd::unordered_set<AZ::SceneAPI::Events::ExportProduct>& products = context.m_products.GetProducts();
             for (const AZ::SceneAPI::Events::ExportProduct& product : products)
             {
                 if (product.m_assetType == type)


### PR DESCRIPTION
## What does this PR do?
Fixes (or band-aides) an issue discovered when running a newly created project that was built based on an SNAP installed O3DE on ubuntu. For some reason when running AP from the snap installation, the scene processor is creating multiple products for the same file, causing the sanity check set for this to fail, even though they are all the same product. 

```
~~1695766386405~~1~~0x7fa5891ec640~~AssetBuilder~~SceneAPI: Listed product: {FD340C30-755C-5911-92A3-19A3F7A77931}+0x150541c0 - /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx/Objects/Shaderball/shaderball_default_1m_fbx.procprefab (type {9B7C8459-471E-4EAD-A363-7990CC4065A9})
~~1695766386405~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Output folder] = /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx
~~1695766386405~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Platform] = linux
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~SceneAPI: Listed product: {FD340C30-755C-5911-92A3-19A3F7A77931}+0x150541c0 - /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx/Objects/Shaderball/shaderball_default_1m_fbx.procprefab (type {9B7C8459-471E-4EAD-A363-7990CC4065A9})
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Output folder] = /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Platform] = linux
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~SceneAPI: Listed product: {FD340C30-755C-5911-92A3-19A3F7A77931}+0x150541c0 - /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx/Objects/Shaderball/shaderball_default_1m_fbx.procprefab (type {9B7C8459-471E-4EAD-A363-7990CC4065A9})
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Output folder] = /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Platform] = linux
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~SceneAPI: Listed product: {FD340C30-755C-5911-92A3-19A3F7A77931}+0x150541c0 - /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx/Objects/Shaderball/shaderball_default_1m_fbx.procprefab (type {9B7C8459-471E-4EAD-A363-7990CC4065A9})
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Output folder] = /home/o3de/O3DE/Projects/RobotTest/user/AssetProcessorTemp/JobTemp-aSULJx
~~1695766386406~~1~~0x7fa5891ec640~~AssetBuilder~~C: [Platform] = linux
```

This behavior is not reproducible with a debian or source based installation, only from snap, so it could be an issue that the snap confinement exposes.

The fix is to add additional logic to `ExportProductList::AddProduct` to either create a new one or return the existing one if it was already created. This fixes the multiple product issues (since its the same product anyways), so FBX files now work (and we can see the default shader ball)

fixes https://github.com/o3de/o3de/issues/16799

## How was this PR tested?

* Built a snap package
* Installed to a clean 22.04 image
* Launched O3DE
* Created a new project
* Built the new project
* Open the Editor
* Wait for all the assets to process
* Confirm there are no failed assets, and that we can see the default shader ball


_Please describe any testing performed._
