### PR TITLE
Fixed pass timings not showing correct values in certain cases

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -188,6 +188,7 @@ namespace AZ
 
         void RenderPass::FrameBeginInternal(FramePrepareParams params)
         {
+            m_timestampResult = AZ::RPI::TimestampResult();
             if (GetScopeId().IsEmpty())
             {
                 InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass);


### PR DESCRIPTION
## What does this PR do?
Added a fix to that allows pass timings to be properly recorded when a pass does not do anything for a single frame.

## How was this PR tested?

This fix was tested on Windows using the Vulkan and DX12 RHI.
