### PR TITLE
Make sure ios export script uses correct asset processor path

### DIFF
--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -56,7 +56,7 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
         
     # Optionally process the assets
     if not skip_asset_processing:
-        asset_processor_batch_path = exp.get_asset_processor_batch_path(tools_build_folder, True)
+        asset_processor_batch_path = exp.get_asset_processor_batch_path(tools_build_folder, required=True)
         exp.process_command([ str(asset_processor_batch_path), '--platforms=ios',
                         '--project-path', ctx.project_path ], cwd=ctx.project_path)
 


### PR DESCRIPTION
## What does this PR do?
A small error was discovered with the iOS exporter script where it would mistakenly use the path of the installer SDK binaries for asset processor, due to a mislabeled parameter. This PR introduces a one line fix to correct the behavior.

## How was this PR tested?
Tested on a mac with the AtomSampleViewer project. Export script successfully ran generating xcode file and processing assets.