### PR TITLE
Cherrypick - Consolidate the  `CreateTestFile` function into the AzTest library (#16859)

### DIFF
--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryOriginTrackerTests.cpp
@@ -6,21 +6,21 @@
  *
  */
 
-#include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/UnitTest/TestTypes.h>
 
+#include <AzCore/JSON/document.h>
+#include <AzCore/JSON/writer.h>
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Settings/SettingsRegistryOriginTracker.h>
+#include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
-#include <AzCore/std/containers/deque.h>
-#include <AzCore/JSON/document.h>
-#include <AzCore/JSON/writer.h>
 
 #include <AZTestShared/Utils/Utils.h>
 
@@ -33,15 +33,14 @@ namespace AZ
         *os << "key path: " << origin.m_settingsKey.c_str() << '\n';
         *os << "value when origin set: " << (origin.m_settingsValue.has_value() ? origin.m_settingsValue->c_str() : "<removed>") << '\n';
     }
-}
+} // namespace AZ
 
 namespace SettingsRegistryOriginTrackerTests
 {
     const AZStd::string OBJECT_VALUE = "<object>";
     const AZStd::string ARRAY_VALUE = "<array>";
 
-    class SettingsRegistryOriginTrackerFixture
-        : public UnitTest::LeakDetectionFixture
+    class SettingsRegistryOriginTrackerFixture : public UnitTest::LeakDetectionFixture
     {
     public:
         SettingsRegistryOriginTrackerFixture()
@@ -74,26 +73,8 @@ namespace SettingsRegistryOriginTrackerTests
             m_registry.reset();
         }
 
-        static bool CreateTestFile(const AZ::IO::FixedMaxPath& testPath, AZStd::string_view content)
-        {
-            AZ::IO::SystemFile file;
-            if (!file.Open(testPath.c_str(), AZ::IO::SystemFile::OpenMode::SF_OPEN_CREATE
-                | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
-            {
-                AZ_Assert(false, "Unable to open test file for writing: %s", testPath.c_str());
-                return false;
-            }
-
-            if (file.Write(content.data(), content.size()) != content.size())
-            {
-                AZ_Assert(false, "Unable to write content to test file: %s", testPath.c_str());
-                return false;
-            }
-
-            return true;
-        }
-
-        void CheckOriginsAtPath(const AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack& expected, AZStd::string_view path = "")
+        void CheckOriginsAtPath(
+            const AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack& expected, AZStd::string_view path = "")
         {
             AZStd::vector<AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin> originArray;
             auto GetOrigins = [&originArray](AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin origin)
@@ -116,12 +97,11 @@ namespace SettingsRegistryOriginTrackerTests
         bool m_createdNameDictionary = false;
     };
 
-   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
-   {
-       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
-       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
-       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_TracksOrigin_Successful)
+    {
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.json";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.json";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
            {
                "O3DE": {
                    "Settings": {
@@ -138,8 +118,8 @@ namespace SettingsRegistryOriginTrackerTests
                    }
                }
            }
-       )"));
-       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        )"));
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
            {
                "O3DE": {
                    "Settings": {
@@ -155,29 +135,28 @@ namespace SettingsRegistryOriginTrackerTests
                    }
                }
            }
-       )"));
-       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "",
-           nullptr);
-       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(),
-           AZ::SettingsRegistryInterface::Format::JsonMergePatch,
-           "",
-           nullptr);
-       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
-           { filePath2.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE},
-           { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" },
-           { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
-           { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
-       };
-       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
-   }
+        )"));
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile(
+            (tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        m_registry->MergeSettingsFile(
+            (tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
 
-   TEST_F(SettingsRegistryOriginTrackerFixture, MergeArraySettings_TracksArrayOriginWithPatch_Successful)
-   {
-       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setregpatch";
-       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setregpatch";
-       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/Settings/ObjectValue/IntKey2", "9001" },
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
+        };
+        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
+    }
+
+    TEST_F(SettingsRegistryOriginTrackerFixture, MergeArraySettings_TracksArrayOriginWithPatch_Successful)
+    {
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.setregpatch";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.setregpatch";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
            [
                {"op": "add", "path": "/O3DE", "value": {}},
                {"op": "add", "path" : "/O3DE/ArrayValue", "value": []},
@@ -186,35 +165,36 @@ namespace SettingsRegistryOriginTrackerTests
                {"op": "add", "path" : "/O3DE/ArrayValue/2", "value": 40000000},
                {"op": "add", "path" : "/O3DE/ArrayValue/3", "value": -89396}
            ]
-       )"));
-       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        )"));
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
            [
                {"op": "replace", "path" : "/O3DE/ArrayValue/0", "value" : 27},
                {"op": "replace", "path" : "/O3DE/ArrayValue/1", "value" : 39},
                {"op": "replace", "path" : "/O3DE/ArrayValue/2", "value" : 42}
            ]
-       )"));
-       m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
-       m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
-       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedArrayValueOriginStack = {
-           {filePath1.String(), "/O3DE/ArrayValue", ARRAY_VALUE },
-           { filePath1.String(), "/O3DE/ArrayValue/3", "-89396" },
-           { filePath1.String(), "/O3DE/ArrayValue/2", "40000000" },
-           { filePath2.String(), "/O3DE/ArrayValue/2", "42" },
-           { filePath1.String(), "/O3DE/ArrayValue/1", "7" },
-           { filePath2.String(), "/O3DE/ArrayValue/1", "39" },
-           { filePath1.String(), "/O3DE/ArrayValue/0", "5" },
-           { filePath2.String(), "/O3DE/ArrayValue/0", "27" },
-       };
-       CheckOriginsAtPath(expectedArrayValueOriginStack, "/O3DE/ArrayValue");
-   }
+        )"));
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
+        m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonPatch);
 
-   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_RemoveDuplicateOrigin_Successful)
-   {
-       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
-       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
-       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedArrayValueOriginStack = {
+            { tempRootFolder / filePath1, "/O3DE/ArrayValue", ARRAY_VALUE },
+            { tempRootFolder / filePath1, "/O3DE/ArrayValue/3", "-89396" },
+            { tempRootFolder / filePath1, "/O3DE/ArrayValue/2", "40000000" },
+            { tempRootFolder / filePath2, "/O3DE/ArrayValue/2", "42" },
+            { tempRootFolder / filePath1, "/O3DE/ArrayValue/1", "7" },
+            { tempRootFolder / filePath2, "/O3DE/ArrayValue/1", "39" },
+            { tempRootFolder / filePath1, "/O3DE/ArrayValue/0", "5" },
+            { tempRootFolder / filePath2, "/O3DE/ArrayValue/0", "27" },
+        };
+        CheckOriginsAtPath(expectedArrayValueOriginStack, "/O3DE/ArrayValue");
+    }
+
+    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFile_RemoveDuplicateOrigin_Successful)
+    {
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.json";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.json";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
            {
                "O3DE": {
                    "Settings": {
@@ -225,8 +205,8 @@ namespace SettingsRegistryOriginTrackerTests
                    }
                }
            }
-       )"));
-       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        )"));
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
            {
                "O3DE": {
                    "Settings": {
@@ -236,26 +216,26 @@ namespace SettingsRegistryOriginTrackerTests
                    }
                }
            }
-       )"));
-       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
-           { filePath2.String(), "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
-           { filePath1.String(), "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
-           { filePath1.String(), "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
-           { filePath2.String(), "/O3DE/Settings/ObjectValue/IntKey2", "9001" }
-       };
-       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
-   }
+        )"));
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/Settings/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue/BoolKey1", "true" },
+            { tempRootFolder / filePath1, "/O3DE/Settings/ObjectValue/StringKey1", "\"Hello\"" },
+            { tempRootFolder / filePath2, "/O3DE/Settings/ObjectValue/IntKey2", "9001" }
+        };
+        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/Settings/ObjectValue");
+    }
 
-   TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFileAndCode_TracksOrigin_Successful)
-   {
-       auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-       AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
-       AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
-       ASSERT_TRUE(CreateTestFile(filePath1, R"(
+    TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFileAndCode_TracksOrigin_Successful)
+    {
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.setreg";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.setreg";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
            {
                "O3DE": {
                    "ObjectValue": {
@@ -265,8 +245,8 @@ namespace SettingsRegistryOriginTrackerTests
 
                }
            }
-       )"));
-       ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        )"));
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
            {
                "O3DE": {
                    "ObjectValue": {
@@ -275,30 +255,31 @@ namespace SettingsRegistryOriginTrackerTests
                    }
                }
            }
-       )"));
-       m_registry->MergeSettingsFile(filePath1.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-       AZStd::string_view stringKey1Path = "/O3DE/ObjectValue/StringKey1";
-       AZStd::string_view stringKey1NewValue = R"(Greetings)";
-       ASSERT_TRUE(m_registry->Set(stringKey1Path, stringKey1NewValue));
-       m_registry->MergeSettingsFile(filePath2.FixedMaxPathString(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
-       AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-           { filePath1.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
-           { filePath2.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
-           { filePath2.String(), "/O3DE/ObjectValue/IntKey2", "9001" },
-           { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
-           { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" },
-           { "<in-memory>", "/O3DE/ObjectValue/StringKey1", "\"Greetings\"" },
-           { filePath2.String(), "/O3DE/ObjectValue/StringKey1", "\"Hi\"" }
-       };
-       CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/ObjectValue");
-   }
+        )"));
+
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        AZStd::string_view stringKey1Path = "/O3DE/ObjectValue/StringKey1";
+        AZStd::string_view stringKey1NewValue = R"(Greetings)";
+        ASSERT_TRUE(m_registry->Set(stringKey1Path, stringKey1NewValue));
+        m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "", nullptr);
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/ObjectValue/IntKey2", "9001" },
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue/BoolKey1", "true" },
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue/StringKey1", "\"Hello\"" },
+            { "<in-memory>", "/O3DE/ObjectValue/StringKey1", "\"Greetings\"" },
+            { tempRootFolder / filePath2, "/O3DE/ObjectValue/StringKey1", "\"Hi\"" }
+        };
+        CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/ObjectValue");
+    }
 
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_NestedMerge_Successful)
     {
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.setreg";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.setreg";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
             {
                 "O3DE": {
                     "foo": 1,
@@ -307,7 +288,7 @@ namespace SettingsRegistryOriginTrackerTests
                 }
             }
         )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
             {
                 "O3DE": {
                     "foo": 3,
@@ -317,25 +298,25 @@ namespace SettingsRegistryOriginTrackerTests
             }
         )"));
         bool mergeFile = true;
-        auto callback = [this, &mergeFile, &filePath2](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        auto callback = [this, &tempRootFolder, &mergeFile, &filePath2](const AZ::SettingsRegistryInterface::NotifyEventArgs& notifyEventArgs)
         {
             if (notifyEventArgs.m_jsonKeyPath == "/O3DE" && mergeFile)
             {
                 mergeFile = false;
-                m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+                m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
             }
         };
         auto testNotifier = m_registry->RegisterNotifier(callback);
-        m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
-        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack =
-        {
-            { filePath1.String(), "/O3DE", OBJECT_VALUE },
-            { filePath2.String(), "/O3DE/foo", "3" },
-            { filePath1.String(), "/O3DE/foo", "1" },
-            { filePath1.String(), "/O3DE/bar", "true" },
-            { filePath2.String(), "/O3DE/bar", "false" },
-            { filePath1.String(), "/O3DE/baz", R"("yes")" },
-            { filePath2.String(), "/O3DE/baz", R"("no")"},
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+        AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack = {
+            { tempRootFolder / filePath1, "/O3DE", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/foo", "3" },
+            { tempRootFolder / filePath1, "/O3DE/foo", "1" },
+            { tempRootFolder / filePath1, "/O3DE/bar", "true" },
+            { tempRootFolder / filePath2, "/O3DE/bar", "false" },
+            { tempRootFolder / filePath1, "/O3DE/baz", R"("yes")" },
+            { tempRootFolder / filePath2, "/O3DE/baz", R"("no")" }
         };
         AZStd::vector<AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin> originArray;
         auto GetOrigins = [&originArray](AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin origin)
@@ -352,30 +333,36 @@ namespace SettingsRegistryOriginTrackerTests
 
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_LargeInput_Successful)
     {
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
         int numIterations = 10;
         for (int i = 0; i < numIterations; i++)
         {
-            AZ::IO::FixedMaxPath filePath = tempRootFolder / AZStd::string::format("file%d.setreg", i);
-            ASSERT_TRUE(CreateTestFile(filePath, AZStd::string::format(R"(
+            AZ::IO::FixedMaxPath filePath = AZ::IO::FixedMaxPathString::format("file%d.setreg", i);
+            ASSERT_TRUE(AZ::Test::CreateTestFile(
+                m_testFolder,
+                filePath,
+                AZStd::string::format(
+                    R"(
                 {
                     "O3DE": {
                         "persistentKey": %d,
                         "changingKey%d": true
                     }
                 }
-            )",i, i)));
-            m_registry->MergeSettingsFile(filePath.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+            )",
+                    i,
+                    i)));
+            m_registry->MergeSettingsFile((tempRootFolder / filePath).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         }
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedO3DEOriginStack;
         for (int i = 0; i < numIterations; i++)
         {
-            AZ::IO::FixedMaxPath filePath = tempRootFolder / AZStd::string::format("file%d.setreg", i);
-            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin o3deOrigin{ filePath.String(), "/O3DE", OBJECT_VALUE };
-            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin persistentKeyOrigin{ filePath.String(),
+            AZ::IO::FixedMaxPath filePath = AZ::IO::FixedMaxPathString::format("file%d.setreg", i);
+            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin o3deOrigin{ tempRootFolder / filePath, "/O3DE", OBJECT_VALUE };
+            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin persistentKeyOrigin{ tempRootFolder / filePath,
                                                                                            "/O3DE/persistentKey",
                                                                                            AZStd::string::format("%d", i) };
-            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin changingKeyOrigin{ filePath.String(),
+            AZ::SettingsRegistryOriginTracker::SettingsRegistryOrigin changingKeyOrigin{ tempRootFolder / filePath,
                                                                                          AZStd::string::format("/O3DE/changingKey%d", i),
                                                                                          "true" };
             expectedO3DEOriginStack.emplace_back(o3deOrigin);
@@ -387,10 +374,9 @@ namespace SettingsRegistryOriginTrackerTests
 
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_IncludeTrackingFilter_Successful)
     {
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.json";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.json";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.json";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.json";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
            {
                "O3DE": {
                     "ObjectValue": {
@@ -400,7 +386,7 @@ namespace SettingsRegistryOriginTrackerTests
                }
            }
        )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
            {
                "O3DE": {
                     "ObjectValue": {
@@ -418,23 +404,23 @@ namespace SettingsRegistryOriginTrackerTests
             return true;
         };
         m_originTracker->SetTrackingFilter(trackingFilterCallback);
-        m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
-        m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+        m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         AZ::SettingsRegistryOriginTracker::SettingsRegistryOriginStack expectedObjectValueOriginStack = {
-            { filePath1.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
-            { filePath2.String(), "/O3DE/ObjectValue", OBJECT_VALUE },
-            { filePath1.String(), "/O3DE/ObjectValue/BoolKey1", "true" },
-            { filePath1.String(), "/O3DE/ObjectValue/StringKey1", "\"Hello\"" }
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath2, "/O3DE/ObjectValue", OBJECT_VALUE },
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue/BoolKey1", "true" },
+            { tempRootFolder / filePath1, "/O3DE/ObjectValue/StringKey1", "\"Hello\"" }
         };
         CheckOriginsAtPath(expectedObjectValueOriginStack, "/O3DE/ObjectValue");
     }
 
     TEST_F(SettingsRegistryOriginTrackerFixture, MergeSettingsFiles_FindLastOrigin_Successful)
     {
-        auto tempRootFolder = AZ::IO::FixedMaxPath(m_testFolder.GetDirectory());
-        AZ::IO::FixedMaxPath filePath1 = tempRootFolder / "folder1" / "file1.setreg";
-        AZ::IO::FixedMaxPath filePath2 = tempRootFolder / "folder2" / "file2.setreg";
-        ASSERT_TRUE(CreateTestFile(filePath1, R"(
+        constexpr AZ::IO::PathView filePath1 = "folder1/file1.setreg";
+        constexpr AZ::IO::PathView filePath2 = "folder2/file2.setreg";
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath1, R"(
             {
                 "O3DE": {
                     "foo": 1,
@@ -443,7 +429,7 @@ namespace SettingsRegistryOriginTrackerTests
                 }
             }
         )"));
-        ASSERT_TRUE(CreateTestFile(filePath2, R"(
+        ASSERT_TRUE(AZ::Test::CreateTestFile(m_testFolder, filePath2, R"(
             {
                 "O3DE": {
                     "foo": 3,
@@ -451,16 +437,18 @@ namespace SettingsRegistryOriginTrackerTests
                 }
             }
         )"));
-        m_registry->MergeSettingsFile(filePath1.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
-        m_registry->MergeSettingsFile(filePath2.Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+
+        auto tempRootFolder = m_testFolder.GetDirectoryAsPath();
+        m_registry->MergeSettingsFile((tempRootFolder / filePath1).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
+        m_registry->MergeSettingsFile((tempRootFolder / filePath2).Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch);
         AZ::IO::Path lastFooOriginPath;
         ASSERT_TRUE(m_originTracker->FindLastOrigin(lastFooOriginPath, "/O3DE/foo"));
-        EXPECT_EQ(filePath2, lastFooOriginPath);
+        EXPECT_EQ(tempRootFolder / filePath2, lastFooOriginPath);
         AZ::IO::Path lastBarOriginPath;
         ASSERT_TRUE(m_originTracker->FindLastOrigin(lastBarOriginPath, "/O3DE/bar"));
-        EXPECT_EQ(filePath1, lastBarOriginPath);
+        EXPECT_EQ(tempRootFolder / filePath1, lastBarOriginPath);
         AZ::IO::Path lastBazOriginPath;
         ASSERT_TRUE(m_originTracker->FindLastOrigin(lastBazOriginPath, "/O3DE/baz"));
-        EXPECT_EQ(filePath2, lastBazOriginPath);
+        EXPECT_EQ(tempRootFolder / filePath2, lastBazOriginPath);
     }
-}
+} // namespace SettingsRegistryOriginTrackerTests

--- a/Code/Framework/AzTest/AzTest/Utils.cpp
+++ b/Code/Framework/AzTest/AzTest/Utils.cpp
@@ -6,10 +6,6 @@
  *
  */
 #include "Utils.h"
-#include <algorithm>
-#include <cstring>
-#include <AzCore/base.h>
-#include <AzCore/std/functional.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/SystemFile.h>
@@ -17,254 +13,286 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/base.h>
+#include <AzCore/std/functional.h>
+#include <algorithm>
+#include <cstring>
 
-namespace AZ
+namespace AZ::Test
 {
-    namespace Test
+    bool ContainsParameter(int argc, char** argv, const std::string& param)
     {
-        bool ContainsParameter(int argc, char** argv, const std::string& param)
-        {
-            int index = GetParameterIndex(argc, argv, param);
-            return index < 0 ? false : true;
-        }
+        return GetParameterIndex(argc, argv, param) >= 0;
+    }
 
-        void CopyParameters(int argc, char** target, char** source)
+    void CopyParameters(int argc, char** target, char** source)
+    {
+        for (int i = 0; i < argc; i++)
         {
-            for (int i = 0; i < argc; i++)
+            const size_t dstSize = std::strlen(source[i]) + 1;
+            target[i] = new char[dstSize];
+            azstrcpy(target[i], dstSize, source[i]);
+        }
+    }
+
+    int GetParameterIndex(int argc, char** argv, const std::string& param)
+    {
+        for (int i = 0; i < argc; i++)
+        {
+            if (param == argv[i])
             {
-                const size_t dstSize = std::strlen(source[i]) + 1;
-                target[i] = new char[dstSize];
-                azstrcpy(target[i], dstSize, source[i]);
+                return i;
             }
         }
+        return -1;
+    }
 
-        int GetParameterIndex(int argc, char** argv, const std::string& param)
+    std::vector<std::string> GetParameterList(int& argc, char** argv, const std::string& param, bool removeOnReturn)
+    {
+        std::vector<std::string> parameters;
+        int paramIndex = GetParameterIndex(argc, argv, param);
+        if (paramIndex > 0)
         {
-            for (int i = 0; i < argc; i++)
+            int index = paramIndex + 1;
+            while (index < argc && !StartsWith(argv[index], "-"))
             {
-                if (param == argv[i])
-                {
-                    return i;
-                }
+                parameters.push_back(std::string(argv[index]));
+                index++;
             }
-            return -1;
         }
-
-        std::vector<std::string> GetParameterList(int& argc, char** argv, const std::string& param, bool removeOnReturn)
+        if (removeOnReturn)
         {
-            std::vector<std::string> parameters;
-            int paramIndex = GetParameterIndex(argc, argv, param);
-            if (paramIndex > 0)
-            {
-                int index = paramIndex + 1;
-                while (index < argc && !StartsWith(argv[index], "-"))
-                {
-                    parameters.push_back(std::string(argv[index]));
-                    index++;
-                }
-            }
+            RemoveParameters(argc, argv, paramIndex, paramIndex + (int)parameters.size());
+        }
+        return parameters;
+    }
+
+    std::string GetParameterValue(int& argc, char** argv, const std::string& param, bool removeOnReturn)
+    {
+        std::string value("");
+        int index = GetParameterIndex(argc, argv, param);
+        // Make sure we have a valid parameter index and value after the parameter index
+        if (index > 0 && index < (argc - 1))
+        {
+            value = argv[index + 1];
             if (removeOnReturn)
             {
-                RemoveParameters(argc, argv, paramIndex, paramIndex + (int)parameters.size());
+                RemoveParameters(argc, argv, index, index + 1);
             }
-            return parameters;
+        }
+        return value;
+    }
+
+    void RemoveParameters(int& argc, char** argv, int startIndex, int endIndex)
+    {
+        // protect against invalid order of parameters
+        if (startIndex > endIndex)
+        {
+            return;
         }
 
-        std::string GetParameterValue(int& argc, char** argv, const std::string& param, bool removeOnReturn)
+        // constraint to valid range
+        endIndex = std::min(endIndex, argc - 1);
+        startIndex = std::max(startIndex, 0);
+
+        int numRemoved = 0;
+        int i = startIndex;
+        int j = endIndex + 1;
+
+        // copy all existing paramters
+        while (j < argc)
         {
-            std::string value("");
-            int index = GetParameterIndex(argc, argv, param);
-            // Make sure we have a valid parameter index and value after the parameter index
-            if (index > 0 && index < (argc - 1))
-            {
-                value = argv[index + 1];
-                if (removeOnReturn)
-                {
-                    RemoveParameters(argc, argv, index, index + 1);
-                }
-            }
-            return value;
+            argv[i++] = argv[j++];
         }
 
-        void RemoveParameters(int& argc, char** argv, int startIndex, int endIndex)
+        // null out all the remaining parameters and count how many
+        // were removed simultaneously
+        while (i < argc)
         {
-            // protect against invalid order of parameters
-            if (startIndex > endIndex)
-            {
-                return;
-            }
-
-            // constraint to valid range
-            endIndex = std::min(endIndex, argc - 1);
-            startIndex = std::max(startIndex, 0);
-
-            int numRemoved = 0;
-            int i = startIndex;
-            int j = endIndex + 1;
-
-            // copy all existing paramters
-            while (j < argc)
-            {
-                argv[i++] = argv[j++];
-            }
-
-            // null out all the remaining parameters and count how many
-            // were removed simultaneously
-            while (i < argc)
-            {
-                argv[i++] = nullptr;
-                ++numRemoved;
-            }
-
-            argc -= numRemoved;
+            argv[i++] = nullptr;
+            ++numRemoved;
         }
 
-        char** SplitCommandLine(int& size, char* const cmdLine)
+        argc -= numRemoved;
+    }
+
+    char** SplitCommandLine(int& size, char* const cmdLine)
+    {
+        std::vector<char*> tokens;
+        [[maybe_unused]] char* next_token = nullptr;
+        char* tok = azstrtok(cmdLine, 0, " ", &next_token);
+        while (tok != nullptr)
         {
-            std::vector<char*> tokens;
-            [[maybe_unused]] char* next_token = nullptr;
-            char* tok = azstrtok(cmdLine, 0, " ", &next_token);
-            while (tok != nullptr)
-            {
-                tokens.push_back(tok);
-                tok = azstrtok(nullptr, 0, " ", &next_token);
-            }
-            size = (int)tokens.size();
-            char** token_array = new char*[size];
-            for (size_t i = 0; i < size; i++)
-            {
-                const size_t dstSize = std::strlen(tokens[i]) + 1;
-                token_array[i] = new char[dstSize];
-                azstrcpy(token_array[i], dstSize, tokens[i]);
-            }
-            return token_array;
+            tokens.push_back(tok);
+            tok = azstrtok(nullptr, 0, " ", &next_token);
         }
-
-        bool EndsWith(const std::string& s, const std::string& ending)
+        size = (int)tokens.size();
+        char** token_array = new char*[size];
+        for (size_t i = 0; i < size; i++)
         {
-            if (ending.length() > s.length())
-            {
-                return false;
-            }
-            return std::equal(ending.rbegin(), ending.rend(), s.rbegin());
+            const size_t dstSize = std::strlen(tokens[i]) + 1;
+            token_array[i] = new char[dstSize];
+            azstrcpy(token_array[i], dstSize, tokens[i]);
         }
+        return token_array;
+    }
 
-        bool StartsWith(const std::string& s, const std::string& beginning)
+    bool EndsWith(const std::string& s, const std::string& ending)
+    {
+        if (ending.length() > s.length())
         {
-            if (beginning.length() > s.length())
-            {
-                return false;
-            }
-            return std::equal(beginning.begin(), beginning.end(), s.begin());
+            return false;
         }
+        return std::equal(ending.rbegin(), ending.rend(), s.rbegin());
+    }
 
-        AZStd::string GetCurrentExecutablePath()
+    bool StartsWith(const std::string& s, const std::string& beginning)
+    {
+        if (beginning.length() > s.length())
         {
-            char exeDirectory[AZ_MAX_PATH_LEN];
-            AZ::Utils::GetExecutableDirectory(exeDirectory, AZ_ARRAY_SIZE(exeDirectory));
-
-            AZStd::string executablePath = exeDirectory;
-            return executablePath;
+            return false;
         }
+        return std::equal(beginning.begin(), beginning.end(), s.begin());
+    }
 
-        AZStd::string GetEngineRootPath()
+    AZStd::string GetCurrentExecutablePath()
+    {
+        AZStd::string executablePath{ AZStd::string_view(AZ::Utils::GetExecutableDirectory()) };
+        return executablePath;
+    }
+
+    AZStd::string GetEngineRootPath()
+    {
+        if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
         {
-            if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
+            return AZ::SettingsRegistryMergeUtils::FindEngineRoot(*registry).String();
+        }
+        else
+        {
+            AZ::SettingsRegistryImpl localRegistry;
+            return AZ::SettingsRegistryMergeUtils::FindEngineRoot(localRegistry).String();
+        }
+    }
+
+    void AddActiveGem(AZStd::string_view gemName, AZ::SettingsRegistryInterface& registry, AZ::IO::FileIOBase* fileIo)
+    {
+        // Merge an empty object to the ActiveGems
+        using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+        const auto activeGemEntry =
+            FixedValueString::format("%s/%.*s", AZ::SettingsRegistryMergeUtils::ActiveGemsRootKey, AZ_STRING_ARG(gemName));
+        registry.MergeSettings("{}", AZ::SettingsRegistryInterface::Format::JsonMergePatch, activeGemEntry);
+
+        if (fileIo != nullptr)
+        {
+            auto gemPathEntry =
+                FixedValueString::format("%s/%.*s/Path", AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey, AZ_STRING_ARG(gemName));
+            if (AZ::IO::FixedMaxPath gemRootPath; registry.Get(gemRootPath.Native(), gemPathEntry))
             {
-                return AZ::SettingsRegistryMergeUtils::FindEngineRoot(*registry).String();
+                const auto gemAlias{ FixedValueString::format("@gemroot:%.*s@", AZ_STRING_ARG(gemName)) };
+                const auto gemAliasPath = FixedValueString(gemRootPath);
+                fileIo->SetAlias(gemAlias.c_str(), gemAliasPath.c_str());
             }
             else
             {
-                AZ::SettingsRegistryImpl localRegistry;
-                return AZ::SettingsRegistryMergeUtils::FindEngineRoot(localRegistry).String();
-            }
-        }
-
-        void AddActiveGem(AZStd::string_view gemName, AZ::SettingsRegistryInterface& registry, AZ::IO::FileIOBase* fileIo)
-        {
-            // Merge an empty object to the ActiveGems
-            using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
-            const auto activeGemEntry = FixedValueString::format("%s/%.*s",
-                AZ::SettingsRegistryMergeUtils::ActiveGemsRootKey, AZ_STRING_ARG(gemName));
-            registry.MergeSettings("{}", AZ::SettingsRegistryInterface::Format::JsonMergePatch,
-                activeGemEntry);
-
-            if (fileIo != nullptr)
-            {
-                auto gemPathEntry = FixedValueString::format("%s/%.*s/Path",
-                    AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey, AZ_STRING_ARG(gemName));
-                if (AZ::IO::FixedMaxPath gemRootPath;  registry.Get(gemRootPath.Native(), gemPathEntry))
-                {
-                    const auto gemAlias{ FixedValueString::format("@gemroot:%.*s@", AZ_STRING_ARG(gemName)) };
-                    const auto gemAliasPath = FixedValueString(gemRootPath);
-                    fileIo->SetAlias(gemAlias.c_str(), gemAliasPath.c_str());
-                }
-                else
-                {
-                    AZ_Error("AzTest", false, "Cannot set @gemroot@ alias for gem \"%.*s\"."
-                        " It does not have a gem root folder path within"
-                        " the \"%s\" section of the SettingsRegistry. Make the sure gem is registered in an"
-                        " o3de manifest (o3de_manifest.json, engine.json, project.json, gem.json)"
-                        " and that the manifest files have been merged to the SettingsRegistry."
-                        " Invoke `AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ManifestGemsPaths`"
-                        " to explicitly merge the gem root folder paths from all manifest to the registry",
-                        AZ_STRING_ARG(gemName), AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey);
-                }
-            }
-        }
-
-        AZ::IO::Path ScopedAutoTempDirectory::Resolve(const char* path) const
-        {
-            return AZ::IO::Path(m_tempDirectory) / path;
-        }
-
-        const char* ScopedAutoTempDirectory::GetDirectory() const
-        {
-            return m_tempDirectory;
-        }
-
-        AZ::IO::Path ScopedAutoTempDirectory::GetDirectoryAsPath() const
-        {
-            return m_tempDirectory;
-        }
-
-        AZ::IO::FixedMaxPath ScopedAutoTempDirectory::GetDirectoryAsFixedMaxPath() const
-        {
-            return m_tempDirectory;
-        }
-
-        // Method to delete a folder recursively
-        static void DeleteFolderRecursive(const AZ::IO::PathView& path)
-        {
-            auto callback = [&path](AZStd::string_view filename, bool isFile) -> bool {
-                if (isFile)
-                {
-                    auto filePath = AZ::IO::FixedMaxPath(path) / filename;
-                    AZ::IO::SystemFile::Delete(filePath.c_str());
-                }
-                else
-                {
-                    if (filename != "." && filename != "..")
-                    {
-                        auto folderPath = AZ::IO::FixedMaxPath(path) / filename;
-                        DeleteFolderRecursive(folderPath);
-                    }
-                }
-                return true;
-            };
-            auto searchPath = AZ::IO::FixedMaxPath(path) / "*";
-            AZ::IO::SystemFile::FindFiles(searchPath.c_str(), callback);
-            AZ::IO::SystemFile::DeleteDir(AZ::IO::FixedMaxPathString(path.Native()).c_str());
-        }
-
-        ScopedAutoTempDirectory::~ScopedAutoTempDirectory()
-        {
-            if (m_tempDirectory[0] != '\0')
-            {
-                // Delete the directory and its contents if a temp directory was created
-                AZ::IO::PathView pathView(m_tempDirectory);
-                DeleteFolderRecursive(pathView);
+                AZ_Error(
+                    "AzTest",
+                    false,
+                    "Cannot set @gemroot@ alias for gem \"%.*s\"."
+                    " It does not have a gem root folder path within"
+                    " the \"%s\" section of the SettingsRegistry. Make the sure gem is registered in an"
+                    " o3de manifest (o3de_manifest.json, engine.json, project.json, gem.json)"
+                    " and that the manifest files have been merged to the SettingsRegistry."
+                    " Invoke `AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ManifestGemsPaths`"
+                    " to explicitly merge the gem root folder paths from all manifest to the registry",
+                    AZ_STRING_ARG(gemName),
+                    AZ::SettingsRegistryMergeUtils::ManifestGemsRootKey);
             }
         }
     }
-}
+
+    AZ::IO::Path ScopedAutoTempDirectory::Resolve(const char* path) const
+    {
+        return AZ::IO::Path(m_tempDirectory) / path;
+    }
+
+    const char* ScopedAutoTempDirectory::GetDirectory() const
+    {
+        return m_tempDirectory;
+    }
+
+    AZ::IO::Path ScopedAutoTempDirectory::GetDirectoryAsPath() const
+    {
+        return m_tempDirectory;
+    }
+
+    AZ::IO::FixedMaxPath ScopedAutoTempDirectory::GetDirectoryAsFixedMaxPath() const
+    {
+        return m_tempDirectory;
+    }
+
+    // Method to delete a folder recursively
+    static void DeleteFolderRecursive(const AZ::IO::PathView& path)
+    {
+        AZ::IO::FixedMaxPath nullTerminatedPath{ path };
+        auto callback = [&nullTerminatedPath](AZStd::string_view filename, bool isFile) -> bool
+        {
+            if (isFile)
+            {
+                auto filePath = nullTerminatedPath / filename;
+                AZ::IO::SystemFile::Delete(filePath.c_str());
+            }
+            else
+            {
+                if (filename != "." && filename != "..")
+                {
+                    auto folderPath = nullTerminatedPath / filename;
+                    DeleteFolderRecursive(folderPath);
+                }
+            }
+            return true;
+        };
+        auto searchPath = nullTerminatedPath / "*";
+        AZ::IO::SystemFile::FindFiles(searchPath.c_str(), callback);
+        AZ::IO::SystemFile::DeleteDir(nullTerminatedPath.c_str());
+    }
+
+    ScopedAutoTempDirectory::~ScopedAutoTempDirectory()
+    {
+        if (m_tempDirectory[0] != '\0')
+        {
+            // Delete the directory and its contents if a temp directory was created
+            AZ::IO::PathView pathView(m_tempDirectory);
+            DeleteFolderRecursive(pathView);
+        }
+    }
+
+    AZStd::optional<AZ::IO::FixedMaxPath> CreateTestFile(const ScopedAutoTempDirectory& tempDirectory, AZ::IO::PathView relativePath, AZStd::string_view content)
+    {
+        return CreateTestFile(tempDirectory, relativePath, AZStd::span(reinterpret_cast<const AZStd::byte*>(content.data()), content.size()));
+    }
+
+    AZStd::optional<AZ::IO::FixedMaxPath> CreateTestFile(
+        const ScopedAutoTempDirectory& tempDirectory, AZ::IO::PathView relativePath, AZStd::span<const AZStd::byte> content)
+    {
+        auto path = tempDirectory.GetDirectoryAsFixedMaxPath() / relativePath;
+
+        constexpr auto openMode =
+            AZ::IO::SystemFile::OpenMode::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
+
+        AZ::IO::SystemFile file;
+        if (!file.Open(path.c_str(), openMode))
+        {
+            return AZStd::nullopt;
+        }
+
+        if (file.Write(content.data(), content.size()) != content.size())
+        {
+            // If the contents of the file could not be written return nullopt and delete the file
+            AZ_Assert(false, "Unable to write content to test file: %s", path.c_str());
+            file.Close();
+            AZ::IO::SystemFile::Delete(file.Name());
+        }
+
+        return AZ::IO::FixedMaxPath(file.Name());
+    }
+} // namespace AZ::Test


### PR DESCRIPTION
## What does this PR do?

Cherry-picks this PR from development to the point-release as it is a prerequisite for cherry-picking a separate PR in o3de-extras for fixing SDF importing.

Value: High, enables cherry-picking of SDF import fixes for nested models. Most non-trivial SDF files have nested models, this makes them work.
Blast Radius: Low, this PR only affects test code.

## How was this PR tested?

Ran AzCore.Tests after the cherrypick and verified they all passed.
