### PR TITLE
Vulkan: Better device removed error message when GPU-CPU in-sync is on

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -86,7 +86,7 @@ namespace AZ
             AZ_Assert(static_cast<uint32_t>(m_lastCompletedScope + 1) == contextIndex, "Contexts must be recorded in order!");
 
             const Scope* scope = m_scopes[contextIndex];
-            m_commandList->SetName(m_mergedCommandListName);
+            m_commandList->SetName(m_name);
             m_commandList->BeginDebugLabel(scope->GetMarkerLabel().data());
             context.SetCommandList(*m_commandList);
 
@@ -145,6 +145,11 @@ namespace AZ
         void FrameGraphExecuteGroupMerged::SetRenderPasscontexts(AZStd::span<const RenderPassContext> renderPassContexts)
         {
             m_renderPassContexts = renderPassContexts;
+        }
+
+        void FrameGraphExecuteGroupMerged::SetName(const Name& name)
+        {
+            m_name = name;
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.h
@@ -34,6 +34,8 @@ namespace AZ
             void SetPrimaryCommandList(CommandList& commandList);
             //! Set the list of renderpasses that the group will use.
             void SetRenderPasscontexts(AZStd::span<const RenderPassContext> renderPassContexts);
+            //! Set the name of the commandlist the group will use
+            void SetName(const Name& name);
 
             //////////////////////////////////////////////////////////////////////////
             // FrameGraphExecuteGroupBase
@@ -62,7 +64,7 @@ namespace AZ
             // List of renderpasses and framebuffers used by the scopes in the group.
             AZStd::span<const RenderPassContext> m_renderPassContexts;
             // Name used by the command list encoding the work for this group
-            const AZ::Name m_mergedCommandListName{ "Merged" };
+            AZ::Name m_name{ "Merged" };
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -85,6 +85,7 @@ namespace AZ
                 {
                     mergedScopes.push_back(&scope);
                     FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
+                    multiScopeContextGroup->SetName(scope.GetName());
                     multiScopeContextGroup->Init(device, AZStd::move(mergedScopes));
                 }
                 scopePrev = &scope;


### PR DESCRIPTION
## What does this PR do?

The device removed error message was always "GPU device was removed while working on pass Merged. Check the log file for more detail.", even though we know the name of the pass when GPU-CPU in-sync is turned on.
This PR replaces the `Merged` in the error message with the Pass name.

## How was this PR tested?

Vulkan and Windows
