### PR TITLE
Fixes compile errors and cmake errors for linux release

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.cpp
@@ -81,9 +81,9 @@ namespace AZ
             }
         }
 
-        using AllocationString = AZStd::fixed_string<1024>;
-
-        static constexpr const char* MemoryTag = "mem";
+        // Note that AllocationString and MemoryTag may be unused in release builds.
+        using AllocationString [[maybe_unused]] = AZStd::fixed_string<1024>;
+        [[maybe_unused]] static constexpr const char* MemoryTag = "mem";
 
         size_t allocationCount{};
         size_t totalAllocations{};
@@ -251,8 +251,9 @@ namespace AZ
 
     static void DumpAllocationsForAllocatorToFile(const AZ::ConsoleCommandContainer& arguments)
     {
-        using AllocationString = AZStd::fixed_string<1024>;
-        static constexpr const char* MemoryTag = "mem";
+        // Note that AllocationString and MemoryTag may be unused in release builds.
+        using AllocationString [[maybe_unused]] = AZStd::fixed_string<1024>;
+        [[maybe_unused]] static constexpr const char* MemoryTag = "mem";
 
         constexpr size_t DumpToFileMinArgumentCount = 1;
 
@@ -312,8 +313,9 @@ namespace AZ
 
     static void DumpAllocationsForAllocatorToDevWriteStorage(const AZ::ConsoleCommandContainer& arguments)
     {
-        using AllocationString = AZStd::fixed_string<1024>;
-        static constexpr const char* MemoryTag = "mem";
+        // Note that AllocationString and MemoryTag may be unused in release builds.
+        using AllocationString [[maybe_unused]] = AZStd::fixed_string<1024>;
+        [[maybe_unused]] static constexpr const char* MemoryTag = "mem";
 
         // Dump allocation records to <dev-write-storage>/allocation_records/records.<iso8601-timestamp>.<process-id>.log
         // Use a ISO8601 timestamp + the process ID to provide uniqueness to the metrics json files
@@ -354,8 +356,9 @@ namespace AZ
 
     static void DumpAllocationsForAllocatorInRange(const AZ::ConsoleCommandContainer& arguments)
     {
-        using AllocationString = AZStd::fixed_string<1024>;
-        static constexpr const char* MemoryTag = "mem";
+        // Note that AllocationString and MemoryTag may be unused in release builds.
+        using AllocationString [[maybe_unused]] = AZStd::fixed_string<1024>;
+        [[maybe_unused]] static constexpr const char* MemoryTag = "mem";
 
         constexpr size_t rangeArgumentCount = 2;
 

--- a/Gems/UiBasics/CMakeLists.txt
+++ b/Gems/UiBasics/CMakeLists.txt
@@ -7,7 +7,5 @@
 #
 
 # This will export its "SourcePaths" to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME UiBasics.Builders NAMESPACE Gem)
-    ly_create_alias(NAME UiBasics.Tools NAMESPACE Gem)
-endif()
+ly_create_alias(NAME UiBasics.Builders NAMESPACE Gem)
+ly_create_alias(NAME UiBasics.Tools NAMESPACE Gem)


### PR DESCRIPTION
Fixes a 'unused variable' compile error when trying to use the package.py script from DefaultProject to build a linux monolithic release.  Specifically, building a monolithic release installer on linux fails with compile errors, and cmake errors.

The compiler errors were 'unused variable', the cmake errors were that other libraries like lyshine and so on were asking for the uibasics targets without necessarily having the same logic around them. 

 Since the UiBasics builders and tools don't contain any actual code or targets, the dummy aliases are fine to have in any configuration and simplifies the use of them from other locations.

## How was this PR tested?

Tested by running a linux build release install for monolithic install.