### PR TITLE
Fix destruction of articulations

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystem.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystem.h
@@ -153,7 +153,7 @@ namespace AzPhysics
         void RegisterSceneAddedEvent(SystemEvents::OnSceneAddedEvent::Handler& handler) { handler.Connect(m_sceneAddedEvent); }
         //! Register to receive notifications when the a Scene is removed from the simulation.
         //! @param handler The handler to receive the event.
-        void RegisterSceneRemovedEvent(SystemEvents::OnSceneAddedEvent::Handler& handler) { handler.Connect(m_sceneRemovedEvent); }
+        void RegisterSceneRemovedEvent(SystemEvents::OnSceneRemovedEvent::Handler& handler) { handler.Connect(m_sceneRemovedEvent); }
         //! Register to receive notifications when the SystemConfiguration changes.
         //! @param handler The handler to receive the event.
         void RegisterSystemConfigurationChangedEvent(SystemEvents::OnConfigurationChangedEvent::Handler& handler) { handler.Connect(m_configChangeEvent); }

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -129,7 +129,7 @@ namespace PhysX
                 // Create a handler that in the case that the scene was removed before the deactivation of the component,
                 // ensures that all articulations are destroyed.
                 m_sceneRemovedHandler = AzPhysics::SystemEvents::OnSceneRemovedEvent::Handler(
-                    [this]([[maybe_unused]] AzPhysics::SceneHandle sceneHandle)
+                    [this](AzPhysics::SceneHandle sceneHandle)
                     {
                         if (sceneHandle == m_attachedSceneHandle && m_articulation)
                         {

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -180,6 +180,8 @@ namespace PhysX
 
         if (IsRootArticulation())
         {
+            m_sceneRemovedHandler.Disconnect();
+
             if (m_articulation)
             {
                 DestroyArticulation();

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -127,6 +127,7 @@ namespace PhysX
         AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
         AZStd::vector<AzPhysics::SimulatedBodyHandle> m_articulationLinks;
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
+        AzPhysics::SystemEvents::OnSceneRemovedEvent::Handler m_sceneRemovedHandler;
 
         using EntityIdArticulationLinkPair = AZStd::pair<AZ::EntityId, physx::PxArticulationLink*>;
         AZStd::unordered_map<AZ::EntityId, physx::PxArticulationLink*> m_articulationLinksByEntityId;


### PR DESCRIPTION
## What does this PR do?

This PR resolves https://github.com/o3de/o3de/issues/16990, by adding a handler that destroys articulations if the scene is removed. It also prevents a crash during the deactivation of the component by checking if the scene is a `nullptr`.

## How was this PR tested?

This PR was tested by reproducing the behavior described in https://github.com/o3de/o3de/issues/16990.
