### PR TITLE
Remove unused Material Edit mode

### DIFF
--- a/Code/Editor/Commands/CommandManager.cpp
+++ b/Code/Editor/Commands/CommandManager.cpp
@@ -477,13 +477,6 @@ void CEditorCommandManager::LogCommand(const AZStd::string& fullCmdName, const C
 
     cmdLine += ")";
 
-    // If it's not SandBox main editor (one case is the standalone material editor triggered by 3ds Max exporter),
-    // we should not cast it into main editor for further operation.
-    if (GetIEditor()->IsInMatEditMode())
-    {
-        return;
-    }
-
     // Then, register it to the terminal.
     QtViewPane* scriptTermPane = QtViewPaneManager::instance()->GetPane(SCRIPT_TERM_WINDOW_NAME);
     if (!scriptTermPane)

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -387,8 +387,6 @@ public:
     bool m_bExport = false;
     bool m_bExportTexture = false;
 
-    bool m_bMatEditMode = false;
-
     bool m_bConsoleMode = false;
     bool m_bNullRenderer = false;
     bool m_bDeveloperMode = false;
@@ -429,7 +427,6 @@ public:
             { "exportTexture", m_bExportTexture },
             { "test", m_bTest },
             { "auto_level_load", m_bAutoLoadLevel },
-            { "MatEdit", m_bMatEditMode },
             { "BatchMode", m_bConsoleMode },
             { "NullRenderer", m_bNullRenderer },
             { "devmode", m_bDeveloperMode },
@@ -885,8 +882,6 @@ void CCryEditApp::InitFromCommandLine(CEditCommandLineInfo& cmdInfo)
     m_execLineCmd = cmdInfo.m_execLineCmd;
     m_bAutotestMode = cmdInfo.m_bAutotestMode || cmdInfo.m_bConsoleMode;
 
-    m_pEditor->SetMatEditMode(cmdInfo.m_bMatEditMode);
-
     if (m_bExportMode)
     {
         m_exportFile = cmdInfo.m_exportFile;
@@ -967,7 +962,7 @@ bool CCryEditApp::CheckIfAlreadyRunning()
 /////////////////////////////////////////////////////////////////////////////
 bool CCryEditApp::InitGame()
 {
-    if (!m_bPreviewMode && !GetIEditor()->IsInMatEditMode())
+    if (!m_bPreviewMode)
     {
         AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
         Log((QString("project_path = %1").arg(!projectPath.empty() ? projectPath.c_str() : "<not set>")).toUtf8().data());
@@ -1107,7 +1102,6 @@ void CCryEditApp::InitLevel(const CEditCommandLineInfo& cmdInfo)
                 doLevelNeedLoading = true;
                 if (gSettings.bShowDashboardAtStartup
                     && !runningPythonScript
-                    && !GetIEditor()->IsInMatEditMode()
                     && !m_bConsoleMode
                     && !m_bSkipWelcomeScreenDialog
                     && !m_bPreviewMode
@@ -1597,9 +1591,7 @@ bool CCryEditApp::InitInstance()
 #ifdef Q_OS_MACOS
     auto mainWindowWrapper = new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionDisabled);
 #else
-    // No need for mainwindow wrapper for MatEdit mode
-    auto mainWindowWrapper = new AzQtComponents::WindowDecorationWrapper(cmdInfo.m_bMatEditMode ? AzQtComponents::WindowDecorationWrapper::OptionDisabled
-        : AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons);
+    auto mainWindowWrapper = new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons);
 #endif
     mainWindowWrapper->setGuest(mainWindow);
     HWND mainWindowWrapperHwnd = (HWND)mainWindowWrapper->winId();
@@ -1678,7 +1670,7 @@ bool CCryEditApp::InitInstance()
             AZ::Environment::FindVariable<int>("assertVerbosityLevel").Set(1);
             m_pConsoleDialog->raise();
         }
-        else if (!GetIEditor()->IsInMatEditMode())
+        else
         {
             MainWindow::instance()->show();
             MainWindow::instance()->raise();
@@ -1711,10 +1703,7 @@ bool CCryEditApp::InitInstance()
     }
 
     SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), nullptr);
-    if (!GetIEditor()->IsInMatEditMode())
-    {
-        m_pEditor->InitFinished();
-    }
+    m_pEditor->InitFinished();
 
     // Make sure Python is started before we attempt to restore the Editor layout, since the user
     // might have custom view panes in the saved layout that will need to be registered.
@@ -1724,7 +1713,7 @@ bool CCryEditApp::InitInstance()
         editorPythonEventsInterface->StartPython();
     }
 
-    if (!GetIEditor()->IsInMatEditMode() && !GetIEditor()->IsInConsolewMode())
+    if (!GetIEditor()->IsInConsolewMode())
     {
         bool restoreDefaults = !mainWindowWrapper->restoreGeometryFromSettings();
         QtViewPaneManager::instance()->RestoreLayout(restoreDefaults);
@@ -2064,7 +2053,7 @@ int CCryEditApp::ExitInstance(int exitCode)
         }
     }
 
-    if (GetIEditor() && !GetIEditor()->IsInMatEditMode())
+    if (GetIEditor())
     {
         //Nobody seems to know in what case that kind of exit can happen so instrumented to see if it happens at all
         if (m_pEditor)
@@ -3491,7 +3480,7 @@ void CCryEditApp::AddToRecentFileList(const QString& lpszPathName)
 bool CCryEditApp::IsInRegularEditorMode()
 {
     return !IsInTestMode() && !IsInPreviewMode()
-           && !IsInExportMode() && !IsInConsoleMode() && !IsInLevelLoadTestMode() && !GetIEditor()->IsInMatEditMode();
+           && !IsInExportMode() && !IsInConsoleMode() && !IsInLevelLoadTestMode();
 }
 
 void CCryEditApp::SetEditorWindowTitle(QString sTitleStr, QString sPreTitleStr, QString sPostTitleStr)
@@ -3798,7 +3787,7 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
         {
             CEditCommandLineInfo cmdInfo;
             if (!cmdInfo.m_bAutotestMode && !cmdInfo.m_bConsoleMode && !cmdInfo.m_bExport && !cmdInfo.m_bExportTexture &&
-                !cmdInfo.m_bNullRenderer && !cmdInfo.m_bMatEditMode && !cmdInfo.m_bTest)
+                !cmdInfo.m_bNullRenderer && !cmdInfo.m_bTest)
             {
                 if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
                 {

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -416,7 +416,7 @@ void EditorViewportWidget::Update()
         return;
     }
 
-    if (m_rcClient.isEmpty() || GetIEditor()->IsInMatEditMode())
+    if (m_rcClient.isEmpty())
     {
         return;
     }

--- a/Code/Editor/IEditor.h
+++ b/Code/Editor/IEditor.h
@@ -450,8 +450,6 @@ struct IEditor
     virtual bool IsInConsolewMode() = 0;
     //! return true if editor is running the level load tests mode.
     virtual bool IsInLevelLoadTestMode() = 0;
-    //! Return true if Editor runs in the material editing mode.
-    virtual bool IsInMatEditMode() = 0;
     //! Enable/Disable updates of editor.
     virtual void EnableUpdate(bool enable) = 0;
     virtual SFileVersion GetFileVersion() = 0;

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -114,7 +114,6 @@ CEditorImpl::CEditorImpl()
     , m_pConsoleSync(nullptr)
     , m_pSettingsManager(nullptr)
     , m_pLevelIndependentFileMan(nullptr)
-    , m_bMatEditMode(false)
     , m_bShowStatusText(true)
     , m_bInitialized(false)
     , m_bExiting(false)
@@ -498,7 +497,7 @@ void CEditorImpl::SetDataModified()
 
 void CEditorImpl::SetStatusText(const QString& pszString)
 {
-    if (m_bShowStatusText && !m_bMatEditMode && GetMainStatusBar())
+    if (m_bShowStatusText && GetMainStatusBar())
     {
         GetMainStatusBar()->SetStatusText(pszString);
     }
@@ -1336,11 +1335,6 @@ bool CEditorImpl::IsSourceControlConnected()
     }
 
     return false;
-}
-
-void CEditorImpl::SetMatEditMode(bool bIsMatEditMode)
-{
-    m_bMatEditMode = bIsMatEditMode;
 }
 
 void CEditorImpl::ShowStatusText(bool bEnable)

--- a/Code/Editor/IEditorImpl.h
+++ b/Code/Editor/IEditorImpl.h
@@ -122,7 +122,6 @@ public:
     bool IsInPreviewMode() override;
     bool IsInConsolewMode() override;
     bool IsInLevelLoadTestMode() override;
-    bool IsInMatEditMode() override { return m_bMatEditMode; }
 
     //! Enables/Disable updates of editor.
     void EnableUpdate(bool enable) override { m_bUpdates = enable; };
@@ -255,8 +254,6 @@ public:
     bool IsSourceControlAvailable() override;
     //! Only returns true if source control is both available AND currently connected and functioning
     bool IsSourceControlConnected() override;
-    //! Setup Material Editor mode
-    void SetMatEditMode(bool bIsMatEditMode);
     void ReduceMemory() override;
     ESystemConfigPlatform GetEditorConfigPlatform() const override;
     void ReloadTemplates() override;
@@ -337,10 +334,6 @@ protected:
     QString m_selectFileBuffer;
     QString m_levelNameBuffer;
 
-
-    //! True if the editor is in material edit mode. Fast preview of materials.
-    //! In this mode only very limited functionality is available.
-    bool m_bMatEditMode;
     bool m_bShowStatusText;
     bool m_bInitialized;
     bool m_bExiting;

--- a/Code/Editor/Lib/Tests/IEditorMock.h
+++ b/Code/Editor/Lib/Tests/IEditorMock.h
@@ -65,7 +65,6 @@ public:
     MOCK_METHOD0(IsInPreviewMode, bool());
     MOCK_METHOD0(IsInConsolewMode, bool());
     MOCK_METHOD0(IsInLevelLoadTestMode, bool());
-    MOCK_METHOD0(IsInMatEditMode, bool());
     MOCK_METHOD1(EnableUpdate, void(bool));
     MOCK_METHOD0(GetFileVersion, SFileVersion());
     MOCK_METHOD0(GetProductVersion, SFileVersion());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
@@ -32,8 +32,6 @@ namespace AzToolsFramework
                 {
                     editContext->Class<EditorPrefabComponent>("Prefab Component", "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
-                        ->Attribute(AZ::Edit::Attributes::HideIcon, true)
                         ->Attribute(
                             AZ::Edit::Attributes::SliceFlags,
                             AZ::Edit::SliceFlags::HideOnAdd | AZ::Edit::SliceFlags::PushWhenHidden |


### PR DESCRIPTION
## What does this PR do?

First of a few subsequent CRs to remove unused legacy CBaseObject classes from the codebase.

## How was this PR tested?

Manual testing to ensure Editor works as expected. Also ran unit tests in the affected areas successfully.