### PR TITLE
Fix alpha clipping, cut out, and add opacity factor in material graph based material types

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
@@ -111,6 +111,28 @@ bool NeedsTangentFrame()
     
 void EvaluateSurface(VsOutput IN, PixelGeometryData geoData)
 {
+    const float3 bitangent = cross((float3)IN.normal, (float3)IN.tangent);
+    const float3 O3DE_MC_POSITION = (float3)IN.position;
+    const float3 O3DE_MC_NORMAL = (float3)IN.normal;
+    const float3 O3DE_MC_TANGENT = (float3)IN.tangent;
+    const float3 O3DE_MC_BITANGENT = (float3)bitangent;
+    const float3 O3DE_MC_POSITION_WS = geoData.positionWS;
+    const float3 O3DE_MC_NORMAL_WS = geoData.vertexNormal;
+    const float3 O3DE_MC_TANGENT_WS = geoData.tangents[0];
+    const float3 O3DE_MC_BITANGENT_WS = geoData.bitangents[0];
+    #define O3DE_MC_UV(index) geoData.uvs[clamp(index, 0, UvSetCount-1)];
+
+    // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
+    const bool placeHolder = MaterialSrg::m_placeHolder;
+
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inAlpha, inOpacityFactor
+    real inAlpha = 1.0;
+    real inOpacityFactor = 1.0;
+    // O3DE_GENERATED_INSTRUCTIONS_END
+
+    #undef O3DE_MC_UV
+
+    CheckClipping((real)inAlpha, (real)inOpacityFactor);
 }
 
 #else

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -43,7 +43,7 @@ Surface EvaluateSurface_MaterialGraphName(
     // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
     const bool placeHolder = MaterialSrg::m_placeHolder;
 
-    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inOpacityFactor, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
     real3 inNormal = normalWS;
     real3 inBaseColor = {1.0, 1.0, 1.0};
     real inMetallic = 0.0;
@@ -51,6 +51,7 @@ Surface EvaluateSurface_MaterialGraphName(
     real inSpecularF0Factor = 0.0;
     real3 inEmissive = {0.0, 0.0, 0.0};
     real inAlpha = 1.0;
+    real inOpacityFactor = 1.0;
     real inDiffuseAmbientOcclusion = 1.0;
     real inSpecularOcclusion = 1.0;
     real inClearCoatFactor = 0.0;
@@ -59,6 +60,8 @@ Surface EvaluateSurface_MaterialGraphName(
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_UV
+
+    CheckClipping((real)inAlpha, (real)inOpacityFactor);
 
     Surface surface;
     surface.position = positionWS;
@@ -77,13 +80,11 @@ Surface EvaluateSurface_MaterialGraphName(
     }
 #endif
 
-    surface.alpha = inAlpha;
+    surface.alpha = (real)inAlpha * (real)inOpacityFactor;
     surface.emissiveLighting = inEmissive;
     surface.diffuseAmbientOcclusion = inDiffuseAmbientOcclusion;
     surface.specularOcclusion = inSpecularOcclusion;
     surface.opacityAffectsSpecularFactor = o_opacity_affects_specular_factor;
-
-    CheckClipping(surface.alpha, 0.5);
 
     // ------- Clearcoat -------
 

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphnode
@@ -462,6 +462,23 @@
                 }
             },
             {
+                "name": "inOpacityFactor",
+                "displayName": "Opacity Factor",
+                "description": "Opacity Factor",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "defaultValue": {
+                    "$type": "float",
+                    "Value": 1.0
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
                 "name": "inDiffuseAmbientOcclusion",
                 "displayName": "Diffuse Ambient Occlusion",
                 "description": "Diffuse Ambient Occlusion",

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphtemplate
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphtemplate
@@ -293,6 +293,17 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inOpacityFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inPositionOffset"
                             },
                             "Value": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test5.materialgraph
@@ -293,6 +293,17 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inOpacityFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inPositionOffset"
                             },
                             "Value": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test9.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test9.materialgraph
@@ -404,6 +404,17 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inOpacityFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inPositionOffset"
                             },
                             "Value": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_normalmaps.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_normalmaps.materialgraph
@@ -277,7 +277,7 @@
                                             "guid": "{7B12D830-4138-51C2-8612-3ED5B4DFA23A}",
                                             "subId": 1000
                                         },
-                                        "assetHint": "Textures/UtilCharts/test_chart_norm.tif"
+                                        "assetHint": "textures/utilcharts/test_chart_norm.tif.streamingimage"
                                     }
                                 }
                             }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_propertysorting.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_propertysorting.materialgraph
@@ -557,6 +557,17 @@
                         },
                         {
                             "Key": {
+                                "m_name": "inOpacityFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
                                 "m_name": "inPositionOffset"
                             },
                             "Value": {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_scrolling_uvs.materialgraph
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/TestData/test_scrolling_uvs.materialgraph
@@ -272,7 +272,7 @@
                             "Value": {
                                 "m_value": {
                                     "$type": "float",
-                                    "Value": 0.0
+                                    "Value": 1.0
                                 }
                             }
                         },
@@ -358,13 +358,196 @@
                 }
             },
             {
-                "Key": 4,
+                "Key": 2,
                 "Value": {
                     "$type": "DynamicNode",
+                    "m_propertySlots": [
+                        {
+                            "Key": {
+                                "m_name": "inDescription"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inGroup"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inName"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inValue"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Color",
+                                    "Value": [
+                                        0.9693293571472168,
+                                        0.0,
+                                        0.0,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
                     "toolId": {
                         "Value": 2034248906
                     },
-                    "configId": "{5559A2B1-331C-4E52-8F3E-916CD114F41D}"
+                    "configId": "{2A23578C-FB72-4A9F-AC95-06B278CEA913}"
+                }
+            },
+            {
+                "Key": 3,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inValue1"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector4",
+                                    "Value": [
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inValue2"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector4",
+                                    "Value": [
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{7DE0F2F0-1ADC-4B4B-ADDB-CA21B8D97816}"
+                }
+            },
+            {
+                "Key": 4,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_propertySlots": [
+                        {
+                            "Key": {
+                                "m_name": "inDescription"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inGroup"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inName"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                    "Value": ""
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSampler"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "SamplerState"
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inValue"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "{403A7CFE-B218-5D57-8540-BD58E734BCFE} Asset<StreamingImageAsset>",
+                                    "Value": {
+                                        "assetId": {
+                                            "guid": "{E11F2A91-690A-557B-9B73-AC8DC5BB2197}",
+                                            "subId": 1000
+                                        },
+                                        "assetHint": "ui/icons/assetbrowsercheckers.png.streamingimage"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inUV"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector2",
+                                    "Value": [
+                                        0.0,
+                                        0.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{C0ADB0F0-39DD-48D9-A4D2-58B40C76C285}"
                 }
             },
             {
@@ -374,6 +557,83 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
+                                "m_name": "inIndex"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "unsigned int",
+                                    "Value": 0
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{8E836C09-FA68-42B0-B302-CAC3FD6E4EA2}"
+                }
+            },
+            {
+                "Key": 6,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inValue1"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector4",
+                                    "Value": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inValue2"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector4",
+                                    "Value": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{FEA94EB4-72AA-4CC2-80F5-75A62ED9B7CA}"
+                }
+            },
+            {
+                "Key": 7,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{5559A2B1-331C-4E52-8F3E-916CD114F41D}"
+                }
+            },
+            {
+                "Key": 8,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
                                 "m_name": "inValue"
                             },
                             "Value": {
@@ -392,107 +652,7 @@
                     "toolId": {
                         "Value": 2034248906
                     },
-                    "configId": "{ACFD2852-1C39-4E11-9F48-56618DF90689}"
-                }
-            },
-            {
-                "Key": 6,
-                "Value": {
-                    "$type": "DynamicNode",
-                    "m_propertySlots": [
-                        {
-                            "Key": {
-                                "m_name": "inValue"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        0.0,
-                                        1.0,
-                                        1.0
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "toolId": {
-                        "Value": 2034248906
-                    },
-                    "configId": "{643F25FA-FB10-4AF6-9657-2E1BDC2AC219}"
-                }
-            },
-            {
-                "Key": 7,
-                "Value": {
-                    "$type": "DynamicNode",
-                    "m_inputDataSlots": [
-                        {
-                            "Key": {
-                                "m_name": "inValue1"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        1.0,
-                                        1.0,
-                                        1.0
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "m_name": "inValue2"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        1.0,
-                                        1.0,
-                                        1.0
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "toolId": {
-                        "Value": 2034248906
-                    },
-                    "configId": "{7DE0F2F0-1ADC-4B4B-ADDB-CA21B8D97816}"
-                }
-            },
-            {
-                "Key": 8,
-                "Value": {
-                    "$type": "DynamicNode",
-                    "m_propertySlots": [
-                        {
-                            "Key": {
-                                "m_name": "inValue"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        0.0,
-                                        0.0,
-                                        1.0
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "toolId": {
-                        "Value": 2034248906
-                    },
-                    "configId": "{643F25FA-FB10-4AF6-9657-2E1BDC2AC219}"
+                    "configId": "{229D9C2B-6AD4-45DC-83F0-AB5BE771298C}"
                 }
             },
             {
@@ -502,33 +662,23 @@
                     "m_inputDataSlots": [
                         {
                             "Key": {
-                                "m_name": "inValue1"
+                                "m_name": "inX"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        1.0,
-                                        1.0,
-                                        1.0
-                                    ]
+                                    "$type": "float",
+                                    "Value": 0.0
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "m_name": "inValue2"
+                                "m_name": "inY"
                             },
                             "Value": {
                                 "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        1.0,
-                                        1.0,
-                                        1.0,
-                                        1.0
-                                    ]
+                                    "$type": "float",
+                                    "Value": 0.0
                                 }
                             }
                         }
@@ -536,50 +686,50 @@
                     "toolId": {
                         "Value": 2034248906
                     },
-                    "configId": "{7DE0F2F0-1ADC-4B4B-ADDB-CA21B8D97816}"
-                }
-            },
-            {
-                "Key": 10,
-                "Value": {
-                    "$type": "DynamicNode",
-                    "m_inputDataSlots": [
-                        {
-                            "Key": {
-                                "m_name": "inValue"
-                            },
-                            "Value": {
-                                "m_value": {
-                                    "$type": "Vector4",
-                                    "Value": [
-                                        0.0,
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    "toolId": {
-                        "Value": 2034248906
-                    },
-                    "configId": "{2E53F7CC-3C6D-4737-B092-2FB41204ECAC}"
+                    "configId": "{8FC3A30B-5D12-4959-A9ED-4127F2F39A13}"
                 }
             }
         ],
         "m_connections": [
             {
                 "m_sourceEndpoint": [
-                    4,
+                    2,
                     {
-                        "m_name": "outTime"
+                        "m_name": "outValue"
                     }
                 ],
                 "m_targetEndpoint": [
-                    5,
+                    3,
                     {
-                        "m_name": "inValue"
+                        "m_name": "inValue1"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    3,
+                    {
+                        "m_name": "outValue"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    1,
+                    {
+                        "m_name": "inBaseColor"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    4,
+                    {
+                        "m_name": "outColor"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    3,
+                    {
+                        "m_name": "inValue2"
                     }
                 ]
             },
@@ -591,37 +741,9 @@
                     }
                 ],
                 "m_targetEndpoint": [
-                    7,
+                    4,
                     {
-                        "m_name": "inValue1"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    8,
-                    {
-                        "m_name": "outValue"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    9,
-                    {
-                        "m_name": "inValue1"
-                    }
-                ]
-            },
-            {
-                "m_sourceEndpoint": [
-                    7,
-                    {
-                        "m_name": "outValue"
-                    }
-                ],
-                "m_targetEndpoint": [
-                    9,
-                    {
-                        "m_name": "inValue2"
+                        "m_name": "inUV"
                     }
                 ]
             },
@@ -629,11 +751,25 @@
                 "m_sourceEndpoint": [
                     5,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outUV"
                     }
                 ],
                 "m_targetEndpoint": [
-                    10,
+                    6,
+                    {
+                        "m_name": "inValue1"
+                    }
+                ]
+            },
+            {
+                "m_sourceEndpoint": [
+                    7,
+                    {
+                        "m_name": "outTime"
+                    }
+                ],
+                "m_targetEndpoint": [
+                    8,
                     {
                         "m_name": "inValue"
                     }
@@ -641,29 +777,29 @@
             },
             {
                 "m_sourceEndpoint": [
-                    10,
+                    8,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outSin"
                     }
                 ],
                 "m_targetEndpoint": [
-                    7,
+                    9,
                     {
-                        "m_name": "inValue2"
+                        "m_name": "inX"
                     }
                 ]
             },
             {
                 "m_sourceEndpoint": [
-                    7,
+                    8,
                     {
-                        "m_name": "outValue"
+                        "m_name": "outCos"
                     }
                 ],
                 "m_targetEndpoint": [
-                    1,
+                    9,
                     {
-                        "m_name": "inEmissive"
+                        "m_name": "inY"
                     }
                 ]
             },
@@ -675,9 +811,9 @@
                     }
                 ],
                 "m_targetEndpoint": [
-                    1,
+                    6,
                     {
-                        "m_name": "inBaseColor"
+                        "m_name": "inValue2"
                     }
                 ]
             }
@@ -686,7 +822,12 @@
             "m_sceneMetadata": {
                 "ComponentData": {
                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
-                        "$type": "SceneComponentSaveData"
+                        "$type": "SceneComponentSaveData",
+                        "ViewParams": {
+                            "Scale": 0.38905434290152674,
+                            "AnchorX": -1226.0498046875,
+                            "AnchorY": -668.287109375
+                        }
                     }
                 }
             },
@@ -705,8 +846,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1740.0,
-                                    -40.0
+                                    460.0,
+                                    -200.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -714,7 +855,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{931CC6D4-CD3C-4979-A8E7-DD3458B6BA78}"
+                                "PersistentId": "{95691AFE-3797-4594-8B1A-FAEF334C5165}"
                             }
                         }
                     }
@@ -726,11 +867,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "MaterialInputNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    300.0,
-                                    120.0
+                                    -140.0,
+                                    -280.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -738,7 +883,11 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{442701F5-F477-4BA6-8C7D-3CDBB5330C8D}"
+                                "PersistentId": "{83D28BFA-DD41-45BD-A865-08DF58801D15}"
+                            },
+                            "{FC18625B-1E97-415D-9832-B222DE054680}": {
+                                "$type": "GraphCanvasSelectionData",
+                                "selected": true
                             }
                         }
                     }
@@ -750,11 +899,15 @@
                             "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
                                 "$type": "NodeSaveData"
                             },
+                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                "$type": "GeneralNodeTitleComponentSaveData",
+                                "PaletteOverride": "MathNodeTitlePalette"
+                            },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    200.0,
-                                    100.0
+                                    160.0,
+                                    140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -762,7 +915,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{3D0698E8-41FE-4601-BF60-CE65F83BD1CF}"
+                                "PersistentId": "{EB75F674-CC7F-43DD-9135-402923C9757A}"
                             }
                         }
                     }
@@ -776,13 +929,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "TimeNodeTitlePalette"
+                                "PaletteOverride": "TexturingNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    220.0,
-                                    100.0
+                                    -140.0,
+                                    0.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -790,7 +943,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{2D5F8E87-CDF7-4B52-A92F-0319E068032C}"
+                                "PersistentId": "{607FFEB0-C866-42EE-B9B3-87C7D94E56D4}"
                             },
                             "{FC18625B-1E97-415D-9832-B222DE054680}": {
                                 "$type": "GraphCanvasSelectionData",
@@ -808,13 +961,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "MathNodeTitlePalette"
+                                "PaletteOverride": "VertexNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    380.0,
-                                    100.0
+                                    -740.0,
+                                    -20.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -822,11 +975,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{C30020BC-EE14-411E-9C65-812EFFC9E8E3}"
-                            },
-                            "{FC18625B-1E97-415D-9832-B222DE054680}": {
-                                "$type": "GraphCanvasSelectionData",
-                                "selected": true
+                                "PersistentId": "{51E89EE1-C24C-4B08-A5FC-F68CEEFE20CA}"
                             }
                         }
                     }
@@ -840,13 +989,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "ConstantNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    540.0,
-                                    -160.0
+                                    -440.0,
+                                    140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -854,11 +1003,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{79D6F1B5-F012-4AB0-9354-B5F9F435E114}"
-                            },
-                            "{FC18625B-1E97-415D-9832-B222DE054680}": {
-                                "$type": "GraphCanvasSelectionData",
-                                "selected": true
+                                "PersistentId": "{E876F31F-D443-48EA-B1CC-CCA065C82974}"
                             }
                         }
                     }
@@ -872,13 +1017,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "MathNodeTitlePalette"
+                                "PaletteOverride": "TimeNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1100.0,
-                                    20.0
+                                    -1200.0,
+                                    160.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -886,7 +1031,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{080B66FB-1AB7-4993-87A9-FEC1334F7CC6}"
+                                "PersistentId": "{E8576D01-C5F3-440E-AD86-AB3A3DE21731}"
                             }
                         }
                     }
@@ -900,13 +1045,13 @@
                             },
                             "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                 "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "ConstantNodeTitlePalette"
+                                "PaletteOverride": "MathNodeTitlePalette"
                             },
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    540.0,
-                                    -420.0
+                                    -1040.0,
+                                    140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -914,11 +1059,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{86380651-C9D0-4AEC-BE29-36A3338DBFBE}"
-                            },
-                            "{FC18625B-1E97-415D-9832-B222DE054680}": {
-                                "$type": "GraphCanvasSelectionData",
-                                "selected": true
+                                "PersistentId": "{AEB17C3A-9522-463C-9803-3FE2B9B0E223}"
                             }
                         }
                     }
@@ -937,8 +1078,8 @@
                             "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                 "$type": "GeometrySaveData",
                                 "Position": [
-                                    1440.0,
-                                    -40.0
+                                    -740.0,
+                                    140.0
                                 ]
                             },
                             "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -946,39 +1087,7 @@
                             },
                             "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                 "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{AA403502-AA12-4FAF-B6FE-F2472993F4C6}"
-                            }
-                        }
-                    }
-                },
-                {
-                    "Key": 10,
-                    "Value": {
-                        "ComponentData": {
-                            "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                "$type": "NodeSaveData"
-                            },
-                            "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                "$type": "GeneralNodeTitleComponentSaveData",
-                                "PaletteOverride": "MathNodeTitlePalette"
-                            },
-                            "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                "$type": "GeometrySaveData",
-                                "Position": [
-                                    680.0,
-                                    100.0
-                                ]
-                            },
-                            "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                "$type": "StylingComponentSaveData"
-                            },
-                            "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                "$type": "PersistentIdComponentSaveData",
-                                "PersistentId": "{72E332FB-DBAB-4F1A-8F51-4D873E2BEF0D}"
-                            },
-                            "{FC18625B-1E97-415D-9832-B222DE054680}": {
-                                "$type": "GraphCanvasSelectionData",
-                                "selected": true
+                                "PersistentId": "{D129FF6D-D89F-401C-9D50-62422F746893}"
                             }
                         }
                     }


### PR DESCRIPTION
## What does this PR do?

- This change updates material craft templates and material types to perform alpha clipping using the same logic as the stock material types.
- Opacity factor input was added to standard PBR node, to be used as a multiplier for tinted and blended opacity modes and a clipping threshold for cut out.
- Added simple code generation block for alpha clipping death and shadows.
- Updated test graphs and templates with new field

Fixes https://github.com/o3de/o3de/issues/16874

## How was this PR tested?

Compiled existing test graphs and templates
Created graphs to test different opacity modes
Configure different graphs with different values for alpha and opacity factor
