### PR TITLE
Changes to support Tool applications(Editor, AP, AssetBundler) in non-monolithic release

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -130,7 +130,7 @@ namespace AZ::Internal
         // is a debug, profile, or release build.
         return static_cast<DevelopmentSettingsOverrides>(ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES);
 #elif AZ_RELEASE_BUILD
-        // By default, if no compile setting was provided, turn allow overrides from the engine, gem and project registry files in release builds.
+        // By default, if no compile setting was provided, allow overrides from the engine, gem and project registry files in release builds.
         return DevelopmentSettingsOverrides::ProjectOnly;
 #else
         // By default, if no compile setting was provided, turn on all overrides in non-release builds.

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -115,8 +115,9 @@ namespace AZ::Internal
     {
         None, // 0 = no overrides are allowed
         CommandLineOnly, // 1 = registry overrides are allowed from the command line
-        CommandLineAndProject, // 2 = registry overrides are allowed from the command line, engine, gem, and project files
-        CommandLineProjectAndUser // 3 = registry overrides are allowed from the command line, engine, gem, project, and user files
+        ProjectOnly, // 2 = registry overrides are allowed from the engine, gem and project registry files
+        CommandLineAndProject, // 3 = registry overrides are allowed from the command line, engine, gem, and project files
+        CommandLineProjectAndUser // 4 = registry overrides are allowed from the command line, engine, gem, project, and user files
     };
 
     //! Determines which development settings (user registry files, project registry files, etc) should
@@ -129,8 +130,8 @@ namespace AZ::Internal
         // is a debug, profile, or release build.
         return static_cast<DevelopmentSettingsOverrides>(ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES);
 #elif AZ_RELEASE_BUILD
-        // By default, if no compile setting was provided, turn off all overrides in release builds.
-        return DevelopmentSettingsOverrides::None;
+        // By default, if no compile setting was provided, turn allow overrides from the engine, gem and project registry files in release builds.
+        return DevelopmentSettingsOverrides::ProjectOnly;
 #else
         // By default, if no compile setting was provided, turn on all overrides in non-release builds.
         return DevelopmentSettingsOverrides::CommandLineProjectAndUser;
@@ -1085,7 +1086,11 @@ namespace AZ
         const AZ::SettingsRegistryInterface::Specializations& specializations,
         AZStd::vector<char>& scratchBuffer)
     {
-        if constexpr (AZ::Internal::GetDevelopmentSettingsOverrides() >= AZ::Internal::DevelopmentSettingsOverrides::CommandLineOnly)
+        constexpr bool overridesAllowedFromCommandLine =
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineOnly ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineAndProject ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineProjectAndUser;
+        if constexpr (overridesAllowedFromCommandLine)
         {
             if constexpr (
                 AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineProjectAndUser)
@@ -1129,8 +1134,11 @@ namespace AZ
             registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
 
 #if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
-        if constexpr (
-            AZ::Internal::GetDevelopmentSettingsOverrides() >= AZ::Internal::DevelopmentSettingsOverrides::CommandLineAndProject)
+        constexpr bool overridesAllowedFromProjectRegistries =
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::ProjectOnly ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineAndProject ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineProjectAndUser;
+        if constexpr (overridesAllowedFromProjectRegistries)
         {
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_EngineRegistry(
                 registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
@@ -1147,7 +1155,11 @@ namespace AZ
         const AZ::SettingsRegistryInterface::Specializations& specializations,
         AZStd::vector<char>& scratchBuffer)
     {
-        if constexpr (AZ::Internal::GetDevelopmentSettingsOverrides() >= AZ::Internal::DevelopmentSettingsOverrides::CommandLineOnly)
+        constexpr bool overridesAllowedFromCommandLine =
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineOnly ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineAndProject ||
+            AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineProjectAndUser;
+        if constexpr (overridesAllowedFromCommandLine)
         {
             if constexpr (
                 AZ::Internal::GetDevelopmentSettingsOverrides() == AZ::Internal::DevelopmentSettingsOverrides::CommandLineProjectAndUser)

--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -22,15 +22,16 @@ endif()
 
 # By default, the Settings Registry will apply user and project registry files as overrides in development (non-release) builds,
 # and will ignore all overrides in release builds.
-# This behavior can be overridden by passing -DALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES=0, 1, 2 or 3 when generating the build files.
+# This behavior can be overridden by passing -DALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES=0, 1, 2, 3 or 4 when generating the build files.
 # The override can be removed by passing -UALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES when generating the build files.
 set(ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES "" CACHE STRING 
 "Forces the Settings Registry development overrides to be used or ignored.
   If unset, development overrides are used in development builds and ignored in release builds.
   0 disables the development overrides in all builds.
   1 = registry overrides are allowed from the command line.
-  2 = registry overrides are allowed from the command line, engine, gem, and project files.
-  3 = registry overrides are allowed from the command line, engine, gem, project, and user files.")
+  2 = registry overrides are allowed from the engine, gem, and project files (not command line).
+  3 = registry overrides are allowed from the command line, engine, gem, and project files.
+  4 = registry overrides are allowed from the command line, engine, gem, project, and user files.")
 
 # If there's a value in ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES, the compiler flag will get set to it.
 # Otherwise, the variable will be empty and no compiler flag will be set, leaving it to the code to decide

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -43,7 +43,7 @@
 namespace AZ::IO
 {
     AZ_CVAR(int, sys_PakPriority, aznumeric_cast<int>(ArchiveVars{}.m_fileSearchPriority), nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
-        "If set to 0, tells Archive to try to open the file on the file system first othewise check mounted paks.\n"
+        "If set to 0, tells Archive to try to open the file on the file system first otherwise check mounted paks.\n"
         "If set to 1, tells Archive to try to open the file in pak first, then go to file system.\n"
         "If set to 2, tells the Archive to only open files from the pak");
     AZ_CVAR(int, sys_report_files_not_found_in_paks, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,

--- a/Code/Framework/AzFramework/AzFramework/Archive/ArchiveVars.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ArchiveVars.cpp
@@ -16,9 +16,7 @@ namespace AZ::IO
 #if defined(LY_ARCHIVE_FILE_SEARCH_MODE)
         return FileSearchPriority{ LY_ARCHIVE_FILE_SEARCH_MODE };
 #else
-        return FileSearchPriority{ !ArchiveVars::IsReleaseConfig
-            ? FileSearchPriority::FileFirst
-            : FileSearchPriority::PakOnly };
+        return FileSearchPriority{ FileSearchPriority::FileFirst };
 #endif
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/feature_options.cmake
+++ b/Code/Framework/AzFramework/AzFramework/feature_options.cmake
@@ -8,6 +8,6 @@
 
 set(LY_ARCHIVE_FILE_SEARCH_MODE "" CACHE STRING "Set the default file search mode to locate non-Pak files within the Archive System\n\
     Valid values are:\n\
-    0 = Search FileSystem first, before searching within mounted Paks (default in debug/profile)\n\
+    0 = Search FileSystem first, before searching within mounted Paks (default in debug/profile/release)\n\
     1 = Search mounted Paks first, before searching FileSystem\n\
-    2 = Search only mounted Paks (default in release)\n")
+    2 = Search only mounted Paks\n")

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
@@ -156,7 +156,7 @@ namespace ScriptCanvas
         LogicLibrary::Reflect(reflectContext);
         OperatorsLibrary::Reflect(reflectContext);
 
-#ifndef _RELEASE
+#if !defined(AZ_MONOLITHIC_BUILD)
         UnitTestingLibrary::Reflect(reflectContext);
 #endif
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestingLibrary.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestingLibrary.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#ifndef _RELEASE
+#if !defined(AZ_MONOLITHIC_BUILD)
 
 #include "UnitTestingLibrary.h"
 

--- a/engine.json
+++ b/engine.json
@@ -7,7 +7,7 @@
     "version": "3.0.0",
     "api_versions": {
         "editor": "1.0.0",
-        "framework": "1.2.0",
+        "framework": "1.2.1",
         "launcher": "1.0.0",
         "tools": "1.1.0"
     },


### PR DESCRIPTION
The Tool applications such as the Editor, AssetProcessor and AssetBundler now can work in release configuration when NOT using the monolithic-permutation.

There are two main changes.
1. Updated the default value for `sys_PakPriority` CVAR to change its file search priority to FileFirst in release configuration. Previously this was Pak only
2. Updated the Settings Registry Development Settings Overrides to allow merging from the engine, each active gem and the active project `Registry` folders when using the release configuration.

Both this changes combined allows the AssetProcessor and Editor to locate the files within the project directory and to load necessary settings registry files required for operation. For example the AssetProcessor(Batch) needs to load the
`AssetProcessorPlatformConfig.setreg` from the `<engine-root>/Registry` directory in order bootstrap the AP with enabled platforms, exclude patterns, the location of the engine's and projects scan folders, etc...


## How was this PR tested?

Verified that the Editor worked in release configuration with no noticeable issues or crashes.
Verified that the AssetProcessor and AssetProcessorBatch were able to successfully process all AutomatedTesting projects assets from a clean cache in Release configuration
Verified that the AssetBundler(Batch) was able to run successfully.
