### PR TITLE
Asset processor skippable host fix

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.cpp
@@ -122,13 +122,12 @@ namespace AzToolsFramework::AssetUtils
         AZStd::vector<AZStd::string>& enabledPlatforms)
     {
         // note that the current host platform is enabled by default.
-        enabledPlatforms.push_back(AzToolsFramework::AssetSystem::GetHostAssetPlatform());
-
         // in the setreg the platform can be missing (commented out)
         // in which case it is disabled implicitly by not being there
         // or it can be 'disabled' which means that it is explicitly disabled.
         // or it can be 'enabled' which means that it is explicitly enabled.
         EnabledPlatformsVisitor visitor;
+        visitor.m_enabledPlatforms.push_back(AzToolsFramework::AssetSystem::GetHostAssetPlatform());
         settingsRegistry.Visit(visitor, AZ::SettingsRegistryInterface::FixedValueString(Internal::AssetProcessorSettingsKey) + "/Platforms");
         enabledPlatforms.insert(enabledPlatforms.end(), AZStd::make_move_iterator(visitor.m_enabledPlatforms.begin()),
             AZStd::make_move_iterator(visitor.m_enabledPlatforms.end()));


### PR DESCRIPTION
## What does this PR do?

It was discovered that the Asset Processor has very slow performance when performing processing for iOS platform. Part of the reason for this was because it was processing macOS assets even though they should be unrelated. This issue occurred even after setting the mac platform as disabled in the Asset Processor Registry settings.

This PR is a one-line fix to correct that behavior. It corrects the `AssetUtils::ReadEnabledPlatformsFromSettingsRegistry` to also consider the host platform in the logic for detecting enabled platforms, instead of assuming it is enabled by default. 

## How was this PR tested?

The changes were tested on a macOS laptop. Asset Processor was tested in workloads for O3DE Atom Sample Viewer in scenarios where ios is enabled, and mac platform is disabled. Afterwards it was tested in the scenario where both platforms are enabled.

The changes behaved as expected. In the first scenario, only the ios folder was found in the AssetProcessor cache, while in the second scenario, both ios and mac folders are present in the AssetProcessor cache.
