### PR TITLE
Ensure only relevant menu options are enabled when no graphs are open

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1356,6 +1356,7 @@ namespace ScriptCanvasEditor
             RunGraphValidation(false);
             SetActiveAsset(activeGraph);
             SetRecentAssetId(activeGraph);
+            EnableOpenDocumentActions(true);
         }
         else
         {
@@ -1880,7 +1881,27 @@ namespace ScriptCanvasEditor
 
             OpenNextFile();
         }
+
+        EnableOpenDocumentActions(true);
+
     }
+
+    void MainWindow::EnableOpenDocumentActions(bool enable)
+    {
+        ui->action_Save->setEnabled(enable);
+        ui->action_Save_As->setEnabled(enable);
+        ui->action_AlignTop->setEnabled(enable);
+        ui->action_AlignLeft->setEnabled(enable);
+        ui->action_AlignRight->setEnabled(enable);
+        ui->action_AlignBottom->setEnabled(enable);
+        ui->action_EnableSelection->setEnabled(enable);
+        ui->action_DisableSelection->setEnabled(enable);
+        ui->action_ClearSelection->setEnabled(enable);
+        ui->action_ZoomSelection->setEnabled(enable);
+        ui->action_GotoStartOfChain->setEnabled(enable);
+        ui->action_GotoEndOfChain->setEnabled(enable);
+    }
+
 
     void MainWindow::SetupEditMenu()
     {
@@ -2477,6 +2498,7 @@ namespace ScriptCanvasEditor
     {
         m_tabBar->CloseAllTabs();
         SetActiveAsset({});
+        EnableOpenDocumentActions(false);
     }
 
     void MainWindow::OnTabCloseButtonPressed(int index)
@@ -2573,6 +2595,7 @@ namespace ScriptCanvasEditor
             {
                 m_isClosingTabs = false;
                 m_skipTabOnClose.Clear();
+                EnableOpenDocumentActions(false);
                 return;
             }
 
@@ -2627,6 +2650,11 @@ namespace ScriptCanvasEditor
             {
                 // The last tab has been removed.
                 SetActiveAsset({});
+            }
+
+            if (m_tabBar->count() == 0)
+            {
+                EnableOpenDocumentActions(false);
             }
 
             // Handling various close all events because the save is async need to deal with this in a bunch of different ways
@@ -4411,6 +4439,7 @@ namespace ScriptCanvasEditor
         m_createScriptCanvas->setEnabled(false);
 
         UpdateMenuState(false);
+        EnableOpenDocumentActions(false);
 
         ui->action_New_Script->setEnabled(false);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -519,6 +519,7 @@ namespace ScriptCanvasEditor
         AZ::EntityId FindAssetNodeIdByEditorNodeId(const SourceHandle& assetId, AZ::EntityId editorNodeId) const override;
 
     private:
+
         void SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid fileAssetId) override;
         void SourceFileRemoved(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid fileAssetId) override;
 
@@ -636,10 +637,10 @@ namespace ScriptCanvasEditor
 
         void OpenNextFile();
 
-
         void DisableAssetView(const SourceHandle& memoryAssetId);
         void EnableAssetView(const SourceHandle& memoryAssetId);
 
+        void EnableOpenDocumentActions(bool enable);
 
         QWidget* m_host = nullptr;
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/mainwindow.ui
@@ -183,11 +183,17 @@
    <property name="text">
     <string>&amp;Save</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_Save_As">
    <property name="text">
     <string>&amp;Save As...</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_Open">
    <property name="text">
@@ -680,6 +686,9 @@
    <property name="shortcut">
     <string>Shift+Left</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_AlignRight">
    <property name="text">
@@ -688,6 +697,9 @@
    <property name="shortcut">
     <string>Shift+Right</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_AlignTop">
    <property name="text">
@@ -696,6 +708,9 @@
    <property name="shortcut">
     <string>Shift+Up</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_AlignBottom">
    <property name="text">
@@ -704,6 +719,9 @@
    <property name="shortcut">
     <string>Shift+Down</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_SelectAll">
    <property name="text">
@@ -728,6 +746,9 @@
    <property name="shortcut">
     <string>Esc</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_GotoStartOfChain">
    <property name="text">
@@ -736,6 +757,9 @@
    <property name="shortcut">
     <string>Ctrl+Shift+Left</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_GotoEndOfChain">
    <property name="text">
@@ -744,6 +768,9 @@
    <property name="shortcut">
     <string>Ctrl+Shift+Right</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="actionZoom_To">
    <property name="text">
@@ -757,6 +784,9 @@
    <property name="shortcut">
     <string>Ctrl+Shift+Up</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_EnableSelection">
    <property name="text">
@@ -765,6 +795,9 @@
    <property name="shortcut">
     <string>Ctrl+K, Ctrl+U</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="action_DisableSelection">
    <property name="text">
@@ -773,6 +806,9 @@
    <property name="shortcut">
     <string>Ctrl+K, Ctrl+C</string>
    </property>
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
   </action>
   <action name="actionEditor_Graph">
    <property name="text">


### PR DESCRIPTION
Set the starting state of menu options to disabled and only enable them when graphs are open.

Closes #16599 