### PR TITLE
Fix duplicate FileProcessor::AssessAddedFile call

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1524,9 +1524,8 @@ bool ApplicationManagerBase::Activate()
 
     auto notifyUuidManagerAndFileProcessor = [this](QString changedFile)
     {
-        // these are not necessarily time sensitive.
+        // this is not necessarily time sensitive.
         m_uuidManager->FileChanged(changedFile.toUtf8().constData());
-        m_fileProcessor->AssessAddedFile(changedFile);
     };
 
     QObject::connect(


### PR DESCRIPTION
## What does this PR do?

When the threading gods are angry `FileProcessor::AssessAddedFile()` can get called on the Main thread via `notifyUuidManagerAndFileProcessor` and Qt thread from `FileWatcher::fileAdded` resulting in a [lockup in sqlite3 trying to insert the same file](https://github.com/o3de/o3de/issues/17097).  This usually repros on the first run when there are lots of assets and there is a higher likelihood of encountering the race condition.

Fixes https://github.com/o3de/o3de/issues/17097

This code was part of an optimization in https://github.com/o3de/o3de/pull/12654

I'm not 100% certain there may be some case where a modified file needs to have FileAdded called again to fix up some intermediate assets, please comment if you can think of a test case for this.

## How was this PR tested?

- ran AssetProcessor to build all products in Carbonated game (15k assets) and AssetProcessor unit tests (passed).
