### PR TITLE
adjusting export script to allow for non-monolithic building

### DIFF
--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -79,7 +79,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
     """
 
     is_installer_sdk = manifest.is_sdk_engine(engine_path=ctx.engine_path)
-
+    
     # Use a provided logger or get the current system one
     if not logger:
         logger = logging.getLogger()
@@ -87,14 +87,18 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
 
     # Calculate the tools and game build paths
     default_base_build_path = ctx.engine_path / 'build' if engine_centric else ctx.project_path / 'build'
-    if not tools_build_path:
-        if is_installer_sdk:
+    
+    if is_installer_sdk:
             tools_build_path = ctx.engine_path / 'bin' / exp.get_platform_installer_folder_name(selected_platform) / tool_config / 'Default'
-        else:
-            tools_build_path = default_base_build_path / 'tools'
-    if not launcher_build_path:
+    
+    if not tools_build_path:
+        tools_build_path = default_base_build_path / 'tools'
+    if not launcher_build_path or not launcher_build_path.is_absolute() or \
+        not (launcher_build_path.is_relative() and pathlib.Path.cwd() in [ctx.engine_path, ctx.project_path]):
         launcher_build_path = default_base_build_path / 'launcher'
-    if not asset_bundling_path:
+    
+    if not asset_bundling_path or not asset_bundling_path.is_absolute() or \
+        not (asset_bundling_path.is_relative() and pathlib.Path.cwd() in [ctx.engine_path, ctx.project_path]):
         asset_bundling_path = default_base_build_path / 'asset_bundling'
 
     # Resolve (if possible) and validate any provided seedlist files
@@ -197,8 +201,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                                              expected_bundles_path / f'engine_{selected_platform}.pak'],
                                             export_layout=export_layout,
                                             archive_output_format=archive_output_format,
-                                            logger=logger)      
-
+                                            logger=logger)
 
 # This code is only run by the 'export-project' O3DE CLI command
 if "o3de_context" in globals():

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -7,6 +7,7 @@
 #
 
 import argparse
+import glob
 import logging
 import os
 import sys
@@ -89,6 +90,14 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
     default_base_build_path = ctx.engine_path / 'build' if engine_centric else ctx.project_path / 'build'
     
     if is_installer_sdk:
+            # Check if we have any monolithic entries if building monolithic
+            monolithic_artifacts = glob.glob(f'cmake/Platform/{exp.get_platform_installer_folder_name()}/Monolithic/ConfigurationTypes_*.cmake',
+                      root_dir=ctx.engine_path)
+            has_monolithic_artifacts = len(monolithic_artifacts) > 0
+
+            if monolithic_build and not has_monolithic_artifacts:
+                logger.error("Trying to create monolithic build, but no monolithic artifacts are detected in the engine installation! Please re-run the script with '-nomonolithic' and '-config profile'.")
+                return 1
             tools_build_path = ctx.engine_path / 'bin' / exp.get_platform_installer_folder_name(selected_platform) / tool_config / 'Default'
     
     if not tools_build_path:

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -80,7 +80,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
     """
 
     is_installer_sdk = manifest.is_sdk_engine(engine_path=ctx.engine_path)
-    
+
     # Use a provided logger or get the current system one
     if not logger:
         logger = logging.getLogger()

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -37,6 +37,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                               should_build_game_launcher: bool = True,
                               should_build_server_launcher: bool = True,
                               should_build_unified_launcher: bool = True,
+                              monolithic_build: bool = True,
                               allow_registry_overrides: bool = False,
                               tools_build_path: pathlib.Path | None =None,
                               launcher_build_path: pathlib.Path | None =None,
@@ -67,6 +68,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
     :param should_build_game_launcher:              Option to build the game launcher package
     :param should_build_server_launcher:            Option to build the server launcher package
     :param should_build_unified_launcher:           Option to build the unified launcher package
+    :param monolithic_build:                        Option to build the game binaries monolithically
     :param allow_registry_overrides:                Option to allow registry overrides in the build process
     :param tools_build_path:                        Optional build path to build the tools. (Will default to build/tools if not supplied)
     :param launcher_build_path:                     Optional build path to build the game launcher(s). (Will default to build/launcher if not supplied)
@@ -132,6 +134,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                launcher_types=launcher_type,
                                allow_registry_overrides=allow_registry_overrides,
                                tool_config=tool_config,
+                               monolithic_build=monolithic_build,
                                logger=logger)
 
     # Optionally build the assets
@@ -194,7 +197,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                                              expected_bundles_path / f'engine_{selected_platform}.pak'],
                                             export_layout=export_layout,
                                             archive_output_format=archive_output_format,
-                                            logger=logger)
+                                            logger=logger)      
 
 
 # This code is only run by the 'export-project' O3DE CLI command
@@ -367,6 +370,7 @@ if "o3de_context" in globals():
                                            disable_override_arg=['-pc', '--project-centric'],
                                            disable_override_desc="Enable the project-centric work flow to export the project.")
 
+        parser.add_argument('-nomonolithic', '--no-monolithic-build', action='store_true', help='Build the project binaries as shared libraries (as opposed to default monolithic build).')
         parser.add_argument('-pl', '--platform', type=str, default=exp.get_default_asset_platform(), choices=['pc', 'linux', 'mac'])
 
         parser.add_argument('-q', '--quiet', action='store_true', help='Suppresses logging information unless an error occurs.')
@@ -454,6 +458,7 @@ if "o3de_context" in globals():
                                   tools_build_path=args.tools_build_path,
                                   launcher_build_path=args.launcher_build_path,
                                   archive_output_format=args.archive_output,
+                                  monolithic_build=not args.no_monolithic_build,
                                   logger=o3de_logger)
     except exp.ExportProjectError as err:
         print(err)

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -694,6 +694,7 @@ def build_game_targets(ctx: O3DEScriptExportContext,
                        launcher_types: int,
                        allow_registry_overrides: bool,
                        tool_config: str = PREREQUISITE_TOOL_BUILD_CONFIG,
+                       monolithic_build:bool = True,
                        logger: logging.Logger = None) -> None:
     """
     Build the launchers for the project (game, server, unified)
@@ -737,10 +738,10 @@ def build_game_targets(ctx: O3DEScriptExportContext,
     if ctx.cmake_additional_configure_args:
         cmake_configure_command.extend(ctx.cmake_additional_configure_args)
 
-    cmake_configure_command.extend(["-DLY_MONOLITHIC_GAME=1",
+    cmake_configure_command.extend([ f"-DLY_MONOLITHIC_GAME={'0' if not monolithic_build else '1'}",
                                     f"-DALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES={'0' if not allow_registry_overrides else '1'}"])
     if logger:
-        logger.info(f"Generating (monolithic) project the build folder for project {ctx.project_name}")
+        logger.info(f"Generating {'monolithic' if monolithic_build else 'non-monolithic'} build folder for project {ctx.project_name}")
     ret = process_command(cmake_configure_command)
     if ret != 0:
         raise ExportProjectError(f"Error generating projects for project {ctx.project_name}.")


### PR DESCRIPTION
## What does this PR do?
This PR fixes the export script issue found in issue https://github.com/o3de/o3de/issues/17192. For now it focuses on correcting erroneous behavior for profile builds by allowing the abillity to compile non-monolithic builds.

## How was this PR tested?
These changes were tested from an SDK install using a minimal project template. @AMZN-Gene has confirmed that these changes do work and provide a working launcher.