### PR TITLE
Fix clang compile warning about implicit conversion of default parameter value

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -139,7 +139,7 @@ namespace AzNetworking
         //! @param minValue the minimum value expected during serialization
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
-        virtual bool Serialize(unsigned long& value, const char* name, unsigned long minValue = AZStd::numeric_limits<unsigned long>::min(), unsigned long maxValue = AZStd::numeric_limits<uint64_t>::max()) = 0;
+        virtual bool Serialize(unsigned long& value, const char* name, unsigned long minValue = AZStd::numeric_limits<unsigned long>::min(), unsigned long maxValue = AZStd::numeric_limits<unsigned long>::max()) = 0;
 
         //! Serialize an unsigned 64-bit integer (unsigned long long).
         //! @param value    unsigned 64-bit integer input value to serialize


### PR DESCRIPTION
## What does this PR do?

Fix the compile warning `error: implicit conversion from 'unsigned long long' to 'unsigned long' changes value from 18446744073709551615 to 4294967295 [-Werror,-Wconstant-conversion]
`, which is shown by Clang16.
This function was introduced in PR #16626, and I assume the wrong type for the default parameter was overlooked then.

## How was this PR tested?

Compiling the Engine with Clang and MSVC
