### PR TITLE
Escaping windows registry key in pydoc to fix python warning in Editor Python Test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/registry_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/registry_utils.py
@@ -15,7 +15,7 @@ LUMBERYARD_SETTINGS_PATH = r'Software\O3DE\O3DE\Settings'
 def set_ly_registry_value(reg_path, value_name, new_value, value_type=winreg.REG_DWORD):
     """
     Sets the specified value for the specified value_name in the LY registry key.
-    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\O3DE\O3DE\Settings)
+    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\\O3DE\\O3DE\\Settings)
     :param value_name: A string that identifies the value name (e.g. UndoLevels, ViewportInteractionModel)
     :param new_value: Value to set on the specified value_name
     :param value_type: The type of value set. Defaults to a 32-bit number.
@@ -41,7 +41,7 @@ def set_ly_registry_value(reg_path, value_name, new_value, value_type=winreg.REG
 def get_ly_registry_value(reg_path, value_name):
     """
     Gets the current value for an existing value_name in the LY registry key.
-    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\O3DE\O3DE\Settings)
+    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\\O3DE\\O3DE\\Settings)
     :param value_name: A string that identifies the value name (e.g. UndoLevels, ViewportInteractionModel)
     :return: Value set for the specified value_name
     """
@@ -63,7 +63,7 @@ def get_ly_registry_value(reg_path, value_name):
 def delete_ly_registry_value(reg_path, value_name):
     """
     Deletes the specific registry value_name found in the reg_path key.
-    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\O3DE\O3DE\Settings)
+    :param reg_path: A string that identifies the registry path to the desired key (e.g. Software\\O3DE\\O3DE\\Settings)
     :param value_name: A string that identifies the value name (e.g. UndoLevels, ViewportInteractionModel)
     :return: None
     """


### PR DESCRIPTION

```
20:40:35  ..\..\..\..\..\..\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:16
20:40:35    D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:16: DeprecationWarning: invalid escape sequence '\O'
20:40:35      """
20:40:35
20:40:35  ..\..\..\..\..\..\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:42
20:40:35    D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:42: DeprecationWarning: invalid escape sequence '\O'
20:40:35      """
20:40:35
20:40:35  ..\..\..\..\..\..\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:64
20:40:35    D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\automatedtesting_shared\registry_utils.py:64: DeprecationWarning: invalid escape sequence '\O'
```
