### PR TITLE
Simplifying thumbnail system asynchronous loading.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -346,10 +346,10 @@ namespace AzToolsFramework
         {
             if (m_thumbnailKey)
             {
-                disconnect(m_thumbnailKey.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &AssetBrowserEntry::ThumbnailUpdated);
+                disconnect(m_thumbnailKey.data(), nullptr, this, nullptr);
             }
             m_thumbnailKey = thumbnailKey;
-            connect(m_thumbnailKey.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &AssetBrowserEntry::ThumbnailUpdated);
+            connect(m_thumbnailKey.data(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
         }
 
         SharedThumbnailKey AssetBrowserEntry::GetThumbnailKey() const
@@ -369,7 +369,7 @@ namespace AzToolsFramework
             SetThumbnailKey(CreateThumbnailKey());
         }
 
-        void AssetBrowserEntry::ThumbnailUpdated()
+        void AssetBrowserEntry::SetThumbnailDirty()
         {
             if (EntryCache* cache = EntryCache::GetInstance())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
@@ -193,8 +193,8 @@ namespace AzToolsFramework
             virtual void UpdateChildPaths(AssetBrowserEntry* child) const;
             virtual void PathsUpdated();
 
-            protected Q_SLOTS:
-            virtual void ThumbnailUpdated();
+        protected:
+            virtual void SetThumbnailDirty();
 
         private:
             SharedThumbnailKey m_thumbnailKey;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.cpp
@@ -100,11 +100,11 @@ namespace AzToolsFramework
             return nullptr;
         }
 
-        void ProductAssetBrowserEntry::ThumbnailUpdated()
+        void ProductAssetBrowserEntry::SetThumbnailDirty()
         {
             if (EntryCache* cache = EntryCache::GetInstance())
             {
-                // if source is displaying product's thumbnail, then it needs to also listen to its ThumbnailUpdated
+                // if source is displaying product's thumbnail, then it needs to also SetThumbnailDirty
                 if (m_parentAssetEntry)
                 {
                     cache->m_dirtyThumbnailsSet.insert(m_parentAssetEntry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.h
@@ -46,7 +46,7 @@ namespace AzToolsFramework
 
             static ProductAssetBrowserEntry* GetProductByAssetId(const AZ::Data::AssetId& assetId);
 
-            void ThumbnailUpdated() override;
+            void SetThumbnailDirty() override;
 
         private:
             AZ::s64 m_productId = -1;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.cpp
@@ -145,10 +145,10 @@ namespace AzToolsFramework
         {
             if (m_sourceControlThumbnailKey)
             {
-                disconnect(m_sourceControlThumbnailKey.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &AssetBrowserEntry::ThumbnailUpdated);
+                disconnect(m_sourceControlThumbnailKey.data(), nullptr, this, nullptr);
             }
             m_sourceControlThumbnailKey = MAKE_TKEY(SourceControlThumbnailKey, m_fullPath.c_str());
-            connect(m_sourceControlThumbnailKey.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &AssetBrowserEntry::ThumbnailUpdated);
+            connect(m_sourceControlThumbnailKey.data(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
         }
 
         SharedThumbnailKey SourceAssetBrowserEntry::CreateThumbnailKey()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
@@ -42,14 +42,16 @@ namespace AzToolsFramework
             : Thumbnail(key)
         {}
 
-        void FolderThumbnail::LoadThread()
+        void FolderThumbnail::Load()
         {
+            m_state = State::Loading;
             AZ_Assert(azrtti_cast<const FolderThumbnailKey*>(m_key.data()), "Incorrect key type, excpected FolderThumbnailKey");
 
             const char* folderIcon = FolderIconPath;
             auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / folderIcon;
             m_pixmap.load(absoluteIconPath.c_str());
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
+            Thumbnail::LoadComplete();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.h
@@ -42,7 +42,7 @@ namespace AzToolsFramework
             Q_OBJECT
         public:
             FolderThumbnail(SharedThumbnailKey key);
-            void LoadThread() override;
+            void Load() override;
         };
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
@@ -57,8 +57,10 @@ namespace AzToolsFramework
             : Thumbnail(key)
         {}
 
-        void ProductThumbnail::LoadThread() 
+        void ProductThumbnail::Load() 
         {
+            m_state = State::Loading;
+
             auto productKey = azrtti_cast<const ProductThumbnailKey*>(m_key.data());
             AZ_Assert(productKey, "Incorrect key type, excpected ProductThumbnailKey");
 
@@ -96,6 +98,7 @@ namespace AzToolsFramework
 
             m_pixmap.load(iconPath);
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
+            Thumbnail::LoadComplete();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.h
@@ -41,9 +41,7 @@ namespace AzToolsFramework
             Q_OBJECT
         public:
             ProductThumbnail(Thumbnailer::SharedThumbnailKey key);
-
-        protected:
-            void LoadThread() override;
+            void Load() override;
         };
 
         //! ProductAssetBrowserEntry thumbnails

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
@@ -59,8 +59,10 @@ namespace AzToolsFramework
         {
         }
 
-        void SourceThumbnail::LoadThread()
+        void SourceThumbnail::Load()
         {
+            m_state = State::Loading;
+
             auto sourceKey = azrtti_cast<const SourceThumbnailKey*>(m_key.data());
             AZ_Assert(sourceKey, "Incorrect key type, excpected SourceThumbnailKey");
 
@@ -121,6 +123,7 @@ namespace AzToolsFramework
 
             m_pixmap.load(iconPathToUse);
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
+            Thumbnail::LoadComplete();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.h
@@ -41,9 +41,7 @@ namespace AzToolsFramework
             Q_OBJECT
         public:
             SourceThumbnail(SharedThumbnailKey key);
-
-        protected:
-            void LoadThread() override;
+            void Load() override;
 
         private:
             static QMutex m_mutex;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
@@ -40,15 +40,10 @@ namespace AzToolsFramework
             BusDisconnect();
         }
 
-        void LoadingThumbnail::UpdateTime(float)
+        void LoadingThumbnail::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
         {
             m_pixmap = m_loadingMovie.currentPixmap();
-            Q_EMIT Updated();
-        }
-
-        void LoadingThumbnail::OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/)
-        {
-            UpdateTime(deltaTime);
+            emit ThumbnailUpdated();
         }
 
     } // namespace Thumbnailer

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.h
@@ -28,12 +28,8 @@ namespace AzToolsFramework
             LoadingThumbnail();
             ~LoadingThumbnail() override;
 
-            void UpdateTime(float /*deltaTime*/) override;
-
-            //////////////////////////////////////////////////////////////////////////
             // TickBus
-            //////////////////////////////////////////////////////////////////////////
-            //! LoadingThumbnail is not part pf any thumbnail cache, so it needs to be updated manually
+            //! LoadingThumbnail needs to update the loading animation
             void OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/) override;
 
         private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
@@ -44,7 +44,7 @@ namespace AzToolsFramework
                 return false;
             }
             m_nextUpdate = now + m_updateInterval;
-            emit UpdateThumbnailSignal();
+            emit ThumbnailUpdateRequested();
             return true;
         }
 
@@ -130,7 +130,7 @@ namespace AzToolsFramework
                 m_pixmap = QPixmap();
             }
             m_readyForUpdate = true;
-            emit Updated();
+            emit ThumbnailUpdated();
         }
 
         void SourceControlThumbnail::Update()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
@@ -13,7 +13,6 @@ AZ_PUSH_DISABLE_WARNING(4127 4251 4800 4244, "-Wunknown-warning-option") // 4127
                                                                          // 4800: 'QTextBoundaryFinderPrivate *const ': forcing value to bool 'true' or 'false' (performance warning)
                                                                          // 4244: conversion from 'int' to 'qint8', possible loss of data
 #include <QtConcurrent/QtConcurrent>
-#include <QThreadPool>
 AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework
@@ -26,6 +25,7 @@ namespace AzToolsFramework
         void ThumbnailKey::SetReady(bool ready)
         {
             m_ready = ready;
+            emit ThumbnailUpdated();
         }
 
         bool ThumbnailKey::IsReady() const
@@ -39,7 +39,7 @@ namespace AzToolsFramework
             {
                 return false;
             }
-            emit UpdateThumbnailSignal();
+            emit ThumbnailUpdateRequested();
             return true;
         }
 
@@ -61,27 +61,10 @@ namespace AzToolsFramework
             , m_state(State::Unloaded)
             , m_key(key)
         {
-            connect(&m_watcher, &QFutureWatcher<void>::finished, this, [this]()
-                {
-                    if (m_state == State::Loading)
-                    {
-                        m_state = State::Ready;
-                    }
-                    Q_EMIT Updated();
-                });
-
-            connect(&m_watcher, &QFutureWatcher<void>::canceled, this, [this]()
-                {
-                    m_state = State::Unloaded;
-                    Q_EMIT Updated();
-                });
         }
 
         Thumbnail::~Thumbnail()
         {
-            m_watcher.disconnect();
-            m_watcher.cancel();
-            m_watcher.waitForFinished();
         }
 
         bool Thumbnail::operator==(const Thumbnail& other) const
@@ -91,15 +74,11 @@ namespace AzToolsFramework
 
         void Thumbnail::Load()
         {
-            if (m_state == State::Unloaded)
-            {
-                m_state = State::Loading;
-                m_watcher.setFuture(QtConcurrent::run([this](){ LoadThread(); }));
-            }
         }
 
-        void Thumbnail::UpdateTime([[maybe_unused]] float deltaTime)
+        void Thumbnail::LoadComplete()
         {
+            QTimer::singleShot(0, this, &Thumbnail::ThumbnailUpdated);
         }
 
         const QPixmap& Thumbnail::GetPixmap() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.inl
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.inl
@@ -15,22 +15,11 @@ namespace AzToolsFramework
         template <class ThumbnailType, class Hasher, class EqualKey>
         ThumbnailCache<ThumbnailType, Hasher, EqualKey>::ThumbnailCache()
         {
-            BusConnect();
         }
 
         template <class ThumbnailType, class Hasher, class EqualKey>
         ThumbnailCache<ThumbnailType, Hasher, EqualKey>::~ThumbnailCache()
         {
-            BusDisconnect();
-        }
-
-        template <class ThumbnailType, class Hasher, class EqualKey>
-        void ThumbnailCache<ThumbnailType, Hasher, EqualKey>::OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/)
-        {
-            for (auto& kvp : m_cache)
-            {
-                kvp.second->UpdateTime(deltaTime);
-            }
         }
 
         template <class ThumbnailType, class Hasher, class EqualKey>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
@@ -34,10 +34,10 @@ namespace AzToolsFramework
         {
             if (m_key)
             {
-                disconnect(m_key.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &ThumbnailWidget::KeyUpdatedSlot);
+                disconnect(m_key.data(), nullptr, this, nullptr);
             }
             m_key = key;
-            connect(m_key.data(), &ThumbnailKey::ThumbnailUpdatedSignal, this, &ThumbnailWidget::KeyUpdatedSlot);
+            connect(m_key.data(), &ThumbnailKey::ThumbnailUpdated, this, &ThumbnailWidget::RepaintThumbnail);
             repaint();
         }
 
@@ -76,7 +76,7 @@ namespace AzToolsFramework
             QWidget::paintEvent(event);
         }
 
-        void ThumbnailWidget::KeyUpdatedSlot()
+        void ThumbnailWidget::RepaintThumbnail()
         {
             repaint();
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.h
@@ -46,7 +46,7 @@ namespace AzToolsFramework
             SharedThumbnailKey m_key;
 
         private Q_SLOTS:
-            void KeyUpdatedSlot();
+            void RepaintThumbnail();
         };
     } // namespace Thumbnailer
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
@@ -50,7 +50,7 @@ namespace AzToolsFramework
             SharedThumbnail GetThumbnail(SharedThumbnailKey thumbnailKey) override;
             bool IsLoading(SharedThumbnailKey thumbnailKey) override;
 
-            void RedrawThumbnail();
+            void RepaintThumbnail();
 
         private:
             struct ProviderCompare
@@ -69,9 +69,9 @@ namespace AzToolsFramework
             //! Default loading thumbnail used when thumbnail is found by is not yet generated
             SharedThumbnail m_loadingThumbnail;
             //! Maximum number of concurrent jobs allowed.
-            int m_maxThumbnailJobs;
+            int m_maxThumbnailJobs{};
             //! Current number of jobs running.
-            int m_currentJobsCount;
+            AZStd::set<SharedThumbnail> m_thumbnailsBeingLoaded;
         };
     } // Thumbnailer
 } // namespace AssetBrowser

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
@@ -57,28 +57,25 @@ namespace ImageProcessingAtom
             AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
         }
 
-        void ImageThumbnail::LoadThread()
+        void ImageThumbnail::Load()
         {
             m_state = State::Loading;
             AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::Event(
                 AZ::RPI::StreamingImageAsset::RTTI_Type(), &AzToolsFramework::Thumbnailer::ThumbnailerRendererRequests::RenderThumbnail,
                 m_key, ImageThumbnailSize);
-
-            // wait for response from thumbnail renderer
-            m_renderWait.acquire();
         }
 
         void ImageThumbnail::ThumbnailRendered(const QPixmap& thumbnailImage)
         {
             m_pixmap = thumbnailImage;
             m_state = State::Ready;
-            m_renderWait.release();
+            Thumbnail::LoadComplete();
         }
 
         void ImageThumbnail::ThumbnailFailedToRender()
         {
             m_state = State::Failed;
-            m_renderWait.release();
+            Thumbnail::LoadComplete();
         }
 
         void ImageThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.h
@@ -36,15 +36,12 @@ namespace ImageProcessingAtom
             //! AzToolsFramework::ThumbnailerRendererNotificationBus::Handler overrides...
             void ThumbnailRendered(const QPixmap& thumbnailImage) override;
             void ThumbnailFailedToRender() override;
-
-        protected:
-            void LoadThread() override;
+            void Load() override;
 
         private:
             // AzFramework::AssetCatalogEventBus::Handler interface overrides...
             void OnCatalogAssetChanged(const AZ::Data::AssetId& assetId) override;
 
-            AZStd::binary_semaphore m_renderWait;
             AZStd::unordered_set<AZ::Data::AssetId> m_assetIds;
         };
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -192,7 +192,7 @@ namespace AtomToolsFramework
             m_thumbnailKeys[pathWithAlias] = thumbnailKey;
 
             connect(
-                thumbnailKey.data(), &AzToolsFramework::Thumbnailer::ThumbnailKey::ThumbnailUpdatedSignal, this,
+                thumbnailKey.data(), &AzToolsFramework::Thumbnailer::ThumbnailKey::ThumbnailUpdated, this,
                 [this, pathWithAlias]() { QueueUpdateThumbnail(pathWithAlias); });
 
             QueueUpdateThumbnail(pathWithAlias);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
@@ -41,28 +41,25 @@ namespace AZ
             AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
         }
 
-        void SharedThumbnail::LoadThread()
+        void SharedThumbnail::Load()
         {
             m_state = State::Loading;
             AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::QueueEvent(
                 m_assetInfo.m_assetType, &AzToolsFramework::Thumbnailer::ThumbnailerRendererRequests::RenderThumbnail, m_key,
                 SharedThumbnailSize);
-
-            // wait for response from thumbnail renderer
-            m_renderWait.acquire();
         }
 
         void SharedThumbnail::ThumbnailRendered(const QPixmap& thumbnailImage)
         {
             m_pixmap = thumbnailImage;
             m_state = State::Ready;
-            m_renderWait.release();
+            Thumbnail::LoadComplete();
         }
 
         void SharedThumbnail::ThumbnailFailedToRender()
         {
             m_state = State::Failed;
-            m_renderWait.release();
+            Thumbnail::LoadComplete();
         }
 
         void SharedThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.h
@@ -34,16 +34,13 @@ namespace AZ
             //! AzToolsFramework::ThumbnailerRendererNotificationBus::Handler overrides...
             void ThumbnailRendered(const QPixmap& thumbnailImage) override;
             void ThumbnailFailedToRender() override;
-
-        protected:
-            void LoadThread() override;
+            void Load() override;
 
         private:
             // AzFramework::AssetCatalogEventBus::Handler interface overrides...
             void OnCatalogAssetChanged(const AZ::Data::AssetId& assetId) override;
             void OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo) override;
 
-            AZStd::binary_semaphore m_renderWait;
             Data::AssetInfo m_assetInfo;
         };
 


### PR DESCRIPTION
## What does this PR do?

## What does this PR do?

Switching to the job system instead of qt futures, watchers, and thread pools.

Removed LoadThread function and made Load virtual. The thumbnailer will call load using a job function. The job function will capture the shared pointer to the thumbnail and keep it alive so it should be safe to fire and forget. Changed some state variables to be atomic.

Replaced counter for number of active loads with set of thumbnail share pointers currently being loaded. This will also make it easier to debug which thumbnails have not completed.

Renamed signals, slots, and other functions used throughout the system that had hard to follow naming.

## How was this PR tested?

- Opening main editor, switching between asset browser views, scrolling through images, using the search filter to specifically search for images, materials, models, and other types that either load instantly or render using the frame capture system.
- So far, using manual testing, I have not noticed any thumbnails locking up with perpetual loading animation, despite being temporarily confused by staring at the thumbnail for the loading animation itself.
- Looking at material component and other property editors, the thumbnails and previews render correctly but do not always refresh immediately unless there is mouse movement over the window. 
- Continuing to test the asset picker, material editor, and other views with thumbnail widget.