### PR TITLE
Update multi-device resource classes

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -96,8 +96,8 @@ namespace AZ::RHI
         constexpr DeviceMask AllDevices{ static_cast<DeviceMask>(AZStd::numeric_limits<uint32_t>::max()) };
         constexpr DeviceMask DefaultDevice{ 1u };
 
-        constexpr uint32_t DefaultDeviceIndex { 0 };
+        constexpr int DefaultDeviceIndex{ 0 };
     }
 
-    constexpr uint32_t InvalidIndex = AZStd::numeric_limits<uint32_t>::max();
+    constexpr int InvalidIndex = AZStd::numeric_limits<int>::max();
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -177,15 +177,6 @@ namespace AZ::RHI
 
     struct DrawItemProperties
     {
-        DrawItemProperties() = default;
-
-        DrawItemProperties(const DrawItem* item, DrawItemSortKey sortKey = 0, DrawFilterMask filterMask = DrawFilterMaskDefaultValue)
-            : m_item{item}
-            , m_sortKey{sortKey}
-            , m_drawFilterMask{filterMask}
-        {
-        }
-
         bool operator==(const DrawItemProperties& rhs) const
         {
             return m_item == rhs.m_item &&
@@ -208,12 +199,12 @@ namespace AZ::RHI
         //! A pointer to the draw item
         const DrawItem* m_item = nullptr;
         //! A sorting key of this draw item which is used for sorting draw items in DrawList
-        // Check RHI::SortDrawList() function for detail
+        //! Check RHI::SortDrawList() function for detail
         DrawItemSortKey m_sortKey = 0;
+        //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
+        DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
         //! A depth value this draw item which is used for sorting draw items in DrawList
         //! Check RHI::SortDrawList() function for detail
         float m_depth = 0.0f;
-        //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
-        DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -74,10 +74,9 @@ namespace AZ::RHI
         AZ_RTTI(MultiDeviceBufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", MultiDeviceResourceView);
         virtual ~MultiDeviceBufferView() = default;
 
-        MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::BufferView>>&& cache)
+        MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor)
             : m_buffer{ buffer }
             , m_descriptor{ descriptor }
-            , m_cache{AZStd::move(cache)}
         {
         }
 
@@ -115,6 +114,6 @@ namespace AZ::RHI
         //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
         //! which now, with multi-device objects in use, need to be held in memory as long as
         //! the multi-device view is held.
-        AZStd::unordered_map<int, Ptr<RHI::BufferView>> m_cache;
+        mutable AZStd::unordered_map<int, Ptr<RHI::BufferView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -66,7 +66,7 @@ namespace AZ::RHI
     };
 
     //! A MultiDeviceBufferView is a light-weight representation of a view onto a multi-device buffer.
-    //! It holds an RHI::Ptr to a multi-device buffer as well as a BufferViewDescriptor
+    //! It holds a raw pointer to a multi-device buffer as well as a BufferViewDescriptor
     //! Using both, single-device BufferViews can be retrieved
     class MultiDeviceBufferView : public MultiDeviceResourceView
     {
@@ -112,6 +112,9 @@ namespace AZ::RHI
         //! The corresponding BufferViewDescriptor for this view.
         BufferViewDescriptor m_descriptor;
         //! BufferView cache
+        //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
+        //! which now, with multi-device objects in use, need to be held in memory as long as
+        //! the multi-device view is held.
         AZStd::unordered_map<int, Ptr<RHI::BufferView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -52,6 +52,9 @@ namespace AZ::RHI
 
         void InvalidateViews() override final;
 
+        //! Returns true if the ResourceView is in the cache of all single device buffers
+        bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
+
     protected:
         void SetDescriptor(const BufferDescriptor& descriptor);
 
@@ -63,12 +66,12 @@ namespace AZ::RHI
     };
 
     //! A MultiDeviceBufferView is a light-weight representation of a view onto a multi-device buffer.
-    //! It holds a raw pointer to a multi-device buffer as well as a BufferViewDescriptor object.
-    //! Using both, single-device BufferViews can be retrieved.
-    class MultiDeviceBufferView : public Object
+    //! It holds an RHI::Ptr to a multi-device buffer as well as a BufferViewDescriptor
+    //! Using both, single-device BufferViews can be retrieved
+    class MultiDeviceBufferView : public MultiDeviceResourceView
     {
     public:
-        AZ_RTTI(MultiDeviceBufferView, "{CD764967-6AC1-4B9D-9573-498FA61F8F84}", Object);
+        AZ_RTTI(MultiDeviceBufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", MultiDeviceResourceView);
         virtual ~MultiDeviceBufferView() = default;
 
         MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::BufferView>>&& cache)
@@ -91,6 +94,16 @@ namespace AZ::RHI
         const BufferViewDescriptor& GetDescriptor() const
         {
             return m_descriptor;
+        }
+
+        const MultiDeviceResource* GetResource() const override
+        {
+            return m_buffer;
+        }
+
+        const ResourceView* GetDeviceResourceView(int deviceIndex) const override
+        {
+            return GetDeviceBufferView(deviceIndex).get();
         }
 
     private:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -71,9 +71,10 @@ namespace AZ::RHI
         AZ_RTTI(MultiDeviceBufferView, "{CD764967-6AC1-4B9D-9573-498FA61F8F84}", Object);
         virtual ~MultiDeviceBufferView() = default;
 
-        MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor)
+        MultiDeviceBufferView(const RHI::MultiDeviceBuffer* buffer, BufferViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::BufferView>>&& cache)
             : m_buffer{ buffer }
             , m_descriptor{ descriptor }
+            , m_cache{AZStd::move(cache)}
         {
         }
 
@@ -97,5 +98,7 @@ namespace AZ::RHI
         const RHI::MultiDeviceBuffer* m_buffer;
         //! The corresponding BufferViewDescriptor for this view.
         BufferViewDescriptor m_descriptor;
+        //! BufferView cache
+        AZStd::unordered_map<int, Ptr<RHI::BufferView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -53,7 +53,7 @@ namespace AZ::RHI
             case DispatchType::Direct:
                 return DispatchArguments(m_direct);
             case DispatchType::Indirect:
-                return DispatchArguments(m_mdIndirect.GetDeviceIndirectArguments(deviceIndex));
+                return DispatchArguments(DispatchIndirect{m_mdIndirect.m_maxSequenceCount, m_mdIndirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_mdIndirect.m_indirectBufferByteOffset, m_mdIndirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get(), m_mdIndirect.m_countBufferByteOffset});
             default:
                 return DispatchArguments();
             }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -264,16 +264,6 @@ namespace AZ::RHI
 
     struct MultiDeviceDrawItemProperties
     {
-        MultiDeviceDrawItemProperties() = default;
-
-        MultiDeviceDrawItemProperties(
-            const MultiDeviceDrawItem* item, DrawItemSortKey sortKey = 0, DrawFilterMask filterMask = DrawFilterMaskDefaultValue)
-            : m_mdItem{ item }
-            , m_sortKey{ sortKey }
-            , m_drawFilterMask{ filterMask }
-        {
-        }
-
         bool operator==(const MultiDeviceDrawItemProperties& rhs) const
         {
             return m_mdItem == rhs.m_mdItem && m_sortKey == rhs.m_sortKey && m_depth == rhs.m_depth &&
@@ -305,10 +295,10 @@ namespace AZ::RHI
         //! A sorting key of this draw item which is used for sorting draw items in DrawList
         //! Check RHI::SortDrawList() function for detail
         DrawItemSortKey m_sortKey = 0;
+        //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
+        DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
         //! A depth value this draw item which is used for sorting draw items in DrawList
         //! Check RHI::SortDrawList() function for detail
         float m_depth = 0.0f;
-        //! A filter mask which helps decide whether to submit this draw item to a Scope's command list or not
-        DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -295,8 +295,7 @@ namespace AZ::RHI
         {
             AZ_Assert(m_mdItem, "Not initialized with MultiDeviceDrawItem\n");
 
-            DrawItemProperties result{ &m_mdItem->GetDeviceDrawItem(deviceIndex), m_sortKey, m_drawFilterMask };
-            result.m_depth = m_depth;
+            DrawItemProperties result{ &m_mdItem->GetDeviceDrawItem(deviceIndex), m_sortKey, m_drawFilterMask, m_depth };
 
             return result;
         }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -95,6 +95,9 @@ namespace AZ::RHI
         //! Invalidate all device-specific views by setting off events on all corresponding ResourceInvalidateBusses
         void InvalidateViews() override final;
 
+        //! Returns true if the ResourceView is in the cache of all single device images
+        bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
+
     protected:
         virtual void SetDescriptor(const ImageDescriptor& descriptor);
 
@@ -110,12 +113,12 @@ namespace AZ::RHI
     };
 
     //! A MultiDeviceImageView is a light-weight representation of a view onto a multi-device image.
-    //! It holds a raw pointer to a multi-device image as well as an ImageViewDescriptor.
-    //! Using both, single-device ImageViews can be retrieved.
-    class MultiDeviceImageView : public Object
+    //! It holds an RHI::Ptr to a multi-device image as well as an ImageViewDescriptor
+    //! Using both, single-device ImageViews can be retrieved
+    class MultiDeviceImageView : public MultiDeviceResourceView
     {
     public:
-        AZ_RTTI(MultiDeviceImageView, "{C837818B-2A4D-49F2-A37E-349494A9C9B7}", Object);
+        AZ_RTTI(MultiDeviceImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", MultiDeviceResourceView);
         virtual ~MultiDeviceImageView() = default;
 
         MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::ImageView>>&& cache)
@@ -138,6 +141,16 @@ namespace AZ::RHI
         const ImageViewDescriptor& GetDescriptor() const
         {
             return m_descriptor;
+        }
+
+        const MultiDeviceResource* GetResource() const override
+        {
+            return m_image;
+        }
+
+        const ResourceView* GetDeviceResourceView(int deviceIndex) const override
+        {
+            return GetDeviceImageView(deviceIndex).get();
         }
 
     private:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -121,10 +121,9 @@ namespace AZ::RHI
         AZ_RTTI(MultiDeviceImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", MultiDeviceResourceView);
         virtual ~MultiDeviceImageView() = default;
 
-        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::ImageView>>&& cache)
+        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor)
             : m_image{ image }
             , m_descriptor{ descriptor }
-            , m_cache{AZStd::move(cache)}
         {
         }
 
@@ -162,6 +161,6 @@ namespace AZ::RHI
         //! This cache is necessary as the caller receives raw pointers from the ResourceCache,
         //! which now, with multi-device objects in use, need to be held in memory as long as
         //! the multi-device view is held.
-        AZStd::unordered_map<int, Ptr<RHI::ImageView>> m_cache;
+        mutable AZStd::unordered_map<int, Ptr<RHI::ImageView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -17,9 +17,7 @@ namespace AZ::RHI
 {
     class ImageFrameAttachment;
     class MultiDeviceShaderResourceGroup;
-    class ImageView;
     class MultiDeviceImageView;
-    struct ImageViewDescriptor;
 
     //! MultiDeviceImage represents a collection of MultiDeviceImage Subresources, where each subresource comprises a one to three
     //! dimensional grid of pixels. Images are divided into an array of mip-map chains. A mip map chain is
@@ -120,9 +118,10 @@ namespace AZ::RHI
         AZ_RTTI(MultiDeviceImageView, "{C837818B-2A4D-49F2-A37E-349494A9C9B7}", Object);
         virtual ~MultiDeviceImageView() = default;
 
-        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor)
+        MultiDeviceImageView(const RHI::MultiDeviceImage* image, ImageViewDescriptor descriptor, AZStd::unordered_map<int, Ptr<RHI::ImageView>>&& cache)
             : m_image{ image }
             , m_descriptor{ descriptor }
+            , m_cache{AZStd::move(cache)}
         {
         }
 
@@ -146,5 +145,7 @@ namespace AZ::RHI
         const RHI::MultiDeviceImage* m_image;
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
+        //! ImageView cache
+        AZStd::unordered_map<int, Ptr<RHI::ImageView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -113,7 +113,7 @@ namespace AZ::RHI
     };
 
     //! A MultiDeviceImageView is a light-weight representation of a view onto a multi-device image.
-    //! It holds an RHI::Ptr to a multi-device image as well as an ImageViewDescriptor
+    //! It holds a raw pointer to a multi-device image as well as an ImageViewDescriptor
     //! Using both, single-device ImageViews can be retrieved
     class MultiDeviceImageView : public MultiDeviceResourceView
     {
@@ -159,6 +159,9 @@ namespace AZ::RHI
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
         //! ImageView cache
+        //! This cache is necessary as the caller receives raw pointers from the ResourceCache,
+        //! which now, with multi-device objects in use, need to be held in memory as long as
+        //! the multi-device view is held.
         AZStd::unordered_map<int, Ptr<RHI::ImageView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -65,16 +65,23 @@ namespace AZ::RHI
             return m_mdGeometries;
         }
 
+        [[nodiscard]] const RayTracingAccelerationStructureBuildFlags& GetBuildFlags() const
+        {
+            return m_mdBuildFlags;
+        }
+
         //! Build operations
         MultiDeviceRayTracingBlasDescriptor* Build();
         MultiDeviceRayTracingBlasDescriptor* Geometry();
         MultiDeviceRayTracingBlasDescriptor* VertexBuffer(const RHI::MultiDeviceStreamBufferView& vertexBuffer);
         MultiDeviceRayTracingBlasDescriptor* VertexFormat(RHI::Format vertexFormat);
         MultiDeviceRayTracingBlasDescriptor* IndexBuffer(const RHI::MultiDeviceIndexBufferView& indexBuffer);
+        MultiDeviceRayTracingBlasDescriptor* BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags& buildFlags);
 
     private:
         MultiDeviceRayTracingGeometryVector m_mdGeometries;
         MultiDeviceRayTracingGeometry* m_mdBuildContext = nullptr;
+        RayTracingAccelerationStructureBuildFlags m_mdBuildFlags = AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE;
     };
 
     //! MultiDeviceRayTracingBlas
@@ -115,6 +122,7 @@ namespace AZ::RHI
     {
         uint32_t m_instanceID = 0;
         uint32_t m_hitGroupIndex = 0;
+        uint32_t m_instanceMask = 0x1; // Setting this to 1 to be backwards-compatible
         AZ::Transform m_transform = AZ::Transform::CreateIdentity();
         AZ::Vector3 m_nonUniformScale = AZ::Vector3::CreateOne();
         bool m_transparent = false;
@@ -177,6 +185,7 @@ namespace AZ::RHI
         MultiDeviceRayTracingTlasDescriptor* Build();
         MultiDeviceRayTracingTlasDescriptor* Instance();
         MultiDeviceRayTracingTlasDescriptor* InstanceID(uint32_t instanceID);
+        MultiDeviceRayTracingTlasDescriptor* InstanceMask(uint32_t instanceMask);
         MultiDeviceRayTracingTlasDescriptor* HitGroupIndex(uint32_t hitGroupIndex);
         MultiDeviceRayTracingTlasDescriptor* Transform(const AZ::Transform& transform);
         MultiDeviceRayTracingTlasDescriptor* NonUniformScale(const AZ::Vector3& nonUniformScale);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -84,4 +84,27 @@ namespace AZ::RHI
         //! The version is monotonically incremented any time the backing resource is changed.
         uint32_t m_version = 0;
     };
+
+    class MultiDeviceBuffer;
+    class MultiDeviceImage;
+    class ResourceView;
+
+    /**
+     * ResourceView is a base class for views which are dependent on a Resource instance.
+     *
+     * NOTE: While initialization is separate from creation, explicit shutdown is not allowed
+     * for resource views. This is because the cost of dependency tracking with ShaderResourceGroups
+     * is too high. Instead, resource views are reference counted.
+     */
+    class MultiDeviceResourceView : public Object
+    {
+    public:
+        virtual ~MultiDeviceResourceView() = default;
+
+        /// Returns the resource associated with this view.
+        virtual const MultiDeviceResource* GetResource() const = 0;
+        virtual const ResourceView* GetDeviceResourceView(int deviceIndex) const = 0;
+
+        AZ_RTTI(MultiDeviceResourceView, "{D7442960-531D-4DCC-B60D-FD26FF75BE51}", Object);
+    };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -89,19 +89,14 @@ namespace AZ::RHI
     class MultiDeviceImage;
     class ResourceView;
 
-    /**
-     * ResourceView is a base class for views which are dependent on a Resource instance.
-     *
-     * NOTE: While initialization is separate from creation, explicit shutdown is not allowed
-     * for resource views. This is because the cost of dependency tracking with ShaderResourceGroups
-     * is too high. Instead, resource views are reference counted.
-     */
+    //! MultiDeviceResourceView is a base class for multi-device buffer and image views for
+    //! polymorphic usage of views in a generic way.
     class MultiDeviceResourceView : public Object
     {
     public:
         virtual ~MultiDeviceResourceView() = default;
 
-        /// Returns the resource associated with this view.
+        //! Returns the resource associated with this view.
         virtual const MultiDeviceResource* GetResource() const = 0;
         virtual const ResourceView* GetDeviceResourceView(int deviceIndex) const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -120,27 +120,6 @@ namespace AZ::RHI
         bool SetConstantData(const void* bytes, uint32_t byteCount);
         bool SetConstantData(const void* bytes, uint32_t byteOffset, uint32_t byteCount);
 
-        //! Returns constant data for the given shader input index as a template type.
-        //! The stride of T must match the size of the constant input region. The number
-        //! of elements in the returned span is the number of evenly divisible elements.
-        //! If the strides do not match, an empty span is returned.
-        template <typename T>
-        AZStd::span<const T> GetConstantArray(ShaderInputConstantIndex inputIndex) const;
-
-        //! Returns the constant data as type 'T' returned by value. The size of the constant region
-        //! must match the size of T exactly. Otherwise, an empty instance is returned.
-        template <typename T>
-        T GetConstant(ShaderInputConstantIndex inputIndex) const;
-
-        //! Treats the constant input as an array of type T, returning the element by value at the
-        //! specified array index. The size of the constant region must equally partition into an
-        //! array of type T. Otherwise, an empty instance is returned.
-        template <typename T>
-        T GetConstant(ShaderInputConstantIndex inputIndex, uint32_t arrayIndex) const;
-
-        //! Returns constant data for the given shader input index as a span of bytes.
-        AZStd::span<const uint8_t> GetConstantRaw(ShaderInputConstantIndex inputIndex) const;
-
         //! Returns the device-specific ShaderResourceGroupData for the given index
         const ShaderResourceGroupData& GetDeviceShaderResourceGroupData(int deviceIndex) const
         {
@@ -202,13 +181,6 @@ namespace AZ::RHI
 
         ConstPtr<ShaderResourceGroupLayout> m_shaderResourceGroupLayout;
 
-        //! The backing data store of constants used only for the getters, actual storage happens in the single device SRGs.
-        ConstantsData m_constantsData;
-
-        //! Mask used to check whether to compile a specific resource type. This mask is managed by RPI and copied over to the RHI every
-        //! frame.
-        uint32_t m_updateMask = 0;
-
         //! A map of all device-specific ShaderResourceGroupDatas, indexed by the device index
         AZStd::unordered_map<int, ShaderResourceGroupData> m_deviceShaderResourceGroupDatas;
     };
@@ -218,7 +190,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = m_constantsData.SetConstant(inputIndex, value);
+        bool isValidAll{ true };
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -233,7 +205,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = m_constantsData.SetConstant(inputIndex, value, arrayIndex);
+        bool isValidAll{ true };
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -248,7 +220,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = m_constantsData.SetConstantMatrixRows(inputIndex, value, rowCount);
+        bool isValidAll{ true };
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -266,7 +238,7 @@ namespace AZ::RHI
             EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
         }
 
-        bool isValidAll = m_constantsData.SetConstantArray(inputIndex, values);
+        bool isValidAll{ true };
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -274,24 +246,6 @@ namespace AZ::RHI
         }
 
         return isValidAll;
-    }
-
-    template <typename T>
-    AZStd::span<const T> MultiDeviceShaderResourceGroupData::GetConstantArray(ShaderInputConstantIndex inputIndex) const
-    {
-        return m_constantsData.GetConstantArray<T>(inputIndex);
-    }
-
-    template <typename T>
-    T MultiDeviceShaderResourceGroupData::GetConstant(ShaderInputConstantIndex inputIndex) const
-    {
-        return m_constantsData.GetConstant<T>(inputIndex);
-    }
-
-    template <typename T>
-    T MultiDeviceShaderResourceGroupData::GetConstant(ShaderInputConstantIndex inputIndex, uint32_t arrayIndex) const
-    {
-        return m_constantsData.GetConstant<T>(inputIndex, arrayIndex);
     }
 
     template<typename TShaderInput, typename TShaderInputDescriptor>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -20,21 +20,12 @@ namespace AZ::RHI
     class MultiDeviceShaderResourceGroup;
     class MultiDeviceShaderResourceGroupPool;
 
-    //! Shader resource group data is a light abstraction over a flat table of shader resources
-    //! and shader constants. It utilizes basic reflection information from the shader resource group layout
-    //! to construct the table in the correct format for the platform-specific compile phase. The user
-    //! is expected to create instances of this class, fill data, and then push it to an SRG instance.
+    //! MultiShaderResourceGroupData is a multi-device class holding single-device ShaderResourceGroupData objects,
+    //! one for each device referenced in its deviceMask.
+    //! All calls and data are forwarded to the single-device variants, while the multi-device data is also kept locally,
+    //! including ConstantsData and Samplers.
     //!
-    //! The shader resource group (SRG) includes a set of built-in SRG constants in a single internally-managed
-    //! constant buffer. This is separate from any custom constant buffers that some SRG layouts may include
-    //! as shader resources. SRG constants can be conveniently accessed through a variety of SetConstant.
-    //!
-    //! This data structure holds strong references to the resource views bound onto it.
-    //!
-    //! NOTE [Performance Warning]: This data structure allocates memory. If compiling several SRG's in a batch,
-    //! prefer to share the data between them (i.e. within a single job).
-    //!
-    //! NOTE [SRG Constants]: The ConstantsData class is used for efficiently setting/getting the constants values of the SRG.
+    //! This data structure holds strong references to the multi-device resource views bound onto it.
     class MultiDeviceShaderResourceGroupData
     {
     public:
@@ -42,14 +33,14 @@ namespace AZ::RHI
         MultiDeviceShaderResourceGroupData() = default;
         ~MultiDeviceShaderResourceGroupData() = default;
 
-        //! Creates shader resource group data from a layout.
+        //! Creates MultiDeviceShaderResourceGroupData from a layout and initializes single-device ShaderResourceGroupData.
         explicit MultiDeviceShaderResourceGroupData(
             MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* shaderResourceGroupLayout);
 
-        //! Creates shader resource group data from a pool (usable on any SRG with the same layout).
+        //! Creates MultiDeviceShaderResourceGroupData from a pool (usable on any SRG with the same layout).
         explicit MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroupPool& shaderResourceGroupPool);
 
-        //! Creates shader resource group data from an SRG instance (usable on any SRG with the same layout).
+        //! Creates MultiDeviceShaderResourceGroupData from an SRG instance (usable on any SRG with the same layout).
         explicit MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroup& shaderResourceGroup);
 
         AZ_DEFAULT_COPY_MOVE(MultiDeviceShaderResourceGroupData);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamBufferView.h
@@ -9,12 +9,12 @@
 
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI/StreamBufferView.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 #include <AzCore/Utils/TypeHash.h>
 #include <AzCore/std/containers/span.h>
 
 namespace AZ::RHI
 {
-    class MultiDeviceBuffer;
     class InputStreamLayout;
 
     //! Provides a view into a multi-device buffer, to be used as vertex stream. The content of the view is a contiguous

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceStreamingImagePool.h
@@ -62,8 +62,7 @@ namespace AZ
             //! Return true if the pool was set to new memory budget successfully
             bool SetMemoryBudget(size_t newBudget);
 
-            //! Iterates through all device-specific image pools and returns the HeapMemoryUsage
-            //! from the pool with the maximum memory budget.
+            //! Returns the maximum memory used by one of its pools for a specific heap type.
             const HeapMemoryUsage& GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const;
 
             //! Return if it supports tiled image feature

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -31,6 +31,7 @@ namespace AZ::RHI
     public:
         AZ_CLASS_ALLOCATOR(MultiDeviceSwapChain, AZ::SystemAllocator, 0);
         AZ_RTTI(MultiDeviceSwapChain, "{EB2B3AE5-41C0-4833-ABAD-4D964547029C}", Object);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(SwapChain);
         MultiDeviceSwapChain() = default;
         virtual ~MultiDeviceSwapChain() = default;
 
@@ -38,18 +39,6 @@ namespace AZ::RHI
         //! As the SwapChain uses multi-device resources on just a single device,
         //! it is explicitly initialized with just a deviceIndex
         ResultCode Init(int deviceIndex, const SwapChainDescriptor& descriptor);
-
-        //! Returns the device-specific SwapChain for the given index
-        inline Ptr<SwapChain> GetDeviceSwapChain(int deviceIndex) const
-        {
-            AZ_Error(
-                "MultiDeviceSwapChain",
-                m_deviceSwapChains.find(deviceIndex) != m_deviceSwapChains.end(),
-                "No DeviceSwapChain found for device index %d\n",
-                deviceIndex);
-
-            return m_deviceSwapChains.at(deviceIndex);
-        }
 
         //! Presents the swap chain to the display, and rotates the images.
         void Present();
@@ -133,8 +122,5 @@ namespace AZ::RHI
 
         //! Cache the XR system at initialization time
         RHI::XRRenderingInterface* m_xrSystem = nullptr;
-
-        //! A map of all device-specific SwapChains, indexed by the device index
-        AZStd::unordered_map<int, Ptr<SwapChain>> m_deviceSwapChains;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
@@ -51,7 +51,7 @@ namespace AZ::RHI
     DrawItemProperties DrawPacket::GetDrawItemProperties(size_t index) const
     {
         AZ_Assert(index < GetDrawItemCount(), "Out of bounds array access!");
-        return DrawItemProperties(&m_drawItems[index], m_drawItemSortKeys[index], m_drawFilterMasks[index]);
+        return DrawItemProperties{&m_drawItems[index], m_drawItemSortKeys[index], m_drawFilterMasks[index]};
     }
 
     DrawListTag DrawPacket::GetDrawListTag(size_t index) const

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -65,7 +65,17 @@ namespace AZ::RHI
         IterateObjects<Buffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
         {
             deviceBuffer->InvalidateViews();
+                                           });
+    }
+
+    bool MultiDeviceBuffer::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor)
+    {
+        bool isInResourceCache{true};
+        IterateObjects<Buffer>([&isInResourceCache, &bufferViewDescriptor]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
+        {
+            isInResourceCache &= deviceBuffer->IsInResourceCache(bufferViewDescriptor);
         });
+        return isInResourceCache;
     }
 
     //! Given a device index, return the corresponding BufferView for the selected device

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -194,7 +194,7 @@ namespace AZ::RHI
     {
         AZ_PROFILE_FUNCTION(RHI);
 
-        if (!ValidateIsInitialized() || !ValidateNotDeviceLevel())
+        if (!ValidateIsInitialized())
         {
             return ResultCode::InvalidOperation;
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/MultiDeviceDrawItem.h>
+
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::RHI
+{
+    MultiDeviceDrawItem::MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask)
+        : m_deviceMask{ deviceMask }
+    {
+        auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+        for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+            {
+                m_deviceDrawItems.emplace(deviceIndex, DrawItem{});
+            }
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -107,6 +107,16 @@ namespace AZ::RHI
         });
     }
 
+    bool MultiDeviceImage::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor)
+    {
+        bool isInResourceCache{true};
+        IterateObjects<Image>([&isInResourceCache, &imageViewDescriptor]([[maybe_unused]] auto deviceIndex, auto deviceImage)
+        {
+            isInResourceCache &= deviceImage->IsInResourceCache(imageViewDescriptor);
+        });
+        return isInResourceCache;
+    }
+
     //! Given a device index, return the corresponding BufferView for the selected device
     const RHI::Ptr<RHI::ImageView> MultiDeviceImageView::GetDeviceImageView(int deviceIndex) const
     {

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineLibrary.cpp
@@ -120,4 +120,24 @@ namespace AZ::RHI
 
         return result;
     }
+
+    bool MultiDevicePipelineLibrary::SaveSerializedData(const AZStd::unordered_map<int, AZStd::string>& filePaths) const
+    {
+        if (!ValidateIsInitialized())
+        {
+            return false;
+        }
+
+        bool result = true;
+
+        IterateObjects<PipelineLibrary>(
+            [&result, &filePaths]([[maybe_unused]] auto deviceIndex, auto devicePipelineLibrary)
+            {
+                auto deviceResult{ devicePipelineLibrary->SaveSerializedData(filePaths.at(deviceIndex)) };
+                AZ_Error("MultiDevicePipelineLibrary", deviceResult, "SaveSerializedData failed for device %d", deviceIndex);
+                result &= deviceResult;
+            });
+
+        return result;
+    }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDevicePipelineState.cpp
@@ -78,6 +78,7 @@ namespace AZ::RHI
                         {
                             m_type = PipelineStateType::Dispatch;
                         }
+                        break;
                     }
                 case PipelineStateType::RayTracing:
                     {
@@ -90,10 +91,11 @@ namespace AZ::RHI
                         {
                             m_type = PipelineStateType::RayTracing;
                         }
+                        break;
                     }
                 default:
                     {
-                        AZ_Error("MultiDevicePipelineState", false, "MultiDevicePipelineState already initialized!");
+                        AZ_Error("MultiDevicePipelineState", false, "Unknown PipelineStateType!");
                         resultCode = ResultCode::InvalidArgument;
                         break;
                     }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -64,6 +64,13 @@ namespace AZ::RHI
         return this;
     }
 
+    MultiDeviceRayTracingBlasDescriptor* MultiDeviceRayTracingBlasDescriptor::BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
+    {
+        AZ_Assert(m_mdBuildContext, "BuildFlags property can only be added to a Geometry entry");
+        m_mdBuildFlags = buildFlags;
+        return this;
+    }
+
     RayTracingTlasDescriptor MultiDeviceRayTracingTlasDescriptor::GetDeviceRayTracingTlasDescriptor(int deviceIndex) const
     {
         AZ_Assert(m_mdInstancesBuffer, "No MultiDeviceBuffer available!\n");
@@ -106,6 +113,13 @@ namespace AZ::RHI
     {
         AZ_Assert(m_mdBuildContext, "InstanceID property can only be added to an Instance entry");
         m_mdBuildContext->m_instanceID = instanceID;
+        return this;
+    }
+
+    MultiDeviceRayTracingTlasDescriptor* MultiDeviceRayTracingTlasDescriptor::InstanceMask(uint32_t instanceMask)
+    {
+        AZ_Assert(m_mdBuildContext, "InstanceMask property can only be added to an Instance entry");
+        m_mdBuildContext->m_instanceMask = instanceMask;
         return this;
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -26,8 +26,9 @@ namespace AZ::RHI
 
     MultiDeviceShaderResourceGroupData::MultiDeviceShaderResourceGroupData(
         MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* layout)
-        : m_shaderResourceGroupLayout(layout)
-        , m_deviceMask(deviceMask)
+        : m_deviceMask(deviceMask)
+        , m_shaderResourceGroupLayout(layout)
+        , m_constantsData(layout->GetConstantsLayout())
     {
         auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -28,7 +28,6 @@ namespace AZ::RHI
         MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* layout)
         : m_deviceMask(deviceMask)
         , m_shaderResourceGroupLayout(layout)
-        , m_constantsData(layout->GetConstantsLayout())
     {
         auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
 
@@ -337,11 +336,6 @@ namespace AZ::RHI
         }
 
         return isValidAll;
-    }
-
-    AZStd::span<const uint8_t> MultiDeviceShaderResourceGroupData::GetConstantRaw(ShaderInputConstantIndex inputIndex) const
-    {
-        return m_constantsData.GetConstantRaw(inputIndex);
     }
 
     void MultiDeviceShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -13,6 +13,10 @@
 
 namespace AZ::RHI
 {
+    const ConstPtr<MultiDeviceImageView> MultiDeviceShaderResourceGroupData::s_nullImageView;
+    const ConstPtr<MultiDeviceBufferView> MultiDeviceShaderResourceGroupData::s_nullBufferView;
+    const SamplerState MultiDeviceShaderResourceGroupData::s_nullSamplerState{};
+
     MultiDeviceShaderResourceGroupData::MultiDeviceShaderResourceGroupData(const MultiDeviceShaderResourceGroup& shaderResourceGroup)
         : MultiDeviceShaderResourceGroupData(*shaderResourceGroup.GetPool())
     {
@@ -28,7 +32,12 @@ namespace AZ::RHI
         MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupLayout* layout)
         : m_deviceMask(deviceMask)
         , m_shaderResourceGroupLayout(layout)
+        , m_constantsData(layout->GetConstantsLayout())
     {
+        m_imageViews.resize(layout->GetGroupSizeForImages());
+        m_bufferViews.resize(layout->GetGroupSizeForBuffers());
+        m_samplers.resize(layout->GetGroupSizeForSamplers());
+
         auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
 
         for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
@@ -43,52 +52,6 @@ namespace AZ::RHI
     const ShaderResourceGroupLayout* MultiDeviceShaderResourceGroupData::GetLayout() const
     {
         return m_shaderResourceGroupLayout.get();
-    }
-
-    bool MultiDeviceShaderResourceGroupData::ValidateSetImageView(
-        ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex) const
-    {
-        if (!Validation::IsEnabled())
-        {
-            return true;
-        }
-        if (!GetLayout()->ValidateAccess(inputIndex, arrayIndex))
-        {
-            return false;
-        }
-
-        if (imageView)
-        {
-            if (!ValidateImageViewAccess<ShaderInputImageIndex, ShaderInputImageDescriptor>(inputIndex, imageView, arrayIndex))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    bool MultiDeviceShaderResourceGroupData::ValidateSetBufferView(
-        ShaderInputBufferIndex inputIndex, const MultiDeviceBufferView* bufferView, uint32_t arrayIndex) const
-    {
-        if (!Validation::IsEnabled())
-        {
-            return true;
-        }
-        if (!GetLayout()->ValidateAccess(inputIndex, arrayIndex))
-        {
-            return false;
-        }
-
-        if (bufferView)
-        {
-            if (!ValidateBufferViewAccess<ShaderInputBufferIndex, ShaderInputBufferDescriptor>(inputIndex, bufferView, arrayIndex))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     ShaderInputBufferIndex MultiDeviceShaderResourceGroupData::FindShaderInputBufferIndex(const Name& name) const
@@ -125,11 +88,6 @@ namespace AZ::RHI
         {
             bool isValidAll = true;
 
-            for (size_t i = 0; i < imageViews.size(); ++i)
-            {
-                isValidAll &= ValidateSetImageView(inputIndex, imageViews[i], aznumeric_caster(arrayIndex + i));
-            }
-
             for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
             {
                 AZStd::vector<const ImageView*> deviceImageViews(imageViews.size());
@@ -147,6 +105,15 @@ namespace AZ::RHI
                 EnableResourceTypeCompilation(ResourceTypeMask::ImageViewMask);
             }
 
+            if (isValidAll)
+            {
+                const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+                for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
+                {
+                    m_imageViews[interval.m_min + arrayIndex + imageIndex] = imageViews[imageIndex];
+                }
+            }
+
             return isValidAll;
         }
         return false;
@@ -157,31 +124,34 @@ namespace AZ::RHI
     {
         if (GetLayout()->ValidateAccess(inputIndex))
         {
+            m_imageViewsUnboundedArray.clear();
             bool isValidAll = true;
 
             for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
             {
                 AZStd::vector<const ImageView*> deviceImageViews(imageViews.size());
 
-                for (int i = 0; i < imageViews.size(); ++i)
+                for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
                 {
-                    deviceImageViews[i] = imageViews[i]->GetDeviceImageView(deviceIndex).get();
+                    deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetImageViewUnboundedArray(inputIndex, deviceImageViews);
-            }
-
-            for (size_t i = 0; i < imageViews.size(); ++i)
-            {
-                const bool isValid = ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(
-                    inputIndex, imageViews[i], static_cast<uint32_t>(i));
-                isValidAll &= isValid;
             }
 
             if (!imageViews.empty())
             {
                 EnableResourceTypeCompilation(ResourceTypeMask::ImageViewUnboundedArrayMask);
             }
+
+            if (isValidAll)
+            {
+                for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
+                {
+                    m_imageViewsUnboundedArray.push_back(imageViews[imageIndex]);
+                }
+            }
+
             return isValidAll;
         }
         return false;
@@ -201,11 +171,6 @@ namespace AZ::RHI
         {
             bool isValidAll = true;
 
-            for (size_t i = 0; i < bufferViews.size(); ++i)
-            {
-                isValidAll &= ValidateSetBufferView(inputIndex, bufferViews[i], arrayIndex);
-            }
-
             for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
             {
                 AZStd::vector<const BufferView*> deviceBufferViews(bufferViews.size());
@@ -222,6 +187,16 @@ namespace AZ::RHI
             {
                 EnableResourceTypeCompilation(ResourceTypeMask::BufferViewMask);
             }
+
+            if (isValidAll)
+            {
+                const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+                for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
+                {
+                    m_bufferViews[interval.m_min + arrayIndex + bufferIndex] = bufferViews[bufferIndex];
+                }
+            }
+
             return isValidAll;
         }
         return false;
@@ -232,6 +207,7 @@ namespace AZ::RHI
     {
         if (GetLayout()->ValidateAccess(inputIndex))
         {
+            m_bufferViewsUnboundedArray.clear();
             bool isValidAll = true;
 
             for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
@@ -246,18 +222,19 @@ namespace AZ::RHI
                 isValidAll &= deviceShaderResourceGroupData.SetBufferViewUnboundedArray(inputIndex, deviceBufferViews);
             }
 
-            for (size_t i = 0; i < bufferViews.size(); ++i)
-            {
-                const bool isValid =
-                    ValidateBufferViewAccess<ShaderInputBufferUnboundedArrayIndex, ShaderInputBufferUnboundedArrayDescriptor>(
-                        inputIndex, bufferViews[i], static_cast<uint32_t>(i));
-                isValidAll &= isValid;
-            }
-
             if (!bufferViews.empty())
             {
                 EnableResourceTypeCompilation(ResourceTypeMask::BufferViewUnboundedArrayMask);
             }
+
+            if (isValidAll)
+            {
+                for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
+                {
+                    m_bufferViewsUnboundedArray.push_back(bufferViews[bufferIndex]);
+                }
+            }
+
             return isValidAll;
         }
         return false;
@@ -281,6 +258,12 @@ namespace AZ::RHI
                 isValidAll &= deviceShaderResourceGroupData.SetSamplerArray(inputIndex, samplers, arrayIndex);
             }
 
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            for (size_t i = 0; i < samplers.size(); ++i)
+            {
+                m_samplers[interval.m_min + arrayIndex + i] = samplers[i];
+            }
+
             if (!samplers.empty())
             {
                 EnableResourceTypeCompilation(ResourceTypeMask::SamplerMask);
@@ -300,7 +283,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = true;
+        bool isValidAll = m_constantsData.SetConstantRaw(inputIndex, bytes, byteOffset, byteCount);;
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -314,7 +297,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = true;
+        bool isValidAll = m_constantsData.SetConstantData(bytes, byteCount);
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -328,7 +311,7 @@ namespace AZ::RHI
     {
         EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask);
 
-        bool isValidAll = true;
+        bool isValidAll = m_constantsData.SetConstantData(bytes, byteOffset, byteCount);
 
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
@@ -338,8 +321,109 @@ namespace AZ::RHI
         return isValidAll;
     }
 
+    const RHI::ConstPtr<RHI::MultiDeviceImageView>& MultiDeviceShaderResourceGroupData::GetImageView(RHI::ShaderInputImageIndex inputIndex, uint32_t arrayIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex, arrayIndex))
+        {
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            return m_imageViews[interval.m_min + arrayIndex];
+        }
+        return s_nullImageView;
+    }
+
+    AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> MultiDeviceShaderResourceGroupData::GetImageViewArray(RHI::ShaderInputImageIndex inputIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex, 0))
+        {
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            return AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>>(&m_imageViews[interval.m_min], interval.m_max - interval.m_min);
+        }
+        return {};
+    }
+
+    AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> MultiDeviceShaderResourceGroupData::GetImageViewUnboundedArray(RHI::ShaderInputImageUnboundedArrayIndex inputIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex))
+        {
+            return AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>>(m_imageViewsUnboundedArray.data(), m_imageViewsUnboundedArray.size());
+        }
+        return {};
+    }
+
+    const RHI::ConstPtr<RHI::MultiDeviceBufferView>& MultiDeviceShaderResourceGroupData::GetBufferView(RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex, arrayIndex))
+        {
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            return m_bufferViews[interval.m_min + arrayIndex];
+        }
+        return s_nullBufferView;
+    }
+
+    AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> MultiDeviceShaderResourceGroupData::GetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex, 0))
+        {
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            return AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>>(&m_bufferViews[interval.m_min], interval.m_max - interval.m_min);
+        }
+        return {};
+    }
+
+    AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> MultiDeviceShaderResourceGroupData::GetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex))
+        {
+            return AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>>(m_bufferViewsUnboundedArray.data(), m_bufferViewsUnboundedArray.size());
+        }
+        return {};
+    }
+
+    const RHI::SamplerState& MultiDeviceShaderResourceGroupData::GetSampler(RHI::ShaderInputSamplerIndex inputIndex, uint32_t arrayIndex) const
+    {
+        if (GetLayout()->ValidateAccess(inputIndex, arrayIndex))
+        {
+            const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+            return m_samplers[interval.m_min + arrayIndex];
+        }
+        return s_nullSamplerState;
+    }
+
+    AZStd::span<const RHI::SamplerState> MultiDeviceShaderResourceGroupData::GetSamplerArray(RHI::ShaderInputSamplerIndex inputIndex) const
+    {
+        const Interval interval = GetLayout()->GetGroupInterval(inputIndex);
+        return AZStd::span<const RHI::SamplerState>(&m_samplers[interval.m_min], interval.m_max - interval.m_min);
+    }
+
+    AZStd::span<const uint8_t> MultiDeviceShaderResourceGroupData::GetConstantRaw(ShaderInputConstantIndex inputIndex) const
+    {
+        return m_constantsData.GetConstantRaw(inputIndex);
+    }
+
+    AZStd::span<const ConstPtr<MultiDeviceImageView>> MultiDeviceShaderResourceGroupData::GetImageGroup() const
+    {
+        return m_imageViews;
+    }
+
+    AZStd::span<const ConstPtr<MultiDeviceBufferView>> MultiDeviceShaderResourceGroupData::GetBufferGroup() const
+    {
+        return m_bufferViews;
+    }
+
+    AZStd::span<const SamplerState> MultiDeviceShaderResourceGroupData::GetSamplerGroup() const
+    {
+        return m_samplers;
+    }
+
+    uint32_t MultiDeviceShaderResourceGroupData::GetUpdateMask() const
+    {
+        return m_updateMask;
+    }
+
     void MultiDeviceShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask)
     {
+        m_updateMask = RHI::SetBits(m_updateMask, static_cast<uint32_t>(resourceTypeMask));
+
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
             deviceShaderResourceGroupData.EnableResourceTypeCompilation(resourceTypeMask);
@@ -348,6 +432,8 @@ namespace AZ::RHI
 
     void MultiDeviceShaderResourceGroupData::ResetUpdateMask()
     {
+        m_updateMask = 0;
+
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
             deviceShaderResourceGroupData.ResetUpdateMask();
@@ -380,6 +466,30 @@ namespace AZ::RHI
                 arrayIndex);
         }
 
+        BufferPoolDescriptor desc = static_cast<const MultiDeviceBufferPool*>(indirectResourceBufferView->GetBuffer()->GetPool())->GetDescriptor();
+        AZ_Assert(desc.m_heapMemoryLevel == HeapMemoryLevel::Device, "Indirect buffer that contains indices to the bindless resource views should be device as that is protected against triple buffering.");
+
+        auto key = AZStd::make_pair(indirectResourceBufferIndex, arrayIndex);
+        auto it = m_bindlessResourceViews.find(key);
+        if (it == m_bindlessResourceViews.end())
+        {
+            it = m_bindlessResourceViews.try_emplace(key).first;
+        }
+        else
+        {
+            // Release existing views
+            it->second.m_bindlessResources.clear();
+        }
+
+        AZ_Assert(imageViews.size() == isViewReadOnly.size(), "Mismatch sizes. For each view we need to know if it is read only or readwrite");
+        size_t i = 0;
+        for (const MultiDeviceImageView* imageView : imageViews)
+        {
+            it->second.m_bindlessResources.push_back(imageView);
+            it->second.m_bindlessResourceType = isViewReadOnly[i] ? BindlessResourceType::m_Texture2D : BindlessResourceType::m_RWTexture2D;
+            ++i;
+        }
+
         SetBufferView(indirectResourceBufferIndex, indirectResourceBufferView);
     }
 
@@ -409,6 +519,42 @@ namespace AZ::RHI
                 arrayIndex);
         }
 
+        BufferPoolDescriptor desc = static_cast<const MultiDeviceBufferPool*>(indirectResourceBufferView->GetBuffer()->GetPool())->GetDescriptor();
+        AZ_Assert(desc.m_heapMemoryLevel == HeapMemoryLevel::Device, "Indirect buffer that contains indices to the bindless resource views should be device as that is protected against triple buffering.");
+
+        auto key = AZStd::make_pair(indirectResourceBufferIndex, arrayIndex);
+        auto it = m_bindlessResourceViews.find(key);
+        if (it == m_bindlessResourceViews.end())
+        {
+            it = m_bindlessResourceViews.try_emplace(key).first;
+        }
+        else
+        {
+            // Release existing views
+            it->second.m_bindlessResources.clear();
+        }
+
+        AZ_Assert(bufferViews.size() == isViewReadOnly.size(), "Mismatch sizes. For each view we need to know if it is read only or readwrite");
+
+        size_t i = 0;
+        for (const MultiDeviceBufferView* bufferView : bufferViews)
+        {
+            it->second.m_bindlessResources.push_back(bufferView);
+            it->second.m_bindlessResourceType = isViewReadOnly[i] ? BindlessResourceType::m_ByteAddressBuffer : BindlessResourceType::m_RWByteAddressBuffer;
+            ++i;
+        }
+
         SetBufferView(indirectResourceBufferIndex, indirectResourceBufferView);
+    }
+
+    const uint32_t MultiDeviceShaderResourceGroupData::GetBindlessViewsSize() const
+    {
+        return aznumeric_cast<uint32_t>(m_bindlessResourceViews.size());
+    }
+
+    const AZStd::unordered_map<AZStd::pair<ShaderInputBufferIndex, uint32_t>, MultiDeviceShaderResourceGroupData::MultiDeviceBindlessResourceViews>&
+    MultiDeviceShaderResourceGroupData::GetBindlessResourceViews() const
+    {
+        return m_bindlessResourceViews;
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -338,6 +338,11 @@ namespace AZ::RHI
         return isValidAll;
     }
 
+    AZStd::span<const uint8_t> MultiDeviceShaderResourceGroupData::GetConstantRaw(ShaderInputConstantIndex inputIndex) const
+    {
+        return m_constantsData.GetConstantRaw(inputIndex);
+    }
+
     void MultiDeviceShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask)
     {
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamingImagePool.cpp
@@ -210,7 +210,7 @@ namespace AZ::RHI
 
     const HeapMemoryUsage& MultiDeviceStreamingImagePool::GetHeapMemoryUsage(HeapMemoryLevel heapMemoryLevel) const
     {
-        auto maxUsageIndex{-1};
+        auto maxUsageIndex{RHI::MultiDevice::DefaultDeviceIndex};
         auto maxBudget{0ull};
         IterateObjects<StreamingImagePool>([&maxUsageIndex, &maxBudget, heapMemoryLevel](auto deviceIndex, auto deviceStreamingImagePool)
         {

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
@@ -346,47 +346,38 @@ namespace UnitTest
             // Write the last one as a single value with an offset.
             srgData.SetConstantRaw(nestedDataIndex, &nestedData[15], sizeof(NestedData) * 15, sizeof(NestedData));
 
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                float floatValueResult = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex);
-                EXPECT_EQ(floatValueResult, floatValue);
-            }
+            float floatValueResult = srgData.GetConstant<float>(floatValueIndex);
+            EXPECT_EQ(floatValueResult, floatValue);
 
             const auto ValidateFloat4Values = [&]()
             {
-                for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                {
-                    AZStd::span<const float> float4ValueResult =
-                        srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<float>(float4ValueIndex);
-                    EXPECT_EQ(float4ValueResult.size(), 4);
-                    EXPECT_EQ(float4ValueResult[0], float4Values[0]);
-                    EXPECT_EQ(float4ValueResult[1], float4Values[1]);
-                    EXPECT_EQ(float4ValueResult[2], float4Values[2]);
-                    EXPECT_EQ(float4ValueResult[3], float4Values[3]);
-                }
+                AZStd::span<const float> float4ValueResult =
+                    srgData.GetConstantArray<float>(float4ValueIndex);
+                EXPECT_EQ(float4ValueResult.size(), 4);
+                EXPECT_EQ(float4ValueResult[0], float4Values[0]);
+                EXPECT_EQ(float4ValueResult[1], float4Values[1]);
+                EXPECT_EQ(float4ValueResult[2], float4Values[2]);
+                EXPECT_EQ(float4ValueResult[3], float4Values[3]);
             };
 
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
+            AZStd::span<const uint32_t> uintValuesResult =
+                srgData.GetConstantArray<uint32_t>(uintValueIndex);
+            EXPECT_EQ(uintValuesResult.size(), 3);
+            EXPECT_EQ(uintValuesResult[0], uintValues[0]);
+            EXPECT_EQ(uintValuesResult[1], uintValues[1]);
+            EXPECT_EQ(uintValuesResult[2], uintValues[2]);
+
+            AZStd::span<const NestedData> nestedDataResult =
+                srgData.GetConstantArray<NestedData>(nestedDataIndex);
+            EXPECT_EQ(nestedDataResult.size(), 16);
+
+            ValidateFloat4Values();
+
+            for (uint32_t i = 0; i < 16; ++i)
             {
-                AZStd::span<const uint32_t> uintValuesResult =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<uint32_t>(uintValueIndex);
-                EXPECT_EQ(uintValuesResult.size(), 3);
-                EXPECT_EQ(uintValuesResult[0], uintValues[0]);
-                EXPECT_EQ(uintValuesResult[1], uintValues[1]);
-                EXPECT_EQ(uintValuesResult[2], uintValues[2]);
-
-                AZStd::span<const NestedData> nestedDataResult =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantArray<NestedData>(nestedDataIndex);
-                EXPECT_EQ(nestedDataResult.size(), 16);
-
-                ValidateFloat4Values();
-
-                for (uint32_t i = 0; i < 16; ++i)
-                {
-                    EXPECT_EQ(nestedDataResult[i].m_x, nestedData[i].m_x);
-                    EXPECT_EQ(nestedDataResult[i].m_y, nestedData[i].m_y);
-                    EXPECT_EQ(nestedDataResult[i].m_z, nestedData[i].m_z);
-                }
+                EXPECT_EQ(nestedDataResult[i].m_x, nestedData[i].m_x);
+                EXPECT_EQ(nestedDataResult[i].m_y, nestedData[i].m_y);
+                EXPECT_EQ(nestedDataResult[i].m_z, nestedData[i].m_z);
             }
 
             // SetConstant Matrix tests
@@ -397,60 +388,52 @@ namespace UnitTest
             // SetConstant matrix of type Matrix3x3
             const AZ::Matrix3x3& mat3x3Values = AZ::Matrix3x3::CreateFromRowMajorFloat9(matrixValue);
             srgData.SetConstant(matrix3x3Index, mat3x3Values);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
 
             // SetConstant matrix of type Matrix3x4
             const AZ::Matrix3x4& mat3x4Values = AZ::Matrix3x4::CreateFromRowMajorFloat12(matrixValue);
             srgData.SetConstant(matrix3x4Index, mat3x4Values);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
 
             // SetConstant matrix of type Matrix4x4
             const AZ::Matrix4x4& mat4x4Values = AZ::Matrix4x4::CreateFromRowMajorFloat16(matrixValue);
             srgData.SetConstant(matrix4x4Index, mat4x4Values);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
 
             // Reset the constant matrix3x4Index with identity
             srgData.SetConstant(matrix3x4Index, AZ::Matrix3x4::CreateIdentity());
 
             // SetConstant matrix rows, sets 3 rows from 4x4 matrix (which becomes 3x4 matrix)
             srgData.SetConstantMatrixRows(matrix3x4Index, mat4x4Values, 3);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix3x4>(matrix3x4Index), mat3x4Values);
 
             // Reset the constant matrix3x3Index with identity
             srgData.SetConstant(matrix3x3Index, AZ::Matrix3x3::CreateIdentity());
 
             srgData.SetConstantMatrixRows(matrix3x3Index, mat3x3Values, 3);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix3x3>(matrix3x3Index), mat3x3Values);
 
             // Reset the constant matrix4x4Index with identity
             srgData.SetConstant(matrix4x4Index, AZ::Matrix4x4::CreateIdentity());
 
             srgData.SetConstantMatrixRows(matrix4x4Index, mat4x4Values, 4);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
+            EXPECT_EQ(srgData.GetConstant<AZ::Matrix4x4>(matrix4x4Index), mat4x4Values);
 
             // SetConstant
             {
                 // Attempt to a larger amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, AZ::Vector4::CreateOne());
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
-                for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                    EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
+                EXPECT_EQ(srgData.GetConstant<float>(floatValueIndex), floatValue);
 
                 // Attempt to assign a smaller amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, uint8_t(0));
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
-                for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-                    EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
+                EXPECT_EQ(srgData.GetConstant<float>(floatValueIndex), floatValue);
             }
 
             // SetConstant (ArrayIndex)
@@ -458,7 +441,7 @@ namespace UnitTest
                 // Assign index that overflows array.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, 5.0f, 5);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -472,7 +455,7 @@ namespace UnitTest
 
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, Test(), 1);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -488,7 +471,7 @@ namespace UnitTest
                 float float6Values[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float6Values, AZ_ARRAY_SIZE(float6Values) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -496,7 +479,7 @@ namespace UnitTest
                 float float1Value[] = { 5.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float1Value, AZ_ARRAY_SIZE(float1Value) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
             }
@@ -542,31 +525,19 @@ namespace UnitTest
             const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
 
             EXPECT_TRUE(srgData.SetConstant(vector2index, vector2));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resultVector2 =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
-                const Vector2 vector2result = *reinterpret_cast<const Vector2*>(resultVector2.data());
-                EXPECT_EQ(vector2result, vector2);
-            }
+            AZStd::span<const uint8_t> resultVector2 = srgData.GetConstantRaw(vector2index);
+            const Vector2 vector2result = *reinterpret_cast<const Vector2*>(resultVector2.data());
+            EXPECT_EQ(vector2result, vector2);
 
             EXPECT_TRUE(srgData.SetConstant(vector3index, vector3));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resutVector3 =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
-                const Vector3 vector3result = *reinterpret_cast<const Vector3*>(resutVector3.data());
-                EXPECT_EQ(vector3result, vector3);
-            }
+            AZStd::span<const uint8_t> resutVector3 = srgData.GetConstantRaw(vector3index);
+            const Vector3 vector3result = *reinterpret_cast<const Vector3*>(resutVector3.data());
+            EXPECT_EQ(vector3result, vector3);
 
             EXPECT_TRUE(srgData.SetConstant(vector4index, vector4));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resutVector4 =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector4index);
-                const Vector4 vector4result = *reinterpret_cast<const Vector4*>(resutVector4.data());
-                EXPECT_EQ(vector4result, vector4);
-            }
+            AZStd::span<const uint8_t> resutVector4 = srgData.GetConstantRaw(vector4index);
+            const Vector4 vector4result = *reinterpret_cast<const Vector4*>(resutVector4.data());
+            EXPECT_EQ(vector4result, vector4);
         }
         void TestSetConstantVectorsInvalidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
         {
@@ -593,40 +564,30 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector2index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resutV3 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
-                const Vector3 v3result = *reinterpret_cast<const Vector3*>(resutV3.data());
-                EXPECT_NE(v3result, vector3);
-            }
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZStd::span<const uint8_t> resutV3 = srgData.GetConstantRaw(vector2index);
+            const Vector3 v3result = *reinterpret_cast<const Vector3*>(resutV3.data());
+            EXPECT_NE(v3result, vector3);
 
             // Reset constant vector3index to zero
             EXPECT_TRUE(srgData.SetConstant(vector3index, vector3.CreateZero()));
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector3index, vector4));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resutV4 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
-                const Vector4 v4result = *reinterpret_cast<const Vector4*>(resutV4.data());
-                EXPECT_NE(v4result, vector4);
-            }
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZStd::span<const uint8_t> resutV4 = srgData.GetConstantRaw(vector3index);
+            const Vector4 v4result = *reinterpret_cast<const Vector4*>(resutV4.data());
+            EXPECT_NE(v4result, vector4);
 
             // Reset constant vector4index to zero
             EXPECT_TRUE(srgData.SetConstant(vector4index, vector4.CreateZero()));
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector4index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZStd::span<const uint8_t> resutV3FromIndex4 =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector4index);
-                const Vector4 v4resultFromIndex4 = *reinterpret_cast<const Vector4*>(resutV3FromIndex4.data());
-                EXPECT_NE(v4resultFromIndex4, vector4);
-            }
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZStd::span<const uint8_t> resutV3FromIndex4 = srgData.GetConstantRaw(vector4index);
+            const Vector4 v4resultFromIndex4 = *reinterpret_cast<const Vector4*>(resutV3FromIndex4.data());
+            EXPECT_NE(v4resultFromIndex4, vector4);
         }
 
         void TestGetConstantVectorsValidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
@@ -650,25 +611,16 @@ namespace UnitTest
             const Vector4 vector4 = Vector4::CreateFromFloat4(vector4values);
 
             EXPECT_TRUE(srgData.SetConstantRaw(vector2index, &vector2, 8));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                const Vector2 vector2result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector2>(vector2index);
-                EXPECT_EQ(vector2result, vector2);
-            }
+            const Vector2 vector2result = srgData.GetConstant<Vector2>(vector2index);
+            EXPECT_EQ(vector2result, vector2);
 
             EXPECT_TRUE(srgData.SetConstantRaw(vector3index, &vector3, 12));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                const Vector3 vector3result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector3>(vector3index);
-                EXPECT_EQ(vector3result, vector3);
-            }
+            const Vector3 vector3result = srgData.GetConstant<Vector3>(vector3index);
+            EXPECT_EQ(vector3result, vector3);
 
             EXPECT_TRUE(srgData.SetConstantRaw(vector4index, &vector4, 16));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                const Vector4 vector4result = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector4>(vector4index);
-                EXPECT_EQ(vector4result, vector4);
-            }
+            const Vector4 vector4result = srgData.GetConstant<Vector4>(vector4index);
+            EXPECT_EQ(vector4result, vector4);
         }
         void TestGetConstantVectorsInvalidCase(const RHI::ConstPtr<RHI::ShaderResourceGroupLayout>& srgLayout)
         {
@@ -692,34 +644,22 @@ namespace UnitTest
 
             // Invalid cases for GetConstant
             EXPECT_TRUE(srgData.SetConstantRaw(vector2index, &vector2, 8));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZ_TEST_START_ASSERTTEST;
-                const Vector3 invalidVector3result =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector3>(vector2index);
-                EXPECT_NE(invalidVector3result, vector3);
-                AZ_TEST_STOP_ASSERTTEST(1);
-            }
+            AZ_TEST_START_ASSERTTEST;
+            const Vector3 invalidVector3result = srgData.GetConstant<Vector3>(vector2index);
+            EXPECT_NE(invalidVector3result, vector3);
+            AZ_TEST_STOP_ASSERTTEST(1);
 
             EXPECT_TRUE(srgData.SetConstantRaw(vector3index, &vector3, 12));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZ_TEST_START_ASSERTTEST;
-                const Vector4 invalidVector4result =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector4>(vector3index);
-                EXPECT_NE(invalidVector4result, vector4);
-                AZ_TEST_STOP_ASSERTTEST(1);
-            }
+            AZ_TEST_START_ASSERTTEST;
+            const Vector4 invalidVector4result = srgData.GetConstant<Vector4>(vector3index);
+            EXPECT_NE(invalidVector4result, vector4);
+            AZ_TEST_STOP_ASSERTTEST(1);
 
             EXPECT_TRUE(srgData.SetConstantRaw(vector4index, &vector4, 16));
-            for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-            {
-                AZ_TEST_START_ASSERTTEST;
-                const Vector2 invalidVector2result =
-                    srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<Vector2>(vector4index);
-                EXPECT_NE(invalidVector2result, vector2);
-                AZ_TEST_STOP_ASSERTTEST(1);
-            }
+            AZ_TEST_START_ASSERTTEST;
+            const Vector2 invalidVector2result = srgData.GetConstant<Vector2>(vector4index);
+            EXPECT_NE(invalidVector2result, vector2);
+            AZ_TEST_STOP_ASSERTTEST(1);
         }
 
         TEST_F(MultiDeviceShaderResourceGroupTests, TestShaderResourceGroupLayout)

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
@@ -439,7 +439,7 @@ namespace UnitTest
                 // Attempt to a larger amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, AZ::Vector4::CreateOne());
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
                     EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
@@ -447,7 +447,7 @@ namespace UnitTest
                 // Attempt to assign a smaller amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, uint8_t(0));
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
                     EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
@@ -458,7 +458,7 @@ namespace UnitTest
                 // Assign index that overflows array.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, 5.0f, 5);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -472,7 +472,7 @@ namespace UnitTest
 
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, Test(), 1);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -488,7 +488,7 @@ namespace UnitTest
                 float float6Values[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float6Values, AZ_ARRAY_SIZE(float6Values) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
 
@@ -496,7 +496,7 @@ namespace UnitTest
                 float float1Value[] = { 5.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float1Value, AZ_ARRAY_SIZE(float1Value) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
 
                 ValidateFloat4Values();
             }
@@ -593,7 +593,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector2index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV3 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
@@ -606,7 +606,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector3index, vector4));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV4 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
@@ -619,7 +619,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector4index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV3FromIndex4 =

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
@@ -439,7 +439,7 @@ namespace UnitTest
                 // Attempt to a larger amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, AZ::Vector4::CreateOne());
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
                     EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
@@ -447,7 +447,7 @@ namespace UnitTest
                 // Attempt to assign a smaller amount of data than is supported.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(floatValueIndex, uint8_t(0));
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
                     EXPECT_EQ(srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstant<float>(floatValueIndex), floatValue);
@@ -458,7 +458,7 @@ namespace UnitTest
                 // Assign index that overflows array.
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, 5.0f, 5);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 ValidateFloat4Values();
 
@@ -472,7 +472,7 @@ namespace UnitTest
 
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstant(float4ValueIndex, Test(), 1);
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 ValidateFloat4Values();
 
@@ -488,7 +488,7 @@ namespace UnitTest
                 float float6Values[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float6Values, AZ_ARRAY_SIZE(float6Values) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 ValidateFloat4Values();
 
@@ -496,7 +496,7 @@ namespace UnitTest
                 float float1Value[] = { 5.0f };
                 AZ_TEST_START_ASSERTTEST;
                 srgData.SetConstantArray<float>(float4ValueIndex, { float1Value, AZ_ARRAY_SIZE(float1Value) });
-                AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+                AZ_TEST_STOP_ASSERTTEST(DeviceCount);
 
                 ValidateFloat4Values();
             }
@@ -593,7 +593,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector2index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV3 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector2index);
@@ -606,7 +606,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector3index, vector4));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV4 = srgData.GetDeviceShaderResourceGroupData(deviceIndex).GetConstantRaw(vector3index);
@@ -619,7 +619,7 @@ namespace UnitTest
 
             AZ_TEST_START_ASSERTTEST;
             EXPECT_FALSE(srgData.SetConstant(vector4index, vector3));
-            AZ_TEST_STOP_ASSERTTEST(DeviceCount + 1);
+            AZ_TEST_STOP_ASSERTTEST(DeviceCount);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 AZStd::span<const uint8_t> resutV3FromIndex4 =

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -62,6 +62,7 @@ set(FILES
     Source/RHI/DrawListContext.cpp
     Source/RHI/DrawPacket.cpp
     Source/RHI/DrawPacketBuilder.cpp
+    Source/RHI/MultiDeviceDrawItem.cpp
     Include/Atom/RHI/Device.h
     Include/Atom/RHI/DeviceBusTraits.h
     Include/Atom/RHI/DeviceObject.h


### PR DESCRIPTION
## What does this PR do?

During the integration of multi-device resources into the engine (as is currently done on the branch [multi-device-resources](https://github.com/o3de/o3de/tree/multi-device-resources)), further testing revealed smaller issues, which have been fixed on that branch and shall now propagate to the multi-device classes already in `development`.
This also includes some integration of code that changed the single-device resource classes in the mean while and now is replicated in the multi-device classes.
The full list of PRs already in `development` is as follows:
| Name | Link | Status |
| --- | --- | --- |
|Preparation|[#16138](https://github.com/o3de/o3de/pull/16138)|merged|
|Base Resources|[#16202](https://github.com/o3de/o3de/pull/16202)|merged|
| Pipelines | [#16261](https://github.com/o3de/o3de/pull/16261) | merged |
|Independent Resources|[#16262](https://github.com/o3de/o3de/pull/16262)|merged|
| Buffers | [#16590](https://github.com/o3de/o3de/pull/16590)| merged |
| Images | [#16591](https://github.com/o3de/o3de/pull/16591)| merged |
|Indirect*|[#16681](https://github.com/o3de/o3de/pull/16681)|merged|
| SRGs|[#16680](https://github.com/o3de/o3de/pull/16680) | merged |
| TransientAttachmentPool | [#16712](https://github.com/o3de/o3de/pull/16712) | merged |
|RayTracing Resources| [#16767](https://github.com/o3de/o3de/pull/16767) |merged|
| Items | [#16768](https://github.com/o3de/o3de/pull/16768) | merged |
| Views | [#16804](https://github.com/o3de/o3de/pull/16804) | merged |
|SwapChain|[#17146](https://github.com/o3de/o3de/pull/17146)|open|

## How was this PR tested?

Using the newly added multi-device RHI tests, including:
- `MultiDeviceBufferTests.cpp`
- `MultiDeviceImageTests.cpp`
- `MultiDeviceIndirectBufferTests.cpp`
- `MultiDevicePipelineStateTests.cpp`
- `MultiDeviceQueryTests.cpp`
- `MultiDeviceShaderResourceGroupTests.cpp`
