### PR TITLE
Introduce multi-device SwapChain

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -36,6 +36,7 @@ namespace AZ::RHI
         friend class MultiDeviceImagePool;
         friend class MultiDeviceTransientAttachmentPool;
         friend class MultiDeviceStreamingImagePool;
+        friend class MultiDeviceSwapChain;
 
         using Base = MultiDeviceResource;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -21,6 +21,11 @@ namespace AZ::RHI
     //!
     //! The frame scheduler controls presentation of the swap chain. The user may attach a swap chain to a scope
     //! in order to render to the current image.
+    //!
+    //! Although a multi-device resource class, we still enforce single-device behavior, as a SwapChain is tied to a
+    //! specific window. This is done by initializing it with a device index, which sets the correspondings bit in the
+    //! deviceMask. The need for a multi-device class arises from the interoperability within a multi-device context,
+    //! especially attachments and the FrameGraph.
     class MultiDeviceSwapChain : public MultiDeviceImagePoolBase
     {
     public:
@@ -30,6 +35,8 @@ namespace AZ::RHI
         virtual ~MultiDeviceSwapChain() = default;
 
         //! Initializes the swap chain, making it ready for attachment.
+        //! As the SwapChain uses multi-device resources on just a single device,
+        //! it is explicitly initialized with just a deviceIndex
         ResultCode Init(int deviceIndex, const SwapChainDescriptor& descriptor);
 
         //! Returns the device-specific SwapChain for the given index

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -30,7 +30,7 @@ namespace AZ::RHI
         virtual ~MultiDeviceSwapChain() = default;
 
         //! Initializes the swap chain, making it ready for attachment.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor);
+        ResultCode Init(int deviceIndex, const SwapChainDescriptor& descriptor);
 
         //! Returns the device-specific SwapChain for the given index
         inline Ptr<SwapChain> GetDeviceSwapChain(int deviceIndex) const

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/SwapChainDescriptor.h>
+#include <Atom/RHI/MultiDeviceImagePoolBase.h>
+#include <Atom/RHI/SwapChain.h>
+#include <Atom/RHI/XRRenderingInterface.h>
+
+namespace AZ::RHI
+{
+    //! The platform-independent, multi-device swap chain base class. Swap chains contain a "chain" of images which
+    //! map to a platform-specific window, displayed on a physical monitor. The user is allowed
+    //! to adjust the swap chain outside of the current FrameScheduler frame. Doing so within a frame scheduler
+    //! frame results in undefined behavior.
+    //!
+    //! The frame scheduler controls presentation of the swap chain. The user may attach a swap chain to a scope
+    //! in order to render to the current image.
+    class MultiDeviceSwapChain : public MultiDeviceImagePoolBase
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(MultiDeviceSwapChain, AZ::SystemAllocator, 0);
+        AZ_RTTI(MultiDeviceSwapChain, "{EB2B3AE5-41C0-4833-ABAD-4D964547029C}", Object);
+        MultiDeviceSwapChain() = default;
+        virtual ~MultiDeviceSwapChain() = default;
+
+        //! Initializes the swap chain, making it ready for attachment.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor);
+
+        //! Returns the device-specific SwapChain for the given index
+        inline Ptr<SwapChain> GetDeviceSwapChain(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceSwapChain",
+                m_deviceSwapChains.find(deviceIndex) != m_deviceSwapChains.end(),
+                "No DeviceSwapChain found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceSwapChains.at(deviceIndex);
+        }
+
+        //! Presents the swap chain to the display, and rotates the images.
+        void Present();
+
+        //! Sets the vertical sync interval for the swap chain.
+        //!      0 - No vsync.
+        //!      N - Sync to every N vertical refresh.
+        //!
+        //! A value of 1 syncs to the refresh rate of the monitor.
+        void SetVerticalSyncInterval(uint32_t verticalSyncInterval);
+
+        //! Resizes the display resolution of the swap chain. Ideally, this matches the platform window
+        //! resolution. Typically, the resize operation will occur in reaction to a platform window size
+        //! change. Takes effect immediately and results in a GPU pipeline flush.
+        ResultCode Resize(const SwapChainDimensions& dimensions);
+
+        //! Returns the number of images in the swap chain.
+        uint32_t GetImageCount() const;
+
+        //! Returns the current image of the swap chain.
+        MultiDeviceImage* GetCurrentImage() const;
+
+        //! Returns the image associated with the provided index, where the total number of images
+        //! is given by GetImageCount().
+        MultiDeviceImage* GetImage(uint32_t index) const;
+
+        //! Returns the ID used for the MultiDeviceSwapChain's attachment
+        const AttachmentId& GetAttachmentId() const;
+
+        //! Returns the descriptor provided when initializing the swap chain.
+        const RHI::SwapChainDescriptor& GetDescriptor() const override final;
+
+        //! Returns True if the swap chain prefers to use exclusive full screen mode.
+        bool IsExclusiveFullScreenPreferred() const;
+
+        //! Returns True if the swap chain prefers exclusive full screen mode and it is currently true, false otherwise.
+        bool GetExclusiveFullScreenState() const;
+
+        //! Return True if the swap chain prefers exclusive full screen mode and a transition happened, false otherwise.
+        bool SetExclusiveFullScreenState(bool fullScreenState);
+
+        //! Recreate the swapchain if it becomes invalid during presenting. This should happen at the end of the frame
+        //! due to images being used as attachments in the frame graph.
+        void ProcessRecreation();
+
+        //! Shuts down the pool. This method will shutdown all resources associated with the pool.
+        void Shutdown() override final;
+
+    protected:
+        struct InitImageRequest
+        {
+            //! Pointer to the image to initialize.
+            MultiDeviceImage* m_mdImage = nullptr;
+
+            //! Index of the image in the swap chain.
+            uint32_t m_imageIndex = 0;
+
+            //! Descriptor for the image.
+            ImageDescriptor m_descriptor;
+        };
+
+        //! Shutdown and clear all the images.
+        void ShutdownImages();
+
+        //! Initialized all the images.
+        ResultCode InitImages();
+
+        //! Return the xr system interface
+        RHI::XRRenderingInterface* GetXRSystem() const;
+
+        //! Flag indicating if swapchain recreation is needed at the end of the frame.
+        bool m_pendingRecreation = false;
+
+    private:
+        bool ValidateDescriptor(const SwapChainDescriptor& descriptor) const;
+
+        SwapChainDescriptor m_descriptor;
+
+        //! Images corresponding to each image in the swap chain.
+        AZStd::vector<Ptr<MultiDeviceImage>> m_mdImages;
+
+        //! Cache the XR system at initialization time
+        RHI::XRRenderingInterface* m_xrSystem = nullptr;
+
+        //! A map of all device-specific SwapChains, indexed by the device index
+        AZStd::unordered_map<int, Ptr<SwapChain>> m_deviceSwapChains;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    bool MultiDeviceSwapChain::ValidateDescriptor(const SwapChainDescriptor& descriptor) const
+    {
+        if (Validation::IsEnabled())
+        {
+            const bool isValidDescriptor = descriptor.m_dimensions.m_imageWidth != 0 && descriptor.m_dimensions.m_imageHeight != 0 &&
+                descriptor.m_dimensions.m_imageCount != 0;
+
+            if (!isValidDescriptor)
+            {
+                AZ_Warning("MultiDeviceSwapChain", false, "MultiDeviceSwapChain display dimensions cannot be 0.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    ResultCode MultiDeviceSwapChain::Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor)
+    {
+        if (!ValidateDescriptor(descriptor))
+        {
+            return ResultCode::InvalidArgument;
+        }
+
+        if (descriptor.m_isXrSwapChain)
+        {
+            m_xrSystem = RHI::RHISystemInterface::Get()->GetXRSystem();
+            AZ_Assert(m_xrSystem, "XR System is null");
+        }
+
+        SwapChainDimensions nativeDimensions = descriptor.m_dimensions;
+        ResultCode resultCode = MultiDeviceResourcePool::Init(
+            deviceMask,
+            [this, &descriptor, &nativeDimensions]()
+            {
+                ResultCode result = ResultCode::Success;
+
+                IterateDevices(
+                    [this, &descriptor, &result, &nativeDimensions](int deviceIndex)
+                    {
+                        auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
+                        m_deviceSwapChains[deviceIndex] = Factory::Get().CreateSwapChain();
+                        result = m_deviceSwapChains[deviceIndex]->Init(*device, descriptor);
+                        nativeDimensions = m_deviceSwapChains[deviceIndex]->GetDescriptor().m_dimensions;
+
+                        return result == ResultCode::Success;
+                    });
+
+                return result;
+            });
+
+        if (resultCode == ResultCode::Success)
+        {
+            m_descriptor = descriptor;
+            // Overwrite descriptor dimensions with the native ones (the ones assigned by the platform) returned by InitInternal.
+            // Note: dimensions of each swap chain could be different, we are taking the dimensions of the last one if there are multiple
+            m_descriptor.m_dimensions = nativeDimensions;
+
+            resultCode = InitImages();
+        }
+        else
+        {
+            // Reset already initialized device-specific SwapChains and set deviceMask to 0
+            m_deviceSwapChains.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    void MultiDeviceSwapChain::ShutdownImages()
+    {
+        // Shutdown existing set of images.
+        uint32_t imageSize = aznumeric_cast<uint32_t>(m_mdImages.size());
+        for (uint32_t imageIdx = 0; imageIdx < imageSize; ++imageIdx)
+        {
+            m_mdImages[imageIdx]->Shutdown();
+        }
+
+        m_mdImages.clear();
+    }
+
+    ResultCode MultiDeviceSwapChain::InitImages()
+    {
+        ResultCode resultCode = ResultCode::Success;
+
+        m_mdImages.reserve(m_descriptor.m_dimensions.m_imageCount);
+
+        // If the new display mode has more buffers, add them.
+        for (uint32_t i = 0; i < m_descriptor.m_dimensions.m_imageCount; ++i)
+        {
+            m_mdImages.emplace_back(aznew MultiDeviceImage());
+        }
+
+        InitImageRequest request;
+
+        RHI::ImageDescriptor& imageDescriptor = request.m_descriptor;
+        imageDescriptor.m_dimension = RHI::ImageDimension::Image2D;
+        imageDescriptor.m_bindFlags = RHI::ImageBindFlags::Color;
+        imageDescriptor.m_size.m_width = m_descriptor.m_dimensions.m_imageWidth;
+        imageDescriptor.m_size.m_height = m_descriptor.m_dimensions.m_imageHeight;
+        imageDescriptor.m_format = m_descriptor.m_dimensions.m_imageFormat;
+
+        for (uint32_t imageIdx = 0; imageIdx < m_descriptor.m_dimensions.m_imageCount; ++imageIdx)
+        {
+            request.m_mdImage = m_mdImages[imageIdx].get();
+            request.m_imageIndex = imageIdx;
+
+            resultCode = MultiDeviceImagePoolBase::InitImage(
+                request.m_mdImage,
+                imageDescriptor,
+                [this, imageIdx]()
+                {
+                    ResultCode result = ResultCode::Success;
+
+                    for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+                    {
+                        m_mdImages[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
+                    }
+
+                    return result;
+                });
+
+            if (resultCode != ResultCode::Success)
+            {
+                AZ_Error("Swapchain", false, "Failed to initialize images.");
+                Shutdown();
+                break;
+            }
+        }
+
+        return resultCode;
+    }
+
+    ResultCode MultiDeviceSwapChain::Resize(const RHI::SwapChainDimensions& dimensions)
+    {
+        ResultCode resultCode = ResultCode::Success;
+
+        ShutdownImages();
+
+        RHI::SwapChainDimensions nativeDimensions;
+
+        IterateObjects<SwapChain>(
+            [&resultCode, &nativeDimensions, &dimensions](auto deviceIndex, auto deviceSwapChain)
+            {
+                resultCode = deviceSwapChain->Resize(dimensions);
+                nativeDimensions = deviceSwapChain->GetDescriptor().m_dimensions;
+
+                return resultCode;
+            });
+
+        if (resultCode == ResultCode::Success)
+        {
+            m_descriptor.m_dimensions = nativeDimensions;
+            resultCode = InitImages();
+        }
+
+        return resultCode;
+    }
+
+    void MultiDeviceSwapChain::SetVerticalSyncInterval(uint32_t verticalSyncInterval)
+    {
+        for (auto& [deviceIndex, deviceSwapChain] : m_deviceSwapChains)
+        {
+            deviceSwapChain->SetVerticalSyncInterval(verticalSyncInterval);
+        }
+
+        m_descriptor.m_verticalSyncInterval = verticalSyncInterval;
+    }
+
+    const AttachmentId& MultiDeviceSwapChain::GetAttachmentId() const
+    {
+        return m_descriptor.m_attachmentId;
+    }
+
+    const SwapChainDescriptor& MultiDeviceSwapChain::GetDescriptor() const
+    {
+        return m_descriptor;
+    }
+
+    bool MultiDeviceSwapChain::IsExclusiveFullScreenPreferred() const
+    {
+        auto result{ true };
+
+        for (auto& [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            result &= deviceSwapChain->IsExclusiveFullScreenPreferred();
+        }
+
+        return result;
+    }
+
+    bool MultiDeviceSwapChain::GetExclusiveFullScreenState() const
+    {
+        auto result{ true };
+
+        for (auto& [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            result &= deviceSwapChain->GetExclusiveFullScreenState();
+        }
+
+        return result;
+    }
+
+    bool MultiDeviceSwapChain::SetExclusiveFullScreenState(bool fullScreenState)
+    {
+        auto result{ true };
+
+        for (auto& [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            result &= deviceSwapChain->SetExclusiveFullScreenState(fullScreenState);
+        }
+
+        return result;
+    }
+
+    void MultiDeviceSwapChain::ProcessRecreation()
+    {
+        for (auto& [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            deviceSwapChain->ProcessRecreation();
+        }
+    }
+
+    uint32_t MultiDeviceSwapChain::GetImageCount() const
+    {
+        return aznumeric_cast<uint32_t>(m_mdImages.size());
+    }
+
+    MultiDeviceImage* MultiDeviceSwapChain::GetCurrentImage() const
+    {
+        if (m_descriptor.m_isXrSwapChain)
+        {
+            return m_mdImages[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
+        }
+        AZ_Error("Swapchain", !m_deviceSwapChains.empty(), "No device swapchain image available.");
+        // Note: Taking the current swapchain image index from the first device swap chain if there are multiple
+        auto currentImageIndex{ m_deviceSwapChains.begin()->second->GetCurrentImageIndex() };
+        return m_mdImages[currentImageIndex].get();
+    }
+
+    MultiDeviceImage* MultiDeviceSwapChain::GetImage(uint32_t index) const
+    {
+        return m_mdImages[index].get();
+    }
+
+    void MultiDeviceSwapChain::Present()
+    {
+        for (auto& [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            deviceSwapChain->Present();
+        }
+    }
+
+    RHI::XRRenderingInterface* MultiDeviceSwapChain::GetXRSystem() const
+    {
+        return m_xrSystem;
+    }
+
+    void MultiDeviceSwapChain::Shutdown()
+    {
+        for (auto [_, deviceSwapChain] : m_deviceSwapChains)
+        {
+            deviceSwapChain->Shutdown();
+        }
+        MultiDeviceResourcePool::Shutdown();
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -29,7 +29,7 @@ namespace AZ::RHI
         return true;
     }
 
-    ResultCode MultiDeviceSwapChain::Init(MultiDevice::DeviceMask deviceMask, const SwapChainDescriptor& descriptor)
+    ResultCode MultiDeviceSwapChain::Init(int deviceIndex, const SwapChainDescriptor& descriptor)
     {
         if (!ValidateDescriptor(descriptor))
         {
@@ -41,6 +41,8 @@ namespace AZ::RHI
             m_xrSystem = RHI::RHISystemInterface::Get()->GetXRSystem();
             AZ_Assert(m_xrSystem, "XR System is null");
         }
+
+        MultiDevice::DeviceMask deviceMask{ 1u << deviceIndex };
 
         SwapChainDimensions nativeDimensions = descriptor.m_dimensions;
         ResultCode resultCode = MultiDeviceResourcePool::Init(

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -158,7 +158,7 @@ namespace AZ::RHI
         RHI::SwapChainDimensions nativeDimensions;
 
         IterateObjects<SwapChain>(
-            [&resultCode, &nativeDimensions, &dimensions](auto deviceIndex, auto deviceSwapChain)
+            [&resultCode, &nativeDimensions, &dimensions]([[maybe_unused]]auto deviceIndex, auto deviceSwapChain)
             {
                 resultCode = deviceSwapChain->Resize(dimensions);
                 nativeDimensions = deviceSwapChain->GetDescriptor().m_dimensions;

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -202,7 +202,7 @@ set(FILES
     Source/RHI/ImageScopeAttachment.cpp
     Source/RHI/ResolveScopeAttachment.cpp
     Source/RHI/ScopeAttachment.cpp
-    Include/Atom/RHI/ShaderResourceGroup.h    
+    Include/Atom/RHI/ShaderResourceGroup.h
     Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
     Include/Atom/RHI/ShaderResourceGroupData.h
     Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -222,7 +222,9 @@ set(FILES
     Include/Atom/RHI/MemoryStatisticsBus.h
     Source/RHI/MemoryStatisticsBuilder.cpp
     Include/Atom/RHI/SwapChain.h
+    Include/Atom/RHI/MultiDeviceSwapChain.h
     Source/RHI/SwapChain.cpp
+    Source/RHI/MultiDeviceSwapChain.cpp
     Include/Atom/RHI/RHISystem.h
     Include/Atom/RHI/RHISystemInterface.h
     Source/RHI/RHISystem.cpp


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, including:

- `MultiDeviceSwapChain`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## Discussion
As noted in our original PR to introduce `MultiDeviceImage*` resources (https://github.com/o3de/o3de/pull/16591), specifically in this discussion (https://github.com/o3de/o3de/pull/16591#discussion_r1320087572), we chose to remove the `MultiDeviceSwapChain` from this PR as, at the time, we weren't sure if we could get by without it.
Now, as we prepare to integrate multi-device resources throughout the codebase, we found multiple locations which necessitate a multi-device version of `SwapChain`.

To name just two:
1. `FrameGraphAttachmentDatabase::ImportSwapChain()`
    - The `SwapChain` is packaged into a `SwapChainFrameAttachment`, which then is placed both in the `FrameGraphAttachmentDatabase::m_swapChainAttachments` and `FrameGraphAttachmentDatabase::m_imageAttachments`, i.e. we need the a `SwapChain` with `MultiDeviceImage`s there
2. `SwapChainFrameAttachment`
    - Inherits from `ImageFrameAttachment`, which internally holds a `MultiDeviceImage` (which it gets from `SwapChain`).

So, to keep a uniform design with the `FrameGraphAttachments`, it would be best to introduce a `MultiDeviceSwapChain`.