### PR TITLE
fixed missed generate source materials function to use progress dialog

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -674,7 +674,7 @@ namespace AZ
                     AssetBuilderSDK::JobProduct defaultMaterialFileProduct;
                     defaultMaterialFileProduct.m_dependenciesHandled = true; // This product is only for reference, not used at runtime
                     defaultMaterialFileProduct.m_productFileName = defaultMaterialFilePath;
-                    defaultMaterialFileProduct.m_productAssetType = AZ::Uuid::CreateString("{FE8E7122-9E96-44F0-A4E4-F134DD9804E2}"); // Need a unique acid type for this raw JSON file
+                    defaultMaterialFileProduct.m_productAssetType = AZ::Uuid::CreateString("{FE8E7122-9E96-44F0-A4E4-F134DD9804E2}"); // Need a unique asset type for this raw JSON file
                     defaultMaterialFileProduct.m_productSubID = (u32)MaterialTypeProductSubId::AllPropertiesMaterialSourceFile;
                     response.m_outputProducts.emplace_back(AZStd::move(defaultMaterialFileProduct));
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentExporter.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentExporter.h
@@ -8,10 +8,15 @@
 
 #pragma once
 
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/containers/vector.h>
-
 #include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Asset/AssetManagerBus.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/string/string.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <QProgressDialog>
+AZ_POP_DISABLE_WARNING
 
 namespace AZ
 {
@@ -64,6 +69,23 @@ namespace AZ
 
             //! Attemts to construct and save material source data from a product asset
             bool ExportMaterialSourceData(const ExportItem& exportItem);
+
+            //! Create a progress dialog for displaying the status of generated material assets.
+            class ProgressDialog
+            {
+            public:
+                ProgressDialog(const AZStd::string& title, const AZStd::string& label, const int itemCount);
+                ~ProgressDialog() = default;
+
+                //! Blocking call that polls for asset info until valid or the user cancels the operation.
+                AZ::Data::AssetInfo ProcessItem(const ExportItem& exportItem);
+
+                //! Increment the progress bar in the dialog.
+                void CompleteItem();
+
+            private:
+                AZStd::unique_ptr<QProgressDialog> m_progressDialog;
+            };
         } // namespace EditorMaterialComponentExporter
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -278,14 +278,18 @@ namespace AZ
 
         void EditorMaterialComponentSlot::ExportMaterial(const AZStd::string& exportPath, bool overwrite)
         {
+            EditorMaterialComponentExporter::ProgressDialog progressDialog("Generating materials", "Generating material...", 1);
+
             EditorMaterialComponentExporter::ExportItem exportItem(GetDefaultAssetId(), GetLabel(), exportPath);
             exportItem.SetOverwrite(overwrite);
 
             if (EditorMaterialComponentExporter::ExportMaterialSourceData(exportItem))
             {
-                if (const auto& assetIdOutcome = AZ::RPI::AssetUtils::MakeAssetId(exportItem.GetExportPath(), 0))
+                const AZ::Data::AssetInfo assetInfo = progressDialog.ProcessItem(exportItem);
+                if (assetInfo.m_assetId.IsValid())
                 {
-                    SetAssetId(assetIdOutcome.GetValue());
+                    SetAssetId(assetInfo.m_assetId);
+                    progressDialog.CompleteItem();
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

- Moved generate source materials progress dialog into its own class so that it can be used in multiple places.
- Updated overlooked, manually invoked function to also use the progress dialog and wait on assets to be processed.
- Updated function that generated material file names to handle and replace dots in the material name.


## How was this PR tested?

Tested updated functions with large models containing 50+ materials and dots in material names.