### PR TITLE
Add missing include in RayTracingPassData.h

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RPI.Reflect/Asset/AssetReference.h>
 #include <Atom/RPI.Reflect/Pass/RenderPassData.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

Adds the include `SerializeContext.h` to the file `RayTracingPassData.h` (which uses `AZ::SerializeContext` later on), which could otherwise lead to compile errors if the file is included somewhere where `AZ::SerializeContext` has not been included before.

## How was this PR tested?

Compile with MSVC and Clang
