### PR TITLE
Asset Builder log hard to decipher because of "from X" suffix

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogLine.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogLine.cpp
@@ -382,7 +382,7 @@ namespace AzToolsFramework
             using namespace AZ::Debug;
 
             const AZStd::string separator = " | ";
-            const AZStd::string From = " from ";
+            const AZStd::string Origin = "origin: ";
             const AZStd::string EOL = "\n";
 
             AZStd::string dateTime = QLocale::system().toString(QDateTime::fromMSecsSinceEpoch(m_messageTime), QLocale::ShortFormat).toUtf8().data();
@@ -405,7 +405,7 @@ namespace AzToolsFramework
                 severity = "Context";
                 break;
             }
-            return dateTime + separator + severity + separator + m_message.c_str() + From + m_window.c_str() + EOL;
+            return dateTime + separator + severity + separator + Origin + m_window.c_str() + separator + m_message.c_str() + EOL;
         }
 
         QVariant LogLine::data(int column, int role) const


### PR DESCRIPTION
## What does this PR do?

Change formatting of messages captured by Asset Processor during build.

## How was this PR tested?

Rebuilding some assets.

Before:

> 19/10/2023 23:08 | Info | AssetBuilder: Running processJob task from AssetBuilder
19/10/2023 23:08 | Info | AssetBuilder: Source = D:/carbonated-o3de-gruber/Gems/PopcornFXPlugin/Assets/shaders/Mesh/Legacy/MeshLit_Legacy.shader from AssetBuilder
19/10/2023 23:08 | Info | AssetBuilder: Platform = pc from AssetBuilder
19/10/2023 23:08 | Info | ShaderAssetBuilder: Original AZSL File: D:\carbonated-o3de-gruber\Gems\PopcornFXPlugin\Assets\shaders\Mesh\Legacy\MeshLit_Legacy.azsl from AssetBuilder
19/10/2023 23:08 | Warn |     #define ENABLE_TRANSMISSION 0 from AssetBuilder
19/10/2023 23:08 | Warn |     from D:/carbonated-o3de-gruber/Gems/PopcornFXPlugin/Assets/shaders/Common/LightingHelper.azsli: 31:    #include <Atom/Features/PBR/Lighting/StandardLighting.azsli> from AssetBuilder

after:

> 19/10/2023 23:08 | Info | origin: AssetBuilder | AssetBuilder: Running processJob task
19/10/2023 23:08 | Info | origin: AssetBuilder | AssetBuilder: Source = D:/carbonated-o3de-gruber/Gems/PopcornFXPlugin/Assets/shaders/Mesh/Legacy/MeshLit_Legacy.shader
19/10/2023 23:08 | Info | origin: AssetBuilder | AssetBuilder: Platform = pc
19/10/2023 23:08 | Info | origin: AssetBuilder | ShaderAssetBuilder: Original AZSL File: D:\carbonated-o3de-gruber\Gems\PopcornFXPlugin\Assets\shaders\Mesh\Legacy\MeshLit_Legacy.azsl
19/10/2023 23:08 | Warn | origin: AssetBuilder |    #define ENABLE_TRANSMISSION 0
19/10/2023 23:08 | Warn | origin: AssetBuilder |    from D:/carbonated-o3de-gruber/Gems/PopcornFXPlugin/Assets/shaders/Common/LightingHelper.azsli: 31:    #include <Atom/Features/PBR/Lighting/StandardLighting.azsli>

Concerns:

Not sure about all impacts that this can have on automatic UI splitters (columns probably relying on "|")
But locally my asset processor Status/Source/Message doesn't seem put off by the change. It swallows the origin field silently, and the "copy all" feature behaves as expected (example above).