### PR TITLE
Added subtitles to UI Set Text nodes

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiDropdownBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiDropdownBus.names
@@ -383,6 +383,7 @@
                     },
                     "details": {
                         "name": "Set Text Element",
+                        "subtitle": "UI Dropdown",
                         "tooltip": "Sets the text element that displays the text of the currently selected option"
                     },
                     "params": [

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiDropdownOptionBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiDropdownOptionBus.names
@@ -117,6 +117,7 @@
                     },
                     "details": {
                         "name": "Set Text Element",
+                        "subtitle": "UI Dropdown Option",
                         "tooltip": "Sets the text element that is used to display the dropdown option’s text"
                     },
                     "params": [

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTextBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTextBus.names
@@ -523,6 +523,7 @@
                     },
                     "details": {
                         "name": "Set Text",
+                        "subtitle": "UI Text",
                         "tooltip": "Sets the text string being displayed by the element"
                     },
                     "params": [

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTextInputBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTextInputBus.names
@@ -186,6 +186,7 @@
                     },
                     "details": {
                         "name": "Set Text",
+                        "subtitle": "UI Text Input",
                         "tooltip": "Sets the text string being displayed or edited by the element"
                     },
                     "params": [
@@ -395,6 +396,7 @@
                     },
                     "details": {
                         "name": "Set Text Entity",
+                        "subtitle": "UI Text Input",
                         "tooltip": "Sets the text element"
                     },
                     "params": [

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTooltipBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTooltipBus.names
@@ -44,6 +44,7 @@
                     },
                     "details": {
                         "name": "Set Text",
+                        "subtitle": "UI Tooltip",
                         "tooltip": "Sets the tooltip text"
                     },
                     "params": [

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTooltipDisplayBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/UiTooltipDisplayBus.names
@@ -280,6 +280,7 @@
                     },
                     "details": {
                         "name": "Set Text Entity",
+                        "subtitle": "UI Tooltip Display",
                         "tooltip": "Sets the text element that is used for resizing"
                     },
                     "params": [


### PR DESCRIPTION
## What does this PR do?

Update the Script Canvas nodes to have a subtitle that explains which category they belong to

Closes #16142 

![image](https://github.com/o3de/o3de/assets/58790905/9d449626-6d13-4e26-949d-6e4124d26931)


