### PR TITLE
[Cherry-pick] Workaround Visual Studio 2019 compiler defect where it warns about

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -2934,7 +2934,7 @@ namespace AZ
                 // supports the AZStd::to_string function
                 auto PairToString = [](const void* pairInst) -> AZStd::string
                 {
-                    auto pairElement = reinterpret_cast<const PairType*>(pairInst);
+                    [[maybe_unused]] auto pairElement = reinterpret_cast<const PairType*>(pairInst);
                     AZStd::string result;
                     if constexpr (AZStd::HasToString_v<T1> && AZStd::HasToString_v<T2>)
                     {


### PR DESCRIPTION
conditionally unused variables via `if constexpr` incorrectly.


## How was this PR tested?

Built using VS2019 successfully in the point-release branch