### PR TITLE
Use latest Visual Studio (2022) for testing installer project builds

### DIFF
--- a/cmake/Platform/Windows/Packaging/Tests/test_installer.py
+++ b/cmake/Platform/Windows/Packaging/Tests/test_installer.py
@@ -97,7 +97,7 @@ def test_compile_project_fixture(test_create_project_fixture, context):
     launcher_target = f"{project_name}.GameLauncher"
 
     # configure
-    result = context.run([str(cmake_path),'-B', str(context.project_build_path), '-S', '.', '-G', 'Visual Studio 16 2019'], cwd=context.project_path)
+    result = context.run([str(cmake_path),'-B', str(context.project_build_path), '-S', '.', '-G', 'Visual Studio 17 2022'], cwd=context.project_path)
     assert result.returncode == 0
     assert (context.project_build_path / f'{project_name}.sln').is_file()
 

--- a/cmake/Platform/Windows/Packaging/Tests/test_installer.py
+++ b/cmake/Platform/Windows/Packaging/Tests/test_installer.py
@@ -97,7 +97,7 @@ def test_compile_project_fixture(test_create_project_fixture, context):
     launcher_target = f"{project_name}.GameLauncher"
 
     # configure
-    result = context.run([str(cmake_path),'-B', str(context.project_build_path), '-S', '.', '-G', 'Visual Studio 17 2022'], cwd=context.project_path)
+    result = context.run([str(cmake_path),'-B', str(context.project_build_path), '-S', '.'], cwd=context.project_path)
     assert result.returncode == 0
     assert (context.project_build_path / f'{project_name}.sln').is_file()
 


### PR DESCRIPTION
## What does this PR do?

Switches installer test to build a project with latest Visual Studio (2022) instead of Visual Studio 2019.  Visual Studio 2022 has been the default version available for some time now from Microsoft.  As time goes on more and more users will use the newer version and that is what our tests should use.

## How was this PR tested?

- n/a this test will run on the build machines and does not impact the build.
