### PR TITLE
Add setters to modify PhysX joints' motors

### DIFF
--- a/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.cpp
+++ b/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.cpp
@@ -26,4 +26,6 @@ namespace PhysX::JointsComponentModeCommon
     const AZStd::string_view ParameterNames::LinearLimits = "Linear Limits";
     const AZStd::string_view ParameterNames::EnableLimits = "Enable Limits";
     const AZStd::string_view ParameterNames::EnableSoftLimits = "Enable SoftLimits";
+    const AZStd::string_view ParameterNames::EnableMotor = "Enable Motor";
+    const AZStd::string_view ParameterNames::DriveForceLimit = "Drive Force Limit";
 } // namespace PhysX::JointsComponentModeCommon

--- a/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.h
+++ b/Gems/PhysX/Code/Editor/Source/ComponentModes/Joints/JointsComponentModeCommon.h
@@ -62,6 +62,8 @@ namespace PhysX::JointsComponentModeCommon
         static const AZStd::string_view LinearLimits;
         static const AZStd::string_view EnableLimits;
         static const AZStd::string_view EnableSoftLimits;
+        static const AZStd::string_view EnableMotor;
+        static const AZStd::string_view DriveForceLimit;
     };
 
     //! A pairing of Sub component Names, and Id.

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -117,6 +117,10 @@ namespace PhysX
         {
             return m_angularLimit.m_standardLimitConfig.m_stiffness;
         }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::DriveForceLimit)
+        {
+            return m_motorConfiguration.m_driveForceLimit;
+        }
 
         return 0.0f;
     }
@@ -182,6 +186,10 @@ namespace PhysX
         {
             m_angularLimit.m_standardLimitConfig.m_isSoftLimit = value;
         }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::EnableMotor)
+        {
+            m_motorConfiguration.m_useMotor = value;
+        }
     }
 
     void EditorHingeJointComponent::SetLinearValue(const AZStd::string& parameterName, float value)
@@ -201,6 +209,10 @@ namespace PhysX
         else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::Stiffness)
         {
             m_angularLimit.m_standardLimitConfig.m_stiffness = value;
+        }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::DriveForceLimit)
+        {
+            m_motorConfiguration.m_driveForceLimit = value;
         }
     }
 
@@ -278,7 +290,6 @@ namespace PhysX
                 points[3].SetX(size);
             }
 
-            
             debugDisplay.SetColor(s_colorSweepArc);
             const float sweepLineDisplaceFactor = 0.5f;
             const float sweepLineThickness = 1.0f * scaleMultiply;
@@ -332,4 +343,4 @@ namespace PhysX
         debugDisplay.PopMatrix(); // pop joint world transform
         debugDisplay.SetState(stateBefore);
     }
-}
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
@@ -108,6 +108,10 @@ namespace PhysX
         {
             return m_linearLimit.m_standardLimitConfig.m_stiffness;
         }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::DriveForceLimit)
+        {
+            return m_motorConfiguration.m_driveForceLimit;
+        }
 
         return 0.0f;
     }
@@ -137,6 +141,10 @@ namespace PhysX
         {
             m_linearLimit.m_standardLimitConfig.m_isSoftLimit = value;
         }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::EnableMotor)
+        {
+            m_motorConfiguration.m_useMotor = value;
+        }
     }
 
     void EditorPrismaticJointComponent::SetLinearValue(const AZStd::string& parameterName, float value)
@@ -156,6 +164,10 @@ namespace PhysX
         else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::Stiffness)
         {
             m_linearLimit.m_standardLimitConfig.m_stiffness = value;
+        }
+        else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::DriveForceLimit)
+        {
+            m_motorConfiguration.m_driveForceLimit = value;
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

The current API for manipulating joint parameters via `EditorJointRequestBus` does not allow modifications of the parameters of motors. The modifications in this PR allow such changes for `EditorHingeJointComponent` and `EditorPrismaticJointComponent`. 

This change will be used by a [ROS 2 Gem](https://github.com/o3de/o3de-extras/tree/development/Gems/ROS2) from creating joints automatically rather than from the Editor (e.g. using Robot Importer tool, which creates _prefabs_ out of URDF or SDFormat descriptions). 

The code can be used as follows:
```cpp
                    jointComponent->Activate();
                    PhysX::EditorJointRequestBus::Event(
                        AZ::EntityComponentIdPair(entityId, jointComponent->GetId()),
                        &PhysX::EditorJointRequests::SetBoolValue,
                        PhysX::JointsComponentModeCommon::ParameterNames::EnableMotor,
                        true);
                    jointComponent->Deactivate();
```

## How was this PR tested?

The code was manually tested using the [modified Robot Importer tool](https://github.com/jhanca-robotecai/o3de-extras/tree/jh/test/model_hooks) and test models from https://github.com/o3de/o3de-extras/pull/609
