### PR TITLE
Allow the Jenkins CONFIGURATION env to specify multiple build configs

### DIFF
--- a/scripts/build/Platform/Linux/build_linux.sh
+++ b/scripts/build/Platform/Linux/build_linux.sh
@@ -65,8 +65,10 @@ else
     CORE_COUNT=$TOTAL_CORE_COUNT
 fi
 
-
-eval echo [ci_build] cmake --build . --target ${CMAKE_TARGET} --config ${CONFIGURATION} -j $CORE_COUNT -- ${CMAKE_NATIVE_BUILD_ARGS}
-eval cmake --build . --target ${CMAKE_TARGET} --config ${CONFIGURATION} -j $CORE_COUNT -- ${CMAKE_NATIVE_BUILD_ARGS}
-
+# Split the configuration on semi-colon and use the cmake --build wrapper to run the underlying build command for each
+for config in $(echo $CONFIGURATION | sed "s/;/ /g")
+do
+    eval echo [ci_build] cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $CORE_COUNT -- ${CMAKE_NATIVE_BUILD_ARGS}
+    eval cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $CORE_COUNT -- ${CMAKE_NATIVE_BUILD_ARGS}
+done
 popd

--- a/scripts/build/Platform/Mac/build_mac.sh
+++ b/scripts/build/Platform/Mac/build_mac.sh
@@ -48,7 +48,11 @@ if [[ ! -z "$RUN_CONFIGURE" ]]; then
     echo "${CONFIGURE_CMD}" > ${LAST_CONFIGURE_CMD_FILE}
 fi
 
-echo [ci_build] cmake --build . --target ${CMAKE_TARGET} --config ${CONFIGURATION} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
-cmake --build . --target ${CMAKE_TARGET} --config ${CONFIGURATION} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
+# Split the configuration on semi-colon and use the cmake --build wrapper to run the underlying build command for each
+for config in $(echo $CONFIGURATION | sed "s/;/ /g")
+do
+    echo [ci_build] cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
+    cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
+done
 
 popd

--- a/scripts/build/Platform/Windows/build_windows.cmd
+++ b/scripts/build/Platform/Windows/build_windows.cmd
@@ -54,9 +54,12 @@ IF DEFINED RUN_CONFIGURE (
     ECHO !CONFIGURE_CMD!> %LAST_CONFIGURE_CMD_FILE%
 )
 
-call ECHO [ci_build] cmake --build . --target %CMAKE_TARGET% --config %CONFIGURATION% %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
-call cmake --build . --target %CMAKE_TARGET% --config %CONFIGURATION% %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
-IF NOT %ERRORLEVEL%==0 GOTO :error
+REM Split the configuration on semi-colon and use the cmake --build wrapper to run the underlying build command for each
+FOR %%C in (%CONFIGURATION%) do (
+    call ECHO [ci_build] cmake --build . --target %CMAKE_TARGET% --config %%C %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
+    call cmake --build . --target %CMAKE_TARGET% --config %%C %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
+    IF NOT %ERRORLEVEL%==0 GOTO :error
+)
 
 POPD
 EXIT /b 0


### PR DESCRIPTION
This allows a single build step in the Jenkins pipeline to build multiple build configuration such as "profile" and "release" at once.
This is done by separating the build configs using a semi-colon.
e.g `"debug;profile;release"`

This opens up the ability for Jenkins to add multiple build configurations such as "profile" and "release" to an installer by specifying the `CONFIGURATION` env to be `profile;release`

## How was this PR tested?

Locally verified on both Windows and Linux the `scripts/build/ci_build.py` script to run the `installer` pipeline step was able to build both `profile` and `release` configuration when the `build_config.json` [CONFIGURATION](https://github.com/o3de/o3de/blob/development/scripts/build/Platform/Windows/build_config.json#L469) env was set to `profile;release`
