### PR TITLE
Query-related resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -19,7 +19,6 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceQuery;
     class ScopeProducer;
 
     //! Supported operations for rendering predication.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
@@ -13,7 +13,7 @@
 
 #include <Atom/RHI.Reflect/Interval.h>
 
-#include <Atom/RHI/SingleDeviceQueryPool.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
 
 #include <AzCore/std/containers/span.h>
 
@@ -60,16 +60,16 @@ namespace AZ
             QueryPool(uint32_t queryCapacity, uint32_t queriesPerResult, RHI::QueryType queryType, RHI::PipelineStatisticsFlags statisticsFlags);
 
             // Returns the RHI Query array as a span.
-            AZStd::span<const RHI::Ptr<RHI::SingleDeviceQuery>> GetRhiQueryArray() const;
+            AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> GetRhiQueryArray() const;
 
         private:
             // Distributes the RHI Query indices into sub-intervals. Each sub interval is assigned to a RPI Query.
             void CreateRhiQueryIntervals();
 
             // Returns a span of RHI Queries depending on the indices that are provided.
-            AZStd::span<const RHI::Ptr<RHI::SingleDeviceQuery>> GetRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
+            AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> GetRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
             // Returns an array of raw RHI Query pointers depending on the indices that are provided.
-            AZStd::vector<RHI::SingleDeviceQuery*> GetRawRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
+            AZStd::vector<RHI::MultiDeviceQuery*> GetRawRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
 
             // Readback results from the provided RHI Query indices.
             QueryResultCode GetQueryResultFromIndices(uint64_t* result, RHI::Interval rhiQueryIndices, RHI::QueryResultFlagBits queryResultFlag);
@@ -110,8 +110,8 @@ namespace AZ
             AZStd::vector<RHI::Interval> m_availableIntervalArray;
 
             // RHI Query related resources.
-            AZStd::vector<RHI::Ptr<RHI::SingleDeviceQuery>> m_rhiQueryArray;
-            RHI::Ptr<RHI::SingleDeviceQueryPool> m_rhiQueryPool;
+            AZStd::vector<RHI::Ptr<RHI::MultiDeviceQuery>> m_rhiQueryArray;
+            RHI::Ptr<RHI::MultiDeviceQueryPool> m_rhiQueryPool;
         };
 
     }; // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
@@ -75,7 +75,7 @@ namespace AZ
             }
 
             // Tell the FrameGraph which RHI QueryPool, and which RHI Queries need to be used.
-            [[maybe_unused]] RHI::ResultCode resultCode = frameGraph.UseQueryPool(m_queryPool->m_rhiQueryPool, rhiQueryIndices.value(), m_attachmentType, m_attachmentAccess);
+            [[maybe_unused]] RHI::ResultCode resultCode = frameGraph.UseQueryPool(m_queryPool->m_rhiQueryPool->GetDeviceQueryPool(RHI::MultiDevice::DefaultDeviceIndex), rhiQueryIndices.value(), m_attachmentType, m_attachmentAccess);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to add the queries to the scope builder");
 
             // Invalidate the ScopeId.
@@ -223,7 +223,7 @@ namespace AZ
             // Calculate the amount of RHI Queries used for this RPI Query.
             const uint32_t queryIndicesCount = rhiQueryIndices.m_max - rhiQueryIndices.m_min + 1u;
             AZ_Assert((queryIndicesCount % m_queryPool->GetQueriesPerResult()) == 0u,
-                "The amount of RHI::SingleDeviceQuery indices used for the RPI::Query is not a multiple of the number of RHI::Queries required to calculate a single result.");
+                "The amount of RHI::MultiDeviceQuery indices used for the RPI::Query is not a multiple of the number of RHI::Queries required to calculate a single result.");
 
             // Calculate the number of query groups.
             const uint32_t subQueryIndexCount = queryIndicesCount / m_queryPool->GetQueriesPerResult();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
@@ -26,18 +26,18 @@ namespace AZ
 
         RHI::ResultCode TimestampQueryPool::BeginQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
         {
-            AZStd::span<const RHI::Ptr<RHI::SingleDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceQuery> beginQuery = rhiQueryArray[rhiQueryIndices.m_min];
+            AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> beginQuery = rhiQueryArray[rhiQueryIndices.m_min];
 
-            return beginQuery->WriteTimestamp(commandList);
+            return beginQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->WriteTimestamp(commandList);
         }
 
         RHI::ResultCode TimestampQueryPool::EndQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
         {
-            AZStd::span<const RHI::Ptr<RHI::SingleDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceQuery> endQuery = rhiQueryArray[rhiQueryIndices.m_max];
+            AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> endQuery = rhiQueryArray[rhiQueryIndices.m_max];
 
-            return endQuery->WriteTimestamp(commandList);
+            return endQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->WriteTimestamp(commandList);
         }
     };  // Namespace RPI
 };  // Namespace AZ

--- a/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
@@ -15,7 +15,6 @@
 
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/FrameGraph.h>
-#include <Atom/RHI/SingleDeviceQueryPool.h>
 
 #include <AzTest/AzTest.h>
 


### PR DESCRIPTION
## What does this PR do?
This specific PR transitions resources related to `SingleDeviceQuery` to use `MultiDeviceQuery`.
### General Idea
This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a https://github.com/o3de/o3de/pull/14079, however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of ->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex) to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using RHI::MultiDevice::DefaultDeviceIndex everywhere because it simplifies the transition.

## How was this PR tested?
- Gem::Atom_RPI.Tests.main



