### PR TITLE
Fixed 'assign ScriptCanvas graph to entity'

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorScriptCanvasComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorScriptCanvasComponent.h
@@ -46,7 +46,11 @@ namespace ScriptCanvasEditor
         EditorScriptCanvasComponent();
         EditorScriptCanvasComponent(const SourceHandle& sourceHandle);
         ~EditorScriptCanvasComponent() override;
-                        
+
+        //=====================================================================
+        // EditorComponentBase
+        void SetPrimaryAsset(const AZ::Data::AssetId&) override;
+
     protected:
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
         {
@@ -63,7 +67,6 @@ namespace ScriptCanvasEditor
         //=====================================================================
         // EditorComponentBase
         void BuildGameEntity(AZ::Entity* gameEntity) override;
-        void SetPrimaryAsset(const AZ::Data::AssetId&) override;
 
     private:
         Configuration m_configuration;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -4103,16 +4103,25 @@ namespace ScriptCanvasEditor
 
         if (usableRequestBus == nullptr)
         {
-            AzToolsFramework::EntityCompositionRequestBus::Broadcast(&EntityCompositionRequests::AddComponentsToEntities, AzToolsFramework::EntityIdList{ entityId }
+            AzToolsFramework::EntityCompositionRequests::AddComponentsOutcome outcome;
+            AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(outcome, &EntityCompositionRequests::AddComponentsToEntities, AzToolsFramework::EntityIdList{ entityId }
                                                                                                                         , AZ::ComponentTypeList{ azrtti_typeid<EditorScriptCanvasComponent>() });
 
-            usableRequestBus = EditorScriptCanvasComponentRequestBus::FindFirstHandler(entityId);
+            if (outcome.IsSuccess())
+            {
+                auto& addedComponent = outcome.GetValue()[entityId].m_componentsAdded[0];
+                AZ_Assert(addedComponent->GetUnderlyingComponentType() == azrtti_typeid<EditorScriptCanvasComponent>(), "Added component returned was not the type requested to add");
+
+                if (EditorScriptCanvasComponent* editorComponent = azrtti_cast<EditorScriptCanvasComponent*>(addedComponent))
+                {
+                    SourceHandle focusedAssetId = m_tabBar->FindAssetId(m_tabBar->currentIndex());
+
+                    AZ::Data::AssetId assetId = static_cast<AZ::Data::AssetId>(focusedAssetId.Id());
+                    editorComponent->SetPrimaryAsset(assetId);
+                }
+            }
         }
 
-        if (usableRequestBus)
-        {
-            usableRequestBus->SetAssetId(m_activeGraph.Describe());
-        }
     }
 
     bool MainWindow::HasSystemTickAction(SystemTickActionFlag action)


### PR DESCRIPTION
## What does this PR do?

Assigning graph to selected entities was not working, this change updates the code to rely on the outcome of the AddComponentsToEntities function to apply the asset Id to the selection

Tested in editor

Closes #11705

