### PR TITLE
prefab override cherry-picks, and defaulting DPE editing to "on" 

### DIFF
--- a/AutomatedTesting/Registry/editorpreferences.setreg
+++ b/AutomatedTesting/Registry/editorpreferences.setreg
@@ -3,5 +3,13 @@
         "Preferences": {
             "EnablePrefabSystem": true
         }
+    },
+"O3DE": {
+        "Autoexec": {
+            "ConsoleCommands": {
+                "ed_enableDPEInspector": true,
+                "ed_enableInspectorOverrideManagement": true
+            }
+        }
     }
 }

--- a/AutomatedTesting/Registry/editorpreferences.setreg
+++ b/AutomatedTesting/Registry/editorpreferences.setreg
@@ -3,13 +3,5 @@
         "Preferences": {
             "EnablePrefabSystem": true
         }
-    },
-"O3DE": {
-        "Autoexec": {
-            "ConsoleCommands": {
-                "ed_enableDPEInspector": true,
-                "ed_enableInspectorOverrideManagement": true
-            }
-        }
     }
 }

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
@@ -126,9 +126,15 @@ namespace AZ
     };
 
     template<class T>
-    struct ConsoleCommandMemberFunctorSignature <T, AZStd::enable_if_t<AZStd::is_class_v<T>>>
+    struct ConsoleCommandMemberFunctorSignature<T, AZStd::enable_if_t<AZStd::is_class_v<T> && !AZStd::is_const_v<T>>>
     {
         using type = void (T::*)(const ConsoleCommandContainer&);
+    };
+
+    template<class T>
+    struct ConsoleCommandMemberFunctorSignature <T, AZStd::enable_if_t<AZStd::is_class_v<T> && AZStd::is_const_v<T>>>
+    {
+        using type = void (T::*)(const ConsoleCommandContainer&) const;
     };
 
     //! @class ConsoleFunctor

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -49,6 +49,12 @@ namespace AZStd
     template<class T>
     class shared_ptr;
 
+    template<class T, class = void>
+    inline constexpr bool HasToString_v = false;
+    template<class T>
+    inline constexpr bool HasToString_v<T, AZStd::enable_if_t<
+        AZStd::is_void_v<decltype(AZStd::to_string(AZStd::declval<AZStd::string&>(), AZStd::declval<T>()), void())>> > = true;
+
     inline namespace AssociativeInternal
     {
         // SFINAE expression to determine whether an associative container is an actual map with a corresponding value for each key,
@@ -2830,6 +2836,27 @@ namespace AZ
             GenericClassPair()
                 : m_classData{ SerializeContext::ClassData::Create<PairType>(AZ::AzTypeInfo<PairType>::Name(), GetSpecializedTypeId(), Internal::NullFactory::GetInstance(), nullptr, &m_pairContainer) }
             {
+                // Convert a pair to a string, if both types of the pair
+                // supports the AZStd::to_string function
+                auto PairToString = [](const void* pairInst) -> AZStd::string
+                {
+                    auto pairElement = reinterpret_cast<const PairType*>(pairInst);
+                    AZStd::string result;
+                    if constexpr (AZStd::HasToString_v<T1> && AZStd::HasToString_v<T2>)
+                    {
+                        AZStd::string value;
+                        AZStd::to_string(value, pairElement->first);
+                        result += "<";
+                        result += value;
+                        result += ", ";
+                        AZStd::to_string(value, pairElement->second);
+                        result += value;
+                        result += ">";
+                    }
+
+                    return result;
+                };
+                m_classData.m_attributes.emplace_back(AZ::Crc32("ToString"), CreateModuleAttribute(AZStd::move(PairToString)));
             }
 
             SerializeContext::ClassData* GetClassData() override

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -63,7 +63,55 @@ namespace AZStd
         constexpr bool IsMapType_v = false;
         template<class T>
         constexpr bool IsMapType_v<T, enable_if_t<Internal::sfinae_trigger_v<typename T::mapped_type>>> = true;
+
+        template <class T>
+        constexpr bool IsOrderedSetImpl_v = false;
+
+        template<class K, class C, class A>
+        constexpr bool IsOrderedSetImpl_v<AZStd::set<K, C, A>> = true;
+
+        template<class K, class C, class A>
+        constexpr bool IsOrderedSetImpl_v<AZStd::multimap<K, C, A>> = true;
+
+        template <class T>
+        constexpr bool IsOrderedMapImpl_v = false;
+
+        template<class K, class M, class C, class A>
+        constexpr bool IsOrderedMapImpl_v<AZStd::map<K, M, C, A>> = true;
+
+        template<class K, class M, class C, class A>
+        constexpr bool IsOrderedMapImpl_v<AZStd::multimap<K, M, C, A>> = true;
+
+        template <class T>
+        constexpr bool IsUnorderedSetImpl_v = false;
+
+        template <class K, class H, class E, class A>
+        constexpr bool IsUnorderedSetImpl_v<AZStd::unordered_set<K, H, E, A>> = true;
+
+        template <class K, class H, class E, class A>
+        constexpr bool IsUnorderedSetImpl_v<AZStd::unordered_multiset<K, H, E, A>> = true;
+
+        template <class T>
+        constexpr bool IsUnorderedMapImpl_v = false;
+
+        template <class K, class M, class H, class E, class A>
+        constexpr bool IsUnorderedMapImpl_v<AZStd::unordered_map<K, M, H, E, A>> = true;
+
+        template <class K, class M, class H, class E, class A>
+        constexpr bool IsUnorderedMapImpl_v<AZStd::unordered_multimap<K, M, H, E, A>> = true;
     }
+
+    template <class T>
+    constexpr bool IsOrderedSet_v = AssociativeInternal::IsOrderedSetImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsOrderedMap_v = AssociativeInternal::IsOrderedMapImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsUnorderedSet_v = AssociativeInternal::IsUnorderedSetImpl_v<AZStd::remove_cvref_t<T>>;
+
+    template <class T>
+    constexpr bool IsUnorderedMap_v = AssociativeInternal::IsUnorderedMapImpl_v<AZStd::remove_cvref_t<T>>;
 }
 
 namespace AZ
@@ -667,8 +715,8 @@ namespace AZ
 
         template<class T>
         class AZStdAssociativeContainer
-            : public SerializeContext::IDataContainer
-            , public SerializeContext::IDataContainer::IAssociativeDataContainer
+            : public Serialize::IDataContainer
+            , public Serialize::IDataContainer::IAssociativeDataContainer
         {
             using ValueType = typename T::value_type;
             using ValueClass = AZStd::remove_pointer_t<ValueType>;
@@ -799,6 +847,11 @@ namespace AZ
                 return this;
             }
 
+            const SerializeContext::IDataContainer::IAssociativeDataContainer* GetAssociativeContainerInterface() const override
+            {
+                return this;
+            }
+
             /// Reserve element
             void*   ReserveElement(void* instance, const  SerializeContext::ClassElement* classElement) override
             {
@@ -825,6 +878,31 @@ namespace AZ
             }
 
         public:
+            Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType GetAssociativeType() const override
+            {
+                using AssociativeType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+                if constexpr (AZStd::IsOrderedSet_v<T>)
+                {
+                    return AssociativeType::Set;
+                }
+                else if constexpr (AZStd::IsOrderedMap_v<T>)
+                {
+                    return AssociativeType::Map;
+                }
+                else if constexpr (AZStd::IsUnorderedSet_v<T>)
+                {
+                    return AssociativeType::UnorderedSet;
+                }
+                else if constexpr (AZStd::IsUnorderedMap_v<T>)
+                {
+                    return AssociativeType::UnorderedMap;
+                }
+                else
+                {
+                    return AssociativeType::Unknown;
+                }
+            }
+
             /// Get an element's address by its index (called before the element is loaded).
             void*   GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
@@ -835,7 +913,7 @@ namespace AZ
             }
 
             /// Get an element's address by its key. Not used for serialization.
-            void*   GetElementByKey(void* instance, const SerializeContext::ClassElement* classElement, const void* key) override
+            void*   GetElementByKey(void* instance, const SerializeContext::ClassElement* classElement, const void* key) const override
             {
                 (void)classElement;
                 T* containerPtr = reinterpret_cast<T*>(instance);
@@ -845,7 +923,7 @@ namespace AZ
 
             /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is
             /// the key itself
-            virtual void* GetValueByKey(void* instance, const void* key) override
+            virtual void* GetValueByKey(void* instance, const void* key) const override
             {
                 void* value = nullptr;
                 T* containerPtr = reinterpret_cast<T*>(instance);
@@ -920,7 +998,7 @@ namespace AZ
             }
 
             /// Inserts an entry at key in the container (for keyed containers only). Not used for serialization.
-            void    SetElementKey(void* element, void* key) override
+            void    SetElementKey(void* element, void* key) const override
             {
                 KeyHelper<ValueType>::SetElementKey(reinterpret_cast<ValueType*>(element), *reinterpret_cast<KeyType*>(key));
             }

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -242,6 +242,22 @@ namespace AZ
             /// Returns true if elements can be retrieved by index.
             bool    CanAccessElementsByIndex() const override   { return false; }
 
+            bool SwapElements(void* instance, size_t firstIndex, size_t secondIndex) override
+            {
+                T* arrayPtr = reinterpret_cast<T*>(instance);
+                size_t containerSize = Size(instance);
+                // Make sure the indices to swap are in range of the container
+                if (firstIndex >= containerSize || secondIndex >= containerSize)
+                {
+                    return false;
+                }
+
+                AZStd::ranges::iter_swap(AZStd::next(arrayPtr->begin(), firstIndex), AZStd::next(arrayPtr->begin(), secondIndex));
+                return true;
+            }
+
+            bool IsSequenceContainer() const override { return true; }
+
             /// Reserve element
             void*   ReserveElement(void* instance, const SerializeContext::ClassElement* classElement) override
             {

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContext.cpp
@@ -8,6 +8,146 @@
 
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Console/IConsoleTypes.h>
+
+namespace AZ
+{
+    static void LogAssociativeContainerFields(const EditContext& editContext, const AZ::ConsoleCommandContainer&)
+    {
+        AZStd::string logString = "\nParent Reflected Class, Associative Element Name, Associative Type\n";
+        Edit::TypeVisitor logFieldVisitor;
+        logFieldVisitor.m_classDataVisitor = [&logString, &editContext](const Edit::ClassData& classData) -> bool
+        {
+            // Iterate over each reflected Edit::ElementData field
+            // and check if it has an associated SerializeContext class element which
+            // provides a DataContainer as part of its SerializeContext ClassData which inherits
+            // from IAssociativeDataContainer
+            for (const AZ::Edit::ElementData& syntheticElement : classData.m_elements)
+            {
+                if (syntheticElement.m_serializeClassElement != nullptr)
+                {
+                    // The edit element data is backed by a serialize context field
+                    // so query its class data
+                    auto elementClassData =
+                        editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
+                    if (elementClassData == nullptr)
+                    {
+                        continue;
+                    }
+
+                    // Check if the type contains an AssociativeContainer
+                    using IAssociativeContainer = Serialize::IDataContainer::IAssociativeDataContainer;
+                    const IAssociativeContainer* associativeContainer = elementClassData->m_container != nullptr
+                        ? elementClassData->m_container->GetAssociativeContainerInterface()
+                        : nullptr;
+                    if (associativeContainer == nullptr)
+                    {
+                        continue;
+                    }
+
+                    // Once this point has been reached, the reflected element corresponds to an associative container
+                    // So log the name of the containing class
+                    logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
+                }
+            }
+            return true;
+        };
+
+        editContext.EnumerateAll(logFieldVisitor);
+        AZ::Debug::Trace::Instance().Output("EditContext", logString.c_str());
+    }
+
+    static void LogSequenceContainerFields(const EditContext& editContext, const AZ::ConsoleCommandContainer&)
+    {
+        AZStd::string logString = "\nParent Reflected Class, Sequence Element Name, Sequence Type\n";
+        Edit::TypeVisitor logFieldVisitor;
+        logFieldVisitor.m_classDataVisitor = [&logString, &editContext](const Edit::ClassData& classData) -> bool
+        {
+            // Iterate over each reflected Edit::ElementData field
+            // and check if it has an associated SerializeContext class element which
+            // provides a IDataContainer which is a sequence container
+            for (const AZ::Edit::ElementData& syntheticElement : classData.m_elements)
+            {
+                if (syntheticElement.m_serializeClassElement != nullptr)
+                {
+                    // The edit element data is backed by a serialize context field
+                    // so query its class data
+                    auto elementClassData =
+                        editContext.GetSerializeContext().FindClassData(syntheticElement.m_serializeClassElement->m_typeId);
+
+                    // If the class element doesn't have an IDataContainer that is a sequence then continue to the next element
+                    if (elementClassData == nullptr || elementClassData->m_container == nullptr ||
+                        !elementClassData->m_container->IsSequenceContainer())
+                    {
+                        continue;
+                    }
+
+                    logString += AZStd::string::format(R"("%s", "%s", "%s")" "\n", classData.m_name, syntheticElement.m_name, elementClassData->m_name);
+                }
+            }
+            return true;
+        };
+
+        editContext.EnumerateAll(logFieldVisitor);
+        AZ::Debug::Trace::Instance().Output("EditContext", logString.c_str());
+    }
+
+    static void RegisterEditContextLoggingConsoleCommand(
+        Edit::Internal::ConsoleFunctorHandle& consoleFunctorHandle, AZ::IConsole* console, const EditContext& editContext)
+    {
+        if (console == nullptr)
+        {
+            return;
+        }
+
+        consoleFunctorHandle.m_consoleFunctors.emplace_back(
+            *console,
+            "ed_logReflectedAssociativeContainerFields",
+            "Logs all associative container fields (map, set, unordered_map, unordered_set) that have been reflected to the Edit Context.\n"
+            "The name of the field is output along with the name of the class where the field is reflected.\n"
+            "Also output are the names of the types that were reflected.",
+            AZ::ConsoleFunctorFlags::DontReplicate,
+            AZ::TypeId{},
+            editContext,
+            &LogAssociativeContainerFields);
+
+        consoleFunctorHandle.m_consoleFunctors.emplace_back(
+            *console,
+            "ed_logReflectedSequenceContainerFields",
+            "Logs all sequence container fields (array, vector, fixed_vector, list, forward_list) that have been reflected to the Edit Context.\n"
+            "The name of the field is output along with the name of the class where the field is reflected.\n"
+            "Also output are the names of the types that were reflected.\n"
+            "NOTE: The deque container is not supported for reflection in the SerializeContext at this time.",
+            AZ::ConsoleFunctorFlags::DontReplicate,
+            AZ::TypeId{},
+            editContext,
+            &LogSequenceContainerFields);
+    }
+}
+
+namespace AZ::Edit
+{
+    TypeVisitor::TypeVisitor()
+    {
+        m_classDataVisitor = [](const Edit::ClassData&) -> bool
+        {
+            return false;
+        };
+
+        m_enumDataVisitor = [](const TypeId&, const Edit::ElementData&) -> bool
+        {
+            return false;
+        };
+    }
+}
+
+namespace AZ::Edit::Internal
+{
+    ConsoleFunctorHandle::ConsoleFunctorHandle() = default;
+    ConsoleFunctorHandle::~ConsoleFunctorHandle() = default;
+}
+
 namespace AZ
 {
     //=========================================================================
@@ -17,6 +157,7 @@ namespace AZ
     EditContext::EditContext(SerializeContext& serializeContext)
         : m_serializeContext(serializeContext)
     {
+        RegisterEditContextLoggingConsoleCommand(m_consoleCommandHandle, AZ::Interface<AZ::IConsole>::Get(), *this);
     }
 
     //=========================================================================
@@ -96,6 +237,15 @@ namespace AZ
             data = &enumIt->second;
         }
         return data;
+    }
+
+    SerializeContext& EditContext::GetSerializeContext()
+    {
+        return m_serializeContext;
+    }
+    const SerializeContext& EditContext::GetSerializeContext() const
+    {
+        return m_serializeContext;
     }
 
     //=========================================================================
@@ -332,6 +482,31 @@ namespace AZ
 #endif // AZ_ENABLE_SERIALIZER_DEBUG
 
         return keepEnumeratingSiblings;
+    }
+
+    void EditContext::EnumerateAll(const Edit::TypeVisitor& typeVisitor, Edit::VisitFlags visitFlags) const
+    {
+        if (typeVisitor.m_classDataVisitor && (visitFlags & Edit::VisitFlags::Classes) == Edit::VisitFlags::Classes)
+        {
+            for (const Edit::ClassData& editClassData : m_classData)
+            {
+                if (!typeVisitor.m_classDataVisitor(editClassData))
+                {
+                    break;
+                }
+            }
+        }
+
+        if (typeVisitor.m_enumDataVisitor && (visitFlags & Edit::VisitFlags::Enums) == Edit::VisitFlags::Enums)
+        {
+            for (const auto& [enumTypeId, enumElementData] : m_enumData)
+            {
+                if (!typeVisitor.m_enumDataVisitor(enumTypeId, enumElementData))
+                {
+                    break;
+                }
+            }
+        }
     }
 
     namespace Edit

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -228,6 +228,9 @@ namespace AZ
 
             //! Attribute for making a slider have non-linear scale. The default is 0.5, which results in linear scale. Value can be shifted lower or higher to control more precision in the power curve at those ends (minimum = 0, maximum = 1)
             const static AZ::Crc32 SliderCurveMidpoint = AZ_CRC("SliderCurveMidpoint", 0x8c26aea2);
+
+            //! Attribute for binding a function that can convert the type being viewed to a string
+            inline constexpr AZ::Crc32 ToString{ "ToString" };
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Serialization/Json/IntSerializer.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Serialization/Json/MapSerializer.h>
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/SmartPointerSerializer.h>
 #include <AzCore/Serialization/Json/StringSerializer.h>
@@ -24,6 +25,7 @@
 #include <AzCore/Serialization/Json/UnsupportedTypesSerializer.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EnumConstantJsonSerializer.h>
+#include <AzCore/Serialization/PointerObject.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/ConfigurableStack.h>
 #include <AzCore/std/any.h>
@@ -115,6 +117,9 @@ namespace AZ
                 ->HandlesType<AZStd::bitset>();
             jsonContext->Serializer<EnumConstantJsonSerializer>()
                 ->HandlesType<AZ::Edit::EnumConstant>();
+
+            jsonContext->Serializer<PointerJsonSerializer>()
+                ->HandlesType<PointerObject>();
 
             MathReflect(jsonContext);
         }

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/PointerObject.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/utility/charconv.h>
+
+namespace AZ::PointerJsonSerializerInternal
+{
+    constexpr const char* AddressField = "$address";
+    constexpr const char* TypeField = "$type";
+} // namespace AZ::PointerJsonSerializerInternal
+
+namespace AZ
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(PointerJsonSerializer, "PointerJsonSerializer", "{4DC82ED8-1963-4408-980A-E0A512A12EC6}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(PointerJsonSerializer, BaseJsonSerializer);
+    AZ_CLASS_ALLOCATOR_IMPL(PointerJsonSerializer, SystemAllocator);
+
+    JsonSerializationResult::Result PointerJsonSerializer::Load(
+        void* outputValue, const Uuid&, const rapidjson::Value& inputValue, JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::ReadField);
+
+        const char* PointerObjectTypeName = AZ::AzTypeInfo<PointerObject>::Name();
+
+        switch (inputValue.GetType())
+        {
+        case rapidjson::kObjectType:
+            {
+                auto pointerObject = reinterpret_cast<PointerObject*>(outputValue);
+                if (auto addressIt = inputValue.FindMember(PointerJsonSerializerInternal::AddressField);
+                    addressIt != inputValue.MemberEnd())
+                {
+                    // Try to read the pointer address as an integer from the Json field
+                    uintptr_t pointerAddressIntPtr{};
+                    JSR::ResultCode addressResult =
+                        ContinueLoading(&pointerAddressIntPtr, azrtti_typeid<decltype(pointerAddressIntPtr)>(), addressIt->value, context);
+
+                    if (addressResult.GetProcessing() != JSR::Processing::Completed)
+                    {
+                        // Fall back to trying to read the pointer address as a string and convert to a integer after reading
+                        AZStd::string pointerAddressString;
+                        addressResult = ContinueLoading(
+                            &pointerAddressString, azrtti_typeid<decltype(pointerAddressString)>(), addressIt->value, context);
+                        if (addressResult.GetProcessing() == JSR::Processing::Completed)
+                        {
+                            AZStd::from_chars_result stringToIntResult{};
+                            AZStd::string_view pointerAddressView = pointerAddressString;
+                            // Now try to convert the string into a uintptr_t
+                            // std::does not deal with a leading "0x" in a hex string so an explicit check for is performed
+                            // https://en.cppreference.com/w/cpp/utility/from_chars
+                            constexpr AZStd::string_view HexPrefix = "0x";
+                            // Using StringFunc::StartsWith to perform a case-insensitive search for the hex prefix. Both "0x" and "0X" are
+                            // supported
+                            if (AZ::StringFunc::StartsWith(pointerAddressView, HexPrefix))
+                            {
+                                // Skip pass the hex prefix from the pointer string
+                                pointerAddressView = pointerAddressView.substr(HexPrefix.size());
+                                constexpr int HexBase = 16;
+                                stringToIntResult =
+                                    AZStd::from_chars(pointerAddressView.begin(), pointerAddressView.end(), pointerAddressIntPtr, HexBase);
+                            }
+                            else
+                            {
+                                stringToIntResult =
+                                    AZStd::from_chars(pointerAddressView.begin(), pointerAddressView.end(), pointerAddressIntPtr);
+                            }
+
+                            if (stringToIntResult.ec != AZStd::errc{})
+                            {
+                                addressResult.Combine(context.Report(
+                                    JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Invalid),
+                                    ReporterString::format("Cannot convert string %s to a memory address", pointerAddressString.c_str())));
+                            }
+                        }
+                    }
+
+                    result.Combine(addressResult);
+                    if (result.GetProcessing() == JSR::Processing::Completed)
+                    {
+                        // If the value pointer address was successfully read, store it in the address member
+                        pointerObject->m_address = reinterpret_cast<void*>(pointerAddressIntPtr);
+                    }
+                    else
+                    {
+                        result.Combine(context.Report(
+                            result, ReporterString::format("Failed to read pointer address for %s.", PointerObjectTypeName)));
+                    }
+                }
+                if (auto typeIt = inputValue.FindMember(PointerJsonSerializerInternal::TypeField); typeIt != inputValue.MemberEnd())
+                {
+                    result.Combine(ContinueLoading(&pointerObject->m_typeId, azrtti_typeid<AZ::TypeId>(), typeIt->value, context));
+
+                    if (result.GetProcessing() != JSR::Processing::Completed)
+                    {
+                        result.Combine(
+                            context.Report(result, ReporterString::format("Failed to read type id for %s.", PointerObjectTypeName)));
+                    }
+                }
+
+                return context.Report(
+                    result,
+                    result.GetOutcome() <= JSR::Outcomes::PartialSkip
+                        ? ReporterString::format("Successfully loaded data into %s.", PointerObjectTypeName)
+                        : ReporterString::format("Failed to load data into %s.", PointerObjectTypeName));
+            }
+        case rapidjson::kArrayType:
+        case rapidjson::kNullType:
+        case rapidjson::kStringType:
+        case rapidjson::kFalseType:
+        case rapidjson::kTrueType:
+        case rapidjson::kNumberType:
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::Unsupported,
+                ReporterString::format("Unsupported type. %s can only be read from an object.", PointerObjectTypeName));
+
+        default:
+            return context.Report(
+                JSR::Tasks::ReadField,
+                JSR::Outcomes::Unknown,
+                ReporterString::format("Unknown json type encountered for %s.", PointerObjectTypeName));
+        }
+    }
+
+    JsonSerializationResult::Result PointerJsonSerializer::Store(
+        rapidjson::Value& outputValue,
+        const void* inputValue,
+        [[maybe_unused]] const void* defaultValue,
+        const Uuid&,
+        JsonSerializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult;
+
+        JSR::ResultCode result(JSR::Tasks::WriteValue);
+
+        const char* PointerObjectTypeName = AZ::AzTypeInfo<PointerObject>::Name();
+
+        auto pointerObject = reinterpret_cast<const PointerObject*>(inputValue);
+
+        if (!outputValue.IsObject())
+        {
+            outputValue.SetObject();
+        }
+
+        auto pointerAddressAsIntPtr = reinterpret_cast<uintptr_t>(pointerObject->m_address);
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue,
+            rapidjson::StringRef(PointerJsonSerializerInternal::AddressField),
+            &pointerAddressAsIntPtr,
+            nullptr,
+            azrtti_typeid<uintptr_t>(),
+            context));
+
+        result.Combine(ContinueStoringToJsonObjectField(
+            outputValue,
+            rapidjson::StringRef(PointerJsonSerializerInternal::TypeField),
+            &pointerObject->m_typeId,
+            nullptr,
+            azrtti_typeid<AZ::TypeId>(),
+            context));
+
+        return context.Report(
+            result,
+            result.GetProcessing() == JSR::Processing::Completed ? ReporterString::format("%s stored successfully.", PointerObjectTypeName)
+                                                                 : ReporterString::format("Failed to store %s.", PointerObjectTypeName));
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AZ
+{
+    //! JSON serializer for PointerObject
+    //! This is only used for marshaling a pointer to/from a Dom Value in-meory
+    class PointerJsonSerializer : public BaseJsonSerializer
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(PointerJsonSerializer);
+        AZ_RTTI_NO_TYPE_INFO_DECL();
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        JsonSerializationResult::Result Load(
+            void* outputValue,
+            const Uuid& outputValueTypeId,
+            const rapidjson::Value& inputValue,
+            JsonDeserializerContext& context) override;
+        JsonSerializationResult::Result Store(
+            rapidjson::Value& outputValue,
+            const void* inputValue,
+            const void* defaultValue,
+            const Uuid& valueTypeId,
+            JsonSerializerContext& context) override;
+    };
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/PointerJsonSerializer.h
@@ -34,5 +34,7 @@ namespace AZ
             const void* defaultValue,
             const Uuid& valueTypeId,
             JsonSerializerContext& context) override;
+
+        BaseJsonSerializer::OperationFlags GetOperationsFlags() const override;
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/PointerObject.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/PointerObject.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/PointerObject.h>
+
+namespace AZ
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(PointerObject, "PointerObject", "{256581B7-8512-41FD-9A2C-6AF76B3E7BD6}");
+
+    bool PointerObject::IsValid() const
+    {
+        return m_address != nullptr && !m_typeId.IsNull();
+    }
+
+    bool operator==(const PointerObject& lhs, const PointerObject& rhs)
+    {
+        return lhs.m_address == rhs.m_address && lhs.m_typeId == rhs.m_typeId;
+    }
+
+    bool operator!=(const PointerObject& lhs, const PointerObject& rhs)
+    {
+        return !operator==(lhs, rhs);
+    }
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/PointerObject.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/PointerObject.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/TypeInfoSimple.h>
+
+namespace AZ
+{
+    //! Wraps a pointer for serializing the pointer address to JSON
+    //! This is not meant for serialization to filesystem
+    struct PointerObject
+    {
+        AZ_TYPE_INFO_WITH_NAME_DECL(PointerObject);
+        void* m_address{};
+        AZ::TypeId m_typeId;
+
+        bool IsValid() const;
+
+        friend bool operator==(const PointerObject& lhs, const PointerObject& rhs);
+        friend bool operator!=(const PointerObject& lhs, const PointerObject& rhs);
+    };
+
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
@@ -527,4 +527,75 @@ namespace AZ::Utils
         return ptr;
     }
 
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ClassData* editClassData, const AZ::Edit::ElementData* elementEditData)
+    {
+        // Locates attributes by searching in the following order:
+        // 1) Class element edit data attributes (EditContext from the given row of a class)
+        // 2) Class element data attributes (SerializeContext from the given row of a class)
+        // 3) Edit Class data attributes (the attributes added to a EditContext reflected class "EditorData" element)
+        // 4) Class data attributes (the base attributes of a class)
+        if (elementEditData != nullptr)
+        {
+            if (AZ::Edit::Attribute* editAttribute = elementEditData->FindAttribute(attributeId);
+                editAttribute != nullptr)
+            {
+                return editAttribute;
+            }
+        }
+
+        if (classElement != nullptr)
+        {
+            if (auto classFieldAttribute = classElement->FindAttribute(attributeId);
+                classFieldAttribute != nullptr)
+            {
+                return classFieldAttribute;
+            }
+        }
+
+        if (classData != nullptr)
+        {
+            if (auto classDataAttribute = classData->FindAttribute(attributeId);
+                classDataAttribute != nullptr)
+            {
+                return classDataAttribute;
+            }
+        }
+        // Lastly, check the AZ::SerializeContext::ClassData -> AZ::Edit::ClassData -> EditorData for attributes
+        if (editClassData != nullptr)
+        {
+            if (const auto* classEditorData = editClassData->FindElementData(AZ::Edit::ClassElements::EditorData))
+            {
+                if (auto editClassAttribute = classEditorData->FindAttribute(attributeId);
+                    editClassAttribute != nullptr)
+                {
+                    return editClassAttribute;
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ElementData* elementEditData)
+    {
+        const AZ::Edit::ClassData* editClassData = classData != nullptr ? classData->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement, const AZ::Edit::ClassData* editClassData)
+    {
+        const AZ::Edit::ElementData* elementEditData = classElement != nullptr ? classElement->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(AZ::AttributeId attributeId, const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement)
+    {
+        const AZ::Edit::ClassData* editClassData = classData != nullptr ? classData->m_editData : nullptr;
+        const AZ::Edit::ElementData* elementEditData = classElement != nullptr ? classElement->m_editData : nullptr;
+        return FindEditOrSerializeContextAttribute(attributeId, classData, classElement, editClassData, elementEditData);
+    }
 } // namespace AZ::Utils

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2395,6 +2395,7 @@ namespace AZ::Serialize
     AZ_TYPE_INFO_WITH_NAME_IMPL(ClassElement, "ClassElement", "{7D386902-A1D9-4525-8284-F68435FE1D05}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(ClassData, "ClassData", "{20EB8E2E-D807-4039-84E2-CE37D7647CD4}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(IDataContainer, "IDataContainer", "{8565CBEA-C077-4A49-927B-314533A6EDB1}");
+    AZ_RTTI_NO_TYPE_INFO_IMPL(IDataContainer);
     AZ_TYPE_INFO_WITH_NAME_IMPL(IDataContainer::IAssociativeDataContainer, "IAssociativeDataContainer", "{58CF6250-6B0F-4A25-9864-25A64EB55DB1}");
     AZ_TYPE_INFO_WITH_NAME_IMPL(EnumerateInstanceCallContext, "EnumerateInstanceCallContext", "{FCC1DB4B-72BD-4D78-9C23-C84B91589D33}");
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1054,13 +1054,14 @@ namespace AZ::Serialize
     };
 
     /**
-         * Interface for a data container. This might be an AZStd container or just a class with
-         * elements defined in some template manner (usually with templates :) )
-         */
+    * Interface for a data container. This might be an AZStd container or just a class with
+    * elements defined in some template manner (usually with templates :) )
+    */
     class IDataContainer
     {
     public:
         AZ_TYPE_INFO_WITH_NAME_DECL(IDataContainer);
+        AZ_RTTI_NO_TYPE_INFO_DECL()
 
         using ElementCB = AZStd::function< bool(void* /* instance pointer */, const Uuid& /*elementClassId*/, const ClassData* /* elementGenericClassData */, const ClassElement* /* genericClassElement */) >;
         using ElementTypeCB = AZStd::function< bool(const Uuid& /*elementClassId*/, const ClassElement* /* genericClassElement */) >;
@@ -1076,6 +1077,16 @@ namespace AZ::Serialize
             virtual void    FreeKey(void* key) = 0;
 
         public:
+            //! Stores the type structure of container the associative type represents
+            //! The valid values are an ordered set(Set, Map) or a hash table structure(UnorderedSet, UnorderedMap)
+            enum class AssociativeType
+            {
+                Unknown,
+                Set,
+                Map,
+                UnorderedSet,
+                UnorderedMap
+            };
             AZ_TYPE_INFO_WITH_NAME_DECL(IAssociativeDataContainer);
             virtual ~IAssociativeDataContainer() {}
 
@@ -1098,12 +1109,14 @@ namespace AZ::Serialize
             {
                 return AZStd::shared_ptr<void>(AllocateKey(), KeyPtrDeleter(this));
             }
-            /// Get an element's address by its key. Not used for serialization.
-            virtual void* GetElementByKey(void* instance, const ClassElement* classElement, const void* key) = 0;
-            /// Populates element with key (for associative containers). Not used for serialization.
-            virtual void    SetElementKey(void* element, void* key) = 0;
-            /// Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is the key itself
-            virtual void* GetValueByKey(void* instance, const void* key) = 0;
+            //! Get an element's address by its key. Not used for serialization.
+            virtual void* GetElementByKey(void* instance, const ClassElement* classElement, const void* key) const = 0;
+            //! Populates element with key (for associative containers). Not used for serialization.
+            virtual void    SetElementKey(void* element, void* key) const = 0;
+            //! Get the mapped value's address by its key. If there is no mapped value (like in a set<>) the value returned is the key itself
+            virtual void* GetValueByKey(void* instance, const void* key) const = 0;
+            //! Queries the type structure(Set vs. Map, Ordered vs. Hash Table) represented by the AssociativeDataContainer
+            virtual AssociativeType GetAssociativeType() const = 0;
         };
 
         /// Return default element generic name (used by most containers).
@@ -1144,6 +1157,9 @@ namespace AZ::Serialize
             return false;
         }
         virtual IAssociativeDataContainer* GetAssociativeContainerInterface() { return nullptr; }
+        virtual const IAssociativeDataContainer* GetAssociativeContainerInterface() const { return nullptr; }
+        //! Returns true if the IDataContainer represents a reflected sequence type(AZStd array, (fixed)vector, list)
+        virtual bool IsSequenceContainer() const { return false; }
         /// Reserve an element and get its address (called before the element is loaded).
         virtual void* ReserveElement(void* instance, const ClassElement* classElement) = 0;
         /// Free an element that was reserved using ReserveElement, but was not stored by calling StoreElement.

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1139,6 +1139,10 @@ namespace AZ::Serialize
         /// Returns true if elements can be retrieved by index.
         virtual bool    CanAccessElementsByIndex() const = 0;
         /// Returns the associative interface for this container (e.g. the container itself if it inherits it) if available, otherwise null.
+        virtual bool SwapElements([[maybe_unused]] void* instance, [[maybe_unused]] size_t firstIndex, [[maybe_unused]] size_t secondIndex)
+        {
+            return false;
+        }
         virtual IAssociativeDataContainer* GetAssociativeContainerInterface() { return nullptr; }
         /// Reserve an element and get its address (called before the element is loaded).
         virtual void* ReserveElement(void* instance, const ClassElement* classElement) = 0;

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
@@ -20,6 +20,8 @@ namespace AZ
             virtual int64_t GetEnumValueAsInt() const = 0;
         };
 
+        using EnumConstantBasePtr = AZStd::unique_ptr<SerializeContextEnumInternal::EnumConstantBase>;
+
         template<class EnumType>
         struct EnumConstant
             : EnumConstantBase

--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -140,4 +140,46 @@ namespace AZ
         /// expected by the ClassData for this element
         void* ResolvePointer(void* ptr, const SerializeContext::ClassElement& classElement, const SerializeContext& context);
     } // namespace Utils
-} // namespace AzCore
+} // namespace Az
+
+
+namespace AZ::Utils
+{
+    //! Search the Edit context and Serialize Context attributes of class for the first attribute
+    //! matching the attributeId parameter
+    //! Locates attributes by searching in the following order:
+    //! 1) Class element edit data attributes (EditContext from the given row of a class)
+    //! 2) Class element data attributes (SerializeContext from the given row of a class)
+    //! 3) Edit Class data attributes (the attributes added to a EditContext reflected class "EditorData" element)
+    //! 4) Class data attributes (the base attributes of a class)
+    //! @param attributeId numeric ID of attribute to lookup. A string can be converted to an AttributeId by converting it to `AZ::Crc32`
+    //! @param classData Serialize Context reflected ClassData structure
+    //! @param classElement Serialize Context field element for the field being examined. This is added via the SerializeContext
+    //! ClassBuilder `Field` function
+    //! @param editClassData Edit Context reflected ClassData structure
+    //! @param elementEditData Edit Context data element for a specific field. This is added via the EditContext Class Builder `DataElement`
+    //! function
+    //! @return first attribute which matches the specified attribute ID or nullptr
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ClassData* editClassData,
+        const AZ::Edit::ElementData* elementEditData);
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ElementData* elementEditData);
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement,
+        const AZ::Edit::ClassData* editClassData);
+
+    AZ::Attribute* FindEditOrSerializeContextAttribute(
+        AZ::AttributeId attributeId,
+        const AZ::SerializeContext::ClassData* classData,
+        const AZ::SerializeContext::ClassElement* classElement);
+} // namespace AZ::Utils

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -562,6 +562,8 @@ set(FILES
     Serialization/SerializationUtils.cpp
     Serialization/ObjectStream.cpp
     Serialization/ObjectStream.h
+    Serialization/PointerObject.h
+    Serialization/PointerObject.cpp
     Serialization/SerializeContext.cpp
     Serialization/SerializeContext.h
     Serialization/SerializeContext_fwd.h
@@ -613,6 +615,8 @@ set(FILES
     Serialization/Json/MapSerializer.cpp
     Serialization/Json/PathSerializer.h
     Serialization/Json/PathSerializer.cpp
+    Serialization/Json/PointerJsonSerializer.h
+    Serialization/Json/PointerJsonSerializer.cpp
     Serialization/Json/RegistrationContext.h
     Serialization/Json/RegistrationContext.cpp
     Serialization/Json/SmartPointerSerializer.h

--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/azcore.natvis
@@ -973,7 +973,7 @@
 
     <Type Name="AZ::Dom::Path">
         <!-- Shows the DomPathEntry m_value variant using a view option of simple to only show the plain value !-->
-        <Intrinsic Name="size" Expression="m_entries.m_end - m_entries.m_start" />
+        <Intrinsic Name="size" Expression="m_entries.m_last - m_entries.m_start" />
         <DisplayString Condition="size() == 0">""</DisplayString>
         <DisplayString Condition="size() == 1">/{m_entries.m_start->m_value, view(simple)}</DisplayString>
         <DisplayString Condition="size() == 2">/{m_entries.m_start->m_value, view(simple)}</DisplayString>

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -8216,3 +8216,65 @@ namespace UnitTest
         m_serializeContext->DisableRemoveReflection();
     }
 }
+
+namespace UnitTest
+{
+    class AssociativeContainerSerializationFixture
+        : public LeakDetectionFixture
+    {
+    public:
+        AssociativeContainerSerializationFixture()
+        {
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+            m_serializeContext->RegisterGenericType<AZStd::set<int>>();
+            m_serializeContext->RegisterGenericType<AZStd::map<int, int>>();
+            m_serializeContext->RegisterGenericType<AZStd::unordered_set<int>>();
+            m_serializeContext->RegisterGenericType<AZStd::unordered_map<int, int>>();
+        }
+
+        ~AssociativeContainerSerializationFixture() override
+        {
+            m_serializeContext.reset();
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+    };
+
+    TEST_F(AssociativeContainerSerializationFixture, GetAssociativeType_ReturnsCorrectAssociativeStructure)
+    {
+        using AssociativeType = AZ::Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+
+        const auto setClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::set<int>>());
+        ASSERT_NE(nullptr, setClassData);
+        const auto setDataContainer = setClassData->m_container;
+        ASSERT_NE(nullptr, setDataContainer);
+        const auto setAssociativeContainer = setClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, setClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::Set, setAssociativeContainer->GetAssociativeType());
+
+        const auto mapClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::map<int, int>>());
+        ASSERT_NE(nullptr, mapClassData);
+        const auto mapDataContainer = mapClassData->m_container;
+        ASSERT_NE(nullptr, mapDataContainer);
+        const auto mapAssociativeContainer = mapClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, mapClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::Map, mapAssociativeContainer->GetAssociativeType());
+
+        const auto unorderedSetClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::unordered_set<int>>());
+        ASSERT_NE(nullptr, unorderedSetClassData);
+        const auto unorderedSetDataContainer = unorderedSetClassData->m_container;
+        ASSERT_NE(nullptr, unorderedSetDataContainer);
+        const auto unorderedSetAssociativeContainer = unorderedSetClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, unorderedSetClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::UnorderedSet, unorderedSetAssociativeContainer->GetAssociativeType());
+
+        const auto unorderedMapClassData = m_serializeContext->FindClassData(azrtti_typeid<AZStd::unordered_map<int, int>>());
+        ASSERT_NE(nullptr, unorderedMapClassData);
+        const auto unorderedMapDataContainer = unorderedMapClassData->m_container;
+        ASSERT_NE(nullptr, unorderedMapDataContainer);
+        const auto unorderedMapAssociativeContainer = unorderedMapClassData->m_container->GetAssociativeContainerInterface();
+        ASSERT_NE(nullptr, unorderedMapClassData->m_container->GetAssociativeContainerInterface());
+        EXPECT_EQ(AssociativeType::UnorderedMap, unorderedMapAssociativeContainer->GetAssociativeType());
+    }
+}

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
@@ -286,7 +286,7 @@ namespace JsonSerializationTests
         }
 
     protected:
-        void Load_InvalidType_ReturnsUnsupported(rapidjson::Type type)
+        void Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::Type type)
         {
             using namespace AZ::JsonSerializationResult;
 
@@ -306,8 +306,17 @@ namespace JsonSerializationTests
 
                 ResultCode result = serializer->Load(instance.get(), azrtti_typeid(*original), 
                     testValue, *this->m_jsonDeserializationContext);
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
-                EXPECT_EQ(Processing::Altered, result.GetProcessing());
+
+                if (this->m_features.m_mandatoryFields.empty())
+                {
+                    EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                    EXPECT_EQ(Processing::Altered, result.GetProcessing());
+                }
+                else
+                {
+                    EXPECT_THAT(result.GetOutcome(), ::testing::AnyOf(Outcomes::Unsupported, Outcomes::Invalid));
+                    EXPECT_THAT(result.GetProcessing(), ::testing::AnyOf(Processing::Altered, Processing::Halted));
+                }
                 EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
             }
         }
@@ -345,37 +354,37 @@ namespace JsonSerializationTests
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfNullType_ReturnsUnsupported)
     { 
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kNullType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kNullType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfFalseType_ReturnsUnsupported)
     { 
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kFalseType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kFalseType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfTrueType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kTrueType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kTrueType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfObjectType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kObjectType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kObjectType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfArrayType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kArrayType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kArrayType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfStringType_ReturnsUnsupported)
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kStringType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kStringType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_InvalidTypeOfNumberType_ReturnsUnsupported) 
     {
-        this->Load_InvalidType_ReturnsUnsupported(rapidjson::kNumberType);
+        this->Load_InvalidType_ReturnsUnsupportedOrInvalid(rapidjson::kNumberType);
     }
 
     TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeUnreflectedType_ReturnsUnsupported)
@@ -421,10 +430,10 @@ namespace JsonSerializationTests
             }
             else
             {
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
             }
             EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
@@ -457,10 +466,10 @@ namespace JsonSerializationTests
             }
             else
             {
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
             }
             EXPECT_TRUE(this->m_description.AreEqual(*original, *instance));
@@ -683,7 +692,7 @@ namespace JsonSerializationTests
         EXPECT_TRUE(this->m_description.AreEqual(*instance, *compare));
     }
 
-    TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeWithMissingMandatoryField_LoadFailedAndUnsupportedReported)
+    TYPED_TEST_P(JsonSerializerConformityTests, Load_DeserializeWithMissingMandatoryField_LoadFailedAndMissingReported)
     {
         using namespace AZ::JsonSerializationResult;
 
@@ -707,10 +716,10 @@ namespace JsonSerializationTests
                 ResultCode result = serializer->Load(instance.get(), azrtti_typeid(*instance),
                     *this->m_jsonDocument, *this->m_jsonDeserializationContext);
 
-                EXPECT_EQ(Outcomes::Unsupported, result.GetOutcome());
+                EXPECT_EQ(Outcomes::Missing, result.GetOutcome());
                 bool validProcessing =
                     result.GetProcessing() == Processing::Altered ||
-                    result.GetProcessing() == Processing::PartialAlter;
+                    result.GetProcessing() == Processing::Halted;
                 EXPECT_TRUE(validProcessing);
                 EXPECT_TRUE(this->m_description.AreEqual(*instance, *compare));
             }
@@ -1360,7 +1369,7 @@ namespace JsonSerializationTests
         Load_DeserializeFullInstanceOnTopOfPartialDefaulted_SucceedsAndObjectMatchesParialInstance,
         Load_DefaultToPointer_SucceedsAndValueIsInitialized,
         Load_InitializeNewInstance_SucceedsAndValueIsInitialized,
-        Load_DeserializeWithMissingMandatoryField_LoadFailedAndUnsupportedReported,
+        Load_DeserializeWithMissingMandatoryField_LoadFailedAndMissingReported,
         Load_InsertAdditionalData_SucceedsAndObjectMatchesFullySetInstance,
         Load_HaltedThroughCallback_LoadFailsAndHaltReported,
         Load_CorruptedValue_SucceedsWithDefaultValuesUsed,

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
@@ -56,6 +56,7 @@ namespace JsonSerializationTests
             features.m_supportsPartialInitialization = false;
             features.m_supportsInjection = false;
             features.m_defaultIsEqualToEmpty = false;
+            features.m_mandatoryFields = { "$address", "$type" };
         }
 
         bool AreEqual(const AZ::PointerObject& lhs, const AZ::PointerObject& rhs) override

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+
+#include <AzCore/Serialization/Json/PointerJsonSerializer.h>
+#include <AzCore/Serialization/PointerObject.h>
+#include <Tests/Serialization/Json/BaseJsonSerializerFixture.h>
+#include <Tests/Serialization/Json/JsonSerializerConformityTests.h>
+
+namespace JsonSerializationTests
+{
+    class PointerTestDescription
+        : public JsonSerializerConformityTestDescriptor<AZ::PointerObject>
+    {
+        static inline constexpr uintptr_t PointerAddress = 0x00facade;
+        static inline constexpr AZ::TypeId ContrivedTestTypeId = AZ::TypeId::CreateName("facade");
+    public:
+        PointerTestDescription()
+        {
+            m_fullySetJsonString = AZStd::string::format(R"(
+                {
+                    "$address": %)" PRIuPTR R"(,
+                    "$type": "%s"
+                })", PointerAddress, ContrivedTestTypeId.ToFixedString().c_str());
+        }
+        AZStd::shared_ptr<AZ::BaseJsonSerializer> CreateSerializer() override
+        {
+            return AZStd::make_shared<AZ::PointerJsonSerializer>();
+        }
+
+        AZStd::shared_ptr<AZ::PointerObject> CreateDefaultInstance() override
+        {
+            return AZStd::make_shared<AZ::PointerObject>();
+        }
+
+        AZStd::shared_ptr<AZ::PointerObject> CreateFullySetInstance() override
+        {
+            return AZStd::make_shared<AZ::PointerObject>(AZ::PointerObject{ reinterpret_cast<void*>(PointerAddress), ContrivedTestTypeId });
+        }
+
+        AZStd::string_view GetJsonForFullySetInstance() override
+        {
+            // As JSON doesn't support hexidecimal integer values
+            // The value will get output as decimal integer
+            return m_fullySetJsonString;
+        }
+
+        void ConfigureFeatures(JsonSerializerConformityTestDescriptorFeatures& features) override
+        {
+            features.EnableJsonType(rapidjson::kObjectType);
+            features.m_supportsPartialInitialization = false;
+            features.m_supportsInjection = false;
+            features.m_defaultIsEqualToEmpty = false;
+        }
+
+        bool AreEqual(const AZ::PointerObject& lhs, const AZ::PointerObject& rhs) override
+        {
+            return lhs == rhs;
+        }
+
+    private:
+        AZStd::string m_fullySetJsonString;
+    };
+
+    using PointerConformityTestTypes = ::testing::Types<PointerTestDescription>;
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Pointer, JsonSerializerConformityTests, PointerConformityTestTypes));
+} // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -209,6 +209,7 @@ set(FILES
     Serialization/Json/MathVectorSerializerTests.cpp
     Serialization/Json/MathMatrixSerializerTests.cpp
     Serialization/Json/PathSerializerTests.cpp
+    Serialization/Json/PointerSerializerTests.cpp
     Serialization/Json/SmartPointerSerializerTests.cpp
     Serialization/Json/StringSerializerTests.cpp
     Serialization/Json/TestCases.h

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -73,7 +73,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(Container::RemoveNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ClearNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ContainerCanBeModified);
-        system->RegisterNodeAttribute<PropertyEditor>(Container::PromptOnContainerClear);
 
         system->RegisterPropertyEditor<UIElement>();
         system->RegisterNodeAttribute<UIElement>(UIElement::Handler);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -131,6 +131,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto ValueType = TypeIdAttributeDefinition("ValueType");
         static constexpr auto ValueHashed = AttributeDefinition<AZ::u64>("ValueHashed");
         static constexpr auto ParentValue = AttributeDefinition<AZ::Dom::Value>("ParentValue");
+        //! IF the associated value is mapped value of an associative container such as a map or unordered_map
+        //! `pair<const key_type, mapped_type>` element, then the KeyValue attribute stores
+        //! a pointer to the key type and the type id of the key type
+        static constexpr auto KeyValue = AttributeDefinition<AZ::Dom::Value>("KeyValue");
 
         //! If set to true, specifies that this PropertyEditor shouldn't be allocated its own column, but instead appended
         //! to the previous column in the layout, creating a SharedColumn that can hold many PropertyEditors.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -116,7 +116,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t index)>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
         static constexpr auto ContainerCanBeModified = AttributeDefinition<bool>("ContainerCanBeModified");
-        static constexpr auto PromptOnContainerClear = AttributeDefinition<bool>("PromptOnContainerClear");
     };
 
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,
@@ -149,10 +148,10 @@ namespace AZ::DocumentPropertyEditor::Nodes
         //! Specifies the alignment options for a PropertyEditor that has the Alignment attribute.
         enum class Align : AZ::u8
         {
+            UseDefaultAlignment = 0,
             AlignLeft,
             AlignRight,
             AlignCenter,
-            UseDefaultAlignment
         };
         //! Specifies that this PropertyEditor should have a specific alignment within its own column. The alignment of ALL
         //! PropertyEditors inside of a SharedColumn will be the alignment of the last PropertyEditor with a valid alignment attribute.
@@ -225,13 +224,16 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         AddElement,
         RemoveElement,
-        Clear
+        Clear,
+        MoveUp,
+        MoveDown
     };
 
     struct ContainerActionButton : GenericButton
     {
         static constexpr AZStd::string_view Name = "ContainerActionButton";
         static constexpr auto Action = AttributeDefinition<ContainerAction>("Action");
+        static constexpr auto ContainerIndex = AttributeDefinition<AZ::s64>("ContainerIndex");
     };
 
     struct CheckBox : PropertyEditorDefinition

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -35,23 +35,47 @@ namespace AZ::Reflection
         const Name ContainerElementOverride = Name::FromStringLiteral("ContainerElementOverride", AZ::Interface<AZ::NameDictionary>::Get());
     } // namespace DescriptorAttributes
 
+
     // attempts to stringify the passed instance; useful for things like maps where the key element should not be user editable
-    bool GetValueStringHelper(
-        void* instance,
+    AZStd::optional<AZStd::string> StringifyInstance(
+        AZ::PointerObject instanceObject,
         const AZ::SerializeContext::ClassData* classData,
         const AZ::SerializeContext::ClassElement* classElement,
-        AZ::SerializeContext* serializeContext,
-        AZStd::string& value)
+        AZ::SerializeContext* serializeContext)
     {
+        void* instance = instanceObject.m_address;
         if (!classData)
         {
-            return false;
+            return AZStd::nullopt;
         }
-        if (!serializeContext)
+        if (serializeContext == nullptr)
         {
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+            if (auto componentApplicationRequests = AZ::Interface<AZ::ComponentApplicationRequests>::Get();
+                componentApplicationRequests != nullptr)
+            {
+                serializeContext = componentApplicationRequests->GetSerializeContext();
+            }
+            // If the serialize context is still nullptr, then return a null optional
+            if (serializeContext == nullptr)
+            {
+                return AZStd::nullopt;
+            }
         }
 
+        // First check if the instance can be converted to a string using a ToString attribute
+        if (AZ::Attribute* toStringAttribute =
+                AZ::Utils::FindEditOrSerializeContextAttribute(AZ::Edit::Attributes::ToString, classData, classElement);
+            toStringAttribute != nullptr)
+        {
+            AZ::AttributeReader toStringReader(instance, toStringAttribute);
+            AZStd::string value;
+            if (toStringReader.Read<AZStd::string>(value))
+            {
+                return value;
+            }
+        }
+
+        // Next check if the instance class element is an Enum type
         const DocumentPropertyEditor::PropertyEditorSystemInterface* propertyEditorSystem =
             AZ::Interface<DocumentPropertyEditor::PropertyEditorSystemInterface>::Get();
 
@@ -78,22 +102,136 @@ namespace AZ::Reflection
 
         if (serializeContext && !enumId.IsNull())
         {
+            AZ::Uuid underlyingTypeId;
+            extractUuidProperty(classData->m_attributes, Name("EnumUnderlyingType"), underlyingTypeId);
             // got the enumID, now get the enum's underlying type
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 const AZ::Edit::ElementData* enumElementData = editContext->GetEnumElementData(enumId);
                 if (enumElementData)
                 {
-                    AZ::Uuid underlyingTypeId;
-                    extractUuidProperty(classData->m_attributes, Name("EnumUnderlyingType"), underlyingTypeId);
-
+                    AZStd::string value;
                     // Check all underlying enum storage types for the actual representation type to query
                     if (!underlyingTypeId.IsNull() &&
                         AZ::Utils::GetEnumStringRepresentation<AZ::u8, AZ::u16, AZ::u32, AZ::u64, AZ::s8, AZ::s16, AZ::s32, AZ::s64>(
                             value, enumElementData, instance, underlyingTypeId))
                     {
+                        return value;
+                    }
+                }
+            }
+
+            // As a fall back use the Serialize Context Enum reflection option name for the string value
+
+            auto enumClassData = serializeContext->FindClassData(enumId);
+            auto underlyingIntClassData = serializeContext->FindClassData(underlyingTypeId);
+            if (enumClassData != nullptr && underlyingIntClassData != nullptr && underlyingIntClassData->m_azRtti != nullptr)
+            {
+                const TypeTraits underlyingTypeTraits = underlyingIntClassData->m_azRtti->GetTypeTraits();
+                const bool isSigned = (underlyingTypeTraits & TypeTraits::is_signed) == TypeTraits::is_signed;
+                const bool isUnsigned = (underlyingTypeTraits & TypeTraits::is_unsigned) == TypeTraits::is_unsigned;
+
+                AZStd::unordered_map<int64_t, AZStd::string_view> enumConstantsSigned;
+                AZStd::unordered_map<uint64_t, AZStd::string_view> enumConstantsUnsigned;
+                // Get each Enum Value -> Name pair
+                for (const AZ::AttributeSharedPair& enumAttributePair : enumClassData->m_attributes)
+                {
+                    if (enumAttributePair.first == AZ::Serialize::Attributes::EnumValueKey)
+                    {
+                        auto enumConstantAttribute = azrtti_cast<AZ::AttributeData<SerializeContextEnumInternal::EnumConstantBasePtr>*>(enumAttributePair.second.get());
+                        if (enumConstantAttribute == nullptr)
+                        {
+                            continue;
+                        }
+
+                        const SerializeContextEnumInternal::EnumConstantBasePtr& enumConstantPtr = enumConstantAttribute->Get(nullptr);
+                        if (isSigned)
+                        {
+                            enumConstantsSigned.emplace(enumConstantPtr->GetEnumValueAsInt(), enumConstantPtr->GetEnumValueName());
+                        }
+                        else if (isUnsigned)
+                        {
+                            enumConstantsUnsigned.emplace(enumConstantPtr->GetEnumValueAsUInt(), enumConstantPtr->GetEnumValueName());
+                        }
+                    }
+                }
+
+                AZStd::string value;
+                auto GetEnumOptionNameSigned = [&value, &enumConstantsSigned](auto signedValue) -> bool
+                {
+                    auto signedValue64 = static_cast<int64_t>(signedValue);
+                    if (auto foundIt = enumConstantsSigned.find(signedValue64); foundIt != enumConstantsSigned.end())
+                    {
+                        value = foundIt->second;
                         return true;
                     }
+
+                    return false;
+                };
+                auto GetEnumOptionNameUnsigned = [&value, &enumConstantsUnsigned](auto unsignedValue) -> bool
+                {
+                    auto unsignedValue64 = static_cast<uint64_t>(unsignedValue);
+                    if (auto foundIt = enumConstantsUnsigned.find(unsignedValue64); foundIt != enumConstantsUnsigned.end())
+                    {
+                        value = foundIt->second;
+                        return true;
+                    }
+
+                    return false;
+                };
+                // Start checking the 32-bit int and unsigned int types first since they are the more likely to be the underlying
+                // types used for an enum
+                // For example a scoped enum `enum class Foo` has a default underlying type of `int`
+                // For an unscoped enum such as `enum Foo`, the underlying type is usually `int` or `unsigned int` depending on the values
+                // of the enum
+                if (underlyingTypeId == azrtti_typeid<AZ::s32>() && GetEnumOptionNameSigned(*static_cast<AZ::s32*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u32>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u32*>(instance)))
+                {
+                    return value;
+                }
+                // Now check the 8-bit, 16-bit and 64-bit underlying types to see if an Enum uses one of them
+                else if (underlyingTypeId == azrtti_typeid<AZ::s8>() && GetEnumOptionNameSigned(*static_cast<AZ::s8*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::s16>() && GetEnumOptionNameSigned(*static_cast<AZ::s16*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<long>() && GetEnumOptionNameSigned(*static_cast<long*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::s64>() && GetEnumOptionNameSigned(*static_cast<AZ::s64*>(instance)))
+                {
+                    return value;
+                }
+                else if(underlyingTypeId == azrtti_typeid<AZ::u8>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u8*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u16>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u16*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<unsigned long>() && GetEnumOptionNameUnsigned(*static_cast<unsigned long*>(instance)))
+                {
+                    return value;
+                }
+                else if (underlyingTypeId == azrtti_typeid<AZ::u64>() && GetEnumOptionNameUnsigned(*static_cast<AZ::u64*>(instance)))
+                {
+                    return value;
+                }
+                // char is a special case
+                // It is a distinct type from signed char(AZ::s8) and unsigned char(AZ::u8) and can be either signed or unsigned
+                // so both lambdas are called to check if it is in either set
+                if (underlyingTypeId == azrtti_typeid<char>() &&
+                    (GetEnumOptionNameSigned(*static_cast<char*>(instance)) || GetEnumOptionNameUnsigned(*static_cast<char*>(instance))))
+                {
+                    return value;
                 }
             }
         }
@@ -101,27 +239,35 @@ namespace AZ::Reflection
         // Just use our underlying AZStd::string if we're a string
         if (classData->m_typeId == azrtti_typeid<AZStd::string>())
         {
-            value = *reinterpret_cast<AZStd::string*>(instance);
-            return true;
+            AZStd::string value = *reinterpret_cast<AZStd::string*>(instance);
+            return value;
         }
 
         // Fall back on using our serializer's DataToText
         if (classElement)
         {
-            if (auto& serializer = classData->m_serializer)
+            if (const auto& serializer = classData->m_serializer;
+                serializer != nullptr)
             {
+                AZStd::string value;
                 AZ::IO::MemoryStream memStream(instance, 0, classElement->m_dataSize);
                 AZ::IO::ByteContainerStream outStream(&value);
                 serializer->DataToText(memStream, outStream, false);
-                return !value.empty();
+                return value;
             }
         }
 
-        return false;
+        return AZStd::nullopt;
     }
 
     namespace LegacyReflectionInternal
     {
+        // Implement the KeyEntry is valid function
+        bool KeyEntry::IsValid() const
+        {
+            return m_keyInstance.IsValid();
+        }
+
         struct InstanceVisitor
             : IObjectAccess
             , IAttributes
@@ -130,24 +276,12 @@ namespace AZ::Reflection
             SerializeContext* m_serializeContext;
             SerializeContext::EnumerateInstanceCallContext* m_enumerateContext;
 
-            struct AttributeData
-            {
-                // Group from the attribute metadata (generally empty with Serialize/EditContext data)
-                Name m_group;
-                // Name of the attribute
-                Name m_name;
-                // DOM value of the attribute - currently only primitive attributes are supported,
-                // but other types may later be supported via opaque values
-                Dom::Value m_value;
-            };
-
             struct StackEntry
             {
-                void* m_instance;
+                AZ::PointerObject m_instance;
                 // Instance that is used to retrieve attribute values that are tied to invokable functions.
                 // Commonly, it is the parent instance for property nodes, and the instance for UI element nodes.
-                void* m_instanceToInvoke = nullptr;
-                AZ::TypeId m_typeId;
+                AZ::PointerObject m_instanceToInvoke;
 
                 //! Keeps tracks of how many pointers are attached to the instance type
                 //! For example if the actual instance being referenced is an AZ::Component, then m_pointerLevel is 0
@@ -162,7 +296,9 @@ namespace AZ::Reflection
                 DocumentPropertyEditor::Nodes::PropertyVisibility m_computedVisibility =
                     DocumentPropertyEditor::Nodes::PropertyVisibility::Show;
                 bool m_entryClosed = false;
-                size_t m_childElementIndex = 0; // TODO: this should store a PathEntry and support text for associative containers
+                size_t m_childElementIndex = 0;
+                using AssociativeContainerType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
+                AssociativeContainerType m_associativeContainerType = AssociativeContainerType::Unknown;
 
                 AZStd::string_view m_group;
                 bool m_isOpenGroup = false;
@@ -179,8 +315,17 @@ namespace AZ::Reflection
                 // extra data necessary to support Containers composed of pair<> children (like maps!)
                 bool m_extractKeyedPair = false;
                 AZ::SerializeContext::IDataContainer* m_parentContainerInfo = nullptr;
-                void* m_parentContainerOverride = nullptr;
-                void* m_containerElementOverride = nullptr;
+                AZ::PointerObject m_parentContainerOverride;
+                AZ::PointerObject m_containerElementOverride;
+                //! For the pair<> element of an associative container
+                //! this points to key instance and it's attributes
+                KeyEntry m_childKeyEntry;
+                //! Override for the mapped value of a pair<> element of an associative container
+                AZStd::string m_childMappedValueLabelOverride;
+
+                //! For the mapped_type of the pair<> element of an associative container,
+                //! stores the key instance address and type id
+                KeyEntry m_keyEntry;
 
                 const AZ::Edit::ElementData* GetElementEditMetadata() const
                 {
@@ -197,7 +342,7 @@ namespace AZ::Reflection
                 //! So this code make sure that dereferences occurs before returning the address
                 const void* GetRawInstance() const
                 {
-                    const void* directInstance = m_instance;
+                    const void* directInstance = m_instance.m_address;
                     for (AZ::u32 pointersToDereference = m_pointerLevel; pointersToDereference > 0; --pointersToDereference)
                     {
                         directInstance = *reinterpret_cast<const void* const*>(directInstance);
@@ -208,6 +353,11 @@ namespace AZ::Reflection
                 void* GetRawInstance()
                 {
                     return const_cast<void*>(AZStd::as_const(*this).GetRawInstance());
+                }
+
+                AZ::TypeId GetTypeId() const
+                {
+                    return m_instance.m_typeId;
                 }
 
                 AZStd::vector<AZStd::pair<AZStd::string, AZStd::optional<StackEntry>>> m_groups;
@@ -237,7 +387,7 @@ namespace AZ::Reflection
                 , m_serializeContext(serializeContext)
             {
                 // Push a dummy node into stack, which serves as the parent node for the first node.
-                m_stack.emplace_back(StackEntry{ instance, nullptr, typeId });
+                m_stack.emplace_back(StackEntry{ AZ::PointerObject{instance, typeId }, AZ::PointerObject{} });
 
                 m_visitFromRoot = visitFromRoot;
 
@@ -308,7 +458,7 @@ namespace AZ::Reflection
 
                 // Note that this is the dummy parent node for the root node. It contains null classData and classElement.
                 const StackEntry& nodeData = m_stack.back();
-                m_serializeContext->EnumerateInstanceConst(m_enumerateContext, nodeData.GetRawInstance(), nodeData.m_typeId, nullptr, nullptr);
+                m_serializeContext->EnumerateInstanceConst(m_enumerateContext, nodeData.GetRawInstance(), nodeData.m_instance.m_typeId, nullptr, nullptr);
             }
 
             void GenerateNodePath(const StackEntry& parentData, StackEntry& nodeData)
@@ -393,9 +543,8 @@ namespace AZ::Reflection
 
                                     constexpr AZ::u32 pointerLevel = 0;
 
-                                    StackEntry entry = { boolAddress,
+                                    StackEntry entry{ AZ::PointerObject{boolAddress, serializeClassElement->m_typeId},
                                                          nodeData.m_instance,
-                                                         serializeClassElement->m_typeId,
                                                          pointerLevel,
                                                          nullptr,
                                                          currElement.m_serializeClassElement };
@@ -413,9 +562,8 @@ namespace AZ::Reflection
                                     UIElement->m_flags = SerializeContext::ClassElement::Flags::FLG_UI_ELEMENT;
                                     // A UI node isn't backed with a real C++ type, so its pointer level is 0
                                     constexpr AZ::u32 pointerLevel =  0;
-                                    StackEntry entry = { nodeData.m_instance,
+                                    StackEntry entry{ nodeData.m_instance,
                                                          nodeData.m_instance,
-                                                         nodeData.m_classData->m_typeId,
                                                          pointerLevel,
                                                          nodeData.m_classData,
                                                          UIElement };
@@ -474,10 +622,7 @@ namespace AZ::Reflection
                             UIElement->m_flags = SerializeContext::ClassElement::Flags::FLG_UI_ELEMENT;
                             // Use the instance itself to retrieve parameter values that invoke functions on the UI Element.
                             constexpr AZ::u32 pointerLevel = 0;
-                            StackEntry entry = {
-                                nodeData.m_instance, nodeData.m_instance, nodeData.m_classData->m_typeId, pointerLevel,
-                                nodeData.m_classData, UIElement
-                            };
+                            StackEntry entry{ nodeData.m_instance, nodeData.m_instance, pointerLevel, nodeData.m_classData, UIElement };
 
                             AZStd::string pathString = nodeData.m_path;
 
@@ -493,7 +638,7 @@ namespace AZ::Reflection
                                 pathString.append(lastValidElementName);
                             }
 
-                            nodeData.m_nonSerializedChildren.push_back(AZStd::make_pair(pathString.c_str(), entry));
+                            nodeData.m_nonSerializedChildren.emplace_back(AZStd::move(pathString), AZStd::move(entry));
                         }
                         else
                         {
@@ -549,41 +694,47 @@ namespace AZ::Reflection
                 }
             }
 
-            AZStd::optional<bool> HandleNodeAssociativeInterface(StackEntry& parentData, StackEntry& nodeData)
+            enum class VisitEntry
             {
+                VisitChildrenCallVisitObjectBegin,
+                VisitChildrenSkipVisitObjectBegin,
+                VisitNextSiblingSkipVisitObjectBegin
+
+            };
+            VisitEntry HandleNodeAssociativeInterface(StackEntry& parentData, StackEntry& nodeData)
+            {
+                using AssociativeType = Serialize::IDataContainer::IAssociativeDataContainer::AssociativeType;
                 if (parentData.m_classData && parentData.m_classData->m_container)
                 {
                     auto& containerInfo = parentData.m_classData->m_container;
                     AZ::SerializeContext::IDataContainer::IAssociativeDataContainer* parentAssociativeInterface =
                         containerInfo->GetAssociativeContainerInterface();
 
-                    if (parentAssociativeInterface)
+                    if (parentAssociativeInterface != nullptr)
                     {
-                        if (nodeData.m_instance == parentAssociativeInterface->GetValueByKey(parentData.m_instance, nodeData.m_instance))
+                        auto associativeType = parentAssociativeInterface->GetAssociativeType();
+                        // Store the type of associative container
+                        parentData.m_associativeContainerType = associativeType;
+                        switch (associativeType)
                         {
-                            // the element *is* the key. This is some kind of set and has only one read-only value per entry
-                            nodeData.m_skipLabel = true;
-                            nodeData.m_disableEditor = true;
-
-                            // TODO: if preferred, we can still include a label for set elements,
-                            // in this case, the stringified value
-                            /*  GetValueStringHelper(
-                                nodeData->m_instance,
-                                nodeData->m_classData,
-                                nodeData->m_classElement,
-                                m_serializeContext,
-                                nodeData->m_labelOverride); */
-                        }
-                        else
-                        {
-                            // parent is a real associative container with pair<> children,
-                            // extract the info from the parent and just show label/editor pairs
-                            nodeData.m_extractKeyedPair = true;
-                            nodeData.m_parentContainerInfo = parentData.m_classData->m_container;
-                            nodeData.m_parentContainerOverride = parentData.m_instance;
-                            nodeData.m_containerElementOverride = nodeData.m_instance;
-                            nodeData.m_entryClosed = true;
-                            return true;
+                        case AssociativeType::Set:
+                        case AssociativeType::UnorderedSet:
+                            {
+                                // the element *is* the key. This is some kind of set and has only one read-only value per entry
+                                nodeData.m_skipLabel = true;
+                                nodeData.m_disableEditor = true;
+                                break;
+                            }
+                        case AssociativeType::Map:
+                        case AssociativeType::UnorderedMap:
+                            {
+                                // parent is a map associative container with pair<> children,
+                                // extract the info from the parent and just show label/editor pairs
+                                nodeData.m_extractKeyedPair = true;
+                                nodeData.m_parentContainerInfo = parentData.m_classData->m_container;
+                                nodeData.m_parentContainerOverride = parentData.m_instance;
+                                nodeData.m_containerElementOverride = nodeData.m_instance;
+                            }
                         }
                     }
                 }
@@ -593,24 +744,43 @@ namespace AZ::Reflection
                     // alternate behavior for the pair children. The first is the key, stringify it
                     if (parentData.m_childElementIndex % 2 == 0)
                     {
-                        // store the label override in the parent for the next child to consume
-                        GetValueStringHelper(
-                            nodeData.m_instance,
-                            nodeData.m_classData,
-                            nodeData.m_classElement,
-                            m_serializeContext,
-                            parentData.m_labelOverride);
                         nodeData.m_entryClosed = true;
-                        return true;
+                        // Update the parent to store a pointer to the key instance data
+                        parentData.m_childKeyEntry.m_keyInstance = nodeData.m_instance;
+
+                        // Populate the attributes for the key instance into it's m_cachedAttribute
+                        // field and then move it over into the parentData KeyEntry to cache off the value
+                        // until the mapped type is processed in the else block below
+
+                        // Make sure to have the key editor be disabled
+                        nodeData.m_disableEditor = true;
+                        // Store of the stringified value of the key into label override for the mapped value
+                        if (auto stringKey = StringifyInstance(nodeData.m_instance, nodeData.m_classData, nodeData.m_classElement, m_serializeContext);
+                            stringKey)
+                        {
+                            parentData.m_childMappedValueLabelOverride = AZStd::move(*stringKey);
+                        }
+                        CacheAttributes();
+                        parentData.m_childKeyEntry.m_keyAttributes = AZStd::move(nodeData.m_cachedAttributes);
+
+                        // Do not enumerate the key elements itself
+                        // Instead let the mapped type in the else block add a DOM Editor for the key
+                        return VisitEntry::VisitNextSiblingSkipVisitObjectBegin;
                     }
                     else // the second is the value, make an editor as normal
                     {
-                        // this is the second pair<> child, consume the label override stored above
-                        nodeData.m_labelOverride = parentData.m_labelOverride;
+                        // swap the current child key instance stored in the parent with the node key instance field
+                        // and then clear the parent current child key instance field
+                        nodeData.m_keyEntry = AZStd::move(parentData.m_childKeyEntry);
+                        parentData.m_childKeyEntry = {};
+
+                        // Apply the stringified key as the label for the value
+                        nodeData.m_labelOverride = AZStd::move(parentData.m_childMappedValueLabelOverride);
+                        parentData.m_childMappedValueLabelOverride = AZStd::string{};
                     }
                 }
 
-                return AZStd::nullopt;
+                return VisitEntry::VisitChildrenCallVisitObjectBegin;
             }
 
             AZStd::optional<bool> HandleNodeAttributes(StackEntry& parentData, StackEntry& nodeData)
@@ -628,13 +798,13 @@ namespace AZ::Reflection
                 InheritChangeNotify(parentData, nodeData);
 
                 const auto& EnumTypeAttribute = DocumentPropertyEditor::Nodes::PropertyEditor::EnumUnderlyingType;
-                AZStd::optional<AZ::TypeId> enumTypeId = {};
+                AZStd::optional<AZ::TypeId> enumTypeId;
                 if (auto enumTypeValue = Find(EnumTypeAttribute.GetName()); enumTypeValue)
                 {
                     enumTypeId = EnumTypeAttribute.DomToValue(*enumTypeValue);
                 }
 
-                const AZ::TypeId* typeIdForHandler = &nodeData.m_typeId;
+                const AZ::TypeId* typeIdForHandler = &nodeData.m_instance.m_typeId;
                 if (enumTypeId.has_value())
                 {
                     typeIdForHandler = &enumTypeId.value();
@@ -680,21 +850,19 @@ namespace AZ::Reflection
 
 
                 // search up the stack for the "true parent", which is the last entry created by the serialize enumerate itself
-                void* instanceToInvoke = instance;
+                AZ::PointerObject instanceToInvokeObject{ instance, classData ? classData->m_typeId : Uuid::CreateNull() };
                 for (auto rIter = m_stack.rbegin(), rEnd = m_stack.rend(); rIter != rEnd; ++rIter)
                 {
                     auto* currInstance = rIter->GetRawInstance();
                     if (rIter->m_createdByEnumerate && currInstance)
                     {
-                        instanceToInvoke = currInstance;
+                        instanceToInvokeObject = AZ::PointerObject{ currInstance, rIter->GetTypeId() };
                         break;
                     }
                 }
 
-                StackEntry newEntry = {
-                    instance, instanceToInvoke, classData ? classData->m_typeId : Uuid::CreateNull(), pointerLevel,
-                    classData, classElement
-                };
+                AZ::PointerObject instanceObject{ instance, classData ? classData->m_typeId : Uuid::CreateNull() };
+                StackEntry newEntry{ instanceObject, instanceToInvokeObject, pointerLevel, classData, classElement };
                 newEntry.m_createdByEnumerate = true;
 
                 StackEntry& nodeData = m_stack.emplace_back(newEntry);
@@ -714,9 +882,9 @@ namespace AZ::Reflection
                 HandleNodeGroups(nodeData);
                 HandleNodeUiElementsRetrieval(nodeData);
 
-                if (auto result = HandleNodeAssociativeInterface(parentData, nodeData); result.has_value())
+                if (auto result = HandleNodeAssociativeInterface(parentData, nodeData); result != VisitEntry::VisitChildrenCallVisitObjectBegin)
                 {
-                    return result.value();
+                    return result == VisitEntry::VisitChildrenSkipVisitObjectBegin;
                 }
 
                 if (auto result = HandleNodeAttributes(parentData, nodeData); result.has_value())
@@ -782,17 +950,12 @@ namespace AZ::Reflection
                                     // skip the bool that represented the group toggle, it's already in-line with the group
                                     continue;
                                 }
-                                auto& parentEntry = m_stack.back();
-                                StackEntry& newStackEntry = m_stack.emplace_back(StackEntry{ groupEntry.m_instance, nullptr, AZ::TypeId(), groupEntry.m_pointerLevel,
-                                    groupEntry.m_classData, groupEntry.m_classElement });
-                                InheritChangeNotify(parentEntry, newStackEntry);
                                 m_serializeContext->EnumerateInstance(
                                     m_enumerateContext,
-                                    newStackEntry.m_instance,
-                                    newStackEntry.m_typeId,
-                                    newStackEntry.m_classData,
-                                    newStackEntry.m_classElement);
-                                m_stack.pop_back();
+                                    groupEntry.m_instance.m_address,
+                                    groupEntry.m_instance.m_typeId,
+                                    groupEntry.m_classData,
+                                    groupEntry.m_classElement);
                             }
 
                             if (groupPair.second.has_value())
@@ -818,11 +981,6 @@ namespace AZ::Reflection
                 {
                     StackEntry& parentData = m_stack.back();
 
-                    if (!parentData.m_group.empty())
-                    {
-                        EndNode();
-                    }
-
                     if (!m_stack.empty() && parentData.m_computedVisibility == DocumentPropertyEditor::Nodes::PropertyVisibility::Show)
                     {
                         ++m_stack.back().m_childElementIndex;
@@ -832,14 +990,14 @@ namespace AZ::Reflection
                 return true;
             }
 
-            const AZ::TypeId& GetType() const override
+            AZ::TypeId GetType() const override
             {
-                return m_stack.back().m_typeId;
+                return m_stack.back().GetTypeId();
             }
 
             AZStd::string_view GetTypeName() const override
             {
-                const AZ::SerializeContext::ClassData* classData = m_serializeContext->FindClassData(m_stack.back().m_typeId);
+                const AZ::SerializeContext::ClassData* classData = m_serializeContext->FindClassData(m_stack.back().GetTypeId());
                 return classData ? classData->m_name : "<unregistered type>";
             }
 
@@ -878,7 +1036,9 @@ namespace AZ::Reflection
                 else if (m_stack.size() > 1)
                 {
                     const StackEntry& parentNode = m_stack[m_stack.size() - 2];
-                    if (parentNode.m_classData && parentNode.m_classData->m_container)
+                    AZ::Serialize::IDataContainer* dataContainer = parentNode.m_classData ? parentNode.m_classData->m_container : nullptr;
+                    // Only add a label numeric label for sequence containers
+                    if (dataContainer && dataContainer->IsSequenceContainer())
                     {
                         labelAttributeBuffer = AZStd::fixed_string<128>::format("[%zu]", parentNode.m_childElementIndex);
                         return labelAttributeBuffer;
@@ -952,7 +1112,7 @@ namespace AZ::Reflection
                 const Name genericValueListName = Name("GenericValueList");
                 const Name enumValuesCrcName = Name(static_cast<u32>(Crc32("EnumValues")));
 
-                auto checkAttribute = [&](const AttributePair* it, void* instance, bool shouldDescribeChildren)
+                auto checkAttribute = [&](const AttributePair* it, AZ::PointerObject instance, bool shouldDescribeChildren)
                 {
                     bool describesChildren = it->second->m_describesChildren;
                     if (it->second->m_describesChildren != shouldDescribeChildren)
@@ -992,7 +1152,7 @@ namespace AZ::Reflection
                         if (name == PropertyEditor::Visibility.GetName())
                         {
                             auto visibilityValue = PropertyEditor::Visibility.DomToValue(
-                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance, it->second));
+                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance.m_address, it->second));
 
                             if (visibilityValue.has_value())
                             {
@@ -1017,13 +1177,13 @@ namespace AZ::Reflection
                             }
                             else if (
                                 auto visibilityBoolValue =
-                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance, it->second)))
+                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance.m_address, it->second)))
                             {
                                 bool isVisible = visibilityBoolValue.value();
                                 visibility = isVisible ? PropertyVisibility::Show : PropertyVisibility::Hide;
                                 return;
                             }
-                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance, it->second))
+                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance.m_address, it->second))
                             {
                                 // Fallback to generic read if LegacyAttributeToDomValue fails
                                 visibility = PropertyEditor::Visibility.DomToValue(genericVisibility.value()).value();
@@ -1037,7 +1197,7 @@ namespace AZ::Reflection
                         {
                             nodeData.m_disableEditor |=
                                 PropertyEditor::ReadOnly
-                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance, it->second))
+                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance.m_address, it->second))
                                     .value_or(nodeData.m_disableEditor);
                         }
 
@@ -1048,7 +1208,7 @@ namespace AZ::Reflection
                         {
                             if (attributeValue.IsNull())
                             {
-                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance, it->second);
+                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance.m_address, it->second);
                             }
                         };
                         propertyEditorSystem->EnumerateRegisteredAttributes(name, readValue);
@@ -1056,7 +1216,7 @@ namespace AZ::Reflection
                         // Fall back on a generic read that handles primitives.
                         if (attributeValue.IsNull())
                         {
-                            attributeValue = ReadGenericAttributeToDomValue(instance, it->second).value_or(Dom::Value());
+                            attributeValue = ReadGenericAttributeToDomValue(instance.m_address, it->second).value_or(Dom::Value());
                         }
 
                         // If we got a valid DOM value, store it.
@@ -1092,7 +1252,7 @@ namespace AZ::Reflection
                                 // in the PropertyEditorSystem.
                                 // This is reasonable since the attribute's value is an enum with an underlying integral
                                 // type which is safely convertible to AZ::u64.
-                                nodeData.m_typeId = AzTypeInfo<u64>::Uuid();
+                                nodeData.m_instance.m_typeId = AzTypeInfo<u64>::Uuid();
                                 return;
                             }
 
@@ -1194,25 +1354,27 @@ namespace AZ::Reflection
 
                     if (parentNode.m_classData && parentNode.m_classData->m_container)
                     {
-                        auto parentContainerInfo =
+                        AZ::PointerObject parentDataContainerObject;
+                        parentDataContainerObject.m_address =
                             (parentNode.m_parentContainerInfo ? parentNode.m_parentContainerInfo : parentNode.m_classData->m_container);
+                        parentDataContainerObject.m_typeId = azrtti_typeid<AZ::Serialize::IDataContainer>();
 
                         nodeData.m_cachedAttributes.push_back(
-                            { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType<void*>(parentContainerInfo) });
+                            { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType(parentDataContainerObject) });
 
-                        auto parentContainerInstance =
-                            (parentNode.m_parentContainerOverride ? parentNode.m_parentContainerOverride : parentNode.m_instance);
+                        AZ::PointerObject parentContainerObject =
+                            parentNode.m_parentContainerOverride.IsValid() ? parentNode.m_parentContainerOverride : parentNode.m_instance;
 
                         nodeData.m_cachedAttributes.push_back({ group,
                                                                 DescriptorAttributes::ParentContainerInstance,
-                                                                Dom::Utils::ValueFromType<void*>(parentContainerInstance) });
+                                                                Dom::Utils::ValueFromType(parentContainerObject) });
 
-                        if (parentNode.m_containerElementOverride)
+                        if (parentNode.m_containerElementOverride.IsValid())
                         {
                             nodeData.m_cachedAttributes.push_back(
                                 { group,
                                   DescriptorAttributes::ContainerElementOverride,
-                                  Dom::Utils::ValueFromType<void*>(parentNode.m_containerElementOverride) });
+                                  Dom::Utils::ValueFromType(parentNode.m_containerElementOverride) });
                         }
 
                         auto canBeModifiedValue =
@@ -1275,7 +1437,7 @@ namespace AZ::Reflection
 
                 nodeData.m_cachedAttributes.push_back({ group,
                                                         AZ::DocumentPropertyEditor::Nodes::PropertyEditor::ValueType.GetName(),
-                                                        AZ::Dom::Utils::TypeIdToDomValue(nodeData.m_typeId) });
+                                                        AZ::Dom::Utils::TypeIdToDomValue(nodeData.m_instance.m_typeId) });
 
                 if (nodeData.m_disableEditor)
                 {
@@ -1293,15 +1455,26 @@ namespace AZ::Reflection
 
                 if (nodeData.m_classData && nodeData.m_classData->m_container)
                 {
+                    AZ::PointerObject nodeContainerObject;
+                    nodeContainerObject.m_address = nodeData.m_classData->m_container;
+                    nodeContainerObject.m_typeId = azrtti_typeid<AZ::Serialize::IDataContainer>();
                     nodeData.m_cachedAttributes.push_back(
-                        { group, DescriptorAttributes::Container, Dom::Utils::ValueFromType<void*>(nodeData.m_classData->m_container) });
+                        { group, DescriptorAttributes::Container, Dom::Utils::ValueFromType(nodeContainerObject) });
                 }
 
                 // RpePropertyHandlerWrapper would cache the parent info from which a wrapped handler may retrieve the parent instance.
-                if (nodeData.m_instanceToInvoke)
+                if (nodeData.m_instanceToInvoke.IsValid())
                 {
                     nodeData.m_cachedAttributes.push_back(
-                        { group, PropertyEditor::ParentValue.GetName(), Dom::Utils::ValueFromType<void*>(nodeData.m_instanceToInvoke) });
+                        { group, PropertyEditor::ParentValue.GetName(), Dom::Utils::ValueFromType(nodeData.m_instanceToInvoke) });
+                }
+
+                // Create an Attribute for storing the Key Value associated with this value if it is the mapped value of an associative container
+                // https://en.cppreference.com/w/cpp/container/map
+                if (nodeData.m_keyEntry.IsValid())
+                {
+                    nodeData.m_cachedAttributes.push_back(
+                        { group, PropertyEditor::KeyValue.GetName(), Dom::Utils::ValueFromType(nodeData.m_keyEntry) });
                 }
 
                 // Calculate our visibility, going through parent nodes in reverse order to see if we should be hidden
@@ -1441,7 +1614,7 @@ namespace AZ::Reflection
         template<typename T>
         AZStd::shared_ptr<AZ::Attribute> MakeAttribute(T&& value)
         {
-            return AZStd::make_shared<AttributeData<T>>(AZStd::move(value));
+            return AZStd::make_shared<AZ::AttributeData<T>>(AZStd::move(value));
         }
     } // namespace LegacyReflectionInternal
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -761,8 +761,6 @@ namespace AZ::Reflection
                         {
                             parentData.m_childMappedValueLabelOverride = AZStd::move(*stringKey);
                         }
-                        CacheAttributes();
-                        parentData.m_childKeyEntry.m_keyAttributes = AZStd::move(nodeData.m_cachedAttributes);
 
                         // Do not enumerate the key elements itself
                         // Instead let the mapped type in the else block add a DOM Editor for the key

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -33,6 +33,7 @@ namespace AZ::Reflection
         const Name ParentContainerCanBeModified =
             Name::FromStringLiteral("ParentContainerCanBeModified", AZ::Interface<AZ::NameDictionary>::Get());
         const Name ContainerElementOverride = Name::FromStringLiteral("ContainerElementOverride", AZ::Interface<AZ::NameDictionary>::Get());
+        const Name ContainerIndex = Name::FromStringLiteral("ContainerIndex", AZ::Interface<AZ::NameDictionary>::Get());
     } // namespace DescriptorAttributes
 
 
@@ -1354,10 +1355,10 @@ namespace AZ::Reflection
 
                     if (parentNode.m_classData && parentNode.m_classData->m_container)
                     {
-                        AZ::PointerObject parentDataContainerObject;
-                        parentDataContainerObject.m_address =
+                        auto parentContainerInfo =
                             (parentNode.m_parentContainerInfo ? parentNode.m_parentContainerInfo : parentNode.m_classData->m_container);
-                        parentDataContainerObject.m_typeId = azrtti_typeid<AZ::Serialize::IDataContainer>();
+                        AZ::PointerObject parentDataContainerObject = { parentContainerInfo,
+                                                                        azrtti_typeid<AZ::Serialize::IDataContainer>() };
 
                         nodeData.m_cachedAttributes.push_back(
                             { group, DescriptorAttributes::ParentContainer, Dom::Utils::ValueFromType(parentDataContainerObject) });
@@ -1368,6 +1369,13 @@ namespace AZ::Reflection
                         nodeData.m_cachedAttributes.push_back({ group,
                                                                 DescriptorAttributes::ParentContainerInstance,
                                                                 Dom::Utils::ValueFromType(parentContainerObject) });
+
+                        if (parentContainerInfo->IsSequenceContainer())
+                        {
+                            nodeData.m_cachedAttributes.push_back({ group,
+                                                                    DescriptorAttributes::ContainerIndex,
+                                                                    AZ::Dom::Value(parentNode.m_childElementIndex) });
+                        }
 
                         if (parentNode.m_containerElementOverride.IsValid())
                         {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/PointerObject.h>
 #include <AzFramework/DocumentPropertyEditor/Reflection/Attribute.h>
 #include <AzFramework/DocumentPropertyEditor/Reflection/Visitor.h>
 
@@ -60,3 +61,35 @@ namespace AZ::Reflection
     // instances to interface with the Prefab System.
     // void VisitLegacyJsonSerializedInstance(IRead* visitor, Dom::Value instance, const AZ::TypeId& typeId);
 } // namespace AZ::Reflection
+
+namespace AZ::Reflection::LegacyReflectionInternal
+{
+    struct AttributeData
+    {
+        AZ_TYPE_INFO(AttributeData, "{EFD2A3A3-8161-4B9C-90B8-952AA08FD961}");
+
+        // Group from the attribute metadata (generally empty with Serialize/EditContext data)
+        Name m_group;
+        // Name of the attribute
+        Name m_name;
+        // DOM value of the attribute - currently only primitive attributes are supported,
+        // but other types may later be supported via opaque values
+        Dom::Value m_value;
+    };
+
+    //! Stores information about an associative container element key
+    //! This is used by the LegacyReflectionBridge StackEntry
+    //! to have the mapped_type of an associative container element to be able
+    //! access the instance and attribute data for the corresponding key
+    struct KeyEntry
+    {
+        AZ_TYPE_INFO(KeyEntry, "{718537E1-DFF5-4662-AB86-1D5C0C8A0768}");
+
+        //! Stores the address and type ID of an associative contaienr key
+        AZ::PointerObject m_keyInstance;
+        //! Stores the attributes of a single associative container element key
+        AZStd::vector<AttributeData> m_keyAttributes;
+
+        bool IsValid() const;
+    };
+}

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
@@ -48,6 +48,9 @@ namespace AZ::Reflection
         //! If specified, an override for the instance of the element referenced in a container operation.
         //! Type: void*
         extern const Name ContainerElementOverride;
+        //! the index of the element, if it is a member of a sequenced container
+        //! Type: size_t
+        extern const Name ContainerIndex;
     } // namespace DescriptorAttributes
 
     AZStd::shared_ptr<AZ::Attribute> WriteDomValueToGenericAttribute(const AZ::Dom::Value& value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/Visitor.h
@@ -173,7 +173,7 @@ namespace AZ::Reflection
 
     struct IObjectAccess
     {
-        virtual const AZ::TypeId& GetType() const = 0;
+        virtual AZ::TypeId GetType() const = 0;
         virtual AZStd::string_view GetTypeName() const = 0;
 
         virtual void* Get() = 0;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -222,7 +222,7 @@ namespace AZ::DocumentPropertyEditor
                     auto parentContainerInstanceValue = attributes.Find(AZ::Reflection::DescriptorAttributes::ParentContainerInstance);
                     void* parentContainerInstance{};
                     AZStd::optional<AZ::PointerObject> parentContainerInstanceObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(*parentContainerInstanceValue);
-                    if (parentContainerInstanceObject.has_value())
+                    if (parentContainerInstanceObject.has_value() && parentContainerInstanceObject->IsValid())
                     {
                         parentContainerInstance = parentContainerInstanceObject->m_address;
                     }
@@ -234,7 +234,7 @@ namespace AZ::DocumentPropertyEditor
                     if (containerElementOverrideValue)
                     {
                         AZStd::optional<AZ::PointerObject> containerElementOverrideObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(*containerElementOverrideValue);
-                        if (containerElementOverrideObject.has_value())
+                        if (containerElementOverrideObject.has_value() && containerElementOverrideObject->IsValid())
                         {
                             instance = containerElementOverrideObject->m_address;
                         }
@@ -673,7 +673,7 @@ namespace AZ::DocumentPropertyEditor
             if (parentContainer != nullptr && parentContainerInstanceAttribute && !parentContainerInstanceAttribute->IsNull())
             {
                 if (auto parentContainerInstanceObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(*parentContainerInstanceAttribute);
-                    parentContainerInstanceObject)
+                    parentContainerInstanceObject && parentContainerInstanceObject->IsValid())
                 {
                     parentContainerInstance = reinterpret_cast<AZ::Serialize::IDataContainer*>(parentContainerInstanceObject->m_address);
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabEditorPreferences.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabEditorPreferences.cpp
@@ -13,7 +13,7 @@
 AZ_CVAR(
     bool,
     ed_enableInspectorOverrideManagement,
-    false,
+    true,
     nullptr,
     AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
     "If set, enables experimental prefab override support in the Entity Inspector");
@@ -21,7 +21,7 @@ AZ_CVAR(
 AZ_CVAR(
     bool,
     ed_enableOutlinerOverrideManagement,
-    false,
+    true,
     nullptr,
     AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
     "If set, enables experimental prefab override support in the Outliner");
@@ -44,7 +44,7 @@ namespace AzToolsFramework::Prefab
 
     bool IsOutlinerOverrideManagementEnabled()
     {
-        bool isOutlinerOverrideManagementEnabled = false;
+        bool isOutlinerOverrideManagementEnabled = true;
         if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
         {
             console->GetCvarValue("ed_enableOutlinerOverrideManagement", isOutlinerOverrideManagementEnabled);
@@ -54,7 +54,7 @@ namespace AzToolsFramework::Prefab
 
     bool IsInspectorOverrideManagementEnabled()
     {
-        bool isInspectorOverrideManagementEnabled = false;
+        bool isInspectorOverrideManagementEnabled = true;
         if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
         {
             console->GetCvarValue("ed_enableInspectorOverrideManagement", isInspectorOverrideManagementEnabled);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -23,6 +23,8 @@ namespace AzToolsFramework
         static QIcon s_iconAdd(QStringLiteral(":/stylesheet/img/UI20/add-16.svg"));
         static QIcon s_iconRemove(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
         static QIcon s_iconClear(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
+        static QIcon s_iconUp(QStringLiteral(":/stylesheet/img/indicator-arrow-up.svg"));
+        static QIcon s_iconDown(QStringLiteral(":/stylesheet/img/indicator-arrow-down.svg"));
 
         using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
         using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
@@ -42,6 +44,14 @@ namespace AzToolsFramework
             setIcon(s_iconClear);
             setToolTip(tr("Remove all elements"));
             break;
+        case ContainerAction::MoveUp:
+            setIcon(s_iconUp);
+            setToolTip(tr("move this element up"));
+            break;
+        case ContainerAction::MoveDown:
+            setIcon(s_iconDown);
+            setToolTip(tr("move this element down"));
+            break;
         }
     }
 
@@ -52,19 +62,11 @@ namespace AzToolsFramework
 
         if (m_action == ContainerAction::Clear)
         {
-            // Default to true if the PromptOnContainerClear attribute isn't present
-            bool shouldPromptOnClear = Container::PromptOnContainerClear.ExtractFromDomNode(m_node).value_or(true);
-
-            if (shouldPromptOnClear)
+            auto result = QMessageBox::question(
+                this, QObject::tr("Clear container?"), QObject::tr("Are you sure you want to remove all elements from this container?"));
+            if (result == QMessageBox::No)
             {
-                auto result = QMessageBox::question(
-                    this,
-                    QObject::tr("Clear container?"),
-                    QObject::tr("Are you sure you want to remove all elements from this container?"));
-                if (result == QMessageBox::No)
-                {
-                    return;
-                }
+                return;
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -732,7 +732,7 @@ namespace AzToolsFramework
                     priorColumnDomIndex = searchIndex;
                 }
             }
-            AZ_Assert(priorColumnDomIndex != -1, "Tried to share column with an out of bounds index!");
+            AZ_Error("DocumentPropertyEditor", priorColumnDomIndex != -1, "Tried to share column with an out of bounds index!");
             if (priorColumnDomIndex != -1)
             {
                 m_columnLayout->AddSharePriorColumn(priorColumnDomIndex, domIndex);
@@ -1736,7 +1736,7 @@ namespace AzToolsFramework
         // message match for QueryKey
         auto showKeyQueryDialog = [&](AZ::DocumentPropertyEditor::DocumentAdapterPtr* adapter, AZ::Dom::Path containerPath)
         {
-            KeyQueryDPE keyQueryUi(adapter);
+            KeyQueryDPE keyQueryUi(*adapter);
             if (keyQueryUi.exec() == QDialog::Accepted)
             {
                 AZ::DocumentPropertyEditor::Nodes::Adapter::AddContainerKey.InvokeOnDomNode(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -55,9 +55,10 @@ namespace AzToolsFramework
     {
     }
 
-    void DPELayout::Init(int depth, [[maybe_unused]] QWidget* parentWidget)
+    void DPELayout::Init(int depth, bool enforceMinWidth, [[maybe_unused]] QWidget* parentWidget)
     {
         m_depth = depth;
+        m_enforceMinWidth = enforceMinWidth;
     }
 
     void DPELayout::Clear()
@@ -189,7 +190,7 @@ namespace AzToolsFramework
 
         m_cachedMinLayoutSize = QSize(cumulativeWidth, minimumHeight);
 
-        return { cumulativeWidth, minimumHeight };
+        return { (m_enforceMinWidth ? cumulativeWidth : 0), minimumHeight };
     }
 
     void DPELayout::setGeometry(const QRect& rect)
@@ -485,7 +486,7 @@ namespace AzToolsFramework
         : QFrame(nullptr) // parent will be set when the row is added to its layout
         , m_columnLayout(new DPELayout(this))
     {
-        m_columnLayout->Init(-1, this);
+        m_columnLayout->Init(-1, m_enforceMinWidth, this);
         // allow horizontal stretching, but use the vertical size hint exactly
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         QObject::connect(m_columnLayout, &DPELayout::expanderChanged, this, &DPERowWidget::onExpanderChanged);
@@ -1081,7 +1082,8 @@ namespace AzToolsFramework
         {
             rowWidget->m_parentRow = this;
             rowWidget->m_depth = m_depth + 1;
-            rowWidget->m_columnLayout->Init(rowWidget->m_depth, this);
+            rowWidget->m_enforceMinWidth = m_enforceMinWidth;
+            rowWidget->m_columnLayout->Init(rowWidget->m_depth, m_enforceMinWidth, this);
         }
 
         m_columnLayout->SetExpanderShown(true);
@@ -1350,7 +1352,7 @@ namespace AzToolsFramework
 
         m_spawnDebugView = AZ::DocumentPropertyEditor::PropertyEditorSystem::DPEDebugEnabled();
 
-        setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 
         // register as a co-owner of the recycled widgets lists if they exist; create if not
@@ -1428,13 +1430,22 @@ namespace AzToolsFramework
     void DocumentPropertyEditor::SetAllowVerticalScroll(bool allowVerticalScroll)
     {
         m_allowVerticalScroll = allowVerticalScroll;
-
-        /* as a temporary work-around to https://github.com/o3de/o3de/issues/14863 , never prevent vertical scrollbars
-           setVerticalScrollBarPolicy(allowVerticalScroll ? Qt::ScrollBarAsNeeded : Qt::ScrollBarAlwaysOff);
-         */
+        setVerticalScrollBarPolicy(allowVerticalScroll ? Qt::ScrollBarAsNeeded : Qt::ScrollBarAlwaysOff);
 
         auto existingPolicy = sizePolicy();
         setSizePolicy(existingPolicy.horizontalPolicy(), (allowVerticalScroll ? existingPolicy.verticalPolicy() : QSizePolicy::Fixed));
+    }
+
+    void DocumentPropertyEditor::SetEnforceMinWidth(bool enforceMinWidth)
+    {
+        if (m_enforceMinWidth != enforceMinWidth)
+        {
+            m_enforceMinWidth = enforceMinWidth;
+            if (m_rootNode)
+            {
+                HandleReset();
+            }
+        }
     }
 
     QSize DocumentPropertyEditor::sizeHint() const
@@ -1666,6 +1677,7 @@ namespace AzToolsFramework
 
         // invisible root node has a "depth" of -1; its children are all at indent 0
         m_rootNode = m_rowPool->GetInstance();
+        m_rootNode->m_enforceMinWidth = m_enforceMinWidth;
         m_rootNode->setParent(this);
         m_rootNode->hide();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -45,7 +45,7 @@ namespace AzToolsFramework
         // todo: look into caching and QLayoutItem::invalidate()
     public:
         DPELayout(QWidget* parent);
-        void Init(int depth, QWidget* parentWidget = nullptr);
+        void Init(int depth, bool enforceMinWidth, QWidget* parentWidget = nullptr);
         void Clear();
         virtual ~DPELayout();
 
@@ -73,6 +73,7 @@ namespace AzToolsFramework
 
         int m_depth = 0; //!< number of levels deep in the tree. Used for indentation
         bool m_showExpander = false;
+        bool m_enforceMinWidth = true;
         bool m_expanded = true;
         QCheckBox* m_expanderWidget = nullptr;
 
@@ -145,6 +146,7 @@ namespace AzToolsFramework
         DPERowWidget* m_parentRow = nullptr;
         int m_depth = -1; //!< number of levels deep in the tree. Used for indentation
         DPELayout* m_columnLayout = nullptr;
+        bool m_enforceMinWidth = true;
 
         //! widget children in DOM specified order; mix of row and column widgets
         AZStd::deque<QWidget*> m_domOrderedChildren;
@@ -188,6 +190,11 @@ namespace AzToolsFramework
             This is typically used when a DPE is going into another scroll area and it is undesirable
             for the DPE to provide its own vertical scrollbar */
         void SetAllowVerticalScroll(bool allowVerticalScroll);
+
+        /*! Sets whether this DPE should enforce the minimum width of its sub-widgets, or allow the user
+         *  to make the DPE arbitrarily narrow. */
+        void SetEnforceMinWidth(bool enforceMinWidth);
+
         virtual QSize sizeHint() const override;
 
         auto GetAdapter()
@@ -283,6 +290,7 @@ namespace AzToolsFramework
 
         QVBoxLayout* m_layout = nullptr;
         bool m_allowVerticalScroll = true;
+        bool m_enforceMinWidth = true;
 
         AZStd::unique_ptr<AZ::DocumentPropertyEditor::ExpanderSettings> m_dpeSettings;
         bool m_isRecursiveExpansionOngoing = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.cpp
@@ -10,10 +10,10 @@
 
 namespace AzToolsFramework
 {
-    KeyQueryDPE::KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget)
+    KeyQueryDPE::KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr keyQueryAdapter, QWidget* parentWidget)
         : QDialog(parentWidget)
     {
         setupUi(this);
-        dpe->SetAdapter(*keyQueryAdatper);
+        dpe->SetAdapter(keyQueryAdapter);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h
@@ -18,6 +18,6 @@ namespace AzToolsFramework
         , Ui::KeyQueryDPE
     {
     public:
-        KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr* keyQueryAdatper, QWidget* parentWidget = nullptr);
+        KeyQueryDPE(AZ::DocumentPropertyEditor::DocumentAdapterPtr keyQueryAdapter, QWidget* parentWidget = nullptr);
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
@@ -53,7 +53,7 @@ namespace AzToolsFramework
             AZ::Dom::Value value = PropertyEditor::Value.ExtractFromDomNode(node).value_or(AZ::Dom::Value());
             // If the object is a pointer object extract the TypeId from it
             if (auto pointerObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(value);
-                pointerObject)
+                pointerObject && pointerObject->IsValid())
             {
                 typeId = pointerObject->m_typeId;
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyEditorToolsSystem.cpp
@@ -51,7 +51,16 @@ namespace AzToolsFramework
         else
         {
             AZ::Dom::Value value = PropertyEditor::Value.ExtractFromDomNode(node).value_or(AZ::Dom::Value());
-            typeId = AZ::Dom::Utils::GetValueTypeId(value);
+            // If the object is a pointer object extract the TypeId from it
+            if (auto pointerObject = AZ::Dom::Utils::ValueToType<AZ::PointerObject>(value);
+                pointerObject)
+            {
+                typeId = pointerObject->m_typeId;
+            }
+            else
+            {
+                typeId = AZ::Dom::Utils::GetValueTypeId(value);
+            }
         }
 
         AZStd::string_view typeName = PropertyEditor::Type.ExtractFromDomNode(node).value_or("");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -161,6 +161,7 @@ namespace AzToolsFramework
 
             // this DPE is going into a scroll area, don't allow it to provide its own scrollbar
             m_dpe->SetAllowVerticalScroll(false);
+            m_dpe->SetEnforceMinWidth(false); // allow the DPE to get as small as the user prefers
             m_filterAdapter->SetSourceAdapter(m_adapter);
             m_dpe->SetAdapter(m_filterAdapter);
             connect(m_dpe, &DocumentPropertyEditor::ExpanderChangedByUser, this, &ComponentEditor::OnExpansionContractionDone);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -135,14 +135,14 @@ namespace AzToolsFramework
     AZ_CVAR(
         bool,
         ed_enableDPEInspector,
-        false,
+        true,
         nullptr,
         AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
         "If set, enables experimental Document Property Editor support for the Entity Inspector");
 
     static bool ShouldUseDPE()
     {
-        bool dpeEnabled = false;
+        bool dpeEnabled = true;
         if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
         {
             console->GetCvarValue(enableDPECVarName, dpeEnabled);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -393,16 +393,6 @@ namespace AzToolsFramework
 
                         auto proxyClassData = serializeContext->FindClassData(m_proxyClassData.m_typeId);
 
-                        void* proxyAddress{};
-                        if constexpr (AZStd::is_pointer_v<WrappedType>)
-                        {
-                            proxyAddress = m_proxyValue;
-                        }
-                        else
-                        {
-                            proxyAddress = &m_proxyValue;
-                        }
-
                         if (pointerClassData != nullptr && pointerClassData->m_azRtti != nullptr &&
                             pointerClassData->m_azRtti->IsTypeOf<WrappedType>())
                         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.cpp
@@ -52,7 +52,7 @@ namespace AZ
             Uuid functorTypeId;
             if (!inputValue.HasMember(TypeField))
             {
-                return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Unsupported, "Functor type name is not specified.");
+                return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Missing, "Functor type name is not specified.");
             }
 
             // Load the name first and find the type.


### PR DESCRIPTION
## What does this PR do?
- cherry-picks all new features and fixes for the DPE Inspector implemented since the 2310 release
- defaults both prefab override editing flags to "on" for the point release

## How was this PR tested?
- locally, in the Editor project