### PR TITLE
[SMC] Addition of sub-values enumeration

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/ExpandOptionsFullCombinatorials.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/ExpandOptionsFullCombinatorials.py
@@ -40,7 +40,7 @@ def nextElement(inlist, after):
         idx = inlist.index(after)
         return inlist[idx + 1]
     except:
-        return after
+        return after + 1  # need to return something comparable to `end` so that the test "digit > maxValue(desc)" in the `increment` function may pass
 
 def inclusiveRange(start, end):
      return range(start, end + 1)
@@ -99,7 +99,14 @@ def intFromOptionValueName(optionName, valueNameStr):
 
 def hasRestrictions(optionName):
     return optionName in valueRestrictions \
-        and len(valueRestrictions[optionName]) > 0
+        and len(valueRestrictions[optionName]) < optionsByNames[optionName].GetValuesCount() # if everything is "checked" that's no restriction
+
+# check if a value should be skipped for counting (not included in enumeration because it's unchecked)
+def isValueRestricted(optionName, valueNameStr):
+    valAsInt = intFromOptionValueName(optionName, valueNameStr)
+    if hasRestrictions(optionName):
+        return valAsInt not in valueRestrictions[optionName]
+    return False
 
 # "virtualize" access to GetMinValue to reflect the potential value-space restriction
 def getMinValue(descriptor):
@@ -138,12 +145,6 @@ def getNextValueInt(descriptor, digit):
     else:
         return digit + 1
 
-def isValueRestricted(optionName, valueNameStr):
-    valAsInt = intFromOptionValueName(optionName, valueNameStr)
-    if optionName in valueRestrictions:
-        return valAsInt in valueRestrictions[optionName]
-    return False
-
 # small window to select sub-ranges into an option's possible values
 class ValueSelector(QDialog):
     def __init__(self, optionName, optionValuesNames):
@@ -178,8 +179,8 @@ class ValueSelector(QDialog):
     def storeRestriction(self):
         '''update the global dictionary of usable values for this option'''
         global valueRestrictions
-        restrictedList = [intFromOptionValueName(self.optionName, x.text()) for x in listItems(self.valueList) if x.checkState() == QtCore.Qt.Unchecked]
-        if len(restrictedList) == optionsByNames[self.optionName].GetValuesCount():
+        restrictedList = [intFromOptionValueName(self.optionName, x.text()) for x in listItems(self.valueList) if x.checkState() == QtCore.Qt.Checked]
+        if len(restrictedList) == 0:
             msgBox = QMessageBox()
             msgBox.setText("Keep at least one value")
             msgBox.setInformativeText("Nothing to enumerate: just remove the option from the pariticipants altogether.")


### PR DESCRIPTION
New feature of the enumeration script: select a sub-set of the possible values in an option.

Usage:

open shader management console.
In this example I customize `ShadowCatcher`

![image](https://github.com/o3de/o3de/assets/25970839/e626d24f-1e8b-46eb-b720-96e12785a0cf)

I add 3 options, some with enumerations, some bools.
Select the option to customize in the right panel, and right click:

![image](https://github.com/o3de/o3de/assets/25970839/d41e9d79-df77-4c86-8c2f-49defaafcc65)

Doing the action "customize generated values" will show up the popup:

![image](https://github.com/o3de/o3de/assets/25970839/9749923b-b50d-48be-8d08-55ae6ec6caf7)

Select a sub-set you think is actually most useful at runtime:

![image](https://github.com/o3de/o3de/assets/25970839/4a56cc96-12a9-4343-a1ed-1dda2af9796a)

Same for another option:

![image](https://github.com/o3de/o3de/assets/25970839/62b62930-9823-442d-97b0-0533ec51abf1)

Once deselected, the options with custom subsets active will appear purple:

![image](https://github.com/o3de/o3de/assets/25970839/e1ebcf86-0ce0-4496-8e36-e56d3f4a5038)

Click "generate variant list" and exit. The generated result will be:

![image](https://github.com/o3de/o3de/assets/25970839/b690c15c-0637-45e1-8136-12ab4d481b2a)

Of course, it's compatible with multiply as well. _(In that particular example the starting variantlist was empty, so multiply would result in 0 new variants.)_