### PR TITLE
prefab override fixes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -180,14 +180,16 @@ namespace AzToolsFramework::Prefab
                 AZ::Dom::Value firstRowElement = propertyRowValue[0];
                 AZ_Assert(
                     firstRowElement.IsNode() &&
-                    firstRowElement.GetNodeName().GetStringView() == AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Name &&
-                    firstRowElement["Type"].GetString() == PrefabPropertyEditorNodes::PrefabOverrideLabel::Name,
-                    "PrefabComponentAdapter::UpdateDomContents - First element in the property row is not a 'PrefabOverrideLabel'.");
+                    firstRowElement.GetNodeName().GetStringView() == AZ::DocumentPropertyEditor::Nodes::PropertyEditor::Name,
+                    "PrefabComponentAdapter::UpdateDomContents - First element in the property row is not a PropertyEditor node.");
 
-                // Patch the first child in the row, which is going to the PrefabOverrideLabel.
-                patches.PushBack(AZ::Dom::PatchOperation::ReplaceOperation(
-                    pathToProperty / 0 / PrefabPropertyEditorNodes::PrefabOverrideLabel::IsOverridden.GetName(), AZ::Dom::Value(true)));
-                NotifyContentsChanged(patches);
+                if (firstRowElement["Type"].GetString() == PrefabPropertyEditorNodes::PrefabOverrideLabel::Name)
+                {
+                    // Patch the first child in the row, which is going to the PrefabOverrideLabel.
+                    patches.PushBack(AZ::Dom::PatchOperation::ReplaceOperation(
+                        pathToProperty / 0 / PrefabPropertyEditorNodes::PrefabOverrideLabel::IsOverridden.GetName(), AZ::Dom::Value(true)));
+                    NotifyContentsChanged(patches);
+                }
             }
         }
         else if (propertyChangeInfo.changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -32,7 +32,7 @@ namespace AzToolsFramework::Prefab
     {
         static QIcon s_overrideIcon(QStringLiteral(":/Entity/entity_modified_as_override.svg"));
         static QIcon s_emptyIcon;
-        static QSize s_iconSize(7, 7);
+        static QSize s_iconSize(6, 6);
 
         using PrefabPropertyEditorNodes::PrefabOverrideLabel;
 


### PR DESCRIPTION
## What does this PR do?
- fixes prefab override icon size #17063 
- fixes prefab override label assert/crash #17065 

## How was this PR tested?
locally in the Editor project
