### PR TITLE
MultiDeviceBuffers and -pipelines in Meshlets Gem

### DIFF
--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.cpp
@@ -48,7 +48,7 @@ namespace AZ
             {
                 RHI::PipelineStateDescriptorForDispatch pipelineDesc;
                 m_shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
-                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc);
+                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
         }
 
@@ -59,7 +59,7 @@ namespace AZ
             {
                 RHI::PipelineStateDescriptorForDispatch pipelineDesc;
                 m_shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
-                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc);
+                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
         }
 

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
@@ -397,7 +397,7 @@ namespace AZ
 
                         RHI::ShaderInputBufferIndex indexHandle = meshRenderData.RenderObjectSrg->FindShaderInputBufferIndex(bufferDesc.m_paramNameInSrg);
                         bufferDesc.m_resourceShaderIndex = indexHandle.GetIndex();
-                        if (!meshRenderData.RenderObjectSrg->SetBufferView(indexHandle, meshRenderData.RenderBuffersViews[stream].get()))
+                        if (!meshRenderData.RenderObjectSrg->SetBufferView(indexHandle, meshRenderData.RenderBuffersViews[stream]->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
                         {
                             AZ_Error("Meshlets", false, "Failed to bind render buffer view for %s", bufferDesc.m_bufferName.GetCStr());
                             return false;
@@ -409,7 +409,7 @@ namespace AZ
                         bufferDesc.m_viewOffsetInBytes = meshRenderData.ComputeBuffersDescriptors[mappedIdx].m_viewOffsetInBytes;
 
                         meshRenderData.IndexBufferView = RHI::SingleDeviceIndexBufferView(
-                            meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer(),
+                            *meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                             bufferDesc.m_viewOffsetInBytes,
                             (uint64_t)bufferDesc.m_elementCount * bufferDesc.m_elementSize,
                             (bufferDesc.m_elementFormat == RHI::Format::R32_UINT) ? RHI::IndexFormat::Uint32 : RHI::IndexFormat::Uint16);
@@ -417,7 +417,7 @@ namespace AZ
                 }
                 else
                 {   // Regular buffers creation - since they are read only, no need to use the shared buffer
-                    meshRenderData.RenderBuffersViews[stream] = Data::Instance<RHI::SingleDeviceBufferView>();
+                    meshRenderData.RenderBuffersViews[stream] = Data::Instance<RHI::MultiDeviceBufferView>();
                     meshRenderData.RenderBuffers[stream] = UtilityClass::CreateBufferAndBindToSrg(
                         "Meshlets", bufferDesc, meshRenderData.RenderObjectSrg);
 
@@ -558,7 +558,7 @@ namespace AZ
                 else
                 {   // Regular buffers: since these buffers are read only and will not be altered there is no need to
                     // use the shared buffer. This also means that we bind using buffers instead of buffers views.
-                    meshRenderData.ComputeBuffersViews[stream] = Data::Instance<RHI::SingleDeviceBufferView>();
+                    meshRenderData.ComputeBuffersViews[stream] = Data::Instance<RHI::MultiDeviceBufferView>();
                     meshRenderData.ComputeBuffers[stream] = UtilityClass::CreateBuffer("Meshlets", bufferDesc);
 
                     success &= (meshRenderData.ComputeBuffers[stream] ? true : false);

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.h
@@ -64,7 +64,7 @@ namespace AZ
              //! Compute render data
             Data::Instance<RPI::ShaderResourceGroup> ComputeSrg;          // Per object Compute data - can be shared across instances
             AZStd::vector<SrgBufferDescriptor> ComputeBuffersDescriptors;
-            AZStd::vector<Data::Instance<RHI::SingleDeviceBufferView>> ComputeBuffersViews;
+            AZStd::vector<Data::Instance<RHI::MultiDeviceBufferView>> ComputeBuffersViews;
             AZStd::vector<Data::Instance<Meshlets::SharedBufferAllocation>> ComputeBuffersAllocators;
             AZStd::vector <Data::Instance<RPI::Buffer>> ComputeBuffers;   // stand alone non shared buffers
             MeshletsDispatchItem MeshDispatchItem;
@@ -73,7 +73,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> RenderObjectSrg;     // Per object render data - includes instanceId and vertex buffers
             AZStd::vector<SrgBufferDescriptor> RenderBuffersDescriptors;
             RHI::SingleDeviceIndexBufferView IndexBufferView;
-            AZStd::vector<Data::Instance<RHI::SingleDeviceBufferView>> RenderBuffersViews; 
+            AZStd::vector<Data::Instance<RHI::MultiDeviceBufferView>> RenderBuffersViews;
             AZStd::vector <Data::Instance<RPI::Buffer>> RenderBuffers;    // stand alone non shared buffers
 
             const RHI::DrawPacket* MeshDrawPacket = nullptr;    // Should be moved to the instance data structure

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderPass.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderPass.cpp
@@ -180,7 +180,7 @@ namespace AZ
             }
 
             drawRequest.m_listTag = m_drawListTag;
-            drawRequest.m_pipelineState = m_pipelineState;
+            drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             return true;
         }

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.h
@@ -64,7 +64,7 @@ namespace AZ
                 Data::Instance<RPI::ShaderResourceGroup> srg = nullptr
             );
 
-            static Data::Instance<RHI::SingleDeviceBufferView> CreateSharedBufferView(
+            static Data::Instance<RHI::MultiDeviceBufferView> CreateSharedBufferView(
                 const char* warningHeader,
                 SrgBufferDescriptor& bufferDesc,
                 Data::Instance<Meshlets::SharedBufferAllocation>& bufferAllocator
@@ -72,12 +72,12 @@ namespace AZ
 
             static bool BindBufferViewToSrg(
                 [[maybe_unused]] const char* warningHeader,
-                Data::Instance<RHI::SingleDeviceBufferView> bufferView,
+                Data::Instance<RHI::MultiDeviceBufferView> bufferView,
                 SrgBufferDescriptor& bufferDesc,
                 Data::Instance<RPI::ShaderResourceGroup> srg
             );
 
-            static Data::Instance<RHI::SingleDeviceBufferView> CreateSharedBufferViewAndBindToSrg(
+            static Data::Instance<RHI::MultiDeviceBufferView> CreateSharedBufferViewAndBindToSrg(
                 const char* warningHeader,
                 SrgBufferDescriptor& bufferDesc,
                 Data::Instance<Meshlets::SharedBufferAllocation>& outputBufferAllocator,


### PR DESCRIPTION
## What does this PR do?

This commit fixes some instances where `Buffer` and `PipelineState`-related resources where missed during the conversion step (https://github.com/o3de/o3de/pull/17040) from single to multi device versions.

## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`
