### PR TITLE
Gadams3/fix generate source materials to use original material type source path

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialUtils.h
@@ -91,6 +91,11 @@ namespace AZ
             bool CheckIsValidPropertyName(AZStd::string_view name);
             bool CheckIsValidGroupName(AZStd::string_view name);
 
+            //! Convert an intermediate material type path back to the original source material type path.
+            //! @param materialTypeSourcePath Path to material type source in intermediate asset folder.
+            //! @return Absolute path to original material type or original input path.
+            AZStd::string PredictOriginalMaterialTypeSourcePath(const AZStd::string& materialTypeSourcePath);
+
             //! Returns the file path that would be used for an intermediate .materialtype, if there were one, for the given .materialtype path.
             //! @param originalMaterialTypeSourcePath the path to the .materialtype
             //! @param referencingFilePath The @originalMaterialTypeSourcePath can be relative to this path in addition to the asset root.

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
@@ -24,10 +24,11 @@
 #include <AzCore/Serialization/Json/JsonImporter.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/string/regex.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/IO/LocalFileIO.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
 namespace AZ
@@ -269,6 +270,49 @@ namespace AZ
             bool CheckIsValidGroupName(AZStd::string_view name)
             {
                 return CheckIsValidName(name, "Group name");
+            }
+
+            AZStd::string PredictOriginalMaterialTypeSourcePath(const AZStd::string& materialTypeSourcePath)
+            {
+                // Separate the input material type path into a relative path and root folder. This should work for both intermediate,
+                // generated material types and original material types.
+                bool pathFound = false;
+                AZStd::string relativePath;
+                AZStd::string rootFolder;
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    pathFound,
+                    &AzToolsFramework::AssetSystemRequestBus::Events::GenerateRelativeSourcePath,
+                    materialTypeSourcePath.c_str(),
+                    relativePath,
+                    rootFolder);
+
+                if (pathFound)
+                {
+                    // Replace the generated suffix if present
+                    AZ::StringFunc::Replace(relativePath, "_generated.materialtype", ".materialtype");
+
+                    // Search for the original material type file using the stripped generated material type path.
+                    pathFound = false;
+                    AZ::Data::AssetInfo sourceInfo;
+                    AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                        pathFound,
+                        &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+                        relativePath.c_str(),
+                        sourceInfo,
+                        rootFolder);
+
+                    if (pathFound)
+                    {
+                        AZStd::string fullPath;
+                        if (AZ::StringFunc::Path::ConstructFull(rootFolder.c_str(), sourceInfo.m_relativePath.c_str(), fullPath, true))
+                        {
+                            return fullPath;
+                        }
+                    }
+                }
+
+                // Conversion failed. Return the input path.
+                return materialTypeSourcePath;
             }
 
             AZStd::string PredictIntermediateMaterialTypeSourcePath(const AZStd::string& originalMaterialTypeSourcePath)

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialUtils.cpp
@@ -306,10 +306,10 @@ namespace AZ
 
                         if (pathFound)
                         {
-                            AZStd::string fullPath;
-                            if (AZ::StringFunc::Path::ConstructFull(rootFolder.c_str(), sourceInfo.m_relativePath.c_str(), fullPath, true))
+                            const AZ::IO::Path result = AZ::IO::Path(rootFolder) / sourceInfo.m_relativePath;
+                            if (!result.empty())
                             {
-                                return fullPath;
+                                return result.LexicallyNormal().String();
                             }
                         }
                     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -291,14 +291,14 @@ namespace AtomToolsFramework
     //! @return Container of absolute paths to dependency source files
     AZStd::vector<AZStd::string> GetPathsForAssetSourceDependencies(const AZ::Data::AssetInfo& sourceInfo);
     AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesById(const AZ::Data::AssetId& assetId);
-    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcPath);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcePath);
 
     //! @brief Create a list of all asset source files that depend on the input asset
     //! @param assetId ID of the asset for which dependence will be collected
     //! @return Container of absolute paths to dependent source files
     AZStd::vector<AZStd::string> GetPathsForAssetSourceDependents(const AZ::Data::AssetInfo& sourceInfo);
     AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsById(const AZ::Data::AssetId& assetId);
-    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcPath);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcePath);
 
     //! Invokes a visitor function on every file contained in the initial folder, optionally recursing through subfolders and visiting those files as well.
     void VisitFilesInFolder(const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -281,6 +281,25 @@ namespace AtomToolsFramework
     //! Collect a set of file paths contained within asset browser entry or URL mime data
     AZStd::set<AZStd::string> GetPathsFromMimeData(const QMimeData* mimeData);
 
+    //! @brief Get the normalized, absolute path for a source asset by retrieving info from an absolute or relative source path 
+    //! @param path source file path for which the absolute path will be constructed 
+    //! @return absolute problem for the source file if it can be resolved, otherwise the input path 
+    AZStd::string GetAbsolutePathForSourceAsset(const AZStd::string& path);
+
+    //! @brief Create a list of all asset source files the input asset depends on
+    //! @param assetId ID of the asset for which dependencies will be collected
+    //! @return Container of absolute paths to dependency source files
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependencies(const AZ::Data::AssetInfo& sourceInfo);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesById(const AZ::Data::AssetId& assetId);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcPath);
+
+    //! @brief Create a list of all asset source files that depend on the input asset
+    //! @param assetId ID of the asset for which dependence will be collected
+    //! @return Container of absolute paths to dependent source files
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependents(const AZ::Data::AssetInfo& sourceInfo);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsById(const AZ::Data::AssetId& assetId);
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcPath);
+
     //! Invokes a visitor function on every file contained in the initial folder, optionally recursing through subfolders and visiting those files as well.
     void VisitFilesInFolder(const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse);
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -32,6 +32,7 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
+#include <AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h>
 #include <AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
@@ -661,6 +662,197 @@ namespace AtomToolsFramework
         return paths;
     }
 
+    AZStd::string GetAbsolutePathForSourceAsset(const AZStd::string& path)
+    {
+        bool found = false;
+        AZ::Data::AssetInfo sourceInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            found, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, path.c_str(), sourceInfo, watchFolder);
+
+        if (found)
+        {
+            AZStd::string result;
+            if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), sourceInfo.m_relativePath.c_str(), result, true))
+            {
+                return result;
+            }
+        }
+
+        return path;
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependencies(const AZ::Data::AssetInfo& sourceInfo)
+    {
+        AzToolsFramework::AssetDatabase::AssetDatabaseConnection assetDatabaseConnection;
+        assetDatabaseConnection.OpenDatabase();
+
+        AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceEntry;
+        assetDatabaseConnection.QuerySourceBySourceName(
+            sourceInfo.m_relativePath.c_str(),
+            [&sourceEntry](const AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
+            {
+                sourceEntry = entry;
+                return false;
+            });
+
+        if (sourceEntry.m_sourceGuid.IsNull())
+        {
+            return {};
+        }
+
+        AZStd::vector<AZStd::string> sourcePaths;
+        assetDatabaseConnection.QueryDependsOnSourceBySourceDependency(
+            sourceEntry.m_sourceGuid,
+            AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_Any,
+            [&sourcePaths, &assetDatabaseConnection](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& entry)
+            {
+                AZStd::string dependencyName = entry.m_dependsOnSource.GetPath();
+
+                if (entry.m_dependsOnSource.IsUuid())
+                {
+                    assetDatabaseConnection.QuerySourceBySourceGuid(
+                        entry.m_dependsOnSource.GetUuid(),
+                        [&dependencyName](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
+                        {
+                            dependencyName = entry.m_sourceName;
+                            return false;
+                        });
+                }
+
+                if (!dependencyName.empty())
+                {
+                    sourcePaths.emplace_back(GetAbsolutePathForSourceAsset(dependencyName));
+                }
+                return true;
+            });
+
+        AZStd::sort(
+            sourcePaths.begin(),
+            sourcePaths.end(),
+            [](const auto& a, const auto& b)
+            {
+                return a < b;
+            });
+        return sourcePaths;
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesById(const AZ::Data::AssetId& assetId)
+    {
+        bool found = false;
+        AZ::Data::AssetInfo sourceInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            found, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, assetId.m_guid, sourceInfo, watchFolder);
+
+        return GetPathsForAssetSourceDependencies(sourceInfo);
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcPath)
+    {
+        bool found = false;
+        AZ::Data::AssetInfo sourceInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            found,
+            &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+            GetPathWithoutAlias(sourcPath).c_str(),
+            sourceInfo,
+            watchFolder);
+
+        return GetPathsForAssetSourceDependencies(sourceInfo);
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependents(const AZ::Data::AssetInfo& sourceInfo)
+    {
+        AzToolsFramework::AssetDatabase::AssetDatabaseConnection assetDatabaseConnection;
+        assetDatabaseConnection.OpenDatabase();
+
+        AzToolsFramework::AssetDatabase::SourceDatabaseEntry sourceEntry;
+        assetDatabaseConnection.QuerySourceBySourceName(
+            sourceInfo.m_relativePath.c_str(),
+            [&sourceEntry](const AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
+            {
+                sourceEntry = entry;
+                return false;
+            });
+
+        if (sourceEntry.m_sourceGuid.IsNull())
+        {
+            return {};
+        }
+
+        AZStd::string scanFolderPath;
+        assetDatabaseConnection.QueryScanFolderByScanFolderID(
+            sourceEntry.m_scanFolderPK,
+            [&scanFolderPath](const AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry& entry)
+            {
+                scanFolderPath = entry.m_scanFolder;
+                return false;
+            });
+
+        auto absolutePath = AZ::IO::Path(scanFolderPath) / sourceEntry.m_sourceName;
+
+        AZStd::vector<AZStd::string> sourcePaths;
+        assetDatabaseConnection.QuerySourceDependencyByDependsOnSource(
+            sourceEntry.m_sourceGuid,
+            sourceEntry.m_sourceName.c_str(),
+            absolutePath.FixedMaxPathStringAsPosix().c_str(),
+            AzToolsFramework::AssetDatabase::SourceFileDependencyEntry::DEP_Any,
+            [&sourcePaths, &assetDatabaseConnection](AzToolsFramework::AssetDatabase::SourceFileDependencyEntry& entry)
+            {
+                AZStd::string sourceName;
+                assetDatabaseConnection.QuerySourceBySourceGuid(
+                    entry.m_sourceGuid,
+                    [&sourceName](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
+                    {
+                        sourceName = entry.m_sourceName;
+                        return false;
+                    });
+
+                if (!sourceName.empty())
+                {
+                    sourcePaths.emplace_back(GetAbsolutePathForSourceAsset(sourceName));
+                }
+                return true;
+            });
+
+        AZStd::sort(
+            sourcePaths.begin(),
+            sourcePaths.end(),
+            [](const auto& a, const auto& b)
+            {
+                return a < b;
+            });
+        return sourcePaths;
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsById(const AZ::Data::AssetId& assetId)
+    {
+        bool found = false;
+        AZ::Data::AssetInfo sourceInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            found, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, assetId.m_guid, sourceInfo, watchFolder);
+
+        return GetPathsForAssetSourceDependents(sourceInfo);
+    }
+
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcPath)
+    {
+        bool found = false;
+        AZ::Data::AssetInfo sourceInfo;
+        AZStd::string watchFolder;
+        AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+            found,
+            &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
+            GetPathWithoutAlias(sourcPath).c_str(),
+            sourceInfo,
+            watchFolder);
+
+        return GetPathsForAssetSourceDependents(sourceInfo);
+    }
+
     void VisitFilesInFolder(
         const AZStd::string& folder, const AZStd::function<bool(const AZStd::string&)> visitorFn, bool recurse)
     {
@@ -885,6 +1077,13 @@ namespace AtomToolsFramework
             addUtilFunc(behaviorContext->Method("GetPathToExteralReference", GetPathToExteralReference, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithoutAlias", GetPathWithoutAlias, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathWithAlias", GetPathWithAlias, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetAbsolutePathForSourceAsset", GetAbsolutePathForSourceAsset, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependencies", GetPathsForAssetSourceDependencies, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependenciesById", GetPathsForAssetSourceDependenciesById, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependenciesByPath", GetPathsForAssetSourceDependenciesByPath, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependents", GetPathsForAssetSourceDependents, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependentsById", GetPathsForAssetSourceDependentsById, nullptr, ""));
+            addUtilFunc(behaviorContext->Method("GetPathsForAssetSourceDependentsByPath", GetPathsForAssetSourceDependentsByPath, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetPathsInSourceFoldersMatchingExtension", GetPathsInSourceFoldersMatchingExtension, nullptr, ""));
             addUtilFunc(behaviorContext->Method("IsPathIgnored", IsPathIgnored, nullptr, ""));
             addUtilFunc(behaviorContext->Method("GetSupportedSourceFolders", GetSupportedSourceFolders, nullptr, ""));

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -666,16 +666,16 @@ namespace AtomToolsFramework
     {
         bool found = false;
         AZ::Data::AssetInfo sourceInfo;
-        AZStd::string watchFolder;
+        AZStd::string rootFolder;
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            found, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, path.c_str(), sourceInfo, watchFolder);
+            found, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath, path.c_str(), sourceInfo, rootFolder);
 
         if (found)
         {
-            AZStd::string result;
-            if (AzFramework::StringFunc::Path::ConstructFull(watchFolder.c_str(), sourceInfo.m_relativePath.c_str(), result, true))
+            const AZ::IO::Path result = AZ::IO::Path(rootFolder) / sourceInfo.m_relativePath;
+            if (!result.empty())
             {
-                return result;
+                return result.LexicallyNormal().String();
             }
         }
 
@@ -727,13 +727,10 @@ namespace AtomToolsFramework
                 return true;
             });
 
-        AZStd::sort(
-            sourcePaths.begin(),
-            sourcePaths.end(),
-            [](const auto& a, const auto& b)
-            {
-                return a < b;
-            });
+        assetDatabaseConnection.CloseDatabase();
+
+        AZStd::sort(sourcePaths.begin(), sourcePaths.end());
+        sourcePaths.erase(AZStd::unique(sourcePaths.begin(), sourcePaths.end()), sourcePaths.end());
         return sourcePaths;
     }
 
@@ -748,7 +745,7 @@ namespace AtomToolsFramework
         return GetPathsForAssetSourceDependencies(sourceInfo);
     }
 
-    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcPath)
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependenciesByPath(const AZStd::string& sourcePath)
     {
         bool found = false;
         AZ::Data::AssetInfo sourceInfo;
@@ -756,7 +753,7 @@ namespace AtomToolsFramework
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
             found,
             &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
-            GetPathWithoutAlias(sourcPath).c_str(),
+            GetPathWithoutAlias(sourcePath).c_str(),
             sourceInfo,
             watchFolder);
 
@@ -817,13 +814,10 @@ namespace AtomToolsFramework
                 return true;
             });
 
-        AZStd::sort(
-            sourcePaths.begin(),
-            sourcePaths.end(),
-            [](const auto& a, const auto& b)
-            {
-                return a < b;
-            });
+        assetDatabaseConnection.CloseDatabase();
+
+        AZStd::sort(sourcePaths.begin(), sourcePaths.end());
+        sourcePaths.erase(AZStd::unique(sourcePaths.begin(), sourcePaths.end()), sourcePaths.end());
         return sourcePaths;
     }
 
@@ -838,7 +832,7 @@ namespace AtomToolsFramework
         return GetPathsForAssetSourceDependents(sourceInfo);
     }
 
-    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcPath)
+    AZStd::vector<AZStd::string> GetPathsForAssetSourceDependentsByPath(const AZStd::string& sourcePath)
     {
         bool found = false;
         AZ::Data::AssetInfo sourceInfo;
@@ -846,7 +840,7 @@ namespace AtomToolsFramework
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
             found,
             &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourcePath,
-            GetPathWithoutAlias(sourcPath).c_str(),
+            GetPathWithoutAlias(sourcePath).c_str(),
             sourceInfo,
             watchFolder);
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -806,6 +806,10 @@ namespace MaterialEditor
             AZ::RPI::AssetUtils::ResolvePathReference(m_absolutePath, m_materialSourceData.m_parentMaterial);
         m_materialSourceData.m_materialType =
             AZ::RPI::AssetUtils::ResolvePathReference(m_absolutePath, m_materialSourceData.m_materialType);
+        // If the material was previously saved with a reference to a material pipeline generated material type in the intermediate asset
+        // folder, attempt to redirect to the original source material type.
+        m_materialSourceData.m_materialType =
+            AZ::RPI::MaterialUtils::PredictOriginalMaterialTypeSourcePath(m_materialSourceData.m_materialType);
 
         // Load the material type source data which provides the layout and default values of all of the properties
         auto materialTypeOutcome = AZ::RPI::MaterialUtils::LoadMaterialTypeSourceData(m_materialSourceData.m_materialType);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -262,12 +262,12 @@ namespace AZ
                                         .arg(m_editData.m_materialParentSourcePath.c_str())
                                         .arg(materialParentSourceFileName.c_str());
                 }
-                if (!m_editData.m_materialTypeSourcePath.empty())
+                if (!m_editData.m_originalMaterialTypeSourcePath.empty())
                 {
                     // Inserting links that will be used to open the material/type in the material editor
-                    const auto& materialTypeSourceFileName = GetFileName(m_editData.m_materialTypeSourcePath);
+                    const auto& materialTypeSourceFileName = GetFileName(m_editData.m_originalMaterialTypeSourcePath);
                     materialInfo += tr("<tr><td><b>Material Type&emsp;</b></td><td><a href=\"%1\">%2</a></td></tr>")
-                                        .arg(m_editData.m_materialTypeSourcePath.c_str())
+                                        .arg(m_editData.m_originalMaterialTypeSourcePath.c_str())
                                         .arg(materialTypeSourceFileName.c_str());
                 }
                 materialInfo += tr("</table>");

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.cpp
@@ -90,6 +90,17 @@ namespace AZ
                     return false;
                 }
 
+                // With the introduction of the material pipeline, abstract material types, and intermediate assets, the material could
+                // be referencing a generated material type in the intermediate asset folder. We need to map back to the original
+                // material type.
+                editData.m_originalMaterialTypeSourcePath =
+                    AZ::RPI::MaterialUtils::PredictOriginalMaterialTypeSourcePath(editData.m_materialTypeSourcePath);
+                if (editData.m_originalMaterialTypeSourcePath.empty())
+                {
+                    AZ_Error("AZ::Render::EditorMaterialComponentUtil", false, "Build to locate originating source material type asset: %s", editData.m_materialAssetId.ToString<AZStd::string>().c_str());
+                    return false;
+                }
+
                 // Load the material type source data
                 auto materialTypeOutcome = AZ::RPI::MaterialUtils::LoadMaterialTypeSourceData(editData.m_materialTypeSourcePath);
                 if (!materialTypeOutcome.IsSuccess())
@@ -104,7 +115,7 @@ namespace AZ
             bool SaveSourceMaterialFromEditData(const AZStd::string& path, const MaterialEditData& editData)
             {
                 if (path.empty() || !editData.m_materialAsset.IsReady() || !editData.m_materialTypeAsset.IsReady() ||
-                    editData.m_materialTypeSourcePath.empty())
+                    editData.m_materialTypeSourcePath.empty() || editData.m_originalMaterialTypeSourcePath.empty())
                 {
                     AZ_Error("AZ::Render::EditorMaterialComponentUtil", false, "Can not export: %s", path.c_str());
                     return false;
@@ -113,7 +124,10 @@ namespace AZ
                 // Construct the material source data object that will be exported
                 AZ::RPI::MaterialSourceData exportData;
                 exportData.m_materialTypeVersion = editData.m_materialTypeAsset->GetVersion();
-                exportData.m_materialType = AtomToolsFramework::GetPathToExteralReference(path, editData.m_materialTypeSourcePath);
+
+                // Source material files that should reference the originating source material type instead of the potential intermediate
+                // material type asset.
+                exportData.m_materialType = AtomToolsFramework::GetPathToExteralReference(path, editData.m_originalMaterialTypeSourcePath);
                 exportData.m_parentMaterial = AtomToolsFramework::GetPathToExteralReference(path, editData.m_materialParentSourcePath);
 
                 // Copy all of the properties from the material asset to the source data that will be exported

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentUtil.h
@@ -47,6 +47,7 @@ namespace AZ
                 AZ::RPI::MaterialTypeSourceData m_materialTypeSourceData;
                 AZStd::string m_materialSourcePath;
                 AZStd::string m_materialTypeSourcePath;
+                AZStd::string m_originalMaterialTypeSourcePath;
                 AZStd::string m_materialParentSourcePath;
                 MaterialPropertyOverrideMap m_materialPropertyOverrideMap = {};
             };


### PR DESCRIPTION
## What does this PR do?

- This change fixes the generate source materials feature on the material component so that exported materials reference the original source material instead of the generated intermediate asset version.
- Additionally, utility functions have been added to enumerate assets source dependencies and dependents. These functions were originally intended to locate the original source material file from the generated assets but the functions do not resolve the original material type file. Despite that, the functions will be useful in other areas.
- A bespoke function was implemented to convert an intermediate material type path Into a relative path that could be used to locate the original material file.

Fixes https://github.com/o3de/o3de/issues/14847
 
## How was this PR tested?

Tested exporting materials from the generate source materials dialogs to find that they properly reference the original source material.