### PR TITLE
Fix the transparent material slot flickering

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
@@ -35,7 +35,11 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_depth < b.m_depth;
+                    if (a.m_depth != b.m_depth)
+                    {
+                        return a.m_depth < b.m_depth;
+                    }
+                    return a.m_item < b.m_item;
                 }
             );
             break;
@@ -63,7 +67,11 @@ namespace AZ::RHI
                     {
                         return a.m_depth < b.m_depth;
                     }
-                    return a.m_sortKey < b.m_sortKey;
+                    if (a.m_sortKey != b.m_sortKey)
+                    {
+                        return a.m_sortKey < b.m_sortKey;
+                    }
+                    return a.m_item < b.m_item;
                 }
             );
             break;
@@ -75,7 +83,11 @@ namespace AZ::RHI
                     {
                         return a.m_depth > b.m_depth;
                     }
-                    return a.m_sortKey < b.m_sortKey;
+                    if (a.m_sortKey != b.m_sortKey)
+                    {
+                        return a.m_sortKey < b.m_sortKey;
+                    }
+                    return a.m_item < b.m_item;
                 }
             );
             break;

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
@@ -47,7 +47,11 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_depth > b.m_depth;
+                    if (a.m_depth != b.m_depth)
+                    {
+                        return a.m_depth > b.m_depth;
+                    }
+                    return a.m_item < b.m_item;
                 }
             );
             break;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the transparent surface flickering when there are a lot of transparent material slots in the same mesh.

The reason why the transparent surface will flick:

The engine sorts the transparent objects' draw call by the sort key and the depth of the object, however, when there are a lot of transparent material slots in the same object, the sort key and the depth are all the same, then in each frame, the order of those transparent draw calls might change, making the transparent surface flickers. We came across this issue in one of our real projects.

So in this PR, I added a last resort to ensure the draw calls of transparent objects have a certain order to prevent the flickering when the above sorting condition fail.

## How was this PR tested?

Self tested.
