### PR TITLE
Disable duplicate action from connections context menu

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/ConnectionContextMenu.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/ConnectionContextMenu.cpp
@@ -29,5 +29,6 @@ namespace GraphCanvas
         m_editActionsGroup.SetCutEnabled(false);
         m_editActionsGroup.SetCopyEnabled(false);
         m_editActionsGroup.SetPasteEnabled(false);
+        m_editActionsGroup.SetDuplicateEnabled(false);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Closes #13555 

Disables the "Duplicate" option from the connection context menu

![image](https://github.com/o3de/o3de/assets/58790905/edc18177-1d3d-4411-bb37-2021c28c3d90)
