### PR TITLE
Allow IMGUI in release mode and fix sys_deactivateconsole

### DIFF
--- a/Gems/ImGui/Code/CMakeLists.txt
+++ b/Gems/ImGui/Code/CMakeLists.txt
@@ -6,7 +6,12 @@
 #
 #
 
-set(config_base_defines $<IF:$<CONFIG:release>,IMGUI_DISABLED,IMGUI_ENABLED>)
+set(O3DE_IMGUI_RELEASE_ENABLED ON CACHE BOOL "Allow IMGUI in release builds")
+if($<CONFIG:release> AND NOT O3DE_IMGUI_RELEASE_ENABLED)
+    set(config_base_defines IMGUI_DISABLED)
+else()
+    set(config_base_defines IMGUI_ENABLED)
+endif()
 
 o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -13,6 +13,7 @@
 
 #ifdef IMGUI_ENABLED
 
+#include <AzCore/Console/IConsole.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Jobs/Algorithms.h>
 #include <AzCore/Jobs/JobCompletion.h>
@@ -268,6 +269,16 @@ ImDrawData* ImGui::ImGuiManager::GetImguiDrawData()
         } 
         return nullptr;
     }
+    else if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+    {
+        int consoleDeactivated = 0;
+        console->GetCvarValue("sys_DeactivateConsole", consoleDeactivated);
+        if (consoleDeactivated != 0)
+        {
+            ToggleToImGuiVisibleState(DisplayState::Hidden);
+            return nullptr;
+        }
+    }
 
     ImGui::ImGuiContextScope contextScope(m_imguiContext);
 
@@ -346,13 +357,6 @@ ImDrawData* ImGui::ImGuiManager::GetImguiDrawData()
 
     // Start New Frame
     ImGui::NewFrame();
-
-    //// START FROM PREUPDATE
-    ICVar* consoleDisabled = gEnv->pConsole->GetCVar("sys_DeactivateConsole");
-    if (consoleDisabled && consoleDisabled->GetIVal() != 0)
-    {
-        m_clientMenuBarState = DisplayState::Hidden;
-    }
 
     // Advance ImGui by Elapsed Frame Time
     const AZ::TimeUs gameTickTimeUs = AZ::GetSimulationTickDeltaTimeUs();


### PR DESCRIPTION
## What does this PR do?

1. Allow IMGUI in release builds
2. Add `O3DE_IMGUI_RELEASE_ENABLED` CMake var to let the user turn it off if desired
3. Fix issue displaying IMGUI console in release build when sys_deactivateConsole was used

## How was this PR tested?

Created a release build with debug symbols enabled, used sys_deactivateConsole=0 and 1 and tried opening/closing the console and typing commands, changed levels, quit, etc.
