### PR TITLE
Gadams3/fix material builder dependencies

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
@@ -93,14 +93,14 @@ namespace AZ
 
             for (const auto& path : RPI::AssetUtils::GetPossibleDependencyPaths(variantListFullpath, originalShaderPath))
             {
-                AssetBuilderSDK::SourceFileDependency sourceFileDependency;
-                sourceFileDependency.m_sourceFileDependencyPath = path;
-                sourceFileDependency.m_sourceDependencyType = path.contains('*')
+                AssetBuilderSDK::SourceFileDependency sourceDependency;
+                sourceDependency.m_sourceFileDependencyPath = path;
+                sourceDependency.m_sourceDependencyType = path.contains('*')
                     ? AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards
                     : AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Absolute;
-                sourceFileDependencies.emplace_back(AZStd::move(sourceFileDependency));
+                sourceFileDependencies.emplace_back(AZStd::move(sourceDependency));
 
-                if (sourceShaderAbsolutePath.empty() && !path.contains('*'))
+                if (sourceShaderAbsolutePath.empty())
                 {
                     AZ::Data::AssetInfo sourceInfo;
                     AZStd::string watchFolder;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/AssetUtils.h
@@ -69,19 +69,6 @@ namespace AZ
             //! @return A full path for referencedSourceFilePath, if a full path was found. If a full path could not be constructed, returns referencedSourceFilePath unmodified.
             AZStd::string ResolvePathReference(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath);
 
-            //! Returns the list of paths where a source asset file could possibly appear.
-            //! This is intended for use by AssetBuilders when reporting dependencies, to support relative paths between source files.
-            //! When a source data file references another file using a relative path, the path might be relative to the originating
-            //! file or it might be a standard source asset path (i.e. relative to the logical asset-root). This function will help reporting
-            //! dependencies on all possible locations where that file may appear at some point in the future.
-            //! For example a file MyGem/Assets/Foo/a.json might reference another file as "Bar/b.json". In this case, calling
-            //! GetPossibleDepenencyPaths("Foo/a.json", "Bar/b.json") might return {"Foo/Bar/b.json", and "Bar/b.json"} because
-            //! it's possible that b.json could be found in either MyGem/Assets/Foo/Bar/a.json or in MyGem/Assets/Bar/a.json.
-            //! @param originatingSourceFilePath  Path to a file that references referencedSourceFilePath. May be absolute or relative to asset-root.
-            //! @param referencedSourceFilePath   The referenced path as it appears in the originating file. May be relative to the originating file location or relative to asset-root.
-            //! @return the list of possible paths, ordered from highest priority to lowest priority
-            AZStd::vector<AZStd::string> GetPossibleDependencyPaths(const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath);
-
             //! Takes an arbitrary string and replaces some characters to make it a valid filename. The result will be compatible with AzQtComponents::FileDialog.
             //! Ex. SanitizeFileName("Left=>Right.txt") == "Left_Right.txt"
             //! Ex. SanitizeFileName("Material::Red#1") == "Material_Red_1"

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -299,7 +299,7 @@ namespace AZ
             //! See enum Format
             Format GetFormat() const;
 
-            //! Return a concatenated list of shader references from mall collections
+            //! Return a concatenated list of shader references from all collections
             AZStd::vector<ShaderVariantReferenceData> GetShaderReferences() const;
 
         private:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -299,6 +299,9 @@ namespace AZ
             //! See enum Format
             Format GetFormat() const;
 
+            //! Return a concatenated list of shader references from mall collections
+            AZStd::vector<ShaderVariantReferenceData> GetShaderReferences() const;
+
         private:
                 
             const PropertyGroup* FindPropertyGroup(AZStd::span<const AZStd::string_view> parsedPropertyGroupId, AZStd::span<const AZStd::unique_ptr<PropertyGroup>> inPropertyGroupList) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -206,10 +206,7 @@ namespace AZ
                 if (MaterialUtils::LooksLikeImageFileReference(propertyValue))
                 {
                     MaterialBuilderUtils::AddPossibleImageDependencies(
-                        materialSourcePath,
-                        propertyValue.GetValue<AZStd::string>(),
-                        response,
-                        outputJobDescriptor);
+                        materialSourcePath, propertyValue.GetValue<AZStd::string>(), outputJobDescriptor);
                 }
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -150,12 +150,9 @@ namespace AZ
                         resolvedMaterialTypePath,
                         response,
                         outputJobDescriptor,
-                        MaterialTypeBuilder::PipelineStageJobKey,
-                        AssetBuilderSDK::JobDependencyType::Order,
-                        {},
-                        AssetBuilderSDK::CommonPlatformName);
+                        MaterialTypeBuilder::PipelineStageJobKey);
 
-                    const AZStd::string intermediateMaterialTypePath =
+                    const auto& intermediateMaterialTypePath =
                         MaterialUtils::PredictIntermediateMaterialTypeSourcePath(resolvedMaterialTypePath);
                     if (!intermediateMaterialTypePath.empty())
                     {
@@ -170,7 +167,7 @@ namespace AZ
             }
 
             // Assign dependencies from image properties
-            for (auto& [propertyId, propertyValue] : materialSourceData.GetPropertyValues())
+            for (const auto& [propertyId, propertyValue] : materialSourceData.GetPropertyValues())
             {
                 AZ_UNUSED(propertyId);
 
@@ -224,7 +221,7 @@ namespace AZ
             AzFramework::StringFunc::Path::ConstructFull(
                 request.m_watchFolder.c_str(), request.m_sourceFile.c_str(), materialSourcePath, true);
 
-            const auto materialSourceDataOutcome = MaterialUtils::LoadMaterialSourceData(materialSourcePath);
+            const auto& materialSourceDataOutcome = MaterialUtils::LoadMaterialSourceData(materialSourcePath);
             if (!materialSourceDataOutcome)
             {
                 AZ_Error(MaterialBuilderName, false, "Failed to load material source data: %s", materialSourcePath.c_str());
@@ -234,7 +231,7 @@ namespace AZ
             const auto& materialSourceData = materialSourceDataOutcome.GetValue();
 
             // Load the material file and create the MaterialAsset object
-            auto materialAssetOutcome = materialSourceData.CreateMaterialAsset(
+            const auto& materialAssetOutcome = materialSourceData.CreateMaterialAsset(
                 Uuid::CreateRandom(), materialSourcePath, ShouldReportMaterialAssetWarningsAsErrors());
             if (!materialAssetOutcome)
             {
@@ -242,7 +239,7 @@ namespace AZ
                 return;
             }
 
-            AZ::Data::Asset<MaterialAsset> materialAsset = materialAssetOutcome.GetValue();
+            const auto& materialAsset = materialAssetOutcome.GetValue();
             if (!materialAsset)
             {
                 // Errors will have been reported above

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -145,13 +145,22 @@ namespace AZ
                 }
                 else if (materialTypeFormat == MaterialTypeSourceData::Format::Abstract)
                 {
+                    // Create a dependency on the abstract, pipeline, version of the material type and its products. The pipeline based
+                    // material type builder uses the 'common' asset platform ID because it produces immediate assets. The sub ID filter
+                    // should remain empty to observe all produced intermediate assets.
                     MaterialBuilderUtils::AddPossibleDependencies(
                         materialSourcePath,
                         resolvedMaterialTypePath,
                         response,
                         outputJobDescriptor,
-                        MaterialTypeBuilder::PipelineStageJobKey);
+                        MaterialTypeBuilder::PipelineStageJobKey,
+                        AssetBuilderSDK::JobDependencyType::Order,
+                        {},
+                        AssetBuilderSDK::CommonPlatformName);
 
+                    // The abstract, pipeline material type will generate a direct material type as an intermediate source asset. This
+                    // attempts to predict where that source asset will be located in the intermediate asset folder then maps it as a
+                    // product dependency if it exists or a source dependency if it is to be created in the future.
                     const auto& intermediateMaterialTypePath =
                         MaterialUtils::PredictIntermediateMaterialTypeSourcePath(resolvedMaterialTypePath);
                     if (!intermediateMaterialTypePath.empty())

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -156,7 +156,7 @@ namespace AZ
                         AssetBuilderSDK::CommonPlatformName);
 
                     const AZStd::string intermediateMaterialTypePath =
-                        MaterialUtils::PredictIntermediateMaterialTypeSourcePath(materialSourcePath, resolvedMaterialTypePath);
+                        MaterialUtils::PredictIntermediateMaterialTypeSourcePath(resolvedMaterialTypePath);
                     if (!intermediateMaterialTypePath.empty())
                     {
                         MaterialBuilderUtils::AddPossibleDependencies(

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
@@ -14,91 +14,26 @@
 
 namespace AZ::RPI::MaterialBuilderUtils
 {
-    void AddPossibleDependencies(
-        const AZStd::string& originatingSourceFilePath,
-        const AZStd::string& referencedSourceFilePath,
-        AssetBuilderSDK::CreateJobsResponse& response,
-        AssetBuilderSDK::JobDescriptor& jobDescriptor,
-        const AZStd::string& jobKey,
-        const AssetBuilderSDK::JobDependencyType jobDependencyType,
-        const AZStd::vector<AZ::u32>& productSubIds,
-        const AZStd::string& platformId)
-    {
-        // Only the first possible dependency with sorts intro will be added as a job dependency. The rest will be added as source
-        // dependencies. Job dependencies determine the order jobs are processed. Source dependencies cause jobs too be reprocessed whenever
-        // they are created, deleted, or modified.
-        bool dependencyFileFound = false;
-        for (const auto& path : RPI::AssetUtils::GetPossibleDependencyPaths(originatingSourceFilePath, referencedSourceFilePath))
-        {
-            // Any of the dependencies added that require the file to be reprocessed will affect the fingerprint. For materials specifically,
-            // we want additional fingerprinting to cause certain file types to be reprocessed even if they are not modified but their
-            // dependencies are.
-            if (jobDependencyType != AssetBuilderSDK::JobDependencyType::OrderOnce &&
-                jobDependencyType != AssetBuilderSDK::JobDependencyType::OrderOnly)
-            {
-                MaterialBuilderUtils::AddFingerprintForDependency(path, jobDescriptor);
-            }
-
-            AssetBuilderSDK::SourceFileDependency sourceDependency;
-            sourceDependency.m_sourceFileDependencyPath = path;
-            sourceDependency.m_sourceDependencyType = path.contains('*')
-                ? AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards
-                : AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Absolute;
-
-            // We only need to check for source info if we have not already recorded a job dependency for this set of potential files.
-            if (!dependencyFileFound)
-            {
-                AZ::Data::AssetInfo sourceInfo;
-                AZStd::string watchFolder;
-                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-                    dependencyFileFound,
-                    &AzToolsFramework::AssetSystem::AssetSystemRequest::GetSourceInfoBySourcePath,
-                    path.c_str(),
-                    sourceInfo,
-                    watchFolder);
-
-                if (dependencyFileFound)
-                {
-                    AssetBuilderSDK::JobDependency jobDependency;
-                    jobDependency.m_jobKey = jobKey;
-                    jobDependency.m_sourceFile = AZStd::move(sourceDependency);
-                    jobDependency.m_type = jobDependencyType;
-                    jobDependency.m_productSubIds = productSubIds;
-                    jobDependency.m_platformIdentifier = platformId;
-                    jobDescriptor.m_jobDependencyList.emplace_back(AZStd::move(jobDependency));
-                    continue;
-                }
-            }
-
-            // No source info was found. We add a source dependency so if a file shows up later at this location, it will wake up the
-            // builder to try again.
-            response.m_sourceFileDependencyList.emplace_back(AZStd::move(sourceDependency));
-        }
-    }
-
     void AddPossibleImageDependencies(
         const AZStd::string& originatingSourceFilePath,
         const AZStd::string& referencedSourceFilePath,
-        AssetBuilderSDK::CreateJobsResponse& response,
         AssetBuilderSDK::JobDescriptor& jobDescriptor)
     {
         if (!referencedSourceFilePath.empty())
         {
             AZStd::string ext;
             AzFramework::StringFunc::Path::GetExtension(referencedSourceFilePath.c_str(), ext, false);
+            AZStd::to_upper(ext.begin(), ext.end());
 
             if (!ext.empty())
             {
-                AZStd::to_upper(ext.begin(), ext.end());
-                AZStd::string jobKey = "Image Compile: " + ext;
-
-                AddPossibleDependencies(
-                    originatingSourceFilePath,
-                    referencedSourceFilePath,
-                    response,
-                    jobDescriptor,
-                    jobKey,
-                    AssetBuilderSDK::JobDependencyType::OrderOnce);
+                auto& jobDepedency = jobDescriptor.m_jobDependencyList.emplace_back();
+                jobDepedency.m_type = AssetBuilderSDK::JobDependencyType::OrderOnce;
+                jobDepedency.m_sourceFile.m_sourceFileDependencyPath =
+                    AssetUtils::ResolvePathReference(originatingSourceFilePath, referencedSourceFilePath);
+                jobDepedency.m_jobKey = "Image Compile: " + ext;
+                jobDepedency.m_productSubIds = { 0 };
+                AddFingerprintForDependency(jobDepedency.m_sourceFile.m_sourceFileDependencyPath, jobDescriptor);
             }
         }
     }
@@ -107,15 +42,5 @@ namespace AZ::RPI::MaterialBuilderUtils
     {
         jobDescriptor.m_additionalFingerprintInfo +=
             AZStd::string::format("|%u:%llu", (AZ::u32)AZ::Crc32(path), AZ::IO::SystemFile::ModificationTime(path.c_str()));
-    }
-
-    AZStd::string GetRelativeSourcePath(const AZStd::string& path)
-    {
-        bool pathFound{};
-        AZStd::string relativePath;
-        AZStd::string rootFolder;
-        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            pathFound, &AzToolsFramework::AssetSystemRequestBus::Events::GenerateRelativeSourcePath, path, relativePath, rootFolder);
-        return relativePath;
     }
 } // namespace AZ::RPI::MaterialBuilderUtils

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -16,6 +16,23 @@ namespace AZ
     {
         namespace MaterialBuilderUtils
         {
+            //! @brief configure and register a job dependency with the job descriptor
+            //! @param jobDescriptor job descriptor to which dependency will be added
+            //! @param path path to the source file for the dependency
+            //! @param jobKey job key for the builder processing the dependency
+            //! @param platformId list of platform IDs to monitor for the job dependency
+            //! @param subIds list of sub IDs that should be monitored for assets created by the job dependency
+            //! @param updateFingerprint flag specifying if the job descriptor fingerprint should be updated with information from the
+            //! dependency file
+            //! @return reference to the new job dependency added to the job descriptor dependency container
+            AssetBuilderSDK::JobDependency& AddJobDependency(
+                AssetBuilderSDK::JobDescriptor& jobDescriptor,
+                const AZStd::string& path,
+                const AZStd::string& jobKey,
+                const AZStd::string& platformId = {},
+                const AZStd::vector<AZ::u32>& subIds = {},
+                const bool updateFingerprint = true);
+
             //! Resolve potential paths and add source and job dependencies for image assets
             //! @param originatingSourceFilePath The path of the .material or .materialtype file being processed
             //! @param referencedSourceFilePath The path to the referenced file as it appears in the current file

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -16,41 +16,17 @@ namespace AZ
     {
         namespace MaterialBuilderUtils
         {
-            //! Resolves paths to source files, registers job dependencies, and updates the job fingerprint
-            //! @param originatingSourceFilePath The path of the .material or .materialtype file being processed
-            //! @param referencedSourceFilePath The path to the referenced file as it appears in the current file
-            //! @param response Used to update source dependencies
-            //! @param jobDescriptor Used to update job dependencies
-            //! @param jobKey The job key for the job that is expected to process the referenced file
-            //! @param jobDependencyType Assigns the job dependency type for any added dependencies.
-            //! @param productSubIds Sub ids used to filter which product dependencies cause the job to be reprocessed.
-            //! @param platformId Specific platform identifier for any added job dependencies
-            void AddPossibleDependencies(
-                const AZStd::string& originatingSourceFilePath,
-                const AZStd::string& referencedSourceFilePath,
-                AssetBuilderSDK::CreateJobsResponse& response,
-                AssetBuilderSDK::JobDescriptor& jobDescriptor,
-                const AZStd::string& jobKey,
-                const AssetBuilderSDK::JobDependencyType jobDependencyType = AssetBuilderSDK::JobDependencyType::Order,
-                const AZStd::vector<AZ::u32>& productSubIds = { 0 },
-                const AZStd::string& platformId = {});
-
             //! Resolve potential paths and add source and job dependencies for image assets
             //! @param originatingSourceFilePath The path of the .material or .materialtype file being processed
             //! @param referencedSourceFilePath The path to the referenced file as it appears in the current file
-            //! @param response Used to update source dependencies
             //! @param jobDescriptor Used to update job dependencies
             void AddPossibleImageDependencies(
                 const AZStd::string& originatingSourceFilePath,
                 const AZStd::string& referencedSourceFilePath,
-                AssetBuilderSDK::CreateJobsResponse& response,
                 AssetBuilderSDK::JobDescriptor& jobDescriptor);
 
             //! Append a fingerprint value to the job descriptor using the file modification time of the specified file path
             void AddFingerprintForDependency(const AZStd::string& path, AssetBuilderSDK::JobDescriptor& jobDescriptor);
-
-            //! Generate a relative path from an absolute path
-            AZStd::string GetRelativeSourcePath(const AZStd::string& path);
         } // namespace MaterialBuilderUtils
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -23,11 +23,7 @@ namespace AZ
             //! @param jobDescriptor Used to update job dependencies
             //! @param jobKey The job key for the job that is expected to process the referenced file
             //! @param jobDependencyType Assigns the job dependency type for any added dependencies.
-            //! @param productSubIds Sub ids used to filter which product dependencies cause the job to be reprocessed. This should default
-            //! to an empty container so that all nested dependencies cause the job to be reprocessed. Leaving it empty results in the ideal
-            //! propagation and ordering for shaders and materials, where materials always get reprocessed last. However, this causes issues
-            //! if the platform ID is something other than PC. For example, if platform ID is set to server the asset system or streamer
-            //! will fail to correctly resolve products generated from intermediate assets with a correct asset id.
+            //! @param productSubIds Sub ids used to filter which product dependencies cause the job to be reprocessed.
             //! @param platformId Specific platform identifier for any added job dependencies
             void AddPossibleDependencies(
                 const AZStd::string& originatingSourceFilePath,
@@ -36,7 +32,7 @@ namespace AZ
                 AssetBuilderSDK::JobDescriptor& jobDescriptor,
                 const AZStd::string& jobKey,
                 const AssetBuilderSDK::JobDependencyType jobDependencyType = AssetBuilderSDK::JobDependencyType::Order,
-                const AZStd::vector<AZ::u32>& productSubIds = {},
+                const AZStd::vector<AZ::u32>& productSubIds = { 0 },
                 const AZStd::string& platformId = {});
 
             //! Resolve potential paths and add source and job dependencies for image assets

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -36,7 +36,7 @@ namespace AZ
                 AssetBuilderSDK::JobDescriptor& jobDescriptor,
                 const AZStd::string& jobKey,
                 const AssetBuilderSDK::JobDependencyType jobDependencyType = AssetBuilderSDK::JobDependencyType::Order,
-                const AZStd::vector<AZ::u32>& productSubIds = { 0 },
+                const AZStd::vector<AZ::u32>& productSubIds = {},
                 const AZStd::string& platformId = {});
 
             //! Resolve potential paths and add source and job dependencies for image assets

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -44,7 +44,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 44; // Switch from XML to binary assets
+            materialBuilderDescriptor.m_version = 45; // Revising job dependencies
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -218,7 +218,7 @@ namespace AZ
 
             MaterialBuilderUtils::AddFingerprintForDependency(materialTypeSourcePath, outputJobDescriptor);
 
-            for (auto& shader : materialTypeSourceData.m_shaderCollection)
+            for (const auto& shader : materialTypeSourceData.GetShaderReferences())
             {
                 MaterialBuilderUtils::AddPossibleDependencies(
                     materialTypeSourcePath,
@@ -273,18 +273,6 @@ namespace AZ
 
             for (const auto& pipelinePair : materialTypeSourceData.m_pipelineData)
             {
-                for (const auto& shader : pipelinePair.second.m_shaderCollection)
-                {
-                    MaterialBuilderUtils::AddPossibleDependencies(
-                        materialTypeSourcePath,
-                        shader.m_shaderFilePath,
-                        response,
-                        outputJobDescriptor,
-                        "Shader Asset",
-                        AssetBuilderSDK::JobDependencyType::Order,
-                        {});
-                }
-
                 addFunctorDependencies(pipelinePair.second.m_materialFunctorSourceData);
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -225,7 +225,9 @@ namespace AZ
                     shader.m_shaderFilePath,
                     response,
                     outputJobDescriptor,
-                    "Shader Asset");
+                    "Shader Asset",
+                    AssetBuilderSDK::JobDependencyType::Order,
+                    {});
             }
 
             auto addFunctorDependencies = [&response, &outputJobDescriptor, &materialTypeSourcePath](const AZStd::vector<Ptr<MaterialFunctorSourceDataHolder>>& functors)
@@ -278,7 +280,9 @@ namespace AZ
                         shader.m_shaderFilePath,
                         response,
                         outputJobDescriptor,
-                        "Shader Asset");
+                        "Shader Asset",
+                        AssetBuilderSDK::JobDependencyType::Order,
+                        {});
                 }
 
                 addFunctorDependencies(pipelinePair.second.m_materialFunctorSourceData);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -214,13 +214,8 @@ namespace AZ
 
             for (const auto& shader : materialTypeSourceData.GetShaderReferences())
             {
-                auto& shaderJobDependency = outputJobDescriptor.m_jobDependencyList.emplace_back();
-                shaderJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                shaderJobDependency.m_sourceFile.m_sourceFileDependencyPath =
-                    AssetUtils::ResolvePathReference(materialTypeSourcePath, shader.m_shaderFilePath);
-                shaderJobDependency.m_jobKey = "Shader Asset";
-                MaterialBuilderUtils::AddFingerprintForDependency(
-                    shaderJobDependency.m_sourceFile.m_sourceFileDependencyPath, outputJobDescriptor);
+                MaterialBuilderUtils::AddJobDependency(
+                    outputJobDescriptor, AssetUtils::ResolvePathReference(materialTypeSourcePath, shader.m_shaderFilePath), "Shader Asset");
             }
 
             auto addFunctorDependencies = [&outputJobDescriptor, &materialTypeSourcePath](
@@ -231,13 +226,10 @@ namespace AZ
                     for (const MaterialFunctorSourceData::AssetDependency& dependency :
                          functor->GetActualSourceData()->GetAssetDependencies())
                     {
-                        auto& functorJobDependency = outputJobDescriptor.m_jobDependencyList.emplace_back();
-                        functorJobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                        functorJobDependency.m_sourceFile.m_sourceFileDependencyPath =
-                            AssetUtils::ResolvePathReference(materialTypeSourcePath, dependency.m_sourceFilePath);
-                        functorJobDependency.m_jobKey = dependency.m_jobKey;
-                        MaterialBuilderUtils::AddFingerprintForDependency(
-                            functorJobDependency.m_sourceFile.m_sourceFileDependencyPath, outputJobDescriptor);
+                        MaterialBuilderUtils::AddJobDependency(
+                            outputJobDescriptor,
+                            AssetUtils::ResolvePathReference(materialTypeSourcePath, dependency.m_sourceFilePath),
+                            dependency.m_jobKey);
                     }
                 }
             };

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -156,12 +156,14 @@ namespace AZ
 
             auto addPossibleDependencies = [&response, &outputJobDescriptor](const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
-                AZStd::vector<AZStd::string> possibleDependencies =
-                    RPI::AssetUtils::GetPossibleDependencyPaths(originatingSourceFilePath, referencedSourceFilePath);
-                for (const AZStd::string& path : possibleDependencies)
+                for (const auto& path : RPI::AssetUtils::GetPossibleDependencyPaths(originatingSourceFilePath, referencedSourceFilePath))
                 {
-                    response.m_sourceFileDependencyList.push_back({});
-                    response.m_sourceFileDependencyList.back().m_sourceFileDependencyPath = path;
+                    AssetBuilderSDK::SourceFileDependency sourceDependency;
+                    sourceDependency.m_sourceFileDependencyPath = path;
+                    sourceDependency.m_sourceDependencyType = path.contains('*')
+                        ? AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards
+                        : AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Absolute;
+                    response.m_sourceFileDependencyList.emplace_back(AZStd::move(sourceDependency));
                     MaterialBuilderUtils::AddFingerprintForDependency(path, outputJobDescriptor);
                 }
             };
@@ -452,7 +454,7 @@ namespace AZ
 
                     // Only include Object SRGs from material pipelines which have shader templates relevant to this material
                     // This avoids adding extra SRG members in materials for MaterialPipelines it won't be rendered in
-                    if (shaderTemplateList.size() > 0)
+                    if (!shaderTemplateList.empty())
                     {
                         objectSrgAdditionsFromMaterialPipelines.push_back(&materialPipeline.m_objectSrgAdditions);
                     }
@@ -571,6 +573,7 @@ namespace AZ
                 {
                     AssetBuilderSDK::JobProduct product;
                     product.m_outputFlags = AssetBuilderSDK::ProductOutputFlags::IntermediateAsset;
+                    product.m_dependenciesHandled = true;
                     product.m_productFileName = outputShaderFilePath.String();
                     product.m_productSubID = nextProductSubID++;
                     response.m_outputProducts.emplace_back(AZStd::move(product));
@@ -630,6 +633,7 @@ namespace AZ
             {
                 AssetBuilderSDK::JobProduct product;
                 product.m_outputFlags = AssetBuilderSDK::ProductOutputFlags::IntermediateAsset;
+                product.m_dependenciesHandled = true;
                 product.m_productFileName = outputMaterialTypeFilePath.String();
                 product.m_productAssetType = azrtti_typeid<RPI::MaterialTypeSourceData>();
                 product.m_productSubID = MaterialTypeSourceData::IntermediateMaterialTypeSubId;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
@@ -127,44 +127,6 @@ namespace AZ
                 return referencedPath.String();
             }
 
-            AZStd::vector<AZStd::string> GetPossibleDependencyPaths(
-                const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
-            {
-                AZStd::vector<AZStd::string> results;
-
-                if (referencedSourceFilePath.empty())
-                {
-                    return results;
-                }
-
-                AZ::IO::FixedMaxPath resolvedPath{ ResolvePathReference(originatingSourceFilePath, referencedSourceFilePath) };
-                if (resolvedPath.IsAbsolute())
-                {
-                    results.push_back(resolvedPath.String());
-                    return results;
-                }
-
-                AZ::IO::FixedMaxPath originatingPath;
-                AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(originatingPath, AZ::IO::PathView{ originatingSourceFilePath });
-                originatingPath = originatingPath.LexicallyNormal();
-
-                AZ::IO::FixedMaxPath referencedPath;
-                AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(referencedPath, AZ::IO::PathView{ referencedSourceFilePath });
-                referencedPath = referencedPath.LexicallyNormal();
-
-                AZ::IO::FixedMaxPath combinedPath;
-                combinedPath /= originatingPath.ParentPath();
-                combinedPath /= "*";
-                combinedPath /= referencedPath;
-                results.push_back(combinedPath.LexicallyNormal().String());
-
-                combinedPath.clear();
-                combinedPath /= "*";
-                combinedPath /= referencedPath;
-                results.push_back(combinedPath.LexicallyNormal().String());
-                return results;
-            }
-
             Outcome<Data::AssetId> MakeAssetId(const AZStd::string& sourcePath, uint32_t productSubId, TraceLevel reporting)
             {
                 AZ::IO::FixedMaxPath sourcePathNoAlias;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/AssetUtils.cpp
@@ -131,8 +131,16 @@ namespace AZ
                 const AZStd::string& originatingSourceFilePath, const AZStd::string& referencedSourceFilePath)
             {
                 AZStd::vector<AZStd::string> results;
+
                 if (referencedSourceFilePath.empty())
                 {
+                    return results;
+                }
+
+                AZ::IO::FixedMaxPath resolvedPath{ ResolvePathReference(originatingSourceFilePath, referencedSourceFilePath) };
+                if (resolvedPath.IsAbsolute())
+                {
+                    results.push_back(resolvedPath.String());
                     return results;
                 }
 
@@ -144,17 +152,16 @@ namespace AZ
                 AZ::IO::FileIOBase::GetInstance()->ReplaceAlias(referencedPath, AZ::IO::PathView{ referencedSourceFilePath });
                 referencedPath = referencedPath.LexicallyNormal();
 
-                AZ::IO::FixedMaxPath combinedPath = originatingPath.ParentPath();
+                AZ::IO::FixedMaxPath combinedPath;
+                combinedPath /= originatingPath.ParentPath();
+                combinedPath /= "*";
                 combinedPath /= referencedPath;
-                combinedPath = combinedPath.LexicallyNormal();
+                results.push_back(combinedPath.LexicallyNormal().String());
 
-                if (referencedPath.IsAbsolute())
-                {
-                    results.push_back(referencedPath.String());
-                }
-
-                results.push_back(combinedPath.String());
-                results.push_back(referencedPath.String());
+                combinedPath.clear();
+                combinedPath /= "*";
+                combinedPath /= referencedPath;
+                results.push_back(combinedPath.LexicallyNormal().String());
                 return results;
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -121,18 +121,17 @@ namespace AZ
         Outcome<Data::Asset<MaterialAsset>> MaterialSourceData::CreateMaterialAsset(
             Data::AssetId assetId, const AZStd::string& materialSourceFilePath, bool elevateWarnings) const
         {
-            MaterialAssetCreator materialAssetCreator;
-            materialAssetCreator.SetElevateWarnings(elevateWarnings);
-
             if (m_materialType.empty())
             {
                 AZ_Error("MaterialSourceData", false, "materialType was not specified");
                 return Failure();
             }
 
-            Outcome<Data::AssetId> materialTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(materialSourceFilePath, m_materialType);
-            if (!materialTypeAssetId)
+            const auto& materialTypeSourcePath =
+                MaterialUtils::GetFinalMaterialTypeSourcePath(materialSourceFilePath, m_materialType);
+            if (materialTypeSourcePath.empty())
             {
+                AZ_Error("MaterialSourceData", false, "Could not find material type file: '%s'.", m_materialType.c_str());
                 return Failure();
             }
 
@@ -141,61 +140,59 @@ namespace AZ
             // So we use this filter to ignore the image assets
             Data::AssetLoadParameters dontLoadImageAssets{ [](const AZ::Data::AssetFilterInfo& filterInfo)
                                                            {
-                                                               if (filterInfo.m_assetType == AZ::AzTypeInfo<StreamingImageAsset>::Uuid() ||
-                                                                   filterInfo.m_assetType == AZ::AzTypeInfo<AttachmentImageAsset>::Uuid() ||
-                                                                   filterInfo.m_assetType == AZ::AzTypeInfo<ImageAsset>::Uuid())
-                                                               {
-                                                                   return false;
-                                                               }
-
-                                                               return true;
+                                                               return
+                                                                   filterInfo.m_assetType != AZ::AzTypeInfo<StreamingImageAsset>::Uuid() &&
+                                                                   filterInfo.m_assetType != AZ::AzTypeInfo<AttachmentImageAsset>::Uuid() &&
+                                                                   filterInfo.m_assetType != AZ::AzTypeInfo<ImageAsset>::Uuid();
                                                            } };
 
             // In this case we need to load the material type data in preparation for the material->Finalize() step below.
-            auto materialTypeAssetOutcome = AssetUtils::LoadAsset<MaterialTypeAsset>(
-                materialTypeAssetId.GetValue(), m_materialType.c_str(), AssetUtils::TraceLevel::Error, dontLoadImageAssets);
+            const auto& materialTypeAssetOutcome =
+                AssetUtils::LoadAsset<MaterialTypeAsset>(materialTypeSourcePath, 0, AssetUtils::TraceLevel::Error, dontLoadImageAssets);
             if (!materialTypeAssetOutcome)
             {
                 return Failure();
             }
 
-            Data::Asset<MaterialTypeAsset> materialTypeAsset = materialTypeAssetOutcome.GetValue();
+            const auto& materialTypeAsset = materialTypeAssetOutcome.GetValue();
+            const auto& materialTypeAssetId = materialTypeAsset.GetId();
 
+            MaterialAssetCreator materialAssetCreator;
+            materialAssetCreator.SetElevateWarnings(elevateWarnings);
             materialAssetCreator.Begin(assetId, materialTypeAsset);
-
             materialAssetCreator.SetMaterialTypeVersion(m_materialTypeVersion);
 
             if (!m_parentMaterial.empty())
             {
                 constexpr uint32_t subId = 0;
-                auto parentMaterialAsset = AssetUtils::LoadAsset<MaterialAsset>(
+                const auto& parentMaterialAssetOutcome = AssetUtils::LoadAsset<MaterialAsset>(
                     materialSourceFilePath, m_parentMaterial, subId, AssetUtils::TraceLevel::Error, dontLoadImageAssets);
-                if (!parentMaterialAsset.IsSuccess())
+                if (!parentMaterialAssetOutcome.IsSuccess())
                 {
                     return Failure();
                 }
 
-                // Make sure the parent material has the same material type
-                {
-                    Data::AssetId parentsMaterialTypeId = parentMaterialAsset.GetValue()->GetMaterialTypeAsset().GetId();
+                const auto& parentMaterialAsset = parentMaterialAssetOutcome.GetValue();
+                const auto& parentMaterialTypeAsset = parentMaterialAsset->GetMaterialTypeAsset();
+                const auto& parentsMaterialTypeId = parentMaterialTypeAsset.GetId();
 
-                    if (materialTypeAssetId.GetValue() != parentsMaterialTypeId)
-                    {
-                        AZ_Error("MaterialSourceData", false, "This material and its parent material do not share the same material type.");
-                        return Failure();
-                    }
+                // Make sure the parent material has the same material type
+                if (materialTypeAssetId != parentsMaterialTypeId)
+                {
+                    AZ_Error("MaterialSourceData", false, "This material and its parent material do not share the same material type.");
+                    return Failure();
                 }
 
                 // Inherit the parent's property values...
-                const MaterialPropertiesLayout* propertiesLayout = parentMaterialAsset.GetValue()->GetMaterialPropertiesLayout();
+                const MaterialPropertiesLayout* propertiesLayout = parentMaterialAsset->GetMaterialPropertiesLayout();
 
-                if (parentMaterialAsset.GetValue()->GetPropertyValues().size() != propertiesLayout->GetPropertyCount())
+                if (parentMaterialAsset->GetPropertyValues().size() != propertiesLayout->GetPropertyCount())
                 {
                     AZ_Assert(
                         false,
                         "The parent material should have been finalized with %zu properties but it has %zu. Something is out of sync.",
                         propertiesLayout->GetPropertyCount(),
-                        parentMaterialAsset.GetValue()->GetPropertyValues().size());
+                        parentMaterialAsset->GetPropertyValues().size());
                     return Failure();
                 }
 
@@ -203,7 +200,7 @@ namespace AZ
                 {
                     materialAssetCreator.SetPropertyValue(
                         propertiesLayout->GetPropertyDescriptor(MaterialPropertyIndex{ propertyIndex })->GetName(),
-                        parentMaterialAsset.GetValue()->GetPropertyValues()[propertyIndex]);
+                        parentMaterialAsset->GetPropertyValues()[propertyIndex]);
                 }
             }
 
@@ -214,10 +211,8 @@ namespace AZ
             {
                 return Success(material);
             }
-            else
-            {
-                return Failure();
-            }
+
+            return Failure();
         }
 
         Outcome<Data::Asset<MaterialAsset>> MaterialSourceData::CreateMaterialAssetFromSourceData(
@@ -232,8 +227,8 @@ namespace AZ
                 return Failure();
             }
 
-            const AZStd::string materialTypeSourcePath = MaterialUtils::GetFinalMaterialTypeSourcePath(materialSourceFilePath, m_materialType);
-            const auto materialTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(materialSourceFilePath, m_materialType);
+            const auto& materialTypeSourcePath = MaterialUtils::GetFinalMaterialTypeSourcePath(materialSourceFilePath, m_materialType);
+            const auto& materialTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(materialSourceFilePath, m_materialType);
 
             if (!materialTypeAssetId.IsSuccess() || materialTypeSourcePath.empty())
             {
@@ -241,16 +236,17 @@ namespace AZ
                 return Failure();
             }
 
-            auto materialTypeLoadOutcome = MaterialUtils::LoadMaterialTypeSourceData(materialTypeSourcePath, nullptr, sourceDependencies);
+            const auto& materialTypeLoadOutcome =
+                MaterialUtils::LoadMaterialTypeSourceData(materialTypeSourcePath, nullptr, sourceDependencies);
             if (!materialTypeLoadOutcome)
             {
                 AZ_Error("MaterialSourceData", false, "Failed to load MaterialTypeSourceData: '%s'.", materialTypeSourcePath.c_str());
                 return Failure();
             }
 
-            MaterialTypeSourceData materialTypeSourceData = materialTypeLoadOutcome.TakeValue();
+            const auto& materialTypeSourceData = materialTypeLoadOutcome.GetValue();
 
-            const auto materialTypeAsset =
+            const auto& materialTypeAsset =
                 materialTypeSourceData.CreateMaterialTypeAsset(materialTypeAssetId.GetValue(), materialTypeSourcePath, elevateWarnings);
             if (!materialTypeAsset.IsSuccess())
             {
@@ -278,17 +274,17 @@ namespace AZ
                     return Failure();
                 }
 
-                auto loadParentResult = MaterialUtils::LoadMaterialSourceData(parentSourceAbsPath);
+                const auto& loadParentResult = MaterialUtils::LoadMaterialSourceData(parentSourceAbsPath);
                 if (!loadParentResult)
                 {
                     AZ_Error("MaterialSourceData", false, "Failed to load MaterialSourceData for parent material: '%s'.", parentSourceAbsPath.c_str());
                     return Failure();
                 }
                 
-                MaterialSourceData parentSourceData = loadParentResult.TakeValue();
+                const auto& parentSourceData = loadParentResult.GetValue();
 
                 // Make sure that all materials in the hierarchy share the same material type
-                const auto parentTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(parentSourceAbsPath, parentSourceData.m_materialType);
+                const auto& parentTypeAssetId = MaterialUtils::GetFinalMaterialTypeAssetId(parentSourceAbsPath, parentSourceData.m_materialType);
                 if (!parentTypeAssetId)
                 {
                     AZ_Error("MaterialSourceData", false, "Parent material asset ID wasn't found: '%s'.", parentSourceAbsPath.c_str());
@@ -313,7 +309,6 @@ namespace AZ
             MaterialAssetCreator materialAssetCreator;
             materialAssetCreator.SetElevateWarnings(elevateWarnings);
             materialAssetCreator.Begin(assetId, materialTypeAsset.GetValue());
-            
             materialAssetCreator.SetMaterialTypeVersion(m_materialTypeVersion);
 
             // Traverse the parent source data stack in reverse, applying properties from each material parent source data on to the asset
@@ -349,7 +344,7 @@ namespace AZ
         void MaterialSourceData::ApplyPropertiesToAssetCreator(
             AZ::RPI::MaterialAssetCreator& materialAssetCreator, const AZStd::string_view& materialSourceFilePath) const
         {
-            for (auto& [propertyId, propertyValue] : m_propertyValues)
+            for (const auto& [propertyId, propertyValue] : m_propertyValues)
             {
                 if (!propertyValue.IsValid())
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -164,9 +164,8 @@ namespace AZ
 
             if (!m_parentMaterial.empty())
             {
-                constexpr uint32_t subId = 0;
                 const auto& parentMaterialAssetOutcome = AssetUtils::LoadAsset<MaterialAsset>(
-                    materialSourceFilePath, m_parentMaterial, subId, AssetUtils::TraceLevel::Error, dontLoadImageAssets);
+                    materialSourceFilePath, m_parentMaterial, 0, AssetUtils::TraceLevel::Error, dontLoadImageAssets);
                 if (!parentMaterialAssetOutcome.IsSuccess())
                 {
                     return Failure();

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -895,6 +895,21 @@ namespace AZ
             }
         }
 
+        AZStd::vector<MaterialTypeSourceData::ShaderVariantReferenceData> MaterialTypeSourceData::GetShaderReferences() const
+        {
+            AZStd::vector<ShaderVariantReferenceData> shaderReferences;
+
+            shaderReferences.insert(shaderReferences.end(), m_shaderCollection.begin(), m_shaderCollection.end());
+
+            for (const auto& pipelinePair : m_pipelineData)
+            {
+                shaderReferences.insert(
+                    shaderReferences.end(), pipelinePair.second.m_shaderCollection.begin(), pipelinePair.second.m_shaderCollection.end());
+            }
+
+            return shaderReferences;
+        }
+
         bool MaterialTypeSourceData::AddShaders(
             MaterialTypeAssetCreator& materialTypeAssetCreator,
             const Name& materialPipelineName,


### PR DESCRIPTION
## What does this PR do?

- Changed the material and material type builders to better handle intermediate asset dependencies.
- Changed the material builder to directly assign absolute and wild card job dependencies for generated material types and shaders. This will prevent the material builder from processing until all of the shaders generated material types and shaders have completed their own processing. This helps enforce that the material updates and reloads after material type and shader changes. This also eliminates numerous warnings about unresolved or missing dependencies.
- Updated the abstract material type dependency to use the common platform id correctly.
- Updated material and material type source data to use the complete resolve file name in log messages.

## How was this PR tested?

- Verified that all assets build in the automated testing project using server and pc configurations on the asset profile build.
- Verified that all assets build in the multiplayer sample project on Windows PC build.
- Verified that materials and material types no longer report several warnings or errors on the above projects.
- Verified that material assets process after generated shaders and material types and the hot reload in the main editor, at least as much as extensive  manual testing confirmed.