### PR TITLE
feature: improve assertions for RHI Vulkan result

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/RHI/WSISurface_Android.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/RHI/WSISurface_Android.cpp
@@ -26,7 +26,7 @@ namespace AZ
             createInfo.flags = 0;
             createInfo.window = reinterpret_cast<ANativeWindow*>(m_descriptor.m_windowHandle.GetIndex());
             const VkResult result = instance.GetContext().CreateAndroidSurfaceKHR(instance.GetNativeInstance(), &createInfo, VkSystemAllocator::Get(), &m_nativeSurface);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Linux/RHI/WSISurface_Linux.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Linux/RHI/WSISurface_Linux.cpp
@@ -64,7 +64,7 @@ namespace AZ
             createInfo.connection = xcb_connection;
             createInfo.window = static_cast<xcb_window_t>(m_descriptor.m_windowHandle.GetIndex());
             const VkResult result = instance.GetContext().CreateXcbSurfaceKHR(instance.GetNativeInstance(), &createInfo, VkSystemAllocator::Get(), &m_nativeSurface);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
 #endif

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/WSISurface_Windows.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/WSISurface_Windows.cpp
@@ -26,9 +26,9 @@ namespace AZ
             createInfo.flags = 0;
             createInfo.hinstance = hinstance;
             createInfo.hwnd = reinterpret_cast<HWND>(m_descriptor.m_windowHandle.GetIndex());
-            const VkResult result = instance.GetContext().CreateWin32SurfaceKHR(
+            const VkResult vkResult = instance.GetContext().CreateWin32SurfaceKHR(
                 instance.GetNativeInstance(), &createInfo, VkSystemAllocator::Get(), &m_nativeSurface);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(vkResult);
 
             return ConvertResult(result);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/WSISurface_Windows.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/WSISurface_Windows.cpp
@@ -30,7 +30,7 @@ namespace AZ
                 instance.GetNativeInstance(), &createInfo, VkSystemAllocator::Get(), &m_nativeSurface);
             VK_RESULT_ASSERT(vkResult);
 
-            return ConvertResult(result);
+            return ConvertResult(vkResult);
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
@@ -46,7 +46,7 @@ namespace AZ
             memReq.alignment = AZStd::max(memReq.alignment, descriptor.m_alignment);
             memReq.size = descriptor.m_budgetInBytes;
             VkResult vkResult = vmaAllocateMemory(device.GetVmaAllocator(), &memReq, &allocInfo, &vmaAllocation, nullptr);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RHI::ResultCode result = ConvertResult(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
@@ -129,6 +129,6 @@ namespace AZ
         const AliasedHeap::Descriptor& AliasedHeap::GetDescriptor() const
         {
             return m_descriptor;
-        }        
+        }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
@@ -97,13 +97,15 @@ namespace AZ
                 m_signalEvent->Wait(m_waitDependencies);
             }
             auto& device = static_cast<Device&>(GetDevice());
-            VK_RESULT_ASSERT(device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX));
+            [[maybe_unused]] VkResult vkResult = device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX);
+            VK_RESULT_ASSERT(vkResult);
         }
 
         void BinaryFence::ResetInternal()
         {
             auto& device = static_cast<Device&>(GetDevice());
-            VK_RESULT_ASSERT(device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence));
+            [[maybe_unused]] VkResult vkResult = device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence);
+            VK_RESULT_ASSERT(vkResult);
             m_inSignalledState = false;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
@@ -56,7 +56,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateFence(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeFence);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
             m_signalEvent = {};
@@ -97,13 +97,13 @@ namespace AZ
                 m_signalEvent->Wait(m_waitDependencies);
             }
             auto& device = static_cast<Device&>(GetDevice());
-            AssertSuccess(device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX));
+            VK_RESULT_ASSERT(device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX));
         }
 
         void BinaryFence::ResetInternal()
         {
             auto& device = static_cast<Device&>(GetDevice());
-            AssertSuccess(device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence));
+            VK_RESULT_ASSERT(device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence));
             m_inSignalledState = false;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinarySemaphore.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinarySemaphore.cpp
@@ -28,7 +28,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateSemaphore(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSemaphore);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BindlessDescriptorPool.cpp
@@ -93,7 +93,7 @@ namespace AZ::Vulkan
                 m_device->GetNativeDevice(), &layoutInfo, VkSystemAllocator::Get(), &m_descriptorSetLayout);
             if (result != VK_SUCCESS)
             {
-                AssertSuccess(result);
+                VK_RESULT_ASSERT(result);
                 return ConvertResult(result);
             }
 
@@ -106,7 +106,7 @@ namespace AZ::Vulkan
             result = m_device->GetContext().AllocateDescriptorSets(m_device->GetNativeDevice(), &allocInfo, &m_set);
             if (result != VK_SUCCESS)
             {
-                AssertSuccess(result);
+                VK_RESULT_ASSERT(result);
                 return ConvertResult(result);
             }
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemory.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemory.cpp
@@ -37,7 +37,7 @@ namespace AZ
                 createInfo.GetCreateInfo(),
                 &m_vkBuffer);
 
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RHI::ResultCode result = ConvertResult(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
@@ -82,7 +82,7 @@ namespace AZ
                 &vmaAlloc,
                 nullptr);
 
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RHI::ResultCode result = ConvertResult(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
@@ -157,7 +157,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateBufferView(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeBufferView);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -778,8 +778,8 @@ namespace AZ
                 beginInfo.pInheritanceInfo = nullptr;
             }
 
-            VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().BeginCommandBuffer(m_nativeCommandBuffer, &beginInfo);
-            AssertSuccess(vkResult);
+            [[maybe_unused]] VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().BeginCommandBuffer(m_nativeCommandBuffer, &beginInfo);
+            VK_RESULT_ASSERT(vkResult);
         }
 
         void CommandList::EndCommandBuffer()
@@ -788,7 +788,8 @@ namespace AZ
 
             m_state.m_framebuffer = nullptr;
             m_state.m_subpassIndex = 0;
-            AssertSuccess(static_cast<Device&>(GetDevice()).GetContext().EndCommandBuffer(m_nativeCommandBuffer));
+            [[maybe_unused]] VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().EndCommandBuffer(m_nativeCommandBuffer);
+            VK_RESULT_ASSERT(vkResult);
             m_isUpdating = false;
         }
 
@@ -884,7 +885,7 @@ namespace AZ
             VkResult vkResult = static_cast<Device&>(GetDevice())
                                     .GetContext()
                                     .AllocateCommandBuffers(m_descriptor.m_device->GetNativeDevice(), &allocInfo, &m_nativeCommandBuffer);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             return ConvertResult(vkResult);
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandPool.cpp
@@ -56,7 +56,7 @@ namespace AZ
         RHI::ResultCode CommandPool::BuildNativeCommandPool()
         {
             auto& device = static_cast<Device&>(GetDevice());
-            
+
             VkCommandPoolCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
             createInfo.pNext = nullptr;
@@ -65,7 +65,7 @@ namespace AZ
 
             const VkResult result = device.GetContext().CreateCommandPool(
                 device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeCommandPool);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
         }
@@ -79,8 +79,8 @@ namespace AZ
         {
             RHI::Ptr<CommandList> cmdList;
             // Search the free list first
-            auto it = AZStd::find_if(m_freeCommandLists.begin(), m_freeCommandLists.end(), [&level](const RHI::Ptr<CommandList>& cmdList) 
-            { 
+            auto it = AZStd::find_if(m_freeCommandLists.begin(), m_freeCommandLists.end(), [&level](const RHI::Ptr<CommandList>& cmdList)
+            {
                 return cmdList->m_descriptor.m_level == level;
             });
 
@@ -123,7 +123,7 @@ namespace AZ
             }
             m_freeCommandLists.insert(m_freeCommandLists.end(), AZStd::make_move_iterator(m_commandLists.begin()), AZStd::make_move_iterator(m_commandLists.end()));
             m_commandLists.clear();
-            AssertSuccess(device.GetContext().ResetCommandPool(device.GetNativeDevice(), m_nativeCommandPool, 0));
-        }        
+            VK_RESULT_ASSERT(device.GetContext().ResetCommandPool(device.GetNativeDevice(), m_nativeCommandPool, 0));
+        }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandPool.cpp
@@ -123,7 +123,8 @@ namespace AZ
             }
             m_freeCommandLists.insert(m_freeCommandLists.end(), AZStd::make_move_iterator(m_commandLists.begin()), AZStd::make_move_iterator(m_commandLists.end()));
             m_commandLists.clear();
-            VK_RESULT_ASSERT(device.GetContext().ResetCommandPool(device.GetNativeDevice(), m_nativeCommandPool, 0));
+            [[maybe_unused]] VkResult vkResult = device.GetContext().ResetCommandPool(device.GetNativeDevice(), m_nativeCommandPool, 0);
+            VK_RESULT_ASSERT(vkResult);
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueueContext.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueueContext.cpp
@@ -96,8 +96,9 @@ namespace AZ
             auto supportsPresentation = [&swapchain, &device, &vkPhysicalDevice](uint32_t familyIndex)
             {
                 VkBool32 supported = VK_FALSE;
-                AssertSuccess(device.GetContext().GetPhysicalDeviceSurfaceSupportKHR(
-                    vkPhysicalDevice, familyIndex, swapchain.GetSurface().GetNativeSurface(), &supported));
+                [[maybe_unused]] VkResult result = device.GetContext().GetPhysicalDeviceSurfaceSupportKHR(
+                    vkPhysicalDevice, familyIndex, swapchain.GetSurface().GetNativeSurface(), &supported);
+                VK_RESULT_ASSERT(result);
                 return supported == VK_TRUE;
             };
 
@@ -114,9 +115,9 @@ namespace AZ
             uint32_t familyIndex = 0;
             uint32_t commandQueueIndex = 0;
             if (SelectQueueFamily(device, familyIndex, RHI::HardwareQueueClassMask::None, supportsPresentation))
-            {                
+            {
                 [[maybe_unused]] RHI::ResultCode result = CreateQueue(device, commandQueueIndex, familyIndex, "Presentation queue");
-                AZ_Assert(result == RHI::ResultCode::Success, "Failed to create presentation queue");                
+                AZ_Assert(result == RHI::ResultCode::Success, "Failed to create presentation queue");
             }
             else
             {
@@ -214,7 +215,7 @@ namespace AZ
                 // Compute or Graphic queue.
                 { RHI::HardwareQueueClassMask::Copy, RHI::HardwareQueueClassMask::Compute, RHI::HardwareQueueClassMask::Graphics }
             };
-            
+
             RHI::ResultCode result;
             for (uint32_t hardwareQueueIndex = 0; hardwareQueueIndex < RHI::HardwareQueueClassCount; ++hardwareQueueIndex)
             {
@@ -230,7 +231,7 @@ namespace AZ
                         m_queueClassMapping[hardwareQueueIndex] = static_cast<uint32_t>(commandQueueIndex);
                         break;
                     }
-                }                
+                }
             }
 
             return RHI::ResultCode::Success;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorPool.cpp
@@ -100,7 +100,7 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
             const VkResult result = device.GetContext().CreateDescriptorPool(
                 device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeDescriptorPool);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
         }
@@ -132,7 +132,7 @@ namespace AZ
             {
                 return AZStd::make_pair(vkResult, nullptr);
             }
-            
+
             m_objects.insert(descriptorSets);
             return AZStd::make_pair(vkResult, descriptorSets);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
@@ -236,12 +236,12 @@ namespace AZ
                     descriptor.m_device->GetNativeDevice(), &allocInfo, &m_nativeDescriptorSet);
                 if (result == VK_ERROR_FRAGMENTED_POOL)
                 {
-                    // fragmented pool will be re-created subsequently in DescriptorSetAllocator, so warning only 
+                    // fragmented pool will be re-created subsequently in DescriptorSetAllocator, so warning only
                     AZ_Warning("Vulkan RHI", false, "Fragmented pool, will be recreated in DescriptorSetAllocator afterward");
                 }
-                else 
+                else
                 {
-                    AssertSuccess(result);
+                    VK_RESULT_ASSERT(result);
                 }
 
                 if (result != VK_SUCCESS)
@@ -292,8 +292,9 @@ namespace AZ
             {
                 AZ_Assert(m_descriptor.m_descriptorPool, "Descriptor pool is null.");
                 auto& device = static_cast<Device&>(GetDevice());
-                AssertSuccess(device.GetContext().FreeDescriptorSets(
-                    device.GetNativeDevice(), m_descriptor.m_descriptorPool->GetNativeDescriptorPool(), 1, &m_nativeDescriptorSet));
+                [[maybe_unused]] VkResult result = device.GetContext().FreeDescriptorSets(
+                    device.GetNativeDevice(), m_descriptor.m_descriptorPool->GetNativeDescriptorPool(), 1, &m_nativeDescriptorSet);
+                VK_RESULT_ASSERT(result);
                 m_nativeDescriptorSet = VK_NULL_HANDLE;
             }
             m_constantDataBufferView = nullptr;
@@ -461,11 +462,13 @@ namespace AZ
                         // release existing descriptor set if necessary
                         if (m_nativeDescriptorSet)
                         {
-                            AssertSuccess(m_descriptor.m_device->GetContext().FreeDescriptorSets(
+
+                            [[maybe_unused]] VkResult vkResult = m_descriptor.m_device->GetContext().FreeDescriptorSets(
                                 m_descriptor.m_device->GetNativeDevice(),
                                 m_descriptor.m_descriptorPool->GetNativeDescriptorPool(),
                                 1,
-                                &m_nativeDescriptorSet));
+                                &m_nativeDescriptorSet);
+                            VK_RESULT_ASSERT(vkResult);
                             m_nativeDescriptorSet = VK_NULL_HANDLE;
                         }
                     }
@@ -488,9 +491,9 @@ namespace AZ
                 allocInfo.descriptorPool = m_descriptor.m_descriptorPool->GetNativeDescriptorPool();
                 allocInfo.descriptorSetCount = 1;
                 allocInfo.pSetLayouts = &nativeLayout;
-
-                AssertSuccess(m_descriptor.m_device->GetContext().AllocateDescriptorSets(
-                    m_descriptor.m_device->GetNativeDevice(), &allocInfo, &m_nativeDescriptorSet));
+                [[maybe_unused]] VkResult vkResult = m_descriptor.m_device->GetContext().AllocateDescriptorSets(
+                    m_descriptor.m_device->GetNativeDevice(), &allocInfo, &m_nativeDescriptorSet);
+                VK_RESULT_ASSERT(vkResult);
 
                 m_currentUnboundedArrayAllocation = unboundedArraySize;
                 SetName(GetName());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -576,7 +576,7 @@ namespace AZ
                 &deviceInfo,
                 VkSystemAllocator::Get(),
                 &m_nativeDevice);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
 
             LoaderContext::Descriptor loaderDescriptor;
@@ -732,7 +732,7 @@ namespace AZ
                 VkImage vkImage = VK_NULL_HANDLE;
                 VkResult vkResult =
                     GetContext().CreateImage(GetNativeDevice(), createInfo.GetCreateInfo(), VkSystemAllocator::Get(), &vkImage);
-                AssertSuccess(vkResult);
+                VK_RESULT_ASSERT(vkResult);
 
                 VkMemoryRequirements memoryRequirements = {};
                 GetContext().GetImageMemoryRequirements(GetNativeDevice(), vkImage, &memoryRequirements);
@@ -760,7 +760,8 @@ namespace AZ
                 VkBuffer vkBuffer = VK_NULL_HANDLE;
                 VkResult vkResult =
                     GetContext().CreateBuffer(GetNativeDevice(), createInfo.GetCreateInfo(), VkSystemAllocator::Get(), &vkBuffer);
-                AssertSuccess(vkResult);
+                VK_RESULT_ASSERT(vkResult);
+
 
                 VkMemoryRequirements memoryRequirements = {};
                 GetContext().GetBufferMemoryRequirements(GetNativeDevice(), vkBuffer, &memoryRequirements);
@@ -1083,8 +1084,9 @@ namespace AZ
 
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetPhysicalDevice());
             uint32_t surfaceFormatCount = 0;
-            AssertSuccess(GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
-                physicalDevice.GetNativePhysicalDevice(), vkSurface, &surfaceFormatCount, nullptr));
+            [[maybe_unused]] VkResult vkResult = GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
+                physicalDevice.GetNativePhysicalDevice(), vkSurface, &surfaceFormatCount, nullptr);
+            VK_RESULT_ASSERT(vkResult);
             if (surfaceFormatCount == 0)
             {
                 AZ_Assert(false, "Surface support no format.");
@@ -1092,8 +1094,9 @@ namespace AZ
             }
 
             AZStd::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
-            AssertSuccess(GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
-                physicalDevice.GetNativePhysicalDevice(), vkSurface, &surfaceFormatCount, surfaceFormats.data()));
+            vkResult = GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
+                physicalDevice.GetNativePhysicalDevice(), vkSurface, &surfaceFormatCount, surfaceFormats.data());
+            VK_RESULT_ASSERT(vkResult);
 
             bool colorSpaceExt = false;
             if (r_hdrOutput)
@@ -1728,7 +1731,7 @@ namespace AZ
             }
 
             VkResult errorCode = vmaCreateAllocator(&allocatorInfo, &m_vmaAllocator);
-            AssertSuccess(errorCode);
+            VK_RESULT_ASSERT(errorCode);
 
             return ConvertResult(errorCode);
         }
@@ -1901,14 +1904,15 @@ namespace AZ
             vkCreateInfo.usage = CalculateImageUsageFlags(descriptor);
 
             VkImageFormatProperties formatProps{};
-            AssertSuccess(GetContext().GetPhysicalDeviceImageFormatProperties(
+            [[maybe_unused]] VkResult vkResult = GetContext().GetPhysicalDeviceImageFormatProperties(
                 physicalDevice.GetNativePhysicalDevice(),
                 vkCreateInfo.format,
                 vkCreateInfo.imageType,
                 vkCreateInfo.tiling,
                 vkCreateInfo.usage,
                 vkCreateInfo.flags,
-                &formatProps));
+                &formatProps);
+            VK_RESULT_ASSERT(vkResult);
 
             AZ_Assert(descriptor.m_sharedQueueMask != RHI::HardwareQueueClassMask::None, "Invalid shared queue mask");
             createInfo.m_queueFamilyIndices = GetCommandQueueContext().GetQueueFamilyIndices(descriptor.m_sharedQueueMask);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -730,7 +730,7 @@ namespace AZ
                 // This will not allocate or bind memory.
                 ImageCreateInfo createInfo = BuildImageCreateInfo(descriptor);
                 VkImage vkImage = VK_NULL_HANDLE;
-                VkResult vkResult =
+                [[maybe_unused]] VkResult vkResult =
                     GetContext().CreateImage(GetNativeDevice(), createInfo.GetCreateInfo(), VkSystemAllocator::Get(), &vkImage);
                 VK_RESULT_ASSERT(vkResult);
 
@@ -758,10 +758,9 @@ namespace AZ
                 // This will not allocate or bind memory.
                 BufferCreateInfo createInfo = BuildBufferCreateInfo(descriptor);
                 VkBuffer vkBuffer = VK_NULL_HANDLE;
-                VkResult vkResult =
+                [[maybe_unused]] VkResult vkResult =
                     GetContext().CreateBuffer(GetNativeDevice(), createInfo.GetCreateInfo(), VkSystemAllocator::Get(), &vkBuffer);
                 VK_RESULT_ASSERT(vkResult);
-
 
                 VkMemoryRequirements memoryRequirements = {};
                 GetContext().GetBufferMemoryRequirements(GetNativeDevice(), vkBuffer, &memoryRequirements);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -792,7 +792,7 @@ namespace AZ
             const VkResult vkResult =
                 device.GetContext().CreateImage(device.GetNativeDevice(), createInfo.GetCreateInfo(), VkSystemAllocator::Get(), &m_vkImage);
 
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RHI::ResultCode result = ConvertResult(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
@@ -851,7 +851,7 @@ namespace AZ
             }
 
             m_isOwnerOfNativeImage = true;
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             return ConvertResult(result);
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -119,7 +119,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateImageView(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_vkImageView);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 
             m_hash = TypeHash64(m_imageSubresourceRange.GetHash(), m_hash);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -32,7 +32,7 @@ namespace AZ
 
             uint32_t physicalDeviceCount = 0;
             result = instance.GetContext().EnumeratePhysicalDevices(instance.GetNativeInstance(), &physicalDeviceCount, nullptr);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             if (physicalDeviceCount == 0)
             {
                 AZ_Error("Vulkan", false, "No Vulkan compatible physical devices were found!");
@@ -44,7 +44,7 @@ namespace AZ
 
             result =
                 instance.GetContext().EnumeratePhysicalDevices(instance.GetNativeInstance(), &physicalDeviceCount, physicalDevices.data());
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             if (ConvertResult(result) != RHI::ResultCode::Success)
             {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLibrary.cpp
@@ -44,7 +44,7 @@ namespace AZ
 
             const VkResult result = device.GetContext().CreatePipelineCache(
                 device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativePipelineCache);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 
             SetName(GetName());
@@ -79,7 +79,7 @@ namespace AZ
 
             const VkResult result = device.GetContext().MergePipelineCaches(
                 device.GetNativeDevice(), m_nativePipelineCache, static_cast<uint32_t>(pipelineCaches.size()), pipelineCaches.data());
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
         }
@@ -90,7 +90,7 @@ namespace AZ
 
             size_t dataSize = 0;
             VkResult result = device.GetContext().GetPipelineCacheData(device.GetNativeDevice(), m_nativePipelineCache, &dataSize, nullptr);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             if (result != VK_SUCCESS)
             {
                 return RHI::ConstPtr<RHI::PipelineLibraryData>();
@@ -98,7 +98,7 @@ namespace AZ
 
             AZStd::vector<uint8_t> data(dataSize);
             result = device.GetContext().GetPipelineCacheData(device.GetNativeDevice(), m_nativePipelineCache, &dataSize, data.data());
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return RHI::PipelineLibraryData::Create(AZStd::move(data));
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -158,7 +158,7 @@ namespace AZ
             const VkResult result = static_cast<Device&>(GetDevice())
                                         .GetContext()
                                         .QueueSubmit(m_nativeQueue, submitCount, submitCount ? &submitInfo : nullptr, nativeFence);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 
             // Signal all signaling semaphores that they can be used.
@@ -188,7 +188,8 @@ namespace AZ
                         GetDevice().SetDeviceRemoved();
                     }
                 }
-                AssertSuccess(result);
+
+                VK_RESULT_ASSERT(result);
             }
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -20,9 +20,9 @@ namespace AZ::Vulkan
 
     void RayTracingAccelerationStructure::Init(Device& device, const VkAccelerationStructureCreateInfoKHR& createInfo)
     {
-        VkResult vkResult = device.GetContext().CreateAccelerationStructureKHR(
+        [[maybe_unused]] VkResult vkResult = device.GetContext().CreateAccelerationStructureKHR(
             device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_accelerationStructure);
-        AssertSuccess(vkResult);
+        VK_RESULT_ASSERT(vkResult);
         DeviceObject::Init(device);
     }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.h
@@ -159,7 +159,7 @@ namespace AZ
         {
             T builder(*m_descriptor.m_device);
             auto [vkResult, vkRenderPass] = builder.Build(m_descriptor);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             m_nativeRenderPass = vkRenderPass;
             return ConvertResult(vkResult);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Sampler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Sampler.cpp
@@ -131,7 +131,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateSampler(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSampler);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             return ConvertResult(result);
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderModule.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderModule.cpp
@@ -43,7 +43,7 @@ namespace AZ
                     .GetContext()
                     .CreateShaderModule(
                         descriptor.m_device->GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeShaderModule);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
@@ -69,7 +69,7 @@ namespace AZ
                 allocations.data(),
                 nullptr);
 
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             if (vkResult == VK_SUCCESS)
             {
                 // Initialize all vma allocations as Vulkan::Allocations
@@ -109,7 +109,7 @@ namespace AZ
             heapMemoryUsage.m_usedResidentInBytes -= usedMem;
             heapMemoryUsage.m_totalResidentInBytes -= usedMem;
             blocks.clear();
-        }        
+        }
 
         RHI::ResultCode StreamingImagePool::InitInternal(RHI::Device& deviceBase, [[maybe_unused]] const RHI::StreamingImagePoolDescriptor& descriptor)
         {
@@ -118,9 +118,9 @@ namespace AZ
             m_enableTileResource = device.GetFeatures().m_tiledResource;
 
 #ifndef AZ_RHI_VULKAN_USE_TILED_RESOURCES
-            // Disable tile resource for all 
+            // Disable tile resource for all
             m_enableTileResource = false;
-#endif 
+#endif
             return RHI::ResultCode::Success;
         }
 
@@ -238,7 +238,7 @@ namespace AZ
         RHI::ResultCode StreamingImagePool::SetMemoryBudgetInternal(size_t newBudget)
         {
             RHI::HeapMemoryUsage& heapMemoryUsage = m_memoryUsage.GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device);
-            
+
             if (newBudget == 0)
             {
                 return RHI::ResultCode::Success;
@@ -267,10 +267,10 @@ namespace AZ
             {
                 heapMemoryUsage.m_budgetInBytes = newBudget;
             }
-            
+
             return RHI::ResultCode::Success;
         }
-        
+
         bool StreamingImagePool::SupportTiledImageInternal() const
         {
             return m_enableTileResource;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -437,7 +437,7 @@ namespace AZ
             [[maybe_unused]] VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, nullptr);
             VK_RESULT_ASSERT(vkResult);
-        
+
             AZ_Assert(surfaceFormatCount > 0, "Surface support no format.");
             AZStd::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
 
@@ -489,7 +489,7 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
 
             uint32_t modeCount = 0;
-            vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
+            VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, nullptr);
             VK_RESULT_ASSERT(vkResult);
             // VK_PRESENT_MODE_FIFO_KHR has to be supported.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -489,7 +489,7 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
 
             uint32_t modeCount = 0;
-            VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
+            [[maybe_unused]] VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, nullptr);
             VK_RESULT_ASSERT(vkResult);
             // VK_PRESENT_MODE_FIFO_KHR has to be supported.
@@ -521,7 +521,7 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
 
             VkSurfaceCapabilitiesKHR surfaceCapabilities;
-            VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfaceCapabilitiesKHR(
+            [[maybe_unused]] VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfaceCapabilitiesKHR(
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceCapabilities);
             VK_RESULT_ASSERT(vkResult);
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -434,12 +434,16 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
             uint32_t surfaceFormatCount = 0;
-            AssertSuccess(device.GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
-                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, nullptr));
+            [[maybe_unused]] VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
+                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, nullptr);
+            VK_RESULT_ASSERT(vkResult);
+        
             AZ_Assert(surfaceFormatCount > 0, "Surface support no format.");
             AZStd::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
-            AssertSuccess(device.GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
-                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, surfaceFormats.data()));
+
+            vkResult = device.GetContext().GetPhysicalDeviceSurfaceFormatsKHR(
+                    physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, surfaceFormats.data());
+            VK_RESULT_ASSERT(vkResult);
 
             const VkFormat format = ConvertFormat(rhiFormat);
             VkSurfaceFormatKHR matchedFormat = {};
@@ -485,14 +489,16 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
 
             uint32_t modeCount = 0;
-            AssertSuccess(device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
-                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, nullptr));
+            vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
+                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, nullptr);
+            VK_RESULT_ASSERT(vkResult);
             // VK_PRESENT_MODE_FIFO_KHR has to be supported.
             // https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentModeKHR.html
             AZ_Assert(modeCount > 0, "no available present mode.");
             AZStd::vector<VkPresentModeKHR> supportedModes(modeCount);
-            AssertSuccess(device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
-                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, supportedModes.data()));
+            vkResult = device.GetContext().GetPhysicalDeviceSurfacePresentModesKHR(
+                physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &modeCount, supportedModes.data());
+            VK_RESULT_ASSERT(vkResult);
 
             for (VkPresentModeKHR preferredMode : preferredModes)
             {
@@ -517,7 +523,7 @@ namespace AZ
             VkSurfaceCapabilitiesKHR surfaceCapabilities;
             VkResult vkResult = device.GetContext().GetPhysicalDeviceSurfaceCapabilitiesKHR(
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceCapabilities);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
 
             return surfaceCapabilities;
         }
@@ -607,7 +613,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateSwapchainKHR(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSwapChain);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             if(hdrEnabled)
             {
@@ -722,7 +728,7 @@ namespace AZ
             m_dimensions.m_imageCount = 0;
             VkResult vkResult =
                 device.GetContext().GetSwapchainImagesKHR(device.GetNativeDevice(), m_nativeSwapChain, &m_dimensions.m_imageCount, nullptr);
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
 
             m_swapchainNativeImages.resize(m_dimensions.m_imageCount);
@@ -731,7 +737,7 @@ namespace AZ
             // available when we init the images in InitImageInternal
             vkResult = device.GetContext().GetSwapchainImagesKHR(
                 device.GetNativeDevice(), m_nativeSwapChain, &m_dimensions.m_imageCount, m_swapchainNativeImages.data());
-            AssertSuccess(vkResult);
+            VK_RESULT_ASSERT(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
             AZLOG_DEBUG("Obtained presentable images.\n");
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphore.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphore.cpp
@@ -37,7 +37,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateSemaphore(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSemaphore);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
@@ -78,7 +78,7 @@ namespace AZ
 
             const VkResult result =
                 device.GetContext().CreateSemaphore(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSemaphore);
-            AssertSuccess(result);
+            VK_RESULT_ASSERT(result);
 
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
@@ -454,7 +454,8 @@ namespace AZ
                     info.objectType = objectType;
                     info.objectHandle = objectHandle;
                     info.pObjectName = name;
-                    AssertSuccess(device.GetContext().SetDebugUtilsObjectNameEXT(device.GetNativeDevice(), &info));
+                    [[maybe_unused]] VkResult vkResult = device.GetContext().SetDebugUtilsObjectNameEXT(device.GetNativeDevice(), &info);
+                    VK_RESULT_ASSERT(vkResult);
                 }
 #endif
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
@@ -52,7 +52,7 @@ namespace AZ
         {
             return IsSuccess(result) == false;
         }
-        
+
         const char* GetResultString(const VkResult result)
         {
             switch (result)
@@ -110,7 +110,7 @@ namespace AZ
             default:
                 return "Unknown error";
             }
-        }    
+        }
 
         void ToRawStringList(const StringList& source, RawStringList& dest)
         {
@@ -223,7 +223,7 @@ namespace AZ
                 if (!RHI::CheckBitsAll(lhsImageView.GetAspectFlags(), flag))
                 {
                     return false;
-                }                
+                }
             }
             return true;
         }
@@ -305,7 +305,7 @@ namespace AZ
 
         namespace Debug
         {
-            const char* s_debugMessageLabel = "vkDebugMessage";            
+            const char* s_debugMessageLabel = "vkDebugMessage";
 
             VkDebugUtilsMessengerEXT s_messageCallback = VK_NULL_HANDLE;
             VKAPI_ATTR VkBool32 VKAPI_CALL MessageCallbak(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, [[maybe_unused]] void* pUserData)
@@ -314,7 +314,7 @@ namespace AZ
                 if (RHI::CheckBitsAny(messageSeverity, VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT))
                 {
                     severtityString = "[VERBOSE]";
-                } 
+                }
                 else if (RHI::CheckBitsAny(messageSeverity, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT))
                 {
                     severtityString = "[INFO]";

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -134,7 +134,7 @@ namespace AZ
                 return result;\
             }
 
-        #define VK_RESULT_ASSERT(result) AZ_Assert(result == VK_SUCCESS ,"ASSERT: Vulkan API method failed: %s", AZ::Vulkan::GetResultString(result))
+        #define VK_RESULT_ASSERT(result) AZ_Assert((result) == VK_SUCCESS ,"ASSERT: Vulkan API method failed: %s", AZ::Vulkan::GetResultString(result))
 
         /// Checks whether the result is successful; if not, reports the error and returns false. Otherwise, returns true.
         bool IsSuccess(VkResult result);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -87,7 +87,7 @@ namespace AZ
         {
             /// Default color used for debug labels.
             const AZ::Color DefaultLabelColor = AZ::Color::CreateFromRgba(0, 255, 0, 255);
-            
+
             enum class DebugMessageTypeFlag
             {
                 Info = AZ_BIT(0),
@@ -134,14 +134,7 @@ namespace AZ
                 return result;\
             }
 
-        /// Checks whether the result is successful; if not, it break program execution.
-        inline void AssertSuccess([[maybe_unused]] VkResult result)
-        {
-            if (result != VK_SUCCESS)
-            {
-                AZ_Assert(false, "ASSERT: Vulkan API method failed: %s", GetResultString(result));
-            }
-        }
+        #define VK_RESULT_ASSERT(result) AZ_Assert(result == VK_SUCCESS ,"ASSERT: Vulkan API method failed: %s", AZ::Vulkan::GetResultString(result))
 
         /// Checks whether the result is successful; if not, reports the error and returns false. Otherwise, returns true.
         bool IsSuccess(VkResult result);


### PR DESCRIPTION
## What does this PR do?

`AssertSuccess` wraps an assertion for a given line but the asserted code is in a nested call. this just moves the assertion to a macro so the inlined call will be correctly reflected in the logs. 

```
==================================================================
System: Trace::Assert
 /home/michaelpollind/projects/o3de/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp(336): (139819752497152) 'virtual RHI::ResultCode AZ::Vulkan::Device::InitInternal(RHI::PhysicalDevice &)'
System: ASSERT: Vulkan API method failed: Feature not present
```