### PR TITLE
Fix linux linker error in debug mode for PairIteratorCategory

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/Views/PairIterator.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/Views/PairIterator.h
@@ -45,23 +45,23 @@ namespace AZ
                     template<typename FirstIterator, typename SecondIterator>
                     struct PairIteratorCategory
                     {
-                        static const bool s_sameCategory = AZStd::is_same<
-                                typename AZStd::iterator_traits<FirstIterator>::iterator_category,
-                                typename AZStd::iterator_traits<SecondIterator>::iterator_category>::value;
+                        static constexpr bool s_sameCategory = AZStd::is_same<
+                            typename AZStd::iterator_traits<FirstIterator>::iterator_category,
+                            typename AZStd::iterator_traits<SecondIterator>::iterator_category>::value;
 
                         // True if both categories are the same.
                         // True if FirstIterator has the lower category in the hierarchy
                         // False if ValueItator has the lower category or is unrelated.
-                        static const bool s_firstIteratorCategoryIsBaseOfSecondIterator = AZStd::is_base_of<
-                                typename AZStd::iterator_traits<FirstIterator>::iterator_category,
-                                typename AZStd::iterator_traits<SecondIterator>::iterator_category>::value;
+                        static constexpr bool s_firstIteratorCategoryIsBaseOfSecondIterator = AZStd::is_base_of<
+                            typename AZStd::iterator_traits<FirstIterator>::iterator_category,
+                            typename AZStd::iterator_traits<SecondIterator>::iterator_category>::value;
 
                         // True if both categories are the same.
                         // True if SecondIterator has the lower category in the hierarchy
                         // False if FirstItator has the lower category or is unrelated.
-                        static const bool s_SecondIteratorCategoryIsBaseOfFirstIterator = AZStd::is_base_of<
-                                typename AZStd::iterator_traits<SecondIterator>::iterator_category,
-                                typename AZStd::iterator_traits<FirstIterator>::iterator_category>::value;
+                        static constexpr bool s_SecondIteratorCategoryIsBaseOfFirstIterator = AZStd::is_base_of<
+                            typename AZStd::iterator_traits<SecondIterator>::iterator_category,
+                            typename AZStd::iterator_traits<FirstIterator>::iterator_category>::value;
 
                         static_assert(s_sameCategory || (s_firstIteratorCategoryIsBaseOfSecondIterator != s_SecondIteratorCategoryIsBaseOfFirstIterator),
                             "The iterator categories for the first and second in the PairIterator are unrelated categories.");


### PR DESCRIPTION
## What does this PR do?
This PR changes the declaration of the static members of `PairIteratorCategory` from `const` to `constexpr`, which otherwise results in a linker error using `Debug` build on linux, with the following errors (similar for the other members):

```
[build] ld.lld: error: undefined symbol: AZ::SceneAPI::Containers::Views::Internal::PairIteratorCategory<int*, int*>::s_sameCategory
[build] >>> referenced by PairIteratorTests.cpp:27 (Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/PairIteratorTests.cpp:27)
[build] >>>               Code/Tools/SceneAPI/SceneCore/CMakeFiles/SceneCore.Tests.dir/debug/Unity/unity_1_cxx.cxx.o:(AZ::SceneAPI::Containers::Views::Internal::PairIteratorCategoryTests_Declaration_SameCategory_TwoIteratorsHaveEqualCategory_Test::TestBody())
[build] clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

## How was this PR tested?

This issue arises when building in `Debug` mode, this was tested using `arch` and `clang16.0.6`.
This issues does not arise when building in `Profile` or `Release` mode (probably due to optimizations inlining the values).
