### PR TITLE
Switch detection of Windows version to access WMI

### DIFF
--- a/Code/Editor/LogFile.cpp
+++ b/Code/Editor/LogFile.cpp
@@ -193,8 +193,8 @@ namespace LogFileInternal
         AZStd::string m_version;
     };
 
-    // This use the GetVersionEx API which was deprecated in Windows 10
-    // as fall back to query the version information for Windows
+    // This uses the GetVersionEx API which was deprecated in Windows 10
+    // as a fall back to query the version information for Windows
     // On Windows 10 and after, this always returns the version as 6.2
     OSInfo QueryOSInfoUsingGetVersionEx()
     {
@@ -205,12 +205,12 @@ namespace LogFileInternal
 
         AZ_PUSH_DISABLE_WARNING(4996, "-Wunknown-warning-option")
             GetVersionEx(&osVersionInfo);
-        AZ_POP_DISABLE_WARNING
+        AZ_POP_DISABLE_WARNING;
 
-            // Default the name of the operating system to just Windows as the version information
-            // is based on the manifest at the time application was built, which probably
-            // does not match the current version of wndows that is running
-            osInfo.m_name = "Windows";
+        // Default the name of the operating system to just Windows as the version information
+        // is based on the manifest at the time application was built, which probably
+        // does not match the current version of Windows that is running
+        osInfo.m_name = "Windows";
         osInfo.m_version = AZStd::string::format("%ld.%ld", osVersionInfo.dwMajorVersion, osVersionInfo.dwMinorVersion);
         return osInfo;
     }

--- a/Code/Editor/LogFile.cpp
+++ b/Code/Editor/LogFile.cpp
@@ -183,6 +183,7 @@ void CLogFile::FormatLineV(const char * format, va_list argList)
 
 namespace LogFileInternal
 {
+#if defined(AZ_PLATFORM_WINDOWS)
     // Stores information about the OS queried from WMI
     struct OSInfo
     {
@@ -192,117 +193,177 @@ namespace LogFileInternal
         AZStd::string m_version;
     };
 
-    OSInfo QueryOSInfo()
+    // This use the GetVersionEx API which was deprecated in Windows 10
+    // as fall back to query the version information for Windows
+    // On Windows 10 and after, this always returns the version as 6.2
+    OSInfo QueryOSInfoUsingGetVersionEx()
     {
-        // The GetVersion WinAPI function returns the version of Windows
-        // that was manifested at the time the application was built
-        // and not the version of Windows that is currently running
-        // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversion
+        OSInfo osInfo;
+
+        OSVERSIONINFO osVersionInfo;
+        osVersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+
+        AZ_PUSH_DISABLE_WARNING(4996, "-Wunknown-warning-option")
+            GetVersionEx(&osVersionInfo);
+        AZ_POP_DISABLE_WARNING
+
+            // Default the name of the operating system to just Windows as the version information
+            // is based on the manifest at the time application was built, which probably
+            // does not match the current version of wndows that is running
+            osInfo.m_name = "Windows";
+        osInfo.m_version = AZStd::string::format("%ld.%ld", osVersionInfo.dwMajorVersion, osVersionInfo.dwMinorVersion);
+        return osInfo;
+    }
+
+    // This specifically avoids using the GetVersion/GetVersionEx WinAPI
+    // functions because those will only return the version of Windows
+    // that was manifested at the time the application was built
+    // and not the version of Windows that is currently running
+    // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversion
+    AZ::Outcome<OSInfo, AZStd::string> QueryOSInfoUsingWMI()
+    {
+        // Get the thread Id as an numeric value
+        static_assert(sizeof(AZStd::thread_id) <= sizeof(uintptr_t), "Thread Id should less than a size of a pointer");
+        // Using curly braces to zero initalize all bytes the uintptr_t
+        // If the thread Id is < sizeof(uintptr_t), the high bytes would be zeroed out
+        uintptr_t numericThreadId{};
+        *reinterpret_cast<AZStd::thread_id*>(&numericThreadId) = AZStd::this_thread::get_id();
 
         OSInfo osInfo;
         // Query the Windows version using WMI
-        CoInitialize(nullptr);
+        HRESULT hResult = CoInitialize(nullptr);
+        if (FAILED(hResult))
+        {
+            return AZ::Failure(AZStd::string::format(
+                "Failed to initialize the Com library on thread %#" PRIxPTR ": %lu", numericThreadId, static_cast<unsigned long>(hResult)));
+        }
 
         // Obtain the initial locator to Windows Management on a particular host computer.
         IWbemLocator* locator = nullptr;
-        HRESULT hResult = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&locator);
-        if (!FAILED(hResult))
+        hResult = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&locator);
+        if (FAILED(hResult))
         {
-            // Connect to the root\cimv2 namespace with the current user and obtain pointer pSvc to make IWbemServices calls.
-            IWbemServices* services = nullptr;
-            auto serverPath = SysAllocString(TEXT(R"(ROOT\CIMV2)"));
-            hResult = locator->ConnectServer(serverPath, nullptr, nullptr, 0, 0, nullptr, nullptr, &services);
-            SysFreeString(serverPath);
+            return AZ::Failure(
+                AZStd::string::format("Failed to create the Windows Management COM class: %lu", static_cast<unsigned long>(hResult)));
+        }
+        // Connect to the root\cimv2 namespace with the current user and obtain pointer pSvc to make IWbemServices calls.
+        IWbemServices* services = nullptr;
+        auto serverPath = SysAllocString(TEXT(R"(ROOT\CIMV2)"));
+        hResult = locator->ConnectServer(serverPath, nullptr, nullptr, 0, 0, nullptr, nullptr, &services);
+        SysFreeString(serverPath);
 
-            if (!FAILED(hResult))
+        if (FAILED(hResult))
+        {
+            return AZ::Failure(
+                AZStd::string::format("Could not connect the WMI on the local machine: %lu", static_cast<unsigned long>(hResult)));
+        }
+
+        // Set the IWbemServices proxy so that impersonation of the user (client) occurs.
+        hResult = CoSetProxyBlanket(
+            services,
+            RPC_C_AUTHN_WINNT,
+            RPC_C_AUTHZ_NONE,
+            nullptr,
+            RPC_C_AUTHN_LEVEL_CALL,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            nullptr,
+            EOAC_NONE);
+
+        if (FAILED(hResult))
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot impersonate current user for proxy call: %lu", static_cast<unsigned long>(hResult)));
+        }
+
+        IEnumWbemClassObject* classObjectEnumerator = nullptr;
+
+        // query the Name and Version property from the Win32_OperatingSystem class
+        // https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-operatingsystem
+        AZStd::wstring propertyQuery{ L"SELECT Name,Version FROM Win32_OperatingSystem" };
+
+        // ExecQuery expects BSTR types
+        auto query = SysAllocString(propertyQuery.c_str());
+        auto language = SysAllocString(L"WQL");
+        hResult =
+            services->ExecQuery(language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &classObjectEnumerator);
+        SysFreeString(language);
+        SysFreeString(query);
+
+        if (FAILED(hResult))
+        {
+            return AZ::Failure(AZStd::string::format(
+                "WQL query from Win32_OperatingSystem WMI class has failed: %lu", static_cast<unsigned long>(hResult)));
+        }
+
+        // prepare to enumerate the object, blocking until the objects are ready
+        IWbemClassObject* classObject = nullptr;
+        ULONG numResults = 0;
+        hResult = classObjectEnumerator->Next(WBEM_INFINITE, 1, &classObject, &numResults);
+
+        if (FAILED(hResult))
+        {
+            return AZ::Failure(AZStd::string::format(
+                "Enumerating the CIM objects has failed with result code: %lu", static_cast<unsigned long>(hResult)));
+        }
+        else if (classObject == nullptr || numResults == 0)
+        {
+            return AZ::Failure(AZStd::string(
+                "There are no CIM objects found when querying the Win32_OperatingSystem class"));
+        }
+
+        constexpr const wchar_t* namePropertyName{ L"Name" };
+        constexpr const wchar_t* versionPropertyName{ L"Version" };
+        // get the class object's property value
+        VARIANT propertyValue;
+        // Query the Name field
+        if (FAILED(classObject->Get(namePropertyName, 0, &propertyValue, nullptr, nullptr)))
+        {
+            return AZ::Failure(AZStd::string::format(
+                R"(Could not retrieve the ")" AZ_TRAIT_FORMAT_STRING_PRINTF_WSTRING R"(" property from the CIM object: %lu)", namePropertyName, static_cast<unsigned long>(hResult)));
+        }
+
+        // If the name is a binary string copy it over
+        if ((propertyValue.vt & VT_BSTR) == VT_BSTR)
+        {
+            AZStd::to_string(osInfo.m_name, V_BSTR(&propertyValue));
+        }
+        // VariantClear must be called on the variant retrieved from `IWbemClassObject::Get`
+        // according to the documentation:
+        // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get
+        VariantClear(&propertyValue);
+
+        // Query the Version field
+        if (FAILED(classObject->Get(versionPropertyName, 0, &propertyValue, nullptr, nullptr)))
+        {
             {
-                // Set the IWbemServices proxy so that impersonation of the user (client) occurs.
-                hResult = CoSetProxyBlanket(services,
-                    RPC_C_AUTHN_WINNT,
-                    RPC_C_AUTHZ_NONE,
-                    nullptr,
-                    RPC_C_AUTHN_LEVEL_CALL,
-                    RPC_C_IMP_LEVEL_IMPERSONATE,
-                    nullptr,
-                    EOAC_NONE);
-
-                if (!FAILED(hResult))
-                {
-                    IEnumWbemClassObject* classObjectEnumerator = nullptr;
-
-                    // query the Name and Version property from the Win32_OperatingSystem class
-                    // https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-operatingsystem
-                    AZStd::wstring propertyQuery{ L"SELECT Name,Version FROM Win32_OperatingSystem" };
-
-                    // ExecQuery expects BSTR types
-                    auto query = SysAllocString(propertyQuery.c_str());
-                    auto language = SysAllocString(L"WQL");
-                    hResult = services->ExecQuery(language, query,
-                        WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-                        nullptr,
-                        &classObjectEnumerator);
-                    SysFreeString(language);
-                    SysFreeString(query);
-
-                    if (!FAILED(hResult))
-                    {
-                        // prepare to enumerate the object, blocking until the objects are ready
-                        IWbemClassObject* classObject = nullptr;
-                        ULONG numResults = 0;
-                        hResult = classObjectEnumerator->Next(WBEM_INFINITE, 1, &classObject, &numResults);
-
-                        if (!FAILED(hResult) && classObject && numResults != 0)
-                        {
-                            constexpr const wchar_t* namePropertyName{ L"Name" };
-                            constexpr const wchar_t* versionPropertyName{ L"Version" };
-                            // get the class object's property value
-                            VARIANT propertyValue;
-                            // Query the Name field
-                            if (!FAILED(classObject->Get(namePropertyName, 0, &propertyValue, nullptr, nullptr)))
-                            {
-                                // If the name is a binary string copy it over
-                                if ((propertyValue.vt & VT_BSTR) == VT_BSTR)
-                                {
-                                    AZStd::to_string(osInfo.m_name, V_BSTR(&propertyValue));
-                                }
-                            }
-                            // VariantClear must be called on the variant retrieved from `IWbemClassObject::Get`
-                            // according to the documentation:
-                            // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get
-                            VariantClear(&propertyValue);
-
-                            // Query the Version field
-                            if (!FAILED(classObject->Get(versionPropertyName, 0, &propertyValue, nullptr, nullptr)))
-                            {
-                                // If the name is a binary string copy it over
-                                if ((propertyValue.vt & VT_BSTR) == VT_BSTR)
-                                {
-                                    AZStd::to_string(osInfo.m_version, V_BSTR(&propertyValue));
-                                }
-                            }
-                            // VariantClear must be called on the variant retrieved from `IWbemClassObject::Get`
-                            // according to the documentation:
-                            // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get
-                            VariantClear(&propertyValue);
-                        }
-
-                        if (classObject)
-                        {
-                            classObject->Release();
-                        }
-                    }
-
-                    if (classObjectEnumerator)
-                    {
-                        classObjectEnumerator->Release();
-                    }
-                }
+                return AZ::Failure(AZStd::string::format(
+                    R"(Could not retrieve the ")" AZ_TRAIT_FORMAT_STRING_PRINTF_WSTRING R"(" property from the CIM object: %lu)", versionPropertyName, static_cast<unsigned long>(hResult)));
             }
+        }
 
-            if (services)
-            {
-                services->Release();
-            }
+        // If the name is a binary string copy it over
+        if ((propertyValue.vt & VT_BSTR) == VT_BSTR)
+        {
+            AZStd::to_string(osInfo.m_version, V_BSTR(&propertyValue));
+        }
+        // VariantClear must be called on the variant retrieved from `IWbemClassObject::Get`
+        // according to the documentation:
+        // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get
+        VariantClear(&propertyValue);
+
+        if (classObject)
+        {
+            classObject->Release();
+        }
+
+        if (classObjectEnumerator)
+        {
+            classObjectEnumerator->Release();
+        }
+
+        if (services)
+        {
+            services->Release();
         }
 
         if (locator)
@@ -314,6 +375,20 @@ namespace LogFileInternal
 
         return osInfo;
     }
+
+    OSInfo QueryOSInfo()
+    {
+        auto queryOSInfoOutcome = QueryOSInfoUsingWMI();
+        if (!queryOSInfoOutcome)
+        {
+            CryLog("Failed to query Windows version info using WMI with error: %s.\n"
+                "Falling back to using GetVersionEx", queryOSInfoOutcome.GetError().c_str());
+            return QueryOSInfoUsingGetVersionEx();
+        }
+        return queryOSInfoOutcome.GetValue();
+    }
+
+#endif
 }
 
 void CLogFile::AboutSystem()


### PR DESCRIPTION
Previously the Windows was queried using GetVersionEx which only returns Windows 8 for any version of Windows 8 or newer.

The new method uses a WQL query to access Win32_OperatingSystem class for the current version information of the OS

The output now looks like the following when run on a Windows 10 OS "Microsoft Windows 10 Enterprise|C:\Windows|\Device\Harddisk0\Partition3 10.0.19045"

The previous output for a Windows 10 machine was
"Windows 8 6.2 (C:\Windows)"


## How was this PR tested?

Verified that Windows 10 was detected on a Window 10 OS
