### PR TITLE
Scene Settings Load Changes

### DIFF
--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
@@ -93,7 +93,7 @@ namespace AZ
         }
     }
 
-    bool AssetBrowserContextProvider::HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry)
+    bool AssetBrowserContextProvider::HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const
     {
         using namespace AzToolsFramework;
 

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
@@ -77,17 +77,29 @@ namespace AZ
         return AzToolsFramework::AssetBrowser::SourceFileDetails();
     }
 
-    bool AssetBrowserContextProvider::PreviewSceneSettings(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry)
+    void AssetBrowserContextProvider::PreviewSceneSettings(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry)
     {
         using namespace AzToolsFramework;
 
         if (const SourceAssetBrowserEntry* sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(selectedEntry))
         {
-            if (HandlesSource(sourceEntry))
+            if (HandlesSource(sourceEntry) && sourceEntry != m_currentEntry)
             {
-                AssetImporterPlugin::GetInstance()->EditImportSettings(sourceEntry->GetFullPath());
-                return true;
+                if (AssetImporterPlugin::GetInstance()->EditImportSettings(sourceEntry->GetFullPath()))
+                {
+                    m_currentEntry = sourceEntry;
+                }
             }
+        }
+    }
+
+    bool AssetBrowserContextProvider::HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry)
+    {
+        using namespace AzToolsFramework;
+
+        if (const SourceAssetBrowserEntry* sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(selectedEntry))
+        {
+            return HandlesSource(sourceEntry);
         }
 
         return false;

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.h
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.h
@@ -35,11 +35,14 @@ namespace AZ
         AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
 
         // AzToolsFramework::AssetBrowser::AssetBrowserPreviewRequestBus::Handler overrides ...
-        bool PreviewSceneSettings(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) override;
+        void PreviewSceneSettings(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) override;
+        bool HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) override;
         QMainWindow* GetSceneSettings() override;
         bool SaveBeforeClosing() override;
 
     protected:
         bool HandlesSource(const AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry* entry) const; // return true if we care about this kind of source file.
+
+        const AzToolsFramework::AssetBrowser::SourceAssetBrowserEntry* m_currentEntry = nullptr;
     };
 }

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.h
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.h
@@ -36,7 +36,7 @@ namespace AZ
 
         // AzToolsFramework::AssetBrowser::AssetBrowserPreviewRequestBus::Handler overrides ...
         void PreviewSceneSettings(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) override;
-        bool HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) override;
+        bool HandleSource(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const override;
         QMainWindow* GetSceneSettings() override;
         bool SaveBeforeClosing() override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -358,7 +358,7 @@ namespace AzToolsFramework
             virtual void PreviewSceneSettings([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry){};
 
             //! Check if the source asset can be opened in the scene settings
-            virtual bool HandleSource([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry){ return false; };
+            virtual bool HandleSource([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const { return false; };
 
             //! Opens and returns the scene settings window
             virtual QMainWindow* GetSceneSettings() { return nullptr; }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -355,7 +355,10 @@ namespace AzToolsFramework
             virtual void ClearPreview(){};
 
             //! Preview the selected entry in the scene settings window, returns true if successful 
-            virtual bool PreviewSceneSettings([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry){ return false; };
+            virtual void PreviewSceneSettings([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry){};
+
+            //! Check if the source asset can be opened in the scene settings
+            virtual bool HandleSource([[maybe_unused]]const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry){ return false; };
 
             //! Opens and returns the scene settings window
             virtual QMainWindow* GetSceneSettings() { return nullptr; }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -18,7 +18,7 @@
 #include <QPushButton>
 #include <QSplitter>
 #include <QUrl>
-
+#pragma optimize("",off)
 static constexpr int MinimumPopulatedWidth = 328;
 
 namespace AzToolsFramework
@@ -139,6 +139,7 @@ namespace AzToolsFramework
                     this,
                     [this]
                     {
+                        AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::PreviewSceneSettings, m_currentEntry);
                         m_settingsSwitcher->setCurrentIndex(1);
                         m_sceneSettingsButton->setChecked(true);
                         m_detailsButton->setChecked(false);
@@ -386,7 +387,7 @@ namespace AzToolsFramework
             {
                 bool validSceneSettings = false;
                 AssetBrowserPreviewRequestBus::BroadcastResult(
-                    validSceneSettings, &AssetBrowserPreviewRequest::PreviewSceneSettings, selectedEntry);
+                    validSceneSettings, &AssetBrowserPreviewRequest::HandleSource, selectedEntry);
                 if (validSceneSettings)
                 {
                     QString defaultSettings = fileType.isEmpty() ? "Scene" : fileType;
@@ -615,3 +616,4 @@ namespace AzToolsFramework
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
+#pragma optimize("", on)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -18,7 +18,7 @@
 #include <QPushButton>
 #include <QSplitter>
 #include <QUrl>
-#pragma optimize("",off)
+
 static constexpr int MinimumPopulatedWidth = 328;
 
 namespace AzToolsFramework
@@ -616,4 +616,3 @@ namespace AzToolsFramework
         }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
-#pragma optimize("", on)


### PR DESCRIPTION
## What does this PR do?

Modify the asset inspector to load the scene settings when the scene settings button is clicked in the inspector, rather than when an asset is selected from the asset browser. 
For assets that have thousands of submeshes and can take some time to load, this should unblock developers that want to inspect those assets and are not interested in viewing the scene settings.

## How was this PR tested?

Manually in the inspector
