### PR TITLE
Adding fixes for CMake configuration when starting from SDK Installer build of O3DE

### DIFF
--- a/Gems/DiffuseProbeGrid/gem.json
+++ b/Gems/DiffuseProbeGrid/gem.json
@@ -7,6 +7,7 @@
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/o3de",
     "summary": "The DiffuseProbeGrid Gem implements Diffuse Global Illumination using the Nvidia RTX-GI SDK.  It renders global illumination on any meshes inside a user-placed volume, and can be set to real-time or baked.",
+    "type": "Code",
     "canonical_tags": [
         "Gem"
     ],

--- a/Gems/LyShineExamples/gem.json
+++ b/Gems/LyShineExamples/gem.json
@@ -6,7 +6,7 @@
     "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/o3de",
-    "type": "Asset",
+    "type": "Code",
     "summary": "The LyShine Examples Gem provides example code and assets for LyShine, the runtime UI system and editor for Open 3D Engine projects.",
     "canonical_tags": [
         "Gem"

--- a/Gems/SceneLoggingExample/gem.json
+++ b/Gems/SceneLoggingExample/gem.json
@@ -6,7 +6,7 @@
     "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/o3de",
-    "type": "Asset",
+    "type": "Code",
     "summary": "The Scene Logging Example Gem demonstrates the basics of extending the Open 3D Engine Scene API by adding additional logging to the pipeline.",
     "canonical_tags": [
         "Gem"

--- a/Gems/Terrain/gem.json
+++ b/Gems/Terrain/gem.json
@@ -7,6 +7,7 @@
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/o3de",
     "summary": "The Terrain Gem is an experimental terrain system.  The terrain system maps height, color, and surface data to regions of the world, provides gradient-based and shape-based authoring tools and workflows, includes specialized rendering for efficient display, and integrates with physics for physical simulation.",
+    "type": "Code",
     "canonical_tags": [
         "Gem"
     ],


### PR DESCRIPTION
## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
Discovered an issue when trying to build a project from the project manager using CMake configure:
```
CMake Error at C:/workspace/dev/o3de/install/cmake/LYWrappers.cmake:766 (message):
  ly_de_alias_target called on non-existent target: Gem::UiBasics.Tools
Call Stack (most recent call first):
  C:/workspace/dev/o3de/install/cmake/SettingsRegistry.cmake:137 (ly_de_alias_target)
  C:/workspace/dev/o3de/install/cmake/SettingsRegistry.cmake:270 (o3de_get_gem_load_dependencies)
  C:/workspace/dev/o3de/install/CMakeLists.txt:116 (ly_delayed_generate_settings_registry)


-- Configuring incomplete, errors occurred!
See also "C:/workspace/sdk-test/SDKTestProject/build/windows/CMakeFiles/CMakeOutput.log".
See also "C:/workspace/sdk-test/SDKTestProject/build/windows/CMakeFiles/CMakeError.log".
```
This turned out to be an issue with certain asset gems not getting included in the build process. The PR addresses this by including optional fixes if the gem in question is an asset type (along with some corrections for mis-labeled gems).
## How was this PR tested?

_Please describe any testing performed._
This was tested from a windows machine with the latest SDK installer version