### PR TITLE
Reduce the gap between DPE property rows

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -53,6 +53,8 @@ namespace AzToolsFramework
         : QHBoxLayout(parent)
         , m_depth(-1)
     {
+        setContentsMargins(0, 0, 0, 0);
+        setSpacing(0);
     }
 
     void DPELayout::Init(int depth, bool enforceMinWidth, [[maybe_unused]] QWidget* parentWidget)
@@ -1353,6 +1355,9 @@ namespace AzToolsFramework
     {
         QWidget* scrollSurface = new QWidget(this);
         m_layout = new QVBoxLayout(scrollSurface);
+        m_layout->setContentsMargins(0, 0, 0, 0);
+        m_layout->setSpacing(2);
+
         setWidget(scrollSurface);
         setWidgetResizable(true);
 


### PR DESCRIPTION
## What does this PR do?

Changed the spacing and margins for the DPE to look more like the RPE. This reduces a large gap between the property rows that added screen real estate and required extra scrolling. This was especially a problem for large property stacks, like material component with complex scenes that have 20, 50, or more materials.

## How was this PR tested?

Open the material component with 50+ materials to see that the gap has been reduced.
Examined other components like mesh and transform to make sure reduced gap did not interfere with them.