### PR TITLE
Fix ChangeValidate functions not triggering in Property Editors

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
@@ -217,7 +217,7 @@ namespace AZ::Dom::Utils
         {
             return value.IsNumber();
         }
-        else if constexpr (AZStd::is_constructible_v<AZStd::string_view, WrapperType>)
+        else if constexpr (AZStd::is_constructible_v<WrapperType, AZStd::string_view>)
         {
             return value.IsString();
         }

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.h
@@ -282,10 +282,8 @@ namespace AZ::Dom
         bool HasMember(KeyType name) const;
         bool HasMember(AZStd::string_view name) const;
 
-        Value& AddMember(KeyType name, const Value& value);
-        Value& AddMember(AZStd::string_view name, const Value& value);
-        Value& AddMember(KeyType name, Value&& value);
-        Value& AddMember(AZStd::string_view name, Value&& value);
+        Value& AddMember(KeyType name, Value value);
+        Value& AddMember(AZStd::string_view name, Value value);
 
         void RemoveAllMembers();
         void RemoveMember(KeyType name);
@@ -321,6 +319,15 @@ namespace AZ::Dom
         Value& ArrayReserve(size_t newCapacity);
         Value& ArrayPushBack(Value value);
         Value& ArrayPopBack();
+
+        // Insert a contigious span of Dom Values before position
+        Array::Iterator ArrayInsertRange(Array::ConstIterator insertPos, AZStd::span<Value> values);
+        // Insert elements from range [first, last) before position
+        Array::Iterator ArrayInsert(Array::ConstIterator insertPos, Array::ConstIterator first, Array::ConstIterator last);
+        // Insert an array from an initializer_list
+        Array::Iterator ArrayInsert(Array::ConstIterator insertPos, AZStd::initializer_list<Value> initList);
+        // Insert single Value value before position
+        Array::Iterator ArrayInsert(Array::ConstIterator insertPos, Value value);
 
         Array::Iterator ArrayErase(Array::Iterator pos);
         Array::Iterator ArrayErase(Array::Iterator first, Array::Iterator last);

--- a/Code/Framework/AzCore/Tests/AttributeDomInteropTests.cpp
+++ b/Code/Framework/AzCore/Tests/AttributeDomInteropTests.cpp
@@ -9,6 +9,8 @@
 #include <AzCore/DOM/DomUtils.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzCore/UnitTest/MockComponentApplication.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <DOM/DomFixtures.h>
 
@@ -24,21 +26,20 @@ namespace AZ::AttributeDomInteropTests
     template<typename R, typename... Args>
     struct InvokeTestHelper<R(Args...)>
     {
-        AZ_RTTI((InvokeTestHelper, "{BE273EAA-FB6A-464F-A9F8-8A5C59650D70}", R(Args...)));
-        using ThisType = InvokeTestHelper<R(Args...)>;
+        AZ_TYPE_INFO(InvokeTestHelper, "{BE273EAA-FB6A-464F-A9F8-8A5C59650D70}", R(Args...));
         using FunctionType = AZStd::function<R(Args...)>;
+        FunctionType m_fn;
 
-        InvokeTestHelper(FunctionType fn)
+        template<class F>
+        InvokeTestHelper(F fn)
             : m_fn(AZStd::move(fn))
         {
             s_instance = this;
         }
 
-        virtual ~InvokeTestHelper() = default;
+        ~InvokeTestHelper() = default;
 
-        FunctionType m_fn;
-
-        inline static ThisType* s_instance = nullptr;
+        inline static InvokeTestHelper* s_instance = nullptr;
         static R GlobalFunction(Args... args)
         {
             return s_instance->m_fn(args...);
@@ -51,16 +52,26 @@ namespace AZ::AttributeDomInteropTests
 
         void TestInvokeWithDomValues(AZ::Dom::Value expectedResult, AZ::Dom::Value args, bool invokeExpectedToWork = true)
         {
-            AZ::AttributeInvocable<FunctionType> invokeAttribute(m_fn);
+            // The invocable method must accept the class instance as the first argument
+            auto invocableClassMethod = [](InvokeTestHelper* self, Args... args) -> R
+            {
+                return self->m_fn(args...);
+            };
+            AZ::AttributeInvocable invokeAttribute(invocableClassMethod);
             AZ::AttributeFunction<R(Args...)> functionAttribute(&GlobalFunction);
-            AZ::AttributeMemberFunction<R (ThisType::*)(Args...)> memberFunctionAttribute(&ThisType::MemberFunction);
+            AZ::AttributeMemberFunction<R (InvokeTestHelper::*)(Args...)> memberFunctionAttribute(&InvokeTestHelper::MemberFunction);
             AZStd::array<AZ::Attribute*, 3> attributesToTest = { &invokeAttribute, &functionAttribute, &memberFunctionAttribute };
+
+            AZ::Dom::Value instanceAndArgs(AZ::Dom::Type::Array);
+            instanceAndArgs.ArrayPushBack(AZ::Dom::Utils::ValueFromType(this));
+            instanceAndArgs.ArrayInsert(instanceAndArgs.ArrayEnd(), args.ArrayBegin(), args.ArrayEnd());
 
             for (AZ::Attribute* attribute : attributesToTest)
             {
                 EXPECT_EQ(true, attribute->IsInvokable());
-                EXPECT_EQ(invokeExpectedToWork, attribute->CanDomInvoke(args));
-                EXPECT_TRUE(AZ::Dom::Utils::DeepCompareIsEqual(expectedResult, attribute->DomInvoke(this, args)));
+                EXPECT_EQ(invokeExpectedToWork, attribute->CanDomInvoke(instanceAndArgs));
+                // Move the arguments into an instanceAndArgs array and prepend the instance to the dom array
+                EXPECT_TRUE(AZ::Dom::Utils::DeepCompareIsEqual(expectedResult, attribute->DomInvoke(instanceAndArgs)));
             }
         }
 
@@ -69,11 +80,37 @@ namespace AZ::AttributeDomInteropTests
         {
             AZ::Dom::Value domArgs(AZ::Dom::Type::Array);
             (domArgs.ArrayPushBack(AZ::Dom::Utils::ValueFromType<Args>(args)), ...);
-            TestInvokeWithDomValues(AZ::Dom::Utils::ValueFromType(expectedResult), domArgs);
+            TestInvokeWithDomValues(AZ::Dom::Utils::ValueFromType(expectedResult), AZStd::move(domArgs));
         }
     };
 
-    using AttributeDomInteropTests = AZ::Dom::Tests::DomTestFixture;
+    class AttributeDomInteropTests
+        : public AZ::Dom::Tests::DomTestFixture
+    {
+    public:
+        AttributeDomInteropTests()
+            : m_serializeContext(AZStd::make_unique<AZ::SerializeContext>())
+            , m_jsonRegistrationContext(AZStd::make_unique<AZ::JsonRegistrationContext>())
+        {
+            m_componentApplicationMock = AZStd::make_unique<::testing::NiceMock<UnitTest::MockComponentApplication>>();
+            ON_CALL(*m_componentApplicationMock.get(), GetSerializeContext())
+                .WillByDefault(::testing::Return(m_serializeContext.get()));
+
+            ON_CALL(*m_componentApplicationMock.get(), GetJsonRegistrationContext())
+                .WillByDefault(::testing::Return(m_jsonRegistrationContext.get()));
+        }
+
+        ~AttributeDomInteropTests()
+        {
+            m_componentApplicationMock.reset();
+            m_serializeContext.reset();
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+        AZStd::unique_ptr<AZ::JsonRegistrationContext> m_jsonRegistrationContext;
+        AZStd::unique_ptr<::testing::NiceMock<UnitTest::MockComponentApplication>> m_componentApplicationMock;
+    };
 
     TEST_F(AttributeDomInteropTests, ArgumentHandling)
     {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AggregateAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AggregateAdapter.cpp
@@ -930,15 +930,21 @@ namespace AZ::DocumentPropertyEditor
                                 typeField->second.GetString() == Attribute::GetTypeName())
                             {
                                 // last chance! Check if it's an invokable Attribute
-                                void* instance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(functionValue[AZ::Attribute::GetInstanceField()]);
                                 AZ::Attribute* attribute =
                                     AZ::Dom::Utils::ValueToTypeUnsafe<AZ::Attribute*>(functionValue[AZ::Attribute::GetAttributeField()]);
 
-                                const bool canInvoke = attribute->IsInvokable() && attribute->CanDomInvoke(message.m_messageParameters);
+                                AZ::Dom::Value instanceAndArgs(AZ::Dom::Type::Array);
+                                instanceAndArgs.ArrayPushBack(functionValue[AZ::Attribute::GetInstanceField()]);
+                                instanceAndArgs.ArrayInsert(
+                                    instanceAndArgs.ArrayEnd(),
+                                    message.m_messageParameters.ArrayBegin(),
+                                    message.m_messageParameters.ArrayEnd());
+
+                                const bool canInvoke = attribute->IsInvokable() && attribute->CanDomInvoke(instanceAndArgs);
                                 AZ_Assert(canInvoke, "message attribute is not invokable!");
                                 if (canInvoke)
                                 {
-                                    result = attribute->DomInvoke(instance, message.m_messageParameters);
+                                    result = attribute->DomInvoke(instanceAndArgs);
                                 }
                             }
                         }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.cpp
@@ -42,9 +42,9 @@ namespace AZ::DocumentPropertyEditor
         return AZStd::make_shared<AZ::AttributeData<AZ::Uuid>>(AZStd::move(uuidValue));
     }
 
-    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
+    AZ::Dom::Value TypeIdAttributeDefinition::LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const
     {
-        AZ::AttributeReader reader(instance, attribute);
+        AZ::AttributeReader reader(instanceObject.m_address, attribute);
         AZ::Uuid value;
         if (!reader.Read<AZ::Uuid>(value))
         {
@@ -78,10 +78,10 @@ namespace AZ::DocumentPropertyEditor
         return AZStd::make_shared<AZ::AttributeData<AZ::Crc32>>(crc);
     }
 
-    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const
+    AZ::Dom::Value NamedCrcAttributeDefinition::LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const
     {
         AZ::Name result;
-        AZ::AttributeReader reader(instance, attribute);
+        AZ::AttributeReader reader(instanceObject.m_address, attribute);
 
         AZ::Crc32 valueCrc = 0;
         if (!reader.Read<AZ::Crc32>(valueCrc))

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -120,7 +120,7 @@ namespace AZ::DocumentPropertyEditor
 
         /*! Converts this attribute from an AZ::Attribute to a Dom::Value usable in the DocumentPropertyEditor.
             @param fallback if false, a Read<AttributeType> failure will return a null Value; if true, it will attempt a fallback on failure */
-        virtual AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const = 0;
+        virtual AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const = 0;
     };
 
     //! Defines an attribute applicable to a Node.
@@ -197,7 +197,7 @@ namespace AZ::DocumentPropertyEditor
             }
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -206,18 +206,20 @@ namespace AZ::DocumentPropertyEditor
 
             if constexpr (AZStd::is_same_v<AttributeType, AZ::Dom::Value>)
             {
-                return AZ::Reflection::ReadGenericAttributeToDomValue(instance, attribute).value_or(AZ::Dom::Value());
+                return AZ::Reflection::ReadGenericAttributeToDomValue(instanceObject, attribute).value_or(AZ::Dom::Value());
             }
             else
             {
-                AZ::AttributeReader reader(instance, attribute);
+                AZ::AttributeReader reader(instanceObject.m_address, attribute);
                 AttributeType value;
                 if (!reader.Read<AttributeType>(value))
                 {
                     // Handle the attribute providing an invokable function instead of the value directly
-                    if (attribute->CanDomInvoke(Dom::Value(Dom::Type::Array)))
+                    Dom::Value instanceAndArguments(Dom::Type::Array);
+                    instanceAndArguments.ArrayPushBack(AZ::Dom::Utils::ValueFromType(instanceObject.m_address));
+                    if (attribute->CanDomInvoke(instanceAndArguments))
                     {
-                        return attribute->DomInvoke(instance, Dom::Value(Dom::Type::Array));
+                        return attribute->DomInvoke(instanceAndArguments);
                     }
                     else
                     {
@@ -244,7 +246,7 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value ValueToDom(const AZ::TypeId& attribute) const override;
         AZStd::optional<AZ::TypeId> DomToValue(const Dom::Value& value) const override;
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool fallback = true) const override;
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override;
     };
 
     //! Represents an attribute that should be stored as an AZ::Name, but legacy attribute instances (AZ::Attribute*)
@@ -260,7 +262,7 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value ValueToDom(const AZ::Name& attribute) const override;
         AZStd::optional<AZ::Name> DomToValue(const Dom::Value& value) const override;
         AZStd::shared_ptr<AZ::Attribute> DomValueToLegacyAttribute(const AZ::Dom::Value& value, bool fallback = true) const override;
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override;
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override;
     };
 
     template<typename GenericValueType>
@@ -294,7 +296,7 @@ namespace AZ::DocumentPropertyEditor
             return result;
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -307,12 +309,12 @@ namespace AZ::DocumentPropertyEditor
                 using EnumConstantBaseType = AZ::SerializeContextEnumInternal::EnumConstantBase;
                 if (auto data = azdynamic_cast<AttributeData<AZStd::unique_ptr<EnumConstantBaseType>>*>(attribute); data != nullptr)
                 {
-                    EnumConstantBaseType* value = static_cast<EnumConstantBaseType*>(data->Get(instance).get());
+                    EnumConstantBaseType* value = static_cast<EnumConstantBaseType*>(data->Get(instanceObject.m_address).get());
                     return ValueToDom(AZStd::make_pair(value->GetEnumValueAsUInt(), value->GetEnumValueName()));
                 }
             }
 
-            AZ::AttributeReader reader(instance, attribute);
+            AZ::AttributeReader reader(instanceObject.m_address, attribute);
             if (GenericValuePair value; reader.Read<GenericValuePair>(value))
             {
                 return ValueToDom(value);
@@ -376,7 +378,7 @@ namespace AZ::DocumentPropertyEditor
             return result;
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override
         {
             if (attribute == nullptr)
             {
@@ -384,7 +386,7 @@ namespace AZ::DocumentPropertyEditor
             }
 
             auto attributeInvocable = attribute->GetVoidInstanceAttributeInvocable();
-            AttributeReader reader = AttributeReader(instance, attributeInvocable.get());
+            AttributeReader reader = AttributeReader(instanceObject.m_address, attributeInvocable.get());
             if (GenericValueList value; reader.Read<GenericValueList>(value))
             {
                 return ValueToDom(value);
@@ -447,9 +449,9 @@ namespace AZ::DocumentPropertyEditor
                 return AZ::Success(fn(args...));
             }
 
-            static ResultType InvokeOnAttribute(AZ::Attribute* attribute, void* instance, const Dom::Value& args)
+            static ResultType InvokeOnAttribute(AZ::Attribute* attribute, const Dom::Value& instanceAndArgs)
             {
-                return AZ::Success(AZ::Dom::Utils::ValueToTypeUnsafe<Result>(attribute->DomInvoke(instance, args)));
+                return AZ::Success(AZ::Dom::Utils::ValueToTypeUnsafe<Result>(attribute->DomInvoke(instanceAndArgs)));
             }
 
             static FunctionType InvokeOnAttribute(void* instance, AZ::Attribute* attribute)
@@ -490,9 +492,9 @@ namespace AZ::DocumentPropertyEditor
                 return AZ::Success();
             }
 
-            static ResultType InvokeOnAttribute(AZ::Attribute* attribute, void* instance, const Dom::Value& args)
+            static ResultType InvokeOnAttribute(AZ::Attribute* attribute, const Dom::Value& instanceAndArgs)
             {
-                attribute->DomInvoke(instance, args);
+                attribute->DomInvoke(instanceAndArgs);
                 return AZ::Success();
             }
 
@@ -533,11 +535,12 @@ namespace AZ::DocumentPropertyEditor
                     // For RPE callbacks, we may store an AZ::Attribute and its instance in a DOM value
                     if (typeField->second.GetString() == Attribute::GetTypeName())
                     {
-                        void* instance = nullptr;
+                        AZ::Dom::Value marshalledArguments(AZ::Dom::Type::Array);
                         auto foundInstance = value.FindMember(AZ::Attribute::GetInstanceField());
                         if (foundInstance != value.MemberEnd())
                         {
-                            instance = AZ::Dom::Utils::ValueToTypeUnsafe<void*>(foundInstance->second);
+                            // Push the instance arguments as the first marshelled argument for the attribute functor
+                            marshalledArguments.ArrayPushBack(foundInstance->second);
                         }
 
                         AZ::Attribute* attribute =
@@ -548,7 +551,8 @@ namespace AZ::DocumentPropertyEditor
                             return AZ::Failure<ErrorType>("Attempted to invoke a non-invokable attribute");
                         }
 
-                        AZ::Dom::Value marshalledArguments(AZ::Dom::Type::Array);
+                        // Push the remaining non-class type arguments to the Dom array containing the arguments
+                        // of the attribute functor that would be inovked
                         (marshalledArguments.ArrayPushBack(AZ::Dom::Utils::ValueFromType(args)), ...);
 
                         if (!attribute->CanDomInvoke(marshalledArguments))
@@ -556,7 +560,7 @@ namespace AZ::DocumentPropertyEditor
                             return AZ::Failure<ErrorType>("Attempted to invoke an AZ::Attribute with invalid parameters");
                         }
 
-                        return CallbackTraits::InvokeOnAttribute(attribute, instance, marshalledArguments);
+                        return CallbackTraits::InvokeOnAttribute(attribute, marshalledArguments);
                     }
                     // For messages handled by the adapter, we store a marshalled BoundAdapterMessage
                     else if (typeField->second.GetString() == BoundAdapterMessage::s_typeName)
@@ -653,9 +657,9 @@ namespace AZ::DocumentPropertyEditor
             return AZStd::make_shared<AZ::AttributeInvocable<CallbackSignature>>(function.value());
         }
 
-        AZ::Dom::Value LegacyAttributeToDomValue(void* instance, AZ::Attribute* attribute) const override
+        AZ::Dom::Value LegacyAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute) const override
         {
-            return attribute->GetAsDomValue(instance);
+            return attribute->GetAsDomValue(instanceObject);
         }
     };
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -167,7 +167,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto GenericValueList = GenericValueListAttributeDefinition<GenericValueType>("GenericValueList");
 
         static constexpr auto ChangeNotify = CallbackAttributeDefinition<PropertyRefreshLevel()>("ChangeNotify");
-        static constexpr auto ChangeValidate = CallbackAttributeDefinition<AZ::Outcome<void, AZStd::string>(void*, const AZ::Uuid&)>("ChangeValidate");
+        static constexpr auto ChangeValidate = CallbackAttributeDefinition<AZ::Outcome<void, AZStd::string>(void*, AZ::Uuid)>("ChangeValidate");
         static constexpr auto RequestTreeUpdate = CallbackAttributeDefinition<void(PropertyRefreshLevel)>("RequestTreeUpdate");
     };
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1151,7 +1151,7 @@ namespace AZ::Reflection
                         if (name == PropertyEditor::Visibility.GetName())
                         {
                             auto visibilityValue = PropertyEditor::Visibility.DomToValue(
-                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance.m_address, it->second));
+                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance, it->second));
 
                             if (visibilityValue.has_value())
                             {
@@ -1176,13 +1176,13 @@ namespace AZ::Reflection
                             }
                             else if (
                                 auto visibilityBoolValue =
-                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance.m_address, it->second)))
+                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance, it->second)))
                             {
                                 bool isVisible = visibilityBoolValue.value();
                                 visibility = isVisible ? PropertyVisibility::Show : PropertyVisibility::Hide;
                                 return;
                             }
-                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance.m_address, it->second))
+                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance, it->second))
                             {
                                 // Fallback to generic read if LegacyAttributeToDomValue fails
                                 visibility = PropertyEditor::Visibility.DomToValue(genericVisibility.value()).value();
@@ -1196,7 +1196,7 @@ namespace AZ::Reflection
                         {
                             nodeData.m_disableEditor |=
                                 PropertyEditor::ReadOnly
-                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance.m_address, it->second))
+                                    .DomToValue(PropertyEditor::ReadOnly.LegacyAttributeToDomValue(instance, it->second))
                                     .value_or(nodeData.m_disableEditor);
                         }
 
@@ -1207,7 +1207,7 @@ namespace AZ::Reflection
                         {
                             if (attributeValue.IsNull())
                             {
-                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance.m_address, it->second);
+                                attributeValue = attributeReader.LegacyAttributeToDomValue(instance, it->second);
                             }
                         };
                         propertyEditorSystem->EnumerateRegisteredAttributes(name, readValue);
@@ -1215,7 +1215,7 @@ namespace AZ::Reflection
                         // Fall back on a generic read that handles primitives.
                         if (attributeValue.IsNull())
                         {
-                            attributeValue = ReadGenericAttributeToDomValue(instance.m_address, it->second).value_or(Dom::Value());
+                            attributeValue = ReadGenericAttributeToDomValue(instance, it->second).value_or(Dom::Value());
                         }
 
                         // If we got a valid DOM value, store it.
@@ -1643,9 +1643,9 @@ namespace AZ::Reflection
         }
     }
 
-    AZStd::optional<AZ::Dom::Value> ReadGenericAttributeToDomValue(void* instance, AZ::Attribute* attribute)
+    AZStd::optional<AZ::Dom::Value> ReadGenericAttributeToDomValue(AZ::PointerObject instanceObject, AZ::Attribute* attribute)
     {
-        AZ::Dom::Value result = attribute->GetAsDomValue(instance);
+        AZ::Dom::Value result = attribute->GetAsDomValue(instanceObject);
         if (!result.IsNull())
         {
             return result;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
@@ -54,7 +54,7 @@ namespace AZ::Reflection
     } // namespace DescriptorAttributes
 
     AZStd::shared_ptr<AZ::Attribute> WriteDomValueToGenericAttribute(const AZ::Dom::Value& value);
-    AZStd::optional<AZ::Dom::Value> ReadGenericAttributeToDomValue(void* instance, AZ::Attribute* attribute);
+    AZStd::optional<AZ::Dom::Value> ReadGenericAttributeToDomValue(AZ::PointerObject instance, AZ::Attribute* attribute);
 
     void VisitLegacyInMemoryInstance(
         IRead* visitor, void* instance, const AZ::TypeId& typeId, AZ::SerializeContext* serializeContext = nullptr);


### PR DESCRIPTION
Both the Reflected Property Editor and Document Property Editor weren't not triggering ChangeValidate events.

For the Reflected Property Editor, the reason why it wasn't triggering ChangeValidate events was that the
`PropertyRowWidget::HandleChangeValidateAttribute` function incorrectly casted the ChangeValidate attribute function to a function that returned a `bool` type. However all of the Change Validate functions return the type of `AZ::Outcome<void, AZStd::string>`.

The Document Property Editor issue was more involved.

First the signature of the ChangeValidate functions had the form of `AZ::Outcome<void, AZStd::string>(C::*)(void*, const Uuid&)`.

Now the way the DomUtils API works now when it comes to storing non-builtin types such as Uuids, it uses Json Serialization to map a Uuid to an `AZ::Dom::Value`. Now the Json Serializer for a Uuid writes it out as just a string.

Now when the DocumentSchema tries to invoke the ChangeValidate attribute callback, it tries to convert the Dom::Value into the **exact** type of the function signature.

Now as the Dom::Value is stores a string of a Uuid such as "{EA2C3E90-AFBE-44d4-A90D-FAAF79BAF93D}" it would use the Uuid Json Deserializer to convert the string into an `AZ::Uuid`.

However the DomUtils ValueToType uses special case logic when it tries to convert the Dom Value back it a C++ type which is a reference. In this case as the second parameter to ChangeValidate is a `const Uuid&` it triggers the special case logic.

What that logic does, is instead of trying to use Json Serialization system to "deserialize" the Uuid string back into an AZ::Uuid it tries to return a reference to an AZ::Uuid stored in the Dom Value.

Now because Uuid uses Json Serialization, it is not directly stored in the Dom::Value as a type, so reference for it cannot be retrieved. Due to this the conversion from the Dom Value to `const Uuid&` fails.

The fix for the issue is to take the `ChangeValidate` function that gets specified in the `EditContext::Attribute` function and wrap it in a lambda with the signature of
`AZ::Outcome<void,AZStd::string>(C*, void*, Uuid)` where the Uuid is accepted by value.

In order to support calling the lambda using the DomInvoke API, the AttributeInvocable class needs to be able to check if the object it is storing can be called in a member function like manner. As the AttributeInvocable can store either a raw function pointer, member function pointer, member data pointer, or a C++ type with an `operator()`, a `GetPotentialClassType` function has been added to return the class type if the AttributeInvocable is storing a member function pointer or a member data pointer. Or if the AttributeInvocable is storing a function object with an `operator()` it returns the type of the first argument to that function if that argument is a C++ class.

fixes #16961

## How was this PR tested?

Verified that the ChangeValidate function was triggering for the TerrainWorldComponent min and max height field when the Document Property Editor is enabled as well as when the Document Property Editor was invoked.

Updated the AttributeDomInteropTests to make sure they pass with the changes made to the `AZ::Attribute` classes in ReflectContext.h

![RPE Change Validate](https://github.com/o3de/o3de/assets/56135373/b522d13c-69a4-4df9-a1cf-fc56b72fbd46)
![DPE Change Validate](https://github.com/o3de/o3de/assets/56135373/769f8a22-8e9b-4d8b-8a94-0edc0ffe717f)
