### PR TITLE
Clang build fix removed unused `proxyAddress` variable.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -393,16 +393,6 @@ namespace AzToolsFramework
 
                         auto proxyClassData = serializeContext->FindClassData(m_proxyClassData.m_typeId);
 
-                        void* proxyAddress{};
-                        if constexpr (AZStd::is_pointer_v<WrappedType>)
-                        {
-                            proxyAddress = m_proxyValue;
-                        }
-                        else
-                        {
-                            proxyAddress = &m_proxyValue;
-                        }
-
                         if (pointerClassData != nullptr && pointerClassData->m_azRtti != nullptr &&
                             pointerClassData->m_azRtti->IsTypeOf<WrappedType>())
                         {


### PR DESCRIPTION
The variable is causing a set, but not used warning when building with clang

```
o3de/Code/Framework/AzToolsFramework/./AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h:396:31: error: variable 'proxyAddress' set but not used [-Werror,-Wunused-but-set-variable]
                        void* proxyAddress{};
```


## How was this PR tested?

Built using Clang 16 on a Linux platform successfully
