### PR TITLE
RayTracing-related resources

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -130,13 +130,13 @@ namespace AZ
             {
                 if (rayTracingFeatureProcessor->GetRevision() != m_rayTracingRevision)
                 {
-                    RHI::SingleDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
+                    RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
                     RayTracingFeatureProcessor::SubMeshVector& subMeshes = rayTracingFeatureProcessor->GetSubMeshes();
                     uint32_t rayTracingSubMeshCount = rayTracingFeatureProcessor->GetSubMeshCount();
 
                     // create the TLAS descriptor
-                    RHI::SingleDeviceRayTracingTlasDescriptor tlasDescriptor;
-                    RHI::SingleDeviceRayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
+                    RHI::MultiDeviceRayTracingTlasDescriptor tlasDescriptor;
+                    RHI::MultiDeviceRayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
 
                     uint32_t instanceIndex = 0;
                     for (auto& subMesh : subMeshes)
@@ -155,17 +155,17 @@ namespace AZ
                     }
 
                     // create the TLAS buffers based on the descriptor
-                    RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& rayTracingTlas = rayTracingFeatureProcessor->GetTlas();
-                    rayTracingTlas->CreateBuffers(*device, &tlasDescriptor, rayTracingBufferPools);
+                    RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& rayTracingTlas = rayTracingFeatureProcessor->GetTlas();
+                    rayTracingTlas->CreateBuffers(RHI::MultiDevice::AllDevices, &tlasDescriptor, rayTracingBufferPools);
 
                     // import and attach the TLAS buffer
-                    const RHI::Ptr<RHI::SingleDeviceBuffer>& rayTracingTlasBuffer = rayTracingTlas->GetTlasBuffer();
+                    const RHI::Ptr<RHI::MultiDeviceBuffer>& rayTracingTlasBuffer = rayTracingTlas->GetTlasBuffer();
                     if (rayTracingTlasBuffer && rayTracingSubMeshCount)
                     {
                         AZ::RHI::AttachmentId tlasAttachmentId = rayTracingFeatureProcessor->GetTlasAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer);
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                         }
 
@@ -247,7 +247,7 @@ namespace AZ
                         if (blasInstance.second.m_blasBuilt == false)
                         {
                             // Always build the BLAS, if it has not previously been built
-                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas);
+                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
                             continue;
                         }
 
@@ -259,14 +259,17 @@ namespace AZ
                         if (isSkinnedMesh && (assetGuid + submeshIndex + m_frameCount) % SKINNED_BLAS_REBUILD_FRAME_INTERVAL != 0)
                         {
                             // Skinned mesh that simply needs an update
-                            context.GetCommandList()->UpdateBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas);
+                            context.GetCommandList()->UpdateBottomLevelAccelerationStructure(
+                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
                         }
                         else
                         {
                             // Fall back to building the BLAS in any case
-                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas);
+                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(
+                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
                         }
-                        changedBlasList.push_back(submeshBlasInstance.m_blas.get());
+                        changedBlasList.push_back(
+                            submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex).get());
                     }
 
                     blasInstance.second.m_blasBuilt = true;
@@ -274,7 +277,7 @@ namespace AZ
             }
 
             // build the TLAS object
-            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas(), changedBlasList);
+            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas()->GetDeviceRayTracingTlas(RHI::MultiDevice::DefaultDeviceIndex), changedBlasList);
 
             ++m_frameCount;
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
@@ -11,7 +11,6 @@
 #include <Atom/RPI.Public/GpuQuery/Query.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -50,15 +50,15 @@ namespace AZ
             m_transformServiceFeatureProcessor = GetParentScene()->GetFeatureProcessor<TransformServiceFeatureProcessor>();
 
             // initialize the ray tracing buffer pools
-            m_bufferPools = RHI::SingleDeviceRayTracingBufferPools::CreateRHIRayTracingBufferPools();
-            m_bufferPools->Init(device);
+            m_bufferPools = aznew RHI::MultiDeviceRayTracingBufferPools;
+            m_bufferPools->Init(RHI::MultiDevice::AllDevices);
 
             // create TLAS attachmentId
             AZStd::string uuidString = AZ::Uuid::CreateRandom().ToString<AZStd::string>();
             m_tlasAttachmentId = RHI::AttachmentId(AZStd::string::format("RayTracingTlasAttachmentId_%s", uuidString.c_str()));
 
             // create the TLAS object
-            m_tlas = AZ::RHI::SingleDeviceRayTracingTlas::CreateRHIRayTracingTlas();
+            m_tlas = aznew RHI::MultiDeviceRayTracingTlas;
 
             // load the RayTracingSrg asset asset
             m_rayTracingSrgAsset = RPI::AssetUtils::LoadCriticalAsset<RPI::ShaderAsset>("shaderlib/atom/features/rayTracing/raytracingsrgs.azshader");
@@ -161,12 +161,12 @@ namespace AZ
             {
                 SubMesh& subMesh = m_subMeshes[mesh.m_subMeshIndices[subMeshIndex]];
 
-                RHI::SingleDeviceRayTracingBlasDescriptor blasDescriptor;
+                RHI::MultiDeviceRayTracingBlasDescriptor blasDescriptor;
                 blasDescriptor.Build()
                     ->Geometry()
                         ->VertexFormat(subMesh.m_positionFormat)
-                        ->VertexBuffer(subMesh.m_positionVertexBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex))
-                        ->IndexBuffer(subMesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex))
+                        ->VertexBuffer(subMesh.m_positionVertexBufferView)
+                        ->IndexBuffer(subMesh.m_indexBufferView)
                         ->BuildFlags(buildFlags)
                 ;
 
@@ -184,11 +184,11 @@ namespace AZ
                     AZ_Assert(blasInstanceFound == false, "Partial set of RayTracingBlas objects found for mesh");
 
                     // create the BLAS object and store it in the BLAS list
-                    RHI::Ptr<RHI::SingleDeviceRayTracingBlas> rayTracingBlas = AZ::RHI::SingleDeviceRayTracingBlas::CreateRHIRayTracingBlas();
+                    RHI::Ptr<RHI::MultiDeviceRayTracingBlas> rayTracingBlas = aznew RHI::MultiDeviceRayTracingBlas;
                     itMeshBlasInstance->second.m_subMeshes.push_back({ rayTracingBlas });
 
                     // create the buffers from the BLAS descriptor
-                    rayTracingBlas->CreateBuffers(*device, &blasDescriptor, *m_bufferPools);
+                    rayTracingBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &blasDescriptor, *m_bufferPools);
 
                     // store the BLAS in the mesh
                     subMesh.m_blas = rayTracingBlas;
@@ -684,7 +684,7 @@ namespace AZ
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_scene"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
+            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             // directional lights
             const auto directionalLightFP = GetParentScene()->GetFeatureProcessor<DirectionalLightFeatureProcessor>();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -13,8 +13,8 @@
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
 #include <Atom/RHI/MultiDeviceIndexBufferView.h>
 #include <Atom/RHI/MultiDeviceStreamBufferView.h>
-#include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
 #include <Atom/RHI/SingleDeviceBufferView.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
 #include <AzCore/Math/Color.h>
@@ -116,7 +116,7 @@ namespace AZ
                 AZ::Color m_irradianceColor = AZ::Color(1.0f);
 
                 // ray tracing Blas
-                RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_blas;
+                RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_blas;
 
                 // material data
                 AZ::Color m_baseColor = AZ::Color(0.0f);
@@ -214,8 +214,8 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> GetRayTracingMaterialSrg() const { return m_rayTracingMaterialSrg; }
 
             //! Retrieves the RayTracingTlas
-            const RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& GetTlas() const { return m_tlas; }
-            RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& GetTlas() { return m_tlas; }
+            const RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& GetTlas() const { return m_tlas; }
+            RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& GetTlas() { return m_tlas; }
 
             //! Retrieves the revision number of the ray tracing data.
             //! This is used to determine if the RayTracingShaderTable needs to be rebuilt.
@@ -227,7 +227,7 @@ namespace AZ
             }
 
             //! Retrieves the buffer pools used for ray tracing operations.
-            RHI::SingleDeviceRayTracingBufferPools& GetBufferPools() { return *m_bufferPools; }
+            RHI::MultiDeviceRayTracingBufferPools& GetBufferPools() { return *m_bufferPools; }
 
             //! Retrieves the total number of ray tracing meshes.
             uint32_t GetSubMeshCount() const { return m_subMeshCount; }
@@ -246,7 +246,7 @@ namespace AZ
 
             struct SubMeshBlasInstance
             {
-                RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_blas;
+                RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_blas;
             };
 
             struct MeshBlasInstance
@@ -284,10 +284,10 @@ namespace AZ
             SubMeshVector m_subMeshes;
 
             // buffer pools used in ray tracing operations
-            RHI::Ptr<RHI::SingleDeviceRayTracingBufferPools> m_bufferPools;
+            RHI::Ptr<RHI::MultiDeviceRayTracingBufferPools> m_bufferPools;
 
             // ray tracing acceleration structure (TLAS)
-            RHI::Ptr<RHI::SingleDeviceRayTracingTlas> m_tlas;
+            RHI::Ptr<RHI::MultiDeviceRayTracingTlas> m_tlas;
 
             // RayTracingScene and RayTracingMaterial asset and Srgs
             Data::Asset<RPI::ShaderAsset> m_rayTracingSrgAsset;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -141,9 +141,9 @@ namespace AZ
             m_requiresRayTracingSceneSrg = (rayTracingSceneSrgLayout != nullptr);
 
             // build the ray tracing pipeline state descriptor
-            RHI::SingleDeviceRayTracingPipelineStateDescriptor descriptor;
+            RHI::MultiDeviceRayTracingPipelineStateDescriptor descriptor;
             descriptor.Build()
-                ->PipelineState(m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get())
+                ->PipelineState(m_globalPipelineState.get())
                 ->MaxPayloadSize(m_passData->m_maxPayloadSize)
                 ->MaxAttributeSize(m_passData->m_maxAttributeSize)
                 ->MaxRecursionDepth(m_passData->m_maxRecursionDepth);
@@ -166,8 +166,8 @@ namespace AZ
             descriptor.HitGroup(AZ::Name("HitGroup"))->ClosestHitShaderName(AZ::Name(m_passData->m_closestHitShaderName.c_str()));
 
             // create the ray tracing pipeline state object
-            m_rayTracingPipelineState = RHI::Factory::Get().CreateRayTracingPipelineState();
-            m_rayTracingPipelineState->Init(*device.get(), &descriptor);
+            m_rayTracingPipelineState = aznew RHI::MultiDeviceRayTracingPipelineState;
+            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
 
             // make sure the shader table rebuilds if we're hotreloading
             m_rayTracingRevision = 0;
@@ -232,10 +232,10 @@ namespace AZ
             if (!m_rayTracingShaderTable)
             {
                 RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-                RHI::SingleDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
+                RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
 
-                m_rayTracingShaderTable = RHI::Factory::Get().CreateRayTracingShaderTable();
-                m_rayTracingShaderTable->Init(*device.get(), rayTracingBufferPools);
+                m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;
+                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
             }
 
             RPI::RenderPass::FrameBeginInternal(params);
@@ -252,13 +252,13 @@ namespace AZ
 
             // TLAS
             {
-                const RHI::Ptr<RHI::SingleDeviceBuffer>& rayTracingTlasBuffer = rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer();
+                const RHI::Ptr<RHI::MultiDeviceBuffer>& rayTracingTlasBuffer = rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer();
                 if (rayTracingTlasBuffer)
                 {
                     AZ::RHI::AttachmentId tlasAttachmentId = rayTracingFeatureProcessor->GetTlasAttachmentId();
                     if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId) == false)
                     {
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer);
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                     }
 
@@ -299,12 +299,12 @@ namespace AZ
                 // scene changed, need to rebuild the shader table
                 m_rayTracingRevision = rayTracingRevision;
 
-                AZStd::shared_ptr<RHI::SingleDeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::SingleDeviceRayTracingShaderTableDescriptor>();
+                AZStd::shared_ptr<RHI::MultiDeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::MultiDeviceRayTracingShaderTableDescriptor>();
 
                 if (rayTracingFeatureProcessor->GetSubMeshCount())
                 {
                     // build the ray tracing shader table descriptor
-                    RHI::SingleDeviceRayTracingShaderTableDescriptor* descriptorBuild = descriptor->Build(AZ::Name("RayTracingShaderTable"), m_rayTracingPipelineState)
+                    RHI::MultiDeviceRayTracingShaderTableDescriptor* descriptorBuild = descriptor->Build(AZ::Name("RayTracingShaderTable"), m_rayTracingPipelineState)
                         ->RayGenerationRecord(AZ::Name(m_passData->m_rayGenerationShaderName.c_str()))
                         ->MissRecord(AZ::Name(m_passData->m_missShaderName.c_str()));
 
@@ -395,8 +395,9 @@ namespace AZ
 
             dispatchRaysItem.m_shaderResourceGroupCount = aznumeric_cast<uint32_t>(shaderResourceGroups.size());
             dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups.data();
-            dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
-            dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
+            dispatchRaysItem.m_rayTracingPipelineState =
+                m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(RHI::MultiDevice::DefaultDeviceIndex).get();
             dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             // submit the DispatchRays item

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <AzCore/Memory/SystemAllocator.h>
-#include <Atom/RHI/SingleDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/SingleDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
@@ -71,9 +71,9 @@ namespace AZ
             Data::Instance<RPI::Shader> m_rayGenerationShader;
             Data::Instance<RPI::Shader> m_missShader;
             Data::Instance<RPI::Shader> m_closestHitShader;
-            RHI::Ptr<RHI::SingleDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
             RHI::ConstPtr<RHI::MultiDevicePipelineState> m_globalPipelineState;
-            RHI::Ptr<RHI::SingleDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+            RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
             bool m_requiresViewSrg = false;
             bool m_requiresSceneSrg = false;
             bool m_requiresRayTracingMaterialSrg = false;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -65,16 +65,23 @@ namespace AZ::RHI
             return m_mdGeometries;
         }
 
+        [[nodiscard]] const RayTracingAccelerationStructureBuildFlags& GetBuildFlags() const
+        {
+            return m_mdBuildFlags;
+        }
+
         //! Build operations
         MultiDeviceRayTracingBlasDescriptor* Build();
         MultiDeviceRayTracingBlasDescriptor* Geometry();
         MultiDeviceRayTracingBlasDescriptor* VertexBuffer(const RHI::MultiDeviceStreamBufferView& vertexBuffer);
         MultiDeviceRayTracingBlasDescriptor* VertexFormat(RHI::Format vertexFormat);
         MultiDeviceRayTracingBlasDescriptor* IndexBuffer(const RHI::MultiDeviceIndexBufferView& indexBuffer);
+        MultiDeviceRayTracingBlasDescriptor* BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags& buildFlags);
 
     private:
         MultiDeviceRayTracingGeometryVector m_mdGeometries;
         MultiDeviceRayTracingGeometry* m_mdBuildContext = nullptr;
+        RayTracingAccelerationStructureBuildFlags m_mdBuildFlags = AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE;
     };
 
     //! MultiDeviceRayTracingBlas
@@ -115,6 +122,7 @@ namespace AZ::RHI
     {
         uint32_t m_instanceID = 0;
         uint32_t m_hitGroupIndex = 0;
+        uint32_t m_instanceMask = 0x1; // Setting this to 1 to be backwards-compatible
         AZ::Transform m_transform = AZ::Transform::CreateIdentity();
         AZ::Vector3 m_nonUniformScale = AZ::Vector3::CreateOne();
         bool m_transparent = false;
@@ -177,6 +185,7 @@ namespace AZ::RHI
         MultiDeviceRayTracingTlasDescriptor* Build();
         MultiDeviceRayTracingTlasDescriptor* Instance();
         MultiDeviceRayTracingTlasDescriptor* InstanceID(uint32_t instanceID);
+        MultiDeviceRayTracingTlasDescriptor* InstanceMask(uint32_t instanceMask);
         MultiDeviceRayTracingTlasDescriptor* HitGroupIndex(uint32_t hitGroupIndex);
         MultiDeviceRayTracingTlasDescriptor* Transform(const AZ::Transform& transform);
         MultiDeviceRayTracingTlasDescriptor* NonUniformScale(const AZ::Vector3& nonUniformScale);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h
@@ -18,22 +18,22 @@ namespace AZ::RHI
 {
     class SingleDeviceRayTracingBufferPools;
 
-        //! RayTracingAccelerationStructureBuildFlags
-        //!
-        //! These build flags can be used to signal to the API what kind of Ray Tracing Acceleration Structure (RTAS) build it should prefer.
-        //! For example, if skinned meshes are present in the scene, it might be best to enable a mode where the RTAS is
-        //! periodically updated and not completely rebuilt every frame. These options can be set on both BLAS objects.
-        //!
-        //! FAST_TRACE: Sets a preference to build the RTAS to have faster raytracing capabilities. Can incur longer build times.
-        //! FAST_BUILD: Sets a preference for faster build times of the Acceleration Structure over faster raytracing.
-        //! ENABLE_UPDATE: Enables incremental updating of a BLAS object. Needs to be set at BLAS creation time.
-        enum class RayTracingAccelerationStructureBuildFlags : uint32_t
-        {
-            FAST_TRACE = AZ_BIT(1),
-            FAST_BUILD = AZ_BIT(2),
-            ENABLE_UPDATE = AZ_BIT(3),
-        };
-        AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::RayTracingAccelerationStructureBuildFlags);
+    //! RayTracingAccelerationStructureBuildFlags
+    //!
+    //! These build flags can be used to signal to the API what kind of Ray Tracing Acceleration Structure (RTAS) build it should prefer.
+    //! For example, if skinned meshes are present in the scene, it might be best to enable a mode where the RTAS is
+    //! periodically updated and not completely rebuilt every frame. These options can be set on both BLAS objects.
+    //!
+    //! FAST_TRACE: Sets a preference to build the RTAS to have faster raytracing capabilities. Can incur longer build times.
+    //! FAST_BUILD: Sets a preference for faster build times of the Acceleration Structure over faster raytracing.
+    //! ENABLE_UPDATE: Enables incremental updating of a BLAS object. Needs to be set at BLAS creation time.
+    enum class RayTracingAccelerationStructureBuildFlags : uint32_t
+    {
+        FAST_TRACE = AZ_BIT(1),
+        FAST_BUILD = AZ_BIT(2),
+        ENABLE_UPDATE = AZ_BIT(3),
+    };
+    AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::RayTracingAccelerationStructureBuildFlags);
 
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Bottom Level Acceleration Structure (BLAS)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -64,6 +64,13 @@ namespace AZ::RHI
         return this;
     }
 
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
+    {
+        AZ_Assert(m_mdBuildContext, "BuildFlags property can only be added to a Geometry entry");
+        m_mdBuildFlags = buildFlags;
+        return this;
+    }
+
     SingleDeviceRayTracingTlasDescriptor MultiDeviceRayTracingTlasDescriptor::GetDeviceRayTracingTlasDescriptor(int deviceIndex) const
     {
         AZ_Assert(m_mdInstancesBuffer, "No MultiDeviceBuffer available!\n");
@@ -106,6 +113,13 @@ namespace AZ::RHI
     {
         AZ_Assert(m_mdBuildContext, "InstanceID property can only be added to an Instance entry");
         m_mdBuildContext->m_instanceID = instanceID;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstanceMask(uint32_t instanceMask)
+    {
+        AZ_Assert(m_mdBuildContext, "InstanceMask property can only be added to an Instance entry");
+        m_mdBuildContext->m_instanceMask = instanceMask;
         return this;
     }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -51,7 +51,7 @@ namespace AZ
             m_cullable.SetDebugName(AZ::Name("DiffuseProbeGrid Volume"));
 
             // create the visualization TLAS
-            m_visualizationTlas = AZ::RHI::SingleDeviceRayTracingTlas::CreateRHIRayTracingTlas();
+            m_visualizationTlas = aznew RHI::MultiDeviceRayTracingTlas;
 
             // create the grid data buffer
             m_gridDataBuffer = aznew RHI::MultiDeviceBuffer;
@@ -690,7 +690,7 @@ namespace AZ
 
             uint32_t tlasInstancesBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasInstancesBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, tlasInstancesBufferByteCount / RayTracingTlasInstanceElementSize, RayTracingTlasInstanceElementSize);
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->GetBufferView(bufferViewDescriptor).get());
+            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
@@ -707,7 +707,7 @@ namespace AZ
 
             uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/DrawPacketBuilder.h>
-#include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/PipelineState.h>
 #include <Atom/RPI.Public/Scene.h>
@@ -309,8 +309,8 @@ namespace AZ
             static constexpr int32_t DefaultNumRelocationIterations = 100;
 
             // visualization TLAS
-            const RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& GetVisualizationTlas() const { return m_visualizationTlas; }
-            RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& GetVisualizationTlas() { return m_visualizationTlas; }
+            const RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& GetVisualizationTlas() const { return m_visualizationTlas; }
+            RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& GetVisualizationTlas() { return m_visualizationTlas; }
 
             bool GetVisualizationTlasUpdateRequired() const;
             void ResetVisualizationTlasUpdateRequired() { m_visualizationTlasUpdateRequired = false; }
@@ -454,7 +454,7 @@ namespace AZ
             bool m_visualizationEnabled = false;
             bool m_visualizationShowInactiveProbes = false;
             float m_visualizationSphereRadius = DefaultVisualizationSphereRadius;
-            RHI::Ptr<RHI::SingleDeviceRayTracingTlas> m_visualizationTlas;
+            RHI::Ptr<RHI::MultiDeviceRayTracingTlas> m_visualizationTlas;
             bool m_visualizationTlasUpdateRequired = false;
             RHI::AttachmentId m_visualizationTlasAttachmentId;
             RHI::AttachmentId m_visualizationTlasInstancesAttachmentId;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -119,8 +119,8 @@ namespace AZ
             if (device->GetFeatures().m_rayTracing)
             {
                 // initialize the buffer pools for the DiffuseProbeGrid visualization
-                m_visualizationBufferPools = RHI::SingleDeviceRayTracingBufferPools::CreateRHIRayTracingBufferPools();
-                m_visualizationBufferPools->Init(device);
+                m_visualizationBufferPools = aznew RHI::MultiDeviceRayTracingBufferPools;
+                m_visualizationBufferPools->Init(RHI::MultiDevice::AllDevices);
 
                 // load probe visualization model, the BLAS will be created in OnAssetReady()
 
@@ -959,11 +959,11 @@ namespace AZ
                 0);
             AZ_Assert(result, "Failed to retrieve DiffuseProbeGrid visualization mesh stream buffer views");
 
-            m_visualizationVB = streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
-            m_visualizationIB = mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+            m_visualizationVB = streamBufferViews[0];
+            m_visualizationIB = mesh.m_indexBufferView;
 
             // create the BLAS object
-            RHI::SingleDeviceRayTracingBlasDescriptor blasDescriptor;
+            RHI::MultiDeviceRayTracingBlasDescriptor blasDescriptor;
             blasDescriptor.Build()
                 ->Geometry()
                 ->VertexFormat(PositionStreamFormat)
@@ -972,10 +972,10 @@ namespace AZ
             ;
 
             RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            m_visualizationBlas = AZ::RHI::SingleDeviceRayTracingBlas::CreateRHIRayTracingBlas();
+            m_visualizationBlas = aznew RHI::MultiDeviceRayTracingBlas;
             if (device->GetFeatures().m_rayTracing)
             {
-                m_visualizationBlas->CreateBuffers(*device, &blasDescriptor, *m_visualizationBufferPools);
+                m_visualizationBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &blasDescriptor, *m_visualizationBufferPools);
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <DiffuseProbeGrid/DiffuseProbeGridFeatureProcessorInterface.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
 #include <Atom/RPI.Public/Model/Model.h>
 #include <Render/DiffuseProbeGrid.h>
 
@@ -98,11 +98,11 @@ namespace AZ
             DiffuseProbeGridVector& GetVisibleRealTimeProbeGrids() { return m_visibleRealTimeDiffuseProbeGrids; }
 
             // returns the RayTracingBufferPool used for the DiffuseProbeGrid visualization
-            RHI::SingleDeviceRayTracingBufferPools& GetVisualizationBufferPools() { return *m_visualizationBufferPools; }
+            RHI::MultiDeviceRayTracingBufferPools& GetVisualizationBufferPools() { return *m_visualizationBufferPools; }
 
             // returns the RayTracingBlas for the visualization model
-            const RHI::Ptr<RHI::SingleDeviceRayTracingBlas>& GetVisualizationBlas() const { return m_visualizationBlas; }
-            RHI::Ptr<RHI::SingleDeviceRayTracingBlas>& GetVisualizationBlas() { return m_visualizationBlas; }
+            const RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& GetVisualizationBlas() const { return m_visualizationBlas; }
+            RHI::Ptr<RHI::MultiDeviceRayTracingBlas>& GetVisualizationBlas() { return m_visualizationBlas; }
 
             // adds a worldspace position and direction for an irradiance query, returns the index of the query result in the output buffer
             uint32_t AddIrradianceQuery(const AZ::Vector3& position, const AZ::Vector3& direction);
@@ -204,12 +204,12 @@ namespace AZ
             NotifyTextureAssetVector m_notifyTextureAssets;
 
             // visualization
-            RHI::Ptr<RHI::SingleDeviceRayTracingBufferPools> m_visualizationBufferPools;
+            RHI::Ptr<RHI::MultiDeviceRayTracingBufferPools> m_visualizationBufferPools;
             Data::Asset<RPI::ModelAsset> m_visualizationModelAsset;
-            RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_visualizationBlas;
+            RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_visualizationBlas;
             Data::Instance<RPI::Model> m_visualizationModel;
-            RHI::SingleDeviceStreamBufferView m_visualizationVB;
-            RHI::SingleDeviceIndexBufferView m_visualizationIB;
+            RHI::MultiDeviceStreamBufferView m_visualizationVB;
+            RHI::MultiDeviceIndexBufferView m_visualizationIB;
 
             // irradiance queries
             struct IrradianceQuery

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.h
@@ -10,9 +10,9 @@
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/SingleDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/SingleDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Render/DiffuseProbeGrid.h>
@@ -58,10 +58,10 @@ namespace AZ
             Data::Instance<RPI::Shader> m_rayTracingShader;
             Data::Instance<RPI::Shader> m_closestHitShader;
             Data::Instance<RPI::Shader> m_missShader;
-            RHI::Ptr<RHI::SingleDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
 
             // ray tracing shader table
-            RHI::Ptr<RHI::SingleDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+            RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
 
             // ray tracing global shader resource group layout and pipeline state
             RHI::Ptr<RHI::ShaderResourceGroupLayout> m_globalSrgLayout;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.h
@@ -10,7 +10,7 @@
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
 
 namespace AZ
 {

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -115,8 +115,8 @@ namespace AZ
                 }
 
                 // create the TLAS descriptor by adding an instance entry for each probe in the grid
-                RHI::SingleDeviceRayTracingTlasDescriptor tlasDescriptor;
-                RHI::SingleDeviceRayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
+                RHI::MultiDeviceRayTracingTlasDescriptor tlasDescriptor;
+                RHI::MultiDeviceRayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
 
                 // initialize the transform for each probe to Identity(), they will be updated by the compute shader
                 AZ::Transform transform = AZ::Transform::Identity();
@@ -134,8 +134,8 @@ namespace AZ
                 }
 
                 // create the TLAS buffers from on the descriptor
-                RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& visualizationTlas = diffuseProbeGrid->GetVisualizationTlas();
-                visualizationTlas->CreateBuffers(*device, &tlasDescriptor, diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools());                    
+                RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& visualizationTlas = diffuseProbeGrid->GetVisualizationTlas();
+                visualizationTlas->CreateBuffers(RHI::MultiDevice::AllDevices, &tlasDescriptor, diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools());
             }
 
             RenderPass::FrameBeginInternal(params);
@@ -158,9 +158,9 @@ namespace AZ
                 }
 
                 // import and attach the visualization TLAS and probe data
-                RHI::Ptr<RHI::SingleDeviceRayTracingTlas>& visualizationTlas = diffuseProbeGrid->GetVisualizationTlas();
-                const RHI::Ptr<RHI::SingleDeviceBuffer>& tlasBuffer = visualizationTlas->GetTlasBuffer();
-                const RHI::Ptr<RHI::SingleDeviceBuffer>& tlasInstancesBuffer = visualizationTlas->GetTlasInstancesBuffer();
+                RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& visualizationTlas = diffuseProbeGrid->GetVisualizationTlas();
+                const RHI::Ptr<RHI::MultiDeviceBuffer>& tlasBuffer = visualizationTlas->GetTlasBuffer();
+                const RHI::Ptr<RHI::MultiDeviceBuffer>& tlasInstancesBuffer = visualizationTlas->GetTlasInstancesBuffer();
                 if (tlasBuffer && tlasInstancesBuffer)
                 {
                     // TLAS buffer
@@ -168,7 +168,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer);
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS buffer with error %d", result);
                         }
 
@@ -188,7 +188,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasInstancesAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer);
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS Instances buffer with error %d", result);
                         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -81,9 +81,9 @@ namespace AZ
             AZ_Assert(m_globalSrgLayout != nullptr, "Failed to find RayTracingGlobalSrg layout for shader [%s]", shaderFilePath.c_str());
 
             // build the ray tracing pipeline state descriptor
-            RHI::SingleDeviceRayTracingPipelineStateDescriptor descriptor;
+            RHI::MultiDeviceRayTracingPipelineStateDescriptor descriptor;
             descriptor.Build()
-                ->PipelineState(m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get())
+                ->PipelineState(m_globalPipelineState.get())
                 ->MaxPayloadSize(64)
                 ->MaxAttributeSize(32)
                 ->MaxRecursionDepth(2)
@@ -97,8 +97,8 @@ namespace AZ
                     ->ClosestHitShaderName(AZ::Name("ClosestHit"));
 
             // create the ray tracing pipeline state object
-            m_rayTracingPipelineState = RHI::Factory::Get().CreateRayTracingPipelineState();
-            m_rayTracingPipelineState->Init(*device.get(), &descriptor);
+            m_rayTracingPipelineState = aznew RHI::MultiDeviceRayTracingPipelineState;
+            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
         }
 
         bool DiffuseProbeGridVisualizationRayTracingPass::IsEnabled() const
@@ -143,12 +143,12 @@ namespace AZ
             if (!m_rayTracingShaderTable)
             {
                 RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-                RHI::SingleDeviceRayTracingBufferPools& rayTracingBufferPools = diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools();
+                RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools();
 
-                m_rayTracingShaderTable = RHI::Factory::Get().CreateRayTracingShaderTable();
-                m_rayTracingShaderTable->Init(*device.get(), rayTracingBufferPools);
+                m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;
+                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
 
-                AZStd::shared_ptr<RHI::SingleDeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::SingleDeviceRayTracingShaderTableDescriptor>();
+                AZStd::shared_ptr<RHI::MultiDeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::MultiDeviceRayTracingShaderTableDescriptor>();
 
                 // build the ray tracing shader table descriptor
                 descriptor->Build(AZ::Name("RayTracingShaderTable"), m_rayTracingPipelineState)
@@ -182,12 +182,12 @@ namespace AZ
                 // TLAS
                 {
                     AZ::RHI::AttachmentId tlasAttachmentId = diffuseProbeGrid->GetProbeVisualizationTlasAttachmentId();
-                    const RHI::Ptr<RHI::SingleDeviceBuffer>& visualizationTlasBuffer = diffuseProbeGrid->GetVisualizationTlas()->GetTlasBuffer();
+                    const RHI::Ptr<RHI::MultiDeviceBuffer>& visualizationTlasBuffer = diffuseProbeGrid->GetVisualizationTlas()->GetTlasBuffer();
                     if (visualizationTlasBuffer)
                     {
                         if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId))
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, visualizationTlasBuffer);
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, visualizationTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                         }
 
@@ -305,8 +305,9 @@ namespace AZ
                 dispatchRaysItem.m_arguments.m_direct.m_width = m_outputAttachmentSize.m_width;
                 dispatchRaysItem.m_arguments.m_direct.m_height = m_outputAttachmentSize.m_height;
                 dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
-                dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
-                dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
+                dispatchRaysItem.m_rayTracingPipelineState =
+                    m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(RHI::MultiDevice::DefaultDeviceIndex).get();
                 dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);
                 dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups;
                 dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <Atom/RPI.Public/Pass/RenderPass.h>
-#include <Atom/RHI/SingleDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/SingleDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 namespace AZ
@@ -49,10 +49,10 @@ namespace AZ
             Data::Instance<RPI::Shader> m_rayTracingShader;
             Data::Instance<RPI::Shader> m_missShader;
             Data::Instance<RPI::Shader> m_closestHitShader;
-            RHI::Ptr<RHI::SingleDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
 
             // ray tracing shader table
-            RHI::Ptr<RHI::SingleDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+            RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
 
             // current size of output attachment, updated every frame
             RHI::Size m_outputAttachmentSize;


### PR DESCRIPTION
## What does this PR do?
This specific PR transitions resources related to `RayTracing*` to `MultiDeviceRayTracing*`.
### General Idea
This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a https://github.com/o3de/o3de/pull/14079, however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of ->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex) to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using RHI::MultiDevice::DefaultDeviceIndex everywhere because it simplifies the transition.
## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`

