### PR TITLE
DPE Inspector support for IndexedChildNameLabelOverride

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -73,6 +73,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         system->RegisterNodeAttribute<PropertyEditor>(Container::RemoveNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ClearNotify);
         system->RegisterNodeAttribute<PropertyEditor>(Container::ContainerCanBeModified);
+        system->RegisterNodeAttribute<PropertyEditor>(Container::IndexedChildNameLabelOverride);
 
         system->RegisterPropertyEditor<UIElement>();
         system->RegisterNodeAttribute<UIElement>(UIElement::Handler);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -116,6 +116,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
         static constexpr auto RemoveNotify = CallbackAttributeDefinition<void(size_t index)>("RemoveNotify");
         static constexpr auto ClearNotify = CallbackAttributeDefinition<void()>("ClearNotify");
         static constexpr auto ContainerCanBeModified = AttributeDefinition<bool>("ContainerCanBeModified");
+        static constexpr auto IndexedChildNameLabelOverride = CallbackAttributeDefinition<AZStd::string(size_t index)>("IndexedChildNameLabelOverride");
     };
 
     //! PropertyEditor: A property editor, of a type dictated by its "type" field,

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1053,7 +1053,7 @@ namespace AZ::Reflection
                                 return labelAttributeBuffer;
                             }
                         }
-                        else if (dataContainer->IsSequenceContainer())
+                        if (dataContainer->IsSequenceContainer())
                         {
                             // Only add a numeric label for sequence containers
                             labelAttributeBuffer = AZStd::fixed_string<128>::format("[%zu]", parentNode.m_childElementIndex);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1038,14 +1038,14 @@ namespace AZ::Reflection
                     AZ::Serialize::IDataContainer* dataContainer = parentNode.m_classData ? parentNode.m_classData->m_container : nullptr;
                     if (dataContainer)
                     {
-                        if (auto indexedChildeOverride = Find(
+                        if (auto indexedChildOverride = Find(
                                 AZ::Name(nodeData.m_group),
                                 DocumentPropertyEditor::Nodes::Container::IndexedChildNameLabelOverride.GetName(),
                                 parentNode);
-                            indexedChildeOverride)
+                            indexedChildOverride)
                         {
                             auto retrievedName = DocumentPropertyEditor::Nodes::Container::IndexedChildNameLabelOverride.InvokeOnDomValue(
-                                *indexedChildeOverride, parentNode.m_childElementIndex);
+                                *indexedChildOverride, parentNode.m_childElementIndex);
 
                             if (retrievedName.IsSuccess())
                             {


### PR DESCRIPTION
## What does this PR do?
- Implements support for IndexedChildNameLabelOverride
- const correct Find() so that it can be used from const functions
- Fixes #16058 

## How was this PR tested?
Locally in the Editor project