### PR TITLE
Gadams3/add material canvas compile graph interval setting

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicProperty/DynamicProperty.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/DynamicProperty/DynamicProperty.h
@@ -118,8 +118,9 @@ namespace AtomToolsFramework
 
         // Register is actually use for range-based control types.
         // If all the necessary data is present a slider control will be presented.
+        bool ApplyRangeEditDataAttributesToNumericTypes();
         template<typename AttributeValueType>
-        void ApplyRangeEditDataAttributesWithTypeCheck();
+        bool ApplyRangeEditDataAttributesToNumericType();
         template<typename AttributeValueType>
         void ApplyRangeEditDataAttributes();
         template<typename AttributeValueType>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocument.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Graph/GraphDocument.h
@@ -108,6 +108,8 @@ namespace AtomToolsFramework
         bool m_buildPropertiesQueued = {};
         // This plan will be set to true if a request has been made to compile the graph data.
         bool m_compileGraphQueued = {};
+        // Next time that a cued compile can be executed
+        AZStd::chrono::steady_clock::time_point m_compileGraphQueueTime = AZStd::chrono::steady_clock::now();
         // Container of file paths that were affected by the compiler.
         AZStd::vector<AZStd::string> m_generatedFiles;
         // This is a pointer to the optional graph compiler that can be injected into the graph document to process the graph data.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -358,28 +358,27 @@ namespace AtomToolsFramework
     void DynamicProperty::ApplyRangeEditDataAttributes()
     {
         // Slider and spin box controls require both minimum and maximum ranges to be entered in order to override the default values set
-        // to 0 and 100. They must also be set in a certain order because of clamping that is done as the attributes are applied. If no
-        // value was specified in the property config then numeric limits will be used.
-        AddEditDataAttribute(
-            AZ::Edit::Attributes::Min,
-            m_config.m_min.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_min)
-                                                    : AZStd::numeric_limits<AttributeValueType>::lowest());
-        AddEditDataAttribute(
-            AZ::Edit::Attributes::Max,
-            m_config.m_max.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_max)
-                                                    : AZStd::numeric_limits<AttributeValueType>::max());
-        AddEditDataAttribute(
-            AZ::Edit::Attributes::SoftMin,
-            m_config.m_softMin.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_softMin)
-                                                        : AZStd::numeric_limits<AttributeValueType>::lowest());
-        AddEditDataAttribute(
-            AZ::Edit::Attributes::SoftMax,
-            m_config.m_softMax.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_softMax)
-                                                        : AZStd::numeric_limits<AttributeValueType>::max());
-        AddEditDataAttribute(
-            AZ::Edit::Attributes::Step,
-            m_config.m_step.is<AttributeValueType>() ? AZStd::any_cast<AttributeValueType>(m_config.m_step)
-                                                     : AZStd::numeric_limits<AttributeValueType>::epsilon());
+        // to 0 and 100. They must also be set in a certain order because of clamping that is done as the attributes are applied.
+        if (m_config.m_min.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Min, AZStd::any_cast<AttributeValueType>(m_config.m_min));
+        }
+        if (m_config.m_max.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Max, AZStd::any_cast<AttributeValueType>(m_config.m_max));
+        }
+        if (m_config.m_softMin.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::SoftMin, AZStd::any_cast<AttributeValueType>(m_config.m_softMin));
+        }
+        if (m_config.m_softMax.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::SoftMax, AZStd::any_cast<AttributeValueType>(m_config.m_softMax));
+        }
+        if (m_config.m_step.is<AttributeValueType>())
+        {
+            AddEditDataAttribute(AZ::Edit::Attributes::Step, AZStd::any_cast<AttributeValueType>(m_config.m_step));
+        }
     }
 
     template<typename AttributeValueType>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -154,16 +154,7 @@ namespace AtomToolsFramework
                 AddEditDataAttribute(AZ::Edit::Attributes::Handler, m_config.m_customHandler);
             }
 
-            ApplyRangeEditDataAttributesWithTypeCheck<int8_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<uint8_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<int16_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<uint16_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<int32_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<uint32_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<int64_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<uint64_t>();
-            ApplyRangeEditDataAttributesWithTypeCheck<float>();
-            ApplyRangeEditDataAttributesWithTypeCheck<double>();
+            ApplyRangeEditDataAttributesToNumericTypes();
 
             if (m_value.is<AZ::Vector2>() || m_value.is<AZ::Vector3>() || m_value.is<AZ::Vector4>())
             {
@@ -310,8 +301,15 @@ namespace AtomToolsFramework
 
     bool DynamicProperty::IsValueInteger() const
     {
-        return m_value.is<int8_t>() || m_value.is<uint8_t>() || m_value.is<int16_t>() || m_value.is<uint16_t>() || m_value.is<int32_t>() ||
-            m_value.is<uint32_t>() || m_value.is<int64_t>() || m_value.is<uint64_t>();
+        return
+            m_value.is<int8_t>() || m_value.is<uint8_t>() ||
+            m_value.is<int16_t>() || m_value.is<uint16_t>() ||
+            m_value.is<int32_t>() || m_value.is<uint32_t>() ||
+            m_value.is<int64_t>() || m_value.is<uint64_t>() ||
+            m_value.is<AZ::s8>() || m_value.is<AZ::u8>() ||
+            m_value.is<AZ::s16>() || m_value.is<AZ::u16>() ||
+            m_value.is<AZ::s32>() || m_value.is<AZ::u32>() ||
+            m_value.is<AZ::s64>() || m_value.is<AZ::u64>();
     }
 
     template<typename AttributeValueType>
@@ -327,14 +325,33 @@ namespace AtomToolsFramework
             AZ::Edit::AttributePair(crc, aznew AttributeFixedMemberFunction<AttributeMemberFunctionType>(this, memberFunction)));
     }
 
+    bool DynamicProperty::ApplyRangeEditDataAttributesToNumericTypes()
+    {
+        if (ApplyRangeEditDataAttributesToNumericType<int8_t>() || ApplyRangeEditDataAttributesToNumericType<uint8_t>() ||
+            ApplyRangeEditDataAttributesToNumericType<int16_t>() || ApplyRangeEditDataAttributesToNumericType<uint16_t>() ||
+            ApplyRangeEditDataAttributesToNumericType<int32_t>() || ApplyRangeEditDataAttributesToNumericType<uint32_t>() ||
+            ApplyRangeEditDataAttributesToNumericType<int64_t>() || ApplyRangeEditDataAttributesToNumericType<uint64_t>() ||
+            ApplyRangeEditDataAttributesToNumericType<AZ::s8>() || ApplyRangeEditDataAttributesToNumericType<AZ::u8>() ||
+            ApplyRangeEditDataAttributesToNumericType<AZ::s16>() || ApplyRangeEditDataAttributesToNumericType<AZ::u16>() ||
+            ApplyRangeEditDataAttributesToNumericType<AZ::s32>() || ApplyRangeEditDataAttributesToNumericType<AZ::u32>() ||
+            ApplyRangeEditDataAttributesToNumericType<AZ::s64>() || ApplyRangeEditDataAttributesToNumericType<AZ::u64>() ||
+            ApplyRangeEditDataAttributesToNumericType<float>() || ApplyRangeEditDataAttributesToNumericType<double>())
+        {
+            return true;
+        }
+        return false;
+    }
+
     template<typename AttributeValueType>
-    void DynamicProperty::ApplyRangeEditDataAttributesWithTypeCheck()
+    bool DynamicProperty::ApplyRangeEditDataAttributesToNumericType()
     {
         if (m_value.is<AttributeValueType>())
         {
             ApplyRangeEditDataAttributes<AttributeValueType>();
             ApplySliderEditDataAttributes<AttributeValueType>();
+            return true;
         }
+        return false;
     }
 
     template<typename AttributeValueType>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphDocument.cpp
@@ -416,7 +416,15 @@ namespace AtomToolsFramework
 
         if (IsCompileGraphQueued())
         {
-            CompileGraph();
+            if (m_compileGraphQueueTime <= AZStd::chrono::steady_clock::now())
+            {
+                if (CompileGraph())
+                {
+                    const AZ::u64 intervalMs =
+                        GetSettingsValue("/O3DE/AtomToolsFramework/GraphCompiler/QueueGraphCompileIntervalMs", (AZ::u64)500);
+                    m_compileGraphQueueTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(intervalMs);
+                }
+            }
         }
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewSettings.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Graph/GraphViewSettings.cpp
@@ -140,7 +140,6 @@ namespace AtomToolsFramework
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &GraphViewSettings::m_groupDoubleClickCollapseEnabled, "Group Double Click Collapse Enabled", "Toggle if groups can be expanded or collapsed by double clicking")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &GraphViewSettings::m_bookmarkViewportControlEnabled, "Bookmark Viewport Control Enabled", "Will cause the bookmarks to force the viewport into the state determined by the bookmark type\nBookmark Anchors - The viewport that exists when the bookmark is created.\nNode Groups - The area the Node Group covers")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &GraphViewSettings::m_allowNodeDisabling, "Allow Node Disabling", "Toggle support for enabling and disabling nodes")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &GraphViewSettings::m_allowDataReferenceSlots, "Allow Data Reference Slots", "")
                     ;
             }

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -225,8 +225,15 @@ namespace MaterialCanvas
               AtomToolsFramework::CreateSettingsPropertyValue(
                   "/O3DE/Atom/MaterialCanvas/CreateDefaultDocumentOnStart",
                   "Create Untitled Graph Document On Start",
-                  "Create a default, untitled graph document when Material Canvas starts",
-                  true) });
+                  "Create a default, untitled graph document when Material Canvas starts.",
+                  true),
+              AtomToolsFramework::CreateSettingsPropertyValue(
+                  "/O3DE/AtomToolsFramework/GraphCompiler/QueueGraphCompileIntervalMs",
+                  "Queue Graph Compile Interval Ms",
+                  "The delay (in milliseconds) before the graph is recompiled after changes.",
+                  aznumeric_cast<AZ::s64>(500),
+                  aznumeric_cast<AZ::s64>(0),
+                  aznumeric_cast<AZ::s64>(1000)) });
 
         inspector->AddGroup(
             m_materialCanvasCompileSettingsGroup->m_name,


### PR DESCRIPTION
## What does this PR do?

- Add a setting to specify an interval between queued material graph compiles. This prevents rapid changes in the editor or cycling through undo and redo from canceling and recompiling the graph multiple times in a row and needlessly.
- Fixed problems with dynamic property class minimum and maximum spin box and slider ranges. Some sliders were broken in the settings dialog.
- Removes epsilon as the default step size if no step size is specified in material type properties
- Removed system settings, like allowed disable nodes, from the graph view settings edit context.

fixes https://github.com/o3de/o3de/issues/16983
fixes https://github.com/o3de/o3de/issues/14772
fixes https://github.com/o3de/o3de/issues/13560

## How was this PR tested?

Confirmed that allow disabled node setting was removed from tools settings dialog.
Confirmed that slider based settings can be changed using the sliders and specified ranges in the tools settings dialog.
Confirmed that having a minimum interval between automatic graph compiles resolves 14772.