### PR TITLE
Fix Material Editor failing to Launch in Linux

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/Asset/AssetSystemComponent.h>
 #include <AzFramework/AzFrameworkNativeUIModule.h>
+#include <AzFramework/Components/NativeUISystemComponent.h>
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/Network/AssetProcessorConnection.h>
 #include <AzFramework/StringFunc/StringFunc.h>
@@ -150,6 +151,7 @@ namespace AtomToolsFramework
                 azrtti_typeid<AzToolsFramework::Components::PropertyManagerComponent>(),
                 azrtti_typeid<AzToolsFramework::PerforceComponent>(),
                 azrtti_typeid<AzToolsFramework::Thumbnailer::ThumbnailerComponent>(),
+                azrtti_typeid<AzFramework::NativeUISystemComponent>(),
             });
 
         return components;


### PR DESCRIPTION
## What does this PR do?
This fixes an issue in Linux where the Material Editor fails to launch. 

**Root Cause**
With the Headless Server refactor, applications that require a NativeUI needs to have the AzFramework::NativeUISystemComponent listed as a required component. This was done for `AzToolsApplication`, but not for `AtomToolsApplication`. Since `AtomToolsApplication` does not inherit `AzToolsApplication`, that was missed.

**Fix**
Since this does not inherit from `AzToolsApplication`, the `AzFramework::NativeUISystemComponent` was added to the `AtomToolsApplication` list of required components

## How was this PR tested?
TBD

