### PR TITLE
New XRSpaceNotificationBus

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
@@ -88,6 +88,9 @@ namespace AZ::RPI
         //! Return the controller Pose data associated with provided hand Index.
         virtual RHI::ResultCode GetControllerPose(const AZ::u32 handIndex, PoseData& outPoseData) const = 0;
 
+        //! Same as above, but conveniently returns a transform.
+        virtual RHI::ResultCode GetControllerTransform(const AZ::u32 handIndex, AZ::Transform& outTransform) const = 0;
+
         //! Return the Pose data associated with front view.
         virtual RHI::ResultCode GetViewFrontPose(PoseData& outPoseData) const = 0;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRSpaceNotificationBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRSpaceNotificationBus.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Transform.h>
+
+namespace AZ::RPI
+{
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    //! EBus interface used to listen to changes in XR Poses.
+    //! For example, each Joystick is represented by an XR Pose, just as the Head orientation and location
+    //! within the local or stage spaces.
+    //! In particular, OpenXR systems have the concept of predicted display time for the current frame.
+    //! The predicted display time is used to "locate" XR Spaces and calculate their Poses (aka transforms)
+    //! as they are expected to be when the current frame is displayed. This predicted display time is calculated
+    //! by each OpenXRVk::Device each frame, and this is the ideal moment to update Camera and Controller
+    //! pose locations.
+    class XRSpaceNotifications : public AZ::EBusTraits
+    {
+    public:
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! EBus Trait: Notifications are addressed to a single address (aka Broadcasted to whoever cares)
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! EBus Trait: Notifications can be handled by multiple listeners
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+
+        virtual ~XRSpaceNotifications() = default;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Override to be notified each frame of movements on the VR Headset.
+        //! For convenience the function provides Three transforms:
+        //! @param baseSpaceToHeadTm Transform that defines the Orientation and location of the user's head
+        //!                          relative to the base XR Space.
+        //! @param headToLeftEyeTm Transform that defines the Orientation and location of the user's Left Eye
+        //!                        relative @baseSpaceToHeadTm.
+        //! @param headToRightEyeTm Transform that defines the Orientation and location of the user's Right Eye
+        //!                         relative @baseSpaceToHeadTm.
+        //! REMARK: Upon getting this event, the application can query the XRSystem for the Poses for each Joystick.
+        //! Tips: The location of the Left eye relative to the base XR Space would be:
+        //!     baseSpaceToHeadTm *  headToLeftEyeTm.
+        //! Equivalently for the right eye:
+        //!     baseSpaceToHeadTm *  headToRightEyeTm.
+        virtual void OnXRSpaceLocationsChanged(
+            const AZ::Transform& baseSpaceToHeadTm,
+            const AZ::Transform& headToLeftEyeTm,
+            const AZ::Transform& headToRightEyeTm) = 0;
+
+    };
+    using XRSpaceNotificationBus = AZ::EBus<XRSpaceNotifications>;
+
+} // namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -107,6 +107,7 @@ set(FILES
     Include/Atom/RPI.Public/GpuQuery/TimestampQueryPool.h
     Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
     Include/Atom/RPI.Public/XR/XRRenderingInterface.h
+    Include/Atom/RPI.Public/XR/XRSpaceNotificationBus.h
     Source/RPI.Public/Culling.cpp
     Source/RPI.Public/FeatureProcessor.cpp
     Source/RPI.Public/FeatureProcessorFactory.cpp

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -22,6 +22,7 @@
 
 #include <AzFramework/Viewport/ViewportScreen.h>
 
+
 namespace Camera
 {
     void CameraComponentConfig::Reflect(AZ::ReflectContext* context)
@@ -225,6 +226,14 @@ namespace Camera
     {
         m_entityId = entityId;
 
+        // Let's the set the camera default transforms:
+        AZ::TransformBus::EventResult(m_xrCameraToBaseSpaceTm, m_entityId, &AZ::TransformBus::Handler::GetWorldTM);
+        m_xrBaseSpaceToHeadTm = AZ::Transform::CreateIdentity();
+        m_xrHeadToLeftEyeTm = AZ::Transform::CreateIdentity();
+        m_xrHeadToRightEyeTm = AZ::Transform::CreateIdentity();
+
+        AZ::RPI::XRSpaceNotificationBus::Handler::BusConnect();
+
         auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
         
         if (atomViewportRequests)
@@ -232,7 +241,8 @@ namespace Camera
             const AZ::EntityId editorEntityId = m_config.GetEditorEntityId();
 
             // Lazily create our camera as part of Activate
-            // This will be persisted as part of our config so that it may be shared between the Editor & Game components
+            // This will be persisted as part of our config so that it may be shared between the Editor & Game components.
+            // Also, when using the Editor and opening the level for the first time,  GetViewForEntity() will return a null ViewPtr.
             if (GetView() == nullptr && editorEntityId.IsValid())
             {
                 AZ::RPI::ViewPtr atomEditorView = nullptr;
@@ -261,10 +271,6 @@ namespace Camera
             m_atomCameraViewGroup->Activate();
         }
 
-        AZ::Transform local, world;
-        AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::GetLocalAndWorld, local, world);
-        OnTransformChanged(local, world);
-
         CameraRequestBus::Handler::BusConnect(m_entityId);
         AZ::TransformNotificationBus::Handler::BusConnect(m_entityId);
         CameraBus::Handler::BusConnect();
@@ -284,6 +290,8 @@ namespace Camera
 
     void CameraComponentController::Deactivate()
     {
+        AZ::RPI::XRSpaceNotificationBus::Handler::BusDisconnect();
+
         if (m_renderToTexturePipeline)
         {
             auto scene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("Main"));
@@ -541,28 +549,27 @@ namespace Camera
 
         m_updatingTransformFromEntity = true;
 
-        // Update stereoscopic projection matrix if XR system is active
         if (m_xrSystem && m_xrSystem->ShouldRender())
         {
-            AZ::RPI::PoseData frontPoseData;
-            [[maybe_unused]] AZ::RHI::ResultCode resultCode = m_xrSystem->GetViewLocalPose(frontPoseData);
-            // Convert to O3de's coordinate system and update the camera orientation for the correct eye view
-            AZ::Quaternion viewLocalPoseOrientation = frontPoseData.m_orientation;
-            viewLocalPoseOrientation.SetX(-frontPoseData.m_orientation.GetX());
-            viewLocalPoseOrientation.SetY(frontPoseData.m_orientation.GetZ());
-            viewLocalPoseOrientation.SetZ(-frontPoseData.m_orientation.GetY());
-
-            // Apply the stereoscopic view provided by the device
-            AZ::Matrix3x4 worldTransform =
-                AZ::Matrix3x4::CreateFromQuaternionAndTranslation(viewLocalPoseOrientation, world.GetTranslation());
-
-            for (AZ::u32 i = 0; i < m_numSterescopicViews; i++)
-            {
-                AZ::RPI::ViewType viewType = i == 0 ? AZ::RPI::ViewType::XrLeft : AZ::RPI::ViewType::XrRight;
-                m_atomCameraViewGroup->SetCameraTransform(worldTransform, viewType);
-            }
-
-            m_atomCameraViewGroup->SetCameraTransform(worldTransform);
+            // When the XR System is active, The camera world transform will always be:
+            // camWorldTm = m_xrCameraToBaseSpaceTm * m_xrBaseSpaceToHeadTm.
+            // But when OnTransformChanged is called, may be because a Lua Script is changing
+            // the camera location, we need to apply the inverse operation to preserve the value
+            // of m_xrCameraToBaseSpaceTm.
+            // This is the quick math:
+            // m_xrCameraToBaseSpaceTm~ * camWorldTm = m_xrCameraToBaseSpaceTm~ * m_xrCameraToBaseSpaceTm * m_xrBaseSpaceToHeadTm
+            // m_xrCameraToBaseSpaceTm~ * camWorldTm = m_xrBaseSpaceToHeadTm
+            // m_xrCameraToBaseSpaceTm~ * camWorldTm * camWorldTm~ = m_xrBaseSpaceToHeadTm * camWorldTm~
+            // m_xrCameraToBaseSpaceTm~ = m_xrBaseSpaceToHeadTm * camWorldTm~
+            // m_xrCameraToBaseSpaceTm~~ = (m_xrBaseSpaceToHeadTm * camWorldTm~)~
+            // m_xrCameraToBaseSpaceTm = camWorldTm~~ * m_xrBaseSpaceToHeadTm~
+            // m_xrCameraToBaseSpaceTm = camWorldTm * m_xrBaseSpaceToHeadTm~
+            m_xrCameraToBaseSpaceTm = world * m_xrBaseSpaceToHeadTm.GetInverse();
+            m_updatingTransformFromEntity = false;
+            // We are not going to call m_atomCameraViewGroup->SetCameraTransform() yet.
+            // We need to wait for the OnXRSpaceLocationsChanged() notification, which will give us
+            // the XR Headset orientation.
+            return;
         }
         else
         {
@@ -674,4 +681,40 @@ namespace Camera
             }
         }
     }
+
+    ////////////////////////////////////////////////////////////////////
+    // AZ::RPI::XRSpaceNotificationBus::Handler Overrides
+    void CameraComponentController::OnXRSpaceLocationsChanged(
+        const AZ::Transform& baseSpaceToHeadTm,
+        const AZ::Transform& headToleftEyeTm,
+        const AZ::Transform& headToRightEyeTm)
+    {
+        if (!m_xrSystem || !m_xrSystem->ShouldRender())
+        {
+            return;
+        }
+
+        m_updatingTransformFromEntity = true;
+
+        m_xrBaseSpaceToHeadTm = baseSpaceToHeadTm;
+        const auto mainCameraWorldTm = m_xrCameraToBaseSpaceTm * baseSpaceToHeadTm;
+
+        AZ::TransformBus::Event(m_entityId, &AZ::TransformBus::Handler::SetWorldTM, mainCameraWorldTm);
+
+        m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(mainCameraWorldTm));
+
+        m_xrHeadToLeftEyeTm = headToleftEyeTm;
+        const auto leftEyeWorldTm = mainCameraWorldTm * headToleftEyeTm;
+        m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(leftEyeWorldTm), AZ::RPI::ViewType::XrLeft);
+
+        m_xrHeadToRightEyeTm = headToRightEyeTm;
+        const auto rightEyeWorldTm = mainCameraWorldTm * headToRightEyeTm;
+        m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(rightEyeWorldTm), AZ::RPI::ViewType::XrRight);
+
+        UpdateCamera();
+
+        m_updatingTransformFromEntity = false;
+    }
+    ////////////////////////////////////////////////////////////////////
+
 } //namespace Camera

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -226,7 +226,7 @@ namespace Camera
     {
         m_entityId = entityId;
 
-        // Let's the set the camera default transforms:
+        // Let's set the camera default transforms:
         AZ::TransformBus::EventResult(m_xrCameraToBaseSpaceTm, m_entityId, &AZ::TransformBus::Handler::GetWorldTM);
         m_xrBaseSpaceToHeadTm = AZ::Transform::CreateIdentity();
         m_xrHeadToLeftEyeTm = AZ::Transform::CreateIdentity();
@@ -701,12 +701,15 @@ namespace Camera
 
         AZ::TransformBus::Event(m_entityId, &AZ::TransformBus::Handler::SetWorldTM, mainCameraWorldTm);
 
+        // Update camera world matrix for the main pipeline.
         m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(mainCameraWorldTm));
 
+        // Update camera world matrix for the left eye pipeline.
         m_xrHeadToLeftEyeTm = headToleftEyeTm;
         const auto leftEyeWorldTm = mainCameraWorldTm * headToleftEyeTm;
         m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(leftEyeWorldTm), AZ::RPI::ViewType::XrLeft);
 
+        // Update camera world matrix for the right eye pipeline.
         m_xrHeadToRightEyeTm = headToRightEyeTm;
         const auto rightEyeWorldTm = mainCameraWorldTm * headToRightEyeTm;
         m_atomCameraViewGroup->SetCameraTransform(AZ::Matrix3x4::CreateFromTransform(rightEyeWorldTm), AZ::RPI::ViewType::XrRight);


### PR DESCRIPTION
## What does this PR do?

Added AZ::RPI::XRSpaceNotificationBus

This notification EBus provides an event that is dispatched
per frame at the correct time by the XR Gem. This event is called
  OnXRSpaceLocationsChanged(...), which provides the correct
  transform data for the Headset and each Eye for the current
  frame that is in-flight.

This change improves considerably the rendering of the XR Pipeline
for two reasons:
1- The Headset and Eye poses (transforms) are reported at the correct
time for each frame. This improves jitter (by reducing it).
2- Previously both eyes were using the exact same world Transform. Now
each Eye has the correct world Transform. This improves the sense
of depth if the XR scene.

## How was this PR tested?

This PR was tested with the OpenXRTest project from o3de-extras Gems using a Meta Quest Pro device. It was tested with Link Mode and On-device mode (Android APK). The following PR is required too: https://github.com/o3de/o3de-extras/pull/608

