### PR TITLE
Simplified asset synchronization for Android.

### DIFF
--- a/cmake/Tools/Platform/Android/android_post_build.py
+++ b/cmake/Tools/Platform/Android/android_post_build.py
@@ -71,33 +71,9 @@ def create_link(src: Path, tgt: Path):
     except OSError as os_err:
         raise AndroidPostBuildError(f"Error trying to link  {tgt} => {src} : {os_err}")
 
-
-def safe_clear_folder(target_folder: Path) -> None:
-    """
-    This function is OBSOLETE. The functionality has been replaced with a single call to remove_link_to_directory().
-    The code has been preserved because may become useful in the future should we need to recursively
-    erase the content of a directory.
-    Safely clean the contents of a folder. If items are links/junctions, then attempt to unlink, but if the
-    items are non-linked, then perform a deletion.
-
-    :param target_folder:   Folder to safely clear
-    :param delete_folders:  Optional set of folders to perform a delete on instead of an unlink
-    """
-
-    if not target_folder.exists():
-        logger.warn(f"Nothing to clean. '{target_folder}' does not exist")
-        return
-
-    if not target_folder.is_dir():
-        logger.warn(f"Unable to clean '{target_folder}', target is not a directory")
-        return
-
-    for target_item in target_folder.iterdir():
-        try:
-            target_item.unlink()
-        except OSError as os_err:
-            raise AndroidPostBuildError(f"Error trying to unlink/delete {target_item}: {os_err}")
-
+# deprecated: The functionality has been replaced with a single call to remove_link_to_directory()
+# Go to commit e302882 to get this functionality back.
+# def safe_clear_folder(target_folder: Path) -> None:
 
 def remove_link_to_directory(link_to_directory: Path) -> None:
     """
@@ -113,33 +89,9 @@ def remove_link_to_directory(link_to_directory: Path) -> None:
             raise AndroidPostBuildError(f"Error trying to unlink/delete {link_to_directory}: {os_err}")
 
 
-def synchronize_folders(src: Path, tgt: Path) -> None:
-    """
-    This function is OBSOLETE. The functionality has been replaced with a single call to create_link().
-    The code has been preserved because may become useful in the future when we need to support copying files instead of links/junctions.
-    Create a copy of a source folder 'src' to a target folder 'tgt', but use the following rules:
-    1. Make sure that a 'tgt' folder exists
-    2. For each item in the 'src' folder, call 'copy_or_create_link' to apply a copy or link of the items to the
-       target folder 'tgt'
-
-    :param src:             The source folder to synchronize from
-    :param tgt:             The target folder to synchronize to
-    """
-
-    assert not tgt.is_file()
-    assert src.is_dir()
-
-    # Make sure the target folder exists
-    tgt.mkdir(parents=True, exist_ok=True)
-
-    # Iterate through the items in the source folder and copy to the target folder
-    processed = 0
-    for src_item in src.iterdir():
-        tgt_item = tgt / src_item.name
-        create_link(src_item, tgt_item)
-        processed += 1
-
-    logger.info(f"{processed} items from {src} linked/copied to {tgt}")
+# deprecated: The functionality has been replaced with a single call to create_link()
+# Go to commit e302882 to get this functionality back.
+# def synchronize_folders(src: Path, tgt: Path) -> None:
 
 
 def apply_pak_layout(project_root: Path, asset_bundle_folder: str, target_layout_root: Path) -> None:

--- a/cmake/Tools/Platform/Android/android_post_build.py
+++ b/cmake/Tools/Platform/Android/android_post_build.py
@@ -75,7 +75,7 @@ def create_link(src: Path, tgt: Path):
 def safe_clear_folder(target_folder: Path) -> None:
     """
     This function is OBSOLETE. The functionality has been replaced with a single call to remove_link_to_directory().
-    The code has been preserved because may become useful in the future should we need tp recursively
+    The code has been preserved because may become useful in the future should we need to recursively
     erase the content of a directory.
     Safely clean the contents of a folder. If items are links/junctions, then attempt to unlink, but if the
     items are non-linked, then perform a deletion.
@@ -181,6 +181,7 @@ def apply_loose_layout(project_root: Path, target_layout_root: Path) -> None:
     :param project_root:            The project folder root to look for the loose assets
     :param target_layout_root:      The target layout destination of the loose assets
     """
+
     android_cache_folder = project_root / 'Cache' / ASSET_PLATFORM_KEY
     engine_json_marker = android_cache_folder / 'engine.json'
     if not engine_json_marker.is_file():
@@ -191,7 +192,8 @@ def apply_loose_layout(project_root: Path, target_layout_root: Path) -> None:
     remove_link_to_directory(target_layout_root)
 
 
-    ## Copy/Link the contents to the target folder
+    # Create a symlink or junction {target_layout_root} to this
+    # project Cache folder for the android platform {android_cache_folder}.
     create_link(android_cache_folder, target_layout_root)
 
 

--- a/cmake/Tools/Platform/Android/android_post_build.py
+++ b/cmake/Tools/Platform/Android/android_post_build.py
@@ -209,6 +209,7 @@ def post_build_action(android_app_root: Path, project_root: Path, gradle_version
     :param asset_mode:          The desired asset mode to determine the layout rules
     :param asset_bundle_folder: (For PAK asset modes) the location of where the PAK files are expected.
     """
+
     if not android_app_root.is_dir():
         raise AndroidPostBuildError(f"Invalid Android Gradle build path: {android_app_root} is not a directory or does not exist.")
 

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -992,7 +992,7 @@ CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR = """
         tasks.findAll {{ task->task.name.contains('strip{config}DebugSymbols') }}
     }}
     
-    mergeProfileAssets.dependsOn syncLYLayoutMode{config}
+    merge{config}Assets.dependsOn syncLYLayoutMode{config}
 """
 
 DEFAULT_CONFIG_CHANGES = [


### PR DESCRIPTION
## What does this PR do?
Simplified asset synchronization for Android.

Fixes #17177

Instead of creating symbolic links for each Folder
 and asset in `<ProjectRoot>/Cache/android`, it is simpler
 and less error prone to simply create a single symbolic
 link or; in case of Windows, a Junction, from
 `<build>/android/app/src/main/assets`
 TO:
 `<ProjectRoot>/Cache/android`

Also instead of removing each sym link recursively, it suffices to simply remove the link to the root asset folder.

## How was this PR tested?

This PR was validated with a Windows10 host machine, and generating an Android APK for Meta Oculus Quest Pro device.
