### PR TITLE
Fix performance drop caused by updating material component previews every time the asset load notification is received

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
@@ -26,8 +26,7 @@ namespace AZ
         Data::Instance<AttachmentImage> AttachmentImage::FindOrCreate(const Data::Asset<AttachmentImageAsset>& imageAsset)
         {
             return Data::InstanceDatabase<AttachmentImage>::Instance().FindOrCreate(
-                Data::InstanceId::CreateFromAssetId(imageAsset.GetId()),
-                imageAsset);
+                Data::InstanceId::CreateFromAsset(imageAsset), imageAsset);
         }
 
         Data::Instance<AttachmentImage> AttachmentImage::Create(
@@ -51,11 +50,10 @@ namespace AZ
         {
             Data::Asset<AttachmentImageAsset> imageAsset;
 
-            AZ::Uuid uuid;
+            Data::InstanceId instanceId;
             if (createImageRequest.m_isUniqueName)
             {
-                uuid = Uuid::CreateName(createImageRequest.m_imageName.GetCStr());
-                Data::InstanceId instanceId = Data::InstanceId::CreateFromAssetId(uuid);
+                instanceId = Data::InstanceId::CreateName(createImageRequest.m_imageName.GetCStr());
                 if (Data::InstanceDatabase<AttachmentImage>::Instance().Find(instanceId))
                 {
                     AZ_Error("AttchmentImage", false, "AttachmentImage with an unique name '%s' was already created", createImageRequest.m_imageName.GetCStr());
@@ -64,11 +62,11 @@ namespace AZ
             }
             else
             {
-                uuid = Uuid::CreateRandom();
+                instanceId = Data::InstanceId::CreateRandom();
             }
 
             AttachmentImageAssetCreator imageAssetCreator;
-            imageAssetCreator.Begin(uuid);
+            imageAssetCreator.Begin(instanceId.GetGuid());
             imageAssetCreator.SetImageDescriptor(createImageRequest.m_imageDescriptor);
             imageAssetCreator.SetPoolAsset({createImageRequest.m_imagePool->GetAssetId(), azrtti_typeid<ResourcePoolAsset>()});
 
@@ -86,7 +84,7 @@ namespace AZ
 
             if (imageAssetCreator.End(imageAsset))
             {
-                return AttachmentImage::FindOrCreate(imageAsset);
+                return Data::InstanceDatabase<AttachmentImage>::Instance().FindOrCreate(instanceId, imageAsset);
             }
 
             return nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -305,7 +305,7 @@ namespace AZ
 
             auto systemAttachmentImage = RPI::AttachmentImage::Create(createImageRequest);
             m_systemAttachmentImages[format] = systemAttachmentImage;
-            return systemAttachmentImage;
+            return m_systemAttachmentImages[format];
         }
 
         bool ImageSystem::RegisterAttachmentImage(AttachmentImage* attachmentImage)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -305,7 +305,7 @@ namespace AZ
 
             auto systemAttachmentImage = RPI::AttachmentImage::Create(createImageRequest);
             m_systemAttachmentImages[format] = systemAttachmentImage;
-            return m_systemAttachmentImages[format];
+            return systemAttachmentImage;
         }
 
         bool ImageSystem::RegisterAttachmentImage(AttachmentImage* attachmentImage)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -29,8 +29,7 @@ namespace AZ
         Data::Instance<StreamingImage> StreamingImage::FindOrCreate(const Data::Asset<StreamingImageAsset>& streamingImageAsset)
         {
             return Data::InstanceDatabase<StreamingImage>::Instance().FindOrCreate(
-                Data::InstanceId::CreateFromAssetId(streamingImageAsset.GetId()),
-                streamingImageAsset);
+                Data::InstanceId::CreateFromAsset(streamingImageAsset), streamingImageAsset);
         }
 
         Data::Instance<StreamingImage> StreamingImage::CreateFromCpuData(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -450,11 +450,6 @@ namespace AZ
             }
         }
 
-        void EditorMaterialComponentSlot::OnAssetReady(Data::Asset<Data::AssetData> asset)
-        {
-            UpdatePreview();
-        }
-
         void EditorMaterialComponentSlot::OnAssetReloaded(Data::Asset<Data::AssetData> asset)
         {
             UpdatePreview();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -102,7 +102,6 @@ namespace AZ
                 const AZ::EntityId& entityId, const AZ::Render::MaterialAssignmentId& materialAssignmentId, const QPixmap& pixmap) override;
 
             //! AZ::Data::AssetBus::Handler overrides...
-            void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
             void OnAssetReloaded(Data::Asset<Data::AssetData> asset) override;
 
             void UpdatePreview() const;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -908,9 +908,7 @@ namespace AZ
 
         void DiffuseProbeGridFeatureProcessor::OnVisualizationModelAssetReady(Data::Asset<Data::AssetData> asset)
         {
-            Data::Asset<RPI::ModelAsset> modelAsset = asset;
-
-            m_visualizationModel = RPI::Model::FindOrCreate(modelAsset);
+            m_visualizationModel = RPI::Model::FindOrCreate(asset);
             AZ_Assert(m_visualizationModel.get(), "Failed to load DiffuseProbeGrid visualization model");
             if (!m_visualizationModel)
             {


### PR DESCRIPTION
## What does this PR do?

This change addresses a recently reported performance drop and memory leak that was introduced after material, hot reloading, and instance id changes were merged into the development branch. The main problem causing the slowdown in leak was introduced by changes to the editor material component, trying to compensate for an older bug where the DPE was not refreshing material component previews. The on asset ready handler was getting triggered and handled several times, by several different entities referencing the same materials, updating their own previews even though they weren’t being displayed. The handler was removed, as it was not required by the RPE and does not seem to be required any more by the DPE on the point released branch.

Other fixes include making sure attachment images are created and added using the same instance id.

Fixes https://github.com/o3de/o3de/issues/17009
Should also resolve after additional testing on Linux https://github.com/o3de/o3de/issues/17102

## How was this PR tested?

Tested loading multiplayer sample and the warehouse scene before and after changes. Before changes, all scenes loaded with significantly reduced frame rate and stuttering. Over time, the frame rate improved and the stuttering disappeared, which was reflected in the IMGUI profiler with gaps between blocks of rendering calls that would slowly shrink over time.

After changes were applied, loading all test data levels immediately jumps to 60FPS and runs smoothly without stuttering.
