### PR TITLE
properly inherit DescriptorAttributes::ParentContainerCanBeModified attribute

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1405,7 +1405,8 @@ namespace AZ::Reflection
                         nodeData.m_cachedAttributes.push_back({ group, DescriptorAttributes::ParentContainer, *parentContainer });
 
                         const auto inheritedAttributes = { DescriptorAttributes::ParentContainerInstance,
-                                                               AZ::Reflection::DescriptorAttributes::ContainerIndex };
+                                                           DescriptorAttributes::ParentContainerCanBeModified,
+                                                           AZ::Reflection::DescriptorAttributes::ContainerIndex };
 
                         for (const auto& attributeName : inheritedAttributes)
                         {


### PR DESCRIPTION
## What does this PR do?
Properly inherit DescriptorAttributes::ParentContainerCanBeModified attribute, along with the other parent container attributes. This ensures that containers with invisible members properly display container edit controls

## How was this PR tested?
locally, in the Editor project