### PR TITLE
Fixed bugs in the shaders used by the Eye Material.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.materialtype
@@ -4,7 +4,7 @@
     "propertyLayout": {
         "propertyGroups": [
             {
-                "name": "iris", 
+                "name": "iris",
                 "shaderInputsPrefix": "m_iris_",
                 "shaderOptionsPrefix": "o_iris_",
                 "displayName":  "Iris",
@@ -16,13 +16,13 @@
                     {
                         "$import": "MaterialInputs/NormalPropertyGroup.json"
                     },
-                    { 
+                    {
                         "$import": "MaterialInputs/RoughnessPropertyGroup.json"
                     }
                 ]
             },
             {
-                "name": "sclera", 
+                "name": "sclera",
                 "shaderInputsPrefix": "m_sclera_",
                 "shaderOptionsPrefix": "o_sclera_",
                 "displayName":  "Sclera",
@@ -34,7 +34,7 @@
                     {
                         "$import": "MaterialInputs/NormalPropertyGroup.json"
                     },
-                    { 
+                    {
                         "$import": "MaterialInputs/RoughnessPropertyGroup.json"
                     }
                 ]
@@ -49,9 +49,9 @@
                         "displayName": "Iris Depth",
                         "description": "Distance from the object origin to the plane (XZ) where the iris lays.",
                         "type": "float",
-                        "defaultValue": 0.48,
+                        "defaultValue": 0.423,
                         "min": 0.0,
-                        "softMax": 1.0,
+                        "softMax": 0.5,
                         "connection": {
                             "type": "ShaderInput",
                             "name": "m_irisDepth"
@@ -62,7 +62,7 @@
                         "displayName": "Iris Radius",
                         "description": "Radius of the iris. It extends the iris/sclera mask to get more samples from one or the other (no UV deformation/stretching).",
                         "type": "float",
-                        "defaultValue": 0.2,
+                        "defaultValue": 0.047,
                         "min": 0.0,
                         "softMax": 0.5,
                         "connection": {
@@ -98,22 +98,22 @@
                     }
                 ]
             },
-            { 
+            {
                 "$import": "MaterialInputs/SpecularPropertyGroup.json"
             },
-            { 
+            {
                 "$import": "MaterialInputs/DualSpecularPropertyGroup.json"
             },
-            { 
+            {
                 "$import": "MaterialInputs/SubsurfaceAndTransmissionPropertyGroup.json"
             },
-            { 
+            {
                 "$import": "MaterialInputs/GeneralCommonPropertyGroup.json"
             }
         ]
     },
     // Skin lighting model works well because it supports subsurface scattering, and Eye doesn't need all the other stuff in the Enhanced lighting model.
-    "lightingModel": "Skin", 
+    "lightingModel": "Skin",
     "materialShaderCode": "Eye.azsli",
     "uvNameMap": {
         "UV0": "Tiled",

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.materialtype
@@ -62,7 +62,7 @@
                         "displayName": "Iris Radius",
                         "description": "Radius of the iris. It extends the iris/sclera mask to get more samples from one or the other (no UV deformation/stretching).",
                         "type": "float",
-                        "defaultValue": 0.047,
+                        "defaultValue": 0.19,
                         "min": 0.0,
                         "softMax": 0.5,
                         "connection": {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_MaterialSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_MaterialSrg.azsli
@@ -6,7 +6,7 @@
  *
  */
 
-#pragma once 
+#pragma once
 
 #include "../MaterialInputs/BaseColorInput.azsli"
 #include "../MaterialInputs/DualSpecular.azsli"
@@ -59,20 +59,27 @@ ShaderResourceGroup MaterialSrg : SRG_PerMaterial
     uint m_subsurfaceScatteringInfluenceMapUvIndex;
 
     // Parameters for transmission
-    
+
     // Elements of m_transmissionParams:
     // Thick object mode: (attenuation coefficient, power, distortion, scale)
     // Thin  object mode:  (shrinkFactor, transmissionNdLBias, distanceAttenuation, scale)
     float4 m_transmissionParams;
-    
+
     // (float3 TintColor, thickness)
     float4 m_transmissionTintThickness;
     Texture2D m_transmissionThicknessMap;
     uint m_transmissionThicknessMapUvIndex;
 
-    // Eye parameters
-    float m_irisDepth;
-    float m_eyeIrisRadius;
+    // Normalized Eye parameters. The following three parameters
+    // are unitless and assume normalized Eye geometry, where the
+    // radius of the pseudo-sphere is 0.5.
+    float m_irisDepth; //Distance from the center of the Eye to the center of the Iris-XZ plane.
+    float m_eyeIrisRadius; // Radius of the Iris, measured from the center of the Pupil (imagine a Circle in the XZ plane).
     float m_limbusSize;
+
+    // Index of refraction of the Inner Eye. This is the sequence
+    // of mediums the light has to travel: Air -> Cornea -> Aqueus Humor -> Pupil/Iris Plane.
+    // The Inner Eye, refers to the combined "Cornea -> Aqueus Humor" layers because in real life
+    // their IORs are very similar.
     float m_innerEyeIOR;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -61,18 +61,13 @@ Surface EvaluateSurface_Eye(
     real3x3 uvMatrix = CreateIdentity3x3(); // The eye material type doesn't support UV transforms
 
 #if USE_NORMALIZED_SPACE_ALGORITHM
-    // The most efficient way is to leverage the fact that the UV coordinate of the pupil
-    // is centered at 0.5, 0.5. So the distance to the center of the pupil can be calculated
-    // from the distance of the UV coordinate to the pupil center (0.5, 0.5)
-    #define UV_CENTER (real2(0.50, 0.50))
-    // const real distFromCenter = length(uvs[0] - UV_CENTER);
-
     real3 normalizedLocal = normalize(localPosition);
-    real projection = dot(normalizedLocal, real3(0.0, 1.0, 0.0)) * NORMALIZED_EYE_RADIUS;
+    real projection = dot(normalizedLocal, real3(0.0, 1.0, 0.0));
     // // If the localPosition of the vertex is at the center of the pupil, then the dot product
-    // // with the forward vector will be at maximum value = NORMALIZED_EYE_RADIUS.
-    // // But the iris is in the XZ plane. So we need to set the distance to center to be 0.0 in this case.
-    const real distFromCenter = NORMALIZED_EYE_RADIUS - projection;
+    // // with the forward vector will be at maximum value = 1.0.
+    // // But the iris is in the XZ plane.
+    real tempDistFactor = sqrt(1 - projection * projection);
+    const real distFromCenter = tempDistFactor * NORMALIZED_EYE_RADIUS;
 #else
     // This is the original equation used by the first developer of this shader.
     // This equation suffers issues when the vertex data coming from the FBX changes

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -63,9 +63,9 @@ Surface EvaluateSurface_Eye(
 #if USE_NORMALIZED_SPACE_ALGORITHM
     real3 normalizedLocal = normalize(localPosition);
     real projection = dot(normalizedLocal, real3(0.0, 1.0, 0.0));
-    // // If the localPosition of the vertex is at the center of the pupil, then the dot product
-    // // with the forward vector will be at maximum value = 1.0.
-    // // But the iris is in the XZ plane.
+    // If the localPosition of the vertex is at the center of the pupil, then the dot product
+    // with the forward vector will be at maximum value = 1.0.
+    // But the iris is in the XZ plane.
     real tempDistFactor = sqrt(1 - projection * projection);
     const real distFromCenter = tempDistFactor * NORMALIZED_EYE_RADIUS;
 #else
@@ -82,11 +82,11 @@ Surface EvaluateSurface_Eye(
     surface.vertexNormal = normalize(vertexNormal);
 
     // Get surface normal for each layer (iris/sclera) and blend using the mask defined above
-    float2 irisNormalUv = uvs[MaterialSrg::m_iris_m_normalMapUvIndex];
+    real2 irisNormalUv = uvs[MaterialSrg::m_iris_m_normalMapUvIndex];
     real3 irisNormal = GetNormalInputWS(MaterialSrg::m_iris_m_normalMap, MaterialSrg::m_sampler, irisNormalUv, MaterialSrg::m_iris_m_flipNormalX, MaterialSrg::m_iris_m_flipNormalY, isFrontFace, surface.vertexNormal,
                                     tangents[MaterialSrg::m_iris_m_normalMapUvIndex], bitangents[MaterialSrg::m_iris_m_normalMapUvIndex], uvMatrix, o_iris_o_normal_useTexture, real(MaterialSrg::m_iris_m_normalFactor));
 
-    float2 scleraNormalUv = uvs[MaterialSrg::m_sclera_m_normalMapUvIndex];
+    real2 scleraNormalUv = uvs[MaterialSrg::m_sclera_m_normalMapUvIndex];
     real3 scleraNormal = GetNormalInputWS(MaterialSrg::m_sclera_m_normalMap, MaterialSrg::m_sampler, scleraNormalUv, MaterialSrg::m_sclera_m_flipNormalX, MaterialSrg::m_sclera_m_flipNormalY, isFrontFace, surface.vertexNormal,
                                     tangents[MaterialSrg::m_sclera_m_normalMapUvIndex], bitangents[MaterialSrg::m_sclera_m_normalMapUvIndex], uvMatrix, o_sclera_o_normal_useTexture, real(MaterialSrg::m_sclera_m_normalFactor));
 
@@ -154,12 +154,12 @@ Surface EvaluateSurface_Eye(
     //--------------------- Base Color ----------------------
 
     // Sample iris color map and blend with the base iris color
-    float2 irisBaseColorUv = irisRefractionUv;
+    real2 irisBaseColorUv = irisRefractionUv;
     real3 irisSampledColor = GetBaseColorInput(MaterialSrg::m_iris_m_baseColorMap, MaterialSrg::m_sampler, irisBaseColorUv, real3(MaterialSrg::m_iris_m_baseColor), o_iris_o_baseColor_useTexture);
     real3 irisColor = BlendBaseColor(irisSampledColor, real3(MaterialSrg::m_iris_m_baseColor), real(MaterialSrg::m_iris_m_baseColorFactor), o_iris_o_baseColorTextureBlendMode, o_iris_o_baseColor_useTexture);
 
     // Sample sclera color map and blend with the base sclera color
-    float2 scleraBaseColorUv = uvs[MaterialSrg::m_sclera_m_baseColorMapUvIndex];
+    real2 scleraBaseColorUv = uvs[MaterialSrg::m_sclera_m_baseColorMapUvIndex];
     real3 scleraSampledColor = GetBaseColorInput(MaterialSrg::m_sclera_m_baseColorMap, MaterialSrg::m_sampler, scleraBaseColorUv, real3(MaterialSrg::m_sclera_m_baseColor), o_sclera_o_baseColor_useTexture);
     real3 scleraColor = BlendBaseColor(scleraSampledColor, real3(MaterialSrg::m_sclera_m_baseColor), real(MaterialSrg::m_sclera_m_baseColorFactor), o_sclera_o_baseColorTextureBlendMode, o_sclera_o_baseColor_useTexture);
 
@@ -168,7 +168,7 @@ Surface EvaluateSurface_Eye(
 
     // ------- Specular -------
 
-    float2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
+    real2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
     real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture);
 
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor);
@@ -176,11 +176,11 @@ Surface EvaluateSurface_Eye(
     // ------- Roughness -------
 
     // Get surface roughness for each layer (iris/sclera) and blend using the mask defined above
-    float2 irisRoughnessUv = irisRefractionUv;
+    real2 irisRoughnessUv = irisRefractionUv;
     real irisRoughnessLinear = GetRoughnessInput(MaterialSrg::m_iris_m_roughnessMap, MaterialSrg::m_sampler, irisRoughnessUv, real(MaterialSrg::m_iris_m_roughnessFactor),
                                         real(MaterialSrg::m_iris_m_roughnessLowerBound), real(MaterialSrg::m_iris_m_roughnessUpperBound), o_iris_o_roughness_useTexture);
 
-    float2 scleraRoughnessUv = uvs[MaterialSrg::m_sclera_m_roughnessMapUvIndex];
+    real2 scleraRoughnessUv = uvs[MaterialSrg::m_sclera_m_roughnessMapUvIndex];
     real scleraRoughnessLinear = GetRoughnessInput(MaterialSrg::m_sclera_m_roughnessMap, MaterialSrg::m_sampler, scleraRoughnessUv, real(MaterialSrg::m_sclera_m_roughnessFactor),
                                         real(MaterialSrg::m_sclera_m_roughnessLowerBound), real(MaterialSrg::m_sclera_m_roughnessUpperBound), o_sclera_o_roughness_useTexture);
 
@@ -195,14 +195,14 @@ Surface EvaluateSurface_Eye(
 
     // ------- Subsurface -------
 
-    float2 subsurfaceUv = uvs[MaterialSrg::m_subsurfaceScatteringInfluenceMapUvIndex];
+    real2 subsurfaceUv = uvs[MaterialSrg::m_subsurfaceScatteringInfluenceMapUvIndex];
     surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor));
     surface.subsurfaceScatteringQuality = real(MaterialSrg::m_subsurfaceScatteringQuality);
     surface.scatterDistance = real3(MaterialSrg::m_scatterDistance);
 
     // ------- Transmission -------
 
-    float2 transmissionUv = uvs[MaterialSrg::m_transmissionThicknessMapUvIndex];
+    real2 transmissionUv = uvs[MaterialSrg::m_transmissionThicknessMapUvIndex];
     real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness));
     surface.transmission.tint = transmissionTintThickness.rgb;
     surface.transmission.thickness = transmissionTintThickness.w;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -16,6 +16,31 @@
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>
+#include <Atom/RPI/Math.azsli>
+
+// Control whether to use the new algorithm where all the distances are normalized
+// in a space where the Eye Mesh Radius is 0.5.
+// This macro was created for test and compare purposes between the old algorithm
+// and the new algorithm.
+// The old algorithm assumed the Eye Mesh was a pseudo spherical mesh of world sized radius 0.5,
+// and some calculations produced bad results in cases where the Eye mesh would come from eyes
+// integrated into a human head FBX.
+// The new algorithm uses the UV coordinates of the model, which is a normalized space, and
+// the math is more roboust, regardless of the mesh size.
+#define USE_NORMALIZED_SPACE_ALGORITHM (1)
+#define NORMALIZED_EYE_RADIUS (0.5)
+
+// The Iris Radius Mask is a value between 0.0 and 1.0 that is used to calculate
+// how much of the Iris Texture (which is centered at the pupil) should be covered
+// by the Sclera Texture.
+// Assumptions:
+// 1- Regarding model coordinates, it is assumed that the center of the pupil is aligned
+//    with the center of the sphere along the Y (Forward) axis.
+real GetIrisRadiusMask(real vertexDistanceToCenterOfPupil)
+{
+    // Use a sigmoid to determine the sclera/iris contribution for each point.
+    return PseudoSigmoid(vertexDistanceToCenterOfPupil, real(MaterialSrg::m_eyeIrisRadius), real(MaterialSrg::m_limbusSize));
+}
 
 Surface EvaluateSurface_Eye(
     float3 positionWS,
@@ -35,23 +60,41 @@ Surface EvaluateSurface_Eye(
 
     real3x3 uvMatrix = CreateIdentity3x3(); // The eye material type doesn't support UV transforms
 
-    // Use a sigmoid to determine the sclera/iris contribution for each point
-    real distFromCenter = length(real2(localPosition.xz));
-    real mask = 1.0/(1.0 + exp(-(distFromCenter - real(MaterialSrg::m_eyeIrisRadius)) / (distFromCenter * real(MaterialSrg::m_limbusSize))));
+#if USE_NORMALIZED_SPACE_ALGORITHM
+    // The most efficient way is to leverage the fact that the UV coordinate of the pupil
+    // is centered at 0.5, 0.5. So the distance to the center of the pupil can be calculated
+    // from the distance of the UV coordinate to the pupil center (0.5, 0.5)
+    #define UV_CENTER (real2(0.50, 0.50))
+    // const real distFromCenter = length(uvs[0] - UV_CENTER);
+
+    real3 normalizedLocal = normalize(localPosition);
+    real projection = dot(normalizedLocal, real3(0.0, 1.0, 0.0)) * NORMALIZED_EYE_RADIUS;
+    // // If the localPosition of the vertex is at the center of the pupil, then the dot product
+    // // with the forward vector will be at maximum value = NORMALIZED_EYE_RADIUS.
+    // // But the iris is in the XZ plane. So we need to set the distance to center to be 0.0 in this case.
+    const real distFromCenter = NORMALIZED_EYE_RADIUS - projection;
+#else
+    // This is the original equation used by the first developer of this shader.
+    // This equation suffers issues when the vertex data coming from the FBX changes
+    // from the original assumption that the radius of the eye mesh is 0.5.
+    const real distFromCenter = length(localPosition.xz);
+#endif
+
+    real mask = GetIrisRadiusMask(distFromCenter);
 
     // ------- Normal -------
-    
+
     surface.vertexNormal = normalize(vertexNormal);
-    
+
     // Get surface normal for each layer (iris/sclera) and blend using the mask defined above
     float2 irisNormalUv = uvs[MaterialSrg::m_iris_m_normalMapUvIndex];
     real3 irisNormal = GetNormalInputWS(MaterialSrg::m_iris_m_normalMap, MaterialSrg::m_sampler, irisNormalUv, MaterialSrg::m_iris_m_flipNormalX, MaterialSrg::m_iris_m_flipNormalY, isFrontFace, surface.vertexNormal,
                                     tangents[MaterialSrg::m_iris_m_normalMapUvIndex], bitangents[MaterialSrg::m_iris_m_normalMapUvIndex], uvMatrix, o_iris_o_normal_useTexture, real(MaterialSrg::m_iris_m_normalFactor));
-    
+
     float2 scleraNormalUv = uvs[MaterialSrg::m_sclera_m_normalMapUvIndex];
     real3 scleraNormal = GetNormalInputWS(MaterialSrg::m_sclera_m_normalMap, MaterialSrg::m_sampler, scleraNormalUv, MaterialSrg::m_sclera_m_flipNormalX, MaterialSrg::m_sclera_m_flipNormalY, isFrontFace, surface.vertexNormal,
                                     tangents[MaterialSrg::m_sclera_m_normalMapUvIndex], bitangents[MaterialSrg::m_sclera_m_normalMapUvIndex], uvMatrix, o_sclera_o_normal_useTexture, real(MaterialSrg::m_sclera_m_normalFactor));
-    
+
     surface.normal = normalize(lerp(irisNormal, scleraNormal, mask));
 
     //--------------------- Eye refraction UV offset ----------------------
@@ -64,49 +107,67 @@ Surface EvaluateSurface_Eye(
     real3 refractedDir = refract(viewDir, surface.GetVertexNormal(), refractionFactor);
 
     // Get UV offset due to refraction (based on http://www.iryoku.com/stare-into-the-future)
-    
+
     // Gaze direction corresponds to the front vector (in WS)
     real3 gazeDirWS = normalize(mul(worldMatrix, real4(0,1,0,0)).xyz);
 
-    // Position direction corresponds to the vector from the object's center to the point in WS (in order to support refraction in all orientations)
-    real3 positionDirWS = mul(worldMatrix, real4(localPosition,0.0)).xyz;
-
-    // Object scale of the front vector (Y) 
+    // Object scale of the front vector (Y)
     real scaleY = length(real3(worldMatrix._12, worldMatrix._22, worldMatrix._32));
-    
-    // Compute distance from current point to the iris plane 
+
+
+#if USE_NORMALIZED_SPACE_ALGORITHM
+    real3 positionDirWS = normalize(mul(worldMatrix, real4(localPosition, 0.0)).xyz);
+    const real height = max(dot(gazeDirWS, positionDirWS) * NORMALIZED_EYE_RADIUS - real(MaterialSrg::m_irisDepth), 0.0);
+#else
+    // Position direction corresponds to the vector from the object's center to the point in WS (in order to support refraction in all orientations)
+    real3 positionDirWS = mul(worldMatrix, real4(localPosition, 0.0)).xyz;
+    // Compute distance from current point to the iris plane
     // m_irisDepth corresponds to the distance from the object origin to the local plane (XZ) where the iris lays.
     // By multiplying this parameter by the scale we avoid having to re-tune it everytime we change the object's scale.
-    real height = max(dot(gazeDirWS, positionDirWS) - real(MaterialSrg::m_irisDepth)*scaleY, 0.0); 
+    const real height = max(dot(gazeDirWS, positionDirWS) - real(MaterialSrg::m_irisDepth)*scaleY, 0.0);
+#endif
 
-    // Height encodes the length of the refracted ray projected in (local) Y, but we are interested in the (local) XZ coordinates 
-    // of the ray since these will be directly related to the offset to apply in texture space. Hence, we apply basic trigonometry 
+
+    // Height encodes the length of the refracted ray projected in (local) Y, but we are interested in the (local) XZ coordinates
+    // of the ray since these will be directly related to the offset to apply in texture space. Hence, we apply basic trigonometry
     // to get the actual length of the ray
     real cosAlpha = dot(gazeDirWS, -refractedDir);
     real refractedRayLength = height / cosAlpha;
     real3 refractedRay = refractedRayLength * refractedDir;
 
+#if USE_NORMALIZED_SPACE_ALGORITHM
+    // The following approach calculates the refractionUVOffset assuming
+    // a normalized space. Where the Eye radious is 0.5;
+    // We are going to assume the scale is uniform.
+    real invScale = 1.0 / scaleY;
+    // Now let's calculate the inverse of the world matrix so we can convert the difracted ray
+    // to object local space.
+    real3x3 unscaledObjectToWorlMatrix = real3x3(worldMatrix[0].xyz * invScale,
+                                                 worldMatrix[1].xyz * invScale,
+                                                 worldMatrix[2].xyz * invScale);
+    // preMultiplying is the same as postMultplying by the transpose.
+    // Convert ray to object local space and fetch XZ coordinates (which map to -XY in texture space)
+    real3 objectRefractedRay = mul(refractedRay, unscaledObjectToWorlMatrix);
+    real2 refractionUVOffset = -objectRefractedRay.xz;
+#else
     // Convert ray to object local space and fetch XZ coordinates (which map to -XY in texture space)
     real2 refractionUVOffset = -mul(refractedRay, real3x3(worldMatrixIT)).xz;
+#endif
 
-    // Apply offset to the current UVs
-    for (int uvIdx = 0; uvIdx < UvSetCount; uvIdx++)
-    {
-        uvs[uvIdx] += refractionUVOffset;
-    }
+    real2 irisRefractionUv = real2(uvs[MaterialSrg::m_iris_m_baseColorMapUvIndex]) + refractionUVOffset;
 
     //--------------------- Base Color ----------------------
 
-    // Sample iris color map and blend with the base iris color 
-    float2 irisBaseColorUv = uvs[MaterialSrg::m_iris_m_baseColorMapUvIndex];
-    real3 irisSampledColor = GetBaseColorInput(MaterialSrg::m_iris_m_baseColorMap, MaterialSrg::m_sampler, irisBaseColorUv, real3(MaterialSrg::m_iris_m_baseColor), o_iris_o_baseColor_useTexture);    
+    // Sample iris color map and blend with the base iris color
+    float2 irisBaseColorUv = irisRefractionUv;
+    real3 irisSampledColor = GetBaseColorInput(MaterialSrg::m_iris_m_baseColorMap, MaterialSrg::m_sampler, irisBaseColorUv, real3(MaterialSrg::m_iris_m_baseColor), o_iris_o_baseColor_useTexture);
     real3 irisColor = BlendBaseColor(irisSampledColor, real3(MaterialSrg::m_iris_m_baseColor), real(MaterialSrg::m_iris_m_baseColorFactor), o_iris_o_baseColorTextureBlendMode, o_iris_o_baseColor_useTexture);
-    
-    // Sample sclera color map and blend with the base sclera color 
+
+    // Sample sclera color map and blend with the base sclera color
     float2 scleraBaseColorUv = uvs[MaterialSrg::m_sclera_m_baseColorMapUvIndex];
-    real3 scleraSampledColor = GetBaseColorInput(MaterialSrg::m_sclera_m_baseColorMap, MaterialSrg::m_sampler, scleraBaseColorUv, real3(MaterialSrg::m_sclera_m_baseColor), o_sclera_o_baseColor_useTexture);    
+    real3 scleraSampledColor = GetBaseColorInput(MaterialSrg::m_sclera_m_baseColorMap, MaterialSrg::m_sampler, scleraBaseColorUv, real3(MaterialSrg::m_sclera_m_baseColor), o_sclera_o_baseColor_useTexture);
     real3 scleraColor = BlendBaseColor(scleraSampledColor, real3(MaterialSrg::m_sclera_m_baseColor), real(MaterialSrg::m_sclera_m_baseColorFactor), o_sclera_o_baseColorTextureBlendMode, o_sclera_o_baseColor_useTexture);
-    
+
     // Blend iris and sclera output colors
     real3 baseColor = lerp(irisColor, scleraColor, mask);
 
@@ -120,7 +181,7 @@ Surface EvaluateSurface_Eye(
     // ------- Roughness -------
 
     // Get surface roughness for each layer (iris/sclera) and blend using the mask defined above
-    float2 irisRoughnessUv = uvs[MaterialSrg::m_iris_m_roughnessMapUvIndex];
+    float2 irisRoughnessUv = irisRefractionUv;
     real irisRoughnessLinear = GetRoughnessInput(MaterialSrg::m_iris_m_roughnessMap, MaterialSrg::m_sampler, irisRoughnessUv, real(MaterialSrg::m_iris_m_roughnessFactor),
                                         real(MaterialSrg::m_iris_m_roughnessLowerBound), real(MaterialSrg::m_iris_m_roughnessUpperBound), o_iris_o_roughness_useTexture);
 

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
@@ -128,11 +128,11 @@ real3x3 ExtractFloat3x3(float4x4 input)
 
 // ---------- Intersection -----------
 
-// a simple ray sphere intersection function, didn't take limited precision 
+// a simple ray sphere intersection function, didn't take limited precision
 // mentioned in Ray Tracing Gems : Chapter7 into consider for simplicity
 // input vectors and calculation are in world space
 // return length t to the closest hit point if hit, otherwise return -1
-float RaySphereClosestHitWS(in float3 sphereOrigin, in float sphereRadius, 
+float RaySphereClosestHitWS(in float3 sphereOrigin, in float sphereRadius,
                           in float3 rayOrigin, in float3 rayDir)
 {
     // vector point from sphere to ray origin
@@ -142,12 +142,12 @@ float RaySphereClosestHitWS(in float3 sphereOrigin, in float sphereRadius,
     float DdotD = dot(rayDir, rayDir);
 
     float det = FdotD * FdotD - (DdotD * FdotF - (DdotD * sphereRadius * sphereRadius));
-    
+
     if(det < 0.0f)
     {
         return -1;
     }
-    
+
     float sqrtDet = sqrt(det);
     if(sqrtDet > -FdotD)
     {
@@ -256,7 +256,7 @@ float3 DecodeNormalSignedOctahedron(float3 encodedNormal)
 }
 
 // Encode normal (assume normalized) to a texture coordinate within [0, 1] to save a channel
-// not lossless, but error is negligible. This method is based on Lambert azimuthal projection which usually be used to project world map: 
+// not lossless, but error is negligible. This method is based on Lambert azimuthal projection which usually be used to project world map:
 // https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection
 float2 EncodeNormalSphereMap(float3 normal)
 {
@@ -344,7 +344,7 @@ float PerspectiveDepthToLinear(float clipDepth, float3 coefficients)
 
 // George Marsaglia's Xorshift RNGs
 // https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
-uint Xorshift(in uint value) 
+uint Xorshift(in uint value)
 {
     value ^= value << 13;
     value ^= value >> 17;
@@ -394,4 +394,38 @@ float GaussianNormalized(float x, float expectedValue, float standardDeviation)
 {
     float normalizedAmplitude = 1.0f / (standardDeviation * sqrt(TWO_PI));
     return Gaussian(x, normalizedAmplitude, expectedValue, standardDeviation);
+}
+
+// ------- Useful functions -----------------
+
+// Typical sigmoid function. Returns a value between 0.0 and 1.0.
+real Sigmoid(real x)
+{
+    return 1.0 / (1.0 + exp(-x));
+}
+
+// This function returns a value between 0.0 and 1.0.
+// This function is called "pseudo" sigmoid, because it is based
+// on the sigmoid function, but has slope and inflection point
+// control. Adding extra control parameters comes at the expense
+// of asymmetry. To minimize the asymmetry we have the following
+// restrictions (all parameters will be clamped accordingly):
+// 0 < input
+// 0.01 <=  inflection
+// 0.0001 <= sigmoidWidth <= 0.1. If we allowed values greater than 0.1 the sigmoid
+//                         starts to look asymmetrical around 'inflectionX'
+// @param x The input variable. Expected to be larger than 0.0001.
+// @param inflection The value in 'x' where the sigmoid reaches the inflection point and the output is 0.5.
+// @param sigmoidWidth Width control of the sigmoid. The smaller this value is, the narrower (steeper slope) the sigmoid will be.
+//                     For the minimum value of 0.0001 the sigmoid would look like a step function.
+//                     Caveat: The larger the value of 'inflection' the wider the sigmoid.
+real PseudoSigmoid(real x, real inflection, real sigmoidWidth)
+{
+    x = max(0.0001, x); // Avoids divide by zero
+    inflection = max(0.01, inflection);
+
+    // We limit the maximum value of sigmoidWidth to 0.1 because
+    // the "pseudo" sigmoid becomes remarkably asymmetrical for values larger than 0.1.
+    sigmoidWidth = clamp(sigmoidWidth, 0.0001, 0.1);
+    return Sigmoid((x - inflection) / (x * sigmoidWidth));
 }


### PR DESCRIPTION
## What does this PR do?

The bugs would show up in versions of the Eye model different from the original Eye.fbx.
Other Eye meshes would have different model relative radius than the original `Eye.fbx`, and the original shader
code would assume that the model relative radius of the Eye "sphere" was 0.5. This new version of the shader
code normalizes the vector data, so the Radius is now 0.5 but from a normalized space.  

Added Sigmoid and PseudoSigmoid functions in Atom/RPI/Math.azsli. The PseudoSigmoid function leverages the Sigmoid function but adds control over the inflection point and how wide the sigmoid is around the inflection point.

A macro `USE_NORMALIZED_SPACE_ALGORITHM` was left in `Eye_SurfaceEval.azsli` to help the developer go back and forth between the old and the new methods of calculating the mask for the Iris Radius and the Refraction of the Cornea. By default the macro is set to 1.

## How was this PR tested?

This PR was tested with `AtomSampleViewer`. Also was tested in the Editor with a proprietary Eye model and works well for both the Default O3DE Eye.fbx and our proprietary Eye model. A PR will be posted soon for the `AtomSampleViewer` repository.
