### PR TITLE
Associative Container low-level API improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
@@ -126,9 +126,15 @@ namespace AZ
     };
 
     template<class T>
-    struct ConsoleCommandMemberFunctorSignature <T, AZStd::enable_if_t<AZStd::is_class_v<T>>>
+    struct ConsoleCommandMemberFunctorSignature<T, AZStd::enable_if_t<AZStd::is_class_v<T> && !AZStd::is_const_v<T>>>
     {
         using type = void (T::*)(const ConsoleCommandContainer&);
+    };
+
+    template<class T>
+    struct ConsoleCommandMemberFunctorSignature <T, AZStd::enable_if_t<AZStd::is_class_v<T> && AZStd::is_const_v<T>>>
+    {
+        using type = void (T::*)(const ConsoleCommandContainer&) const;
     };
 
     //! @class ConsoleFunctor

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -57,7 +57,55 @@ namespace AZStd
         constexpr bool IsMapType_v = false;
         template<class T>
         constexpr bool IsMapType_v<T, enable_if_t<Internal::sfinae_trigger_v<typename T::mapped_type>>> = true;
+
+        template <class T>
+        constexpr bool IsOrderedSetImpl_v = false;
+
+        template<class K, class C, class A>
+        constexpr bool IsOrderedSetImpl_v<AZStd::set<K, C, A>> = true;
+
+        template<class K, class C, class A>
+        constexpr bool IsOrderedSetImpl_v<AZStd::multimap<K, C, A>> = true;
+
+        template <class T>
+        constexpr bool IsOrderedMapImpl_v = false;
+
+        template<class K, class M, class C, class A>
+        constexpr bool IsOrderedMapImpl_v<AZStd::map<K, M, C, A>> = true;
+
+        template<class K, class M, class C, class A>
+        constexpr bool IsOrderedMapImpl_v<AZStd::multimap<K, M, C, A>> = true;
+
+        template <class T>
+        constexpr bool IsUnorderedSetImpl_v = false;
+
+        template <class K, class H, class E, class A>
+        constexpr bool IsUnorderedSetImpl_v<AZStd::unordered_set<K, H, E, A>> = true;
+
+        template <class K, class H, class E, class A>
+        constexpr bool IsUnorderedSetImpl_v<AZStd::unordered_multiset<K, H, E, A>> = true;
+
+        template <class T>
+        constexpr bool IsUnorderedMapImpl_v = false;
+
+        template <class K, class M, class H, class E, class A>
+        constexpr bool IsUnorderedMapImpl_v<AZStd::unordered_map<K, M, H, E, A>> = true;
+
+        template <class K, class M, class H, class E, class A>
+        constexpr bool IsUnorderedMapImpl_v<AZStd::unordered_multimap<K, M, H, E, A>> = true;
     }
+
+    template <class T>
+    constexpr bool IsOrderedSet_v = AssociativeInternal::IsOrderedSetImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsOrderedMap_v = AssociativeInternal::IsOrderedMapImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsUnorderedSet_v = AssociativeInternal::IsUnorderedSetImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsUnorderedMap_v = AssociativeInternal::IsUnorderedMapImpl_v<AZStd::remove_cvref_t<T>>;
 }
 
 namespace AZ
@@ -235,6 +283,8 @@ namespace AZ
 
             /// Returns true if elements can be retrieved by index.
             bool    CanAccessElementsByIndex() const override   { return false; }
+
+            bool IsSequenceContainer() const override { return true; }
 
             /// Reserve element
             void*   ReserveElement(void* instance, const SerializeContext::ClassElement* classElement) override
@@ -645,8 +695,8 @@ namespace AZ
 
         template<class T>
         class AZStdAssociativeContainer
-            : public SerializeContext::IDataContainer
-            , public SerializeContext::IDataContainer::IAssociativeDataContainer
+            : public Serialize::IDataContainer
+            , public Serialize::IDataContainer::IAssociativeDataContainer
         {
             using ValueType = typename T::value_type;
             using ValueClass = AZStd::remove_pointer_t<ValueType>;
@@ -777,6 +827,11 @@ namespace AZ
                 return this;
             }
 
+            const SerializeContext::IDataContainer::IAssociativeDataContainer* GetAssociativeContainerInterface() const override
+            {
+                return this;
+            }
+
             /// Reserve element
             void*   ReserveElement(void* instance, const  SerializeContext::ClassElement* classElement) override
             {
@@ -803,6 +858,31 @@ namespace AZ
             }
 
         public:
+            Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType GetAssociativeType() const override
+            {
+                using AssociativeType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+                if constexpr (AZStd::IsOrderedSet_v<T>)
+                {
+                    return AssociativeType::Set;
+                }
+                else if constexpr (AZStd::IsOrderedMap_v<T>)
+                {
+                    return AssociativeType::Map;
+                }
+                else if constexpr (AZStd::IsUnorderedSet_v<T>)
+                {
+                    return AssociativeType::UnorderedSet;
+                }
+                else if constexpr (AZStd::IsUnorderedMap_v<T>)
+                {
+                    return AssociativeType::UnorderedMap;
+                }
+                else
+                {
+                    return AssociativeType::Unknown;
+                }
+            }
+
             /// Get an element's address by its index (called before the element is loaded).
             void*   GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
@@ -813,7 +893,7 @@ namespace AZ
             }
 
             /// Get an element's address by its key. Not used for serialization.
-            void*   GetElementByKey(void* instance, const SerializeContext::ClassElement* classElement, const void* key) override
+            void*   GetElementByKey(void* instance, const SerializeContext::ClassElement* classElement, const void* key) const override
             {
                 (void)classElement;
                 T* containerPtr = reinterpret_cast<T*>(instance);
@@ -823,7 +903,7 @@ namespace AZ
 
             /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is
             /// the key itself
-            virtual void* GetValueByKey(void* instance, const void* key) override
+            virtual void* GetValueByKey(void* instance, const void* key) const override
             {
                 void* value = nullptr;
                 T* containerPtr = reinterpret_cast<T*>(instance);
@@ -898,7 +978,7 @@ namespace AZ
             }
 
             /// Inserts an entry at key in the container (for keyed containers only). Not used for serialization.
-            void    SetElementKey(void* element, void* key) override
+            void    SetElementKey(void* element, void* key) const override
             {
                 KeyHelper<ValueType>::SetElementKey(reinterpret_cast<ValueType*>(element), *reinterpret_cast<KeyType*>(key));
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
@@ -21,14 +21,14 @@ namespace AZ
         {
             // Iterate over each reflected Edit::ElementData field
             // and check if it has an associated SerializeContext class element which
-            // provides a DataContainer as part of it's SerializeContext ClassData which inherits
+            // provides a DataContainer as part of its SerializeContext ClassData which inherits
             // from IAssociativeDataContainer
             for (const AZ::Edit::ElementData& syntheticElement : classData.m_elements)
             {
                 if (syntheticElement.m_serializeClassElement != nullptr)
                 {
                     // The edit element data is backed by a serialize context field
-                    // so query it's class data
+                    // so query its class data
                     auto elementClassData =
                         editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
                     if (elementClassData == nullptr)
@@ -47,7 +47,7 @@ namespace AZ
                     }
 
                     // Once this point has been reached, the reflected element corresponds to an associative container
-                    // So the log the name of the class containing
+                    // So log the name of the containing class
                     logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
                 }
             }
@@ -72,7 +72,7 @@ namespace AZ
                 if (syntheticElement.m_serializeClassElement != nullptr)
                 {
                     // The edit element data is backed by a serialize context field
-                    // so query it's class data
+                    // so query its class data
                     auto elementClassData =
                         editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
 
@@ -83,8 +83,6 @@ namespace AZ
                         continue;
                     }
 
-                    // Once this point has been reached, the reflected element corresponds to an associative container
-                    // So the log the name of the class containing
                     logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
                 }
             }
@@ -124,7 +122,7 @@ namespace AZ
             AZ::ConsoleFunctorFlags::DontReplicate,
             AZ::TypeId{},
             editContext,
-            & LogSequenceContainerFields);
+            &LogSequenceContainerFields);
     }
 }
 

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
@@ -8,6 +8,148 @@
 
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Console/IConsoleTypes.h>
+
+namespace AZ
+{
+    static void LogAssociativeContainerFields(const EditContext& editContext, const AZ::ConsoleCommandContainer&)
+    {
+        AZStd::string logString = "\nParent Reflected Class, Associative Element Name, Associative Type\n";
+        Edit::TypeVisitor logFieldVisitor;
+        logFieldVisitor.m_classDataVisitor = [&logString, &editContext](const Edit::ClassData& classData) -> bool
+        {
+            // Iterate over each reflected Edit::ElementData field
+            // and check if it has an associated SerializeContext class element which
+            // provides a DataContainer as part of it's SerializeContext ClassData which inherits
+            // from IAssociativeDataContainer
+            for (const AZ::Edit::ElementData& syntheticElement : classData.m_elements)
+            {
+                if (syntheticElement.m_serializeClassElement != nullptr)
+                {
+                    // The edit element data is backed by a serialize context field
+                    // so query it's class data
+                    auto elementClassData =
+                        editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
+                    if (elementClassData == nullptr)
+                    {
+                        continue;
+                    }
+
+                    // Check if the type contains an AssociativeContainer
+                    using IAssociativeContainer = Serialize::IDataContainer::IAssociativeDataContainer;
+                    const IAssociativeContainer* associativeContainer = elementClassData->m_container != nullptr
+                        ? elementClassData->m_container->GetAssociativeContainerInterface()
+                        : nullptr;
+                    if (associativeContainer == nullptr)
+                    {
+                        continue;
+                    }
+
+                    // Once this point has been reached, the reflected element corresponds to an associative container
+                    // So the log the name of the class containing
+                    logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
+                }
+            }
+            return true;
+        };
+
+        editContext.EnumerateAll(logFieldVisitor);
+        AZ::Debug::Trace::Instance().Output("EditContext", logString.c_str());
+    }
+
+    static void LogSequenceContainerFields(const EditContext& editContext, const AZ::ConsoleCommandContainer&)
+    {
+        AZStd::string logString = "\nParent Reflected Class, Sequence Element Name, Sequence Type\n";
+        Edit::TypeVisitor logFieldVisitor;
+        logFieldVisitor.m_classDataVisitor = [&logString, &editContext](const Edit::ClassData& classData) -> bool
+        {
+            // Iterate over each reflected Edit::ElementData field
+            // and check if it has an associated SerializeContext class element which
+            // provides a IDataContainer which is a sequence container
+            for (const AZ::Edit::ElementData& syntheticElement : classData.m_elements)
+            {
+                if (syntheticElement.m_serializeClassElement != nullptr)
+                {
+                    // The edit element data is backed by a serialize context field
+                    // so query it's class data
+                    auto elementClassData =
+                        editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
+
+                    // If the class element doesn't have an IDataContainer that is a sequence then continue to the next element
+                    if (elementClassData == nullptr || elementClassData->m_container == nullptr ||
+                        !elementClassData->m_container->IsSequenceContainer())
+                    {
+                        continue;
+                    }
+
+                    // Once this point has been reached, the reflected element corresponds to an associative container
+                    // So the log the name of the class containing
+                    logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
+                }
+            }
+            return true;
+        };
+
+        editContext.EnumerateAll(logFieldVisitor);
+        AZ::Debug::Trace::Instance().Output("EditContext", logString.c_str());
+    }
+
+    static void RegisterEditContextLoggingConsoleCommand(
+        Edit::Internal::ConsoleFunctorHandle& consoleFunctorHandle, AZ::IConsole* console, const EditContext& editContext)
+    {
+        if (console == nullptr)
+        {
+            return;
+        }
+
+        consoleFunctorHandle.m_consoleFunctors.emplace_back(
+            *console,
+            "ed_logReflectedAssociativeContainerFields",
+            "Logs all associative container fields (map, set, unordered_map, unordered_set) that have been reflected to the Edit Context.\n"
+            "The name of the field is output along with the name of the class where the field is reflected.\n"
+            "Also output are the names of the types that were reflected.",
+            AZ::ConsoleFunctorFlags::DontReplicate,
+            AZ::TypeId{},
+            editContext,
+            &LogAssociativeContainerFields);
+
+        consoleFunctorHandle.m_consoleFunctors.emplace_back(
+            *console,
+            "ed_logReflectedSequenceContainerFields",
+            "Logs all sequence container fields (array, vector, fixed_vector, list, forward_list) that have been reflected to the Edit Context.\n"
+            "The name of the field is output along with the name of the class where the field is reflected.\n"
+            "Also output are the names of the types that were reflected.\n"
+            "NOTE: The deque container is not supported for reflection in the SerializeContext at this time.",
+            AZ::ConsoleFunctorFlags::DontReplicate,
+            AZ::TypeId{},
+            editContext,
+            & LogSequenceContainerFields);
+    }
+}
+
+namespace AZ::Edit
+{
+    TypeVisitor::TypeVisitor()
+    {
+        m_classDataVisitor = [](const Edit::ClassData&) -> bool
+        {
+            return false;
+        };
+
+        m_enumDataVisitor = [](const TypeId&, const Edit::ElementData&) -> bool
+        {
+            return false;
+        };
+    }
+}
+
+namespace AZ::Edit::Internal
+{
+    ConsoleFunctorHandle::ConsoleFunctorHandle() = default;
+    ConsoleFunctorHandle::~ConsoleFunctorHandle() = default;
+}
+
 namespace AZ
 {
     //=========================================================================
@@ -17,6 +159,7 @@ namespace AZ
     EditContext::EditContext(SerializeContext& serializeContext)
         : m_serializeContext(serializeContext)
     {
+        RegisterEditContextLoggingConsoleCommand(m_consoleCommandHandle, AZ::Interface<AZ::IConsole>::Get(), *this);
     }
 
     //=========================================================================
@@ -96,6 +239,15 @@ namespace AZ
             data = &enumIt->second;
         }
         return data;
+    }
+
+    SerializeContext& EditContext::GetSerializeContext()
+    {
+        return m_serializeContext;
+    }
+    const SerializeContext& EditContext::GetSerializeContext() const
+    {
+        return m_serializeContext;
     }
 
     //=========================================================================
@@ -332,6 +484,31 @@ namespace AZ
 #endif // AZ_ENABLE_SERIALIZER_DEBUG
 
         return keepEnumeratingSiblings;
+    }
+
+    void EditContext::EnumerateAll(const Edit::TypeVisitor& typeVisitor, Edit::VisitFlags visitFlags) const
+    {
+        if (typeVisitor.m_classDataVisitor && (visitFlags & Edit::VisitFlags::Classes) == Edit::VisitFlags::Classes)
+        {
+            for (const Edit::ClassData& editClassData : m_classData)
+            {
+                if (!typeVisitor.m_classDataVisitor(editClassData))
+                {
+                    break;
+                }
+            }
+        }
+
+        if (typeVisitor.m_enumDataVisitor && (visitFlags & Edit::VisitFlags::Enums) == Edit::VisitFlags::Enums)
+        {
+            for (const auto& [enumTypeId, enumElementData] : m_enumData)
+            {
+                if (!typeVisitor.m_enumDataVisitor(enumTypeId, enumElementData))
+                {
+                    break;
+                }
+            }
+        }
     }
 
     namespace Edit

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2395,6 +2395,7 @@ namespace AZ::Serialize
     AZ_TYPE_INFO_WITH_NAME_IMPL(ClassElement, "ClassElement", "{7D386902-A1D9-4525-8284-F68435FE1D05}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(ClassData, "ClassData", "{20EB8E2E-D807-4039-84E2-CE37D7647CD4}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(IDataContainer, "IDataContainer", "{8565CBEA-C077-4A49-927B-314533A6EDB1}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(IDataContainer);
     AZ_TYPE_INFO_WITH_NAME_IMPL(IDataContainer::IAssociativeDataContainer, "IAssociativeDataContainer", "{58CF6250-6B0F-4A25-9864-25A64EB55DB1}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(EnumerateInstanceCallContext, "EnumerateInstanceCallContext", "{FCC1DB4B-72BD-4D78-9C23-C84B91589D33}");
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1078,7 +1078,7 @@ namespace AZ::Serialize
 
         public:
             //! Stores the type structure of container the associative type represents
-            //! The valid values are an ordered set(Set, Map) or an hash table structure(UnorderedSet, UnorderedMap)
+            //! The valid values are an ordered set(Set, Map) or a hash table structure(UnorderedSet, UnorderedMap)
             enum class AssociativeType
             {
                 Unknown,

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1054,13 +1054,14 @@ namespace AZ::Serialize
     };
 
     /**
-         * Interface for a data container. This might be an AZStd container or just a class with
-         * elements defined in some template manner (usually with templates :) )
-         */
+    * Interface for a data container. This might be an AZStd container or just a class with
+    * elements defined in some template manner (usually with templates :) )
+    */
     class IDataContainer
     {
     public:
         AZ_TYPE_INFO_WITH_NAME_DECL(IDataContainer);
+        AZ_RTTI_NO_TYPE_INFO_DECL()
 
         using ElementCB = AZStd::function< bool(void* /* instance pointer */, const Uuid& /*elementClassId*/, const ClassData* /* elementGenericClassData */, const ClassElement* /* genericClassElement */) >;
         using ElementTypeCB = AZStd::function< bool(const Uuid& /*elementClassId*/, const ClassElement* /* genericClassElement */) >;
@@ -1076,6 +1077,16 @@ namespace AZ::Serialize
             virtual void    FreeKey(void* key) = 0;
 
         public:
+            //! Stores the type structure of container the associative type represents
+            //! The valid values are an ordered set(Set, Map) or an hash table structure(UnorderedSet, UnorderedMap)
+            enum class AssociativeType
+            {
+                Unknown,
+                Set,
+                Map,
+                UnorderedSet,
+                UnorderedMap
+            };
             AZ_TYPE_INFO_WITH_NAME_DECL(IAssociativeDataContainer);
             virtual ~IAssociativeDataContainer() {}
 
@@ -1098,12 +1109,14 @@ namespace AZ::Serialize
             {
                 return AZStd::shared_ptr<void>(AllocateKey(), KeyPtrDeleter(this));
             }
-            /// Get an element's address by its key. Not used for serialization.
-            virtual void* GetElementByKey(void* instance, const ClassElement* classElement, const void* key) = 0;
-            /// Populates element with key (for associative containers). Not used for serialization.
-            virtual void    SetElementKey(void* element, void* key) = 0;
-            /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is the key itself
-            virtual void* GetValueByKey(void* instance, const void* key) = 0;
+            //! Get an element's address by its key. Not used for serialization.
+            virtual void* GetElementByKey(void* instance, const ClassElement* classElement, const void* key) const = 0;
+            //! Populates element with key (for associative containers). Not used for serialization.
+            virtual void    SetElementKey(void* element, void* key) const = 0;
+            //! Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is the key itself
+            virtual void* GetValueByKey(void* instance, const void* key) const = 0;
+            //! Queries the type structure(Set vs. Map, Ordered vs. Hash Table) represented by the AssociativeDataContainer
+            virtual AssociativeType GetAssociativeType() const = 0;
         };
 
         /// Return default element generic name (used by most containers).
@@ -1140,6 +1153,9 @@ namespace AZ::Serialize
         virtual bool    CanAccessElementsByIndex() const = 0;
         /// Returns the associative interface for this container (e.g. the container itself if it inherits it) if available, otherwise null.
         virtual IAssociativeDataContainer* GetAssociativeContainerInterface() { return nullptr; }
+        virtual const IAssociativeDataContainer* GetAssociativeContainerInterface() const { return nullptr; }
+        //! Returns true if the IDataContainer represents a reflected sequence type(AZStd array, (fixed)vector, list)
+        virtual bool IsSequenceContainer() const { return false; }
         /// Reserve an element and get its address (called before the element is loaded).
         virtual void* ReserveElement(void* instance, const ClassElement* classElement) = 0;
         /// Free an element that was reserved using ReserveElement, but was not stored by calling StoreElement.

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -8216,3 +8216,65 @@ namespace UnitTest
         m_serializeContext->DisableRemoveReflection();
     }
 }
+
+namespace UnitTest
+{
+    class AssociativeContainerSerializationFixture
+        : public LeakDetectionFixture
+    {
+    public:
+        AssociativeContainerSerializationFixture()
+        {
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+            m_serializeContext->RegisterGenericType<AZStd::set<int>>();
+            m_serializeContext->RegisterGenericType<AZStd::map<int, int>>();
+            m_serializeContext->RegisterGenericType<AZStd::unordered_set<int>>();
+            m_serializeContext->RegisterGenericType<AZStd::unordered_map<int, int>>();
+        }
+
+        ~AssociativeContainerSerializationFixture() override
+        {
+            m_serializeContext.reset();
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+    };
+
+    TEST_F(AssociativeContainerSerializationFixture, GetAssociativeType_ReturnsCorrectAssociativeStructure)
+    {
+        using AssociativeType = AZ::Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+
+        const auto setClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::set<int>>());
+        ASSERT_NE(nullptr, setClassData);
+        const auto setDataContainer = setClassData->m_container;
+        ASSERT_NE(nullptr, setDataContainer);
+        const auto setAssociativeContainer = setClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, setClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::Set, setAssociativeContainer->GetAssociativeType());
+
+        const auto mapClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::map<int, int>>());
+        ASSERT_NE(nullptr, mapClassData);
+        const auto mapDataContainer = mapClassData->m_container;
+        ASSERT_NE(nullptr, mapDataContainer);
+        const auto mapAssociativeContainer = mapClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, mapClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::Map, mapAssociativeContainer->GetAssociativeType());
+
+        const auto unorderedSetClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::unordered_set<int>>());
+        ASSERT_NE(nullptr, unorderedSetClassData);
+        const auto unorderedSetDataContainer = unorderedSetClassData->m_container;
+        ASSERT_NE(nullptr, unorderedSetDataContainer);
+        const auto unorderedSetAssociativeContainer = unorderedSetClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, unorderedSetClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::UnorderedSet, unorderedSetAssociativeContainer->GetAssociativeType());
+
+        const auto unorderedMapClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::unordered_map<int, int>>());
+        ASSERT_NE(nullptr, unorderedMapClassData);
+        const auto unorderedMapDataContainer = unorderedMapClassData->m_container;
+        ASSERT_NE(nullptr, unorderedMapDataContainer);
+        const auto unorderedMapAssociativeContainer = unorderedMapClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, unorderedMapClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::UnorderedMap, unorderedMapAssociativeContainer->GetAssociativeType());
+    }
+}


### PR DESCRIPTION
Updated the IAssociativeDataContainer interface to expose a `GetAssociativeType` function that can return whether the associative container is a set, map, unordered_set or unordered_map

Updated the IDataContainer interface to expose a `IsSequenceType` function which returns if the DataContainer is a sequence type such as a (Fixed)Vector, (Forward)List or Array.

A const member overload for `GetAssociativeContainerInterface` function have added to allow calling on a const IDataContainer pointer.

Two new console commands have been added to the Edit Context which can log the name of fields that have been reflected to the Edit Context that are sequence types or associative types.

The console commands are `ed_logReflectedAssociativeContainerFields` and `ed_logReflectedSequenceContainerFields`.

The commands output the name of the class in which the field was reflected on and the name of the field has specified to the EditContext `DataElement` function.

## How was this PR tested?

Add Serialization Test to verify the `GetAssociativeType` function returns the correct associative container enum based on the C++ type `AZStd::set, AZStd::map, AZStd::unordered_set, AZStd::unordered_map`

Verified the Console Commands by running them in the Editor
![image](https://github.com/o3de/o3de/assets/56135373/62e7d390-f846-4f1f-a2d4-df6254a2ff09)
![image](https://github.com/o3de/o3de/assets/56135373/3ba2719a-e923-4450-982f-cc656897aee2)


### Findings
It turns out that classes which reflect a set or map like associative container to the Edit Context aren't fields or sub fields of a component, so they are never exposed in the Editor.
This only covers the set of Code that comes with the o3de engine and not external Gems or projects.

```csv
Parent Reflected Class, Associative Element Name, Associative Type
"Definition", "File Tags", "AZStd::set<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, AZStd::less<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"Definition", "File Tag Map", "AZStd::map<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, FileTagData, AZStd::less<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"Material Assignment", "Property Overrides", "AZStd::unordered_map<Name, AZStd::any, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>"
"Layer Categories", "Layer Categories", "AZStd::map<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, int, AZStd::less<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"Material Component Config", "Materials", "AZStd::unordered_map<AZ::Render::MaterialAssignmentId, AZ::Render::MaterialAssignment, AZStd::hash<AZ::Render::MaterialAssignmentId>, AZStd::equal_to<AZ::Render::MaterialAssignmentId>, allocator>"
"Materials", "Texture map", "AZStd::unordered_map<[enum], AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, AZStd::hash<[enum]>, AZStd::equal_to<[enum]>, allocator>"
"ShaderSourceData", "Target Blend States", "AZStd::unordered_map<unsigned int, TargetBlendState, AZStd::hash<unsigned int>, AZStd::equal_to<unsigned int>, allocator>"
"ShaderSourceData", "Shader Options", "AZStd::unordered_map<Name, Name, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>"
"VariantInfo", "Options", "AZStd::unordered_map<Name, Name, AZStd::hash<Name>, AZStd::equal_to<Name>, allocator>"
"DynamicNodeSlotConfig", "Settings", "AZStd::map<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, AZStd::vector<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, allocator>, AZStd::less<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"DynamicNodeConfig", "Settings", "AZStd::map<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, AZStd::vector<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, allocator>, AZStd::less<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"Gestures", "Custom Gestures", "AZStd::unordered_map<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>, Type*, AZStd::hash<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, AZStd::equal_to<AZStd::basic_string<char, AZStd::char_traits<char>, allocator>>, allocator>"
"Variables", "Variables", "AZStd::unordered_map<VariableId, GraphVariable, AZStd::hash<VariableId>, AZStd::equal_to<VariableId>, allocator>"
```