### PR TITLE
Image-related resources

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h
@@ -14,8 +14,8 @@
 #include <ACES/Aces.h>
 #include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
@@ -106,7 +106,7 @@ namespace AZ
             static const int ImagePoolBudget = 1 << 20; // 1 Megabyte
 
             // LUTs that are baked through shaders
-            RHI::Ptr<RHI::SingleDeviceImagePool>                                    m_displayMapperImagePool;
+            RHI::Ptr<RHI::MultiDeviceImagePool> m_displayMapperImagePool;
             AZStd::unordered_map<AZ::Name, DisplayMapperLut>            m_ownedLuts;
             // LUTs loaded from assets
             AZStd::unordered_map<AZStd::string, DisplayMapperAssetLut>  m_assetLuts;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/BakeAcesOutputTransformLutPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/BakeAcesOutputTransformLutPass.h
@@ -13,11 +13,11 @@
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Pass/FullscreenTrianglePass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 
 #include <Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h>
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h
@@ -12,8 +12,7 @@
 
 #include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
-#include <Atom/RHI/SingleDeviceImageView.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 
@@ -23,8 +22,8 @@ namespace AZ
     {
         struct DisplayMapperLut
         {
-            RHI::Ptr<RHI::SingleDeviceImage>        m_lutImage;
-            RHI::Ptr<RHI::SingleDeviceImageView>    m_lutImageView;
+            RHI::Ptr<RHI::MultiDeviceImage> m_lutImage;
+            RHI::Ptr<RHI::MultiDeviceImageView> m_lutImageView;
             RHI::ImageViewDescriptor    m_lutImageViewDescriptor = {};
         };
 

--- a/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
@@ -346,16 +346,14 @@ namespace AZ::Render
 
     void AcesDisplayMapperFeatureProcessor::InitializeImagePool()
     {
-        AZ::RHI::Factory& factory = RHI::Factory::Get();
-        m_displayMapperImagePool = factory.CreateImagePool();
+        m_displayMapperImagePool = aznew RHI::MultiDeviceImagePool;
         m_displayMapperImagePool->SetName(Name("DisplayMapperImagePool"));
 
         RHI::ImagePoolDescriptor   imagePoolDesc = {};
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
         imagePoolDesc.m_budgetInBytes = ImagePoolBudget;
 
-        RHI::Device* device = RHI::RHISystemInterface::Get()->GetDevice();
-        RHI::ResultCode resultCode = m_displayMapperImagePool->Init(*device, imagePoolDesc);
+        RHI::ResultCode resultCode = m_displayMapperImagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
         if (resultCode != RHI::ResultCode::Success)
         {
             AZ_Error("AcesDisplayMapperFeatureProcessor", false, "Failed to initialize image pool.");
@@ -371,10 +369,10 @@ namespace AZ::Render
         }
 
         DisplayMapperLut lutResource;
-        lutResource.m_lutImage = RHI::Factory::Get().CreateImage();
+        lutResource.m_lutImage = aznew RHI::MultiDeviceImage;
         lutResource.m_lutImage->SetName(lutName);
 
-        RHI::SingleDeviceImageInitRequest imageRequest;
+        RHI::MultiDeviceImageInitRequest imageRequest;
         imageRequest.m_image = lutResource.m_lutImage.get();
         static const int LutSize = 32;
         imageRequest.m_descriptor = RHI::ImageDescriptor::Create3D(RHI::ImageBindFlags::ShaderReadWrite, LutSize, LutSize, LutSize, LutFormat);
@@ -387,7 +385,7 @@ namespace AZ::Render
         }
 
         lutResource.m_lutImageViewDescriptor = RHI::ImageViewDescriptor::Create(LutFormat, 0, 0);
-        lutResource.m_lutImageView = lutResource.m_lutImage->GetImageView(lutResource.m_lutImageViewDescriptor);
+        lutResource.m_lutImageView = lutResource.m_lutImage->BuildImageView(lutResource.m_lutImageViewDescriptor);
         if (!lutResource.m_lutImageView.get())
         {
             AZ_Error("AcesDisplayMapperFeatureProcessor", false, "Failed to initialize LUT image view.");

--- a/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
@@ -46,7 +46,7 @@ namespace AZ
                             RPI::Image* image = azrtti_cast<RPI::Image*>(attachment->m_importedResource.get());
                             if (image)
                             {
-                                attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage());
+                                attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                             }
                         }
                     }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -14,30 +14,30 @@
 #include <Atom/RHI/FrameGraphAttachmentInterface.h>
 #include <Atom/RHI/Device.h>
 
-#include <Atom/RPI.Public/Pass/PassUtils.h>
-#include <Atom/RPI.Public/RenderPipeline.h>
-#include <Atom/RPI.Public/RPIUtils.h>
+#include <Atom/Feature/Decals/DecalFeatureProcessorInterface.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RPI.Public/Image/AttachmentImage.h>
+#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassUtils.h>
+#include <Atom/RPI.Public/RPIUtils.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 #include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
-#include <Atom/RPI.Public/View.h>
-#include <AzCore/std/algorithm.h>
 #include <AzCore/Math/MatrixUtils.h>
-#include <Atom/RPI.Public/Scene.h>
+#include <AzCore/Math/Plane.h>
+#include <AzCore/std/algorithm.h>
+#include <CoreLights/CapsuleLightFeatureProcessor.h>
+#include <CoreLights/DiskLightFeatureProcessor.h>
+#include <CoreLights/LightCullingConstants.h>
+#include <CoreLights/PointLightFeatureProcessor.h>
+#include <CoreLights/QuadLightFeatureProcessor.h>
 #include <CoreLights/SimplePointLightFeatureProcessor.h>
 #include <CoreLights/SimpleSpotLightFeatureProcessor.h>
-#include <CoreLights/PointLightFeatureProcessor.h>
-#include <CoreLights/DiskLightFeatureProcessor.h>
-#include <CoreLights/CapsuleLightFeatureProcessor.h>
-#include <CoreLights/QuadLightFeatureProcessor.h>
-#include <Atom/Feature/Decals/DecalFeatureProcessorInterface.h>
-#include <CoreLights/LightCullingConstants.h>
-#include <AzCore/Math/Plane.h>
 #include <cmath>
-#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
-#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
-#include <Atom/RPI.Public/Image/AttachmentImage.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/AcesOutputTransformLutPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/AcesOutputTransformLutPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
             {
                 if (m_displayMapperLut.m_lutImageView != nullptr)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView.get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 }
 
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperBiasIndex, m_shaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/ApplyShaperLookupTablePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/ApplyShaperLookupTablePass.cpp
@@ -107,7 +107,7 @@ namespace AZ
             {
                 if (m_lutResource.m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_lutResource.m_lutStreamingImage->GetImageView());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_lutResource.m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                     m_shaderResourceGroup->SetConstant(m_shaderShaperTypeIndex, m_shaperParams.m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderShaperBiasIndex, m_shaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/BakeAcesOutputTransformLutPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/BakeAcesOutputTransformLutPass.cpp
@@ -67,7 +67,7 @@ namespace AZ
             AZ_Assert(m_displayMapperLut.m_lutImage != nullptr, "BakeAcesOutputTransformLutPass unable to acquire LUT image");
 
             AZ::RHI::AttachmentId imageAttachmentId = AZ::RHI::AttachmentId("DisplayMapperLutImageAttachmentId");
-            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_displayMapperLut.m_lutImage);
+            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_displayMapperLut.m_lutImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
             AZ_Error("BakeAcesOutputTransformLutPass", result == RHI::ResultCode::Success, "Failed to import compute buffer with error %d", result);
 
             RHI::ImageScopeAttachmentDescriptor desc;
@@ -92,7 +92,7 @@ namespace AZ
                 m_shaderResourceGroup->SetConstant(m_shaderInputSurroundGammaIndex, m_displayMapperParameters.m_surroundGamma);
                 m_shaderResourceGroup->SetConstant(m_shaderInputGammaIndex, m_displayMapperParameters.m_gamma);
 
-                m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView.get());
+                m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperBiasIndex, m_shaperParams.m_bias);
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperScaleIndex, m_shaperParams.m_scale);

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2337,7 +2337,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::BaseColor;
-                            subMesh.m_baseColorImageView = image->GetImageView();
+                            subMesh.m_baseColorImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
                             baseColorImage = image;
                         }
                     }
@@ -2349,7 +2349,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Normal;
-                            subMesh.m_normalImageView = image->GetImageView();
+                            subMesh.m_normalImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
                         }
                     }
 
@@ -2360,7 +2360,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Metallic;
-                            subMesh.m_metallicImageView = image->GetImageView();
+                            subMesh.m_metallicImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
                         }
                     }
 
@@ -2371,7 +2371,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Roughness;
-                            subMesh.m_roughnessImageView = image->GetImageView();
+                            subMesh.m_roughnessImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
                         }
                     }
 
@@ -2382,7 +2382,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Emissive;
-                            subMesh.m_emissiveImageView = image->GetImageView();
+                            subMesh.m_emissiveImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
                         }
                     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -124,7 +124,7 @@ namespace AZ
             // import this attachment if it wasn't imported
             if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(imageAttachmentId))
             {
-                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_blendedLut.m_lutImage);
+                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_blendedLut.m_lutImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
                 AZ_Error("BlendColorGradingLutsPass", result == RHI::ResultCode::Success, "Failed to import BlendColorGradingLutImageAttachmentId with error %d", result);
             }
 
@@ -153,7 +153,7 @@ namespace AZ
 
             if (m_shaderResourceGroup != nullptr)
             {
-                m_shaderResourceGroup->SetImageView(m_shaderInputBlendedLutImageIndex, m_blendedLut.m_lutImageView.get());
+                m_shaderResourceGroup->SetImageView(m_shaderInputBlendedLutImageIndex, m_blendedLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendedLutDimensionsIndex, m_blendedLutDimensions);
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendedLutShaperTypeIndex, m_blendedLutShaperParams.m_type);
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendededLutShaperBiasIndex, m_blendedLutShaperParams.m_bias);
@@ -166,7 +166,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[0].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut1ImageIndex, m_colorGradingLuts[0].m_lutStreamingImage->GetImageView());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut1ImageIndex, m_colorGradingLuts[0].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperTypeIndex, m_colorGradingShaperParams[0].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperBiasIndex, m_colorGradingShaperParams[0].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperScaleIndex, m_colorGradingShaperParams[0].m_scale);
@@ -174,7 +174,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[1].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut2ImageIndex, m_colorGradingLuts[1].m_lutStreamingImage->GetImageView());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut2ImageIndex, m_colorGradingLuts[1].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperTypeIndex, m_colorGradingShaperParams[1].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperBiasIndex, m_colorGradingShaperParams[1].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperScaleIndex, m_colorGradingShaperParams[1].m_scale);
@@ -182,7 +182,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[2].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut3ImageIndex, m_colorGradingLuts[2].m_lutStreamingImage->GetImageView());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut3ImageIndex, m_colorGradingLuts[2].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperTypeIndex, m_colorGradingShaperParams[2].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperBiasIndex, m_colorGradingShaperParams[2].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperScaleIndex, m_colorGradingShaperParams[2].m_scale);
@@ -190,7 +190,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[3].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut4ImageIndex, m_colorGradingLuts[3].m_lutStreamingImage->GetImageView());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut4ImageIndex, m_colorGradingLuts[3].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperTypeIndex, m_colorGradingShaperParams[3].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperBiasIndex, m_colorGradingShaperParams[3].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperScaleIndex, m_colorGradingShaperParams[3].m_scale);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.h
@@ -13,11 +13,11 @@
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Pass/FullscreenTrianglePass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 
 #include <Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h>
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -210,7 +210,7 @@ namespace AZ
             {
                 if (m_colorGradingLutEnabled == true && m_blendedColorGradingLut.m_lutImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderColorGradingLutImageIndex, m_blendedColorGradingLut.m_lutImageView.get());
+                    m_shaderResourceGroup->SetImageView(m_shaderColorGradingLutImageIndex, m_blendedColorGradingLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                     m_shaderResourceGroup->SetConstant(m_shaderColorGradingShaperTypeIndex, m_colorGradingShaperParams.m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderColorGradingShaperBiasIndex, m_colorGradingShaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -272,7 +272,7 @@ namespace AZ
                 // add reflection probe data
                 if (mesh.m_reflectionProbe.m_reflectionProbeCubeMap.get())
                 {
-                    materialInfo.m_reflectionProbeCubeMapIndex = mesh.m_reflectionProbe.m_reflectionProbeCubeMap->GetImageView()->GetBindlessReadIndex();
+                    materialInfo.m_reflectionProbeCubeMapIndex = mesh.m_reflectionProbe.m_reflectionProbeCubeMap->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex();
                     if (materialInfo.m_reflectionProbeCubeMapIndex != InvalidIndex)
                     {                        
                         reflectionProbeModelToWorld3x4.StoreToRowMajorFloat12(materialInfo.m_reflectionProbeData.m_modelToWorld.data());
@@ -450,7 +450,7 @@ namespace AZ
 
                 // update all of the subMeshes
                 const Data::Instance<RPI::Image>& reflectionProbeCubeMap = reflectionProbe.m_reflectionProbeCubeMap;
-                uint32_t reflectionProbeCubeMapIndex = reflectionProbeCubeMap.get() ? reflectionProbeCubeMap->GetImageView()->GetBindlessReadIndex() : InvalidIndex;
+                uint32_t reflectionProbeCubeMapIndex = reflectionProbeCubeMap.get() ? reflectionProbeCubeMap->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex;
                 Matrix3x4 reflectionProbeModelToWorld3x4 = Matrix3x4::CreateFromTransform(mesh.m_reflectionProbe.m_modelToWorld);
 
                 for (auto& subMeshIndex : mesh.m_subMeshIndices)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -128,16 +128,15 @@ namespace AZ::RHI
         uint32_t m_offset = 0;
     };
 
-        struct MultiDeviceImageSubresourceLayout
+    struct MultiDeviceImageSubresourceLayout
+    {
+        AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
+
+        MultiDeviceImageSubresourceLayout() = default;
+
+        void Init(RHI::MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout& deviceLayout)
         {
-            AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
-            // static void Reflect(AZ::ReflectContext* context);
-
-            MultiDeviceImageSubresourceLayout() = default;
-
-            void Init(RHI::MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout& deviceLayout)
-            {
-                int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+            int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
 
             for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
             {
@@ -146,7 +145,7 @@ namespace AZ::RHI
                     m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
                 }
             }
-            }
+        }
 
         SingleDeviceImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -10,6 +10,7 @@
 #include <Atom/RHI.Reflect/Size.h>
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
+#include <Atom/RHI/RHISystemInterface.h>
 
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -127,12 +128,25 @@ namespace AZ::RHI
         uint32_t m_offset = 0;
     };
 
-    struct MultiDeviceImageSubresourceLayout
-    {
-        AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
-        static void Reflect(AZ::ReflectContext* context);
+        struct MultiDeviceImageSubresourceLayout
+        {
+            AZ_TYPE_INFO(MultiDeviceImageSubresourceLayout, "{8AD0DC97-5AAA-470F-8853-C8A55E023CD1}");
+            // static void Reflect(AZ::ReflectContext* context);
 
-        MultiDeviceImageSubresourceLayout() = default;
+            MultiDeviceImageSubresourceLayout() = default;
+
+            void Init(RHI::MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout& deviceLayout)
+            {
+                int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+            for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
+                }
+            }
+            }
 
         SingleDeviceImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedHeap.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedHeap.h
@@ -10,11 +10,11 @@
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/TransientAttachmentStatistics.h>
 #include <Atom/RHI/AliasingBarrierTracker.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
 #include <Atom/RHI/FreeListAllocator.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/Object.h>
 #include <Atom/RHI/ObjectCache.h>
+#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/SingleDeviceResourcePool.h>
 #include <Atom/RHI/SingleDeviceTransientAttachmentPool.h>
 #include <AzCore/Memory/SystemAllocator.h>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
@@ -9,7 +9,7 @@
 
 #include <Atom/RHI.Reflect/TransientImageDescriptor.h>
 #include <Atom/RHI/FrameAttachment.h>
-#include <Atom/RHI/SingleDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/ObjectCache.h>
 #include <AzCore/Memory/PoolAllocator.h>
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -118,9 +118,10 @@ namespace AZ::RHI
         AZ_RTTI(MultiDeviceImageView, "{C837818B-2A4D-49F2-A37E-349494A9C9B7}", Object);
         virtual ~MultiDeviceImageView() = default;
 
-        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor)
+        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::SingleDeviceImageView>>&& cache)
             : m_image{ image }
             , m_descriptor{ descriptor }
+            , m_cache{AZStd::move(cache)}
         {
         }
 
@@ -144,5 +145,7 @@ namespace AZ::RHI
         const RHI::MultiDeviceImage* m_image;
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
+        //! SingleDeviceImageView cache
+        AZStd::unordered_map<int, Ptr<RHI::SingleDeviceImageView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -12,14 +12,13 @@
 #include <Atom/RHI/SingleDeviceImage.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
 #include <Atom/RHI/MultiDeviceResource.h>
+#include <Atom/RHI/SingleDeviceImage.h>
 
 namespace AZ::RHI
 {
     class ImageFrameAttachment;
     class MultiDeviceShaderResourceGroup;
-    class SingleDeviceImageView;
     class MultiDeviceImageView;
-    struct ImageViewDescriptor;
 
     //! MultiDeviceImage represents a collection of MultiDeviceImage Subresources, where each subresource comprises a one to three
     //! dimensional grid of pixels. Images are divided into an array of mip-map chains. A mip map chain is

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -62,8 +62,7 @@ namespace AZ
             //! Return true if the pool was set to new memory budget successfully
             bool SetMemoryBudget(size_t newBudget);
 
-            //! Iterates through all device-specific image pools and returns the HeapMemoryUsage
-            //! from the pool with the maximum memory budget.
+            //! Returns the maximum memory used by one of its pools for a specific heap type.
             const HeapMemoryUsage& GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const;
 
             //! Return if it supports tiled image feature

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/XRRenderingInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/XRRenderingInterface.h
@@ -15,7 +15,7 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceImage;
+    class MultiDeviceImage;
     //! Key for the desired foveated rendering level
     inline constexpr const char* XRFoveatedLevelKey = "/O3DE/Atom/OpenXR/FoveatedLevel";
 
@@ -139,6 +139,6 @@ namespace AZ::RHI
         //! Fills the contents of an image that will be use as a variable shading rate attachment depending
         //! on the requested level of foveted rendering. The image must have the proper format and size for using
         //! as a shading rate attachment.
-        virtual AZ::RHI::ResultCode InitVariableRateShadingImageContent(AZ::RHI::SingleDeviceImage* image, XRFoveatedLevel level) const = 0;
+        virtual AZ::RHI::ResultCode InitVariableRateShadingImageContent(AZ::RHI::MultiDeviceImage* image, XRFoveatedLevel level) const = 0;
     };
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/AliasingBarrierTracker.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AliasingBarrierTracker.cpp
@@ -6,9 +6,9 @@
  *
  */
 #include <Atom/RHI/AliasingBarrierTracker.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/Scope.h>
+#include <Atom/RHI/SingleDeviceBuffer.h>
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -45,7 +45,14 @@ namespace AZ::RHI
 
     Ptr<MultiDeviceImageView> MultiDeviceImage::BuildImageView(const ImageViewDescriptor& imageViewDescriptor)
     {
-        return aznew MultiDeviceImageView{ this, imageViewDescriptor };
+        //? TODO: We currently need to cache the SingleDeviceImageViews (as no one else is doing that atm),
+        //?       can possibly be removed once everything handles MultiDeviceResources everywhere
+        AZStd::unordered_map<int, Ptr<RHI::SingleDeviceImageView>> m_cache;
+        IterateObjects<SingleDeviceImage>([&imageViewDescriptor, &m_cache](auto deviceIndex, auto deviceImage)
+        {
+            m_cache[deviceIndex] = deviceImage->GetImageView(imageViewDescriptor);
+        });
+        return aznew MultiDeviceImageView{ this, imageViewDescriptor, AZStd::move(m_cache) };
     }
 
     uint32_t MultiDeviceImage::GetResidentMipLevel() const
@@ -103,6 +110,12 @@ namespace AZ::RHI
     //! Given a device index, return the corresponding SingleDeviceBufferView for the selected device
     const RHI::Ptr<RHI::SingleDeviceImageView> MultiDeviceImageView::GetDeviceImageView(int deviceIndex) const
     {
-        return m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
+        AZ_Error(
+            "MultiDeviceImageView",
+            m_cache.find(deviceIndex) != m_cache.end(),
+            "No SingleDeviceImageView found for device index %d\n",
+            deviceIndex);
+
+        return m_cache.at(deviceIndex);
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
@@ -210,7 +210,7 @@ namespace AZ::RHI
 
     const HeapMemoryUsage& MultiDeviceStreamingImagePool::GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const
     {
-        auto maxUsageIndex{-1};
+        auto maxUsageIndex{RHI::MultiDevice::DefaultDeviceIndex};
         auto maxBudget{0ull};
         IterateObjects<SingleDeviceStreamingImagePool>([&maxUsageIndex, &maxBudget, heapMemoryLevel](auto deviceIndex, auto deviceStreamingImagePool)
         {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImage.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Reflect/Image/Image.h>
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
@@ -17,7 +17,7 @@ namespace AZ
     namespace RHI
     {
         class Device;
-        class SingleDeviceImagePool;
+        class MultiDeviceImagePool;
     }
 
     namespace RPI
@@ -38,19 +38,19 @@ namespace AZ
 
             ~AttachmentImagePool() override = default;
 
-            RHI::SingleDeviceImagePool* GetRHIPool();
+            RHI::MultiDeviceImagePool* GetRHIPool();
 
-            const RHI::SingleDeviceImagePool* GetRHIPool() const;
+            const RHI::MultiDeviceImagePool* GetRHIPool() const;
 
         private:
             AttachmentImagePool() = default;
 
             // Standard asset creation path.
-            static Data::Instance<AttachmentImagePool> CreateInternal(RHI::Device& device, ResourcePoolAsset& poolAsset);
-            RHI::ResultCode Init(RHI::Device& device, ResourcePoolAsset& poolAsset);
+            static Data::Instance<AttachmentImagePool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
+            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
 
             /// The RHI image pool instance.
-            RHI::Ptr<RHI::SingleDeviceImagePool> m_pool;
+            RHI::Ptr<RHI::MultiDeviceImagePool> m_pool;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageSystem.h
@@ -43,7 +43,7 @@ namespace AZ
             static void Reflect(AZ::ReflectContext* context);
             static void GetAssetHandlers(AssetHandlerPtrList& assetHandlers);
 
-            void Init(const ImageSystemDescriptor& desc);
+            void Init(RHI::MultiDevice::DeviceMask deviceMask, const ImageSystemDescriptor& desc);
             void Shutdown();
 
             //! Performs a streaming controller update tick, which will fetch / evict mips

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
@@ -209,7 +209,7 @@ namespace AZ
             Data::Instance<StreamingImagePool> m_pool;
 
             // RHI pool reference cached at init time from the parent pool asset.
-            RHI::SingleDeviceStreamingImagePool* m_rhiPool = nullptr;
+            RHI::MultiDeviceStreamingImagePool* m_rhiPool = nullptr;
 
             // The image asset associated with this image instance.
             Data::Asset<StreamingImageAsset> m_imageAsset;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -38,7 +38,7 @@ namespace AZ
 
         public:
             //! Create a StreamingImageController
-            static AZStd::unique_ptr<StreamingImageController> Create(RHI::SingleDeviceStreamingImagePool& pool);
+            static AZStd::unique_ptr<StreamingImageController> Create(RHI::MultiDeviceStreamingImagePool& pool);
 
             StreamingImageController() = default;
             ~StreamingImageController() = default;
@@ -121,7 +121,7 @@ namespace AZ
 
             ///////////////////////////////////////////////////////////////////
 
-            RHI::SingleDeviceStreamingImagePool* m_pool = nullptr;
+            RHI::MultiDeviceStreamingImagePool* m_pool = nullptr;
 
             // The mutex used to serialize attachment, detachment, and update; as they would otherwise stomp on each other.
             AZStd::mutex m_contextAccessMutex;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h>
 
-#include <Atom/RHI/SingleDeviceStreamingImagePool.h>
+#include <Atom/RHI/MultiDeviceStreamingImagePool.h>
 
 #include <AtomCore/Instance/InstanceData.h>
 
@@ -49,9 +49,9 @@ namespace AZ
             //! @param streamingImagePoolAsset The asset used to instantiate an instance of the streaming image pool.
             static Data::Instance<StreamingImagePool> FindOrCreate(const Data::Asset<StreamingImagePoolAsset>& streamingImagePoolAsset);
 
-            RHI::SingleDeviceStreamingImagePool* GetRHIPool();
+            RHI::MultiDeviceStreamingImagePool* GetRHIPool();
 
-            const RHI::SingleDeviceStreamingImagePool* GetRHIPool() const;
+            const RHI::MultiDeviceStreamingImagePool* GetRHIPool() const;
 
             //! Get the number of streaming images in this pool
             uint32_t GetImageCount() const;
@@ -81,8 +81,8 @@ namespace AZ
             StreamingImagePool() = default;
 
             // Standard init path from asset data.
-            static Data::Instance<StreamingImagePool> CreateInternal(RHI::Device& device, StreamingImagePoolAsset& streamingImagePoolAsset);
-            RHI::ResultCode Init(RHI::Device& device, StreamingImagePoolAsset& poolAsset);
+            static Data::Instance<StreamingImagePool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& streamingImagePoolAsset);
+            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& poolAsset);
 
             // Updates the streaming controller (ticked by the system component).
             void Update();
@@ -94,7 +94,7 @@ namespace AZ
             ///////////////////////////////////////////////////////////////////
 
             // The RHI streaming image pool instance.
-            RHI::Ptr<RHI::SingleDeviceStreamingImagePool> m_pool;
+            RHI::Ptr<RHI::MultiDeviceStreamingImagePool> m_pool;
 
             // The controller used to manage streaming events on the pool.
             AZStd::unique_ptr<StreamingImageController> m_controller;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
@@ -10,7 +10,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
 #include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
@@ -10,9 +10,9 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 
-#include <Atom/RHI/SingleDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 
 #include <AtomCore/Instance/InstanceData.h>
 
@@ -38,13 +38,13 @@ namespace AZ
             bool IsInitialized() const;
 
             //! Returns the mutable GPU image instance initialized at asset load time.
-            RHI::SingleDeviceImage* GetRHIImage();
+            RHI::MultiDeviceImage* GetRHIImage();
 
             //! Returns the immutable GPU image instance initialized at asset load time.
-            const RHI::SingleDeviceImage* GetRHIImage() const;
+            const RHI::MultiDeviceImage* GetRHIImage() const;
 
             //! Returns the default image view instance, mapping the full (resident) image.
-            const RHI::SingleDeviceImageView* GetImageView() const;
+            const RHI::MultiDeviceImageView* GetImageView() const;
 
             //! Returns the image descriptor which contains some image information
             const RHI::ImageDescriptor& GetDescriptor() const;
@@ -53,17 +53,17 @@ namespace AZ
             uint16_t GetMipLevelCount();
                         
             //! Updates content of a single sub-resource in the image from the CPU.
-            virtual RHI::ResultCode UpdateImageContents(const RHI::SingleDeviceImageUpdateRequest& request);
-            
+            virtual RHI::ResultCode UpdateImageContents(const RHI::MultiDeviceImageUpdateRequest& request);
+
         protected:
             // This is a base class for a derived instance variant.
             Image();
 
             // The RHI image instance is created at load time. It contains the resident set of mip levels.
-            RHI::Ptr<RHI::SingleDeviceImage> m_image;
+            RHI::Ptr<RHI::MultiDeviceImage> m_image;
 
             // The default view instance mapping the full resident set of the image mip levels and array slices.
-            RHI::Ptr<RHI::SingleDeviceImageView> m_imageView;
+            RHI::Ptr<RHI::MultiDeviceImageView> m_imageView;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RHI.Reflect/ImageSubresource.h>
 
-#include <Atom/RHI/SingleDeviceStreamingImagePool.h>
+#include <Atom/RHI/MultiDeviceStreamingImagePool.h>
 
 #include <AzCore/std/containers/span.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
@@ -15,7 +15,7 @@
 #include <Atom/RPI.Reflect/Image/AttachmentImageAssetCreator.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <AtomCore/Instance/InstanceDatabase.h>
 
@@ -134,9 +134,9 @@ namespace AZ
                 return RHI::ResultCode::Fail;
             }
 
-            RHI::SingleDeviceImagePool* rhiPool = pool->GetRHIPool();
+            RHI::MultiDeviceImagePool* rhiPool = pool->GetRHIPool();
 
-            RHI::SingleDeviceImageInitRequest initRequest;
+            RHI::MultiDeviceImageInitRequest initRequest;
             initRequest.m_image = GetRHIImage();
             initRequest.m_descriptor = imageAsset.GetImageDescriptor();
             initRequest.m_optimizedClearValue = imageAsset.GetOptimizedClearValue();
@@ -145,7 +145,7 @@ namespace AZ
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_imagePool = pool;
-                m_imageView = m_image->GetImageView(imageAsset.GetImageViewDescriptor());
+                m_imageView = m_image->BuildImageView(imageAsset.GetImageViewDescriptor());
                 if(!m_imageView.get())
                 {
                     AZ_Error("AttachmentImage", false, "AttachmentImage::Init() failed to initialize RHI image view.");

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImagePool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImagePool.cpp
@@ -11,7 +11,7 @@
 #include <Atom/RPI.Reflect/ResourcePoolAsset.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RHI.Reflect/ImagePoolDescriptor.h>
 
@@ -28,10 +28,11 @@ namespace AZ
                 resourcePoolAsset);
         }
 
-        Data::Instance<AttachmentImagePool> AttachmentImagePool::CreateInternal(RHI::Device& device, ResourcePoolAsset& poolAsset)
+        Data::Instance<AttachmentImagePool> AttachmentImagePool::CreateInternal(
+            RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
         {
             Data::Instance<AttachmentImagePool> imagePool = aznew AttachmentImagePool();
-            RHI::ResultCode resultCode = imagePool->Init(device, poolAsset);
+            RHI::ResultCode resultCode = imagePool->Init(deviceMask, poolAsset);
 
             if (resultCode == RHI::ResultCode::Success)
             {
@@ -41,12 +42,12 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode AttachmentImagePool::Init(RHI::Device& device, ResourcePoolAsset& poolAsset)
+        RHI::ResultCode AttachmentImagePool::Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
         {
-            RHI::Ptr<RHI::SingleDeviceImagePool> imagePool = RHI::Factory::Get().CreateImagePool();
+            RHI::Ptr<RHI::MultiDeviceImagePool> imagePool = aznew RHI::MultiDeviceImagePool;
             if (!imagePool)
             {
-                AZ_Error("RPI::ImagePool", false, "Failed to create RHI::SingleDeviceImagePool");
+                AZ_Error("RPI::ImagePool", false, "Failed to create RHI::MultiDeviceImagePool");
                 return RHI::ResultCode::Fail;
             }
 
@@ -58,7 +59,7 @@ namespace AZ
             }
 
             imagePool->SetName(AZ::Name(poolAsset.GetPoolName()));
-            RHI::ResultCode resultCode = imagePool->Init(device, *desc);
+            RHI::ResultCode resultCode = imagePool->Init(deviceMask, *desc);
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_pool = imagePool;
@@ -66,12 +67,12 @@ namespace AZ
             return resultCode;
         }
 
-        const RHI::SingleDeviceImagePool* AttachmentImagePool::GetRHIPool() const
+        const RHI::MultiDeviceImagePool* AttachmentImagePool::GetRHIPool() const
         {
             return m_pool.get();
         }
 
-        RHI::SingleDeviceImagePool* AttachmentImagePool::GetRHIPool()
+        RHI::MultiDeviceImagePool* AttachmentImagePool::GetRHIPool()
         {
             return m_pool.get();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -51,7 +51,8 @@ namespace AZ
             imageDescriptor.m_size = imageSize;
             imageDescriptor.m_format = imageFormat;
 
-            const RHI::SingleDeviceImageSubresourceLayout imageSubresourceLayout = RHI::GetImageSubresourceLayout(imageDescriptor, RHI::ImageSubresource{});
+            const RHI::SingleDeviceImageSubresourceLayout imageSubresourceLayout =
+                RHI::GetImageSubresourceLayout(imageDescriptor, RHI::ImageSubresource{});
 
             const size_t expectedImageDataSize = imageSubresourceLayout.m_bytesPerImage * imageDescriptor.m_size.m_depth;
             if (expectedImageDataSize != imageDataSize)
@@ -131,7 +132,7 @@ namespace AZ
             }
 
             // Cache off the RHI streaming image pool instance.
-            RHI::SingleDeviceStreamingImagePool* rhiPool = pool->GetRHIPool();
+            RHI::MultiDeviceStreamingImagePool* rhiPool = pool->GetRHIPool();
 
             /**
              * NOTE: The tail mip-chain is required to exist as a dependency of this asset. This allows
@@ -144,7 +145,7 @@ namespace AZ
             const ImageMipChainAsset& mipChainTailAsset = imageAsset.GetTailMipChain();
 
             {
-                RHI::SingleDeviceStreamingImageInitRequest initRequest;
+                RHI::MultiDeviceStreamingImageInitRequest initRequest;
                 initRequest.m_image = GetRHIImage();
                 initRequest.m_descriptor = imageAsset.GetImageDescriptor();
                 initRequest.m_tailMipSlices = mipChainTailAsset.GetMipSlices();
@@ -155,7 +156,7 @@ namespace AZ
 
             if (resultCode == RHI::ResultCode::Success)
             {
-                m_imageView = m_image->GetImageView(imageAsset.GetImageViewDescriptor());
+                m_imageView = m_image->BuildImageView(imageAsset.GetImageViewDescriptor());
                 if(!m_imageView.get())
                 {
                    AZ_Error("Image", false, "Failed to initialize RHI image view. This is not a recoverable error and is likely a bug.");
@@ -207,7 +208,7 @@ namespace AZ
                 return RHI::ResultCode::Success;
             }
 
-            AZ_Warning("StreamingImagePool", false, "Failed to initialize RHI::SingleDeviceImage on RHI::SingleDeviceStreamingImagePool.");
+            AZ_Warning("StreamingImagePool", false, "Failed to initialize RHI::MultiDeviceImage on RHI::MultiDeviceStreamingImagePool.");
             return resultCode;
         }
 
@@ -492,7 +493,7 @@ namespace AZ
             {
                 const auto& mipSlices = mipChainAsset->GetMipSlices();
 
-                RHI::SingleDeviceStreamingImageExpandRequest request;
+                RHI::MultiDeviceStreamingImageExpandRequest request;
                 request.m_image = GetRHIImage();
                 request.m_mipSlices = mipSlices;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImageController.cpp
@@ -27,7 +27,7 @@ namespace AZ
         #define StreamingDebugOutput(window, ...)
 #endif
 
-        AZStd::unique_ptr<StreamingImageController> StreamingImageController::Create(RHI::SingleDeviceStreamingImagePool& pool)
+        AZStd::unique_ptr<StreamingImageController> StreamingImageController::Create(RHI::MultiDeviceStreamingImagePool& pool)
         {
             AZStd::unique_ptr<StreamingImageController> controller = AZStd::make_unique<StreamingImageController>();
             controller->m_pool = &pool;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
@@ -27,10 +27,10 @@ namespace AZ
                 streamingImagePoolAsset);
         }
 
-        Data::Instance<StreamingImagePool> StreamingImagePool::CreateInternal(RHI::Device& device, StreamingImagePoolAsset& streamingImagePoolAsset)
+        Data::Instance<StreamingImagePool> StreamingImagePool::CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& streamingImagePoolAsset)
         {
             Data::Instance<StreamingImagePool> streamingImagePool = aznew StreamingImagePool();
-            const RHI::ResultCode resultCode = streamingImagePool->Init(device, streamingImagePoolAsset);
+            const RHI::ResultCode resultCode = streamingImagePool->Init(deviceMask, streamingImagePoolAsset);
 
             if (resultCode == RHI::ResultCode::Success)
             {
@@ -40,7 +40,7 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode StreamingImagePool::Init(RHI::Device& device, StreamingImagePoolAsset& poolAsset)
+        RHI::ResultCode StreamingImagePool::Init(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& poolAsset)
         {
             AZ_PROFILE_FUNCTION(RPI);
 
@@ -53,9 +53,9 @@ namespace AZ
                 }
             }
 
-            RHI::Ptr<RHI::SingleDeviceStreamingImagePool> pool = RHI::Factory::Get().CreateStreamingImagePool();
+            RHI::Ptr<RHI::MultiDeviceStreamingImagePool> pool = aznew RHI::MultiDeviceStreamingImagePool;
 
-            const RHI::ResultCode resultCode = pool->Init(device, poolAsset.GetPoolDescriptor());
+            const RHI::ResultCode resultCode = pool->Init(deviceMask, poolAsset.GetPoolDescriptor());
 
             if (resultCode == RHI::ResultCode::Success)
             {
@@ -65,7 +65,7 @@ namespace AZ
                 return RHI::ResultCode::Success;
             }
 
-            AZ_Warning("StreamingImagePoolAsset", false, "Failed to initialize RHI::SingleDeviceStreamingImagePool.");
+            AZ_Warning("StreamingImagePoolAsset", false, "Failed to initialize RHI::MultiDeviceStreamingImagePool.");
             return resultCode;
         }
 
@@ -91,12 +91,12 @@ namespace AZ
             m_controller->Update();
         }
 
-        RHI::SingleDeviceStreamingImagePool* StreamingImagePool::GetRHIPool()
+        RHI::MultiDeviceStreamingImagePool* StreamingImagePool::GetRHIPool()
         {
             return m_pool.get();
         }
 
-        const RHI::SingleDeviceStreamingImagePool* StreamingImagePool::GetRHIPool() const
+        const RHI::MultiDeviceStreamingImagePool* StreamingImagePool::GetRHIPool() const
         {
             return m_pool.get();
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -934,11 +934,11 @@ namespace AZ
                         Image* image = static_cast<Image*>(attachment->m_importedResource.get());
                         if (currentAttachment == nullptr)
                         {
-                            attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage());
+                            attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
                         }
                         else
                         {
-                            AZ_Assert(currentAttachment->GetResource() == image->GetRHIImage(),
+                            AZ_Assert(currentAttachment->GetResource() == image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get(),
                                 "Importing image attachment named \"%s\" but a different attachment with the "
                                 "same name already exists in the database.\n", attachmentId.GetCStr());
                         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.cpp
@@ -189,7 +189,8 @@ namespace AZ
 
         void EnvironmentCubeMapPass::AttachmentReadbackCallback(const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult)
         {
-            RHI::SingleDeviceImageSubresourceLayout imageLayout = RHI::GetImageSubresourceLayout(readbackResult.m_imageDescriptor.m_size, readbackResult.m_imageDescriptor.m_format);
+            RHI::SingleDeviceImageSubresourceLayout imageLayout =
+                RHI::GetImageSubresourceLayout(readbackResult.m_imageDescriptor.m_size, readbackResult.m_imageDescriptor.m_format);
 
             delete [] m_textureData[m_renderFace];
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
             }
             // Import this scope producer
             params.m_frameGraphBuilder->ImportScopeProducer(*this);
-            attachmentDatabase.ImportImage(m_destAttachmentId, m_destImage->GetRHIImage());
+            attachmentDatabase.ImportImage(m_destAttachmentId, m_destImage->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
         }
 
         void ImageAttachmentCopy::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
@@ -353,7 +353,7 @@ namespace AZ
                     // So the attachment can be still previewed when the pass is disabled.
                     if (m_attachmentCopy && m_attachmentCopy->m_destImage)
                     {
-                        attachmentDatabase.ImportImage(m_attachmentCopy->m_destAttachmentId, m_attachmentCopy->m_destImage->GetRHIImage());
+                        attachmentDatabase.ImportImage(m_attachmentCopy->m_destAttachmentId, m_attachmentCopy->m_destImage->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         isAttachmentValid = true;
                     }
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -433,7 +433,7 @@ namespace AZ
             }
 
             m_rhiSystem.Init(bindlessSrgLayout);
-            m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
+            m_imageSystem.Init(RHI::MultiDevice::AllDevices, m_descriptor.m_imageSystemDescriptor);
             m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
             m_dynamicDraw.Init(m_descriptor.m_dynamicDrawSystemDescriptor);
 
@@ -463,7 +463,7 @@ namespace AZ
 
             //Init rhi/image/buffer systems to match InitializeSystemAssets
             m_rhiSystem.Init();
-            m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
+            m_imageSystem.Init(RHI::MultiDevice::AllDevices, m_descriptor.m_imageSystemDescriptor);
             m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
 
             // Assets aren't actually available or needed for tests, but the m_systemAssetsInitialized flag still needs to be flipped.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -213,7 +213,7 @@ namespace AZ
 
         bool ShaderResourceGroup::SetImage(RHI::ShaderInputImageIndex inputIndex, const Data::Instance<Image>& image, uint32_t arrayIndex)
         {
-            const RHI::SingleDeviceImageView* imageView = image ? image->GetImageView() : nullptr;
+            const auto imageView = image ? image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
 
             if (m_data.SetImageView(inputIndex, imageView, arrayIndex))
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/Image.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/Image.cpp
@@ -10,8 +10,6 @@
 
 #include <Atom/RPI.Reflect/Image/ImageAsset.h>
 
-#include <Atom/RHI/Factory.h>
-
 namespace AZ
 {
     namespace RPI
@@ -29,8 +27,7 @@ namespace AZ
              * pointer around at all times, and then only initialize the image view once.
              */
 
-            auto& factory = RHI::Factory::Get();
-            m_image = factory.CreateImage();
+            m_image = aznew RHI::MultiDeviceImage;
             AZ_Assert(m_image, "Failed to acquire an image instance from the RHI. Is the RHI initialized?");
         }
 
@@ -39,17 +36,17 @@ namespace AZ
             return m_image->IsInitialized();
         }
 
-        RHI::SingleDeviceImage* Image::GetRHIImage()
+        RHI::MultiDeviceImage* Image::GetRHIImage()
         {
             return m_image.get();
         }
 
-        const RHI::SingleDeviceImage* Image::GetRHIImage() const
+        const RHI::MultiDeviceImage* Image::GetRHIImage() const
         {
             return m_image.get();
         }
 
-        const RHI::SingleDeviceImageView* Image::GetImageView() const
+        const RHI::MultiDeviceImageView* Image::GetImageView() const
         {
             return m_imageView.get();
         }
@@ -64,9 +61,9 @@ namespace AZ
             return m_image->GetDescriptor().m_mipLevels;
         }
 
-        RHI::ResultCode Image::UpdateImageContents(const RHI::SingleDeviceImageUpdateRequest& request)
+        RHI::ResultCode Image::UpdateImageContents(const RHI::MultiDeviceImageUpdateRequest& request)
         {
-            RHI::SingleDeviceImagePool* imagePool = azrtti_cast<RHI::SingleDeviceImagePool*> (m_image->GetPool());
+            RHI::MultiDeviceImagePool* imagePool = azrtti_cast<RHI::MultiDeviceImagePool*>(m_image->GetPool());
             return imagePool->UpdateImageContents(request);
         }     
     }

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
@@ -7,30 +7,29 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/ShaderStageFunction.h>
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/FrameGraphCompiler.h>
+#include <Atom/RHI/FrameGraphExecuter.h>
+#include <Atom/RHI/FrameGraphInterface.h>
+#include <Atom/RHI/Scope.h>
 #include <Atom/RHI/SingleDeviceBufferView.h>
 #include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceImageView.h>
+#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/SingleDeviceFence.h>
 #include <Atom/RHI/SingleDeviceImage.h>
 #include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/SingleDeviceIndirectBufferSignature.h>
 #include <Atom/RHI/SingleDeviceIndirectBufferWriter.h>
-#include <Atom/RHI/SingleDeviceStreamingImagePool.h>
-#include <Atom/RHI/SingleDeviceSwapChain.h>
-#include <Atom/RHI/SingleDeviceFence.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroupPool.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RHI/SingleDevicePipelineLibrary.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI/SingleDeviceQuery.h>
 #include <Atom/RHI/SingleDeviceQueryPool.h>
-#include <Atom/RHI/Scope.h>
-#include <Atom/RHI/FrameGraphCompiler.h>
-#include <Atom/RHI/FrameGraphExecuter.h>
+#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
+#include <Atom/RHI/SingleDeviceShaderResourceGroupPool.h>
+#include <Atom/RHI/SingleDeviceStreamingImagePool.h>
+#include <Atom/RHI/SingleDeviceSwapChain.h>
 #include <Atom/RHI/SingleDeviceTransientAttachmentPool.h>
-#include <Atom/RHI/FrameGraphInterface.h>
-#include <Atom/RHI.Reflect/ShaderStageFunction.h>
 
 namespace UnitTest
 {
@@ -98,7 +97,10 @@ namespace UnitTest
             AZ_CLASS_ALLOCATOR(Image, AZ::SystemAllocator);
 
         private:
-            void GetSubresourceLayoutsInternal(const AZ::RHI::ImageSubresourceRange&, AZ::RHI::SingleDeviceImageSubresourceLayout*, size_t*) const override {}
+            void GetSubresourceLayoutsInternal(
+                const AZ::RHI::ImageSubresourceRange&, AZ::RHI::SingleDeviceImageSubresourceLayout*, size_t*) const override
+            {
+            }
             bool IsStreamableInternal() const override {return true;};
         };
 
@@ -197,7 +199,10 @@ namespace UnitTest
             AZ::RHI::ResultCode InitInternal(AZ::RHI::Device&, const AZ::RHI::ImagePoolDescriptor&) override { return AZ::RHI::ResultCode::Success; }
             void ShutdownInternal() override {}
             AZ::RHI::ResultCode UpdateImageContentsInternal(const AZ::RHI::SingleDeviceImageUpdateRequest&) override { return AZ::RHI::ResultCode::Success; }
-            AZ::RHI::ResultCode InitImageInternal(const AZ::RHI::SingleDeviceImageInitRequest&) override { return AZ::RHI::ResultCode::Success; }
+            AZ::RHI::ResultCode InitImageInternal(const AZ::RHI::SingleDeviceImageInitRequest&) override
+            {
+                return AZ::RHI::ResultCode::Success;
+            }
             void ShutdownResourceInternal(AZ::RHI::SingleDeviceResource&) override {}
         };
 

--- a/Gems/Atom/RPI/Code/Tests/Image/StreamingImageTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Image/StreamingImageTests.cpp
@@ -278,7 +278,7 @@ namespace UnitTest
 
             const size_t mipChainTailIndex = imageAsset->GetMipChainCount() - 1;
 
-            RHI::Ptr<RHI::SingleDeviceImage> rhiImage = imageInstance->GetRHIImage();
+            RHI::Ptr<RHI::MultiDeviceImage> rhiImage = imageInstance->GetRHIImage();
 
             // This should no-op.
             imageInstance->TrimToMipChainLevel(mipChainTailIndex);

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
@@ -204,9 +204,9 @@ namespace UnitTest
             EXPECT_EQ(srgData.GetConstant<Vector4>(srgData.FindShaderInputConstantIndex(Name{ "m_float4" })), Vector4(2.1f, 2.2f, 2.3f, 2.4f));
             EXPECT_EQ(srgData.GetConstant<Color>(srgData.FindShaderInputConstantIndex(Name{ "m_color" })), TransformColor(Color(1.0f, 1.0f, 1.0f, 1.0f), ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg));
 
-            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), m_testImage->GetImageView());
+            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), m_testImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
             EXPECT_EQ(srgData.GetConstant<uint32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_enum" })), 2u);
-            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_attachmentImage" }), 0), m_testAttachmentImage->GetImageView());
+            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_attachmentImage" }), 0), m_testAttachmentImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
         }
 
         //! Provides write access to private material asset property values, primarily for simulating
@@ -376,7 +376,7 @@ namespace UnitTest
         EXPECT_EQ(srgData.GetConstant<Vector4>(srgData.FindShaderInputConstantIndex(Name{ "m_float4" })), Vector4(12.1f, 12.2f, 12.3f, 12.4f));
         EXPECT_EQ(srgData.GetConstant<Color>(srgData.FindShaderInputConstantIndex(Name{ "m_color" })), TransformColor(Color(0.1f, 0.2f, 0.3f, 0.4f), ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg));
 
-        EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), otherTestImage->GetImageView());
+        EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), otherTestImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
         EXPECT_EQ(srgData.GetConstant<uint32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_enum" })), 3u);
     }
 

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupImageTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupImageTests.cpp
@@ -66,13 +66,13 @@ namespace UnitTest
             m_threeImages = { m_whiteImage, m_blackImage, m_greyImage };
 
             RHI::ImageViewDescriptor imageViewDescA = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 1, 1);
-            m_imageViewA = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescA);
+            m_imageViewA = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescA)->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
 
             RHI::ImageViewDescriptor imageViewDescB = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 2, 2);
-            m_imageViewB = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescB);
+            m_imageViewB = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescB)->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
 
             RHI::ImageViewDescriptor imageViewDescC = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 3, 3);
-            m_imageViewC = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescC);
+            m_imageViewC = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescC)->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
             
             m_threeImageViews = { m_imageViewA.get(), m_imageViewB.get(), m_imageViewC.get() };
         }
@@ -146,8 +146,8 @@ namespace UnitTest
         EXPECT_EQ(m_blackImage, m_testSrg->GetImage(m_indexImageB));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_whiteImage->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageA, 0));
-        EXPECT_EQ(m_blackImage->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageB, 0));
+        EXPECT_EQ(m_whiteImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageA, 0));
+        EXPECT_EQ(m_blackImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageB, 0));
 
         // Test changing back to null...
 
@@ -171,9 +171,9 @@ namespace UnitTest
         EXPECT_EQ(m_greyImage, m_testSrg->GetImage(m_indexImageArray, 2));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_whiteImage->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 0));
-        EXPECT_EQ(m_blackImage->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
-        EXPECT_EQ(m_greyImage->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
+        EXPECT_EQ(m_whiteImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 0));
+        EXPECT_EQ(m_blackImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
+        EXPECT_EQ(m_greyImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
 
         // Test changing back to null...
 
@@ -199,9 +199,9 @@ namespace UnitTest
         EXPECT_EQ(m_threeImages[0], m_testSrg->GetImage(m_indexImageArray, 0));
         EXPECT_EQ(m_threeImages[1], m_testSrg->GetImage(m_indexImageArray, 1));
         EXPECT_EQ(m_threeImages[2], m_testSrg->GetImage(m_indexImageArray, 2));
-        EXPECT_EQ(m_threeImages[0]->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 0));
-        EXPECT_EQ(m_threeImages[1]->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
-        EXPECT_EQ(m_threeImages[2]->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
+        EXPECT_EQ(m_threeImages[0]->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 0));
+        EXPECT_EQ(m_threeImages[1]->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
+        EXPECT_EQ(m_threeImages[2]->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
 
         // Test replacing just two images including changing one image back to null...
 
@@ -254,8 +254,8 @@ namespace UnitTest
         EXPECT_EQ(twoImages[0], m_testSrg->GetImage(m_indexImageArray, 1));
         EXPECT_EQ(twoImages[1], m_testSrg->GetImage(m_indexImageArray, 2));
         EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 0));
-        EXPECT_EQ(twoImages[0]->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
-        EXPECT_EQ(twoImages[1]->GetImageView(), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
+        EXPECT_EQ(twoImages[0]->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 1));
+        EXPECT_EQ(twoImages[1]->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetImageView(m_indexImageArray, 2));
     }
 
     TEST_F(ShaderResourceGroupImageTests, TestSetImageArrayAtOffset_ValidationFailure)

--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
@@ -25,19 +25,19 @@
 #include <AzFramework/Font/FontInterface.h>
 
 #include <Atom/RHI.Reflect/Base.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/DrawList.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/SingleDeviceIndexBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/DrawList.h>
-#include <Atom/RHI/SingleDeviceImage.h>
+#include <Atom/RHI/SingleDeviceStreamBufferView.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RPI.Public/Shader/Shader.h>
-#include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
+#include <Atom/RPI.Public/Image/StreamingImage.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/WindowContext.h>
-#include <Atom/RPI.Public/Image/StreamingImage.h>
 
 struct ISystem;
 
@@ -274,7 +274,7 @@ namespace AZ
         AZStd::unique_ptr<uint8_t[]> m_fontBuffer;
 
         AZ::Data::Instance<AZ::RPI::StreamingImage> m_fontStreamingImage;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImage>     m_fontImage;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_fontImage;
         uint32_t m_fontImageVersion = 0;
 
         AtomFont* m_atomFont = nullptr;

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1477,7 +1477,7 @@ bool AZ::FFont::UpdateTexture()
 
     RHI::MultiDeviceImageUpdateRequest imageUpdateReq;
     imageUpdateReq.m_image = m_fontImage.get();
-    imageUpdateReq.m_imageSubresource = RHI::ImageSubresource{ 0, 0 };  
+    imageUpdateReq.m_imageSubresource = RHI::ImageSubresource{ 0, 0 };
     imageUpdateReq.m_sourceData = m_fontTexture->GetBuffer();
     imageUpdateReq.m_sourceSubresourceLayout = layout;
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -151,7 +151,7 @@ namespace AZ::Render
         // Initialize our shader
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
         drawSrg->SetConstant(m_viewportSizeIndex, AzFramework::Vector2FromScreenSize(viewportSize));
-        drawSrg->SetImageView(m_textureParameterIndex, image->GetImageView());
+        drawSrg->SetImageView(m_textureParameterIndex, image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
         drawSrg->Compile();
 
         // Scale icons by screen DPI

--- a/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
@@ -129,11 +129,10 @@ namespace AZ
                 return buffer;
             }
 
-            Data::Instance<RHI::SingleDeviceImagePool> UtilityClass::CreateImagePool(RHI::ImagePoolDescriptor& imagePoolDesc)
+            Data::Instance<RHI::MultiDeviceImagePool> UtilityClass::CreateImagePool(RHI::ImagePoolDescriptor& imagePoolDesc)
             {
-                RHI::Ptr<RHI::Device> device = RHI::GetRHIDevice();
-                Data::Instance<RHI::SingleDeviceImagePool> imagePool = RHI::Factory::Get().CreateImagePool();
-                RHI::ResultCode result = imagePool->Init(*device, imagePoolDesc);
+                Data::Instance<RHI::MultiDeviceImagePool> imagePool = aznew RHI::MultiDeviceImagePool;
+                RHI::ResultCode result = imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
                 if (result != RHI::ResultCode::Success)
                 {
                     AZ_Error("CreateImagePool", false, "Failed to create or initialize image pool");
@@ -142,10 +141,11 @@ namespace AZ
                 return imagePool;
             }
 
-            Data::Instance<RHI::SingleDeviceImage> UtilityClass::CreateImage2D(RHI::SingleDeviceImagePool* imagePool, RHI::ImageDescriptor& imageDesc)
+            Data::Instance<RHI::MultiDeviceImage> UtilityClass::CreateImage2D(
+                RHI::MultiDeviceImagePool* imagePool, RHI::ImageDescriptor& imageDesc)
             {
-                Data::Instance<RHI::SingleDeviceImage> rhiImage = RHI::Factory::Get().CreateImage();
-                RHI::SingleDeviceImageInitRequest request;
+                Data::Instance<RHI::MultiDeviceImage> rhiImage = aznew RHI::MultiDeviceImage;
+                RHI::MultiDeviceImageInitRequest request;
                 request.m_image = rhiImage.get();
                 request.m_descriptor = imageDesc;
                 RHI::ResultCode result = imagePool->InitImage(request);

--- a/Gems/AtomTressFX/Code/Rendering/HairCommon.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairCommon.h
@@ -10,7 +10,7 @@
 
 #include <AtomCore/Instance/InstanceData.h>
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
@@ -77,11 +77,10 @@ namespace AZ
                     Data::Instance<RPI::ShaderResourceGroup> srg=nullptr
                 );
 
-                static Data::Instance<RHI::SingleDeviceImagePool> CreateImagePool(
-                    RHI::ImagePoolDescriptor& imagePoolDesc);
+                static Data::Instance<RHI::MultiDeviceImagePool> CreateImagePool(RHI::ImagePoolDescriptor& imagePoolDesc);
 
-                static Data::Instance<RHI::SingleDeviceImage> CreateImage2D(
-                    RHI::SingleDeviceImagePool* imagePool, RHI::ImageDescriptor& imageDesc);
+                static Data::Instance<RHI::MultiDeviceImage> CreateImage2D(
+                    RHI::MultiDeviceImagePool* imagePool, RHI::ImageDescriptor& imageDesc);
             };
 
             //! The following class matches between a constant buffer structure in CPU and its counter

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -5,14 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <AzCore/Jobs/JobCompletion.h>
 #include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <Atom/RHI/Factory.h>
-#include <Atom/RHI/RHIUtils.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
-#include <Atom/RHI/RHISystemInterface.h>
 
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/Scene.h>

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -348,9 +348,9 @@ namespace AZ
                     uint32_t width = GetNumRaysPerProbe().m_rayCount;
                     uint32_t height = GetTotalProbeCount();
 
-                    m_rayTraceImage[m_currentImageIndex] = RHI::Factory::Get().CreateImage();
+                    m_rayTraceImage[m_currentImageIndex] = aznew RHI::MultiDeviceImage;
 
-                    RHI::SingleDeviceImageInitRequest request;
+                    RHI::MultiDeviceImageInitRequest request;
                     request.m_image = m_rayTraceImage[m_currentImageIndex].get();
                     request.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead, width, height, DiffuseProbeGridRenderData::RayTraceImageFormat);
                     [[maybe_unused]] RHI::ResultCode result = m_renderData->m_imagePool->InitImage(request);
@@ -362,9 +362,9 @@ namespace AZ
                     uint32_t width = probeCountX * (DefaultNumIrradianceTexels + 2);
                     uint32_t height = probeCountY * (DefaultNumIrradianceTexels + 2);
 
-                    m_irradianceImage[m_currentImageIndex] = RHI::Factory::Get().CreateImage();
+                    m_irradianceImage[m_currentImageIndex] = aznew RHI::MultiDeviceImage;
 
-                    RHI::SingleDeviceImageInitRequest request;
+                    RHI::MultiDeviceImageInitRequest request;
                     request.m_image = m_irradianceImage[m_currentImageIndex].get();
                     request.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead, width, height, DiffuseProbeGridRenderData::IrradianceImageFormat);
                     RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0.0f, 0.0f, 0.0f, 0.0f);
@@ -378,9 +378,9 @@ namespace AZ
                     uint32_t width = probeCountX * (DefaultNumDistanceTexels + 2);
                     uint32_t height = probeCountY * (DefaultNumDistanceTexels + 2);
 
-                    m_distanceImage[m_currentImageIndex] = RHI::Factory::Get().CreateImage();
+                    m_distanceImage[m_currentImageIndex] = aznew RHI::MultiDeviceImage;
 
-                    RHI::SingleDeviceImageInitRequest request;
+                    RHI::MultiDeviceImageInitRequest request;
                     request.m_image = m_distanceImage[m_currentImageIndex].get();
                     request.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead, width, height, DiffuseProbeGridRenderData::DistanceImageFormat);
                     [[maybe_unused]] RHI::ResultCode result = m_renderData->m_imagePool->InitImage(request);
@@ -392,9 +392,9 @@ namespace AZ
                     uint32_t width = probeCountX;
                     uint32_t height = probeCountY;
 
-                    m_probeDataImage[m_currentImageIndex] = RHI::Factory::Get().CreateImage();
+                    m_probeDataImage[m_currentImageIndex] = aznew RHI::MultiDeviceImage;
 
-                    RHI::SingleDeviceImageInitRequest request;
+                    RHI::MultiDeviceImageInitRequest request;
                     request.m_image = m_probeDataImage[m_currentImageIndex].get();
                     request.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead, width, height, DiffuseProbeGridRenderData::ProbeDataImageFormat);
                     [[maybe_unused]] RHI::ResultCode result = m_renderData->m_imagePool->InitImage(request);
@@ -517,10 +517,10 @@ namespace AZ
             }
 
             m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgGiShadowsNameIndex, m_giShadows);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgUseDiffuseIblNameIndex, m_useDiffuseIbl);
@@ -539,9 +539,9 @@ namespace AZ
             }
 
             m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -555,9 +555,9 @@ namespace AZ
             }
 
             m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -574,7 +574,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowIrradianceSrg.get(), "Failed to create BorderUpdateRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateRowIrradianceSrg->SetImageView(m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateRowIrradianceSrg->SetImageView(m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateRowIrradianceSrg->SetConstant(m_renderData->m_borderUpdateRowIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -586,7 +586,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnIrradianceSrg.get(), "Failed to create BorderUpdateColumnRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateColumnIrradianceSrg->SetImageView(m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateColumnIrradianceSrg->SetImageView(m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateColumnIrradianceSrg->SetConstant(m_renderData->m_borderUpdateColumnIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -598,7 +598,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowDistanceSrg.get(), "Failed to create BorderUpdateRowDistance shader resource group");
                 }
 
-                m_borderUpdateRowDistanceSrg->SetImageView(m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateRowDistanceSrg->SetImageView(m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateRowDistanceSrg->SetConstant(m_renderData->m_borderUpdateRowDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
 
@@ -610,7 +610,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnDistanceSrg.get(), "Failed to create BorderUpdateColumnRowDistance shader resource group");
                 }
 
-                m_borderUpdateColumnDistanceSrg->SetImageView(m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateColumnDistanceSrg->SetImageView(m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateColumnDistanceSrg->SetConstant(m_renderData->m_borderUpdateColumnDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
         }
@@ -624,8 +624,8 @@ namespace AZ
             }
 
             m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -639,8 +639,8 @@ namespace AZ
             }
 
             m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -670,9 +670,9 @@ namespace AZ
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEnableDiffuseGiNameIndex, m_enabled);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEdgeBlendIblNameIndex, m_edgeBlendIbl);
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDistanceNameIndex, GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
 
             m_updateRenderObjectSrg = false;
 
@@ -693,7 +693,7 @@ namespace AZ
             m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->GetBufferView(bufferViewDescriptor).get());
 
             m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationPrepareSrg->SetConstant(m_renderData->m_visualizationPrepareSrgProbeSphereRadiusNameIndex, m_visualizationSphereRadius);
         }
 
@@ -710,9 +710,9 @@ namespace AZ
             m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
 
             m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationRayTraceSrg->SetConstant(m_renderData->m_visualizationRayTraceSrgShowInactiveProbesNameIndex, m_visualizationShowInactiveProbes);
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgOutputNameIndex, outputImageView);
         }
@@ -726,9 +726,9 @@ namespace AZ
             }
 
             m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_querySrg->SetConstant(m_renderData->m_querySrgAmbientMultiplierNameIndex, m_ambientMultiplier);
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
@@ -30,7 +30,7 @@ namespace AZ
             static const RHI::Format ProbeDataImageFormat = RHI::Format::R16G16B16A16_FLOAT;
             static const uint32_t GridDataBufferSize = 112;
 
-            RHI::Ptr<RHI::SingleDeviceImagePool> m_imagePool;          
+            RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
             RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
 
             AZStd::array<RHI::SingleDeviceStreamBufferView, 1> m_boxPositionBufferView;
@@ -273,10 +273,10 @@ namespace AZ
             void UpdateQuerySrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout);
 
             // textures
-            const RHI::Ptr<RHI::SingleDeviceImage> GetRayTraceImage() { return m_rayTraceImage[m_currentImageIndex]; }
-            const RHI::Ptr<RHI::SingleDeviceImage> GetIrradianceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_irradianceImage[m_currentImageIndex] : m_bakedIrradianceImage->GetRHIImage(); }
-            const RHI::Ptr<RHI::SingleDeviceImage> GetDistanceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_distanceImage[m_currentImageIndex] : m_bakedDistanceImage->GetRHIImage(); }
-            const RHI::Ptr<RHI::SingleDeviceImage> GetProbeDataImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_probeDataImage[m_currentImageIndex] : m_bakedProbeDataImage->GetRHIImage(); }
+            const RHI::Ptr<RHI::MultiDeviceImage> GetRayTraceImage() { return m_rayTraceImage[m_currentImageIndex]; }
+            const RHI::Ptr<RHI::MultiDeviceImage> GetIrradianceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_irradianceImage[m_currentImageIndex] : m_bakedIrradianceImage->GetRHIImage(); }
+            const RHI::Ptr<RHI::MultiDeviceImage> GetDistanceImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_distanceImage[m_currentImageIndex] : m_bakedDistanceImage->GetRHIImage(); }
+            const RHI::Ptr<RHI::MultiDeviceImage> GetProbeDataImage() { return m_mode == DiffuseProbeGridMode::RealTime ? m_probeDataImage[m_currentImageIndex] : m_bakedProbeDataImage->GetRHIImage(); }
             const RHI::Ptr<RHI::MultiDeviceBuffer> GetGridDataBuffer() { return m_gridDataBuffer; }
 
             const AZStd::string& GetBakedIrradianceRelativePath() const { return m_bakedIrradianceRelativePath; }
@@ -407,10 +407,10 @@ namespace AZ
             // real-time textures
             static const uint32_t MaxTextureDimension = 8192;
             static const uint32_t ImageFrameCount = 3;
-            RHI::Ptr<RHI::SingleDeviceImage> m_rayTraceImage[ImageFrameCount];
-            RHI::Ptr<RHI::SingleDeviceImage> m_irradianceImage[ImageFrameCount];
-            RHI::Ptr<RHI::SingleDeviceImage> m_distanceImage[ImageFrameCount];
-            RHI::Ptr<RHI::SingleDeviceImage> m_probeDataImage[ImageFrameCount];
+            RHI::Ptr<RHI::MultiDeviceImage> m_rayTraceImage[ImageFrameCount];
+            RHI::Ptr<RHI::MultiDeviceImage> m_irradianceImage[ImageFrameCount];
+            RHI::Ptr<RHI::MultiDeviceImage> m_distanceImage[ImageFrameCount];
+            RHI::Ptr<RHI::MultiDeviceImage> m_probeDataImage[ImageFrameCount];
             uint32_t m_currentImageIndex = 0;
             bool m_updateTextures = false;
             bool m_textureClearRequired = true;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -71,9 +71,9 @@ namespace AZ
                 RHI::ImagePoolDescriptor imagePoolDesc;
                 imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead;
 
-                m_probeGridRenderData.m_imagePool = RHI::Factory::Get().CreateImagePool();
+                m_probeGridRenderData.m_imagePool = aznew RHI::MultiDeviceImagePool;
                 m_probeGridRenderData.m_imagePool->SetName(Name("DiffuseProbeGridRenderImageData"));
-                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(*device, imagePoolDesc);
+                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
             }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -211,7 +211,7 @@ namespace AZ
 
                 // probe raytrace
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetRayTraceImageAttachmentId(), diffuseProbeGrid->GetRayTraceImage());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetRayTraceImageAttachmentId(), diffuseProbeGrid->GetRayTraceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeRayTraceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -231,7 +231,7 @@ namespace AZ
 
                 // probe irradiance
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetIrradianceImageAttachmentId(), diffuseProbeGrid->GetIrradianceImage());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetIrradianceImageAttachmentId(), diffuseProbeGrid->GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeIrradianceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -252,7 +252,7 @@ namespace AZ
 
                 // probe distance
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetDistanceImageAttachmentId(), diffuseProbeGrid->GetDistanceImage());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetDistanceImageAttachmentId(), diffuseProbeGrid->GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeDistanceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -273,7 +273,7 @@ namespace AZ
 
                 // probe data
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetProbeDataImageAttachmentId(), diffuseProbeGrid->GetProbeDataImage());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetProbeDataImageAttachmentId(), diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ProbeDataImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
@@ -131,7 +131,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the irradiance image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetIrradianceImage());
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeIrradianceImage");
                     }
 
@@ -149,7 +149,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the distance image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetDistanceImage());
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeDistanceImage");
                     }
 
@@ -167,7 +167,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the probe data image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage());
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ProbeDataImage");
                     }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -218,7 +218,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeDataImageAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage());
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid probe data buffer with error %d", result);
                         }
 

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
@@ -122,7 +122,7 @@ namespace UnitTest
 
         AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
         m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(imageSystemDescriptor);
+        m_imageSystem->Init(AZ::RHI::MultiDevice::AllDevices, imageSystemDescriptor);
     }
 
     void GradientSignalBaseFixture::TearDownCoreSystems()

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestHelpers.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestHelpers.h
@@ -19,11 +19,11 @@
 
 namespace UnitTest
 {
-    //! Helper method to build a AZ::RHI::SingleDeviceImageSubresourceLayout
+    //! Helper method to build a AZ::RHI::MultiDeviceImageSubresourceLayout
     //! @param width The width of the image
     //! @param height The height of the image
     //! @param pixelSize Number of bytes per pixel
-    //! @return The AZ::RHI::SingleDeviceImageSubresourceLayout that has been filled out appropriately
+    //! @return The AZ::RHI::MultiDeviceImageSubresourceLayout that has been filled out appropriately
     AZ::RHI::SingleDeviceImageSubresourceLayout BuildSubImageLayout(AZ::u32 width, AZ::u32 height, AZ::u32 pixelSize);
 
     //! Build a deterministic random set of image pixel data

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -756,12 +756,12 @@ void CDraw2d::DeferredQuad::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const AZ::RHI::SingleDeviceImageView* imageView = m_image ? m_image->GetImageView() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView();
+        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
     }
 
     if (imageView)
@@ -817,12 +817,12 @@ void CDraw2d::DeferredLine::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const AZ::RHI::SingleDeviceImageView* imageView = m_image ? m_image->GetImageView() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView();
+        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
     }
 
     if (imageView)
@@ -893,12 +893,12 @@ void CDraw2d::DeferredRectOutline::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const AZ::RHI::SingleDeviceImageView* imageView = m_image ? m_image->GetImageView() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView();
+        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
     }
 
     if (imageView)

--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -173,7 +173,7 @@ namespace LyShine
             auto attachmentImageId = attachmentImage->GetAttachmentId();
             if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentImageId))
             {
-                frameGraph.GetAttachmentDatabase().ImportImage(attachmentImageId, attachmentImage->GetRHIImage());
+                frameGraph.GetAttachmentDatabase().ImportImage(attachmentImageId, attachmentImage->GetRHIImage()->GetDeviceImage(AZ::RHI::MultiDevice::DefaultDeviceIndex));
             }
 
             AZ::RHI::ImageScopeAttachmentDescriptor desc;

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -126,7 +126,7 @@ namespace LyShine
             // Default to white texture
             const AZ::Data::Instance<AZ::RPI::Image>& image = m_textures[i].m_texture ? m_textures[i].m_texture
                 : AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-            const AZ::RHI::SingleDeviceImageView* imageView = image->GetImageView();
+            const auto imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
 
             if (imageView)
             {

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsAssets.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsAssets.h
@@ -17,7 +17,7 @@
 #include <AtomCore/Instance/Instance.h>
 #include <AtomCore/Instance/InstanceData.h>
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Material/Material.h>

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.h
@@ -11,7 +11,7 @@
 #include <AtomCore/Instance/InstanceData.h>
 #include <AtomCore/Instance/Instance.h>
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainMacroMaterialComponent.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainMacroMaterialComponent.cpp
@@ -639,15 +639,11 @@ namespace Terrain
 
         // Upload the image changes to the GPU.
         const uint32_t BytesPerPixel = 4;
-        AZ::RHI::SingleDeviceImageUpdateRequest imageUpdateRequest;
+        AZ::RHI::MultiDeviceImageUpdateRequest imageUpdateRequest;
         imageUpdateRequest.m_imageSubresourcePixelOffset.m_left = updateLeftPixel;
         imageUpdateRequest.m_imageSubresourcePixelOffset.m_top = updateTopPixel;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_bytesPerRow = updateWidth * BytesPerPixel;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_bytesPerImage = updateWidth * updateHeight * BytesPerPixel;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_rowCount = updateHeight;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_width = updateWidth;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_height = updateHeight;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_depth = 1;
+        AZ::RHI::SingleDeviceImageSubresourceLayout layout{{updateWidth, updateHeight, 1}, updateHeight, updateWidth * BytesPerPixel, updateWidth * updateHeight * BytesPerPixel, 1, 1};
+        imageUpdateRequest.m_sourceSubresourceLayout.Init(m_colorImage->GetRHIImage()->GetDeviceMask(), layout);
         imageUpdateRequest.m_sourceData = sourceData;
         imageUpdateRequest.m_image = m_colorImage->GetRHIImage();
         m_colorImage->UpdateImageContents(imageUpdateRequest);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -316,7 +316,7 @@ namespace Terrain
     void TerrainClipmapManager::ImportClipmap(ClipmapName clipmapName, AZ::RHI::FrameGraphAttachmentInterface attachmentDatabase) const
     {
         auto clipmap = m_clipmaps[clipmapName];
-        attachmentDatabase.ImportImage(clipmap->GetAttachmentId(), clipmap->GetRHIImage());
+        attachmentDatabase.ImportImage(clipmap->GetAttachmentId(), clipmap->GetRHIImage()->GetDeviceImage(AZ::RHI::MultiDevice::DefaultDeviceIndex));
     }
 
     void TerrainClipmapManager::UseClipmap(ClipmapName clipmapName, AZ::RHI::ScopeAttachmentAccess access, AZ::RHI::FrameGraphInterface frameGraph) const

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -598,7 +598,7 @@ namespace Terrain
 
             if (ref)
             {
-                imageIndex = ref->GetImageView()->GetBindlessReadIndex();
+                imageIndex = ref->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex();
             }
             else if (imageIndex != InvalidImageIndex)
             {
@@ -916,15 +916,11 @@ namespace Terrain
         const int32_t left = textureUpdateAabb.m_min.m_x;
         const int32_t top = textureUpdateAabb.m_min.m_y;
 
-        AZ::RHI::SingleDeviceImageUpdateRequest imageUpdateRequest;
+        AZ::RHI::MultiDeviceImageUpdateRequest imageUpdateRequest;
         imageUpdateRequest.m_imageSubresourcePixelOffset.m_left = aznumeric_cast<uint32_t>(left);
         imageUpdateRequest.m_imageSubresourcePixelOffset.m_top = aznumeric_cast<uint32_t>(top);
-        imageUpdateRequest.m_sourceSubresourceLayout.m_bytesPerRow = width * sizeof(DetailMaterialPixel);
-        imageUpdateRequest.m_sourceSubresourceLayout.m_bytesPerImage = width * height * sizeof(DetailMaterialPixel);
-        imageUpdateRequest.m_sourceSubresourceLayout.m_rowCount = height;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_width = width;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_height = height;
-        imageUpdateRequest.m_sourceSubresourceLayout.m_size.m_depth = 1;
+        AZ::RHI::SingleDeviceImageSubresourceLayout layout{{static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1}, static_cast<uint32_t>(height), static_cast<uint32_t>(width * sizeof(DetailMaterialPixel)), static_cast<uint32_t>(width * height * sizeof(DetailMaterialPixel)), 1, 1};
+        imageUpdateRequest.m_sourceSubresourceLayout.Init(m_detailTextureImage->GetRHIImage()->GetDeviceMask(), layout);
         imageUpdateRequest.m_sourceData = pixels.data();
         imageUpdateRequest.m_image = m_detailTextureImage->GetRHIImage();
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.cpp
@@ -226,7 +226,7 @@ namespace Terrain
 
         auto UpdateImageIndex = [&](uint32_t& indexRef, const AZ::Data::Instance<AZ::RPI::Image>& imageView)
         {
-            indexRef = imageView ? imageView->GetImageView()->GetBindlessReadIndex() : InvalidImageIndex;
+            indexRef = imageView ? imageView->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidImageIndex;
         };
 
         UpdateImageIndex(shaderData.m_colorMapId, macroMaterialData.m_colorImage);

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
@@ -421,7 +421,7 @@ namespace UnitTest
 
         AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
         m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(imageSystemDescriptor);
+        m_imageSystem->Init(AZ::RHI::MultiDevice::AllDevices, imageSystemDescriptor);
 
         // Now that the RPISystem is activated, activate the system entity.
         m_systemEntity->Init();


### PR DESCRIPTION
## What does this PR do?
This specific PR transitions `RPI::Image` to use `MultiDeviceImage`. It is not a small change and thus this is one of the bigger PRs in this set of PRs to come.

### General Idea
This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a https://github.com/o3de/o3de/pull/14079, however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of ->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex) to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using RHI::MultiDevice::DefaultDeviceIndex everywhere because it simplifies the transition.

## How was this PR tested?
- Gem::Atom_RPI.Tests.main

There is still a small issue in the `ShaderResourceGroupImageTests` that needs to be fixed, I will comment here once that is fixed, but the rest of the code can be reviewed.

