### PR TITLE
Fix LyShine UI Rendering

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -130,10 +130,7 @@ namespace AZ::RHI
 
         union
         {
-            struct
-            {
-                bool m_enabled : 1;    // Whether the Draw Item should render
-            };
+            bool m_enabled = { 1 }; // Whether the Draw Item should render
             uint8_t m_allFlags;
         };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -130,7 +130,7 @@ namespace AZ::RHI
 
         union
         {
-            bool m_enabled = { 1 }; // Whether the Draw Item should render
+            bool m_enabled = 1; // Whether the Draw Item should render
             uint8_t m_allFlags;
         };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -493,6 +493,7 @@ namespace AZ
 
             DrawItemInfo drawItemInfo;
             RHI::DrawItem& drawItem = drawItemInfo.m_drawItem;
+            drawItem.m_enabled = true;
 
             // Draw argument
             RHI::DrawIndexed drawIndexed;


### PR DESCRIPTION
- Explicitly enable drawItem when rendering a DynamicDrawContext; this is used by LyShine UI endering and debug viewport text (ex: _r_displayInfo_)

- Enables drawItem by default

Fixes #17018

