### PR TITLE
add function parameter to DOM comparison params to allow rejection of replacement patches on nested rows

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.cpp
@@ -79,7 +79,7 @@ namespace AZ::Dom
             const size_t afterSize = after.ArraySize();
 
             // If more than replaceThreshold values differ, do a replace operation instead
-            if (params.m_replaceThreshold != DeltaPatchGenerationParameters::NoReplace && (params.m_allowRootReplacement || !path.IsEmpty()))
+            if (params.m_replaceThreshold != DeltaPatchGenerationParameters::NoReplace && (!params.m_allowReplacement || params.m_allowReplacement(before, after)))
             {
                 size_t changedValueCount = 0;
                 const size_t entriesToEnumerate = AZStd::min(beforeSize, afterSize);

--- a/Code/Framework/AzCore/AzCore/DOM/DomComparison.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomComparison.h
@@ -26,16 +26,17 @@ namespace AZ::Dom
         static constexpr size_t AlwaysFullReplace = 0;
 
         //! The threshold of changed values in a node or array which, if exceeded, will cause the generation to create an
-        //! entire "replace" oepration instead. If set to NoReplace, no replacement will occur.
+        //! entire "replace" operation instead. If set to NoReplace, no replacement will occur.
         size_t m_replaceThreshold = 3;
         //! If set, the patches generated will avoid using "EndOfPath" entries in favor of explicitly specifying indices.
-        //! This will generate non-conformant JSON patches, but can be useful if there's downstream book-keeping for the patch
+        //! This will generate nonconformant JSON patches, but can be useful if there's downstream book-keeping for the patch
         //! paths themselves. This is used by e.g. DocumentPropertyEditor so that systems can handle patches without introspecting
         //! the previous DOM to generate indices.
         bool m_generateDenormalizedPaths = false;
 
-        //! this specifies whether to allow generation of a delta replacement patch that replaces the entire tree, from the root on down
-        bool m_allowRootReplacement = true;
+        /*! this is an optional function that specifies whether to allow generation of a delta replacement patch that replaces the
+        *   entire \param before value with the \param after value once at least m_replaceThreshold changes have been detected */
+        AZStd::function<bool(const Value& before, const Value& after)> m_allowReplacement;
     };
 
     //! Generates a set of patches such that m_forwardPatches.Apply(beforeState) shall produce a document equivalent to afterState, and


### PR DESCRIPTION
## What does this PR do?
- adds a function parameter to DOM comparison params to allow rejection of replacement patches on nested rows
- fixes #16938 

## How was this PR tested?
locally, in the Editor project
