### PR TITLE
Bump version for ScriptCanvas changes

### DIFF
--- a/Gems/ScriptCanvas/gem.json
+++ b/Gems/ScriptCanvas/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ScriptCanvas",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "display_name": "Script Canvas",
     "license": "Apache-2.0 Or MIT",
     "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",

--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",


### PR DESCRIPTION
Script Canvas node registration was changed in https://github.com/o3de/o3de/pull/16678 and code changes need to be made to support these changes.  Bumping the ScriptCanvas gem and engine versions so developers(e.g. PopcornFX) have a version to use in CMakeLists to determine which registration method to use

## What does this PR do?

Increments the ScriptCanvas gem major version and engine major version.

Related: https://github.com/o3de/o3de/pull/16678

## How was this PR tested?

 - there are no code changes, but configured and built with AutomatedTesting on PC anyways
