### PR TITLE
Asset browser optimizations (changing container types, removing recursion, fixing memory leak)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.cpp
@@ -221,29 +221,33 @@ namespace AzToolsFramework
                 return;
             }
 
-            QModelIndex localParent = mapFromSource(parent);
+            const QModelIndex localParent = mapFromSource(parent);
             emit dataChanged(localParent, localParent);
-            for (int i = 0; i < sourceModel()->rowCount(parent); ++i)
+
+            auto sourceModelPtr = sourceModel();
+            const int rowCount = sourceModelPtr->rowCount(parent);
+            for (int i = 0; i < rowCount; ++i)
             {
-                DataChangedAllSiblings(sourceModel()->index(i, 0, parent));
+                DataChangedAllSiblings(sourceModelPtr->index(i, 0, parent));
             }
         }
 
         void AssetBrowserTreeToTableProxyModel::RowsAboutToBeInserted(const QModelIndex& parent, int start, int end)
         {
-            if (!sourceModel()->hasChildren(parent))
+            auto sourceModelPtr = sourceModel();
+            if (!sourceModelPtr->hasChildren(parent))
             {
-                AZ_Assert(sourceModel()->rowCount(parent) == 0, "Row alredy has children");
+                AZ_Assert(sourceModelPtr->rowCount(parent) == 0, "Row alredy has children");
                 return;
             }
 
             int proxyStart = -1;
 
-            const int rowCount = sourceModel()->rowCount(parent);
+            const int rowCount = sourceModelPtr->rowCount(parent);
 
             if (rowCount > start)
             {
-                const QModelIndex newStart = sourceModel()->index(start, 0, parent);
+                const QModelIndex newStart = sourceModelPtr->index(start, 0, parent);
                 proxyStart = mapFromSource(newStart).row();
             }
             else if (rowCount == 0)
@@ -253,10 +257,10 @@ namespace AzToolsFramework
             else
             {
                 static const int column = 0;
-                QModelIndex idx = sourceModel()->index(rowCount - 1, column, parent);
-                while (sourceModel()->hasChildren(idx) && sourceModel()->rowCount(idx) > 0)
+                QModelIndex idx = sourceModelPtr->index(rowCount - 1, column, parent);
+                while (sourceModelPtr->hasChildren(idx) && sourceModelPtr->rowCount(idx) > 0)
                 {
-                    idx = sourceModel()->index(sourceModel()->rowCount(idx) - 1, column, idx);
+                    idx = sourceModelPtr->index(sourceModelPtr->rowCount(idx) - 1, column, idx);
                 }
                 proxyStart = mapFromSource(idx).row() + 1;
             }
@@ -268,9 +272,10 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeToTableProxyModel::RowsInserted(const QModelIndex& parent, int start, int end)
         {
-            AZ_Assert(sourceModel()->index(start, 0, parent).isValid(), "Index invalid");
+            auto sourceModelPtr = sourceModel();
+            AZ_Assert(sourceModelPtr->index(start, 0, parent).isValid(), "Index invalid");
 
-            const int rowCount = sourceModel()->rowCount(parent);
+            const int rowCount = sourceModelPtr->rowCount(parent);
             const int span = end - start + 1;
 
             if (rowCount == span)
@@ -284,7 +289,7 @@ namespace AzToolsFramework
                 ProcessParents();
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
@@ -298,18 +303,18 @@ namespace AzToolsFramework
 
             if (rowCount == end + 1)
             {
-                const QModelIndex oldIndex = sourceModel()->index(rowCount - 1 - span, column, parent);
+                const QModelIndex oldIndex = sourceModelPtr->index(rowCount - 1 - span, column, parent);
                 AZ_Assert(m_map.TreeContains(oldIndex), "Tree does not contain index");
 
-                const QModelIndex newIndex = sourceModel()->index(rowCount - 1, column, parent);
+                const QModelIndex newIndex = sourceModelPtr->index(rowCount - 1, column, parent);
 
                 QModelIndex indexAbove = oldIndex;
 
                 if (start > 0)
                 {
-                    while (sourceModel()->hasChildren(indexAbove))
+                    while (sourceModelPtr->hasChildren(indexAbove))
                     {
-                        indexAbove = sourceModel()->index(sourceModel()->rowCount(indexAbove) - 1, column, indexAbove);
+                        indexAbove = sourceModelPtr->index(sourceModelPtr->rowCount(indexAbove) - 1, column, indexAbove);
                     }
                 }
 
@@ -324,9 +329,9 @@ namespace AzToolsFramework
 
             for (int row = start; row <= end; ++row)
             {
-                const QModelIndex idx = sourceModel()->index(row, column, parent);
+                const QModelIndex idx = sourceModelPtr->index(row, column, parent);
 
-                if (sourceModel()->hasChildren(idx) && sourceModel()->rowCount(idx) > 0)
+                if (sourceModelPtr->hasChildren(idx) && sourceModelPtr->rowCount(idx) > 0)
                 {
                     m_parents.append(idx);
                 }
@@ -344,7 +349,7 @@ namespace AzToolsFramework
 
             if (start > 0)
             {
-                DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
             }
         }
 
@@ -353,7 +358,6 @@ namespace AzToolsFramework
             m_rowCount = 0;
             m_map.Clear();
             m_parents.clear();
-
             m_parents.append(QModelIndex());
 
             m_processing = true;
@@ -392,13 +396,14 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeToTableProxyModel::RowsAboutToBeRemoved(const QModelIndex& parent, int start, int end)
         {
-            const int proxyStart = mapFromSource(sourceModel()->index(start, 0, parent)).row();
+            auto sourceModelPtr = sourceModel();
+            const int proxyStart = mapFromSource(sourceModelPtr->index(start, 0, parent)).row();
 
             constexpr int column{ 0 };
-            QModelIndex idx = sourceModel()->index(end, column, parent);
-            while (sourceModel()->hasChildren(idx) && sourceModel()->rowCount(idx) > 0)
+            QModelIndex idx = sourceModelPtr->index(end, column, parent);
+            while (sourceModelPtr->hasChildren(idx) && sourceModelPtr->rowCount(idx) > 0)
             {
-                idx = sourceModel()->index(sourceModel()->rowCount(idx) - 1, column, idx);
+                idx = sourceModelPtr->index(sourceModelPtr->rowCount(idx) - 1, column, idx);
             }
             const int proxyEnd = mapFromSource(idx).row();
 
@@ -410,9 +415,10 @@ namespace AzToolsFramework
         QModelIndex AssetBrowserTreeToTableProxyModel::GetFirstDeepest(QAbstractItemModel* model, const QModelIndex& parent, int& count)
         {
             constexpr int column{ 0 };
-            for (int row = 0; row < model->rowCount(parent); ++row)
+            const int rowCount = model->rowCount(parent);
+            for (int row = 0; row < rowCount; ++row)
             {
-                count++;
+                ++count;
                 const QModelIndex child = model->index(row, column, parent);
                 AZ_Assert(child.isValid(), "Child is invalid");
                 if (model->hasChildren(child))
@@ -420,13 +426,14 @@ namespace AzToolsFramework
                     return GetFirstDeepest(model, child, count);
                 }
             }
-            return model->index(model->rowCount(parent) - 1, column, parent);
-        }
 
+            return model->index(rowCount - 1, column, parent);
+        }
 
         void AssetBrowserTreeToTableProxyModel::RowsRemoved(const QModelIndex& parent, int start)
         {
-            const int rowCount = sourceModel()->rowCount(parent);
+            auto sourceModelPtr = sourceModel();
+            const int rowCount = sourceModelPtr->rowCount(parent);
 
             const int proxyStart = m_removePair.first;
             const int proxyEnd = m_removePair.second;
@@ -464,34 +471,34 @@ namespace AzToolsFramework
                 }
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
 
             constexpr int column = 0;
-            const QModelIndex newEnd = sourceModel()->index(rowCount - 1, column, parent);
+            const QModelIndex newEnd = sourceModelPtr->index(rowCount - 1, column, parent);
             if (m_map.Empty())
             {
                 m_map.Insert(newEnd, newEnd.row());
                 endRemoveRows();
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
-            if (sourceModel()->hasChildren(newEnd))
+            if (sourceModelPtr->hasChildren(newEnd))
             {
                 int count = 0;
-                const QModelIndex firstDeepest = GetFirstDeepest(sourceModel(), newEnd, count);
+                const QModelIndex firstDeepest = GetFirstDeepest(sourceModelPtr, newEnd, count);
                 const int firstDeepestProxy = m_map.TreeToTable(firstDeepest);
 
                 m_map.Insert(newEnd, firstDeepestProxy - count);
                 endRemoveRows();
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
@@ -502,8 +509,8 @@ namespace AzToolsFramework
 
                 for (int row = newEnd.row(); row >= 0; --row)
                 {
-                    const QModelIndex newEndSibling = sourceModel()->index(row, column, parent);
-                    if (!sourceModel()->hasChildren(newEndSibling))
+                    const QModelIndex newEndSibling = sourceModelPtr->index(row, column, parent);
+                    if (!sourceModelPtr->hasChildren(newEndSibling))
                     {
                         ++proxyRow;
                     }
@@ -516,7 +523,7 @@ namespace AzToolsFramework
                 endRemoveRows();
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
@@ -533,7 +540,7 @@ namespace AzToolsFramework
                 endRemoveRows();
                 if (start > 0)
                 {
-                    DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                    DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                 }
                 return;
             }
@@ -551,7 +558,7 @@ namespace AzToolsFramework
                     endRemoveRows();
                     if (start > 0)
                     {
-                        DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                        DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
                     }
                     return;
                 }
@@ -600,7 +607,7 @@ namespace AzToolsFramework
 
             if (start > 0)
             {
-                DataChangedAllSiblings(sourceModel()->index(start - 1, 0, parent));
+                DataChangedAllSiblings(sourceModelPtr->index(start - 1, 0, parent));
             }
         }
 
@@ -609,10 +616,11 @@ namespace AzToolsFramework
         {
             LayoutChanged();
 
+            auto sourceModelPtr = sourceModel();
             const QModelIndex index1 = mapFromSource(srcParent);
             const QModelIndex index2 = mapFromSource(destParent);
-            const QModelIndex lastIndex1 = mapFromSource(sourceModel()->index(sourceModel()->rowCount(srcParent) - 1, 0, srcParent));
-            const QModelIndex lastIndex2 = mapFromSource(sourceModel()->index(sourceModel()->rowCount(destParent) - 1, 0, destParent));
+            const QModelIndex lastIndex1 = mapFromSource(sourceModelPtr->index(sourceModelPtr->rowCount(srcParent) - 1, 0, srcParent));
+            const QModelIndex lastIndex2 = mapFromSource(sourceModelPtr->index(sourceModelPtr->rowCount(destParent) - 1, 0, destParent));
             emit dataChanged(index1, lastIndex1);
             if (index1 != index2)
             {
@@ -621,18 +629,19 @@ namespace AzToolsFramework
 
             if (srcStart > 0)
             {
-                DataChangedAllSiblings(sourceModel()->index(srcStart - 1, 0, srcParent));
+                DataChangedAllSiblings(sourceModelPtr->index(srcStart - 1, 0, srcParent));
             }
             if (destStart > 0)
             {
-                DataChangedAllSiblings(sourceModel()->index(destStart - 1, 0, destParent));
+                DataChangedAllSiblings(sourceModelPtr->index(destStart - 1, 0, destParent));
             }
         }
 
         void AssetBrowserTreeToTableProxyModel::ModelReset()
         {
             resetInternalData();
-            if (sourceModel()->hasChildren() && sourceModel()->rowCount() > 0)
+            auto sourceModelPtr = sourceModel();
+            if (sourceModelPtr->hasChildren() && sourceModelPtr->rowCount() > 0)
             {
                 m_parents.append(QModelIndex());
                 ProcessParents();
@@ -683,6 +692,7 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeToTableProxyModel::DataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight)
         {
+            auto sourceModelPtr = sourceModel();
             if (!topLeft.isValid() || !bottomRight.isValid())
             {
                 return;
@@ -692,10 +702,9 @@ namespace AzToolsFramework
 
             for (int i = topRow; i <= bottomRow; ++i)
             {
-                const QModelIndex sourceTopLeft = sourceModel()->index(i, topLeft.column(), topLeft.parent());
-
+                const QModelIndex sourceTopLeft = sourceModelPtr->index(i, topLeft.column(), topLeft.parent());
                 const QModelIndex proxyTopLeft = mapFromSource(sourceTopLeft);
-                const QModelIndex sourceBottomRight = sourceModel()->index(i, bottomRight.column(), bottomRight.parent());
+                const QModelIndex sourceBottomRight = sourceModelPtr->index(i, bottomRight.column(), bottomRight.parent());
                 const QModelIndex proxyBottomRight = mapFromSource(sourceBottomRight);
                 emit dataChanged(proxyTopLeft, proxyBottomRight);
             }
@@ -851,60 +860,52 @@ namespace AzToolsFramework
             auto sourceModelPtr = sourceModel();
             while (!m_parents.isEmpty())
             {
-                QPersistentModelIndexList newPendingParents;
-                for (QPersistentModelIndexList::iterator it = m_parents.begin(); it != m_parents.end();)
+                const QModelIndex sourceParent = m_parents.front();
+                m_parents.pop_front();
+
+                if (!sourceParent.isValid() && m_rowCount > 0)
                 {
-                    const QModelIndex sourceParent = *it;
-                    if (!sourceParent.isValid() && m_rowCount > 0)
-                    {
-                        it = m_parents.erase(it);
-                        continue;
-                    }
-
-                    const int rowCount = sourceModelPtr->rowCount(sourceParent);
-                    if (rowCount == 0)
-                    {
-                        it = m_parents.erase(it);
-                        continue;
-                    }
-
-                    const QPersistentModelIndex sourceIndex = sourceModelPtr->index(rowCount - 1, 0, sourceParent);
-                    const QModelIndex proxyParent = mapFromSource(sourceParent);
-                    const int proxyEndRow = proxyParent.row() + rowCount;
-                    const int proxyStartRow = proxyEndRow - rowCount + 1;
-
-                    if (!m_processing)
-                    {
-                        beginInsertRows(QModelIndex(), proxyStartRow, proxyEndRow);
-                    }
-
-                    UpdateInternalIndices(proxyStartRow, rowCount);
-                    m_map.Insert(sourceIndex, proxyEndRow);
-                    it = m_parents.erase(it);
-                    m_rowCount += rowCount;
-
-                    if (!m_processing)
-                    {
-                        endInsertRows();
-                    }
-
-                    for (int sourceRow = 0; sourceRow < rowCount; ++sourceRow)
-                    {
-                        static const int column = 0;
-                        const QModelIndex child = sourceModelPtr->index(sourceRow, column, sourceParent);
-                        AZ_Assert(child.isValid(), "Child isn't valid");
-
-                        if (sourceModelPtr->hasChildren(child) && sourceModelPtr->rowCount(child) > 0)
-                        {
-                            newPendingParents.append(child);
-                        }
-                    }
+                    continue;
                 }
 
-                m_parents += newPendingParents;
+                const int rowCount = sourceModelPtr->rowCount(sourceParent);
+                if (rowCount == 0)
+                {
+                    continue;
+                }
+
+                const QPersistentModelIndex sourceIndex = sourceModelPtr->index(rowCount - 1, 0, sourceParent);
+                const QModelIndex proxyParent = mapFromSource(sourceParent);
+                const int proxyEndRow = proxyParent.row() + rowCount;
+                const int proxyStartRow = proxyEndRow - rowCount + 1;
+
+                if (!m_processing)
+                {
+                    beginInsertRows(QModelIndex(), proxyStartRow, proxyEndRow);
+                }
+
+                UpdateInternalIndices(proxyStartRow, rowCount);
+                m_map.Insert(sourceIndex, proxyEndRow);
+                m_rowCount += rowCount;
+
+                if (!m_processing)
+                {
+                    endInsertRows();
+                }
+
+                for (int sourceRow = 0; sourceRow < rowCount; ++sourceRow)
+                {
+                    static const int column = 0;
+                    const QModelIndex child = sourceModelPtr->index(sourceRow, column, sourceParent);
+                    AZ_Assert(child.isValid(), "Child isn't valid");
+
+                    if (sourceModelPtr->hasChildren(child) && sourceModelPtr->rowCount(child) > 0)
+                    {
+                        m_parents.append(child);
+                    }
+                }
             }
         }
-
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
@@ -107,7 +107,6 @@ namespace AzToolsFramework
             m_changes.emplace_back(aznew RemoveFileChange(fileId));
         }
 
-
         void AssetEntryChangeset::AddSource(const AZ::Uuid& sourceUuid)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
@@ -28,10 +28,6 @@ namespace AzToolsFramework
 
         AssetEntryChangeset::~AssetEntryChangeset()
         {
-            for (auto change : m_changes)
-            {
-                delete change;
-            }
         }
 
         void AssetEntryChangeset::PopulateEntries()
@@ -73,27 +69,25 @@ namespace AzToolsFramework
 
             // iterate through new changes and try to apply them
             // if application of change fails, try them again next tick
-            AZStd::vector<AssetEntryChange*> changesFailed;
-            for (auto change : m_changes)
+            AZStd::vector<AZStd::shared_ptr<AssetEntryChange>> changesFailed;
+            changesFailed.reserve(m_changes.size());
+
+            for (auto& change : m_changes)
             {
-                if (change->Apply(m_rootEntry))
+                if (!change->Apply(m_rootEntry))
                 {
-                    delete change;
-                }
-                else
-                {
-                    changesFailed.push_back(change);
+                    changesFailed.emplace_back(AZStd::move(change));
                 }
             }
 
 #if AZ_DEBUG_BUILD
-            if (m_changes.size() > 0)
+            if (!m_changes.empty())
             {
                 AZ_TracePrintf("Asset Browser DEBUG", "%d/%d data changes applied\n", m_changes.size() - changesFailed.size(), m_changes.size());
             }
 #endif
             // try again next time.
-            m_changes = changesFailed;
+            AZStd::swap(m_changes, changesFailed);
 
             if (m_rootEntry->IsInitialUpdate())
             {
@@ -104,57 +98,51 @@ namespace AzToolsFramework
         void AssetEntryChangeset::AddFile(const AZ::s64& fileId)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            m_fileIdsToAdd.push_back(fileId);
+            m_fileIdsToAdd.insert(fileId);
         }
 
         void AssetEntryChangeset::RemoveFile(const AZ::s64& fileId)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            m_changes.push_back(aznew RemoveFileChange(fileId));
+            m_changes.emplace_back(aznew RemoveFileChange(fileId));
         }
 
 
         void AssetEntryChangeset::AddSource(const AZ::Uuid& sourceUuid)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            m_sourceUuidsToAdd.push_back(sourceUuid);
+            m_sourceUuidsToAdd.insert(sourceUuid);
         }
 
         void AssetEntryChangeset::RemoveSource(const AZ::Uuid& sourceUuid)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            m_changes.push_back(aznew RemoveSourceChange(sourceUuid));
+            m_changes.emplace_back(aznew RemoveSourceChange(sourceUuid));
         }
 
         void AssetEntryChangeset::AddProduct(const AZ::Data::AssetId& assetId)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            m_productAssetIdsToAdd.push_back(assetId);
+            m_productAssetIdsToAdd.insert(assetId);
         }
 
         void AssetEntryChangeset::RemoveProduct(const AZ::Data::AssetId& assetId)
         {
             AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-            auto findPredicate = [&assetId](const AssetEntryChange* toCheck)
-            {
-                if (const AddProductChange* productChange = azrtti_cast<const AddProductChange*>(toCheck))
-                {
-                    return productChange->GetAssetId() == assetId;
-                }
-
-                return false;
-            };
 
             // make sure any pending "add" commands are erased.
-            m_productAssetIdsToAdd.erase(AZStd::remove(m_productAssetIdsToAdd.begin(), m_productAssetIdsToAdd.end(), assetId), m_productAssetIdsToAdd.end());
-            auto foundExisting = AZStd::find_if(m_changes.begin(), m_changes.end(), findPredicate);
-            if (foundExisting != m_changes.end())
-            {
-                // remove the still-pending "add Product" from the list, no longer necesary.
-                m_changes.erase(foundExisting);
-            }
+            m_productAssetIdsToAdd.erase(assetId);
 
-            m_changes.push_back(aznew RemoveProductChange(assetId));
+            // remove the still-pending "add Product" from the list, no longer necesary.
+            AZStd::erase_if(
+                m_changes,
+                [assetId](const auto& change)
+                {
+                    auto addProductChange = azrtti_cast<AddProductChange*>(change);
+                    return addProductChange && addProductChange->GetAssetId() == assetId;
+                });
+
+            m_changes.emplace_back(aznew RemoveProductChange(assetId));
             
 
         }
@@ -181,19 +169,20 @@ namespace AzToolsFramework
                     {
                         return true;
                     }
-                    m_changes.push_back(aznew AddScanFolderChange(scanFolder));
+
+                    m_changes.emplace_back(aznew AddScanFolderChange(scanFolder));
                     return m_databaseConnection->QueryFilesByScanFolderID(scanFolder.m_scanFolderID,
                         [&](FileDatabaseEntry& file)
                         {
-                            m_changes.push_back(aznew AddFileChange(file));
+                            m_changes.emplace_back(aznew AddFileChange(file));
                             return m_databaseConnection->QuerySourceBySourceNameScanFolderID(file.m_fileName.c_str(), scanFolder.m_scanFolderID,
                                 [&](SourceDatabaseEntry& source)
                                 {
-                                    m_changes.push_back(aznew AddSourceChange({ file.m_fileID, source }));
+                                    m_changes.emplace_back(aznew AddSourceChange({ file.m_fileID, source }));
                                     return m_databaseConnection->QueryProductBySourceID(source.m_sourceID,
                                         [&](ProductDatabaseEntry& product)
                                         {
-                                            m_changes.push_back(aznew AddProductChange({ source.m_sourceGuid, product }));
+                                            m_changes.emplace_back(aznew AddProductChange({ source.m_sourceGuid, product }));
                                             return true;
                                         });
                                 });
@@ -209,18 +198,15 @@ namespace AzToolsFramework
         {
             using namespace AssetDatabase;
 
-            AZStd::vector<AZ::s64> fileIdsToAdd;
-            AZStd::vector<AZ::Uuid> sourceUuidsToAdd;
-            AZStd::vector<AZ::Data::AssetId> productAssetIdsToAdd;
+            AZStd::unordered_set<AZ::s64> fileIdsToAdd;
+            AZStd::unordered_set<AZ::Uuid> sourceUuidsToAdd;
+            AZStd::unordered_set<AZ::Data::AssetId> productAssetIdsToAdd;
 
             {
                 AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-                fileIdsToAdd = AZStd::move(m_fileIdsToAdd);
-                m_fileIdsToAdd.clear();
-                sourceUuidsToAdd = AZStd::move(m_sourceUuidsToAdd);
-                m_sourceUuidsToAdd.clear();
-                productAssetIdsToAdd = AZStd::move(m_productAssetIdsToAdd);
-                m_productAssetIdsToAdd.clear();
+                AZStd::swap(fileIdsToAdd, m_fileIdsToAdd);
+                AZStd::swap(sourceUuidsToAdd, m_sourceUuidsToAdd);
+                AZStd::swap(productAssetIdsToAdd, m_productAssetIdsToAdd);
             }
 
             for (const AZ::s64& fileId : fileIdsToAdd)
@@ -235,7 +221,7 @@ namespace AzToolsFramework
                                 if (!scanFolder.m_isRoot)
                                 {
                                     AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-                                    m_changes.push_back(aznew AddFileChange(file));
+                                    m_changes.emplace_back(aznew AddFileChange(file));
                                 }
                                 return true;
                             });
@@ -244,16 +230,13 @@ namespace AzToolsFramework
 
             for (const AZ::Data::AssetId& assetId : productAssetIdsToAdd)
             {
-                if (AZStd::find(sourceUuidsToAdd.begin(), sourceUuidsToAdd.end(), assetId.m_guid) == sourceUuidsToAdd.end())
-                {
-                    sourceUuidsToAdd.push_back(assetId.m_guid);
-                }
+                sourceUuidsToAdd.insert(assetId.m_guid);
 
                 m_databaseConnection->QueryProductBySourceGuidSubID(assetId.m_guid, assetId.m_subId,
                     [&](ProductDatabaseEntry& product)
                     {
                         AZStd::lock_guard<AZStd::mutex> locker(m_mutex);
-                        m_changes.push_back(aznew AddProductChange({ assetId.m_guid, product }));
+                        m_changes.emplace_back(aznew AddProductChange({ assetId.m_guid, product }));
                         return true;
                     });
             }
@@ -273,23 +256,18 @@ namespace AzToolsFramework
                                         // ignore scanfolders that are non-recursive (e.g. dev folder), as they are used generally for system assets
                                         if (!scanFolder.m_isRoot)
                                         {
-                                            m_changes.push_back(new AddSourceChange({ file.m_fileID, source }));
+                                            m_changes.emplace_back(new AddSourceChange({ file.m_fileID, source }));
                                         }
                                         else
                                         {
                                             // if products belonging to entry in root folder are considered, remove them from changes
-                                            m_changes.erase(AZStd::remove_if(m_changes.begin(), m_changes.end(),
-                                                        [sourceUuid](AssetEntryChange* change)
-                                                        {
-                                                            auto addProductChange = azrtti_cast<AddProductChange*>(change);
-                                                            if (addProductChange && addProductChange->GetUuid() == sourceUuid)
-                                                            {
-                                                                delete change;
-                                                                return true;
-                                                            }
-                                                            return false;
-                                                        }),
-                                                    m_changes.end());
+                                            AZStd::erase_if(
+                                                m_changes,
+                                                [sourceUuid](const auto& change)
+                                                {
+                                                    auto addProductChange = azrtti_cast<AddProductChange*>(change);
+                                                    return addProductChange && addProductChange->GetUuid() == sourceUuid;
+                                                });
                                         }
                                         return true;
                                     });

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.h
@@ -58,11 +58,10 @@ namespace AzToolsFramework
             AZStd::atomic_bool m_fullUpdate;
             bool m_updated;
 
-            AZStd::vector<AssetEntryChange*> m_changes;
-
-            AZStd::vector<AZ::s64> m_fileIdsToAdd;
-            AZStd::vector<AZ::Uuid> m_sourceUuidsToAdd;
-            AZStd::vector<AZ::Data::AssetId> m_productAssetIdsToAdd;
+            AZStd::vector<AZStd::shared_ptr<AssetEntryChange>> m_changes;
+            AZStd::unordered_set<AZ::s64> m_fileIdsToAdd;
+            AZStd::unordered_set<AZ::Uuid> m_sourceUuidsToAdd;
+            AZStd::unordered_set<AZ::Data::AssetId> m_productAssetIdsToAdd;
 
             AZStd::string m_relativePath;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
+#include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
@@ -32,6 +33,11 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
+        inline QString AzToQtUtf8String(AZStd::string_view str)
+        {
+            return QString::fromUtf8(str.data(), static_cast<int>(str.size()));
+        }
+
         RootAssetBrowserEntry::RootAssetBrowserEntry()
             : AssetBrowserEntry()
         {
@@ -111,7 +117,7 @@ namespace AzToolsFramework
                     return;
                 }
 
-                scanFolder = CreateFolders(scanFolderDetailsIt->second.c_str(), this, true);
+                scanFolder = CreateFolders(scanFolderDetailsIt->second, this, true);
                 entryCache->m_scanFolderIdMap[fileDatabaseEntry.m_scanFolderPK] = scanFolder;
             }
             else
@@ -146,7 +152,7 @@ namespace AzToolsFramework
                 auto source = aznew SourceAssetBrowserEntry();
                 source->m_name = absoluteFilePath.Filename().Native();
                 source->m_fileId = fileDatabaseEntry.m_fileID;
-                source->m_displayName = QString::fromUtf8(source->m_name.c_str());
+                source->m_displayName = AzToQtUtf8String(source->m_name);
                 source->m_scanFolderId = fileDatabaseEntry.m_scanFolderPK;
                 source->m_extension = absoluteFilePath.Extension().Native();
                 source->m_diskSize = AZ::IO::SystemFile::Length(absoluteFilePath.c_str());
@@ -320,6 +326,7 @@ namespace AzToolsFramework
             AZ::IO::Path pathFromDatabase(productWithUuidDatabaseEntry.second.m_productName.c_str());
             AZ::IO::PathView cleanedRelative = pathFromDatabase.RelativePath();
             AZ::IO::FixedMaxPath storageForLexicallyRelative{};
+
             // remove the first element from the path if you can:
             if (!cleanedRelative.empty())
             {
@@ -329,25 +336,18 @@ namespace AzToolsFramework
             product->m_relativePath = cleanedRelative;
             product->m_visiblePath = cleanedRelative;
             product->SetFullPath((AZ::IO::Path("@products@") / cleanedRelative).LexicallyNormal());
+
             // compute the display data from the above data.
             // does someone have information about a more friendly name for this type?
             AZStd::string assetTypeName;
             AZ::AssetTypeInfoBus::EventResult(
                 assetTypeName, productWithUuidDatabaseEntry.second.m_assetType, &AZ::AssetTypeInfo::GetAssetTypeDisplayName);
 
-            AZStd::string displayName;
-            if (!assetTypeName.empty())
-            {
-                // someone has more friendly data - use the friendly name
-                displayName = AZStd::string::format("%s (%s)", productName.c_str(), assetTypeName.c_str());
-            }
-            else
-            {
-                // just use the product name (with extension)
-                displayName = product->m_name; 
-            }
-            product->m_displayName = QString::fromUtf8(displayName.c_str());
-            product->m_displayPath = QString::fromUtf8(AZ::IO::Path(cleanedRelative.ParentPath()).c_str());
+            // Create a display name for the product that includes the asset type name, if it is available.
+            product->m_displayName = AzToQtUtf8String(
+                !assetTypeName.empty() ? AZStd::string::format("%s (%s)", productName.c_str(), assetTypeName.c_str()) : product->m_name);
+
+            product->m_displayPath = AzToQtUtf8String(AZ::IO::Path(cleanedRelative.ParentPath()).Native());
             entryCache->m_productAssetIdMap[assetId] = product;
 
             if (needsAdd)
@@ -362,15 +362,14 @@ namespace AzToolsFramework
         void RootAssetBrowserEntry::RemoveProduct(const AZ::Data::AssetId& assetId) const
         {
             auto entryCache = EntryCache::GetInstance();
-            const auto itProduct = entryCache->m_productAssetIdMap.find(assetId);
-            if (itProduct == entryCache->m_productAssetIdMap.end())
+            if (const auto itProduct = entryCache->m_productAssetIdMap.find(assetId); itProduct != entryCache->m_productAssetIdMap.end())
             {
-                return;
+                if (auto parent = itProduct->second->GetParent())
+                {
+                    parent->RemoveChild(itProduct->second);
+                }
             }
-            if (auto parent = itProduct->second->GetParent())
-            {
-                parent->RemoveChild(itProduct->second);
-            }
+
         }
 
         AssetBrowserEntry* RootAssetBrowserEntry::GetNearestAncestor(AZ::IO::PathView absolutePathView, AssetBrowserEntry* parent,
@@ -420,19 +419,16 @@ namespace AzToolsFramework
         {
             auto it = AZStd::find_if(parent->m_children.begin(), parent->m_children.end(), [folderName](AssetBrowserEntry* entry)
             {
-                if (!azrtti_istypeof<FolderAssetBrowserEntry*>(entry))
-                {
-                    return false;
-                }
-                return AZ::IO::PathView(entry->m_name) == AZ::IO::PathView(folderName);
+                return azrtti_istypeof<FolderAssetBrowserEntry*>(entry) && AZ::IO::PathView(entry->m_name) == AZ::IO::PathView(folderName);
             });
             if (it != parent->m_children.end())
             {
                 return azrtti_cast<FolderAssetBrowserEntry*>(*it);
             }
-            const auto folder = aznew FolderAssetBrowserEntry();
+
+            auto folder = aznew FolderAssetBrowserEntry();
             folder->m_name = folderName;
-            folder->m_displayName = QString::fromUtf8(folderName.data(), aznumeric_caster(folderName.size()));
+            folder->m_displayName = AzToQtUtf8String(folderName);
             folder->m_isScanFolder = isScanFolder;
             parent->AddChild(folder);
             folder->m_isGemFolder = m_gemNames.contains(folder->GetFullPath());
@@ -473,7 +469,7 @@ namespace AzToolsFramework
             }
 
             // create all missing folders
-            auto proximateToPath = absolutePathView.IsRelativeTo(parent->m_fullPath)
+            const auto proximateToPath = absolutePathView.IsRelativeTo(parent->m_fullPath)
                 ? absolutePathView.LexicallyProximate(parent->m_fullPath)
                 : AZ::IO::FixedMaxPath(absolutePathView);
 
@@ -483,7 +479,7 @@ namespace AzToolsFramework
                 constructor = constructor / scanFolderSegment;
                 // if this is the final segment, and we are in a scan folder, this represents the actual scan folder.
                 bool isTheScanFolder = isScanFolder && (constructor == proximateToPath);
-                parent = CreateFolder(scanFolderSegment.c_str(), parent, isTheScanFolder);
+                parent = CreateFolder(scanFolderSegment.Native(), parent, isTheScanFolder);
             }
 
             return parent;


### PR DESCRIPTION
## What does this PR do?

Users with large asset databases have had issues with long startup times in the main editor. Profiling has shown that the bottlenecks lie in the asset browser views and models synchronizing/populating and reflecting changes as assets are added and removed.

Most of the time was spent in the following functions
AssetEntryChangeset::Synchronize
AssetBrowserTreeToTableProxyModel::ProcessParents 

These changes add some high level optimizations, caching various values, replacing vectors and linear searches with unordered sets, removing seemingly unnecessary recursion, and other changes.

We should continue exploring options to remove or replace AssetBrowserTreeToTableProxyModel. The largest stall occurs initializing this class after the main asset browser model has been initialized. From what I can tell, AssetBrowserTreeToTableProxyModel Is only used for converting and displaying the asset browser tree model as a flat table when the user enters text in the search text field and the asset browser is in table view mode. Currently looking into adapting QSortFilterProxyModel instead.

## How was this PR tested?

Searching for performance bottlenecks using the visual studio profiler
Testing for consistent behavior loading multiplayer sample, which is the largest publicly available project.
Will run automated tests with AR.