### PR TITLE
Increment engine version for point release

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.1.0",


### PR DESCRIPTION
## What does this PR do?

Bump the engine MINOR version so the point release version number is higher than the last release, but lower than development branch which is > 3.x.x

A corresponding change has been made in the nightly Jenkins job so the engine version matches `2.2.0`

## How was this PR tested?

n/a there is a non-code change
