### PR TITLE
bugfix: resolve crash when loading multiplayer sample

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -64,6 +64,7 @@ namespace AzToolsFramework
                 auto componentDescriptor = GetComponentDescriptor(component);
                 if (!componentDescriptor)
                 {
+                    AZ_Error("Editor", false, "failed to get ComponentDescriptor for component %s.", component->RTTI_GetTypeName());
                     return false;
                 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -62,6 +62,10 @@ namespace AzToolsFramework
             bool AreComponentRequiredServicesMet(const AZ::Component* component, const AZ::Entity::ComponentArrayType& existingComponents)
             {
                 auto componentDescriptor = GetComponentDescriptor(component);
+                if (!componentDescriptor)
+                {
+                    return false;
+                }
 
                 AZ::ComponentDescriptor::DependencyArrayType requiredServices;
                 componentDescriptor->GetRequiredServices(requiredServices, component);
@@ -101,7 +105,7 @@ namespace AzToolsFramework
                     providedService != providedServices.end(); ++providedService)
                 {
                     AZ::EntityUtils::RemoveDuplicateServicesOfAndAfterIterator(
-                        providedService, 
+                        providedService,
                         providedServices,
                         component ? component->GetEntity() : nullptr);
                     for (auto existingComponent : existingComponents)
@@ -507,7 +511,7 @@ namespace AzToolsFramework
                 {
                     delete removedComponent;
                 }
-                
+
                 EntityCompositionNotificationBus::Broadcast(&EntityCompositionNotificationBus::Events::OnEntityCompositionChanged, entityIds);
             }
 
@@ -627,7 +631,7 @@ namespace AzToolsFramework
                         // Repackage the single-entity result into the overall result
                         entityComponentsResult = addExistingComponentsResult.GetValue();
                     }
-                    
+
                 }
             }
 
@@ -679,7 +683,7 @@ namespace AzToolsFramework
                         skipped = true;
                     }
                 }
-                
+
                 if (!skipped)
                 {
                     // If it's not an "editor component" then wrap it in a GenericComponentWrapper.
@@ -687,7 +691,7 @@ namespace AzToolsFramework
                     {
                         component = aznew Components::GenericComponentWrapper(component);
                     }
-                
+
                     // Obliterate any existing component id to allow the entity to set the id
                     component->SetId(AZ::InvalidComponentId);
 


### PR DESCRIPTION
## What does this PR do?
handle missing descriptor for component. The entity this is refering to is Player Spawner 1 I think its failing to fetch the NetworkPlayerSpawnerComponent and then trying to access a null variable. 

```
~~1701837734320~~1~~0x7fce977fe6c0~~AssetProcessor~~Request started builder [B622F462B28B4CA7ABA64B0EC28CB31A] task (process) Prefabs/PlayerSpawner.prefab 
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~AssetBuilder: AllocatorManager before: allocatedBytes = 89103760 capacityBytes = 214748364800
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~AssetBuilder: Running processJob task
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~AssetBuilder: Source = /home/michaelpollind/O3DE/Projects/Multi/Prefabs/PlayerSpawner.prefab
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~AssetBuilder: Platform = linux
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder: Loading Prefab in '/home/michaelpollind/O3DE/Projects/Multi/Prefabs/PlayerSpawner.prefab'.
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Stack config] = GameObjectCreation
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder: Sending Prefab to the processor stack.
~~1701837734340~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Stack config] = GameObjectCreation
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Processor] = Editor info remover
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Trace] = /home/michaelpollind/projects/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/EditorInfoRemover.cpp(51): 'auto AzToolsFramework::Prefab::PrefabConversionUtils::EditorInfoRemover::Process(PrefabProcessorContext &)::(anonymous class)::operator()(PrefabDocument &) const'
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Type] = Trace::Error
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~E: Prefab: Converting to runtime Prefab 'PlayerSpawner' failed, Error: Entity 'Player Spawner 1' [13453922473772743748] - export entity failed. Error: Entity 'Player Spawner 1' [13453922473772743748] - dependency evaluation failed. Error: No descriptor registered for Component class 'NetworkPlayerSpawnerComponent'. .
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Stack config] = GameObjectCreation
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder: Finalizing products.
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Stack config] = GameObjectCreation
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder:     Serializing Prefab product 'PlayerSpawner.spawnable'.
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~C: [Stack config] = GameObjectCreation
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder:     Storing Prefab product 'PlayerSpawner.spawnable'.
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder: Cleaning up.
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~Prefab Builder: Prefab processing completed.
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~AssetBuilder: AllocatorManager after: allocatedBytes = 89104224 capacityBytes = 214748364800; allocated change = 464
~~1701837734341~~1~~0x7fce977fe6c0~~AssetBuilder~~S: 1 errors, 0 warnings
~~1701837734429~~1~~0x7fce977fe6c0~~AssetProcessor~~Request stopped builder [B622F462B28B4CA7ABA64B0EC28CB31A] task (process) Prefabs/PlayerSpawner.prefab 
```


back trace for segfault
```
  frame #0: 0x00007fffefbf932e libEditorLib.so`AzToolsFramework::Components::(anonymous namespace)::AreComponentRequiredServicesMet(component=0x0000555567329700, existingComponents=0x00007fffffffa738) at EditorEntityActionComponent.cpp:70:38
    frame #1: 0x00007fffefbf6db3 libEditorLib.so`AzToolsFramework::Components::(anonymous namespace)::AddAnyValidComponentsToList(validComponents=0x00007fffffffa738, componentsToAdd=0x00007fffffffa718, componentsAdded=0x0000000000000000) at EditorEntityActionComponent.cpp:158:26
    frame #2: 0x00007fffefbf48b7 libEditorLib.so`AzToolsFramework::Components::EditorEntityActionComponent::ScrubEntity(this=0x0000555561185448, entity=0x000055555a3d5358) at EditorEntityActionComponent.cpp:840:24
  * frame #3: 0x00007fffefbf6b19 libEditorLib.so`AzToolsFramework::Components::EditorEntityActionComponent::ScrubEntities(this=0x0000555561185448, entities=0x00007fffffffb3c8) at EditorEntityActionComponent.cpp:782:54
    frame #4: 0x00007fffefbf6c97 libEditorLib.so`non-virtual thunk to AzToolsFramework::Components::EditorEntityActionComponent::ScrubEntities(AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at EditorEntityActionComponent.cpp:0
    frame #5: 0x00007fffefd0a0ee libEditorLib.so`decltype(f=0x00007fffffffad78, arg0=0x0000555561185468, args=0x00007fffffffb3c8)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&>(fp0).*fp(InvokeTraits::forward<AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(fp1))) AZStd::Internal::INVOKE<AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompo
sitionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::EntityCompositionRequests::*&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFra
mework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&, void>(AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionReq
uests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::EntityCompositionRequests::*&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::E
ntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at invoke_traits.h:177:20
    frame #6: 0x00007fffefd0a017 libEditorLib.so`AZStd::invoke_result<AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::EntityCompositionReq
uests::*&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&
, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>::type AZStd::invoke<AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (f=0x00007fffffffad78, args=0x0000
555561185468, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolic
y)1>::HandlerHolder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::EntityC
ompositionRequests::*&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHo
lder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at invoke.h:54:16
    frame #7: 0x00007fffefd09cc5 libEditorLib.so`void AZ::EBusEventProcessingPolicy::Call<AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::
EntityCompositionRequests::*&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::Ha
ndlerHolder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(func=0x00007fffffffad78, iface=0x0000555561185468, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZ::Internal::HandlerNode<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, AZ::Internal::EBusContainer<AzToolsFramework::EntityC
ompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at Policies.h:437:13
    frame #8: 0x00007fffefc09b55 libEditorLib.so`void AZ::Internal::EBusContainer<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::Dispatcher<AZ::EBus<AzToolsFramework::EntityCompositionRequests, AzToolsFramework::EntityCompositionRequests>>::Broadcast<AZ::Outcome<AZStd::unordere
d_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (func=0x00007fffffffad78, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZStd::vector<AZ::Entity*, AZSt
d::allocator> const&>(AZ::Outcome<AZStd::unordered_map<AZ::EntityId, AzToolsFramework::EntityCompositionRequests::RemoveComponentsResults, AZStd::hash<AZ::EntityId>, AZStd::equal_to<AZ::EntityId>, AZStd::allocator>, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator>> (AzToolsFramework::EntityCompositionRequests::*&&)(AZStd::vector<AZ::Entity*, AZStd::al
locator> const&), AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at BusContainer.h:1365:29
    frame #9: 0x00007fffefbf2265 libEditorLib.so`AzToolsFramework::EditorEntityContextComponent::SetupEditorEntities(this=0x000055555bd561b0, entities=0x00007fffffffb3c8) at EditorEntityContextComponent.cpp:717:13
    frame #10: 0x00007fffefbf3285 libEditorLib.so`AzToolsFramework::EditorEntityContextComponent::OnContextEntitiesAdded(this=0x000055555bd561b0, entities=0x00007fffffffb3c8) at EditorEntityContextComponent.cpp:679:9
    frame #11: 0x00007ffff3174822 libEditorLib.so`AzFramework::EntityContext::HandleEntitiesAdded(this=0x000055555bd561d0, entities=0x00007fffffffb3c8) at EntityContext.cpp:178:9
    frame #12: 0x00007ffff318ae0d libEditorLib.so`AzFramework::EntityContext::InitContext(this=0x0000555562a6f608, entityList=0x00007fffffffb3c8)::$_0::operator()(AZStd::vector<AZ::Entity*, AZStd::allocator> const&) const at EntityContext.cpp:128:19
    frame #13: 0x00007ffff318ad6f libEditorLib.so`decltype(f=0x0000555562a6f608, args=0x00007fffffffb3c8)::$_0&>(fp)(InvokeTraits::forward<AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(fp0))) AZStd::Internal::INVOKE<AzFramework::EntityContext::InitContext()::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(AzFramework::EntityContext::InitContext()::$_0&, 
AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at invoke_traits.h:208:20
    frame #14: 0x00007ffff318ad0f libEditorLib.so`AZStd::invoke_result<AzFramework::EntityContext::InitContext()::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>::type AZStd::invoke<AzFramework::EntityContext::InitContext(f=0x0000555562a6f608, args=0x00007fffffffb3c8)::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(AzFramework::EntityContext::InitCo
ntext()::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at invoke.h:54:16
    frame #15: 0x00007ffff318acaa libEditorLib.so`void AZStd::Internal::function_util::invoke_void_return_wrapper<void>::call<AzFramework::EntityContext::InitContext(args=0x0000555562a6f608, args=0x00007fffffffb3c8)::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>(AzFramework::EntityContext::InitContext()::$_0&, AZStd::vector<AZ::Entity*, AZStd::allocator> cons
t&) at function_template.h:41:21
    frame #16: 0x00007ffff318abc2 libEditorLib.so`void AZStd::Internal::function_util::get_invoker<void (AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZStd::Internal::function_util::function_obj_tag, AZStd::allocator>::call<AzFramework::EntityContext::InitContext(function_obj_ptr=0x0000555562a6f608, args=0x00007fffffffb3c8)::$_0>(AZStd::Internal::function_util::f
unction_buffer&, AZStd::vector<AZ::Entity*, AZStd::allocator> const&) at function_template.h:172:28
    frame #17: 0x00007fffefbacd16 libEditorLib.so`AZStd::function_intermediate<void, AZStd::vector<AZ::Entity*, AZStd::allocator> const&>::operator(this=0x0000555562a6f600, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&) const at function_template.h:604:16
    frame #18: 0x00007fffefa3ad5a libEditorLib.so`AZStd::function<void (AZStd::vector<AZ::Entity*, AZStd::allocator> const&)>::operator(this=0x0000555562a6f600, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&) const at function_template.h:684:31
    frame #19: 0x00007fffefa011c6 libEditorLib.so`AzToolsFramework::PrefabEditorEntityOwnershipService::HandleEntitiesAdded(this=0x0000555562a6f2f0, entities=0x00007fffffffb3c8) at PrefabEditorEntityOwnershipService.cpp:237:9
    frame #20: 0x00007fffefbf1220 libEditorLib.so`AzToolsFramework::EditorEntityContextComponent::HandleEntitiesAdded(this=0x000055555bd561b0, entities=0x00007fffffffb3c8) at EditorEntityContextComponent.cpp:310:35
    frame #21: 0x00007fffeea0c143 libEditorLib.so`decltype(f=0x00007fffffffb2a8, arg0=0x00007fffffffb188, args=0x00007fffffffb3c8).*fp(InvokeTraits::forward<AZStd::vector<AZ::Entity*, AZStd::allocator>&>(fp1))) AZStd::Internal::INVOKE<void (AzToolsFramework::EditorEntityContextRequests::*)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntit
yContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&, void>(void (AzToolsFramework::EditorEntityContextRequests::*&&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&) at invoke_traits.h:177:20
    frame #22: 0x00007fffeea0c084 libEditorLib.so`AZStd::invoke_result<void (AzToolsFramework::EditorEntityContextRequests::*)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&>::type AZStd::invoke<void (f=0x00007fffffffb2a8, args=0x00007fffffffb188, args=0x00007fffffffb3c8)
(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&>(void (AzToolsFramework::EditorEntityContextRequests::*&&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&) at invoke.h:54:
16
    frame #23: 0x00007fffeea0be72 libEditorLib.so`void AZ::EBusEventProcessingPolicy::Call<void (AzToolsFramework::EditorEntityContextRequests::*)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&>(func=0x00007fffffffb2a8, iface=0x00007fffffffb188, args=0x00007fffffffb3c8)(A
ZStd::vector<AZ::Entity*, AZStd::allocator> const&), AzToolsFramework::EditorEntityContextRequests*&, AZStd::vector<AZ::Entity*, AZStd::allocator>&) at Policies.h:437:13
    frame #24: 0x00007fffee9f3008 libEditorLib.so`void AZ::Internal::EBusContainer<AzToolsFramework::EditorEntityContextRequests, AzToolsFramework::EditorEntityContextRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)0>::Dispatcher<AZ::EBus<AzToolsFramework::EditorEntityContextRequests, AzToolsFramework::EditorEntityContextRequests>>::Broadcast<void (func=0x00007
fffffffb2a8, args=0x00007fffffffb3c8)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZStd::vector<AZ::Entity*, AZStd::allocator>&>(void (AzToolsFramework::EditorEntityContextRequests::*&&)(AZStd::vector<AZ::Entity*, AZStd::allocator> const&), AZStd::vector<AZ::Entity*, AZStd::allocator>&) at BusContainer.h:1540:29
    frame #25: 0x00007fffee9d88c7 libEditorLib.so`AzToolsFramework::Prefab::InstanceUpdateExecutor::UpdateTemplateInstancesInQueue(this=0x000055555bd57310) at InstanceUpdateExecutor.cpp:267:29
    frame #26: 0x00007fffeeace90d libEditorLib.so`AzToolsFramework::Prefab::PrefabSystemComponent::OnSystemTick(this=0x000055555bd56ee0) at PrefabSystemComponent.cpp:136:38
    frame #27: 0x00007fffee530983 libEditorLib.so`decltype(f=0x00007fffffffb600, arg0=0x000055555bd56f08)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&>(fp0).*fp()) AZStd::Internal::INVOKE<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (A
Z::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&, void>(void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&) at invoke_traits.h:177:20
    frame #28: 0x00007fffee5308df libEditorLib.so`AZStd::invoke_result<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&>::type AZStd::invoke<void (f=0x00007fffffffb600, a
rgs=0x000055555bd56f08)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&>(void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusConta
iner<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&) at invoke.h:54:16
    frame #29: 0x00007fffee53041a libEditorLib.so`void AZ::EBusEventProcessingPolicy::Call<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&>(func=0x00007fffffffb600, ifac
e=0x000055555bd56f08)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::HandlerHolder, false>&) at Policies.h:437:13
    frame #30: 0x00007fffee4e8ce6 libEditorLib.so`void AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::Dispatcher<AZ::EBus<AZ::SystemTickEvents, AZ::SystemTickEvents>>::Broadcast<void (func=0x00007fffffffb600)()>(void (AZ::SystemTickEvents::*&&)()) at BusContainer.h:1365:29
    frame #31: 0x00007fffee4d0ed3 libEditorLib.so`AZ::ComponentApplication::TickSystem(this=0x00007fffffffc030) at ComponentApplication.cpp:1655:9
    frame #32: 0x00007fffed1142bb libEditorLib.so`CCryEditApp::IdleProcessing(this=0x0000555559429880, bBackgroundUpdate=true) at CryEdit.cpp:2253:35
    frame #33: 0x00007fffed113f52 libEditorLib.so`CCryEditApp::OnIdle(this=0x0000555559429880, lCount=0) at CryEdit.cpp:2168:16
    frame #34: 0x00007fffecfcb3ee libEditorLib.so`Editor::EditorQtApplication::maybeProcessIdle(this=0x000055555942a250) at QtEditorApplication.cpp:316:25
    frame #35: 0x00007fffed0f8d78 libEditorLib.so`QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (Editor::EditorQtApplication::*)()>::call(f=a0 b3 fc ec ff 7f 00 00 00 00 00 00 00 00 00 00, o=0x000055555942a250, arg=0x00007fffffffb960)(), Editor::EditorQtApplication*, void**) at qobjectdefs_impl.h:152:13
    frame #36: 0x00007fffed0f8cca libEditorLib.so`void QtPrivate::FunctionPointer<void (Editor::EditorQtApplication::*)()>::call<QtPrivate::List<>, void>(f=a0 b3 fc ec ff 7f 00 00 00 00 00 00 00 00 00 00, o=0x000055555942a250, arg=0x00007fffffffb960)(), Editor::EditorQtApplication*, void**) at qobjectdefs_impl.h:185:13
    frame #37: 0x00007fffed0f8baf libEditorLib.so`QtPrivate::QSlotObject<void (Editor::EditorQtApplication::*)(), QtPrivate::List<>, void>::impl(which=1, this_=0x00007fffd8002260, r=0x000055555942a250, a=0x00007fffffffb960, ret=0x0000000000000000) at qobjectdefs_impl.h:418:17
    frame #38: 0x00007ffff7b0d596 libQt5Core.so.5`QSingleShotTimer::timerEvent(QTimerEvent*) [inlined] QtPrivate::QSlotObjectBase::call(a=0x00007fffffffb960, r=<unavailable>, this=<unavailable>) at qobjectdefs_impl.h:398:57
    frame #39: 0x00007ffff7b0d588 libQt5Core.so.5`QSingleShotTimer::timerEvent(this=0x000055555963d2b0, (null)=<unavailable>) at qtimer.cpp:320:26
(lldb) 
```
## How was this PR tested?

- download multiplayer sample
- attempt to load map