### PR TITLE
Adding implementation of a no-heap allocation Command Line Parser

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
@@ -16,10 +16,6 @@ namespace AZ
 {
     namespace
     {
-        // Any arguments seen after matching the double dash separator
-        // will be parsed as positional arguments
-        static constexpr AZStd::string_view PositionalArgSeparator = "--";
-
         static const AZStd::string m_emptyValue;
         // helper utility to return a lower version of the string without altering the original.
         // regular to_lower operates directly on the input.
@@ -31,63 +27,40 @@ namespace AZ
             return lowerStr;
         }
 
-        AZStd::string_view UnquoteArgument(AZStd::string_view arg)
-        {
-            if (arg.size() < 2)
-            {
-                return arg;
-            }
-
-            return arg.front() == '"' && arg.back() == '"' ? AZStd::string_view{ arg.begin() + 1, arg.end() - 1 } : arg;
-        }
-
         AZStd::string QuoteArgument(AZStd::string_view arg)
         {
             return !arg.empty() ? AZStd::string::format(R"("%.*s")", aznumeric_cast<int>(arg.size()), arg.data()) : AZStd::string{ arg };
         }
     }
 
-    struct CommandLine::ArgumentParserState
-    {
-        //! Set to true if the psuedo argument '--' has been parsed
-        //! This indicates to the argument parser that the remaining
-        //! arguments should be treated as positional arguments only
-        bool m_parseRemainAsPositional{};
-        //! Stores the current option being parsed
-        //! This is used for maintaining state for space separated options
-        //! Ex. --foo bar
-        //! When the "bar" argument is parsed the current switch would be set to "foo"
-        AZStd::string m_currentOption;
-    };
-
     CommandLine::CommandLine()
-        : m_commandLineOptionPrefix(AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX)
     {
+        m_optionPrefixes = Settings::Platform::GetDefaultOptionPrefixes();
     }
 
-    CommandLine::CommandLine(AZStd::string_view commandLineOptionPrefix)
-        : m_commandLineOptionPrefix(commandLineOptionPrefix)
+    CommandLine::CommandLine(Settings::CommandLineOptionPrefixSpan optionPrefixes)
     {
+        // Set the option prefixes on the parser settings
+        m_optionPrefixes.assign(optionPrefixes.begin(), optionPrefixes.end());
     }
 
-    void CommandLine::ParseOptionArgument(AZStd::string_view newOption, AZStd::string_view newValue,
-        CommandArgument* inProgressArgument)
+    void CommandLine::ParseArgument(AZStd::string_view newOption, AZStd::string_view newValue)
     {
-        // Allow argument values wrapped in quotes at both ends to become the value within the quotes
-        AZStd::string_view unquotedValue = UnquoteArgument(newValue);
-        if (unquotedValue != newValue)
+        // Remove any surrounding double quotes from the value
+        AZStd::string_view unquotedValue = Settings::UnquoteArgument(newValue);
+
+        // If the option is an empty string, then a positional argument is being parsed
+        // store unwrap it from any double quotes, but don't perform tokenization to split on commas
+        // or semicolons
+        if (newOption.empty())
         {
-            // Update the inProgressArgument before adding new arguments
-            if(inProgressArgument)
-            {
-                inProgressArgument->m_value = unquotedValue;
-                // Set the inProgressArgument to nullptr to indicate that the inProgressArgument has been fulfilled
-                inProgressArgument = nullptr;
-            }
-            else
-            {
-                m_allValues.push_back({ newOption, unquotedValue });
-            }
+            m_allValues.push_back({ newOption, unquotedValue });
+            return;
+        }
+
+        if (unquotedValue != newValue || unquotedValue.empty())
+        {
+            m_allValues.push_back({ ToLower(newOption), unquotedValue });
         }
         else
         {
@@ -103,81 +76,7 @@ namespace AZ
             // and roots value should be { abc, hij, klm, whee, fun, days }
             for (AZStd::string_view optionValue : tokens)
             {
-                if (inProgressArgument)
-                {
-                    inProgressArgument->m_value = optionValue;
-                    // Set the inProgressArgument to nullptr to indicate that the inProgressArgument has been fulfilled
-                    inProgressArgument = nullptr;
-                }
-                else
-                {
-                    m_allValues.push_back({ newOption, optionValue });
-                }
-            }
-        }
-    }
-
-    void CommandLine::AddArgument(AZStd::string_view currentArg,
-        ArgumentParserState& argumentParserState)
-    {
-        currentArg = AZ::StringFunc::StripEnds(currentArg);
-        if (!currentArg.empty())
-        {
-            if (!argumentParserState.m_parseRemainAsPositional)
-            {
-                // Parse option arguments
-
-                // If the `--` argument is seen, update the
-                // the parser to force parsing remaining arguments as positional
-                if (currentArg == PositionalArgSeparator)
-                {
-                    argumentParserState.m_parseRemainAsPositional = true;
-                    argumentParserState.m_currentOption.clear();
-                    return;
-                }
-
-                // If the `--` argument has been parsed, treat all remaining arguments positional
-                if (m_commandLineOptionPrefix.contains(currentArg.front()))
-                {
-                    // its possible that its a key-value-pair like -blah=whatever
-                    // we support this too, for compatibility.
-
-                    currentArg = currentArg.substr(1);
-                    if (currentArg[0] == '-') // for -- extra
-                    {
-                        currentArg = currentArg.substr(1);
-                    }
-
-                    AZStd::size_t foundPos = AZ::StringFunc::Find(currentArg, "=");
-                    if (foundPos != AZStd::string::npos)
-                    {
-                        AZStd::string_view argumentView{ currentArg };
-                        AZStd::string_view option = AZ::StringFunc::StripEnds(argumentView.substr(0, foundPos));
-                        AZStd::string_view value = AZ::StringFunc::StripEnds(argumentView.substr(foundPos + 1));
-                        ParseOptionArgument(ToLower(option), value, nullptr);
-                        argumentParserState.m_currentOption.clear();
-                    }
-                    else
-                    {
-                        // its in this format -switchName switchvalue
-                        // (no equals)
-                        argumentParserState.m_currentOption = ToLower(currentArg);
-                        m_allValues.push_back({ argumentParserState.m_currentOption, "" });
-                    }
-                    return;
-                }
-            }
-
-            if (argumentParserState.m_currentOption.empty())
-            {
-                // Parse positional argument
-                m_allValues.push_back({ "", UnquoteArgument(currentArg) });
-            }
-            else
-            {
-                // Finish parsing of values for option argument
-                ParseOptionArgument(argumentParserState.m_currentOption, currentArg, &m_allValues.back());
-                argumentParserState.m_currentOption.clear();
+                m_allValues.push_back({ ToLower(newOption), optionValue });
             }
         }
     }
@@ -185,60 +84,68 @@ namespace AZ
     void CommandLine::Parse(int argc, char** argv)
     {
         m_allValues.clear();
-
-        // Stores the state of arguments being parsed
-        // Allows the AddArgument function to update the state
-        ArgumentParserState parseState;
-
-        // Start on 1 because 0 is the executable name
-        for (int i = 1; i < argc; ++i)
+        if (argc == 0)
         {
-            if (argv[i])
-            {
-                AZStd::string_view currentArg = argv[i]; // this eats the / or -
-                AddArgument(currentArg, parseState);
-            }
+            return;
         }
+
+        Settings::CommandLineParserSettings parserSettings;
+        parserSettings.m_optionPrefixes = m_optionPrefixes;
+        parserSettings.m_parseCommandLineEntryFunc = [this](Settings::CommandLineArgument argument)
+        {
+            ParseArgument(argument.m_option, argument.m_value);
+            return true;
+        };
+
+        // Skip the zeroth argument for backwards compatibility
+        --argc;
+        ++argv;
+        Settings::ParseCommandLine(argc, argv, parserSettings);
     }
 
     void CommandLine::Parse(const ParamContainer& commandLine)
     {
         m_allValues.clear();
 
-        // Stores the state of arguments being parsed
-        ArgumentParserState parseState;
-
-        // This version of Parse does not skip over 0th index
-        for (int i = 0; i < commandLine.size(); ++i)
+        Settings::CommandLineParserSettings parserSettings;
+        parserSettings.m_optionPrefixes = m_optionPrefixes;
+        parserSettings.m_parseCommandLineEntryFunc = [this](Settings::CommandLineArgument argument)
         {
-            AddArgument(commandLine[i], parseState);
-        }
+            ParseArgument(argument.m_option, argument.m_value);
+            return true;
+        };
+
+        AZStd::vector<AZStd::string_view> commandLineView(commandLine.begin(), commandLine.end());
+        Settings::ParseCommandLine(commandLineView, parserSettings);
     }
 
     void CommandLine::Parse(AZStd::span<const AZStd::string_view> commandLine)
     {
         m_allValues.clear();
 
-        // Stores the state of arguments being parsed
-        ArgumentParserState parseState;
-
-        // This version of Parse does not skip over 0th index
-        for (int i = 0; i < commandLine.size(); ++i)
+        // Create lambda which parses command line argument
+        Settings::CommandLineParserSettings parserSettings;
+        parserSettings.m_optionPrefixes = m_optionPrefixes;
+        parserSettings.m_parseCommandLineEntryFunc = [this](Settings::CommandLineArgument argument)
         {
-            AddArgument(commandLine[i], parseState);
-        }
+            ParseArgument(argument.m_option, argument.m_value);
+            return true;
+        };
+
+        Settings::ParseCommandLine(commandLine, parserSettings);
     }
 
     void CommandLine::Dump(ParamContainer& commandLineDumpOutput) const
     {
-        AZ_Error("CommandLine", !m_commandLineOptionPrefix.empty(),
+        AZ_Error("CommandLine", !m_optionPrefixes.empty(),
             "Cannot dump command line switches from a command line with an empty option prefix");
 
         for (const CommandArgument& argument : m_allValues)
         {
             if (!argument.m_option.empty())
             {
-                commandLineDumpOutput.emplace_back(m_commandLineOptionPrefix.front() + argument.m_option);
+                AZStd::string_view firstOptionPrefix = m_optionPrefixes.front();
+                commandLineDumpOutput.emplace_back(AZStd::string(firstOptionPrefix) + argument.m_option);
             }
             if (!argument.m_value.empty())
             {

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
@@ -50,7 +50,7 @@ namespace AZ
         AZStd::string_view unquotedValue = Settings::UnquoteArgument(newValue);
 
         // If the option is an empty string, then a positional argument is being parsed
-        // store unwrap it from any double quotes, but don't perform tokenization to split on commas
+        // store it unwrapped from any double quotes, but don't perform tokenization to split on commas
         // or semicolons
         if (newOption.empty())
         {
@@ -97,7 +97,9 @@ namespace AZ
             return true;
         };
 
-        // Skip the zeroth argument for backwards compatibility
+        // For legacy reasons, the executable name argument(arg0) has not been parsed by this overload
+        // of the command line class
+        // So skip the first argument and continue parsing from the second argument(arg1)
         --argc;
         ++argv;
         Settings::ParseCommandLine(argc, argv, parserSettings);

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Settings/CommandLineParser.h>
 #include <AzCore/std/containers/span.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/fixed_string.h>
@@ -61,9 +62,9 @@ namespace AZ
         CommandLine();
 
         /**
-         * Initializes a CommandLine instance which uses the provided commandLineOptionPreix for parsing switches
+         * Initializes a CommandLine instance which uses the provided commandLineOptionPrefix for parsing switches
          */
-        CommandLine(AZStd::string_view commandLineOptionPrefix);
+        CommandLine(Settings::CommandLineOptionPrefixSpan optionPrefixes);
         /**
         * Construct a command line parser.
         * It will load parameters from the given ARGC/ARGV parameters instead of process command line.
@@ -148,13 +149,12 @@ namespace AZ
         auto crend() const -> ArgumentVector::const_reverse_iterator;
 
     private:
-        struct ArgumentParserState;
-        void AddArgument(AZStd::string_view currentArg, ArgumentParserState&);
-        void ParseOptionArgument(AZStd::string_view newOption, AZStd::string_view newValue, CommandArgument* inProgressArgument);
+        void ParseArgument(AZStd::string_view newOption, AZStd::string_view newValue);
 
         ArgumentVector m_allValues;
 
-        inline static constexpr size_t MaxCommandOptionPrefixes = 8;
-        AZStd::fixed_string<MaxCommandOptionPrefixes> m_commandLineOptionPrefix;
+        // Stores the option prefixes which is used to configure the CommandLineParserSettings
+        // to determine what kind of tokens are treated as command line options
+        Settings::CommandLineOptionPrefixArray m_optionPrefixes;
     };
 }

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.cpp
@@ -22,7 +22,7 @@ namespace AZ::Settings
         //! Set to true if the psuedo argument '--' has been parsed
         //! This indicates to the argument parser that the remaining
         //! arguments should be treated as positional arguments only
-        bool m_parseRemainAsPositional{};
+        bool m_parseRemainingArgsAsPositional{};
 
         //! A view of the option being parsed
         //! This is used for maintaining state for space separated options
@@ -187,14 +187,14 @@ namespace AZ::Settings
 
         // Determine if the argument should be parsed as positional argument or option
         bool tokenIsOption{};
-        if (!argumentParserState.m_parseRemainAsPositional)
+        if (!argumentParserState.m_parseRemainingArgsAsPositional)
         {
             // If the token matches the positional argument separator update the parser state
             // to indicate that future tokens should be parsed as positional arguments
             // and return to continue to the next token
             if (currentToken == commandLineParserSettings.m_positionalArgSeparator)
             {
-                argumentParserState.m_parseRemainAsPositional = true;
+                argumentParserState.m_parseRemainingArgsAsPositional = true;
                 argumentParserState.m_currentOption = {};
                 argumentParserState.m_currentOptionAction = CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption;
                 return parseOutcome;
@@ -298,7 +298,7 @@ namespace AZ::Settings
                     parseOutcome = AZStd::unexpected(AZStd::move(argumentParseOutcome.error()));
                 }
                 {
-                    // Handles the case for the second and thereafter error by appending it to the failure string
+                    // Errors after the first one are appended to the failure string
                     parseOutcome.error() += AZStd::move(argumentParseOutcome.error());
                 }
             }
@@ -333,7 +333,7 @@ namespace AZ::Settings
                     parseOutcome = AZStd::unexpected(AZStd::move(argumentParseOutcome.error()));
                 }
                 {
-                    // Handles the case for the second and thereafter error by appending it to the failure string
+                    // Errors after the first one are appended to the failure string
                     parseOutcome.error() += AZStd::move(argumentParseOutcome.error());
                 }
             }

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Settings/CommandLineParser.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/string/conversions.h>
+
+namespace AZ::Settings
+{
+    //! Structure which tracks the current state of parsing the command line
+    //! It stores whether the remaining arguments should be treated as positional
+    //! in case a '--' argument has been parsed
+    //! It also tracks the previous command token if it is an option, so that it can
+    //! be paired with a value
+    struct CommandArgumentParserState
+    {
+        //! Set to true if the psuedo argument '--' has been parsed
+        //! This indicates to the argument parser that the remaining
+        //! arguments should be treated as positional arguments only
+        bool m_parseRemainAsPositional{};
+
+        //! A view of the option being parsed
+        //! This is used for maintaining state for space separated options
+        //! Ex. --foo bar
+        //! When the "bar" argument is parsed the current switch would be set to "foo"
+        AZStd::string_view m_currentOption;
+
+        //! Determines how the next token should be parsed for the current option
+        CommandLineParserSettings::OptionAction m_currentOptionAction{ CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption };
+    };
+
+    auto CommandLineParserSettings::DefaultOptionDelimiter(AZStd::string_view token) -> AZStd::optional<CommandLineArgument>
+    {
+        constexpr AZStd::string_view CommandLineArgumentDelimiters{ "=" };
+
+        // If no characters in the delimiter set can be found in the token,
+        // then return a nullopt to indicate that the option cannot be split
+        if (CommandLineArgumentDelimiters.find_first_of(token) == AZStd::string_view::npos)
+        {
+            return AZStd::nullopt;
+        }
+
+        CommandLineArgument argument;
+
+        // Moves optionToken past any delimiters via the StringFunc::TokenizeNext function
+        // If there are no delimiters in the string, then optionToken would be pointing to the end of view
+        // where return value would be view pointing to the entire token
+        // Therefore return value would always point to the option and the optionToken would always point to the value
+        if (auto argumentOpt = AZ::StringFunc::TokenizeNext(token, CommandLineArgumentDelimiters); argumentOpt.has_value())
+        {
+            // The TokenizeNext function moves the string_view to next token after the equal sign
+            // so optionToken now actually refers to the argument value
+            argument.m_option = AZ::StringFunc::StripEnds(argumentOpt.value());
+            argument.m_value = AZ::StringFunc::StripEnds(token);
+        }
+
+        return argument;
+    };
+
+    auto CommandLineParserSettings::DefaultOptionAction(AZStd::string_view) -> OptionAction
+    {
+        // Use the next token as the value for the option if it is a non-option token
+        // i.e `--foo <value>` will use <value> as the value for option "foo"
+        // but `--foo --bar` will use empty string as the value for option "foo" since the next token is an option
+        return OptionAction::NextTokenIsValueIfNonOption;
+    };
+
+    //! Removes surrounding double quotes around a command line argument value
+    AZStd::string_view UnquoteArgument(AZStd::string_view arg)
+    {
+        if (arg.size() < 2)
+        {
+            return arg;
+        }
+
+        return arg.front() == '"' && arg.back() == '"' ? AZStd::string_view{ arg.begin() + 1, arg.end() - 1 } : arg;
+    }
+
+    static CommandLineParseOutcome InvokeCommandLineEntryCallback(
+        const CommandLineParserSettings::ParseCommandLineEntryFunc& parseCommandLineEntryFunc,
+        const CommandLineArgument& commandLineArgument)
+    {
+        CommandLineParseOutcome parseOutcome;
+        if (!parseCommandLineEntryFunc(commandLineArgument))
+        {
+            parseOutcome = AZStd::unexpected(CommandLineParseErrorString("The Parse Command Line Entry callback returned false for"));
+            if (commandLineArgument.m_option.empty())
+            {
+                parseOutcome.error() += R"( positional argument value=")";
+                parseOutcome.error() += commandLineArgument.m_value;
+                parseOutcome.error() += R"(")";
+            }
+            else
+            {
+                parseOutcome.error() += R"( option argument name=")";
+                parseOutcome.error() += commandLineArgument.m_option;
+                if (!commandLineArgument.m_value.empty())
+                {
+                    // Append the value to failure message if there is one
+                    parseOutcome.error() += R"(", value=")";
+                    parseOutcome.error() += commandLineArgument.m_value;
+                }
+
+                parseOutcome.error() += R"(")";
+            }
+
+            // Add newline to the end of the failure message
+            parseOutcome.error() += '\n';
+        }
+
+        return parseOutcome;
+    }
+
+    //! Used by the subfunctions that are called by the ParseArgument function
+    //! to indicate whether the ParseArgument function should continue
+    //! to parse the current command line current token or continue
+    enum class ParseArgumentAction
+    {
+        //! Indicate that the current token should continue to be parsed in ParseArgument
+        ContinueParsing,
+        //! Indicates the parsing of the current token should stop and move to the next token
+        ParseNextToken
+    };
+    // Finish parsing an option from the previous call to ParseArgument
+    static ParseArgumentAction FinishOptionParse(
+        CommandLineParseOutcome& parseOutcome,
+        CommandArgumentParserState& argumentParserState,
+        AZStd::string_view currentToken,
+        const CommandLineParserSettings& commandLineParserSettings,
+        bool currentTokenIsOption)
+    {
+        ParseArgumentAction parseArgumentAction = ParseArgumentAction::ContinueParsing;
+        CommandLineArgument commandLineArgument;
+        // If the argument parser state parsed the previous token as an option
+        // then depending on the OptionAction, the current token may be a value for that option
+        if (!argumentParserState.m_currentOption.empty())
+        {
+            switch (argumentParserState.m_currentOptionAction)
+            {
+            case CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption:
+                commandLineArgument.m_option = AZStd::move(argumentParserState.m_currentOption);
+                if (!currentTokenIsOption)
+                {
+                    commandLineArgument.m_value = currentToken;
+                    // The current token is the value for the current option entry, so proceed to the next token
+                    parseArgumentAction = ParseArgumentAction::ParseNextToken;
+                }
+                parseOutcome = InvokeCommandLineEntryCallback(commandLineParserSettings.m_parseCommandLineEntryFunc, commandLineArgument);
+                break;
+            case CommandLineParserSettings::OptionAction::NextTokenIsValue:
+                commandLineArgument.m_option = AZStd::move(argumentParserState.m_currentOption);
+                commandLineArgument.m_value = currentToken;
+                parseOutcome = InvokeCommandLineEntryCallback(commandLineParserSettings.m_parseCommandLineEntryFunc, commandLineArgument);
+                // The current token is the value for the current option entry, so proceed to the next token
+                parseArgumentAction = ParseArgumentAction::ParseNextToken;
+            }
+
+            // Reset the current option parsing parameter back to an empty string as the next argument has now been processed
+            argumentParserState.m_currentOption = {};
+            argumentParserState.m_currentOptionAction = CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption;
+        }
+
+        return parseArgumentAction;
+    }
+
+    static CommandLineParseOutcome ParseArgument(
+        CommandArgumentParserState& argumentParserState,
+        AZStd::string_view currentToken,
+        const CommandLineParserSettings& commandLineParserSettings)
+    {
+        CommandLineParseOutcome parseOutcome;
+        // Strip any surrounding whitespace from the token
+        currentToken = AZ::StringFunc::StripEnds(currentToken);
+        if (currentToken.empty())
+        {
+            // The token is empty so there is nothing to parse for the current token
+            // return a successful expectation
+            return parseOutcome;
+        }
+
+        CommandLineArgument commandLineArgument;
+
+        // Determine if the argument should be parsed as positional argument or option
+        bool tokenIsOption{};
+        if (!argumentParserState.m_parseRemainAsPositional)
+        {
+            // If the token matches the positional argument separator update the parser state
+            // to indicate that future tokens should be parsed as positional arguments
+            // and return to continue to the next token
+            if (currentToken == commandLineParserSettings.m_positionalArgSeparator)
+            {
+                argumentParserState.m_parseRemainAsPositional = true;
+                argumentParserState.m_currentOption = {};
+                argumentParserState.m_currentOptionAction = CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption;
+                return parseOutcome;
+            }
+
+            // Check if the token is an option
+            for (const CommandLineOptionPrefixString& optionPrefix : commandLineParserSettings.m_optionPrefixes)
+            {
+                if (currentToken.starts_with(optionPrefix))
+                {
+                    // An option prefix has been found, so parse the token as an option
+                    // by making a sub view after the option prefix token and break out of the loop
+                    currentToken = currentToken.substr(optionPrefix.size());
+                    tokenIsOption = argumentParserState.m_currentOptionAction != CommandLineParserSettings::OptionAction::NextTokenIsValue;
+                    break;
+                }
+            }
+
+            ParseArgumentAction parseArgumentAction =
+                FinishOptionParse(parseOutcome, argumentParserState, currentToken, commandLineParserSettings, tokenIsOption);
+            // If the current token was treated as the "value" for the previous token "option", then the parsing for the current token has
+            // completed
+            if (parseArgumentAction == ParseArgumentAction::ParseNextToken)
+            {
+                return parseOutcome;
+            }
+
+            if (tokenIsOption)
+            {
+                // Default the option field to be the current token
+                commandLineArgument.m_option = currentToken;
+                // If there is a delimiter function try to split the current token
+                // into a option, value pair
+                AZStd::optional<CommandLineArgument> commandArgumentOpt;
+                if (commandLineParserSettings.m_optionDelimiterFunc)
+                {
+                    commandArgumentOpt = commandLineParserSettings.m_optionDelimiterFunc(currentToken);
+                }
+
+                // The option contains a delimiter, so store the complete argument into the command line entry structure
+                if (commandArgumentOpt.has_value())
+                {
+                    commandLineArgument = AZStd::move(commandArgumentOpt.value());
+                }
+                else
+                {
+                    // The option wasn't split on a delimiter so it may be a case
+                    // where the next token is the value for the option.
+                    // such as --project-path <value>
+
+                    CommandLineParserSettings::OptionAction optionAction = commandLineParserSettings.m_optionActionFunc
+                        ? commandLineParserSettings.m_optionActionFunc(commandLineArgument.m_option)
+                        : CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption;
+                    if (optionAction == CommandLineParserSettings::OptionAction::NextTokenIsValueIfNonOption ||
+                        optionAction == CommandLineParserSettings::OptionAction::NextTokenIsValue)
+                    {
+                        // Store the current option in the argument parser state
+                        // and the next iteration of this function will parse the value
+                        argumentParserState.m_currentOption = currentToken;
+                        argumentParserState.m_currentOptionAction = optionAction;
+
+                        // Return here as the option requires the next token to determine if it is complete
+                        return parseOutcome;
+                    }
+                }
+            }
+        }
+
+        // If the token is not an option or the remaining arguments are treated
+        // as positional, then add set the value entry for the argument
+        if (!tokenIsOption)
+        {
+            // The argument is treated has a positional in this case
+            commandLineArgument.m_value = currentToken;
+        }
+
+        return InvokeCommandLineEntryCallback(commandLineParserSettings.m_parseCommandLineEntryFunc, commandLineArgument);
+    }
+
+    CommandLineParseOutcome ParseCommandLine(int argc, char** argv, const CommandLineParserSettings& commandLineParserSettings)
+    {
+        if (!commandLineParserSettings.m_parseCommandLineEntryFunc)
+        {
+            return AZStd::unexpected(
+                CommandLineParseErrorString("A Parse Command Line Entry function needs to be supplied to parse a command line argument"));
+        }
+
+        // Stores parse failure message for each command argument token
+        CommandLineParseOutcome parseOutcome;
+
+        // Stores the current state of the command line parsing after each argument
+        CommandArgumentParserState argumentParserState;
+        for (int i = 0; i < argc; ++i)
+        {
+            if (auto argumentParseOutcome = ParseArgument(argumentParserState, argv[i], commandLineParserSettings); !argumentParseOutcome)
+            {
+                // Aggregate failure messages together for the parseOutcome
+                if (parseOutcome)
+                {
+                    // For the first error move the error messages directly into the parseOutcome
+                    parseOutcome = AZStd::unexpected(AZStd::move(argumentParseOutcome.error()));
+                }
+                {
+                    // Handles the case for the second and thereafter error by appending it to the failure string
+                    parseOutcome.error() += AZStd::move(argumentParseOutcome.error());
+                }
+            }
+        }
+
+        return parseOutcome;
+    }
+
+    CommandLineParseOutcome ParseCommandLine(
+        AZStd::span<AZStd::string_view const> commandLine, const CommandLineParserSettings& commandLineParserSettings)
+    {
+        if (!commandLineParserSettings.m_parseCommandLineEntryFunc)
+        {
+            return AZStd::unexpected(
+                CommandLineParseErrorString("A Parse Command Line Entry function needs to be supplied to parse a command line argument"));
+        }
+
+        // Stores parse failure message for each command argument token
+        CommandLineParseOutcome parseOutcome;
+
+        // Stores the current state of the command line parsing after each argument
+        CommandArgumentParserState argumentParserState;
+        for (int i = 0; i < commandLine.size(); ++i)
+        {
+            if (auto argumentParseOutcome = ParseArgument(argumentParserState, commandLine[i], commandLineParserSettings);
+                !argumentParseOutcome)
+            {
+                // Aggregate failure messages together for the parseOutcome
+                if (parseOutcome)
+                {
+                    // For the first error move the error messages directly into the parseOutcome
+                    parseOutcome = AZStd::unexpected(AZStd::move(argumentParseOutcome.error()));
+                }
+                {
+                    // Handles the case for the second and thereafter error by appending it to the failure string
+                    parseOutcome.error() += AZStd::move(argumentParseOutcome.error());
+                }
+            }
+        }
+
+        return parseOutcome;
+    }
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLineParser.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/fixed_vector.h>
+#include <AzCore/std/containers/span_fwd.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/std/string/fixed_string.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/utility/expected.h>
+
+namespace AZ::Settings
+{
+    //! Stores the prefix used for option arguments
+    //! The cap is MaxOptionPrefixes
+    //! The prefixes can't be larger than 4 characters
+    inline static constexpr size_t MaxOptionPrefixes = 8;
+    inline static constexpr size_t MaxOptionPrefixSize = 4;
+    using CommandLineOptionPrefixString = AZStd::basic_fixed_string<char, MaxOptionPrefixSize, AZStd::char_traits<char>>;
+    using CommandLineOptionPrefixArray = AZStd::fixed_vector<CommandLineOptionPrefixString, MaxOptionPrefixes>;
+    using CommandLineOptionPrefixSpan = AZStd::span<CommandLineOptionPrefixString const>;
+}
+
+namespace AZ::Settings::Platform
+{
+    CommandLineOptionPrefixArray GetDefaultOptionPrefixes();
+}
+
+namespace AZ::Settings
+{
+    //! Struct which contains a string view for option name and the value of a command line argument
+    //! If the command line argument is a positional argument, then the m_option string_view is empty
+    struct CommandLineArgument
+    {
+        AZStd::string_view m_option;
+        AZStd::string_view m_value;
+    };
+
+    //! Settings structure which is used to how to parse CLI command line parameters
+    //! It is setup to invoke an callback with each argument option name and value
+    //! to allow parsing of the command line with allocation of any heap memory
+    //! This can be used to parse the command line in order to read in settings
+    //! which can configure memory allocators before they are available without the need
+    //! to allocate any heap memory as long as the user supplied callback itself is careful
+    //! and how it stores it's settings.
+    //! Suggestion: Using structures such as fixed_vector and fixed_string, allows arrays and string like structures
+    //! that uses stack memory to store the command line settings in a structure for further use which avoids
+    //! any heap allocations
+    struct CommandLineParserSettings
+    {
+
+        //! Callback invoked for each parsed argument.
+        //! This is the the only member that is required to be set within this struct
+        //! All other members are defaulted to work with command line arguments
+        //! IMPORTANT: Any lambda functions or class instances that are larger than 16 bytes
+        //! in size requires a memory allocation to store.
+        //! So it is recommended that users binding a lambda bind at most 2 reference or pointer members
+        //! to avoid dynamic heap allocations
+        //!
+        //! NOTE: This function will not be called if the key is empty
+        //! @return True should be returned from this function to indicate that parsing of the config entry
+        //! has succeeded
+        using ParseCommandLineEntryFunc = AZStd::function<bool(const CommandLineArgument&)>;
+
+        //! Function which is used to supplied the parsed command line argument entry
+        ParseCommandLineEntryFunc m_parseCommandLineEntryFunc;
+
+        //! Determines what kind of action should be taken for the option flag that was parsed
+        //! An option of the form -key or --key
+        enum class OptionAction
+        {
+            //! This indicates that the next "non-option" token should be parsed
+            //! as the value for the current option being parsed
+            //! A non-option token is one that doesn't start with an option prefix such as '-' or '--'
+            //! For a token sequence of `--project-path <value>`
+            //! "<value>" is used as value for "project-path" option
+            //! However for a token sequence of `--project-path --project-cache-path <value>`
+            //! the "project-path" option uses "" as its value because the very next token is an option of "--project-cache-path"
+            //! the "project-cache-path" does have its value set to "<value>"
+            NextTokenIsValueIfNonOption,
+            //! This indicates that the option is a flag
+            //! and contains no additional value parameters
+            //! For a token sequence of `--force <value>`
+            //! The "force" option uses a value of "". This allows the user to treated is a flag option
+            //! The "<value>" token in this case is treated as positional parameter
+            IsFlag,
+            // This indicates the the next token should be parsed as the value in all cases
+            // Even if the next token is an option (--foo)
+            // So a token sequence of `-project-path --project-cache-path <value>`
+            // will have the "project-path" option value set to "--project-cache-path"
+            // The "<value>" token would then be parsed as a positional parameter
+            NextTokenIsValue
+        };
+        //! Determines the default action the command line should take when it parses an option token WITHOUT a value
+        //! @param option string containing the name of the parsed command line option
+        //! @return The default action to take for the option.
+        //! The default return value is to treat the next command line token as the value for the option string
+        static OptionAction DefaultOptionAction(AZStd::string_view option);
+
+        //! Callback function which is invoked when an option token by itself is parsed
+        //! @return The type of action to take for the option, which is to either parse the next command line token
+        //! as the value for the option or treat the option as just a CLI flag, such as `--quiet` or `-verbose`
+        using OptionActionFunc = AZStd::function<OptionAction(AZStd::string_view option)>;
+
+        //! Function invoked ONLY after parsing an option Token that was not split from a CLI delimiter such as an '='
+        //! The algorithm that determines when this function is called is explained with the following sample command line arguments
+        //! `Editor --project-path=<project-path> --force --engine-path <engine-path> positionalArgument
+        //! For the "project-path" option, this function is NOT invoked since the value is gathered by spliting the CLI token on '='
+        //! result: option="project-path", value="<project-path>"
+        //! For the "force" option, this function IS invoked to determine how the next token should be treated
+        //! If the function returns `OptionAction::NextTokenIsValueIfNonOption`, then the following "--engine-path" token is read as an
+        //! option If the function returns `OptionAction::IsFlag`, then the following "--engine-path" token is read as an option If the
+        //! function returns `OptionAction::NextTokenIsValue`, then the following "--engine-path" token is treated as the value for the
+        //! "force" option
+        OptionActionFunc m_optionActionFunc = &DefaultOptionAction;
+
+        //! Splits a command line option token into an option and value
+        //! Surrounding whitespace around the key and value are not part of the string views
+        //! @param token to split into an option and value
+        //! @return option, value pair structure representing the command line argument option name and value
+        static AZStd::optional<CommandLineArgument> DefaultOptionDelimiter(AZStd::string_view token);
+
+        //! Callback function which is invoked when an option argument(-short=value or --long=value) is processed
+        //! to split the the option into an option name value pair
+        //! @return Argument containing the option name and Token
+        using OptionDelimiterFunc = AZStd::function<AZStd::optional<CommandLineArgument>(AZStd::string_view token)>;
+
+        //! Function which is invoked to split an option into an option name and option value pair
+        OptionDelimiterFunc m_optionDelimiterFunc = &DefaultOptionDelimiter;
+
+        //! By default the option prefixes are "--" and "-"
+        //! NOTE: The order is important here as double dash is checked first before single dash
+        //! to make sure an argument such as `--foo bar` parses both dashes before the option name.
+        //! Otherwise the option name would be parses as "-foo" which is incorrect.
+        //! The correct parsing is "foo" for the option name
+        CommandLineOptionPrefixArray m_optionPrefixes{ Platform::GetDefaultOptionPrefixes() };
+
+        //! Separator which is used to separate normal argument parsing(option/positional) from just positional argument parsing
+        //! Positional arguments can still be parsed before the separator, however options will not be parsed
+        //! (i.e `-- --foo bar`) will parse `--foo` as a positional argument not an option with a value of "bar"
+        AZStd::string_view m_positionalArgSeparator = "--";
+    };
+
+    // Expected structure which encapsulates the result of the ParseCommandLine function
+    using CommandLineParseErrorString = AZStd::basic_fixed_string<char, 512, AZStd::char_traits<char>>;
+    using CommandLineParseOutcome = AZStd::expected<void, CommandLineParseErrorString>;
+
+    //! Parses a set of command line arguments
+    //! This function will NOT allocate any heap memory on its on
+    //! It is safe to call without any AZ Allocators being initialized
+    //!
+    //! @param commandLine A contiguous range of string_view arguments pointing to each command line token
+    //! @param configParseSettings struct defining how the command line arguments should be parsed
+    //! @return success outcome if the each token on the command line was parsed successfully,
+    //! otherwise a failure string with the parse error is returned
+    CommandLineParseOutcome ParseCommandLine(
+        AZStd::span<AZStd::string_view const> commandLine, const CommandLineParserSettings& commandLineParserSettings);
+
+    //! Parses a set of command line arguments using the defacto integer argument count parameter and char double pointer to the argument
+    //! array
+    //! @param argc number of command line arguments
+    //! @param argv pointer to the begining of array of c-strings pointing to each command line argument
+    CommandLineParseOutcome ParseCommandLine(int argc, char** argv, const CommandLineParserSettings& commandLineParserSettings);
+
+    //! Removes surrounding double quotes around a command line argument value
+    AZStd::string_view UnquoteArgument(AZStd::string_view arg);
+} // namespace AZ::Settings

--- a/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
+++ b/Code/Framework/AzCore/AzCore/Settings/ConfigParser.h
@@ -64,7 +64,7 @@ namespace AZ::Settings
         //! All other members are defaulted to work with INI style files
         //! IMPORTANT: Any lambda functions or class instances that are larger than 16 bytes
         //! in size requires a memory allocation to store.
-        //! So it is recommmended that users binding a lambda bind at most 2 reference or pointer members
+        //! So it is recommended that users binding a lambda bind at most 2 reference or pointer members
         //! to avoid dynamic heap allocations
         //!
         //! NOTE: This function will not be called if the key is empty
@@ -112,7 +112,7 @@ namespace AZ::Settings
         //! to split the key,value pair of a line
         //! NOTE: Leading and trailing whitespace will be removed from the line before invoking the callback
         //!
-        //! @return an instance of a ConfigKeyValuePair with the split key and value with surrounding whitespaced
+        //! @return an instance of a ConfigKeyValuePair with the split key and value with surrounding whitespace
         //! trimmed
         using DelimiterFunc = AZStd::function<ConfigKeyValuePair(AZStd::string_view line)>;
 
@@ -144,7 +144,7 @@ namespace AZ::Settings
     //! This function will NOT allocate any dynamic memory.
     //! It is safe to call without any AZ Allocators
     //! @param stream GenericStream derived class where the configuration data will be read from
-    //! @param configParseSettigs struct defining configuration on how the INI style file should be parsed
+    //! @param configParseSettings struct defining configuration on how the INI style file should be parsed
     //! @return success outcome if the configuration file was parsed without error,
     //! otherwise a failure string is provided with the parse error
     ParseOutcome ParseConfigFile(AZ::IO::GenericStream& stream, const ConfigParserSettings& configParserSettings);

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -634,6 +634,8 @@ set(FILES
     Serialization/std/VariantReflection.inl
     Settings/CommandLine.cpp
     Settings/CommandLine.h
+    Settings/CommandLineParser.cpp
+    Settings/CommandLineParser.h
     Settings/ConfigParser.cpp
     Settings/ConfigParser.h
     Settings/ConfigurableStack.cpp

--- a/Code/Framework/AzCore/Platform/Android/AzCore/AzCore_Traits_Android.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/AzCore_Traits_Android.h
@@ -64,7 +64,6 @@
 #define AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL 1
 
 // Misc ...
-#define AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX "-"
 #define AZ_TRAIT_CTIME_GMTIME(tm_ptr, time_t_ptr) gmtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CTIME_LOCALTIME(tm_ptr, time_t_ptr) localtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CVARS_ENABLED_FOR_RELEASE_BUILDS 1

--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -53,6 +53,7 @@ set(FILES
     ../Common/UnixLike/AzCore/Module/DynamicModuleHandle_UnixLike.cpp
     AzCore/Module/DynamicModuleHandle_Android.cpp
     AzCore/NativeUI/NativeUISystemComponent_Android.cpp
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
@@ -10,8 +10,8 @@
 
 namespace AZ::Settings::Platform
 {
-    // The option prefix of -- and -  are used by default to indicate
-    // if a command line token is a option on UnixLIke OS
+    // The option prefixes of `--` and `-` are used by default to indicate
+    // if a command line token should be parsed as an option on Unix-like OS
     // Ex. App.exe --foo -bar positional_argument
     CommandLineOptionPrefixArray GetDefaultOptionPrefixes()
     {

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Settings/CommandLineParser.h>
+
+namespace AZ::Settings::Platform
+{
+    // The option prefix of -- and -  are used by default to indicate
+    // if a command line token is a option on UnixLIke OS
+    // Ex. App.exe --foo -bar positional_argument
+    CommandLineOptionPrefixArray GetDefaultOptionPrefixes()
+    {
+        return CommandLineOptionPrefixArray{ "--", "-" };
+    }
+}

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
@@ -10,8 +10,8 @@
 
 namespace AZ::Settings::Platform
 {
-    // The option prefix of --, - and / are used by default to indicate
-    // if a command line token is a option on Windows API compatible OS
+    // The option prefixes of `--`, `-` and `/` are used by default to indicate
+    // if a command line token should be parsed as an option on Windows
     // Ex. App.exe --foo -bar /baz positional_argument
     CommandLineOptionPrefixArray GetDefaultOptionPrefixes()
     {

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Settings/CommandLineParser.h>
+
+namespace AZ::Settings::Platform
+{
+    // The option prefix of --, - and / are used by default to indicate
+    // if a command line token is a option on Windows API compatible OS
+    // Ex. App.exe --foo -bar /baz positional_argument
+    CommandLineOptionPrefixArray GetDefaultOptionPrefixes()
+    {
+        return CommandLineOptionPrefixArray{ "--", "-", "/" };
+    }
+}

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
@@ -76,7 +76,6 @@
 #define AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL 1
 
 // Misc ...
-#define AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX "-"
 #define AZ_TRAIT_CTIME_GMTIME(tm_ptr, time_t_ptr) gmtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CTIME_LOCALTIME(tm_ptr, time_t_ptr) localtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CVARS_ENABLED_FOR_RELEASE_BUILDS 0

--- a/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
@@ -57,6 +57,7 @@ set(FILES
     ../Common/UnixLike/AzCore/PlatformIncl_UnixLike.h
     ../Common/UnixLike/AzCore/Platform_UnixLike.cpp
     AzCore/PlatformIncl_Platform.h
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/AzCore_Traits_Mac.h
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/AzCore_Traits_Mac.h
@@ -64,7 +64,6 @@
 #define AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL 1
 
 // Misc ...
-#define AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX "-"
 #define AZ_TRAIT_CTIME_GMTIME(tm_ptr, time_t_ptr) gmtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CTIME_LOCALTIME(tm_ptr, time_t_ptr) localtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CVARS_ENABLED_FOR_RELEASE_BUILDS 1

--- a/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
@@ -59,6 +59,7 @@ set(FILES
     ../Common/UnixLike/AzCore/PlatformIncl_UnixLike.h
     AzCore/Platform_Mac.cpp
     AzCore/PlatformIncl_Platform.h
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/AzCore_Traits_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/AzCore_Traits_Windows.h
@@ -64,7 +64,6 @@
 #define AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL 1
 
 // Misc ...
-#define AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX "-/"
 #define AZ_TRAIT_CTIME_GMTIME(tm_ptr, time_t_ptr) gmtime_s(tm_ptr, time_t_ptr)
 #define AZ_TRAIT_CTIME_LOCALTIME(tm_ptr, time_t_ptr) localtime_s(tm_ptr, time_t_ptr)
 #define AZ_TRAIT_CVARS_ENABLED_FOR_RELEASE_BUILDS 0

--- a/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
@@ -62,6 +62,7 @@ set(FILES
     AzCore/Platform_Windows.cpp
     AzCore/PlatformIncl_Platform.h
     AzCore/PlatformIncl_Windows.h
+    ../Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
     ../Common/WinAPI/AzCore/Socket/AzSocket_fwd_WinAPI.h
     ../Common/WinAPI/AzCore/Socket/AzSocket_WinAPI.cpp
     ../Common/WinAPI/AzCore/Socket/AzSocket_WinAPI.h

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/AzCore_Traits_iOS.h
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/AzCore_Traits_iOS.h
@@ -65,7 +65,6 @@
 
 
 // Misc ...
-#define AZ_TRAIT_COMMAND_LINE_OPTION_PREFIX "-"
 #define AZ_TRAIT_CTIME_GMTIME(tm_ptr, time_t_ptr) gmtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CTIME_LOCALTIME(tm_ptr, time_t_ptr) localtime_r(time_t_ptr, tm_ptr)
 #define AZ_TRAIT_CVARS_ENABLED_FOR_RELEASE_BUILDS 1

--- a/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
@@ -57,6 +57,7 @@ set(FILES
     ../Common/UnixLike/AzCore/PlatformIncl_UnixLike.h
     ../Common/UnixLike/AzCore/Platform_UnixLike.cpp
     AzCore/PlatformIncl_Platform.h
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/CommandLineTests.cpp
@@ -62,7 +62,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_MiscValues_Simple)
     {
-        AZ::CommandLine cmd{ "-" };
+        AZ::CommandLine cmd{ AZ::Settings::CommandLineOptionPrefixArray{ "-" } };
 
         const char* argValues[] = {
             "programname.exe", "-switch1", "test", "miscvalue1", "miscvalue2"
@@ -80,7 +80,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_Complex)
     {
-        AZ::CommandLine cmd{ "-/" };
+        AZ::CommandLine cmd{ AZ::Settings::CommandLineOptionPrefixArray{ "--", "-", "/" } };
 
         const char* argValues[] = {
             "programname.exe", "-switch1", "test", "--switch1", "test2", "/switch2", "otherswitch", "miscvalue", "/switch3=abc,def", "miscvalue2", "/switch3", "hij,klm"
@@ -107,7 +107,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_WhitespaceTolerant)
     {
-        AZ::CommandLine cmd{ "-/" };
+        AZ::CommandLine cmd{ AZ::Settings::CommandLineOptionPrefixArray{ "--", "-", "/" } };
 
         const char* argValues[] = {
             "programname.exe", "/switch1 ", "test ", " /switch1", " test2", " --switch1", " abc, def ", " /switch1 = abc, def " 
@@ -128,7 +128,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_CustomCommandOption_IsUsedInsteadOfDefault)
     {
-        AZ::CommandLine cmd{ "+" };
+        AZ::CommandLine cmd{ AZ::Settings::CommandLineOptionPrefixArray{ "+" } };
 
         const char* argValues[] =
         {
@@ -142,7 +142,7 @@ namespace UnitTest
         EXPECT_FALSE(cmd.HasSwitch("fakeswitch2"));
         EXPECT_FALSE(cmd.HasSwitch("fakeswitch3"));
         EXPECT_TRUE(cmd.HasSwitch("realswitch1"));
-        EXPECT_TRUE(cmd.HasSwitch("realswitch2"));
+        EXPECT_TRUE(cmd.HasSwitch("-realswitch2"));
         EXPECT_EQ(7, cmd.GetNumMiscValues());
         EXPECT_EQ("-fakeswitch1", cmd.GetMiscValue(0));
         EXPECT_EQ("test", cmd.GetMiscValue(1));
@@ -152,10 +152,10 @@ namespace UnitTest
         EXPECT_EQ("/fakeswitch3=abc,def", cmd.GetMiscValue(5));
         EXPECT_EQ("miscvalue2", cmd.GetMiscValue(6));
         EXPECT_EQ(1, cmd.GetNumSwitchValues("realswitch1"));
-        EXPECT_EQ(2, cmd.GetNumSwitchValues("realswitch2"));
+        EXPECT_EQ(2, cmd.GetNumSwitchValues("-realswitch2"));
         EXPECT_EQ("othervalue", cmd.GetSwitchValue("realswitch1", 0));
-        EXPECT_EQ("More", cmd.GetSwitchValue("realswitch2", 0));
-        EXPECT_EQ("Real", cmd.GetSwitchValue("realswitch2", 1));
+        EXPECT_EQ("More", cmd.GetSwitchValue("-realswitch2", 0));
+        EXPECT_EQ("Real", cmd.GetSwitchValue("-realswitch2", 1));
 
     }
 
@@ -375,7 +375,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_DumpingCommandLineAndParsingAgain_ResultsInEquivalentCommandLine)
     {
-        AZ::CommandLine origCommandLine{ "-/" };
+        AZ::CommandLine origCommandLine{ AZ::Settings::CommandLineOptionPrefixArray{ "-", "/" } };
 
         const char* argValues[] =
         {
@@ -386,7 +386,7 @@ namespace UnitTest
         AZ::CommandLine::ParamContainer dumpedCommandLine;
         origCommandLine.Dump(dumpedCommandLine);
 
-        AZ::CommandLine newCommandLine{ "-/" };
+        AZ::CommandLine newCommandLine{ AZ::Settings::CommandLineOptionPrefixArray{ "-", "/" } };
         newCommandLine.Parse(dumpedCommandLine);
 
         AZStd::initializer_list<AZ::CommandLine> commandLines{ origCommandLine, newCommandLine };
@@ -413,7 +413,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, CommandLineParser_GetSwitchValue_WithNoArgument_ReturnsLastValue)
     {
-        AZ::CommandLine commandLine{ "-" };
+        AZ::CommandLine commandLine{ AZ::Settings::CommandLineOptionPrefixArray{ "--", "-" } };
 
         constexpr AZStd::string_view argValues[] =
         {
@@ -430,7 +430,7 @@ namespace UnitTest
 
     TEST_F(CommandLineTests, ArgumentsParsed_AfterDoubleDash_ArePositionalArgumentsOnly)
     {
-        AZ::CommandLine commandLine{ "-" };
+        AZ::CommandLine commandLine{ AZ::Settings::CommandLineOptionPrefixArray{ "--", "-" } };
 
         constexpr AZStd::string_view argValues[] =
         {
@@ -449,4 +449,49 @@ namespace UnitTest
         EXPECT_EQ("--", commandLine.GetMiscValue(3));
         EXPECT_EQ("baz", commandLine.GetMiscValue(4));
     }
+
+    class CommandLineParserTests
+        : public LeakDetectionFixture
+    {
+    };
+        TEST_F(CommandLineParserTests, CanParseAllTokensAfterOptionAsValue)
+        {
+            AZ::Settings::CommandLineParserSettings parserSettings;
+
+            struct Argument
+            {
+                AZStd::string m_option;
+                AZStd::string m_value;
+            };
+            AZStd::vector<Argument> parsedArguments;
+            parserSettings.m_parseCommandLineEntryFunc = [&parsedArguments](const AZ::Settings::CommandLineArgument& argument)
+            {
+                parsedArguments.push_back(Argument{ argument.m_option, argument.m_value });
+                return true;
+            };
+
+            constexpr AZStd::string_view argValues[] =
+            {
+                "programname.exe", "--foo=1", "--", "--foo=2", "bar", "--", "baz"
+            };
+
+            auto parseOutcome = AZ::Settings::ParseCommandLine(argValues, parserSettings);
+            EXPECT_TRUE(parseOutcome);
+
+            ASSERT_EQ(6, parsedArguments.size());
+
+            EXPECT_TRUE(parsedArguments[0].m_option.empty());
+            EXPECT_EQ("programname.exe", parsedArguments[0].m_value);
+            EXPECT_EQ("foo", parsedArguments[1].m_option);
+            EXPECT_EQ("1", parsedArguments[1].m_value);
+            EXPECT_TRUE(parsedArguments[2].m_option.empty());
+            EXPECT_EQ("--foo=2", parsedArguments[2].m_value);
+            EXPECT_TRUE(parsedArguments[3].m_option.empty());
+            EXPECT_EQ("bar", parsedArguments[3].m_value);
+            EXPECT_TRUE(parsedArguments[4].m_option.empty());
+            EXPECT_EQ("--", parsedArguments[4].m_value);
+            EXPECT_TRUE(parsedArguments[5].m_option.empty());
+            EXPECT_EQ("baz", parsedArguments[5].m_value);
+        }
+
 }   // namespace UnitTest


### PR DESCRIPTION
The Command Line Parser supports a user supplied callback function which is passed each parsed command line option paired with it's value or a positional parameter when the option field is empty.

The existing `AZ::CommandLine` class has been retrofitted to use the `AZ::Settings::CommandLineParser` under the hood.

## How was this PR tested?

Verified the AZ::CommandLine test passes successuflly.
Also added additional UnitTest to verify the `AZ::Settings::ParseCommandLine` function directly.
