### PR TITLE
Cherry-pick Script Canvas fix to point release

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/GraphTabBar.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/GraphTabBar.cpp
@@ -235,13 +235,8 @@ namespace ScriptCanvasEditor
 
         SourceHandle GraphTabBar::FindTabByPath(AZStd::string_view path) const
         {
-            auto candidateOption = ScriptCanvasEditor::CompleteDescription(SourceHandle::FromRelativePath(nullptr, {}, path));
-            if (!candidateOption)
-            {
-                return {};
-            }
-
-            auto candidate = *candidateOption;
+            SourceHandle candidate;
+            candidate = SourceHandle::MarkAbsolutePath(candidate, path);
 
             for (int index = 0; index < count(); ++index)
             {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -242,7 +242,8 @@ namespace ScriptCanvas
     {
         return m_data && m_data == other.m_data
             || !m_id.IsNull() && m_id == other.m_id
-            || !m_relativePath.empty() && m_relativePath == other.m_relativePath;
+            || !m_relativePath.empty() && m_relativePath == other.m_relativePath
+            || !m_absolutePath.empty() && m_absolutePath == other.m_absolutePath;
     }
 
     void SourceHandle::Clear()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.cpp
@@ -127,6 +127,7 @@ namespace ScriptCanvas
         AZ::JsonDeserializerSettings settings;
         settings.m_serializeContext = serializeContext;
         settings.m_metadata.Create<SerializationListeners>();
+        settings.m_clearContainers = true;
 
         auto loadResult = JSRU::LoadObjectFromStringByType
             ( &(*result.m_graphDataPtr)


### PR DESCRIPTION
## What does this PR do?

Cherry picks the fix for https://github.com/o3de/o3de/issues/17166
Fixed opening graphs resulting in duplicated slots (#17109)
* Fixed opening graphs resulting in duplicated slots
* Fixed comparison operation to account all paths
## How was this PR tested?

-  testing was done in original branch
- compiled and ran Editor