### PR TITLE
Script Canvas: Add translation support to method node execution slots

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -473,7 +473,7 @@ namespace ScriptCanvasEditor::Nodes
                     key << context << className << "methods" << updatedMethodName << direction << "name";
 
                     bool success = false;
-                    AZStd::string result = "";
+                    AZStd::string result;
                     GraphCanvas::TranslationRequestBus::BroadcastResult(success, &GraphCanvas::TranslationRequests::Get, key, result);
                     if (success)
                     {

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -464,6 +464,32 @@ namespace ScriptCanvasEditor::Nodes
                     GraphCanvas::TranslationRequestBus::BroadcastResult(
                         details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
                 }
+                else
+                {
+                    AZStd::string direction = (slot.IsInput()) ? "entry" : "exit";
+
+                    // Get the translated value for the execution slot
+                    key.clear();
+                    key << context << className << "methods" << updatedMethodName << direction << "name";
+
+                    bool success = false;
+                    AZStd::string result = "";
+                    GraphCanvas::TranslationRequestBus::BroadcastResult(success, &GraphCanvas::TranslationRequests::Get, key, result);
+                    if (success)
+                    {
+                        details.m_name = result;
+                    }
+
+                    key.clear();
+                    key << context << className << "methods" << updatedMethodName << direction << "tooltip";
+
+                    GraphCanvas::TranslationRequestBus::BroadcastResult(success, &GraphCanvas::TranslationRequests::Get, key, result);
+                    if (success)
+                    {
+                        details.m_tooltip = result;
+                    }
+
+                }
 
                 GraphCanvas::SlotRequestBus::Event(
                     graphCanvasSlotId, &GraphCanvas::SlotRequests::SetDetails, details.m_name, details.m_tooltip);


### PR DESCRIPTION
## What does this PR do?

Add translation support to method node execution slots. 

Closes #13692 