### PR TITLE
Editor material component optimization to only render custom previews if properties are overridden

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -104,8 +104,13 @@ namespace AZ
 
             //! Check if the material slot contains an explicit material asset override
             //! @param materialAssignmentId ID of material slot.
-            //! @returns true if a valid material asset has been assigned. 
+            //! @returns true if a valid material asset has been assigned.
             virtual bool IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
+            //! Check if the material slot contains any overridden property values
+            //! @param materialAssignmentId ID of material slot.
+            //! @returns true if any property values have been overridden on this material slot.
+            virtual bool HasPropertiesOverridden(const MaterialAssignmentId& materialAssignmentId) const = 0;
 
             //! Set a material property override value wrapped by an AZStd::any
             //! @param materialAssignmentId ID of material slot.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -167,7 +167,17 @@ namespace AZ
 
         AZStd::vector<char> EditorMaterialComponentSlot::GetPreviewPixmapData() const
         {
+            // Don't display a custom image if there is no material asset assigned to this slot.
             if (!GetActiveAssetId().IsValid())
+            {
+                return {};
+            }
+
+            // Don't display a custom image if no properties have been overridden. It will fall back to the default thumbnail.
+            bool hasPropertiesOverridden = false;
+            MaterialComponentRequestBus::EventResult(
+                hasPropertiesOverridden, m_entityId, &MaterialComponentRequestBus::Events::HasPropertiesOverridden, m_id);
+            if (!hasPropertiesOverridden)
             {
                 return {};
             }
@@ -462,6 +472,15 @@ namespace AZ
         void EditorMaterialComponentSlot::UpdatePreview() const
         {
             m_updatePreview = false;
+
+            bool hasPropertiesOverridden = false;
+            MaterialComponentRequestBus::EventResult(
+                hasPropertiesOverridden, m_entityId, &MaterialComponentRequestBus::Events::HasPropertiesOverridden, m_id);
+            if (!hasPropertiesOverridden)
+            {
+                return;
+            }
+
             EditorMaterialSystemComponentRequestBus::Broadcast(
                 &EditorMaterialSystemComponentRequestBus::Events::RenderMaterialPreview, m_entityId, m_id);
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -58,6 +58,7 @@ namespace AZ
                     ->Event("GetMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId, "GetMaterialOverride")
                     ->Event("ClearMaterialAssetId", &MaterialComponentRequestBus::Events::ClearMaterialAssetId, "ClearMaterialOverride")
                     ->Event("IsMaterialAssetIdOverridden", &MaterialComponentRequestBus::Events::IsMaterialAssetIdOverridden)
+                    ->Event("HasPropertiesOverridden", &MaterialComponentRequestBus::Events::HasPropertiesOverridden)
                     ->Event("SetPropertyValue", &MaterialComponentRequestBus::Events::SetPropertyValue, "SetPropertyOverride")
                         ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)
                     ->Event("SetPropertyValueBool", &MaterialComponentRequestBus::Events::SetPropertyValueT<bool>, "SetPropertyOverrideBool")
@@ -577,6 +578,12 @@ namespace AZ
         {
             const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             return materialIt != m_configuration.m_materials.end() && materialIt->second.m_materialAsset.GetId().IsValid();
+        }
+
+        bool MaterialComponentController::HasPropertiesOverridden(const MaterialAssignmentId& materialAssignmentId) const
+        {
+            const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
+            return materialIt != m_configuration.m_materials.end() && !materialIt->second.m_propertyOverrides.empty();
         }
 
         void MaterialComponentController::SetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -66,6 +66,7 @@ namespace AZ
             AZ::Data::AssetId GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
             void ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) override;
             bool IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const override;
+            bool HasPropertiesOverridden(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) override;
             AZStd::any GetPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
             void ClearPropertyValue(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) override;


### PR DESCRIPTION
## What does this PR do?

This is an optimization that causes the material component to only render custom previews if properties are overridden on the slot that would display the preview.

If no custom or live preview is rendered then the property asset control thumbnail widget will display the thumbnail for the assigned or default material asset.

# How was this PR tested?

- Prior to this, material component rendered live, custom previews for every material slot.
- After this, material component only renders those previews if the slot has custom properties set.
- If no custom properties are set, it uses the property asset control thumbnail widget to display the loading animation and eventually the loaded thumbnail.
- For some reason, the property editor does not always refresh when the thumbnail is ready without mousing over.
- When used in conjunction with https://github.com/o3de/o3de/pull/17152, the DPE will refresh to display the modified or unmodified material as changes are made in the material instance editor.