### PR TITLE
bugfix: resolve VectorInput labels gray upon activate/deactive component

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
@@ -16,6 +16,7 @@
 #include <QLabel>
 #include <QStyleOptionSpinBox>
 #include <QHBoxLayout>
+#include <QEvent>
 
 namespace AzQtComponents
 {
@@ -107,6 +108,15 @@ void VectorElement::onSpinBoxEditingFinished()
 void VectorElement::setCoordinate(VectorElement::Coordinate coordinate)
 {
     setProperty(g_CoordinatePropertyName, QVariant::fromValue(coordinate));
+}
+
+void VectorElement::changeEvent(QEvent* event) {
+
+    if(event->type() == QEvent::EnabledChange) {
+         style()->unpolish(m_label);
+         style()->polish(m_label);
+    }
+    QWidget::changeEvent(event);
 }
 
 QSize VectorElement::sizeHint() const

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.h
@@ -106,6 +106,7 @@ namespace AzQtComponents
 
         void onSpinBoxEditingFinished();
 
+        virtual void changeEvent(QEvent* event) override;
     private:
         struct DeferredSetValue
         {


### PR DESCRIPTION
## What does this PR do?
resolves issue https://github.com/o3de/o3de/issues/16956

not sure what the difference is between setting the background-color this way and using a property to drive it.  This doesn't seem like the correct solution but this does resolve the issue in the PR wonder what the difference in the handling would cause this? would be interested in seeing why this would be the case with QT? maybe there is a better solution that I haven't found?

## How was this PR tested?

follow steps of the linked PR

[Screencast from 2023-12-03 22-47-03.webm](https://github.com/o3de/o3de/assets/854359/2eae373b-8a38-46b3-96f3-ec2d18efa3f6)
