### PR TITLE
Fix divide-by-zero bug when surface material size is too large.

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -243,7 +243,8 @@ namespace Terrain
             m_detailTextureScale, &AzFramework::Terrain::TerrainDataRequests::GetTerrainSurfaceDataQueryResolution);
 
         // Texture size needs to be twice the render distance because the camera is positioned in the middle of the texture.
-        m_detailTextureSize = static_cast<int32_t>(lroundf(m_config.m_renderDistance / m_detailTextureScale) * 2);
+        // Clamp the value to be at least 1 pixel in size in case the render distance is smaller than the detail texture scale.
+        m_detailTextureSize = AZStd::max(1, static_cast<int32_t>(lroundf(m_config.m_renderDistance / m_detailTextureScale) * 2));
 
         ClipmapBoundsDescriptor desc;
         desc.m_clipmapUpdateMultiple = 1;


### PR DESCRIPTION
## What does this PR do?

Fixes #16923 . There was a divide by zero bug that would happen in the ClipmapBounds constructor due to m_detailTextureSize getting rounded down to zero when the render distance is lower than the texture scale. By clamping the detail texture size to be at least 1 pixel, the divide-by-zero is avoided.

## How was this PR tested?

Went through the steps in the bug and verified the crash is gone. Note that there are still other crashes (#16889 and #16927 ) that can show up while testing this bugfix, but this specific bug is fixed.
