### PR TITLE
Fixed warnings and errors related to material type builder producing all properties material

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -701,6 +701,7 @@ namespace AZ
                     AssetBuilderSDK::JobProduct defaultMaterialFileProduct;
                     defaultMaterialFileProduct.m_dependenciesHandled = true; // This product is only for reference, not used at runtime
                     defaultMaterialFileProduct.m_productFileName = defaultMaterialFilePath;
+                    defaultMaterialFileProduct.m_productAssetType = AZ::Uuid::CreateString("{FE8E7122-9E96-44F0-A4E4-F134DD9804E2}"); // Need a unique acid type for this raw JSON file
                     defaultMaterialFileProduct.m_productSubID = (u32)MaterialTypeProductSubId::AllPropertiesMaterialSourceFile;
                     response.m_outputProducts.emplace_back(AZStd::move(defaultMaterialFileProduct));
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -44,7 +44,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
-            materialBuilderDescriptor.m_version = 45; // Revising job dependencies
+            materialBuilderDescriptor.m_version = 47; // Fixed warnings related to all properties material JSON
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -682,7 +682,7 @@ namespace AZ
             {
                 AZStd::string defaultMaterialFileName;
                 AzFramework::StringFunc::Path::GetFileName(materialTypeSourcePath.c_str(), defaultMaterialFileName);
-                defaultMaterialFileName += "_AllProperties.material";
+                defaultMaterialFileName += "_AllProperties.json";
 
                 AZStd::string defaultMaterialFilePath;
                 AzFramework::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), defaultMaterialFileName.c_str(), defaultMaterialFilePath, true);

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/fbx_to_atom.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/fbx_to_atom.py
@@ -20,7 +20,7 @@ ToDo:
 Add FBX2glTF subprocess to the script. 
 """
 
-atom_material = atomMat("C:\\atom\\dev\\AtomTest\\Editor\\Scripts\\atom\\maya\\StandardPBR_AllProperties.material")
+atom_material = atomMat("C:\\atom\\dev\\AtomTest\\Editor\\Scripts\\atom\\maya\\StandardPBR_AllProperties.json")
 
 """ All these path could be in configure file or bootstrapped """
 fbx_root = 'C:\\atom\\dev\\Gems\\AtomContent\\AtomDemoContent\\Assets\\Objects\\Peccy\\'

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/stingrayPBS_converter.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/stingrayPBS_converter.py
@@ -40,7 +40,7 @@ site.addsitedir(_MAYA_SCRIPTS)
 from atom_mat import AtomMaterial as atomMAT
 
 _ATOM_MAT_TEMPLATE = atomMAT(Path(_MAYA_SCRIPTS,
-                                  'StandardPBR_AllProperties.material').resolve())
+                                  'StandardPBR_AllProperties.json').resolve())
 
 _model_asset_dir = Path(_REL_ROOT, 'Objects/Characters/Peccy').resolve()
 _atom_mat_path = Path(_REL_ROOT, 'Objects/Characters/Peccy').resolve()

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/stingrayPBS_converter_maya.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/stingraypbs_converter/stingrayPBS_converter_maya.py
@@ -42,7 +42,7 @@ site.addsitedir(_MAYA_SCRIPTS)
 from atom_mat import AtomMaterial as atomMAT
 
 _ATOM_MAT_TEMPLATE = atomMAT(Path(_MAYA_SCRIPTS,
-                                  'StandardPBR_AllProperties.material').resolve())
+                                  'StandardPBR_AllProperties.json').resolve())
 
 
 import pymel.core as pm

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Substance/builder/atom_material.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Substance/builder/atom_material.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     material_path = Path(Path(__file__).parent.parent, 'resources', 'atom')
     # material_01 = AtomPBR("atom_pbr.material", "awesome.material")
     # material_01 = AtomPBR("atom_pbr.material")
-    material_01 = AtomMaterial(Path(material_path, "StandardPBR_AllProperties.material"))
+    material_01 = AtomMaterial(Path(material_path, "StandardPBR_AllProperties.json"))
     # material_01.load("atom_pbr.material")
     # material_01.map(material_01.tex[2]).textureMap = "materials/substance/amazing_xzzzx.tif"
     # # print(material_01.metallic)

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Substance/builder/sb_gui_main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Substance/builder/sb_gui_main.py
@@ -181,7 +181,7 @@ class Window(QtWidgets.QDialog):
                                                'substance',
                                                'resources',
                                                'atom',
-                                               'StandardPBR_AllProperties.material')
+                                               'StandardPBR_AllProperties.json')
         else:
             self._default_material_path = default_material_path
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/material_utilities.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/o3de/renderer/materials/material_utilities.py
@@ -180,7 +180,7 @@ def get_all_properties_description(material_type: str):
     description_location = get_material_templates_location()
     if description_location:
         for file in [x for x in description_location.glob('**/*') if x.is_file()]:
-            if file.name == f'{material_type.lower()}_allproperties.material':
+            if file.name == f'{material_type.lower()}_allproperties.json':
                 with open(str(file), 'r') as data:
                     return json.loads(data.read())
     return None


### PR DESCRIPTION
## What does this PR do?

The material type builder produces a default material type file with all properties explicitly listed. This is done for technical artists and scriptures to be able to easily enumerate all of the properties without parsing the material type format, which was much more complicated than it is and can reference other files. When this feature was added, it used the source material extension and did not register an asset type uuid.

This change renames the extension to avoid confusion with normal materials and adds the uuid to prevent the error spam in the editor.

Fixes https://github.com/o3de/o3de/issues/13677

## How was this PR tested?

Tested by enabling feature and building materials to see files with new extension were produced without causing warnings.