### PR TITLE
DX12: Fix binding of bindless resources

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -240,9 +240,6 @@ namespace AZ
                 // A queue of tile mappings to execute on the command queue at submission time (prior to executing the command list).
                 TileMapRequestList m_tileMapRequests;
 
-                // Signal that the global bindless heap is bound to the index
-                int m_bindlessHeapLastIndex = -1;
-
                 // The currently bound shading rate image
                 const ImageView* m_shadingRateImage = nullptr;
 
@@ -382,11 +379,6 @@ namespace AZ
                 const auto& device = static_cast<Device&>(GetDevice());
                 if (srgSlot == device.GetBindlessSrgSlot() && shaderResourceGroup == nullptr)
                 {
-                    // Skip in case the global static heap is already bound
-                    if (m_state.m_bindlessHeapLastIndex == binding.m_bindlessTable.GetIndex())
-                    {
-                        continue;
-                    }
                     AZ_Assert(binding.m_bindlessTable.IsValid(), "BindlessSRG handles is not valid.");
 
                     switch (pipelineType)
@@ -407,10 +399,9 @@ namespace AZ
                         AZ_Assert(false, "Invalid PipelineType");
                         break;
                     }
-                    m_state.m_bindlessHeapLastIndex = binding.m_bindlessTable.GetIndex();
                     continue;
                 }
-                
+
                 if (AZ::RHI::Validation::IsEnabled())
                 {
                     if (!shaderResourceGroup)


### PR DESCRIPTION
## What does this PR do?

This is a follow up to https://github.com/o3de/o3de/pull/16787

There is a case where checking the bound index won't work:
1. Scope 1 binds the Bindless SRG to index X
2. Scope 2 binds something different to index X
3. Scope 3 wants to bind the Bindless SRG to index X. The commandList assumes that the Bindless SRG is already bound to this index, although there is something else bound there.

I removed the check entirely, so the Bindless SRG is bound every Draw/Dispatch instead.

## How was this PR tested?

DX12 and Windows
