### PR TITLE
Fixing Skin Dual Specular and IBL getting applied twice

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
@@ -79,7 +79,15 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     // --- Normal ---
 
     OUT.m_normal.rgb = EncodeNormalSignedOctahedron(surface.normal);
-    OUT.m_normal.a = EncodeUnorm2BitFlags(o_enableIBL, o_specularF0_enableMultiScatterCompensation);
+
+    // --- Fullscreen Passes IBL & Multiscatter ---
+
+    bool applyIblInFullscreenPasses = o_enableIBL;
+#if FORCE_IBL_IN_FORWARD_PASS
+    applyIblInFullscreenPasses = false;
+#endif
+
+    OUT.m_normal.a = EncodeUnorm2BitFlags(applyIblInFullscreenPasses, o_specularF0_enableMultiScatterCompensation);
 
     // --- Emissive ---
     // Sending to specular output for historical reasons until sending to diffuse can be validated

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DualSpecular.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DualSpecular.azsli
@@ -29,7 +29,6 @@ void GetDualSpecularInput(float3 normal, float roughnessLinear, float specularF0
         outDualSpecRoughness = pow(roughnessLinear, dualSpecRoughnessExponent) * dualSpecRoughnessMultiplier;
         CalculateRoughnessValues(normal, outDualSpecRoughness, dummyRoughnessA, outDualSpecRoughnessA2);
         outDualSpecF0 = specularF0 * dualSpecF0Multiplier;
-        outDualSpecFactor = 0;
     }
     else
     {


### PR DESCRIPTION
Fixing Skin Dual Specular and IBL getting applied twice.
Dual Spec factor was getting overridden by copy-pasted code.
IBL was getting applied twice because the flag we set in the normal encoding to notify the DiffuseCompositePass whether or not to apply the global IBL wasn't being turned off when we used the FORCE_IBL_IN_FORWARD_PASS macro.
This macro causes the global IBL to be applied during the forward pass, which means the application of it in the DiffuseCompositePass isn't necessary.