### PR TITLE
Raytracing Acceleration Structure Build: Moved the BLAS barriers to right before the TLAS build

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -50,7 +50,7 @@ namespace AZ
             m_timestampResult = RPI::TimestampResult();
             if(GetScopeId().IsEmpty())
             {
-                InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Graphics);
+                InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Compute);
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -42,7 +42,7 @@ namespace AZ
 
         void RayTracingAccelerationStructurePass::BuildInternal()
         {
-            InitScope(RHI::ScopeId(GetPathName()));
+            InitScope(RHI::ScopeId(GetPathName()), AZ::RHI::HardwareQueueClass::Compute);
         }
 
         void RayTracingAccelerationStructurePass::FrameBeginInternal(FramePrepareParams params)
@@ -234,6 +234,7 @@ namespace AZ
             BeginScopeQuery(context);
 
             // build newly added or skinned BLAS objects
+            AZStd::vector<const AZ::RHI::RayTracingBlas*> changedBlasList;
             RayTracingFeatureProcessor::BlasInstanceMap& blasInstances = rayTracingFeatureProcessor->GetBlasInstances();
             for (auto& blasInstance : blasInstances)
             {
@@ -265,6 +266,7 @@ namespace AZ
                             // Fall back to building the BLAS in any case
                             context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas);
                         }
+                        changedBlasList.push_back(submeshBlasInstance.m_blas.get());
                     }
 
                     blasInstance.second.m_blasBuilt = true;
@@ -272,7 +274,7 @@ namespace AZ
             }
 
             // build the TLAS object
-            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas());
+            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas(), changedBlasList);
 
             ++m_frameCount;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -85,8 +85,9 @@ namespace AZ::RHI
         /// Updates a Bottom Level Acceleration Structure (BLAS) for ray tracing operations, which is made up of RayTracingGeometry entries
         virtual void UpdateBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) = 0;
 
-        /// Builds a Top Level Acceleration Structure (TLAS) for ray tracing operations, which is made up of RayTracingInstance entries that refer to a BLAS entry
-        virtual void BuildTopLevelAccelerationStructure(const RHI::RayTracingTlas& rayTracingTlas) = 0;
+            /// Builds a Top Level Acceleration Structure (TLAS) for ray tracing operations, which is made up of RayTracingInstance entries that refer to a BLAS entry
+            virtual void BuildTopLevelAccelerationStructure(
+                const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) = 0;
 
         /// Defines the submit range for a CommandList
         /// Note: the default is 0 items, which disables validation for items submitted outside of the framegraph

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -676,14 +676,6 @@ namespace AZ
             blasDesc.DestAccelerationStructureData = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetGpuAddress();
             ID3D12GraphicsCommandList4* commandList = static_cast<ID3D12GraphicsCommandList4*>(GetCommandList());
             commandList->BuildRaytracingAccelerationStructure(&blasDesc, 0, nullptr);
-
-            // create an immediate barrier for BLAS completion
-            // this is required since the buffer must be built prior to using it in the TLAS
-            D3D12_RESOURCE_BARRIER barrier;
-            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
-            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-            barrier.UAV.pResource = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetMemory();
-            commandList->ResourceBarrier(1, &barrier);        
 #endif
         }
 
@@ -702,14 +694,6 @@ namespace AZ
             blasDesc.DestAccelerationStructureData = blasDesc.SourceAccelerationStructureData;
             ID3D12GraphicsCommandList4* commandList = static_cast<ID3D12GraphicsCommandList4*>(GetCommandList());
             commandList->BuildRaytracingAccelerationStructure(&blasDesc, 0, nullptr);
-
-            // create an immediate barrier for BLAS completion
-            // this is required since the buffer must be built prior to using it in the TLAS
-            D3D12_RESOURCE_BARRIER barrier;
-            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
-            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-            barrier.UAV.pResource = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetMemory();
-            commandList->ResourceBarrier(1, &barrier);
 #endif
         }
 
@@ -725,9 +709,30 @@ namespace AZ
             m_state.m_shadingRateState.Set(rate, combinators);
         }
 
-        void CommandList::BuildTopLevelAccelerationStructure([[maybe_unused]] const RHI::RayTracingTlas& rayTracingTlas)
+        void CommandList::BuildTopLevelAccelerationStructure(
+            const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList)
         {
 #ifdef AZ_DX12_DXR_SUPPORT
+            ID3D12GraphicsCommandList4* commandList = static_cast<ID3D12GraphicsCommandList4*>(GetCommandList());
+            if (!changedBlasList.empty())
+            {
+                // create a barrier for BLAS completion
+                // this is required since all BLAS must be built prior to using it in the TLAS
+                std::vector<D3D12_RESOURCE_BARRIER> barriers;
+                barriers.reserve(changedBlasList.size());
+                for (const auto* blas : changedBlasList)
+                {
+                const auto dx12RayTracingBlas = static_cast<const RayTracingBlas*>(blas);
+                const RayTracingBlas::BlasBuffers& blasBuffers = dx12RayTracingBlas->GetBuffers();
+
+                D3D12_RESOURCE_BARRIER barrier;
+                barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+                barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+                barrier.UAV.pResource = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetMemory();
+                barriers.push_back(barrier);
+                }
+                commandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
+            }
             const RayTracingTlas& dx12RayTracingTlas = static_cast<const RayTracingTlas&>(rayTracingTlas);
             const RayTracingTlas::TlasBuffers& tlasBuffers = dx12RayTracingTlas.GetBuffers();
 
@@ -736,8 +741,7 @@ namespace AZ
             tlasDesc.Inputs = dx12RayTracingTlas.GetInputs();
             tlasDesc.ScratchAccelerationStructureData = static_cast<Buffer*>(tlasBuffers.m_scratchBuffer.get())->GetMemoryView().GetGpuAddress();
             tlasDesc.DestAccelerationStructureData = static_cast<Buffer*>(tlasBuffers.m_tlasBuffer.get())->GetMemoryView().GetGpuAddress();
-        
-            ID3D12GraphicsCommandList4* commandList = static_cast<ID3D12GraphicsCommandList4*>(GetCommandList());
+
             commandList->BuildRaytracingAccelerationStructure(&tlasDesc, 0, nullptr);
 #endif
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -718,18 +718,18 @@ namespace AZ
             {
                 // create a barrier for BLAS completion
                 // this is required since all BLAS must be built prior to using it in the TLAS
-                std::vector<D3D12_RESOURCE_BARRIER> barriers;
+                AZStd::vector<D3D12_RESOURCE_BARRIER> barriers;
                 barriers.reserve(changedBlasList.size());
                 for (const auto* blas : changedBlasList)
                 {
-                const auto dx12RayTracingBlas = static_cast<const RayTracingBlas*>(blas);
-                const RayTracingBlas::BlasBuffers& blasBuffers = dx12RayTracingBlas->GetBuffers();
+                    const auto dx12RayTracingBlas = static_cast<const RayTracingBlas*>(blas);
+                    const RayTracingBlas::BlasBuffers& blasBuffers = dx12RayTracingBlas->GetBuffers();
 
-                D3D12_RESOURCE_BARRIER barrier;
-                barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
-                barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-                barrier.UAV.pResource = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetMemory();
-                barriers.push_back(barrier);
+                    D3D12_RESOURCE_BARRIER barrier;
+                    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+                    barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+                    barrier.UAV.pResource = static_cast<Buffer*>(blasBuffers.m_blasBuffer.get())->GetMemoryView().GetMemory();
+                    barriers.push_back(barrier);
                 }
                 commandList->ResourceBarrier(static_cast<UINT>(barriers.size()), barriers.data());
             }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -80,7 +80,8 @@ namespace AZ
             void EndPredication() override;
             void BuildBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
-            void BuildTopLevelAccelerationStructure(const RHI::RayTracingTlas& rayTracingTlas) override;
+            void BuildTopLevelAccelerationStructure(
+                const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) override;
             void SetFragmentShadingRate(
                 RHI::ShadingRate rate,
                 const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -902,7 +902,8 @@ namespace AZ
             AZ_Assert(false, "Not implemented");
         }
 
-        void CommandList::BuildTopLevelAccelerationStructure(const RHI::RayTracingTlas& rayTracingTlas)
+        void CommandList::BuildTopLevelAccelerationStructure(
+            const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList)
         {
             // [GFX TODO][ATOM-5268] Implement Metal Ray Tracing
             AZ_Assert(false, "Not implemented");

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -70,7 +70,9 @@ namespace AZ
             void EndPredication() override {}
             void BuildBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
-            void BuildTopLevelAccelerationStructure(const RHI::RayTracingTlas& rayTracingTlas) override;
+            void BuildTopLevelAccelerationStructure(
+                const RHI::RayTracingTlas &rayTracingTlas,
+                const AZStd::vector<const RHI::RayTracingBlas *> &changedBlasList) override;
             void SetFragmentShadingRate(
                 [[maybe_unused]] RHI::ShadingRate rate,
                 [[maybe_unused]] const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override {}

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
@@ -41,7 +41,7 @@ namespace AZ
             void EndPredication() override {}
             void BuildBottomLevelAccelerationStructure([[maybe_unused]] const RHI::RayTracingBlas& rayTracingBlas) override {}
             void UpdateBottomLevelAccelerationStructure([[maybe_unused]] const RHI::RayTracingBlas& rayTracingBlas) override {}
-            void BuildTopLevelAccelerationStructure([[maybe_unused]] const RHI::RayTracingTlas& rayTracingTlas) override {}
+            void BuildTopLevelAccelerationStructure([[maybe_unused]] const RHI::RayTracingTlas& rayTracingTlas, [[maybe_unused]] const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) override {}
             void SetFragmentShadingRate(
                 [[maybe_unused]] RHI::ShadingRate rate,
                 [[maybe_unused]] const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override {}

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -87,7 +87,8 @@ namespace AZ
             void EndPredication() override;
             void BuildBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) override;
-            void BuildTopLevelAccelerationStructure(const RHI::RayTracingTlas& rayTracingTlas) override;
+            void BuildTopLevelAccelerationStructure(
+                const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) override;
             void SetFragmentShadingRate(
                 RHI::ShadingRate rate,
                 const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -151,10 +151,12 @@ namespace AZ
 
             // build the visualization BLAS from the DiffuseProbeGridFeatureProcessor
             // Note: the BLAS is used by all DiffuseProbeGrid visualization TLAS objects
+            AZStd::vector<const RHI::RayTracingBlas*> changedBlasList;
             if (m_visualizationBlasBuilt == false)
             {
                 context.GetCommandList()->BuildBottomLevelAccelerationStructure(*diffuseProbeGridFeatureProcessor->GetVisualizationBlas());
                 m_visualizationBlasBuilt = true;
+                changedBlasList.push_back(diffuseProbeGridFeatureProcessor->GetVisualizationBlas().get());
             }
 
             // call BuildTopLevelAccelerationStructure for each DiffuseProbeGrid in this range
@@ -172,7 +174,7 @@ namespace AZ
                 }
 
                 // build the TLAS object
-                context.GetCommandList()->BuildTopLevelAccelerationStructure(*diffuseProbeGrid->GetVisualizationTlas());
+                context.GetCommandList()->BuildTopLevelAccelerationStructure(*diffuseProbeGrid->GetVisualizationTlas(), changedBlasList);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This PR speeds up the Raytracing Acceleration Structure Build by moving the barriers between BLAS build calls to right before the TLAS build. The BLAS build commands do not depend on each other. This means that the barriers are not necessary there and they impact the performance quite a bit. We also moved the RaytracingAccelerationStructurePass to the Async Compute Queue.

The performance impact of the barriers is especially noticeable when multiple Actor components are in the scene. In a scene with 16 Actors the runtime of the pass was reduced from ~5.2ms to ~0.5ms (on DX12), as reported by the PassTimings in O3DE.
Unfortunately the speedup for Vulkan was not nearly as big. Here the pass timings only got down to ~4ms.
I think the Build calls are parallelized with DX12, whereas they are still serialized in Vulkan (even without barriers).

I think that we would need to submit the build commands to different queues, as suggested [here](https://stackoverflow.com/questions/64384786/how-to-execute-parallel-compute-shaders-across-multiple-compute-queues-in-vulkan) and [here](https://old.reddit.com/r/vulkan/comments/jc5nko/parallel_shader_execution_across_multiple_queues/). I don't know how I would do that in O3DE.
Can someone help me with the problem, or did someone have a similar problem in the past?

If the problem cannot be resolved I would still merge this PR. The performance with DirectX is much better, and there is also a bit of a performance improvement with Vulkan.

Here are two trace file I captured with Nsight Graphics 2023.3: [captures.zip](https://github.com/o3de/o3de/files/13279885/captures.zip)

## How was this PR tested?

Windws + Vulkan/DX12 with multiple Actor components, on an Nvidia RTX 3090
