### PR TITLE
Fix various Clang16 compile warnings on Windows

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobInfo.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobInfo.h
@@ -123,7 +123,7 @@ namespace TestImpact
 
     //! Comparison between jobs of the same job type.
     template<typename AdditionalInfo>
-    bool operator==(const typename JobInfo<AdditionalInfo>& lhs, const typename JobInfo<AdditionalInfo>& rhs)
+    bool operator==(const JobInfo<AdditionalInfo>& lhs, const JobInfo<AdditionalInfo>& rhs)
     {
         return lhs.GetId().m_value == rhs.GetId().m_value;
     }

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/Process/JobRunner/TestImpactProcessJobRunner.h
@@ -31,7 +31,7 @@ namespace TestImpact
     public:
         using JobData = AdditionalInfo;
         using JobInfo = JobInfo<AdditionalInfo>;
-        using JobInfos = AZStd::vector<typename JobInfo>; //!< @note job ids are not assumed to be correlated with their position in the array, nor contiguous.
+        using JobInfos = AZStd::vector<JobInfo>; //!< @note job ids are not assumed to be correlated with their position in the array, nor contiguous.
         using Command = typename JobInfo::Command;
         using JobPayload = Payload;
         using Job = Job<JobInfo, Payload>;

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestRunner/Common/Job/TestImpactTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Include/Static/TestRunner/Common/Job/TestImpactTestJobInfoGenerator.h
@@ -81,7 +81,7 @@ namespace TestImpact
         RepoPath m_testRunnerBinary;
 
     private:
-        typename CachePolicy m_cachePolicy = CachePolicy::Write;
+        CachePolicy m_cachePolicy = CachePolicy::Write;
     };
 
     template<typename TestJobRunner, typename TestTarget>

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestRunner/Common/Run/TestImpactTestCoverageSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestRunner/Common/Run/TestImpactTestCoverageSerializer.cpp
@@ -135,7 +135,7 @@ namespace TestImpact
             rootNode->append_node(packagesNode);
 
             // Individual modules covered
-            for (const auto moduleCovered : testCoverage.GetModuleCoverages())
+            for (const auto& moduleCovered : testCoverage.GetModuleCoverages())
             {
                 AZ::rapidxml::xml_node<>* packageNode = doc.allocate_node(AZ::rapidxml::node_element, Keys[PackageKey]);
 

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestUtilities.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestUtilities.h
@@ -54,7 +54,7 @@ namespace ScriptCanvasTests
     {
         using namespace ScriptCanvas;
         t_NodeType* node{};
-        SystemRequestBus::BroadcastResult(node, &SystemRequests::GetNode<t_NodeType>, nodeID);
+        ScriptCanvas::SystemRequestBus::BroadcastResult(node, &ScriptCanvas::SystemRequests::GetNode<t_NodeType>, nodeID);
         EXPECT_TRUE(node != nullptr);
         return node;
     }
@@ -68,7 +68,7 @@ namespace ScriptCanvasTests
         entity->Init();
         entityOut = entity->GetId();
         EXPECT_TRUE(entityOut.IsValid());
-        SystemRequestBus::Broadcast(&SystemRequests::CreateNodeOnEntity, entityOut, scriptCanvasId, azrtti_typeid<t_NodeType>());
+        ScriptCanvas::SystemRequestBus::Broadcast(&ScriptCanvas::SystemRequests::CreateNodeOnEntity, entityOut, scriptCanvasId, azrtti_typeid<t_NodeType>());
         return GetTestNode<t_NodeType>(scriptCanvasId, entityOut);
     }
 


### PR DESCRIPTION
## What does this PR do?

Fix various Clang16 compile warnings on Windows, such as wrong usage of `typename` and ambiguous references

## How was this PR tested?

Compile with Clang16 and MSVC
