### PR TITLE
MSVC 14.38 toolset build fixes (VS2022 17.8.x series).

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
@@ -24,8 +24,6 @@
 #include <QTableView>
 #include <QListView>
 
-#include <QtGui/private/qtextengine_p.h>
-
 namespace AzQtComponents
 {
     TableView::Config TableView::loadConfig(QSettings& settings)

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -26,6 +26,7 @@ endif()
 ly_append_configurations_options(
     DEFINES
         _ENABLE_EXTENDED_ALIGNED_STORAGE # Enables support for extended alignment for the MSVC std::aligned_storage class
+        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING # Prevents triggering of STL4043 when checked iterators are used in 3rdParty libraries(QT and AWSNativSDK)
     COMPILATION
         /fp:fast        # allows the compiler to reorder, combine, or simplify floating-point operations to optimize floating-point code for speed and space
         /Gd             # Use _cdecl calling convention for all functions

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -26,7 +26,7 @@ endif()
 ly_append_configurations_options(
     DEFINES
         _ENABLE_EXTENDED_ALIGNED_STORAGE # Enables support for extended alignment for the MSVC std::aligned_storage class
-        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING # Prevents triggering of STL4043 when checked iterators are used in 3rdParty libraries(QT and AWSNativSDK)
+        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING # Prevents triggering of STL4043 when checked iterators are used in 3rdParty libraries(QT and AWSNativeSDK)
     COMPILATION
         /fp:fast        # allows the compiler to reorder, combine, or simplify floating-point operations to optimize floating-point code for speed and space
         /Gd             # Use _cdecl calling convention for all functions


### PR DESCRIPTION
The QT and AWS library are using Microsoft extension for `stdext::checked_array_iterator` which has been deprecated as part of the MSVC compiler 14.38 toolset.

This fixes the compiler warning of 
`// warning C4996: 'stdext::checked_array_iterator<const T *>': warning STL4043: stdext::checked_array_iterator,`

The deprecation of the check_array_iterator class occured in this Microsoft STL commit a few months back
https://github.com/microsoft/STL/commit/90dcf2672a5062f4be144b27a7232720d4d2c744

## How was this PR tested?

Verified that building the entire O3DE engine solution using Visual Studio 2022 17.8.0 Preview 5.0 with the 14.38 toolset compiled successfully
