### PR TITLE
Added support to show GPU timings for the RayTracingAccelerationStructure Pass

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/ScopeProducer.h>
+#include <Atom/RPI.Public/GpuQuery/Query.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RHI/RayTracingBufferPools.h>
@@ -24,6 +25,8 @@ namespace AZ
         public:
             AZ_RPI_PASS(RayTracingAccelerationStructurePass);
 
+            using ScopeQuery = AZStd::array<AZ::RHI::Ptr<AZ::RPI::Query>, static_cast<size_t>(AZ::RPI::ScopeQueryType::Count)>;
+
             AZ_RTTI(RayTracingAccelerationStructurePass, "{6BAA1755-D7D2-497F-BCDB-CA28B42728DC}", Pass);
             AZ_CLASS_ALLOCATOR(RayTracingAccelerationStructurePass, SystemAllocator);
 
@@ -31,6 +34,8 @@ namespace AZ
             static RPI::Ptr<RayTracingAccelerationStructurePass> Create(const RPI::PassDescriptor& descriptor);
 
             ~RayTracingAccelerationStructurePass() = default;
+
+            void AddScopeQueryToFrameGraph(AZ::RHI::FrameGraphInterface frameGraph);
 
         private:
             explicit RayTracingAccelerationStructurePass(const RPI::PassDescriptor& descriptor);
@@ -43,6 +48,30 @@ namespace AZ
             void BuildInternal() override;
             void FrameBeginInternal(FramePrepareParams params) override;
 
+            // Helper function to get the query by the scope index and query type
+            AZ::RHI::Ptr<AZ::RPI::Query> GetQuery(AZ::RPI::ScopeQueryType queryType);
+
+            // Executes a lambda depending on the passed ScopeQuery types
+            template<typename Func>
+            void ExecuteOnTimestampQuery(Func&& func);
+            template<typename Func>
+            void ExecuteOnPipelineStatisticsQuery(Func&& func);
+
+            RPI::TimestampResult GetTimestampResultInternal() const override;
+            RPI::PipelineStatisticsResult GetPipelineStatisticsResultInternal() const override;
+
+            // Begin recording commands for the ScopeQueries
+            void BeginScopeQuery(const AZ::RHI::FrameGraphExecuteContext& context);
+
+            // End recording commands for the ScopeQueries
+            void EndScopeQuery(const AZ::RHI::FrameGraphExecuteContext& context);
+
+            // Readback the results from the ScopeQueries
+            void ReadbackScopeQueryResults();
+
+            // Used to set some build options for the TLASes
+            static AZ::RHI::RayTracingAccelerationStructureBuildFlags CreateRayTracingAccelerationStructureBuildFlags(bool isSkinnedMesh);
+
             // buffer view descriptor for the TLAS
             RHI::BufferViewDescriptor m_tlasBufferViewDescriptor;
 
@@ -54,6 +83,16 @@ namespace AZ
 
             // the bits of this constant are used to check if a skinned BLAS is going to be rebuilt in any given frame
             static constexpr uint32_t SKINNED_BLAS_REBUILD_FRAME_INTERVAL = 8;
+
+            // Readback results from the Timestamp queries
+            AZ::RPI::TimestampResult m_timestampResult;
+
+            // Readback results from the PipelineStatistics queries
+            AZ::RPI::PipelineStatisticsResult m_statisticsResult;
+
+            // For each ScopeProducer an instance of the ScopeQuery is created, which consists
+            // of a Timestamp and PipelineStatistic query.
+            ScopeQuery m_scopeQueries;
         };
     }   // namespace RPI
 }   // namespace AZ


### PR DESCRIPTION
## What does this PR do?
Prior to this PR, ImGUI GPU Profiler did not report any timings for the `RayTracingAccelerationStructure`. These changes add support proper reading out and displaying of the timings for this scope. A screenshot of the fix is shown below:

![image](https://github.com/o3de/o3de/assets/143601175/fc478b1a-b562-49db-b95d-0a6cd0bfdf77)

## How was this PR tested?

Tested within the editor on Windows using the Vulkan and DX12 RHI.
