### PR TITLE
Fix attachment image assert on editor startup with clean cache

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
@@ -26,7 +26,7 @@ namespace AZ
         Data::Instance<AttachmentImage> AttachmentImage::FindOrCreate(const Data::Asset<AttachmentImageAsset>& imageAsset)
         {
             return Data::InstanceDatabase<AttachmentImage>::Instance().FindOrCreate(
-                Data::InstanceId::CreateFromAsset(imageAsset), imageAsset);
+                Data::InstanceId::CreateFromAssetId(imageAsset.GetId()), imageAsset);
         }
 
         Data::Instance<AttachmentImage> AttachmentImage::Create(


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/17178

The pass system is creating an attachment image instance from the brdf texture attachment image asset when the editor starts up and when the level opens. The function that creates the instance ID for the attachment image was changed to use the asset id and the creation token instead of just the asset ID.

If the editor is loaded while the initial batch of assets is still being processed by the AP, the pass system seems to load the attachment asset and create an instance with one creation token as the editor starts, then again with another creation token when opening the level. Because of that, the same asset is being re-registered with the same attachment name/ID, triggering the assert.

Temporarily reverting the change so that it only considers the asset id for now. Alternatively, if the image is registered with the same name it could replace the old one or the previously registered image could be unregistered when the level loads.

## How was this PR tested?

Confirmed that reverting the code to only use the asset ID stops the assert.