### PR TITLE
fix error caused by streaming image instance being created from cpu data with mismatching ids

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -42,7 +42,8 @@ namespace AZ
             size_t imageDataSize,
             Uuid id)
         {
-            Data::Instance<StreamingImage> existingImage = Data::InstanceDatabase<StreamingImage>::Instance().Find(Data::InstanceId::CreateFromAssetId(id));
+            const Data::InstanceId instanceId = Data::InstanceId::CreateUuid(id);
+            Data::Instance<StreamingImage> existingImage = Data::InstanceDatabase<StreamingImage>::Instance().Find(instanceId);
             AZ_Error("StreamingImage", !existingImage, "StreamingImage::CreateFromCpuData found an existing entry in the instance database for the provided id.");
 
             RHI::ImageDescriptor imageDescriptor;
@@ -93,20 +94,14 @@ namespace AZ
                 }
             }
 
-            return StreamingImage::FindOrCreate(streamingImageAsset);
+            return Data::InstanceDatabase<StreamingImage>::Instance().FindOrCreate(instanceId, streamingImageAsset);
         }
 
         Data::Instance<StreamingImage> StreamingImage::CreateInternal(StreamingImageAsset& streamingImageAsset)
         {
             Data::Instance<StreamingImage> streamingImage = aznew StreamingImage();
             const RHI::ResultCode resultCode = streamingImage->Init(streamingImageAsset);
-
-            if (resultCode == RHI::ResultCode::Success)
-            {
-                return streamingImage;
-            }
-
-            return nullptr;
+            return resultCode == RHI::ResultCode::Success ? streamingImage : nullptr;
         }
 
         RHI::ResultCode StreamingImage::Init(StreamingImageAsset& imageAsset)


### PR DESCRIPTION
## What does this PR do?

The instance ID class was changed to support multiple sub ids and require explicit construction from different data sources like assets, asset ids, or uuids, which set the sub Ids differently. The streaming image function was searching for an existing instance based on a raw uuid treated as an asset id but creating the instance using the asset id from the asset creator, which could assign different sub Ids and a creation token, affecting the instance id.

To guarantee that the instance is created and looked up using the same id, we switched to the create from UUID function so that sub Ids will be ignored.

## How was this PR tested?

Create from CPU data error message no longer appears in console