### PR TITLE
Fence-related resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
     class SingleDeviceSwapChain;
     class SingleDeviceResourcePool;
     class SingleDeviceQueryPool;
-    class SingleDeviceFence;
+    class MultiDeviceFence;
     struct Interval;
 
     //! The frame graph is a graph of scopes, where edges are derived from attachment usage. It can be visualized as a sparse 2D grid.
@@ -109,7 +109,7 @@ namespace AZ::RHI
         ResultCode UseQueryPool(Ptr<SingleDeviceQueryPool> queryPool, const RHI::Interval& interval, QueryPoolScopeAttachmentType type, ScopeAttachmentAccess access);
         void ExecuteAfter(const ScopeId& scopeId);
         void ExecuteBefore(const ScopeId& scopeId);
-        void SignalFence(SingleDeviceFence& fence);
+        void SignalFence(MultiDeviceFence& fence);
         void SetEstimatedItemCount(uint32_t itemCount);
         void SetHardwareQueueClass(HardwareQueueClass hardwareQueueClass);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
 {
     class SingleDeviceResourcePool;
     class SingleDeviceQueryPool;
-    class SingleDeviceFence;
+    class MultiDeviceFence;
     struct Interval;
 
     //! This interface exposes FrameGraph functionality to non-RHI systems (like the RPI).
@@ -203,11 +203,11 @@ namespace AZ::RHI
             m_frameGraph.ExecuteBefore(consumerScopeId);
         }
             
-        //! Requests that the provided fence be signaled after the scope has completed.
-        void SignalFence(SingleDeviceFence& fence)
-        {
-            m_frameGraph.SignalFence(fence);
-        }
+            //! Requests that the provided fence be signaled after the scope has completed.
+            void SignalFence(MultiDeviceFence& fence)
+            {
+                m_frameGraph.SignalFence(fence);
+            }
             
         //! Sets the number of work items (Draw / Dispatch / etc) that will be processed by
         //! this scope. This value is used to load-balance the scope across command lists. A small

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -12,7 +12,7 @@
 #include <Atom/RHI.Reflect/Handle.h>
 #include <Atom/RHI/SingleDeviceResourcePool.h>
 #include <Atom/RHI/SingleDeviceQueryPool.h>
-#include <Atom/RHI/SingleDeviceFence.h>
+#include <Atom/RHI/MultiDeviceFence.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/array.h>
 
@@ -114,8 +114,8 @@ namespace AZ::RHI
         //! Returns a list of swap chains which require presentation at the end of the scope.
         const AZStd::vector<SingleDeviceSwapChain*>& GetSwapChainsToPresent() const;
 
-        //! Returns a list of fences to signal on completion of the scope.
-        const AZStd::vector<Ptr<SingleDeviceFence>>& GetFencesToSignal() const;
+            /// Returns a list of fences to signal on completion of the scope.
+            const AZStd::vector<Ptr<MultiDeviceFence>>& GetFencesToSignal() const;
 
         //! Initializes the scope.
         void Init(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass = HardwareQueueClass::Graphics);
@@ -149,8 +149,8 @@ namespace AZ::RHI
         //! Links the producer and consumer according to their queues.
         static void LinkProducerConsumerByQueues(Scope* producer, Scope* consumer);
 
-        //! Adds a fence that will be signaled at the end of the scope.
-        void AddFenceToSignal(Ptr<SingleDeviceFence> fence);
+            /// Adds a fence that will be signaled at the end of the scope.
+            void AddFenceToSignal(Ptr<MultiDeviceFence> fence);
 
     protected:
         //! Called when the scope will use a query pool during it's execution. Some platforms need this information.
@@ -237,8 +237,8 @@ namespace AZ::RHI
         /// The set of swap chain present actions requested.
         AZStd::vector<SingleDeviceSwapChain*>                m_swapChainsToPresent;
 
-        /// The set of fences to signal on scope completion.
-        AZStd::vector<Ptr<SingleDeviceFence>>                m_fencesToSignal;
+            /// The set of fences to signal on scope completion.
+            AZStd::vector<Ptr<MultiDeviceFence>>                m_fencesToSignal;
 
         /// The set query pools.
         AZStd::vector<Ptr<SingleDeviceQueryPool>>                m_queryPools;

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -424,10 +424,10 @@ namespace AZ::RHI
         }
     }
 
-    void FrameGraph::SignalFence(SingleDeviceFence& fence)
-    {
-        m_currentScope->m_fencesToSignal.push_back(&fence);
-    }
+        void FrameGraph::SignalFence(MultiDeviceFence& fence)
+        {
+            m_currentScope->m_fencesToSignal.push_back(&fence);
+        }
 
     ResultCode FrameGraph::TopologicalSort()
     {

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -217,7 +217,7 @@ namespace AZ::RHI
         return m_swapChainsToPresent;
     }
 
-    const AZStd::vector<Ptr<SingleDeviceFence>>& Scope::GetFencesToSignal() const
+    const AZStd::vector<Ptr<MultiDeviceFence>>& Scope::GetFencesToSignal() const
     {
         return m_fencesToSignal;
     }
@@ -251,7 +251,7 @@ namespace AZ::RHI
         consumer->m_producersByQueue[static_cast<uint32_t>(producer->GetHardwareQueueClass())] = producer;
     }
 
-    void Scope::AddFenceToSignal(Ptr<SingleDeviceFence> fence)
+    void Scope::AddFenceToSignal(Ptr<MultiDeviceFence> fence)
     {
         m_fencesToSignal.push_back(fence);
     }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -49,7 +49,7 @@ namespace AZ
                     auto& fencesToSignal = m_workRequest.m_userFencesToSignal;
 
                     fencesToSignal.reserve(fencesToSignal.size() + scope->GetFencesToSignal().size());
-                    for (const RHI::Ptr<RHI::SingleDeviceFence>& fence : scope->GetFencesToSignal())
+                    for (const RHI::Ptr<RHI::SingleDeviceFence>& fence : scope->GetFencesToSignal()->GetDeviceFence(device.GetDeviceIndex()))
                     {
                         fencesToSignal.push_back(&static_cast<FenceImpl&>(*fence).Get());
                     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -11,6 +11,7 @@
 #include <Atom/RHI/BufferProperty.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/MultiDeviceFence.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
 #include <RHI/CommandList.h>
@@ -331,7 +332,7 @@ namespace AZ
             m_signalFences.reserve(fences.size());
             for (const auto& fence : fences)
             {
-                m_signalFences.push_back(AZStd::static_pointer_cast<Fence>(fence));
+                m_signalFences.push_back(AZStd::static_pointer_cast<Fence>(fence->GetDeviceFence(deviceBase.GetDeviceIndex())));
             }
 
             Device& device = static_cast<Device&>(deviceBase);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
@@ -172,7 +172,7 @@ namespace AZ
 
             ReadbackState m_state = ReadbackState::Uninitialized;
 
-            Ptr<RHI::SingleDeviceFence> m_fence;
+            Ptr<RHI::MultiDeviceFence> m_fence;
 
             // Callback function when read back finished
             CallbackFunction m_callback = nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -17,7 +17,7 @@
 
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceFence.h>
+#include <Atom/RHI/MultiDeviceFence.h>
 #include <Atom/RHI/FrameGraphExecuteContext.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/RHISystemInterface.h>
@@ -119,10 +119,9 @@ namespace AZ
             }
             
             // Create fence
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            m_fence = RHI::Factory::Get().CreateFence();
+            m_fence = aznew RHI::MultiDeviceFence;
             AZ_Assert(m_fence != nullptr, "AttachmentReadback failed to create a fence");
-            [[maybe_unused]] RHI::ResultCode result = m_fence->Init(*device, RHI::FenceState::Reset);
+            [[maybe_unused]] RHI::ResultCode result = m_fence->Init(RHI::MultiDevice::AllDevices, RHI::FenceState::Reset);
             AZ_Assert(result == RHI::ResultCode::Success, "AttachmentReadback failed to init fence");
 
             // Load shader and srg


### PR DESCRIPTION
## What does this PR do?
This specific PR transitions resources related to `SingleDeviceFence` to `MultiDeviceFence`.
### General Idea
This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a https://github.com/o3de/o3de/pull/14079, however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of ->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex) to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using RHI::MultiDevice::DefaultDeviceIndex everywhere because it simplifies the transition.
## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`

