### PR TITLE
Remove Error Log Duplicate Spam

### DIFF
--- a/Code/Legacy/CrySystem/AZCoreLogSink.h
+++ b/Code/Legacy/CrySystem/AZCoreLogSink.h
@@ -93,7 +93,7 @@ public:
         {
             return false; // allow AZCore to do its default behavior.
         }
-        gEnv->pLog->LogError("(%s) - %s", window, message);
+
         AZStd::string_view windowView = window;
         if (!windowView.empty())
         {


### PR DESCRIPTION
Make sure error logs are only printed once
Look below the change to see that the error log will be printed again based on if it has a window or not.

Fixes #17161
