### PR TITLE
Adding missing image conversions

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2337,7 +2337,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::BaseColor;
-                            subMesh.m_baseColorImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
+                            subMesh.m_baseColorImageView = image->GetImageView();
                             baseColorImage = image;
                         }
                     }
@@ -2349,7 +2349,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Normal;
-                            subMesh.m_normalImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
+                            subMesh.m_normalImageView = image->GetImageView();
                         }
                     }
 
@@ -2360,7 +2360,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Metallic;
-                            subMesh.m_metallicImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
+                            subMesh.m_metallicImageView = image->GetImageView();
                         }
                     }
 
@@ -2371,7 +2371,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Roughness;
-                            subMesh.m_roughnessImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
+                            subMesh.m_roughnessImageView = image->GetImageView();
                         }
                     }
 
@@ -2382,7 +2382,7 @@ namespace AZ
                         if (image.get())
                         {
                             subMesh.m_textureFlags |= RayTracingSubMeshTextureFlags::Emissive;
-                            subMesh.m_emissiveImageView = image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex);
+                            subMesh.m_emissiveImageView = image->GetImageView();
                         }
                     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -255,17 +255,17 @@ namespace AZ
                 materialInfo.m_textureStartIndex = m_materialTextureIndices.AddEntry(
                 {
 #if USE_BINDLESS_SRG
-                    subMesh.m_baseColorImageView.get() ? subMesh.m_baseColorImageView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_normalImageView.get() ? subMesh.m_normalImageView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_metallicImageView.get() ? subMesh.m_metallicImageView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_roughnessImageView.get() ? subMesh.m_roughnessImageView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_emissiveImageView.get() ? subMesh.m_emissiveImageView->GetBindlessReadIndex() : InvalidIndex
+                    subMesh.m_baseColorImageView.get() ? subMesh.m_baseColorImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_normalImageView.get() ? subMesh.m_normalImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_metallicImageView.get() ? subMesh.m_metallicImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_roughnessImageView.get() ? subMesh.m_roughnessImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_emissiveImageView.get() ? subMesh.m_emissiveImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex
 #else
-                    m_materialTextures.AddResource(subMesh.m_baseColorImageView.get()),
-                    m_materialTextures.AddResource(subMesh.m_normalImageView.get()),
-                    m_materialTextures.AddResource(subMesh.m_metallicImageView.get()),
-                    m_materialTextures.AddResource(subMesh.m_roughnessImageView.get()),
-                    m_materialTextures.AddResource(subMesh.m_emissiveImageView.get())
+                    m_materialTextures.AddResource(subMesh.m_baseColorImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
+                    m_materialTextures.AddResource(subMesh.m_normalImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
+                    m_materialTextures.AddResource(subMesh.m_metallicImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
+                    m_materialTextures.AddResource(subMesh.m_roughnessImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
+                    m_materialTextures.AddResource(subMesh.m_emissiveImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get())
 #endif
                 });
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -125,11 +125,11 @@ namespace AZ
                 RayTracingSubMeshTextureFlags m_textureFlags = RayTracingSubMeshTextureFlags::None;
 
                 // material textures
-                RHI::Ptr<const RHI::SingleDeviceImageView> m_baseColorImageView;
-                RHI::Ptr<const RHI::SingleDeviceImageView> m_normalImageView;
-                RHI::Ptr<const RHI::SingleDeviceImageView> m_metallicImageView;
-                RHI::Ptr<const RHI::SingleDeviceImageView> m_roughnessImageView;
-                RHI::Ptr<const RHI::SingleDeviceImageView> m_emissiveImageView;
+                RHI::Ptr<const RHI::MultiDeviceImageView> m_baseColorImageView;
+                RHI::Ptr<const RHI::MultiDeviceImageView> m_normalImageView;
+                RHI::Ptr<const RHI::MultiDeviceImageView> m_metallicImageView;
+                RHI::Ptr<const RHI::MultiDeviceImageView> m_roughnessImageView;
+                RHI::Ptr<const RHI::MultiDeviceImageView> m_emissiveImageView;
 
                 // parent mesh
                 Mesh* m_mesh = nullptr;

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -756,17 +756,17 @@ void CDraw2d::DeferredQuad::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
+        imageView = image->GetImageView();
     }
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
     }
 
     // Set projection matrix
@@ -817,17 +817,17 @@ void CDraw2d::DeferredLine::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
+        imageView = image->GetImageView();
     }
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
     }
 
     // Set projection matrix
@@ -893,17 +893,17 @@ void CDraw2d::DeferredRectOutline::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
 
     // Set texture
-    const auto* imageView = m_image ? m_image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
+    const auto* imageView = m_image ? m_image->GetImageView() : nullptr;
     if (!imageView)
     {
         // Default to white texture
         auto image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-        imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
+        imageView = image->GetImageView();
     }
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
     }
 
     // Set projection matrix


### PR DESCRIPTION
## What does this PR do?

This commit fixes some instances where `Image`-related resources where missed during the conversion step (https://github.com/o3de/o3de/pull/17040) from single to multi device versions.

## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`
