### PR TITLE
Exclude .git, Gems and remove legacy .cdf

### DIFF
--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -206,7 +206,7 @@
                 "Exclude Install": {
                     "glob": "install/*"
                 },
-                // Exlude Gems inside Projects, their Assets folders will still be included
+                // Exclude Gems inside Projects, their Assets folders will still be included
                 "Exclude Gems": {
                     "glob": "Gems/*"
                 },

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -206,6 +206,14 @@
                 "Exclude Install": {
                     "glob": "install/*"
                 },
+                // Exlude Gems inside Projects, their Assets folders will still be included
+                "Exclude Gems": {
+                    "glob": "Gems/*"
+                },
+                // Exclude the .git folder which is commonly found in projects
+                "Exclude Git": {
+                    "glob": ".git/*"
+                },
 
                 //------------------------------------------------------------------------------
                 // Copying Files Automatically Into the Cache
@@ -329,11 +337,6 @@
                 "RC bspace": {
                     "glob": "*.bspace",
                     "params": "copy"
-                },
-                "RC cdf": {
-                    "glob": "*.cdf",
-                    "params": "copy",
-                    "productAssetType": "{DF036C63-9AE6-4AC3-A6AC-8A1D76126C01}"
                 },
                 "RC comb": {
                     "glob": "*.comb",


### PR DESCRIPTION
## What does this PR do?

This change removes the legacy .cdf character format which no longer exists.  It also excludes a couple common folders that can add thousands of files to the AssetProcessor.

When examining the Sqlite database for the Carbonated project I noticed it included files in the `.git` and `Gems` folders.  The `.git` folder is common with projects stored in Git and the `Gems` folder is common for projects that include gems inside their project. 
 Excluding these two folders excluded 5k+ files in the Carbonated project and decreased the database size from 70mb to 40mb.

Now, if the `Gems` folder thing seems to dangerous for existing projects - we can move that setting into project templates so it only applies to new projects.  Of course in the long run we want to use a single `Assets` folder inside the project to avoid the need for these exclusions.

## How was this PR tested?

- Ran AP in Carbonated project with 15k assets
