### PR TITLE
Cherrypick - Scene Import mesh/material bugfixes (#16724)

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.cpp
@@ -42,32 +42,6 @@ namespace AZ
                 return boneCount > 0;
             }
 
-            bool AreAllMeshesValid(const aiNode& node, const aiScene& scene)
-            {
-                for (unsigned meshIdx = 0; meshIdx < node.mNumMeshes; ++meshIdx)
-                {
-                    const aiMesh* mesh = scene.mMeshes[node.mMeshes[meshIdx]];
-                    for (unsigned int faceIdx = 0; faceIdx < mesh->mNumFaces; ++faceIdx)
-                    {
-                        aiFace face = mesh->mFaces[faceIdx];
-                        if (face.mNumIndices < 3)
-                        {
-                            // If the mesh has any faces that have less than 3 indices, mark this mesh as invalid.
-                            // This is commonly a control curve object that should be ignored by the mesh importer.
-                            // NOTE: meshes that contain more than 3 vertices are still considered a valid mesh at this step,
-                            // although they should be triangulated already in the assImp import process. Non triangulated meshes
-                            // will be ignored in the later process.
-                            AZ_Printf(Utilities::LogWindow,
-                                "Mesh on node %s has a face with %d vertices. This is likely a control curve object and therefore will be ignored.",
-                                node.mName.C_Str(),
-                                face.mNumIndices);
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }
-
             bool IsPivotNode(const aiString& nodeName, size_t* pos)
             {
                 AZStd::string_view name(nodeName.C_Str(), nodeName.length);

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.h
@@ -24,9 +24,6 @@ namespace AZ::SceneAPI::SceneBuilder
 
     bool IsSkinnedMesh(const aiNode& node, const aiScene& scene);
 
-    // Check if the all the meshes under the node are valid meshes.
-    bool AreAllMeshesValid(const aiNode& node, const aiScene& scene);
-
     // Checks if a node name is a pivot node and optionally returns the position in the name of the pivot marker (for splitting out the parts later)
     bool IsPivotNode(const aiString& nodeName, size_t* pos = nullptr);
 

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
@@ -144,33 +144,35 @@ namespace AZ
                         }
 
                         materialMap[materialIndex] = material;
+
+                        Events::ProcessingResult materialResult;
+                        Containers::SceneGraph::NodeIndex newIndex =
+                            context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, materialName.c_str());
+
+                        AZ_Assert(newIndex.IsValid(), "Failed to create SceneGraph node for attribute.");
+                        if (!newIndex.IsValid())
+                        {
+                            combinedMaterialImportResults += Events::ProcessingResult::Failure;
+                            continue;
+                        }
+
+                        AssImpSceneAttributeDataPopulatedContext dataPopulated(context, material, newIndex, materialName);
+                        materialResult = Events::Process(dataPopulated);
+
+                        if (materialResult != Events::ProcessingResult::Failure)
+                        {
+                            materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(dataPopulated);
+                        }
+
+                        combinedMaterialImportResults += materialResult;
                     }
                     else
                     {
                         material = matFound->second;
                         materialName = material.get()->GetMaterialName();
+                        AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "Duplicate material references to %s from node %s",
+                            materialName.c_str(), context.m_sourceNode.GetName());
                     }
-
-                    Events::ProcessingResult materialResult;
-                    Containers::SceneGraph::NodeIndex newIndex =
-                        context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, materialName.c_str());
-
-                    AZ_Assert(newIndex.IsValid(), "Failed to create SceneGraph node for attribute.");
-                    if (!newIndex.IsValid())
-                    {
-                        combinedMaterialImportResults += Events::ProcessingResult::Failure;
-                        continue;
-                    }
-
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, material, newIndex, materialName);
-                    materialResult = Events::Process(dataPopulated);
-
-                    if (materialResult != Events::ProcessingResult::Failure)
-                    {
-                        materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(dataPopulated);
-                    }
-
-                    combinedMaterialImportResults += materialResult;
                 }
 
                 return combinedMaterialImportResults.GetResult();

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMeshImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMeshImporter.cpp
@@ -44,7 +44,7 @@ namespace AZ
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
 
-                if (!context.m_sourceNode.ContainsMesh() || IsSkinnedMesh(*currentNode, *scene) || !AreAllMeshesValid(*currentNode, *scene))
+                if (!context.m_sourceNode.ContainsMesh() || IsSkinnedMesh(*currentNode, *scene))
                 {
                     return Events::ProcessingResult::Ignored;
                 }


### PR DESCRIPTION
## What does this PR do?

Cherrypicks fixes to DAE imports from development into the point release.

## How was this PR tested?

Imported the shoulder.dae file used to test the original PR to verify that it still imports correctly in the point release.
