### PR TITLE
Fix DPE component adapter to respect attributes when requested

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -131,12 +131,21 @@ namespace AZ::DocumentPropertyEditor
             return;
         }
 
-        if (m_queuedRefreshLevel == AzToolsFramework::PropertyModificationRefreshLevel::Refresh_None)
+        switch (m_queuedRefreshLevel)
         {
-            return;
+        case AzToolsFramework::PropertyModificationRefreshLevel::Refresh_None:
+            break;
+        case AzToolsFramework::PropertyModificationRefreshLevel::Refresh_Values:
+            NotifyResetDocument(DocumentResetType::SoftReset);
+            break;
+        case AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues:
+        case AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree:
+        case AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree_NewContent:
+            NotifyResetDocument(DocumentResetType::HardReset);
+            break;
         }
+
         m_queuedRefreshLevel = AzToolsFramework::PropertyModificationRefreshLevel::Refresh_None;
-        NotifyResetDocument();
     }
 
     Dom::Value ComponentAdapter::HandleMessage(const AdapterMessage& message)


### PR DESCRIPTION
## What does this PR do?

Noticed that the DPE was not updating previews while using the material component instance inspector. The preview images were not updating in response to changing colors and other properties. This is controlled by invalidating the property editor and sending image data via an attribute that gets applied to an icon on the property asset control. 

The adapter only has three refresh levels, none, soft, and hard, compared to the RPE which has a few more. The adapter was only performing a soft refresh whenever invalidation was requested. Hard refresh is required to update attributes.

This should also impact other components and property editors that have dynamic attributes

## How was this PR tested?

Before the changes, the property asset control never received the new attributes.
After the changes, the property asset control receives the updated attributes and updates the image.