### PR TITLE
Fix terrain crash from dereferencing a null rtData structure.

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -172,9 +172,12 @@ namespace Terrain
     {
         for (RayTracedItem& item : m_rayTracedItems)
         {
-            RtSector::MeshGroup& meshGroup = item.m_sector->m_rtData->m_meshGroups.at(item.m_meshGroupIndex);
-            meshGroup.m_isVisible = false;
-            m_rayTracingFeatureProcessor->RemoveMesh(meshGroup.m_id);
+            if (auto& rtData = item.m_sector->m_rtData; rtData)
+            {
+                RtSector::MeshGroup& meshGroup = rtData->m_meshGroups.at(item.m_meshGroupIndex);
+                meshGroup.m_isVisible = false;
+                m_rayTracingFeatureProcessor->RemoveMesh(meshGroup.m_id);
+            }
         }
         m_rayTracedItems.clear();
     }


### PR DESCRIPTION
## What does this PR do?

On Linux, the terrain system would sometimes crash when changing values on the Terrain System level component. These crashes were caused from dereferencing null rtData structures on teardown. The fix is just to put in a null check.

Repro steps:
* Create a new level.
* Add a Terrain System and a Terrain Renderer level component.
* Add an entity with a Terrain Layer Spawner and an Axis Aligned Bounding Box sized 1024 x 1024 x 100.
* On the Terrain System, change Min Height to -512.
* (crash)

## How was this PR tested?

Ran on Linux, verified that the Terrain System could be modified with the repro steps above.
