### PR TITLE
Updated the Json Deserialization for AZ::PointerObject

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
@@ -30,6 +30,8 @@ namespace AZ
     {
         namespace JSR = JsonSerializationResult;
 
+        AZ::PointerObject localInstance;
+
         JSR::ResultCode result(JSR::Tasks::ReadField);
 
         const char* PointerObjectTypeName = AZ::AzTypeInfo<PointerObject>::Name();
@@ -90,7 +92,7 @@ namespace AZ
                     if (result.GetProcessing() == JSR::Processing::Completed)
                     {
                         // If the value pointer address was successfully read, store it in the address member
-                        pointerObject->m_address = reinterpret_cast<void*>(pointerAddressIntPtr);
+                        localInstance.m_address = reinterpret_cast<void*>(pointerAddressIntPtr);
                     }
                     else
                     {
@@ -110,7 +112,7 @@ namespace AZ
                 }
                 if (auto typeIt = inputValue.FindMember(PointerJsonSerializerInternal::TypeField); typeIt != inputValue.MemberEnd())
                 {
-                    result.Combine(ContinueLoading(&pointerObject->m_typeId, azrtti_typeid<AZ::TypeId>(), typeIt->value, context));
+                    result.Combine(ContinueLoading(&localInstance.m_typeId, azrtti_typeid<AZ::TypeId>(), typeIt->value, context));
 
                     if (result.GetProcessing() != JSR::Processing::Completed)
                     {
@@ -129,6 +131,13 @@ namespace AZ
                             PointerObjectTypeName)));
                 }
 
+                // All fields have been succesfully loaded into the local instance
+                // so copy it over to the outputValue address
+                if (result.GetProcessing() == JSR::Processing::Completed)
+                {
+                    *pointerObject = AZStd::move(localInstance);
+                }
+
                 return context.Report(
                     result,
                     result.GetOutcome() <= JSR::Outcomes::PartialSkip
@@ -143,7 +152,7 @@ namespace AZ
         case rapidjson::kNumberType:
             return context.Report(
                 JSR::Tasks::ReadField,
-                JSR::Outcomes::TypeMismatch,
+                JSR::Outcomes::Invalid,
                 ReporterString::format("Unsupported type. %s can only be read from an object.", PointerObjectTypeName));
 
         default:
@@ -195,5 +204,10 @@ namespace AZ
             result,
             result.GetProcessing() == JSR::Processing::Completed ? ReporterString::format("%s stored successfully.", PointerObjectTypeName)
                                                                  : ReporterString::format("Failed to store %s.", PointerObjectTypeName));
+    }
+
+    auto PointerJsonSerializer::GetOperationsFlags() const -> BaseJsonSerializer::OperationFlags
+    {
+        return BaseJsonSerializer::OperationFlags::ManualDefault;
     }
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
@@ -98,6 +98,16 @@ namespace AZ
                             result, ReporterString::format("Failed to read pointer address for %s.", PointerObjectTypeName)));
                     }
                 }
+                else
+                {
+                    result.Combine(context.Report(
+                        JSR::Tasks::ReadField,
+                        JSR::Outcomes::Missing,
+                        ReporterString::format(
+                            R"(Field "%s" is required for reading a %s.)",
+                            PointerJsonSerializerInternal::AddressField,
+                            PointerObjectTypeName)));
+                }
                 if (auto typeIt = inputValue.FindMember(PointerJsonSerializerInternal::TypeField); typeIt != inputValue.MemberEnd())
                 {
                     result.Combine(ContinueLoading(&pointerObject->m_typeId, azrtti_typeid<AZ::TypeId>(), typeIt->value, context));
@@ -107,6 +117,16 @@ namespace AZ
                         result.Combine(
                             context.Report(result, ReporterString::format("Failed to read type id for %s.", PointerObjectTypeName)));
                     }
+                }
+                else
+                {
+                    result.Combine(context.Report(
+                        JSR::Tasks::ReadField,
+                        JSR::Outcomes::Missing,
+                        ReporterString::format(
+                            R"(Field "%s" is required for reading a %s.)",
+                            PointerJsonSerializerInternal::TypeField,
+                            PointerObjectTypeName)));
                 }
 
                 return context.Report(
@@ -123,7 +143,7 @@ namespace AZ
         case rapidjson::kNumberType:
             return context.Report(
                 JSR::Tasks::ReadField,
-                JSR::Outcomes::Unsupported,
+                JSR::Outcomes::TypeMismatch,
                 ReporterString::format("Unsupported type. %s can only be read from an object.", PointerObjectTypeName));
 
         default:

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
@@ -34,5 +34,7 @@ namespace AZ
             const void* defaultValue,
             const Uuid& valueTypeId,
             JsonSerializerContext& context) override;
+
+        BaseJsonSerializer::OperationFlags GetOperationsFlags() const override;
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
@@ -286,7 +286,7 @@ namespace JsonSerializationTests
         }
 
     protected:
-        void Load_InvalidType_ReturnsUnsupported(rapidjson::Type type)
+        void Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::Type type)
         {
             using namespace AZ::JsonSerializationResult;
 
@@ -306,8 +306,17 @@ namespace JsonSerializationTests
 
                 ResultCode result = serializer->Load(instance.get(), azrtti_typeid(*original), 
                     testValue, *this->m_jsonDeserializationContext);
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
-                EXPECT_EQ(Processing::Altered, result.GetProcessing());
+
+                if (this->m_features.m_mandatoryFields.empty())
+                {
+                    EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                    EXPECT_EQ(Processing::Altered, result.GetProcessing());
+                }
+                else
+                {
+                    EXPECT_THAT(result.GetOutcome(), ::testing::AnyOf(Outcomes::Unsupported, Outcomes::Invalid));
+                    EXPECT_THAT(result.GetProcessing(), ::testing::AnyOf(Processing::Altered, Processing::Halted));
+                }
                 EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
             }
         }
@@ -345,37 +354,37 @@ namespace JsonSerializationTests
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfNullType_ReturnsUnsupported)
     { 
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kNullType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kNullType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfFalseType_ReturnsUnsupported)
     { 
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kFalseType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kFalseType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfTrueType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kTrueType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kTrueType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfObjectType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kObjectType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kObjectType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfArrayType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kArrayType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kArrayType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfStringType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kStringType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kStringType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfNumberType_ReturnsUnsupported) 
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kNumberType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kNumberType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeUnreflectedType_ReturnsUnsupported)
@@ -421,10 +430,10 @@ namespace JsonSerializationTests
             }
             else
             {
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
             }
             EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
@@ -457,10 +466,10 @@ namespace JsonSerializationTests
             }
             else
             {
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
             }
             EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
@@ -683,7 +692,7 @@ namespace JsonSerializationTests
         EXPECT_TRUE(this->m_description.AreEqual(*instance, *compare));
     }
 
-    TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeWithMissingMandatoryField_LoadFailedAndUnsupportedReported)
+    TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeWithMissingMandatoryField_LoadFailedAndMissingReported)
     {
         using namespace AZ::JsonSerializationResult;
 
@@ -707,10 +716,10 @@ namespace JsonSerializationTests
                 ResultCode result = serializer->Load(instance.get(), azrtti_typeid(*instance),
                     *this->m_jsonDocument, *this->m_jsonDeserializationContext);
 
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
                 EXPECT_TRUE(this->m_description.AreEqual(*instance, *compare));
             }
@@ -1360,7 +1369,7 @@ namespace JsonSerializationTests
         Load_DeserializeFullInstanceOnTopOfPartialDefaulted_SucceedsAndObjectMatchesParialInstance,
         Load_DefaultToPointer_SucceedsAndValueIsInitialized,
         Load_InitializeNewInstance_SucceedsAndValueIsInitialized,
-        Load_DeserializeWithMissingMandatoryField_LoadFailedAndUnsupportedReported,
+        Load_DeserializeWithMissingMandatoryField_LoadFailedAndMissingReported,
         Load_InsertAdditionalData_SucceedsAndObjectMatchesFullySetInstance,
         Load_HaltedThroughCallback_LoadFailsAndHaltReported,
         Load_CorruptedValue_SucceedsWithDefaultValuesUsed,

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
@@ -56,6 +56,7 @@ namespace JsonSerializationTests
             features.m_supportsPartialInitialization = false;
             features.m_supportsInjection = false;
             features.m_defaultIsEqualToEmpty = false;
+            features.m_mandatoryFields = { "$address", "$type" };
         }
 
         bool AreEqual(const AZ::PointerObject& lhs, const AZ::PointerObject& rhs) override

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.cpp
@@ -52,7 +52,7 @@ namespace AZ
             Uuid functorTypeId;
             if (!inputValue.HasMember(TypeField))
             {
-                return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Unsupported, "Functor type name is not specified.");
+                return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Missing, "Functor type name is not specified.");
             }
 
             // Load the name first and find the type.


### PR DESCRIPTION
The Loading of an AZ::PointerObject is now strict with it requiring that the JSON being deserialized to be a JSON object and the fields of "$address" and "$type" are required to exist.

This makes sure that de-serializing to an `AZ::PointerObject` doesn't succeed in the cases when the [Dom::Utils::ValueToType](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/DOM/DomUtils.h#L361-L374) function first converts the DOM::Value to a RapidJSON document and then use JSON Deserialization to convert the type to an `AZ::PointerObject`.

## How was this PR tested?

Verified that the CVar Editor correctly shows the property handlers for integers, bools and string values

Also verified that modifying checkbox values correctly applies the change to the underlying bool of a console variable

![image](https://github.com/o3de/o3de/assets/56135373/18eda699-8660-4a72-932d-12330462b827)

