### PR TITLE
Cherry Pick unused variable fix on Linux to point release

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -297,7 +297,7 @@ namespace AZ
             }
 
             RHI::Ptr<RHI::XRDeviceDescriptor> xrDescriptor = m_rhiSystem.GetDevice()->BuildXRDescriptor();
-            auto result = xrRender->CreateDevice(xrDescriptor.get());
+            [[maybe_unused]] auto result = xrRender->CreateDevice(xrDescriptor.get());
             AZ_Error("RPISystem", result == RHI::ResultCode::Success, "Failed to initialize XR device");
             AZ::RHI::XRSessionDescriptor sessionDescriptor;
             result = xrRender->CreateSession(&sessionDescriptor);


### PR DESCRIPTION
## What does this PR do?

Using project exporter will fail on Linux release package due to an unused variable error. Cherry picked from commit https://github.com/o3de/o3de/commit/554a8d78fe5e8dfbb0d996b253daf78bde176bd9 



