### PR TITLE
Fix deferred fog issue because its start distance can be larger than end distance

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/EditorDeferredFogComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/EditorDeferredFogComponent.cpp
@@ -67,7 +67,7 @@ namespace AZ
 
                         ->DataElement(AZ::Edit::UIHandlers::Slider, &DeferredFogComponentConfig::m_fogEndDistance,
                             "Fog End Distance", "At what distance from the viewer does the fog take over and mask the background scene out")
-                            ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                            ->Attribute(AZ::Edit::Attributes::Min, &DeferredFogComponentConfig::m_fogStartDistance)
                             ->Attribute(AZ::Edit::Attributes::Max, 5000.0f)
                             ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
                             ->Attribute(AZ::Edit::Attributes::SoftMax, 100.0f)


### PR DESCRIPTION
## What does this PR do?

In the deferred fog component, we can set fog start distance and fog end distance. If the fog start distance is larger than the fog end distance, one may come across wired unexpected rendering result. Our artist found this in one of our real projects.

Here I put a protection to ensure that the deferred fog's end distance is larger than its start distance to prevent the issue.

![image](https://github.com/o3de/o3de/assets/5073925/58b4ddd9-551c-4cfb-a81a-a760fb9c29aa)


## How was this PR tested?

Self tested. It is a minor fix, so I suppose a simple self test might be enough.
