### PR TITLE
Updating pass and post process shader load error messages and readiness checks

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -1432,15 +1432,15 @@ namespace AZ
         void FixedShapeProcessor::LoadShaders()
         {
             // load shaders for constant color and direction light
-            const char* unlitObjectShaderFilePath = "Shaders/auxgeom/auxgeomobject.azshader";
-            const char* litObjectShaderFilePath = "Shaders/auxgeom/auxgeomobjectlit.azshader";
+            constexpr const char* unlitObjectShaderFilePath = "Shaders/auxgeom/auxgeomobject.azshader";
+            constexpr const char* litObjectShaderFilePath = "Shaders/auxgeom/auxgeomobjectlit.azshader";
 
             // constant color shader
             m_unlitShader = RPI::LoadCriticalShader(unlitObjectShaderFilePath);
             // direction light shader
             m_litShader = RPI::LoadCriticalShader(litObjectShaderFilePath);
 
-            if (m_unlitShader.get() == nullptr || m_litShader == nullptr)
+            if (m_unlitShader == nullptr || m_litShader == nullptr)
             {
                 return;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.cpp
@@ -23,7 +23,7 @@ namespace AZ
         {
             seed = TypeHash64(m_intensity, seed);
             seed = TypeHash64(m_overrideStrength, seed);
-            seed = TypeHash64(m_assetId.GetId(), seed);
+            seed = TypeHash64(m_asset.GetId(), seed);
             seed = TypeHash64(m_shaperPreset, seed);
             seed = TypeHash64(m_customMinExposure, seed);
             seed = TypeHash64(m_customMaxExposure, seed);
@@ -44,13 +44,13 @@ namespace AZ
         {
             AZ_Assert(target != nullptr, "LookModificationSettings::ApplySettingsTo called with nullptr as argument.");
 
-            auto lutAssetId = GetColorGradingLut();
-            if (GetEnabled() && lutAssetId.GetId().IsValid())
+            auto lutAsset = GetColorGradingLut();
+            if (GetEnabled() && lutAsset.GetId().IsValid())
             {
                 Render::LutBlendItem lutBlend;
                 lutBlend.m_intensity = GetColorGradingLutIntensity();
                 lutBlend.m_overrideStrength = GetColorGradingLutOverride() * alpha;
-                lutBlend.m_assetId = lutAssetId;
+                lutBlend.m_asset = lutAsset;
                 lutBlend.m_shaperPreset = GetShaperPresetType();
                 lutBlend.m_customMinExposure = GetCustomMinExposure();
                 lutBlend.m_customMaxExposure = GetCustomMaxExposure();
@@ -90,7 +90,7 @@ namespace AZ
                     LutBlendItem blendItem;
                     blendItem.m_intensity = GetColorGradingLutIntensity();
                     blendItem.m_overrideStrength = GetColorGradingLutOverride();
-                    blendItem.m_assetId = GetColorGradingLut();
+                    blendItem.m_asset = GetColorGradingLut();
                     blendItem.m_shaperPreset = GetShaperPresetType();
                     blendItem.m_customMinExposure = GetCustomMinExposure();
                     blendItem.m_customMaxExposure = GetCustomMaxExposure();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.h
@@ -31,7 +31,7 @@ namespace AZ
             //! During LUT blending, this override intensity is considered in conjunction with the LUTs own intensity.
             float m_overrideStrength = 0.0;
             //! Asset ID of LUT
-            Data::Asset<RPI::AnyAsset> m_assetId;
+            Data::Asset<RPI::AnyAsset> m_asset;
             //! Shaper preset type
             ShaperPresetType m_shaperPreset = AZ::Render::ShaperPresetType::Log2_48Nits;
             //! When shaper preset is custom, these values set min and max exposure.

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -334,7 +334,7 @@ namespace AZ
                 for (size_t lutIndex = 0; lutIndex < numLuts; lutIndex++)
                 {
                     LutBlendItem& lutBlendItem = settings->GetLutBlendItem(lutIndex);
-                    const auto assetId = lutBlendItem.m_assetId.GetId();
+                    const auto assetId = lutBlendItem.m_asset.GetId();
 
                     if (assetId.IsValid())
                     {
@@ -343,7 +343,7 @@ namespace AZ
                         if (!m_colorGradingLuts[current].m_lutStreamingImage)
                         {
                             AZ_Warning("BlendColorGradingLutsPass", false, "Unable to load grading LUT from asset %s",
-                                lutBlendItem.m_assetId.ToString<AZStd::string>().c_str());
+                                lutBlendItem.m_asset.ToString<AZStd::string>().c_str());
                             // Skip this LUT
                             continue;
                         }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -92,7 +92,7 @@ namespace AZ
                     return *it;
                 }
                 auto shaderAsset{ AZ::RPI::FindShaderAsset(assetReference.m_assetId, assetReference.m_filePath) };
-                AZ_Assert(shaderAsset.GetId().IsValid(), "Failed to load shader %s", assetReference.m_filePath.c_str());
+                AZ_Assert(shaderAsset.IsReady(), "Failed to load shader %s", assetReference.m_filePath.c_str());
                 auto shader{ AZ::RPI::Shader::FindOrCreate(shaderAsset) };
                 auto shaderVariant{ shader->GetVariant(AZ::RPI::ShaderAsset::RootShaderVariantStableId) };
                 AZ::RHI::PipelineStateDescriptorForRayTracing pipelineStateDescriptor;
@@ -189,7 +189,7 @@ namespace AZ
                 shaderAsset = RPI::FindShaderAsset(shaderAssetReference.m_assetId, shaderAssetReference.m_filePath);
             }
 
-            if (!shaderAsset.GetId().IsValid())
+            if (!shaderAsset.IsReady())
             {
                 AZ_Error("PassSystem", false, "RayTracingPass [%s]: Failed to load shader asset [%s]", GetPathName().GetCStr(), shaderAssetReference.m_filePath.data());
                 return nullptr;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -52,19 +52,19 @@ namespace AZ
             m_horizontalBlurChildPasses.clear();
 
             // load shaders
-            AZStd::string verticalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurVertical.azshader";
+            constexpr const char* verticalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurVertical.azshader";
             Data::Instance<AZ::RPI::Shader> verticalBlurShader = RPI::LoadCriticalShader(verticalBlurShaderFilePath);
             if (verticalBlurShader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), verticalBlurShaderFilePath.c_str());
+                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), verticalBlurShaderFilePath);
                 return;
             }
 
-            AZStd::string horizontalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.azshader";
+            constexpr const char* horizontalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.azshader";
             Data::Instance<AZ::RPI::Shader> horizontalBlurShader = RPI::LoadCriticalShader(horizontalBlurShaderFilePath);
             if (horizontalBlurShader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), horizontalBlurShaderFilePath.c_str());
+                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), horizontalBlurShaderFilePath);
                 return;
             }
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
@@ -35,11 +35,11 @@ namespace AZ
             RPI::PassSystemInterface* passSystem = RPI::PassSystemInterface::Get();
 
             // load shader
-            AZStd::string shaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceDownsampleDepthLinear.azshader";
+            constexpr const char* shaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceDownsampleDepthLinear.azshader";
             Data::Instance<AZ::RPI::Shader> shader = RPI::LoadCriticalShader(shaderFilePath);
             if (shader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceDownsampleDepthLinearPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), shaderFilePath.c_str());
+                AZ_Error("PassSystem", false, "[ReflectionScreenSpaceDownsampleDepthLinearPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), shaderFilePath);
                 return;
             }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
@@ -128,18 +128,19 @@ namespace AZ
             {
                 if (!assetId.IsValid())
                 {
-                    AssetUtilsInternal::ReportIssue(reporting, AZStd::string::format("Could not load '%s'", assetId.ToString<AZStd::string>().c_str()).c_str());
+                    AssetUtilsInternal::ReportIssue(
+                        reporting, AZStd::string::format("Could not load '%s'", assetId.ToString<AZStd::string>().c_str()).c_str());
                     return {};
                 }
 
-                Data::Asset<AssetDataT> asset = AZ::Data::AssetManager::Instance().GetAsset<AssetDataT>(
-                    assetId, AZ::Data::AssetLoadBehavior::PreLoad
-                    );
-                    asset.BlockUntilLoadComplete();
+                Data::Asset<AssetDataT> asset =
+                    AZ::Data::AssetManager::Instance().GetAsset<AssetDataT>(assetId, AZ::Data::AssetLoadBehavior::PreLoad);
+                asset.BlockUntilLoadComplete();
 
                 if (!asset.IsReady())
                 {
-                    AssetUtilsInternal::ReportIssue(reporting, AZStd::string::format("Could not load '%s'", assetId.ToString<AZStd::string>().c_str()).c_str());
+                    AssetUtilsInternal::ReportIssue(
+                        reporting, AZStd::string::format("Could not load '%s'", assetId.ToString<AZStd::string>().c_str()).c_str());
                     return {};
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -126,7 +126,7 @@ namespace AZ
             AZ_Assert(result == RHI::ResultCode::Success, "AttachmentReadback failed to init fence");
 
             // Load shader and srg
-            const char* ShaderPath = "shaders/decomposemsimage.azshader";
+            constexpr const char* ShaderPath = "shaders/decomposemsimage.azshader";
             m_decomposeShader = LoadCriticalShader(ShaderPath);
 
             if (m_decomposeShader == nullptr)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -85,7 +85,7 @@ namespace AZ
                 shaderAsset = RPI::FindShaderAsset(passData->m_shaderReference.m_assetId, passData->m_shaderReference.m_filePath);
             }
 
-            if (!shaderAsset.GetId().IsValid())
+            if (!shaderAsset.IsReady())
             {
                 AZ_Error("PassSystem", false, "[ComputePass '%s']: Failed to load shader '%s'!",
                     GetPathName().GetCStr(),
@@ -96,7 +96,7 @@ namespace AZ
             m_shader = Shader::FindOrCreate(shaderAsset, supervariant);
             if (m_shader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[ComputePass '%s']: Failed to load shader '%s'!",
+                AZ_Error("PassSystem", false, "[ComputePass '%s']: Failed to create shader instance from asset '%s'!",
                     GetPathName().GetCStr(),
                     passData->m_shaderReference.m_filePath.data());
                 return;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -98,7 +98,7 @@ namespace AZ
                 shaderAsset = RPI::FindShaderAsset(shaderAssetId, passData->m_shaderAsset.m_filePath);
             }
 
-            if (!shaderAsset.GetId().IsValid())
+            if (!shaderAsset.IsReady())
             {
                 AZ_Error("PassSystem", false, "[FullscreenTrianglePass '%s']: Failed to load shader '%s'!",
                     GetPathName().GetCStr(),
@@ -109,7 +109,7 @@ namespace AZ
             m_shader = Shader::FindOrCreate(shaderAsset);
             if (m_shader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[FullscreenTrianglePass '%s']: Failed to load shader '%s'!",
+                AZ_Error("PassSystem", false, "[FullscreenTrianglePass '%s']: Failed to create shader instance from asset '%s'!",
                     GetPathName().GetCStr(),
                     passData->m_shaderAsset.m_filePath.data());
                 return;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -256,12 +256,18 @@ namespace AZ
             m_needsShaderLoad = false;
 
             // Load Shader
-            const char* ShaderPath = "shaders/imagepreview.azshader";
+            constexpr const char* ShaderPath = "shaders/imagepreview.azshader";
             Data::Asset<ShaderAsset> shaderAsset = RPI::FindShaderAsset(ShaderPath);
+            if (!shaderAsset.IsReady())
+            {
+                AZ_Error("PassSystem", false, "[ImageAttachmentsPreviewPass]: Failed to load shader '%s'!", GetPathName().GetCStr(), ShaderPath);
+                return;
+            }
+
             m_shader = Shader::FindOrCreate(shaderAsset);
             if (m_shader == nullptr)
             {
-                AZ_Error("PassSystem", false, "[ImageAttachmentsPreviewPass]: Failed to load shader '%s'!", ShaderPath);
+                AZ_Error("PassSystem", false, "[ImageAttachmentsPreviewPass]: Failed to create shader instance from asset '%s'!", ShaderPath);
                 return;
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
@@ -604,7 +604,7 @@ namespace AZ
             Data::AssetId shaderAssetId, const AZStd::string& shaderFilePath, const AZStd::string& supervariantName)
         {
             auto shaderAsset = FindShaderAsset(shaderAssetId, shaderFilePath);
-            if (!shaderAsset)
+            if (!shaderAsset.IsReady())
             {
                 return nullptr;
             }

--- a/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.cpp
@@ -108,7 +108,7 @@ namespace AZ
                 Data::Asset<RPI::ShaderAsset> shaderAsset =
                     RPI::AssetUtils::LoadAssetByProductPath<RPI::ShaderAsset>(shaderFilePath, RPI::AssetUtils::TraceLevel::Error);
 
-                if (!shaderAsset.GetId().IsValid())
+                if (!shaderAsset.IsReady())
                 {
                     AZ_Error("Hair Gem", false, "Invalid shader asset for shader '%s'!", shaderFilePath);
                     return false;
@@ -117,7 +117,7 @@ namespace AZ
                 m_shader = RPI::Shader::FindOrCreate(shaderAsset);
                 if (m_shader == nullptr)
                 {
-                    AZ_Error("Hair Gem", false, "Pass failed to load shader '%s'!", shaderFilePath);
+                    AZ_Error("Hair Gem", false, "Pass failed to create shader instance from asset '%s'!", shaderFilePath);
                     return false;
                 }
 


### PR DESCRIPTION
## What does this PR do?

A separate set of changes was causing errors starting the main editor. Following the trail of error messages, it was not obvious where the error was occurring because the same message was used for different cases.
Updated pass and post process shader load error messages to distinguish between asset load failure and instance creation failure.

Corrected multiple checks for valid asset ids or asset pointers that should have been checking for the asset to be ready.
Checking the asset pointer and asset ID does not confirm that the asset is ready for use.
All of the utility functions used to load the shaders we're already doing blocking loads to force the shader assets to be ready. 

Changed strings to constexpr const char*.

## How was this PR tested?

Build project. Loaded levels in automated testing project. Currently running tests.