### PR TITLE
Fix asserts/crashes caused by missing component serialized identifiers.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -66,6 +66,13 @@ namespace AzToolsFramework
                         // the template is null and the component should not be added.
                         if (component && component->GetUnderlyingComponentType() != genericComponentWrapperTypeId)
                         {
+                            // When a component is first added into the disabledComponents list, it will already have
+                            // a serialized identifier set, which is then used as the componentKey.
+                            // When serializing the component back in, the identifier isn't serialized with the component itself,
+                            // so we need to set it manually with the componentKey to restore the state back to what it was
+                            // at the original point of serialization.
+                            component->SetSerializedIdentifier(componentKey);
+
                             componentInstance->m_disabledComponents.emplace(componentKey, component);
                         }
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -67,6 +67,13 @@ namespace AzToolsFramework
                         // the template is null and the component should not be added.
                         if (component && component->GetUnderlyingComponentType() != genericComponentWrapperTypeId)
                         {
+                            // When a component is first added into the pendingComponents list, it will already have
+                            // a serialized identifier set, which is then used as the componentKey.
+                            // When serializing the component back in, the identifier isn't serialized with the component itself,
+                            // so we need to set it manually with the componentKey to restore the state back to what it was
+                            // at the original point of serialization.
+                            component->SetSerializedIdentifier(componentKey);
+
                             componentInstance->m_pendingComponents.emplace(componentKey, component);
                         }
                     }


### PR DESCRIPTION
## What does this PR do?

Fixes #16807 .

PR #15985 previously fixed some of the issues related to disabled/pending components and how they work relative to component aliases, but there was still a case where loading a prefab containing a disabled or pending component after an Editor restart would assert and crash.

The reason for this is that while editing, the component would get added to the component, then get its SerializedIdentifier set, then get added to the PendingComponent map. If it meets all of its requirements, it then gets removed from the list and added to the entity. If not, it stays in the pending map.

However, when serializing out the component, the SerializedIdentifier doesn't directly get serialized out with the component. It gets serialized as the key for the PendingComponent map, but it wasn't getting added back as a SerializedIdentifier. Consequently, when the entity gets activated and tries to add components from the PendingComponent list, it fails to successfully look it up in the IsComponentPending() call due to the missing SerializedIdentifier, which ultimately leads to asserts and crashes.

(All of the above also applies to disabled components)

The fix is to set the SerializedIdentifier at the point of deserialization, so that when the component is instantiated in the PendingComponent map, it gets a SerializedIdentifier that matches the key to the map, which ensures that it can be found.

NOTE: If the prefab is hand-edited and the serialized identifier is modified to something that clashes with other components on the entity, chaos may ensue, since the assumption is that the read-in identifier is correct and unique.

## How was this PR tested?

Added pending and disabled components to an entity and saved the level. Closed the Editor. Restarted the Editor. Loaded the level and verified that the components could be deleted, re-added, enabled, disabled, without any asserts or crashes.