### PR TITLE
Missing image/buffer resources in ModelLod

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
@@ -43,7 +43,7 @@ namespace AZ
             struct SrgNameViewPair
             {
                 Name m_srgName;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_bufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_bufferView;
             };
 
             //! Inputs to the skinning compute shader and their corresponding srg names
@@ -107,7 +107,7 @@ namespace AZ
 
         private:
             RHI::BufferViewDescriptor CreateInputViewDescriptor(
-                SkinnedMeshInputVertexStreams inputStream, RHI::Format elementFormat, const RHI::SingleDeviceStreamBufferView& streamBufferView);
+                SkinnedMeshInputVertexStreams inputStream, RHI::Format elementFormat, const RHI::MultiDeviceStreamBufferView& streamBufferView);
             
             using HasInputStreamArray = AZStd::array<bool, static_cast<uint8_t>(SkinnedMeshInputVertexStreams::NumVertexStreams)>;
             HasInputStreamArray CreateInputBufferViews(

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2170,26 +2170,26 @@ namespace AZ
                 // occupy a portion of the vertex buffer.  This is necessary since we are accessing it using
                 // a ByteAddressBuffer in the raytracing shaders and passing the byte offset to the shader in a constant buffer.
                 uint32_t positionBufferByteCount = static_cast<uint32_t>(
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetDescriptor().m_byteCount);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor positionBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, positionBufferByteCount);
 
                 uint32_t normalBufferByteCount = static_cast<uint32_t>(
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetDescriptor().m_byteCount);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor normalBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, normalBufferByteCount);
 
                 uint32_t tangentBufferByteCount = static_cast<uint32_t>(
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetDescriptor().m_byteCount);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor tangentBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, tangentBufferByteCount);
 
                 uint32_t bitangentBufferByteCount = static_cast<uint32_t>(
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetDescriptor().m_byteCount);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor bitangentBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, bitangentBufferByteCount);
 
                 uint32_t uvBufferByteCount = static_cast<uint32_t>(
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetDescriptor().m_byteCount);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor uvBufferDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, uvBufferByteCount);
 
-                const RHI::SingleDeviceIndexBufferView& indexBufferView = mesh.m_indexBufferView;
+                const RHI::MultiDeviceIndexBufferView& indexBufferView = mesh.m_indexBufferView;
                 uint32_t indexElementSize = indexBufferView.GetIndexFormat() == RHI::IndexFormat::Uint16 ? 2 : 4;
                 uint32_t indexElementCount = (uint32_t)indexBufferView.GetBuffer()->GetDescriptor().m_byteCount / indexElementSize;
                 RHI::BufferViewDescriptor indexBufferDescriptor;
@@ -2203,12 +2203,12 @@ namespace AZ
                 subMesh.m_positionFormat = PositionStreamFormat;
                 subMesh.m_positionVertexBufferView = streamBufferViews[0];
                 subMesh.m_positionShaderBufferView =
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[0].GetBuffer())->GetBufferView(positionBufferDescriptor);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[0].GetBuffer())->BuildBufferView(positionBufferDescriptor);
 
                 subMesh.m_normalFormat = NormalStreamFormat;
                 subMesh.m_normalVertexBufferView = streamBufferViews[1];
                 subMesh.m_normalShaderBufferView =
-                    const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[1].GetBuffer())->GetBufferView(normalBufferDescriptor);
+                    const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[1].GetBuffer())->BuildBufferView(normalBufferDescriptor);
 
                 if (tangentBufferByteCount > 0)
                 {
@@ -2216,7 +2216,7 @@ namespace AZ
                     subMesh.m_tangentFormat = TangentStreamFormat;
                     subMesh.m_tangentVertexBufferView = streamBufferViews[2];
                     subMesh.m_tangentShaderBufferView =
-                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[2].GetBuffer())->GetBufferView(tangentBufferDescriptor);
+                        const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[2].GetBuffer())->BuildBufferView(tangentBufferDescriptor);
                 }
 
                 if (bitangentBufferByteCount > 0)
@@ -2225,7 +2225,7 @@ namespace AZ
                     subMesh.m_bitangentFormat = BitangentStreamFormat;
                     subMesh.m_bitangentVertexBufferView = streamBufferViews[3];
                     subMesh.m_bitangentShaderBufferView =
-                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[3].GetBuffer())->GetBufferView(bitangentBufferDescriptor);
+                        const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[3].GetBuffer())->BuildBufferView(bitangentBufferDescriptor);
                 }
 
                 if (uvBufferByteCount > 0)
@@ -2234,12 +2234,12 @@ namespace AZ
                     subMesh.m_uvFormat = UVStreamFormat;
                     subMesh.m_uvVertexBufferView = streamBufferViews[4];
                     subMesh.m_uvShaderBufferView =
-                        const_cast<RHI::SingleDeviceBuffer*>(streamBufferViews[4].GetBuffer())->GetBufferView(uvBufferDescriptor);
+                        const_cast<RHI::MultiDeviceBuffer*>(streamBufferViews[4].GetBuffer())->BuildBufferView(uvBufferDescriptor);
                 }
 
                 subMesh.m_indexBufferView = mesh.m_indexBufferView;
                 subMesh.m_indexShaderBufferView =
-                    const_cast<RHI::SingleDeviceBuffer*>(mesh.m_indexBufferView.GetBuffer())->GetBufferView(indexBufferDescriptor);
+                    const_cast<RHI::MultiDeviceBuffer*>(mesh.m_indexBufferView.GetBuffer())->BuildBufferView(indexBufferDescriptor);
 
                 // add material data
                 if (material)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -165,8 +165,8 @@ namespace AZ
                 blasDescriptor.Build()
                     ->Geometry()
                         ->VertexFormat(subMesh.m_positionFormat)
-                        ->VertexBuffer(subMesh.m_positionVertexBufferView)
-                        ->IndexBuffer(subMesh.m_indexBufferView)
+                        ->VertexBuffer(subMesh.m_positionVertexBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex))
+                        ->IndexBuffer(subMesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex))
                         ->BuildFlags(buildFlags)
                 ;
 
@@ -222,12 +222,12 @@ namespace AZ
                 meshInfo.m_bufferStartIndex = m_meshBufferIndices.AddEntry(
                 {
 #if USE_BINDLESS_SRG
-                    subMesh.m_indexShaderBufferView.get() ? subMesh.m_indexShaderBufferView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_positionShaderBufferView.get() ? subMesh.m_positionShaderBufferView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_normalShaderBufferView.get() ? subMesh.m_normalShaderBufferView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_tangentShaderBufferView.get() ? subMesh.m_tangentShaderBufferView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_bitangentShaderBufferView.get() ? subMesh.m_bitangentShaderBufferView->GetBindlessReadIndex() : InvalidIndex,
-                    subMesh.m_uvShaderBufferView.get() ? subMesh.m_uvShaderBufferView->GetBindlessReadIndex() : InvalidIndex
+                    subMesh.m_indexShaderBufferView.get() ? subMesh.m_indexShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_positionShaderBufferView.get() ? subMesh.m_positionShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_normalShaderBufferView.get() ? subMesh.m_normalShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_tangentShaderBufferView.get() ? subMesh.m_tangentShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_bitangentShaderBufferView.get() ? subMesh.m_bitangentShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
+                    subMesh.m_uvShaderBufferView.get() ? subMesh.m_uvShaderBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex
 #else
                     m_meshBuffers.AddResource(subMesh.m_indexShaderBufferView.get()),
                     m_meshBuffers.AddResource(subMesh.m_positionShaderBufferView.get()),

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -11,6 +11,8 @@
 #include <RayTracing/RayTracingResourceList.h>
 #include <RayTracing/RayTracingIndexList.h>
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 #include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
 #include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
 #include <Atom/RHI/SingleDeviceBufferView.h>
@@ -83,28 +85,29 @@ namespace AZ
             {
                 // vertex streams
                 RHI::Format m_positionFormat = RHI::Format::Unknown;
-                RHI::SingleDeviceStreamBufferView m_positionVertexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_positionShaderBufferView;
+
+                RHI::MultiDeviceStreamBufferView m_positionVertexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_positionShaderBufferView;
 
                 RHI::Format m_normalFormat = RHI::Format::Unknown;
-                RHI::SingleDeviceStreamBufferView m_normalVertexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_normalShaderBufferView;
+                RHI::MultiDeviceStreamBufferView m_normalVertexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_normalShaderBufferView;
 
                 RHI::Format m_tangentFormat = RHI::Format::Unknown;
-                RHI::SingleDeviceStreamBufferView m_tangentVertexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_tangentShaderBufferView;
+                RHI::MultiDeviceStreamBufferView m_tangentVertexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_tangentShaderBufferView;
 
                 RHI::Format m_bitangentFormat = RHI::Format::Unknown;
-                RHI::SingleDeviceStreamBufferView m_bitangentVertexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_bitangentShaderBufferView;
+                RHI::MultiDeviceStreamBufferView m_bitangentVertexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_bitangentShaderBufferView;
 
                 RHI::Format m_uvFormat = RHI::Format::Unknown;
-                RHI::SingleDeviceStreamBufferView m_uvVertexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_uvShaderBufferView;
+                RHI::MultiDeviceStreamBufferView m_uvVertexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_uvShaderBufferView;
 
                 // index buffer
-                RHI::SingleDeviceIndexBufferView m_indexBufferView;
-                RHI::Ptr<RHI::SingleDeviceBufferView> m_indexShaderBufferView;
+                RHI::MultiDeviceIndexBufferView m_indexBufferView;
+                RHI::Ptr<RHI::MultiDeviceBufferView> m_indexShaderBufferView;
 
                 // vertex buffer usage flags
                 RayTracingSubMeshBufferFlags m_bufferFlags = RayTracingSubMeshBufferFlags::None;
@@ -377,8 +380,8 @@ namespace AZ
             // without invalidating the indices held here in the m_meshBufferIndices and m_materialTextureIndices lists.
             
             // mesh buffer and material texture resource lists, accessed by the shader through an unbounded array
-            RayTracingResourceList<RHI::SingleDeviceBufferView> m_meshBuffers;
-            RayTracingResourceList<const RHI::SingleDeviceImageView> m_materialTextures;
+            RayTracingResourceList<RHI::MultiDeviceBufferView> m_meshBuffers;
+            RayTracingResourceList<const RHI::MultiDeviceImageView> m_materialTextures;
 #endif
 
             // RayTracingIndexList implements an internal freelist chain stored inside the list itself, allowing entries to be

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -230,7 +230,7 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
 
             drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-            drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
+            drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
             drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
             drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
 
@@ -242,7 +242,7 @@ namespace AZ
             // We have to keep a list of these outside the loops that collect all the shaders because the DrawPacketBuilder
             // keeps pointers to StreamBufferViews until DrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
             // that the memory won't be relocated when new entries are added.
-            AZStd::fixed_vector<ModelLod::StreamBufferViewList, RHI::DrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
+            AZStd::fixed_vector<ModelLod::TempStreamBufferViewList, RHI::DrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
 
             // The root constants are shared by all draw items in the draw packet. We must populate them with default values.
             // The draw packet builder needs to know where the data is coming from during appendShader, but it's not actually read

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -82,8 +82,8 @@ namespace AZ
                         return RHI::ResultCode::InvalidOperation;
                     }
 
-                    meshInstance.m_indexBufferView = RHI::SingleDeviceIndexBufferView(
-                        *indexBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    meshInstance.m_indexBufferView = RHI::MultiDeviceIndexBufferView(
+                        *indexBuffer->GetRHIBuffer(),
                         bufferViewDescriptor.m_elementOffset * bufferViewDescriptor.m_elementSize,
                         bufferViewDescriptor.m_elementCount * bufferViewDescriptor.m_elementSize,
                         indexFormat);
@@ -302,7 +302,7 @@ namespace AZ
 
                         RHI::Format dummyStreamFormat = RHI::Format::R32G32B32A32_FLOAT;
                         layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, dummyStreamFormat);
-                        RHI::SingleDeviceStreamBufferView dummyBuffer{*mesh.m_indexBufferView.GetBuffer(), 0, 0, RHI::GetFormatSize(dummyStreamFormat)};
+                        RHI::MultiDeviceStreamBufferView dummyBuffer{*mesh.m_indexBufferView.GetBuffer(), 0, 0, RHI::GetFormatSize(dummyStreamFormat)};
                         streamBufferViewsOut.push_back(dummyBuffer);
                     }
                     else
@@ -328,8 +328,97 @@ namespace AZ
                         // Note, don't use iter->m_semantic as it can be a UV name matching.
                         layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, iter->m_format);
 
-                        RHI::SingleDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
+                        RHI::MultiDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
                         streamBufferViewsOut.push_back(bufferView);
+                    }
+                }
+            }
+
+            if (success)
+            {
+                layoutOut = layoutBuilder.End();
+
+                success &= RHI::ValidateStreamBufferViews(layoutOut, streamBufferViewsOut);
+            }
+
+            return success;
+        }
+
+        bool ModelLod::GetStreamsForMesh(
+            RHI::InputStreamLayout& layoutOut,
+            TempStreamBufferViewList& streamBufferViewsOut,
+            UvStreamTangentBitmask* uvStreamTangentBitmaskOut,
+            const ShaderInputContract& contract,
+            size_t meshIndex,
+            const MaterialModelUvOverrideMap& materialModelUvMap,
+            const MaterialUvNameMap& materialUvNameMap) const
+        {
+            streamBufferViewsOut.clear();
+
+            RHI::InputStreamLayoutBuilder layoutBuilder;
+
+            const Mesh& mesh = m_meshes[meshIndex];
+
+            bool success = true;
+
+                   // Searching for the first UV in the mesh, so it can be used to paired with tangent/bitangent stream
+            auto firstUv = FindFirstUvStreamFromMesh(meshIndex);
+            auto defaultUv = FindDefaultUvStream(meshIndex, materialUvNameMap);
+            if (uvStreamTangentBitmaskOut)
+            {
+                uvStreamTangentBitmaskOut->Reset();
+            }
+
+            for (auto& contractStreamChannel : contract.m_streamChannels)
+            {
+                auto iter = FindMatchingStream(meshIndex, materialModelUvMap, materialUvNameMap, contractStreamChannel, defaultUv, firstUv, uvStreamTangentBitmaskOut);
+
+                if (iter == mesh.m_streamInfo.end())
+                {
+                    if (contractStreamChannel.m_isOptional)
+                    {
+                        // The configuration of the dummy input stream is a bit touchy, and could result in crashes or validation failures that are platform-specific.
+                        // If you modify this code, be sure to test with "-rhi-device-validation=enable" on every platform.
+                        // Here are some criteria that we've noticed before, even for empty buffers:
+                        // Metal: Mesh stream formats need to be at least 4 byte aligned.
+                        // Vulkan: Mesh stream data type (float vs uint) must match the shader, or validation errors are reported
+                        //        ("does not match vertex shader input type")
+                        // Vulkan: We can't just use a null buffer pointer because vulkan will occasionally crash. So we bind some valid non-null buffer and view it with length 0.
+                        // Dx12: Mesh stream data type (float vs uint) must match the shader, or validation warnings are reported
+                        //       ("the matching entry in the Input Layout declaration ... specifies mismatched format").
+                        //
+                        // The stride value does not seem to matter, just the Format type. Still, we use GetFormatSize to set an accurate stride.
+
+                        RHI::Format dummyStreamFormat = RHI::Format::R32G32B32A32_FLOAT;
+                        layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, dummyStreamFormat);
+                        RHI::MultiDeviceStreamBufferView dummyBuffer{*mesh.m_indexBufferView.GetBuffer(), 0, 0, RHI::GetFormatSize(dummyStreamFormat)};
+                        streamBufferViewsOut.push_back(dummyBuffer.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                    }
+                    else
+                    {
+                        AZ_Warning("Mesh", false, "Mesh does not have all the required input streams. Missing '%s'.", contractStreamChannel.m_semantic.ToString().c_str());
+                        success = false;
+                    }
+                }
+                else
+                {
+                    // Note, we may need to iterate on the details of this validation. It might not be correct for all use cases.
+                    if (RHI::GetFormatComponentCount(iter->m_format) < contractStreamChannel.m_componentCount)
+                    {
+                        AZ_Error("Mesh", false, "Mesh format (%s) for stream '%s' provides %d components but the shader requires %d.",
+                                 RHI::ToString(iter->m_format),
+                                 contractStreamChannel.m_semantic.ToString().c_str(),
+                                 RHI::GetFormatComponentCount(iter->m_format),
+                                 contractStreamChannel.m_componentCount);
+                        success = false;
+                    }
+                    else
+                    {
+                        // Note, don't use iter->m_semantic as it can be a UV name matching.
+                        layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, iter->m_format);
+
+                        RHI::MultiDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
+                        streamBufferViewsOut.push_back(bufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
                     }
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -361,7 +361,7 @@ namespace AZ
 
             bool success = true;
 
-                   // Searching for the first UV in the mesh, so it can be used to paired with tangent/bitangent stream
+            // Searching for the first UV in the mesh, so it can be used to paired with tangent/bitangent stream
             auto firstUv = FindFirstUvStreamFromMesh(meshIndex);
             auto defaultUv = FindDefaultUvStream(meshIndex, materialUvNameMap);
             if (uvStreamTangentBitmaskOut)

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -128,7 +128,7 @@ namespace AZ::Render
         drawPacketBuilder.Begin(nullptr);
 
         drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-        drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
+        drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
         drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
         drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
 
@@ -140,7 +140,7 @@ namespace AZ::Render
         // We have to keep a list of these outside the loops that collect all the shaders because the DrawPacketBuilder
         // keeps pointers to StreamBufferViews until DrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
         // that the memory won't be relocated when new entries are added.
-        AZStd::fixed_vector<RPI::ModelLod::StreamBufferViewList, RHI::DrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
+        AZStd::fixed_vector<RPI::ModelLod::TempStreamBufferViewList, RHI::DrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
 
         m_perDrawSrgs.clear();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -959,8 +959,8 @@ namespace AZ
                 0);
             AZ_Assert(result, "Failed to retrieve DiffuseProbeGrid visualization mesh stream buffer views");
 
-            m_visualizationVB = streamBufferViews[0];
-            m_visualizationIB = mesh.m_indexBufferView;
+            m_visualizationVB = streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+            m_visualizationIB = mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
 
             // create the BLAS object
             RHI::SingleDeviceRayTracingBlasDescriptor blasDescriptor;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -369,14 +369,14 @@ namespace Terrain
         uint32_t positionsBufferByteCount = aznumeric_cast<uint32_t>(rhiPositionsBuffer.GetDescriptor().m_byteCount);
         AZ::RHI::Format positionsBufferFormat = rtSector.m_positionsBuffer->GetBufferViewDescriptor().m_elementFormat;
         uint32_t positionsBufferElementSize = AZ::RHI::GetFormatSize(positionsBufferFormat);
-        AZ::RHI::SingleDeviceStreamBufferView positionsVertexBufferView(*rhiPositionsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), 0, positionsBufferByteCount, positionsBufferElementSize);
+        AZ::RHI::MultiDeviceStreamBufferView positionsVertexBufferView(rhiPositionsBuffer, 0, positionsBufferByteCount, positionsBufferElementSize);
         AZ::RHI::BufferViewDescriptor positionsBufferDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, positionsBufferByteCount);
 
         AZ::RHI::MultiDeviceBuffer& rhiNormalsBuffer = *rtSector.m_normalsBuffer->GetRHIBuffer();
         uint32_t normalsBufferByteCount = aznumeric_cast<uint32_t>(rhiNormalsBuffer.GetDescriptor().m_byteCount);
         AZ::RHI::Format normalsBufferFormat = rtSector.m_normalsBuffer->GetBufferViewDescriptor().m_elementFormat;
         uint32_t normalsBufferElementSize = AZ::RHI::GetFormatSize(normalsBufferFormat);
-        AZ::RHI::SingleDeviceStreamBufferView normalsVertexBufferView(*rhiNormalsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), 0, normalsBufferByteCount, normalsBufferElementSize);
+        AZ::RHI::MultiDeviceStreamBufferView normalsVertexBufferView(rhiNormalsBuffer, 0, normalsBufferByteCount, normalsBufferElementSize);
         AZ::RHI::BufferViewDescriptor normalsBufferDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, normalsBufferByteCount);
 
         AZ::RHI::MultiDeviceBuffer& rhiIndexBuffer = *m_rtIndexBuffer->GetRHIBuffer();
@@ -394,11 +394,11 @@ namespace Terrain
 
             subMesh.m_positionFormat = positionsBufferFormat;
             subMesh.m_positionVertexBufferView = positionsVertexBufferView;
-            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(positionsBufferDescriptor);
+            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.BuildBufferView(positionsBufferDescriptor);
             subMesh.m_normalFormat = normalsBufferFormat;
             subMesh.m_normalVertexBufferView = normalsVertexBufferView;
-            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(normalsBufferDescriptor);
-            subMesh.m_indexBufferView = AZ::RHI::SingleDeviceIndexBufferView(*rhiIndexBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex), indexBufferByteOffset, indexBufferByteCount, indexBufferFormat);
+            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.BuildBufferView(normalsBufferDescriptor);
+            subMesh.m_indexBufferView = AZ::RHI::MultiDeviceIndexBufferView(rhiIndexBuffer, indexBufferByteOffset, indexBufferByteCount, indexBufferFormat);
             subMesh.m_baseColor = AZ::Color::CreateFromVector3(AZ::Vector3(0.18f));
 
             AZ::RHI::BufferViewDescriptor indexBufferDescriptor;
@@ -407,7 +407,7 @@ namespace Terrain
             indexBufferDescriptor.m_elementSize = indexElementSize;
             indexBufferDescriptor.m_elementFormat = AZ::RHI::Format::R32_UINT;
 
-            subMesh.m_indexShaderBufferView = rhiIndexBuffer.GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(indexBufferDescriptor);
+            subMesh.m_indexShaderBufferView = rhiIndexBuffer.BuildBufferView(indexBufferDescriptor);
 
             meshGroup.m_mesh.m_assetId = AZ::Data::AssetId(meshGroup.m_id);
             float xyScale = (m_gridSize * m_sampleSpacing) * (1 << lodLevel);


### PR DESCRIPTION
## What does this PR do?

This commit fixes some instances where `Image/Buffer`-related resources where missed during the conversion step (https://github.com/o3de/o3de/pull/17040) from single to multi device versions, mainly in ModelLod.

## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`
