### PR TITLE
Document Property Editor Map Improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -49,6 +49,12 @@ namespace AZStd
     template<class T>
     class shared_ptr;
 
+    template<class T, class = void>
+    inline constexpr bool HasToString_v = false;
+    template<class T>
+    inline constexpr bool HasToString_v<T, AZStd::enable_if_t<
+        AZStd::is_void_v<decltype(AZStd::to_string(AZStd::declval<AZStd::string&>(), AZStd::declval<T>()), void())>> > = true;
+
     inline namespace AssociativeInternal
     {
         // SFINAE expression to determine whether an associative container is an actual map with a corresponding value for each key,
@@ -2910,6 +2916,27 @@ namespace AZ
             GenericClassPair()
                 : m_classData{ SerializeContext::ClassData::Create<PairType>(AZ::AzTypeInfo<PairType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_pairContainer) }
             {
+                // Convert a pair to a string, if both types of the pair
+                // supports the AZStd::to_string function
+                auto PairToString = [](const void* pairInst) -> AZStd::string
+                {
+                    auto pairElement = reinterpret_cast<const PairType*>(pairInst);
+                    AZStd::string result;
+                    if constexpr (AZStd::HasToString_v<T1> && AZStd::HasToString_v<T2>)
+                    {
+                        AZStd::string value;
+                        AZStd::to_string(value, pairElement->first);
+                        result += "<";
+                        result += value;
+                        result += ", ";
+                        AZStd::to_string(value, pairElement->second);
+                        result += value;
+                        result += ">";
+                    }
+
+                    return result;
+                };
+                m_classData.m_attributes.emplace_back(AZ::Crc32("ToString"), CreateModuleAttribute(AZStd::move(PairToString)));
             }
 
             SerializeContext::ClassData* GetClassData() override

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -228,6 +228,9 @@ namespace AZ
 
             //! Attribute for making a slider have non-linear scale. The default is 0.5, which results in linear scale. Value can be shifted lower or higher to control more precision in the power curve at those ends (minimum = 0, maximum = 1)
             const static AZ::Crc32 SliderCurveMidpoint = AZ_CRC("SliderCurveMidpoint", 0x8c26aea2);
+
+            //! Attribute for binding a function that can convert the type being viewed to a string
+            inline constexpr AZ::Crc32 ToString{ "ToString" };
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Serialization/Json/IntSerializer.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Serialization/Json/MapSerializer.h>
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/SmartPointerSerializer.h>
 #include <AzCore/Serialization/Json/StringSerializer.h>
@@ -24,6 +25,7 @@
 #include <AzCore/Serialization/Json/UnsupportedTypesSerializer.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EnumConstantJsonSerializer.h>
+#include <AzCore/Serialization/PointerObject.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/ConfigurableStack.h>
 #include <AzCore/std/any.h>
@@ -115,6 +117,9 @@ namespace AZ
                 ->HandlesType<AZStd::bitset>();
             jsonContext->Serializer<EnumConstantJsonSerializer>()
                 ->HandlesType<AZ::Edit::EnumConstant>();
+
+            jsonContext->Serializer<PointerJsonSerializer>()
+                ->HandlesType<PointerObject>();
 
             MathReflect(jsonContext);
         }

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/PointerObject.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/utility/charconv.h>
+
+namespace AZ::PointerJsonSerializerInternal
+{
+    constexpr const char* AddressField = "$address";
+    constexpr const char* TypeField = "$type";
+} // namespace AZ::PointerJsonSerializerInternal
+
+namespace AZ
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(PointerJsonSerializer, "PointerJsonSerializer", "{4DC82ED8-1963-4408-980A-E0A512A12EC6}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(PointerJsonSerializer, BaseJsonSerializer);
+    AZ_CLASS_ALLOCATOR_IMPL(PointerJsonSerializer, SystemAllocator);
+
+    JsonSerializationResult::Result PointerJsonSerializer::Load(
+        void* outputValue, const Uuid&, const rapidjson::Value& inputValue, JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::ReadField);
+
+        const char* PointerObjectTypeName = AZ::AzTypeInfo<PointerObject>::Name();
+
+        switch (inputValue.GetType())
+        {
+        case rapidjson::kObjectType:
+            {
+                auto pointerObject = reinterpret_cast<PointerObject*>(outputValue);
+                if (auto addressIt = inputValue.FindMember(PointerJsonSerializerInternal::AddressField);
+                    addressIt != inputValue.MemberEnd())
+                {
+                    // Try to read the pointer address as an integer from the Json field
+                    uintptr_t pointerAddressIntPtr{};
+                    JSR::ResultCode addressResult =
+                        ContinueLoading(&pointerAddressIntPtr, azrtti_typeid<decltype(pointerAddressIntPtr)>(), addressIt->value, context);
+
+                    if (addressResult.GetProcessing() != JSR::Processing::Completed)
+                    {
+                        // Fall back to trying to read the pointer address as a string and convert to a integer after reading
+                        AZStd::string pointerAddressString;
+                        addressResult = ContinueLoading(
+                            &pointerAddressString, azrtti_typeid<decltype(pointerAddressString)>(), addressIt->value, context);
+                        if (addressResult.GetProcessing() == JSR::Processing::Completed)
+                        {
+                            AZStd::from_chars_result stringToIntResult{};
+                            AZStd::string_view pointerAddressView = pointerAddressString;
+                            // Now try to convert the string into a uintptr_t
+                            // std::does not deal with a leading "0x" in a hex string so an explicit check for is performed
+                            // https://en.cppreference.com/w/cpp/utility/from_chars
+                            constexpr AZStd::string_view HexPrefix = "0x";
+                            // Using StringFunc::StartsWith to perform a case-insensitive search for the hex prefix. Both "0x" and "0X" are
+                            // supported
+                            if (AZ::StringFunc::StartsWith(pointerAddressView, HexPrefix))
+                            {
+                                // Skip pass the hex prefix from the pointer string
+                                pointerAddressView = pointerAddressView.substr(HexPrefix.size());
+                                constexpr int HexBase = 16;
+                                stringToIntResult =
+                                    AZStd::from_chars(pointerAddressView.begin(), pointerAddressView.end(), pointerAddressIntPtr, HexBase);
+                            }
+                            else
+                            {
+                                stringToIntResult =
+                                    AZStd::from_chars(pointerAddressView.begin(), pointerAddressView.end(), pointerAddressIntPtr);
+                            }
+
+                            if (stringToIntResult.ec != AZStd::errc{})
+                            {
+                                addressResult.Combine(context.Report(
+                                    JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Invalid),
+                                    ReporterString::format("Cannot convert string %s to a memory address", pointerAddressString.c_str())));
+                            }
+                        }
+                    }
+
+                    result.Combine(addressResult);
+                    if (result.GetProcessing() == JSR::Processing::Completed)
+                    {
+                        // If the value pointer address was successfully read, store it in the address member
+                        pointerObject->m_address = reinterpret_cast<void*>(pointerAddressIntPtr);
+                    }
+                    else
+                    {
+                        result.Combine(context.Report(
+                            result, ReporterString::format("Failed to read pointer address for %s.", PointerObjectTypeName)));
+                    }
+                }
+                if (auto typeIt = inputValue.FindMember(PointerJsonSerializerInternal::TypeField); typeIt != inputValue.MemberEnd())
+                {
+                    result.Combine(ContinueLoading(&pointerObject->m_typeId, azrtti_typeid<AZ::TypeId>(), typeIt->value, context));
+
+                    if (result.GetProcessing() != JSR::Processing::Completed)
+                    {
+                        result.Combine(
+                            context.Report(result, ReporterString::format("Failed to read type id for %s.", PointerObjectTypeName)));
+                    }
+                }
+
+                return context.Report(
+                    result,
+                    result.GetOutcome() <= JSR::Outcomes::PartialSkip
+                        ? ReporterString::format("Successfully loaded data into %s.", PointerObjectTypeName)
+                        : ReporterString::format("Failed to load data into %s.", PointerObjectTypeName));
+            }
+        case rapidjson::kArrayType:
+        case rapidjson::kNullType:
+        case rapidjson::kStringType:
+        case rapidjson::kFalseType:
+        case rapidjson::kTrueType:
+        case rapidjson::kNumberType:
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::Unsupported,
+                ReporterString::format("Unsupported type. %s can only be read from an object.", PointerObjectTypeName));
+
+        default:
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::Unknown,
+                ReporterString::format("Unknown json type encountered for %s.", PointerObjectTypeName));
+        }
+    }
+
+    JsonSerializationResult::Result PointerJsonSerializer::Store(
+        rapidjson::Value& outputValue,
+        const void* inputValue,
+        [[maybe_unused]] const void* defaultValue,
+        const Uuid&,
+        JsonSerializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::WriteValue);
+
+        const char* PointerObjectTypeName = AZ::AzTypeInfo<PointerObject>::Name();
+
+        auto pointerObject = reinterpret_cast<const PointerObject*>(inputValue);
+
+        if (!outputValue.IsObject())
+        {
+            outputValue.SetObject();
+        }
+
+        auto pointerAddressAsIntPtr = reinterpret_cast<uintptr_t>(pointerObject->m_address);
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue,
+            rapidjson::StringRef(PointerJsonSerializerInternal::AddressField),
+            &pointerAddressAsIntPtr,
+            nullptr,
+            azrtti_typeid<uintptr_t>(),
+            context));
+
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue,
+            rapidjson::StringRef(PointerJsonSerializerInternal::TypeField),
+            &pointerObject->m_typeId,
+            nullptr,
+            azrtti_typeid<AZ::TypeId>(),
+            context));
+
+        return context.Report(
+            result,
+            result.GetProcessing() == JSR::Processing::Completed ? ReporterString::format("%s stored successfully.", PointerObjectTypeName)
+                                                                 : ReporterString::format("Failed to store %s.", PointerObjectTypeName));
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AZ
+{
+    //! JSON serializer for PointerObject
+    //! This is only used for marshaling a pointer to/from a Dom Value in-meory
+    class PointerJsonSerializer : public BaseJsonSerializer
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(PointerJsonSerializer);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        JsonSerializationResult::Result Load(
+            void* outputValue,
+            const Uuid& outputValueTypeId,
+            const rapidjson::Value& inputValue,
+            JsonDeserializerContext& context) override;
+        JsonSerializationResult::Result Store(
+            rapidjson::Value& outputValue,
+            const void* inputValue,
+            const void* defaultValue,
+            const Uuid& valueTypeId,
+            JsonSerializerContext& context) override;
+    };
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/PointerObject.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/PointerObject.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/PointerObject.h>
+
+namespace AZ
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(PointerObject, "PointerObject", "{256581B7-8512-41FD-9A2C-6AF76B3E7BD6}");
+
+    bool PointerObject::IsValid() const
+    {
+        return m_address != nullptr && !m_typeId.IsNull();
+    }
+
+    bool operator==(const PointerObject& lhs, const PointerObject& rhs)
+    {
+        return lhs.m_address == rhs.m_address && lhs.m_typeId == rhs.m_typeId;
+    }
+
+    bool operator!=(const PointerObject& lhs, const PointerObject& rhs)
+    {
+        return !operator==(lhs, rhs);
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/PointerObject.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/PointerObject.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/TypeInfoSimple.h>
+
+namespace AZ
+{
+    //! Wraps a pointer for serializing the pointer address to JSON
+    //! This is not meant for serialization to filesystem
+    struct PointerObject
+    {
+        AZ_TYPE_INFO_WITH_NAME_DECL(PointerObject);
+        void* m_address{};
+        AZ::TypeId m_typeId;
+
+        bool IsValid() const;
+
+        friend bool operator==(const PointerObject& lhs, const PointerObject& rhs);
+        friend bool operator!=(const PointerObject& lhs, const PointerObject& rhs);
+    };
+
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
@@ -527,4 +527,75 @@ namespace AZ::Utils
         return ptr;
     }
 
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ClassData* editClassData, const AZ::Edit::ElementData* elementEditData)
+    {
+        // Locates attributes by searching in the following order:
+        // 1) Class element edit data attributes (EditContext from the given row of a class)
+        // 2) Class element data attributes (SerializeContext from the given row of a class)
+        // 3) Edit Class data attributes (the attributes added to a EditContext reflected class "EditorData" element)
+        // 4) Class data attributes (the base attributes of a class)
+        if (elementEditData != nullptr)
+        {
+            if (AZ::Edit::Attribute* editAttribute = elementEditData->FindAttribute(attributeId);
+                editAttribute != nullptr)
+            {
+                return editAttribute;
+            }
+        }
+
+        if (classElement != nullptr)
+        {
+            if (auto classFieldAttribute = classElement->FindAttribute(attributeId);
+                classFieldAttribute != nullptr)
+            {
+                return classFieldAttribute;
+            }
+        }
+
+        if (classData != nullptr)
+        {
+            if (auto classDataAttribute = classData->FindAttribute(attributeId);
+                classDataAttribute != nullptr)
+            {
+                return classDataAttribute;
+            }
+        }
+        // Lastly, check the AZ::SerializeContext::ClassData -> AZ::Edit::ClassData -> EditorData for attributes
+        if (editClassData != nullptr)
+        {
+            if (const auto* classEditorData = editClassData->FindElementData(AZ::Edit::ClassElements::EditorData))
+            {
+                if (auto editClassAttribute = classEditorData->FindAttribute(attributeId);
+                    editClassAttribute != nullptr)
+                {
+                    return editClassAttribute;
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ElementData* elementEditData)
+    {
+        const AZ::Edit::ClassData* editClassData = classData != nullptr ? classData->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ClassData* editClassData)
+    {
+        const AZ::Edit::ElementData* elementEditData = classElement != nullptr ? classElement->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement)
+    {
+        const AZ::Edit::ClassData* editClassData = classData != nullptr ? classData->m_editData : nullptr;
+        const AZ::Edit::ElementData* elementEditData = classElement != nullptr ? classElement->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
 } // namespace AZ::Utils

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
@@ -20,6 +20,8 @@ namespace AZ
             virtual int64_t GetEnumValueAsInt() const = 0;
         };
 
+        using EnumConstantBasePtr = AZStd::unique_ptr<SerializeContextEnumInternal::EnumConstantBase>;
+
         template<class EnumType>
         struct EnumConstant
             : EnumConstantBase

--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -140,4 +140,46 @@ namespace AZ
         /// expected by the ClassData for this element
         void* ResolvePointer(void* ptr, const SerializeContext::ClassElement& classElement, const SerializeContext& context);
     } // namespace Utils
-} // namespace AzCore
+} // namespace Az
+
+
+namespace AZ::Utils
+{
+    //! Search the Edit context and Serialize Context attributes of class for the first attribute
+    //! matching the attributeId parameter
+    //! Locates attributes by searching in the following order:
+    //! 1) Class element edit data attributes (EditContext from the given row of a class)
+    //! 2) Class element data attributes (SerializeContext from the given row of a class)
+    //! 3) Edit Class data attributes (the attributes added to a EditContext reflected class "EditorData" element)
+    //! 4) Class data attributes (the base attributes of a class)
+    //! @param attributeId numeric ID of attribute to lookup. A string can be converted to an AttributeId by converting it to `AZ::Crc32`
+    //! @param classData Serialize Context reflected ClassData structure
+    //! @param classElement Serialize Context field element for the field being examined. This is added via the SerializeContext
+    //! ClassBuilder `Field` function
+    //! @param editClassData Edit Context reflected ClassData structure
+    //! @param elementEditData Edit Context data element for a specific field. This is added via the EditContext Class Builder `DataElement`
+    //! function
+    //! @return first attribute which matches the specified attribute ID or nullptr
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ClassData* editClassData,
+        const AZ::Edit::ElementData* elementEditData);
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ElementData* elementEditData);
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ClassData* editClassData);
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement);
+} // namespace AZ::Utils

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -562,6 +562,8 @@ set(FILES
     Serialization/SerializationUtils.cpp
     Serialization/ObjectStream.cpp
     Serialization/ObjectStream.h
+    Serialization/PointerObject.h
+    Serialization/PointerObject.cpp
     Serialization/SerializeContext.cpp
     Serialization/SerializeContext.h
     Serialization/SerializeContext_fwd.h
@@ -613,6 +615,8 @@ set(FILES
     Serialization/Json/MapSerializer.cpp
     Serialization/Json/PathSerializer.h
     Serialization/Json/PathSerializer.cpp
+    Serialization/Json/PointerJsonSerializer.h
+    Serialization/Json/PointerJsonSerializer.cpp
     Serialization/Json/RegistrationContext.h
     Serialization/Json/RegistrationContext.cpp
     Serialization/Json/SmartPointerSerializer.h

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -973,7 +973,7 @@
 
     <Type Name="AZ::Dom::Path">
         <!-- Shows the DomPathEntry m_value variant using a view option of simple to only show the plain value !-->
-        <Intrinsic Name="size" Expression="m_entries.m_end - m_entries.m_start" />
+        <Intrinsic Name="size" Expression="m_entries.m_last - m_entries.m_start" />
         <DisplayString Condition="size() == 0">""</DisplayString>
         <DisplayString Condition="size() == 1">/{m_entries.m_start->m_value, view(simple)}</DisplayString>
         <DisplayString Condition="size() == 2">/{m_entries.m_start->m_value, view(simple)}</DisplayString>

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
+#include <AzCore/Serialization/PointerObject.h>
+#include <Tests/Serialization/Json/BaseJsonSerializerFixture.h>
+#include <Tests/Serialization/Json/JsonSerializerConformityTests.h>
+
+namespace JsonSerializationTests
+{
+    class PointerTestDescription
+        : public JsonSerializerConformityTestDescriptor<AZ::PointerObject>
+    {
+        static inline constexpr uintptr_t PointerAddress = 0x00facade;
+        static inline constexpr AZ::TypeId ContrivedTestTypeId = AZ::TypeId::CreateName("facade");
+    public:
+        PointerTestDescription()
+        {
+            m_fullySetJsonString = AZStd::string::format(R"(
+                {
+                    "$address": %)" PRIuPTR R"(,
+                    "$type": "%s"
+                })", PointerAddress, ContrivedTestTypeId.ToFixedString().c_str());
+        }
+        AZStd::shared_ptr<AZ::BaseJsonSerializer> CreateSerializer() override
+        {
+            return AZStd::make_shared<AZ::PointerJsonSerializer>();
+        }
+
+        AZStd::shared_ptr<AZ::PointerObject> CreateDefaultInstance() override
+        {
+            return AZStd::make_shared<AZ::PointerObject>();
+        }
+
+        AZStd::shared_ptr<AZ::PointerObject> CreateFullySetInstance() override
+        {
+            return AZStd::make_shared<AZ::PointerObject>(AZ::PointerObject{ reinterpret_cast<void*>(PointerAddress), ContrivedTestTypeId });
+        }
+
+        AZStd::string_view GetJsonForFullySetInstance() override
+        {
+            // As JSON doesn't support hexidecimal integer values
+            // The value will get output as decimal integer
+            return m_fullySetJsonString;
+        }
+
+        void ConfigureFeatures(JsonSerializerConformityTestDescriptorFeatures& features) override
+        {
+            features.EnableJsonType(rapidjson::kObjectType);
+            features.m_supportsPartialInitialization = false;
+            features.m_supportsInjection = false;
+            features.m_defaultIsEqualToEmpty = false;
+        }
+
+        bool AreEqual(const AZ::PointerObject& lhs, const AZ::PointerObject& rhs) override
+        {
+            return lhs == rhs;
+        }
+
+    private:
+        AZStd::string m_fullySetJsonString;
+    };
+
+    using PointerConformityTestTypes = ::testing::Types<PointerTestDescription>;
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Pointer, JsonSerializerConformityTests, PointerConformityTestTypes));
+} // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -209,6 +209,7 @@ set(FILES
     Serialization/Json/MathVectorSerializerTests.cpp
     Serialization/Json/MathMatrixSerializerTests.cpp
     Serialization/Json/PathSerializerTests.cpp
+    Serialization/Json/PointerSerializerTests.cpp
     Serialization/Json/SmartPointerSerializerTests.cpp
     Serialization/Json/StringSerializerTests.cpp
     Serialization/Json/TestCases.h

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -131,6 +131,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::u64>("ValueHashed");
         static constexpr auto ParentValue = AttributeDefinition<AZ::Dom::Value>("ParentValue");
+        //! IF the associated value is mapped value of an associative container such as a map or unordered_map
+        //! `pair<const key_type, mapped_type>` element, then the KeyValue attribute stores
+        //! a pointer to the key type and the type id of the key type
+        static constexpr auto KeyValue = AttributeDefinition<AZ::Dom::Value>("KeyValue");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended
         //! to the previous column in the layout, creating a SharedColumn that can hold many PropertyEditors.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Serialization/PointerObject.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
@@ -37,12 +38,13 @@ namespace AZ::Reflection
 
     // attempts to stringify the passed instance; useful for things like maps where the key element should not be user editable
     bool GetValueStringHelper(
-        void* instance,
+        AZ::PointerObject instanceObject,
         const AZ::SerializeContext::ClassData* classData,
         const AZ::SerializeContext::ClassElement* classElement,
         AZ::SerializeContext* serializeContext,
         AZStd::string& value)
     {
+        void* instance = instanceObject.m_address;
         if (!classData)
         {
             return false;
@@ -78,15 +80,14 @@ namespace AZ::Reflection
 
         if (serializeContext && !enumId.IsNull())
         {
+            AZ::Uuid underlyingTypeId;
+            extractUuidProperty(classData->m_attributes, Name("EnumUnderlyingType"), underlyingTypeId);
             // got the enumID, now get the enum's underlying type
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 const AZ::Edit::ElementData* enumElementData = editContext->GetEnumElementData(enumId);
                 if (enumElementData)
                 {
-                    AZ::Uuid underlyingTypeId;
-                    extractUuidProperty(classData->m_attributes, Name("EnumUnderlyingType"), underlyingTypeId);
-
                     // Check all underlying enum storage types for the actual representation type to query
                     if (!underlyingTypeId.IsNull() &&
                         AZ::Utils::GetEnumStringRepresentation<AZ::u8, AZ::u16, AZ::u32, AZ::u64, AZ::s8, AZ::s16, AZ::s32, AZ::s64>(
@@ -94,6 +95,119 @@ namespace AZ::Reflection
                     {
                         return true;
                     }
+                }
+            }
+
+            // As a fall back use the Serialize Context Enum reflection option name for the string value
+
+            auto enumClassData = serializeContext->FindClassData(enumId);
+            auto underlyingIntClassData = serializeContext->FindClassData(underlyingTypeId);
+            if (enumClassData != nullptr && underlyingIntClassData != nullptr && underlyingIntClassData->m_azRtti != nullptr)
+            {
+                const TypeTraits underlyingTypeTraits = underlyingIntClassData->m_azRtti->GetTypeTraits();
+                const bool isSigned = (underlyingTypeTraits & TypeTraits::is_signed) == TypeTraits::is_signed;
+                const bool isUnsigned = (underlyingTypeTraits & TypeTraits::is_unsigned) == TypeTraits::is_unsigned;
+
+                AZStd::unordered_map<int64_t, AZStd::string_view> enumConstantsSigned;
+                AZStd::unordered_map<uint64_t, AZStd::string_view> enumConstantsUnsigned;
+                // Get each Enum Value -> Name pair
+                for (const AZ::AttributeSharedPair& enumAttributePair : enumClassData->m_attributes)
+                {
+                    if (enumAttributePair.first == AZ::Serialize::Attributes::EnumValueKey)
+                    {
+                        auto enumConstantAttribute = azrtti_cast<AZ::AttributeData<SerializeContextEnumInternal::EnumConstantBasePtr>*>(enumAttributePair.second.get());
+                        if (enumConstantAttribute == nullptr)
+                        {
+                            continue;
+                        }
+
+                        const SerializeContextEnumInternal::EnumConstantBasePtr& enumConstantPtr = enumConstantAttribute->Get(nullptr);
+                        if (isSigned)
+                        {
+                            enumConstantsSigned.emplace(enumConstantPtr->GetEnumValueAsInt(), enumConstantPtr->GetEnumValueName());
+                        }
+                        else if (isUnsigned)
+                        {
+                            enumConstantsUnsigned.emplace(enumConstantPtr->GetEnumValueAsUInt(), enumConstantPtr->GetEnumValueName());
+                        }
+                    }
+                }
+
+                auto GetEnumOptionNameSigned = [&value, &enumConstantsSigned](auto signedValue) -> bool
+                {
+                    auto signedValue64 = static_cast<int64_t>(signedValue);
+                    if (auto foundIt = enumConstantsSigned.find(signedValue64); foundIt != enumConstantsSigned.end())
+                    {
+                        value = foundIt->second;
+                        return true;
+                    }
+
+                    return false;
+                };
+                auto GetEnumOptionNameUnsigned = [&value, &enumConstantsUnsigned](auto unsignedValue) -> bool
+                {
+                    auto unsignedValue64 = static_cast<uint64_t>(unsignedValue);
+                    if (auto foundIt = enumConstantsUnsigned.find(unsignedValue64); foundIt != enumConstantsUnsigned.end())
+                    {
+                        value = foundIt->second;
+                        return true;
+                    }
+
+                    return false;
+                };
+                // Start checking the 32-bit int and unsigned int types first since they are the more likely to be the underlying
+                // types used for an enum
+                // For example a scoped enum `enum class Foo` has a default underlying type of `int`
+                // For an unscoped enum such as `enum Foo`, the underlying type is usually `int` or `unsigned int` depending on the values
+                // of the enum
+                if (underlyingTypeId == azrtti_typeid<AZ::s32>() && GetEnumOptionNameSigned(*static_cast<AZ::s32*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u32>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u32*>(instance)))
+                {
+                    return true;
+                }
+                // Now check the 8-bit, 16-bit and 64-bit underlying types to see if an Enum uses one of them
+                else if (underlyingTypeId == azrtti_typeid<AZ::s8>() && GetEnumOptionNameSigned(*static_cast<AZ::s8*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::s16>() && GetEnumOptionNameSigned(*static_cast<AZ::s16*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<long>() && GetEnumOptionNameSigned(*static_cast<long*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::s64>() && GetEnumOptionNameSigned(*static_cast<AZ::s64*>(instance)))
+                {
+                    return true;
+                }
+                else if(underlyingTypeId == azrtti_typeid<AZ::u8>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u8*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u16>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u16*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<unsigned long>() && GetEnumOptionNameUnsigned(*static_cast<unsigned long*>(instance)))
+                {
+                    return true;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u64>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u64*>(instance)))
+                {
+                    return true;
+                }
+                // char is a special case
+                // It is a distinct type from signed char(AZ::s8) and unsigned char(AZ::u8) and can be either signed or unsigned
+                // so both lambdas are called to check if it is in either set
+                if (underlyingTypeId == azrtti_typeid<char>() &&
+                    (GetEnumOptionNameSigned(*static_cast<char*>(instance)) || GetEnumOptionNameUnsigned(*static_cast<char*>(instance))))
+                {
+                    return true;
                 }
             }
         }
@@ -143,11 +257,10 @@ namespace AZ::Reflection
 
             struct StackEntry
             {
-                void* m_instance;
+                AZ::PointerObject m_instance;
                 // Instance that is used to retrieve attribute values that are tied to invokable functions.
                 // Commonly, it is the parent instance for property nodes, and the instance for UI element nodes.
-                void* m_instanceToInvoke = nullptr;
-                AZ::TypeId m_typeId;
+                AZ::PointerObject m_instanceToInvoke;
 
                 //! Keeps tracks of how many pointers are attached to the instance type
                 //! For example if the actual instance being referenced is an AZ::Component, then m_pointerLevel is 0
@@ -162,7 +275,9 @@ namespace AZ::Reflection
                 DocumentPropertyEditor::Nodes::PropertyVisibility m_computedVisibility =
                     DocumentPropertyEditor::Nodes::PropertyVisibility::Show;
                 bool m_entryClosed = false;
-                size_t m_childElementIndex = 0; // TODO: this should store a PathEntry and support text for associative containers
+                size_t m_childElementIndex = 0;
+                using AssociativeContainerType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+                AssociativeContainerType m_associativeContainerType = AssociativeContainerType::Unknown;
 
                 AZStd::string_view m_group;
                 bool m_isOpenGroup = false;
@@ -179,8 +294,14 @@ namespace AZ::Reflection
                 // extra data necessary to support Containers composed of pair<> children (like maps!)
                 bool m_extractKeyedPair = false;
                 AZ::SerializeContext::IDataContainer* m_parentContainerInfo = nullptr;
-                void* m_parentContainerOverride = nullptr;
-                void* m_containerElementOverride = nullptr;
+                AZ::PointerObject m_parentContainerOverride;
+                AZ::PointerObject m_containerElementOverride;
+                //! For the pair<> element of an associative container
+                //! this points to the current child key instance being visited
+                AZ::PointerObject m_childAssociativeKeyInstance;
+                //! For the mapped_type of the pair<> element of an associative container,
+                //! stores the key instance address and type id
+                AZ::PointerObject m_keyInstance{};
 
                 const AZ::Edit::ElementData* GetElementEditMetadata() const
                 {
@@ -197,7 +318,7 @@ namespace AZ::Reflection
                 //! So this code make sure that dereferences occurs before returning the address
                 const void* GetRawInstance() const
                 {
-                    const void* directInstance = m_instance;
+                    const void* directInstance = m_instance.m_address;
                     for (AZ::u32 pointersToDereference = m_pointerLevel; pointersToDereference > 0; --pointersToDereference)
                     {
                         directInstance = *reinterpret_cast<const void* const*>(directInstance);
@@ -208,6 +329,11 @@ namespace AZ::Reflection
                 void* GetRawInstance()
                 {
                     return const_cast<void*>(AZStd::as_const(*this).GetRawInstance());
+                }
+
+                AZ::TypeId GetTypeId() const
+                {
+                    return m_instance.m_typeId;
                 }
 
                 AZStd::vector<AZStd::pair<AZStd::string, AZStd::optional<StackEntry>>> m_groups;
@@ -237,7 +363,7 @@ namespace AZ::Reflection
                 , m_serializeContext(serializeContext)
             {
                 // Push a dummy node into stack, which serves as the parent node for the first node.
-                m_stack.emplace_back(StackEntry{ instance, nullptr, typeId });
+                m_stack.emplace_back(StackEntry{ AZ::PointerObject{instance, typeId }, AZ::PointerObject{} });
 
                 m_visitFromRoot = visitFromRoot;
 
@@ -308,7 +434,7 @@ namespace AZ::Reflection
 
                 // Note that this is the dummy parent node for the root node. It contains null classData and classElement.
                 const StackEntry& nodeData = m_stack.back();
-                m_serializeContext->EnumerateInstanceConst(m_enumerateContext, nodeData.GetRawInstance(), nodeData.m_typeId, nullptr, nullptr);
+                m_serializeContext->EnumerateInstanceConst(m_enumerateContext, nodeData.GetRawInstance(), nodeData.m_instance.m_typeId, nullptr, nullptr);
             }
 
             void GenerateNodePath(const StackEntry& parentData, StackEntry& nodeData)
@@ -393,9 +519,8 @@ namespace AZ::Reflection
 
                                     constexpr AZ::u32 pointerLevel = 0;
 
-                                    StackEntry entry = { boolAddress,
+                                    StackEntry entry{ AZ::PointerObject{boolAddress, serializeClassElement->m_typeId},
                                                          nodeData.m_instance,
-                                                         serializeClassElement->m_typeId,
                                                          pointerLevel,
                                                          nullptr,
                                                          currElement.m_serializeClassElement };
@@ -413,9 +538,8 @@ namespace AZ::Reflection
                                     UIElement->m_flags = SerializeContext::ClassElement::Flags::FLG_UI_ELEMENT;
                                     // A UI node isn't backed with a real C++ type, so its pointer level is 0
                                     constexpr AZ::u32 pointerLevel =  0;
-                                    StackEntry entry = { nodeData.m_instance,
+                                    StackEntry entry{ nodeData.m_instance,
                                                          nodeData.m_instance,
-                                                         nodeData.m_classData->m_typeId,
                                                          pointerLevel,
                                                          nodeData.m_classData,
                                                          UIElement };
@@ -474,10 +598,7 @@ namespace AZ::Reflection
                             UIElement->m_flags = SerializeContext::ClassElement::Flags::FLG_UI_ELEMENT;
                             // Use the instance itself to retrieve parameter values that invoke functions on the UI Element.
                             constexpr AZ::u32 pointerLevel = 0;
-                            StackEntry entry = {
-                                nodeData.m_instance, nodeData.m_instance, nodeData.m_classData->m_typeId, pointerLevel,
-                                nodeData.m_classData, UIElement
-                            };
+                            StackEntry entry{ nodeData.m_instance, nodeData.m_instance, pointerLevel, nodeData.m_classData, UIElement };
 
                             AZStd::string pathString = nodeData.m_path;
 
@@ -493,7 +614,7 @@ namespace AZ::Reflection
                                 pathString.append(lastValidElementName);
                             }
 
-                            nodeData.m_nonSerializedChildren.push_back(AZStd::make_pair(pathString.c_str(), entry));
+                            nodeData.m_nonSerializedChildren.emplace_back(AZStd::move(pathString), AZStd::move(entry));
                         }
                         else
                         {
@@ -549,41 +670,47 @@ namespace AZ::Reflection
                 }
             }
 
-            AZStd::optional<bool> HandleNodeAssociativeInterface(StackEntry& parentData, StackEntry& nodeData)
+            enum class VisitEntry
             {
+                VisitChildrenCallVisitObjectBegin,
+                VisitChildrenSkipVisitObjectBegin,
+                VisitNextSiblingSkipVisitObjectBegin
+
+            };
+            VisitEntry HandleNodeAssociativeInterface(StackEntry& parentData, StackEntry& nodeData)
+            {
+                using AssociativeType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
                 if (parentData.m_classData && parentData.m_classData->m_container)
                 {
                     auto& containerInfo = parentData.m_classData->m_container;
                     AZ::SerializeContext::IDataContainer::IAssociativeDataContainer* parentAssociativeInterface =
                         containerInfo->GetAssociativeContainerInterface();
 
-                    if (parentAssociativeInterface)
+                    if (parentAssociativeInterface != nullptr)
                     {
-                        if (nodeData.m_instance == parentAssociativeInterface->GetValueByKey(parentData.m_instance, nodeData.m_instance))
+                        auto associativeType = parentAssociativeInterface->GetAssociativeType();
+                        // Store the type of associative container
+                        parentData.m_associativeContainerType = associativeType;
+                        switch (associativeType)
                         {
-                            // the element *is* the key. This is some kind of set and has only one read-only value per entry
-                            nodeData.m_skipLabel = true;
-                            nodeData.m_disableEditor = true;
-
-                            // TODO: if preferred, we can still include a label for set elements,
-                            // in this case, the stringified value
-                            /*  GetValueStringHelper(
-                                nodeData->m_instance,
-                                nodeData->m_classData,
-                                nodeData->m_classElement,
-                                m_serializeContext,
-                                nodeData->m_labelOverride); */
-                        }
-                        else
-                        {
-                            // parent is a real associative container with pair<> children,
-                            // extract the info from the parent and just show label/editor pairs
-                            nodeData.m_extractKeyedPair = true;
-                            nodeData.m_parentContainerInfo = parentData.m_classData->m_container;
-                            nodeData.m_parentContainerOverride = parentData.m_instance;
-                            nodeData.m_containerElementOverride = nodeData.m_instance;
-                            nodeData.m_entryClosed = true;
-                            return true;
+                        case AssociativeType::Set:
+                        case AssociativeType::UnorderedSet:
+                            {
+                                // the element *is* the key. This is some kind of set and has only one read-only value per entry
+                                nodeData.m_skipLabel = true;
+                                nodeData.m_disableEditor = true;
+                                break;
+                            }
+                        case AssociativeType::Map:
+                        case AssociativeType::UnorderedMap:
+                            {
+                                // parent is a map associative container with pair<> children,
+                                // extract the info from the parent and just show label/editor pairs
+                                nodeData.m_extractKeyedPair = true;
+                                nodeData.m_parentContainerInfo = parentData.m_classData->m_container;
+                                nodeData.m_parentContainerOverride = parentData.m_instance;
+                                nodeData.m_containerElementOverride = nodeData.m_instance;
+                            }
                         }
                     }
                 }
@@ -593,24 +720,23 @@ namespace AZ::Reflection
                     // alternate behavior for the pair children. The first is the key, stringify it
                     if (parentData.m_childElementIndex % 2 == 0)
                     {
-                        // store the label override in the parent for the next child to consume
-                        GetValueStringHelper(
-                            nodeData.m_instance,
-                            nodeData.m_classData,
-                            nodeData.m_classElement,
-                            m_serializeContext,
-                            parentData.m_labelOverride);
                         nodeData.m_entryClosed = true;
-                        return true;
+                        // Update the parent to store a pointer to the key instance data
+                        parentData.m_childAssociativeKeyInstance = AZ::PointerObject{ nodeData.m_instance };
+                        // Do not enumerate the key elements itself
+                        // Instead let the mapped type in the else block add a DOM Editor for the key
+                        return VisitEntry::VisitNextSiblingSkipVisitObjectBegin;
                     }
                     else // the second is the value, make an editor as normal
                     {
-                        // this is the second pair<> child, consume the label override stored above
-                        nodeData.m_labelOverride = parentData.m_labelOverride;
+                        // swap the current child key instance stored in the parent with the node key instance field
+                        // and then clear the parent current child key instance field
+                        nodeData.m_keyInstance = AZStd::move(parentData.m_childAssociativeKeyInstance);
+                        parentData.m_childAssociativeKeyInstance = AZ::PointerObject{};
                     }
                 }
 
-                return AZStd::nullopt;
+                return VisitEntry::VisitChildrenCallVisitObjectBegin;
             }
 
             AZStd::optional<bool> HandleNodeAttributes(StackEntry& parentData, StackEntry& nodeData)
@@ -628,13 +754,13 @@ namespace AZ::Reflection
                 InheritChangeNotify(parentData, nodeData);
 
                 const auto& EnumTypeAttribute = DocumentPropertyEditor::Nodes::PropertyEditor::EnumUnderlyingType;
-                AZStd::optional<AZ::TypeId> enumTypeId = {};
+                AZStd::optional<AZ::TypeId> enumTypeId;
                 if (auto enumTypeValue = Find(EnumTypeAttribute.GetName()); enumTypeValue)
                 {
                     enumTypeId = EnumTypeAttribute.DomToValue(*enumTypeValue);
                 }
 
-                const AZ::TypeId* typeIdForHandler = &nodeData.m_typeId;
+                const AZ::TypeId* typeIdForHandler = &nodeData.m_instance.m_typeId;
                 if (enumTypeId.has_value())
                 {
                     typeIdForHandler = &enumTypeId.value();
@@ -680,21 +806,19 @@ namespace AZ::Reflection
 
 
                 // search up the stack for the "true parent", which is the last entry created by the serialize enumerate itself
-                void* instanceToInvoke = instance;
+                AZ::PointerObject instanceToInvokeObject{ instance, classData ? classData->m_typeId : Uuid::CreateNull() };
                 for (auto rIter = m_stack.rbegin(), rEnd = m_stack.rend(); rIter != rEnd; ++rIter)
                 {
                     auto* currInstance = rIter->GetRawInstance();
                     if (rIter->m_createdByEnumerate && currInstance)
                     {
-                        instanceToInvoke = currInstance;
+                        instanceToInvokeObject = AZ::PointerObject{ currInstance, rIter->GetTypeId() };
                         break;
                     }
                 }
 
-                StackEntry newEntry = {
-                    instance, instanceToInvoke, classData ? classData->m_typeId : Uuid::CreateNull(), pointerLevel,
-                    classData, classElement
-                };
+                AZ::PointerObject instanceObject{ instance, classData ? classData->m_typeId : Uuid::CreateNull() };
+                StackEntry newEntry{ instanceObject, instanceToInvokeObject, pointerLevel, classData, classElement };
                 newEntry.m_createdByEnumerate = true;
 
                 StackEntry& nodeData = m_stack.emplace_back(newEntry);
@@ -714,9 +838,9 @@ namespace AZ::Reflection
                 HandleNodeGroups(nodeData);
                 HandleNodeUiElementsRetrieval(nodeData);
 
-                if (auto result = HandleNodeAssociativeInterface(parentData, nodeData); result.has_value())
+                if (auto result = HandleNodeAssociativeInterface(parentData, nodeData); result != VisitEntry::VisitChildrenCallVisitObjectBegin)
                 {
-                    return result.value();
+                    return result == VisitEntry::VisitChildrenSkipVisitObjectBegin;
                 }
 
                 if (auto result = HandleNodeAttributes(parentData, nodeData); result.has_value())
@@ -782,17 +906,12 @@ namespace AZ::Reflection
                                     // skip the bool that represented the group toggle, it's already in-line with the group
                                     continue;
                                 }
-                                auto& parentEntry = m_stack.back();
-                                StackEntry& newStackEntry = m_stack.emplace_back(StackEntry{ groupEntry.m_instance, nullptr, AZ::TypeId(), groupEntry.m_pointerLevel,
-                                    groupEntry.m_classData, groupEntry.m_classElement });
-                                InheritChangeNotify(parentEntry, newStackEntry);
                                 m_serializeContext->EnumerateInstance(
                                     m_enumerateContext,
-                                    newStackEntry.m_instance,
-                                    newStackEntry.m_typeId,
-                                    newStackEntry.m_classData,
-                                    newStackEntry.m_classElement);
-                                m_stack.pop_back();
+                                    groupEntry.m_instance.m_address,
+                                    groupEntry.m_instance.m_typeId,
+                                    groupEntry.m_classData,
+                                    groupEntry.m_classElement);
                             }
 
                             if (groupPair.second.has_value())
@@ -818,11 +937,6 @@ namespace AZ::Reflection
                 {
                     StackEntry& parentData = m_stack.back();
 
-                    if (!parentData.m_group.empty())
-                    {
-                        EndNode();
-                    }
-
                     if (!m_stack.empty() && parentData.m_computedVisibility == DocumentPropertyEditor::Nodes::PropertyVisibility::Show)
                     {
                         ++m_stack.back().m_childElementIndex;
@@ -832,14 +946,14 @@ namespace AZ::Reflection
                 return true;
             }
 
-            const AZ::TypeId& GetType() const override
+            AZ::TypeId GetType() const override
             {
-                return m_stack.back().m_typeId;
+                return m_stack.back().GetTypeId();
             }
 
             AZStd::string_view GetTypeName() const override
             {
-                const AZ::SerializeContext::ClassData* classData = m_serializeContext->FindClassData(m_stack.back().m_typeId);
+                const AZ::SerializeContext::ClassData* classData = m_serializeContext->FindClassData(m_stack.back().GetTypeId());
                 return classData ? classData->m_name : "<unregistered type>";
             }
 
@@ -878,7 +992,9 @@ namespace AZ::Reflection
                 else if (m_stack.size() > 1)
                 {
                     const StackEntry& parentNode = m_stack[m_stack.size() - 2];
-                    if (parentNode.m_classData && parentNode.m_classData->m_container)
+                    AZ::Serialize::IDataContainer* dataContainer = parentNode.m_classData ? parentNode.m_classData->m_container : nullptr;
+                    // Only add a label numeric label for sequence containers
+                    if (dataContainer && dataContainer->IsSequenceContainer())
                     {
                         labelAttributeBuffer = AZStd::fixed_string<128>::format("[%zu]", parentNode.m_childElementIndex);
                         return labelAttributeBuffer;
@@ -952,7 +1068,7 @@ namespace AZ::Reflection
                 const Name genericValueListName = Name("GenericValueList");
                 const Name enumValuesCrcName = Name(static_cast<u32>(Crc32("EnumValues")));
 
-                auto checkAttribute = [&](const AttributePair* it, void* instance, bool shouldDescribeChildren)
+                auto checkAttribute = [&](const AttributePair* it, AZ::PointerObject instance, bool shouldDescribeChildren)
                 {
                     bool describesChildren = it->second->m_describesChildren;
                     if (it->second->m_describesChildren != shouldDescribeChildren)
@@ -992,7 +1108,7 @@ namespace AZ::Reflection
                         if (name == PropertyEditor::Visibility.GetName())
                         {
                             auto visibilityValue = PropertyEditor::Visibility.DomToValue(
-                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance, it->second));
+                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance.m_address, it->second));
 
                             if (visibilityValue.has_value())
                             {
@@ -1017,13 +1133,13 @@ namespace AZ::Reflection
                             }
                             else if (
                                 auto visibilityBoolValue =
-                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance, it->second)))
+                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance.m_address, it->second)))
                             {
                                 bool isVisible = visibilityBoolValue.value();
                                 visibility = isVisible ? PropertyVisibility::Show : PropertyVisibility::Hide;
                                 return;
                             }
-                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance, it->second))
+                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance.m_address, it->second))
                             {
                                 // Fallback to generic read if LegacyAttributeToDomValue fails
                                 visibility = PropertyEditor::Visibility.DomToValue(genericVisibility.value()).value();
@@ -1037,7 +1153,7 @@ namespace AZ::Reflection
                         {
                             nodeData.m_disableEditor |=
                                 PropertyEditor::ReadOnly
-                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance, it->second))
+                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance.m_address, it->second))
                                     .value_or(nodeData.m_disableEditor);
                         }
 
@@ -1048,7 +1164,7 @@ namespace AZ::Reflection
                         {
                             if (attributeValue.IsNull())
                             {
-                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance, it->second);
+                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance.m_address, it->second);
                             }
                         };
                         propertyEditorSystem->EnumerateRegisteredAttributes(name, readValue);
@@ -1056,7 +1172,7 @@ namespace AZ::Reflection
                         // Fall back on a generic read that handles primitives.
                         if (attributeValue.IsNull())
                         {
-                            attributeValue = ReadGenericAttributeToDomValue(instance, it->second).value_or(Dom::Value());
+                            attributeValue = ReadGenericAttributeToDomValue(instance.m_address, it->second).value_or(Dom::Value());
                         }
 
                         // If we got a valid DOM value, store it.
@@ -1092,7 +1208,7 @@ namespace AZ::Reflection
                                 // in the PropertyEditorSystem.
                                 // This is reasonable since the attribute's value is an enum with an underlying integral
                                 // type which is safely convertible to AZ::u64.
-                                nodeData.m_typeId = AzTypeInfo<u64>::Uuid();
+                                nodeData.m_instance.m_typeId = AzTypeInfo<u64>::Uuid();
                                 return;
                             }
 
@@ -1194,25 +1310,27 @@ namespace AZ::Reflection
 
                     if (parentNode.m_classData && parentNode.m_classData->m_container)
                     {
-                        auto parentContainerInfo =
+                        AZ::PointerObject parentDataContainerObject;
+                        parentDataContainerObject.m_address =
                             (parentNode.m_parentContainerInfo ? parentNode.m_parentContainerInfo : parentNode.m_classData->m_container);
+                        parentDataContainerObject.m_typeId = azrtti_typeid<AZ::Serialize::IDataContainer>();
 
                         nodeData.m_cachedAttributes.push_back(
-                            { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType<void*>(parentContainerInfo) });
+                            { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType(parentDataContainerObject) });
 
-                        auto parentContainerInstance =
-                            (parentNode.m_parentContainerOverride ? parentNode.m_parentContainerOverride : parentNode.m_instance);
+                        AZ::PointerObject parentContainerObject =
+                            parentNode.m_parentContainerOverride.IsValid() ? parentNode.m_parentContainerOverride : parentNode.m_instance;
 
                         nodeData.m_cachedAttributes.push_back({ group,
                                                                 DescriptorAttributes::ParentContainerInstance,
-                                                                Dom::Utils::ValueFromType<void*>(parentContainerInstance) });
+                                                                Dom::Utils::ValueFromType(parentContainerObject) });
 
-                        if (parentNode.m_containerElementOverride)
+                        if (parentNode.m_containerElementOverride.IsValid())
                         {
                             nodeData.m_cachedAttributes.push_back(
                                 { group,
                                   DescriptorAttributes::ContainerElementOverride,
-                                  Dom::Utils::ValueFromType<void*>(parentNode.m_containerElementOverride) });
+                                  Dom::Utils::ValueFromType(parentNode.m_containerElementOverride) });
                         }
 
                         auto canBeModifiedValue =
@@ -1275,7 +1393,7 @@ namespace AZ::Reflection
 
                 nodeData.m_cachedAttributes.push_back({ group,
                                                         AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueType.GetName(),
-                                                        AZ::Dom::Utils::TypeIdToDomValue(nodeData.m_typeId) });
+                                                        AZ::Dom::Utils::TypeIdToDomValue(nodeData.m_instance.m_typeId) });
 
                 if (nodeData.m_disableEditor)
                 {
@@ -1293,15 +1411,26 @@ namespace AZ::Reflection
 
                 if (nodeData.m_classData && nodeData.m_classData->m_container)
                 {
+                    AZ::PointerObject nodeContainerObject;
+                    nodeContainerObject.m_address = nodeData.m_classData->m_container;
+                    nodeContainerObject.m_typeId = azrtti_typeid<AZ::Serialize::IDataContainer>();
                     nodeData.m_cachedAttributes.push_back(
-                        { group, DescriptorAttributes::Container, Dom::Utils::ValueFromType<void*>(nodeData.m_classData->m_container) });
+                        { group, DescriptorAttributes::Container, Dom::Utils::ValueFromType(nodeContainerObject) });
                 }
 
                 // RpePropertyHandlerWrapper would cache the parent info from which a wrapped handler may retrieve the parent instance.
-                if (nodeData.m_instanceToInvoke)
+                if (nodeData.m_instanceToInvoke.IsValid())
                 {
                     nodeData.m_cachedAttributes.push_back(
-                        { group, PropertyEditor::ParentValue.GetName(), Dom::Utils::ValueFromType<void*>(nodeData.m_instanceToInvoke) });
+                        { group, PropertyEditor::ParentValue.GetName(), Dom::Utils::ValueFromType(nodeData.m_instanceToInvoke) });
+                }
+
+                // Create an Attribute for storing the Key Value associated with this value if it is the mapped value of an associative container
+                // https://en.cppreference.com/w/cpp/container/map
+                if (nodeData.m_keyInstance.IsValid())
+                {
+                    nodeData.m_cachedAttributes.push_back(
+                        { group, PropertyEditor::KeyValue.GetName(), Dom::Utils::ValueFromType(nodeData.m_keyInstance) });
                 }
 
                 // Calculate our visibility, going through parent nodes in reverse order to see if we should be hidden

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/PointerObject.h>
 #include <AzFramework/DocumentPropertyEditor/Reflection/Attribute.h>
 #include <AzFramework/DocumentPropertyEditor/Reflection/Visitor.h>
 
@@ -60,3 +61,35 @@ namespace AZ::Reflection
     // instances to interface with the Prefab System.
     // void VisitLegacyJsonSerializedInstance(IRead* visitor, Dom::Value instance, const AZ::TypeId& typeId);
 } // namespace AZ::Reflection
+
+namespace AZ::Reflection::LegacyReflectionInternal
+{
+    struct AttributeData
+    {
+        AZ_TYPE_INFO(AttributeData, "{EFD2A3A3-8161-4B9C-90B8-952AA08FD961}");
+
+        // Group from the attribute metadata (generally empty with Serialize/EditContext data)
+        Name m_group;
+        // Name of the attribute
+        Name m_name;
+        // DOM value of the attribute - currently only primitive attributes are supported,
+        // but other types may later be supported via opaque values
+        Dom::Value m_value;
+    };
+
+    //! Stores information about an associative container element key
+    //! This is used by the LegacyReflectionBridge StackEntry
+    //! to have the mapped_type of an associative container element to be able
+    //! access the instance and attribute data for the corresponding key
+    struct KeyEntry
+    {
+        AZ_TYPE_INFO(KeyEntry, "{718537E1-DFF5-4662-AB86-1D5C0C8A0768}");
+
+        //! Stores the address and type ID of an associative contaienr key
+        AZ::PointerObject m_keyInstance;
+        //! Stores the attributes of a single associative container element key
+        AZStd::vector<AttributeData> m_keyAttributes;
+
+        bool IsValid() const;
+    };
+}

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
@@ -173,7 +173,7 @@ namespace AZ::Reflection
 
     struct IObjectAccess
     {
-        virtual const AZ::TypeId& GetType() const = 0;
+        virtual AZ::TypeId GetType() const = 0;
         virtual AZStd::string_view GetTypeName() const = 0;
 
         virtual void* Get() = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -731,7 +731,7 @@ namespace AzToolsFramework
                     priorColumnDomIndex = searchIndex;
                 }
             }
-            AZ_Assert(priorColumnDomIndex != -1, "Tried to share column with an out of bounds index!");
+            AZ_Error("DocumentPropertyEditor", priorColumnDomIndex != -1, "Tried to share column with an out of bounds index!");
             if (priorColumnDomIndex != -1)
             {
                 m_columnLayout->AddSharePriorColumn(priorColumnDomIndex, domIndex);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1724,7 +1724,7 @@ namespace AzToolsFramework
         // message match for QueryKey
         auto showKeyQueryDialog = [&](AZ::DocumentPropertyEditor::DocumentAdapterPtr* adapter, AZ::Dom::Path containerPath)
         {
-            KeyQueryDPE keyQueryUi(adapter);
+            KeyQueryDPE keyQueryUi(*adapter);
             if (keyQueryUi.exec() == QDialog::Accepted)
             {
                 AZ::DocumentPropertyEditor::Nodes::Adapter::AddContainerKey.InvokeOnDomNode(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
@@ -10,10 +10,10 @@
 
 namespace AzToolsFramework
 {
-    KeyQueryDPE::KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget)
+    KeyQueryDPE::KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr keyQueryAdapter, QWidget* parentWidget)
         : QDialog(parentWidget)
     {
         setupUi(this);
-        dpe->SetAdapter(*keyQueryAdatper);
+        dpe->SetAdapter(keyQueryAdapter);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
@@ -18,6 +18,6 @@ namespace AzToolsFramework
         , Ui::KeyQueryDPE
     {
     public:
-        KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget = nullptr);
+        KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr keyQueryAdapter, QWidget* parentWidget = nullptr);
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
@@ -51,7 +51,16 @@ namespace AzToolsFramework
         else
         {
             AZ::Dom::Value value = PropertyEditor::Value.ExtractFromDomNode(node).value_or(AZ::Dom::Value());
-            typeId = AZ::Dom::Utils::GetValueTypeId(value);
+            // If the object is a pointer object extract the TypeId from it
+            if (auto pointerObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(value);
+                pointerObject)
+            {
+                typeId = pointerObject->m_typeId;
+            }
+            else
+            {
+                typeId = AZ::Dom::Utils::GetValueTypeId(value);
+            }
         }
 
         AZStd::string_view typeName = PropertyEditor::Type.ExtractFromDomNode(node).value_or("");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -250,7 +250,19 @@ namespace AzToolsFramework
                     auto parentValue = PropertyEditor::ParentValue.ExtractFromDomNode(node);
                     if (parentValue.has_value())
                     {
-                        auto parentValuePtr = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(parentValue.value());
+                        // Retrieve memory address of parent value
+                        void* parentValuePtr{};
+                        // First check if the parent value is a PointerObject
+                        if (auto parentValuePointerObjectOpt = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(parentValue.value());
+                            parentValuePointerObjectOpt && parentValuePointerObjectOpt->IsValid())
+                        {
+                            parentValuePtr = parentValuePointerObjectOpt->m_address;
+                        }
+                        else if (auto parentValueVoidOpt = AZ::Dom::Utils::ValueToType<void*>(parentValue.value());
+                            parentValueVoidOpt)
+                        {
+                            parentValuePtr = *parentValueVoidOpt;
+                        }
                         AZ_Assert(parentValuePtr, "Parent instance was nullptr when attempting to add to instance list.");
 
                         // Only add parent instance if it has not been added previously

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -366,31 +366,60 @@ namespace AzToolsFramework
                 }
             }
 
-            auto value = AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Value.ExtractFromDomNode(node);
-            if (value.has_value())
-            {
-                m_proxyValue = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()).value_or(m_proxyValue);
-            }
-
             AZ::SerializeContext* serializeContext = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(serializeContext, "Serialization context not available");
 
+            AZ::TypeId typeId;
+            auto value = AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Value.ExtractFromDomNode(node);
+            if (value.has_value())
+            {
+                if (auto valueToType = AZ::Dom::Utils::ValueToType<WrappedType>(value.value()); valueToType)
+                {
+                    m_proxyValue = *valueToType;
+                    typeId = m_proxyClassData.m_typeId;
+                }
+                else if (auto valueToPointerObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(value.value()); valueToPointerObject)
+                {
+                    if (valueToPointerObject->m_typeId == m_proxyClassData.m_typeId)
+                    {
+                        m_proxyValue = *reinterpret_cast<WrappedType*>(valueToPointerObject->m_address);
+                        typeId = valueToPointerObject->m_typeId;
+                    }
+                    else
+                    {
+                        const AZ::SerializeContext::ClassData* pointerClassData =
+                            serializeContext != nullptr ? serializeContext->FindClassData(valueToPointerObject->m_typeId) : nullptr;
+                        if (pointerClassData != nullptr && pointerClassData->m_azRtti != nullptr)
+                        {
+                            if (auto castInstance = pointerClassData->m_azRtti->Cast<WrappedType>(valueToPointerObject->m_address); castInstance != nullptr)
+                            {
+                                m_proxyValue = *castInstance;
+                                // Set the type ID to the derived class ID
+                                typeId = valueToPointerObject->m_typeId;
+                            }
+                        }
+                    }
+                }
+            }
+
             // Set the m_genericClassInfo (if any) for our type in case the property handler needs to access it
             // when downcasting to the generic type (e.g. for asset property downcasting to the generic AZ::Data::Asset<AZ::Data::AssetData>)
-            auto typeIdAttribute = node.FindMember(PropertyEditor::ValueType.GetName());
-            AZ::TypeId typeId = AZ::TypeId::CreateNull();
-            if (typeIdAttribute != node.MemberEnd())
+            if (typeId.IsNull())
             {
-                typeId = AZ::Dom::Utils::DomValueToTypeId(typeIdAttribute->second);
-            }
-            else if (value.has_value())
-            {
-                typeId = AZ::Dom::Utils::GetValueTypeId(value.value());
-            }
-            if (!typeId.IsNull())
-            {
-                m_proxyClassElement.m_genericClassInfo = serializeContext->FindGenericClassInfo(typeId);
+                auto typeIdAttribute = node.FindMember(PropertyEditor::ValueType.GetName());
+                if (typeIdAttribute != node.MemberEnd())
+                {
+                    typeId = AZ::Dom::Utils::DomValueToTypeId(typeIdAttribute->second);
+                }
+                else if (value.has_value())
+                {
+                    typeId = AZ::Dom::Utils::GetValueTypeId(value.value());
+                }
+                if (!typeId.IsNull())
+                {
+                    m_proxyClassElement.m_genericClassInfo = serializeContext->FindGenericClassInfo(typeId);
+                }
             }
 
             if (m_widget)
@@ -585,7 +614,7 @@ namespace AzToolsFramework
         InstanceDataNode m_proxyParentNode;
         AZ::SerializeContext::ClassData m_proxyClassData;
         AZ::SerializeContext::ClassElement m_proxyClassElement;
-        WrappedType m_proxyValue;
+        WrappedType m_proxyValue{};
     };
 
     template <class WidgetType>


### PR DESCRIPTION
Added support to the Legacy Reflection Bridge to access Enum options reflected to the Serialize Context, to allow an enum value to be displayed as string instead of a number

Added support for a ToString attribute which works with both the EditContext and SerializeContext, that can be used to convert a type instance to a string.

So far the AZStd::pair reflection has a `ToString` attribute which can convert both elements of a pair to a string.

The Legacy Reflection Bridge associative container support has been updated to query the `ToString` attribute for any key it is processing and use that attribute function to convert the key to a string.

This allows aggregate types like a pair to be convertable to a label that is displayable in the DPE.

fixes #16771
fixes #16770

## How was this PR tested?

Verified the associative container changes in the `DPEDebugViewStandalone` application
![image](https://github.com/o3de/o3de/assets/56135373/8aac67d1-138c-4500-9dff-305b1a83a1ad)

