### PR TITLE
Fix terrain renderer memory trashing.

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -152,16 +152,22 @@ namespace Terrain
         return m_isInitialized;
     }
 
+    void TerrainMeshManager::ClearSectorBuffers()
+    {
+        // RemoveRayTracedMeshes() needs to be called first since it uses pointers into the sector data stored in m_sectorLods.
+        RemoveRayTracedMeshes();
+        m_candidateSectors.clear();
+        m_sectorsThatNeedSrgCompiled.clear();
+        m_sectorLods.clear();
+    }
+
     void TerrainMeshManager::Reset()
     {
         if (m_meshMovedFlag.IsValid())
         {
             m_parentScene->GetViewTagBitRegistry().ReleaseTag(m_meshMovedFlag);
         }
-        RemoveRayTracedMeshes();
-        m_candidateSectors.clear();
-        m_sectorsThatNeedSrgCompiled.clear();
-        m_sectorLods.clear();
+        ClearSectorBuffers();
         m_xyPositions.clear();
         m_cachedDrawData.clear();
 
@@ -442,10 +448,7 @@ namespace Terrain
         // Add one sector of wiggle room so to avoid thrashing updates when going back and forth over a boundary.
         m_1dSectorCount += 1;
 
-        RemoveRayTracedMeshes();
-        m_sectorLods.clear();
-        m_candidateSectors.clear();
-        m_sectorsThatNeedSrgCompiled.clear();
+        ClearSectorBuffers();
 
         const uint8_t lodCount = aznumeric_cast<uint8_t>(AZStd::ceilf(log2f(AZStd::GetMax(1.0f, m_config.m_renderDistance / m_config.m_firstLodDistance)) + 1.0f));
         m_sectorLods.reserve(lodCount);
@@ -655,10 +658,7 @@ namespace Terrain
 
     void TerrainMeshManager::OnTerrainDataDestroyBegin()
     {
-        RemoveRayTracedMeshes();
-        m_sectorLods.clear();
-        m_candidateSectors.clear();
-        m_sectorsThatNeedSrgCompiled.clear();
+        ClearSectorBuffers();
         m_rebuildSectors = true;
     }
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -158,9 +158,9 @@ namespace Terrain
         {
             m_parentScene->GetViewTagBitRegistry().ReleaseTag(m_meshMovedFlag);
         }
+        RemoveRayTracedMeshes();
         m_candidateSectors.clear();
         m_sectorsThatNeedSrgCompiled.clear();
-        RemoveRayTracedMeshes();
         m_sectorLods.clear();
         m_xyPositions.clear();
         m_cachedDrawData.clear();
@@ -170,6 +170,10 @@ namespace Terrain
 
     void TerrainMeshManager::RemoveRayTracedMeshes()
     {
+        AZ_Assert(m_rayTracedItems.empty() || !m_sectorLods.empty(),
+            "RemoveRayTracedMeshes() is being called after the underlying sector data has been deleted. "
+            "The pointers stored in it are no longer valid.");
+
         for (RayTracedItem& item : m_rayTracedItems)
         {
             RtSector::MeshGroup& meshGroup = item.m_sector->m_rtData->m_meshGroups.at(item.m_meshGroupIndex);
@@ -438,10 +442,10 @@ namespace Terrain
         // Add one sector of wiggle room so to avoid thrashing updates when going back and forth over a boundary.
         m_1dSectorCount += 1;
 
+        RemoveRayTracedMeshes();
         m_sectorLods.clear();
         m_candidateSectors.clear();
         m_sectorsThatNeedSrgCompiled.clear();
-        RemoveRayTracedMeshes();
 
         const uint8_t lodCount = aznumeric_cast<uint8_t>(AZStd::ceilf(log2f(AZStd::GetMax(1.0f, m_config.m_renderDistance / m_config.m_firstLodDistance)) + 1.0f));
         m_sectorLods.reserve(lodCount);
@@ -651,10 +655,10 @@ namespace Terrain
 
     void TerrainMeshManager::OnTerrainDataDestroyBegin()
     {
+        RemoveRayTracedMeshes();
         m_sectorLods.clear();
         m_candidateSectors.clear();
         m_sectorsThatNeedSrgCompiled.clear();
-        RemoveRayTracedMeshes();
         m_rebuildSectors = true;
     }
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -252,6 +252,7 @@ namespace Terrain
         void OnTerrainDataDestroyBegin() override;
         void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
 
+        void ClearSectorBuffers();
         bool UpdateGridSize(float distanceToFirstLod);
         void BuildDrawPacket(Sector& sector);
         void BuildRtSector(Sector& sector, uint32_t lodLevel);


### PR DESCRIPTION
## What does this PR do?

Fixes #16889 and #16927 . The sector pointers in the terrain ray tracing data were freed in some cases before they were accessed, causing arbitrary memory to get overwritten. This PR ensures the ray tracing data is freed before the sectors, and adds an assert to validate that assumption.

NOTE: There was a previous PR #16887 submitted to development that hid the issue somewhat, but didn't solve it. When merging point-release changes back to development, any merge conflicts should favor this PR over that one.

## How was this PR tested?

Performed the repro steps in the referenced bugs and verified that they no longer crash.
