### PR TITLE
[Cherry-Pick from development] MSVC 14.38 toolset build fixes (VS2022 17.8.x series). (#16966)

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
@@ -24,8 +24,6 @@
 #include <QTableView>
 #include <QListView>
 
-#include <QtGui/private/qtextengine_p.h>
-
 namespace AzQtComponents
 {
     TableView::Config TableView::loadConfig(QSettings& settings)

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -26,6 +26,7 @@ endif()
 ly_append_configurations_options(
     DEFINES
         _ENABLE_EXTENDED_ALIGNED_STORAGE # Enables support for extended alignment for the MSVC std::aligned_storage class
+        _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING # Prevents triggering of STL4043 when checked iterators are used in 3rdParty libraries(QT and AWSNativeSDK)
     COMPILATION
         /fp:fast        # allows the compiler to reorder, combine, or simplify floating-point operations to optimize floating-point code for speed and space
         /Gd             # Use _cdecl calling convention for all functions


### PR DESCRIPTION
* MSVC 14.38 toolset build fixes (VS2022 17.8.x series).

The QT and AWS library are using Microsoft extension for `stdext::checked_array_iterator` which has been deprecated as part of the MSVC compiler 14.38 toolset.



* Update cmake/Platform/Common/MSVC/Configurations_msvc.cmake

