### PR TITLE
Gadams3/thumbnail optimizations

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
@@ -51,7 +51,7 @@ namespace AzToolsFramework
             auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / folderIcon;
             m_pixmap.load(absoluteIconPath.c_str());
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
@@ -47,8 +47,7 @@ namespace AzToolsFramework
             m_state = State::Loading;
             AZ_Assert(azrtti_cast<const FolderThumbnailKey*>(m_key.data()), "Incorrect key type, excpected FolderThumbnailKey");
 
-            const char* folderIcon = FolderIconPath;
-            auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / folderIcon;
+            auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / FolderIconPath;
             m_pixmap.load(absoluteIconPath.c_str());
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
             QueueThumbnailUpdated();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
@@ -98,7 +98,7 @@ namespace AzToolsFramework
 
             m_pixmap.load(iconPath);
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
@@ -123,7 +123,7 @@ namespace AzToolsFramework
 
             m_pixmap.load(iconPathToUse);
             m_state = m_pixmap.isNull() ? State::Failed : State::Ready;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
@@ -14,39 +14,19 @@ namespace AzToolsFramework
 {
     namespace Thumbnailer
     {
-        static constexpr const int LoadingThumbnailSize = 128;
+        static constexpr const int LoadingThumbnailSize = 1;
 
         //////////////////////////////////////////////////////////////////////////
         // LoadingThumbnail
         //////////////////////////////////////////////////////////////////////////
-        static constexpr const char* LoadingIconPath = "Assets/Editor/Icons/AssetBrowser/in_progress.gif";
-
         LoadingThumbnail::LoadingThumbnail()
             : Thumbnail(MAKE_TKEY(ThumbnailKey))
         {
-            auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / LoadingIconPath;
-            m_loadingMovie.setFileName(absoluteIconPath.c_str());
-            m_loadingMovie.setCacheMode(QMovie::CacheMode::CacheAll);
-            m_loadingMovie.setScaledSize(QSize(LoadingThumbnailSize, LoadingThumbnailSize));
-            m_loadingMovie.start();
-            m_pixmap = m_loadingMovie.currentPixmap();
+            m_pixmap = QPixmap(LoadingThumbnailSize, LoadingThumbnailSize);
+            m_pixmap .fill(Qt::black);
             m_state = State::Ready;
-
-            BusConnect();
         }
-
-        LoadingThumbnail::~LoadingThumbnail()
-        {
-            BusDisconnect();
-        }
-
-        void LoadingThumbnail::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
-        {
-            m_pixmap = m_loadingMovie.currentPixmap();
-            emit ThumbnailUpdated();
-        }
-
-    } // namespace Thumbnailer
+   } // namespace Thumbnailer
 } // namespace AzToolsFramework
 
 #include "Thumbnails/moc_LoadingThumbnail.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.cpp
@@ -23,7 +23,7 @@ namespace AzToolsFramework
             : Thumbnail(MAKE_TKEY(ThumbnailKey))
         {
             m_pixmap = QPixmap(LoadingThumbnailSize, LoadingThumbnailSize);
-            m_pixmap .fill(Qt::black);
+            m_pixmap.fill(Qt::black);
             m_state = State::Ready;
         }
    } // namespace Thumbnailer

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/LoadingThumbnail.h
@@ -9,31 +9,18 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/Thumbnails/Thumbnail.h>
-
-AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: class 'QImageIOHandler::d_ptr': class 'QScopedPointer<QImageIOHandlerPrivate,QScopedPointerDeleter<T>>' needs to have dll-interface to be used by clients of class 'QImageIOHandler'
-#include <QMovie>
 #endif
-AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework
 {
     namespace Thumbnailer
     {
-        class LoadingThumbnail
-            : public Thumbnail
-            , public AZ::TickBus::Handler
+        class LoadingThumbnail : public Thumbnail
         {
             Q_OBJECT
         public:
             LoadingThumbnail();
-            ~LoadingThumbnail() override;
-
-            // TickBus
-            //! LoadingThumbnail needs to update the loading animation
-            void OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/) override;
-
-        private:
-            QMovie m_loadingMovie;
+            ~LoadingThumbnail() override = default;
         };
     } // namespace Thumbnailer
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
@@ -130,7 +130,7 @@ namespace AzToolsFramework
                 m_pixmap = QPixmap();
             }
             m_readyForUpdate = true;
-            emit ThumbnailUpdated();
+            QueueThumbnailUpdated();
         }
 
         void SourceControlThumbnail::Update()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
@@ -25,7 +25,7 @@ namespace AzToolsFramework
         void ThumbnailKey::SetReady(bool ready)
         {
             m_ready = ready;
-            emit ThumbnailUpdated();
+            QTimer::singleShot(0, this, &ThumbnailKey::ThumbnailUpdated);
         }
 
         bool ThumbnailKey::IsReady() const
@@ -76,7 +76,7 @@ namespace AzToolsFramework
         {
         }
 
-        void Thumbnail::LoadComplete()
+        void Thumbnail::QueueThumbnailUpdated()
         {
             QTimer::singleShot(0, this, &Thumbnail::ThumbnailUpdated);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.cpp
@@ -79,6 +79,7 @@ namespace AzToolsFramework
         void Thumbnail::QueueThumbnailUpdated()
         {
             QTimer::singleShot(0, this, &Thumbnail::ThumbnailUpdated);
+            m_lastTimeUpdated = AZStd::chrono::steady_clock::now();
         }
 
         const QPixmap& Thumbnail::GetPixmap() const
@@ -96,6 +97,15 @@ namespace AzToolsFramework
             return m_state;
         }
 
+        AZStd::chrono::steady_clock::time_point Thumbnail::GetLastTimeUpdated() const
+        {
+            return m_lastTimeUpdated;
+        }
+
+        bool Thumbnail::CanAttemptReload() const
+        {
+            return AZStd::chrono::steady_clock::now() > m_lastTimeUpdated + AZStd::chrono::milliseconds(5000);
+        }
     } // namespace Thumbnailer
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
@@ -84,7 +84,6 @@ namespace AzToolsFramework
             ~Thumbnail() override;
             bool operator == (const Thumbnail& other) const;
             virtual void Load();
-            virtual void LoadComplete();
             const QPixmap& GetPixmap() const;
             SharedThumbnailKey GetKey() const;
             State GetState() const;
@@ -96,6 +95,7 @@ namespace AzToolsFramework
             virtual void Update() {}
 
         protected:
+            virtual void QueueThumbnailUpdated();
             AZStd::atomic<State> m_state;
             SharedThumbnailKey m_key;
             QPixmap m_pixmap;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
@@ -13,6 +13,7 @@
 AZ_PUSH_DISABLE_WARNING(4127 4251 4800, "-Wunknown-warning-option") // 4127: conditional expression is constant
                                                                     // 4251: 'QLocale::d': class 'QSharedDataPointer<QLocalePrivate>' needs to have dll-interface to be used by clients of class 'QLocale'
                                                                     // 4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
+
 #include <QObject>
 #include <QPixmap>
 AZ_POP_DISABLE_WARNING
@@ -27,8 +28,7 @@ namespace AzToolsFramework
             ThumbnailKey contains any kind of identifiable information to retrieve thumbnails (e.g. assetId, assetType, filename, etc.)
             To use thumbnail system, keep reference to your thumbnail key, and retrieve Thumbnail via ThumbnailerRequestBus
         */
-        class ThumbnailKey
-            : public QObject
+        class ThumbnailKey : public QObject
         {
             Q_OBJECT
         public:
@@ -64,11 +64,11 @@ namespace AzToolsFramework
         //! Thumbnail is the base class in thumbnailer system.
         /*
             Thumbnail handles storing and updating data for each specific thumbnail
-            Thumbnail also emits Updated signal whenever thumbnail data changes, this signal is listened to by every ThumbnailKey that maps to this thumbnail
-            Because you should be storing reference to ThumbnailKey and not Thumbnail, connect to ThumbnailKey signal instead
+            Thumbnail also emits Updated signal whenever thumbnail data changes, this signal is listened to by every ThumbnailKey that maps
+           to this thumbnail Because you should be storing reference to ThumbnailKey and not Thumbnail, connect to ThumbnailKey signal
+           instead
         */
-        class Thumbnail
-            : public QObject
+        class Thumbnail : public QObject
         {
             Q_OBJECT
         public:
@@ -82,11 +82,13 @@ namespace AzToolsFramework
 
             Thumbnail(SharedThumbnailKey key);
             ~Thumbnail() override;
-            bool operator == (const Thumbnail& other) const;
+            bool operator==(const Thumbnail& other) const;
             virtual void Load();
             const QPixmap& GetPixmap() const;
             SharedThumbnailKey GetKey() const;
             State GetState() const;
+            AZStd::chrono::steady_clock::time_point GetLastTimeUpdated() const;
+            bool CanAttemptReload() const;
 
         Q_SIGNALS:
             void ThumbnailUpdated() const;
@@ -95,7 +97,9 @@ namespace AzToolsFramework
             virtual void Update() {}
 
         protected:
-            virtual void QueueThumbnailUpdated();
+            void QueueThumbnailUpdated();
+
+            AZStd::chrono::steady_clock::time_point m_lastTimeUpdated = AZStd::chrono::steady_clock::now();
             AZStd::atomic<State> m_state;
             SharedThumbnailKey m_key;
             QPixmap m_pixmap;
@@ -110,6 +114,7 @@ namespace AzToolsFramework
             ThumbnailProvider() = default;
             virtual ~ThumbnailProvider() = default;
             virtual bool GetThumbnail(SharedThumbnailKey key, SharedThumbnail& thumbnail) = 0;
+
             //! Priority identifies ThumbnailProvider order
             //! Higher priority means this ThumbnailProvider will take precedence in generating a thumbnail when a supplied ThumbnailKey is
             //! supported by multiple providers.
@@ -122,13 +127,13 @@ namespace AzToolsFramework
         };
 
         typedef QSharedPointer<ThumbnailProvider> SharedThumbnailProvider;
-    }
-}
+    } // namespace Thumbnailer
+} // namespace AzToolsFramework
 
 namespace AZStd
 {
     // hash specialization
-    template <>
+    template<>
     struct hash<AzToolsFramework::Thumbnailer::SharedThumbnailKey>
     {
         AZ_FORCE_INLINE size_t operator()(AzToolsFramework::Thumbnailer::SharedThumbnailKey key) const
@@ -137,15 +142,17 @@ namespace AZStd
         }
     };
 
-    template <>
+    template<>
     struct equal_to<AzToolsFramework::Thumbnailer::SharedThumbnailKey>
     {
-        AZ_FORCE_INLINE bool operator()(const AzToolsFramework::Thumbnailer::SharedThumbnailKey& left, const AzToolsFramework::Thumbnailer::SharedThumbnailKey& right) const
+        AZ_FORCE_INLINE bool operator()(
+            const AzToolsFramework::Thumbnailer::SharedThumbnailKey& left,
+            const AzToolsFramework::Thumbnailer::SharedThumbnailKey& right) const
         {
             return left->Equals(right.data());
         }
     };
-}
+} // namespace AZStd
 
 namespace AzToolsFramework
 {
@@ -160,8 +167,7 @@ namespace AzToolsFramework
             what constitutes a unique key and how should the key collection be optimized
         */
         template<class ThumbnailType, class Hasher = AZStd::hash<SharedThumbnailKey>, class EqualKey = AZStd::equal_to<SharedThumbnailKey>>
-        class ThumbnailCache
-            : public ThumbnailProvider
+        class ThumbnailCache : public ThumbnailProvider
         {
         public:
             ThumbnailCache();
@@ -181,6 +187,5 @@ namespace AzToolsFramework
 } // namespace AzToolsFramework
 
 Q_DECLARE_METATYPE(AzToolsFramework::Thumbnailer::SharedThumbnailKey)
-
 
 #include <AzToolsFramework/Thumbnails/Thumbnail.inl>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
@@ -78,6 +78,7 @@ namespace AzToolsFramework
 
         void ThumbnailWidget::RepaintThumbnail()
         {
+            update();
             repaint();
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -150,7 +150,6 @@ namespace AzToolsFramework
                         m_thumbnailsBeingLoaded.insert(thumbnail);
                         auto job = AZ::CreateJobFunction([thumbnail]() { thumbnail->Load(); }, true);
                         job->Start();
-                        
                     }
 
                     return m_loadingThumbnail;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -112,7 +112,7 @@ namespace AzToolsFramework
                         return thumbnail;
                     }
 
-                    if (thumbnail->GetState() == Thumbnail::State::Failed)
+                    if (thumbnail->GetState() == Thumbnail::State::Failed && !thumbnail->CanAttemptReload())
                     {
                         return m_missingThumbnail;
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
@@ -14,9 +14,7 @@
 #include <AzToolsFramework/Thumbnails/Thumbnail.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 
-#include <QList>
 #include <QObject>
-#include <QThreadPool>
 #endif
 
 class QString;
@@ -29,7 +27,6 @@ namespace AzToolsFramework
         class ThumbnailerComponent
             : public AZ::Component
             , public ThumbnailerRequestBus::Handler
-            , public QObject
         {
         public:
             AZ_COMPONENT(ThumbnailerComponent, "{80090CA5-6A3A-4554-B5FE-A6D74ECB2D84}")
@@ -50,9 +47,9 @@ namespace AzToolsFramework
             SharedThumbnail GetThumbnail(SharedThumbnailKey thumbnailKey) override;
             bool IsLoading(SharedThumbnailKey thumbnailKey) override;
 
-            void RepaintThumbnail();
-
         private:
+            void Cleanup();
+
             struct ProviderCompare
             {
                 bool operator()(const SharedThumbnailProvider& lhs, const SharedThumbnailProvider& rhs) const
@@ -68,6 +65,8 @@ namespace AzToolsFramework
             SharedThumbnail m_missingThumbnail;
             //! Default loading thumbnail used when thumbnail is found by is not yet generated
             SharedThumbnail m_loadingThumbnail;
+            //! Using placeholder object rather than inheritance for connecting signals and slots
+            AZStd::unique_ptr<QObject> m_placeholderObject;
             //! Current number of jobs running.
             AZStd::set<SharedThumbnail> m_thumbnailsBeingLoaded;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.h
@@ -68,8 +68,6 @@ namespace AzToolsFramework
             SharedThumbnail m_missingThumbnail;
             //! Default loading thumbnail used when thumbnail is found by is not yet generated
             SharedThumbnail m_loadingThumbnail;
-            //! Maximum number of concurrent jobs allowed.
-            int m_maxThumbnailJobs{};
             //! Current number of jobs running.
             AZStd::set<SharedThumbnail> m_thumbnailsBeingLoaded;
         };

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
@@ -219,26 +219,25 @@ namespace ImageProcessingAtom
 
         m_imageAssetLoader->QueueAsset(
             product->GetAssetId(),
-            [this](const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& asset) {
-                CreateAndDisplayTextureItemAsync([asset]() -> CreateDisplayTextureResult
-                {
-                    IImageObjectPtr image = Utils::LoadImageFromImageAsset(asset);
-                    if (image)
+            [this](const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& asset)
+            {
+                CreateAndDisplayTextureItemAsync(
+                    [asset]() -> CreateDisplayTextureResult
                     {
-                        // Add product image info
-                        AZStd::string productInfo;
-                        GetImageInfoString(asset, productInfo);
+                        if (IImageObjectPtr image = Utils::LoadImageFromImageAsset(asset); image)
+                        {
+                            // Add product image info
+                            AZStd::string productInfo;
+                            GetImageInfoString(asset, productInfo);
 
-                        QString fileInfo = QStringLiteral("\r\n");
-                        fileInfo += productInfo.c_str();
+                            QString fileInfo = QStringLiteral("\r\n");
+                            fileInfo += productInfo.c_str();
 
-                        return { ConvertImageForPreview(image), fileInfo };
-                    }
-                    else
-                    {
+                            return { ConvertImageForPreview(image), fileInfo };
+                        }
+
                         return { nullptr, "" };
-                    }
-                });
+                    });
             });
 
         DisplayTextureItem();
@@ -251,27 +250,22 @@ namespace ImageProcessingAtom
         m_fileinfo += GetFileSize(source->GetFullPath().c_str());
 
         CreateAndDisplayTextureItemAsync(
-        [fullPath = source->GetFullPath()]
-        () -> CreateDisplayTextureResult
-        {
-            IImageObjectPtr image = IImageObjectPtr(LoadImageFromFile(fullPath));
-
-            if (image)
+            [fullPath = source->GetFullPath()]() -> CreateDisplayTextureResult
             {
-                // Add source image info
-                AZStd::string sourceInfo;
-                GetImageInfoString(image, sourceInfo);
+                if (IImageObjectPtr image = IImageObjectPtr(LoadImageFromFile(fullPath)); image)
+                {
+                    // Add source image info
+                    AZStd::string sourceInfo;
+                    GetImageInfoString(image, sourceInfo);
 
-                QString fileInfo = QStringLiteral("\r\n");
-                fileInfo += sourceInfo.c_str();
+                    QString fileInfo = QStringLiteral("\r\n");
+                    fileInfo += sourceInfo.c_str();
 
-                return { ConvertImageForPreview(image), fileInfo };
-            }
-            else
-            {
+                    return { ConvertImageForPreview(image), fileInfo };
+                }
+
                 return { nullptr, "" };
-            }
-        });
+            });
 
         DisplayTextureItem();
     }
@@ -363,6 +357,6 @@ namespace ImageProcessingAtom
         }
         return result;
     }
-}//namespace ImageProcessingAtom
+} // namespace ImageProcessingAtom
 
 #include <Source/Previewer/moc_ImagePreviewer.cpp>

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.h
@@ -39,6 +39,11 @@ class QResizeEvent;
 
 namespace ImageProcessingAtom
 {
+    namespace Utils
+    {
+        class AsyncImageAssetLoader;
+    }
+
     class ImagePreviewer
         : public AzToolsFramework::AssetBrowser::Previewer
         , private AZ::SystemTickBus::Handler
@@ -87,5 +92,6 @@ namespace ImageProcessingAtom
         using CreateDisplayTextureResult = AZStd::pair<IImageObjectPtr, QString>;
 
         QFuture<CreateDisplayTextureResult> m_createDisplayTextureResult;
+        AZStd::shared_ptr<Utils::AsyncImageAssetLoader> m_imageAssetLoader;
     };
 }//namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
@@ -37,6 +37,10 @@ namespace ImageProcessingAtom
 
             AsyncImageAssetLoader() = default;
             ~AsyncImageAssetLoader();
+
+            //! Queue an asset to be loaded asynchronously. The callback will be executed on the main thread once the asset is ready or fails.
+            //! @param assetId ID of the image asset to be loaded.
+            //! @param callback Callback function to execute once the asset is ready or fails.
             void QueueAsset(const AZ::Data::AssetId& assetId, const Callback& callback);
 
         private:

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
@@ -28,5 +28,27 @@ namespace ImageProcessingAtom
         bool SaveImageToDdsFile(IImageObjectPtr image, AZStd::string_view filePath);
 
         bool NeedAlphaChannel(EAlphaContent alphaContent);
-    }
+
+        //! Load image assets in the background and execute callbacks when complete. 
+        class AsyncImageAssetLoader : public AZ::Data::AssetBus::MultiHandler
+        {
+        public:
+            using Callback = AZStd::function<void(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>&)>;
+
+            AsyncImageAssetLoader() = default;
+            ~AsyncImageAssetLoader();
+            void QueueAsset(const AZ::Data::AssetId& assetId, const Callback& callback);
+
+        private:
+            // AZ::Data::AssetBus::MultiHandler overrides..
+            void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+            void OnAssetError(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+
+            void HandleAssetNotification(AZ::Data::Asset<AZ::Data::AssetData> asset);
+
+            using AssetCallbackPair = AZStd::pair<AZ::Data::Asset<AZ::RPI::StreamingImageAsset>, Callback>;
+            using AssetCallbackMap = AZStd::unordered_map<AZ::Data::AssetId, AssetCallbackPair>;
+            AssetCallbackMap m_assetCallbackMap;
+        };
+    } // namespace Utils
 }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.h
@@ -29,7 +29,7 @@ namespace ImageProcessingAtom
 
         bool NeedAlphaChannel(EAlphaContent alphaContent);
 
-        //! Load image assets in the background and execute callbacks when complete. 
+        //! Load image assets in the background and execute callbacks when complete.
         class AsyncImageAssetLoader : public AZ::Data::AssetBus::MultiHandler
         {
         public:
@@ -38,7 +38,8 @@ namespace ImageProcessingAtom
             AsyncImageAssetLoader() = default;
             ~AsyncImageAssetLoader();
 
-            //! Queue an asset to be loaded asynchronously. The callback will be executed on the main thread once the asset is ready or fails.
+            //! Queue an asset to be loaded asynchronously. The callback will be executed on the main thread once the asset is ready or
+            //! fails.
             //! @param assetId ID of the image asset to be loaded.
             //! @param callback Callback function to execute once the asset is ready or fails.
             void QueueAsset(const AZ::Data::AssetId& assetId, const Callback& callback);
@@ -55,4 +56,4 @@ namespace ImageProcessingAtom
             AssetCallbackMap m_assetCallbackMap;
         };
     } // namespace Utils
-}
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
@@ -60,7 +60,7 @@ namespace ImageProcessingAtom
         void ImageThumbnail::Load()
         {
             m_state = State::Loading;
-            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::Event(
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::QueueEvent(
                 AZ::RPI::StreamingImageAsset::RTTI_Type(), &AzToolsFramework::Thumbnailer::ThumbnailerRendererRequests::RenderThumbnail,
                 m_key, ImageThumbnailSize);
         }
@@ -80,7 +80,7 @@ namespace ImageProcessingAtom
 
         void ImageThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)
         {
-            if (m_state == State::Ready && m_assetIds.find(assetId) != m_assetIds.end())
+            if (m_assetIds.contains(assetId) && (m_state == State::Ready || m_state == State::Failed))
             {
                 m_state = State::Unloaded;
                 Load();

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
@@ -69,13 +69,13 @@ namespace ImageProcessingAtom
         {
             m_pixmap = thumbnailImage;
             m_state = State::Ready;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         void ImageThumbnail::ThumbnailFailedToRender()
         {
             m_state = State::Failed;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         void ImageThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/Utils.h>
@@ -20,9 +19,9 @@
 #include <ImageLoader/ImageLoaders.h>
 #include <Processing/ImageConvert.h>
 #include <Processing/ImageToProcess.h>
-#include <Processing/Utils.h>
 #include <Thumbnail/ImageThumbnail.h>
 #include <Thumbnail/ImageThumbnailSystemComponent.h>
+#include <Processing/Utils.h>
 
 namespace ImageProcessingAtom
 {
@@ -83,6 +82,8 @@ namespace ImageProcessingAtom
             using namespace AzToolsFramework::Thumbnailer;
 
             ThumbnailerRequestBus::Broadcast(&ThumbnailerRequests::RegisterThumbnailProvider, MAKE_TCACHE(Thumbnails::ImageThumbnailCache));
+
+            m_imageAssetLoader.reset(aznew Utils::AsyncImageAssetLoader());
         }
 
         void ImageThumbnailSystemComponent::TeardownThumbnails()
@@ -91,6 +92,8 @@ namespace ImageProcessingAtom
 
             ThumbnailerRequestBus::Broadcast(
                 &ThumbnailerRequests::UnregisterThumbnailProvider, Thumbnails::ImageThumbnailCache::ProviderName);
+
+            m_imageAssetLoader.reset();
         }
 
         void ImageThumbnailSystemComponent::OnApplicationAboutToStop()
@@ -126,9 +129,13 @@ namespace ImageProcessingAtom
             }
             else if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.data()))
             {
-                RenderThumbnailFromImage(thumbnailKey, thumbnailSize,
-                    [assetId = productKey->GetAssetId()]() { return Utils::LoadImageFromImageAsset(assetId); }
-                );
+                m_imageAssetLoader->QueueAsset(
+                    productKey->GetAssetId(),
+                    [this, thumbnailKey, thumbnailSize](const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& asset) {
+                        RenderThumbnailFromImage(thumbnailKey, thumbnailSize, [asset]() {
+                            return Utils::LoadImageFromImageAsset(asset);
+                        });
+                    });
             }
             else
             {
@@ -141,19 +148,17 @@ namespace ImageProcessingAtom
         void ImageThumbnailSystemComponent::RenderThumbnailFromImage(
             AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, MkImageFn mkPreviewImage) const
         {
-            const auto JobRunner = [mkPreviewImage, thumbnailKey, thumbnailSize]() mutable
+            auto jobRunner = [mkPreviewImage, thumbnailKey, thumbnailSize]()
             {
                 IImageObjectPtr previewImage = mkPreviewImage();
                 if (!previewImage)
                 {
                     AZ::SystemTickBus::QueueFunction(
-                    [
-                        thumbnailKey
-                    ]()
-                    {
-                        AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                            thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
-                    });
+                        [thumbnailKey]()
+                        {
+                            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                                thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                        });
 
                     return;
                 }
@@ -174,17 +179,15 @@ namespace ImageProcessingAtom
 
                 // Dispatch event on main thread
                 AZ::SystemTickBus::QueueFunction(
-                [
-                    thumbnailKey,
-                    pixmap = QPixmap::fromImage(image.scaled(QSize(thumbnailSize, thumbnailSize), Qt::KeepAspectRatio, Qt::SmoothTransformation))
-                ]() mutable
-                {
-                    AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                        thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
-                        pixmap);
-                });
+                    [thumbnailKey,
+                     pixmap = QPixmap::fromImage(
+                         image.scaled(QSize(thumbnailSize, thumbnailSize), Qt::KeepAspectRatio, Qt::SmoothTransformation))]()
+                    {
+                        AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                            thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered, pixmap);
+                    });
             };
-            AZ::CreateJobFunction(JobRunner, true)->Start();
+            AZ::CreateJobFunction(jobRunner, true)->Start();
         }
     } // namespace Thumbnails
 } // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
@@ -14,6 +14,11 @@
 
 namespace ImageProcessingAtom
 {
+    namespace Utils
+    {
+        class AsyncImageAssetLoader;
+    }
+
     namespace Thumbnails
     {
         //! System component for image thumbnails.
@@ -51,6 +56,8 @@ namespace ImageProcessingAtom
             template<class MkImageFn>
             void RenderThumbnailFromImage(
                 AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, MkImageFn mkPreviewImage) const;
+
+            AZStd::shared_ptr<Utils::AsyncImageAssetLoader> m_imageAssetLoader;
         };
     } // namespace Thumbnails
 } // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -218,9 +218,8 @@ namespace AZ
                 jobDescriptor.m_critical = false;
                 jobDescriptor.m_jobKey = ShaderAssetBuilderJobKey;
                 jobDescriptor.SetPlatformIdentifier(platformInfo.m_identifier.c_str());
-
-                response.m_createJobOutputs.push_back(jobDescriptor);
-            }  // for all request.m_enabledPlatforms
+                response.m_createJobOutputs.emplace_back(AZStd::move(jobDescriptor));
+            } // for all request.m_enabledPlatforms
 
             AZ_Printf(
                 ShaderAssetBuilderName, "CreateJobs for %s took %llu milliseconds", shaderAssetSourceFileFullPath.c_str(),

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.cpp
@@ -90,17 +90,17 @@ namespace AZ
 
         void CoreLightsSystemComponent::GetProvidedServices(ComponentDescriptor::DependencyArrayType& provided)
         {
-            provided.push_back(AZ_CRC("CoreLightsService", 0x91932ef6));
+            provided.push_back(AZ_CRC_CE("CoreLightsService"));
         }
 
         void CoreLightsSystemComponent::GetIncompatibleServices(ComponentDescriptor::DependencyArrayType& incompatible)
         {
-            incompatible.push_back(AZ_CRC("CoreLightsService", 0x91932ef6));
+            incompatible.push_back(AZ_CRC_CE("CoreLightsService"));
         }
 
         void CoreLightsSystemComponent::GetRequiredServices(ComponentDescriptor::DependencyArrayType& required)
         {
-            required.push_back(AZ_CRC("RPISystem", 0xf2add773));
+            required.push_back(AZ_CRC_CE("RPISystem"));
         }
 
         void CoreLightsSystemComponent::Init()
@@ -109,6 +109,8 @@ namespace AZ
 
         void CoreLightsSystemComponent::Activate()
         {
+            m_ltcCommonInterface.reset(aznew LtcCommon());
+
             AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<SimplePointLightFeatureProcessor, SimplePointLightFeatureProcessorInterface>();
             AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<SimpleSpotLightFeatureProcessor, SimpleSpotLightFeatureProcessorInterface>();
             AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<PointLightFeatureProcessor, PointLightFeatureProcessorInterface>();
@@ -132,6 +134,7 @@ namespace AZ
 
         void CoreLightsSystemComponent::Deactivate()
         {
+            m_ltcCommonInterface.reset();
         }
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.h
@@ -33,7 +33,7 @@ namespace AZ
             void Activate() override;
             void Deactivate() override;
 
-            LtcCommon m_ltcCommonInterface;
+           AZStd::unique_ptr<LtcCommon> m_ltcCommonInterface;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LtcCommon.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LtcCommon.cpp
@@ -12,8 +12,8 @@
 
 namespace AZ::Render
 {
-    static const char* s_LtcGgxMatrixPath = "textures/ltc/ltc_mat_lutrgba32f.dds.streamingimage";
-    static const char* s_LtcGgxAmplificationPath = "textures/ltc/ltc_amp_lutrg32f.dds.streamingimage";
+    static constexpr const char* s_LtcGgxMatrixPath = "textures/ltc/ltc_mat_lutrgba32f.dds.streamingimage";
+    static constexpr const char* s_LtcGgxAmplificationPath = "textures/ltc/ltc_amp_lutrg32f.dds.streamingimage";
 
     LtcCommon::LtcCommon()
     {
@@ -22,6 +22,7 @@ namespace AZ::Render
 
     LtcCommon::~LtcCommon()
     {
+        m_assetLoaders.clear();
         Interface<ILtcCommon>::Unregister(this);
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LtcCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LtcCommon.h
@@ -24,8 +24,7 @@ namespace AZ::Render
     };
 
     // Class that handles basic setup for light types that use linearly transformed cosines.
-    class LtcCommon
-        : public ILtcCommon
+    class LtcCommon : public ILtcCommon
     {
     public:
         AZ_RTTI(AZ::Render::LtcCommon, "{7BB6BD58-A517-4D68-87EC-CAA2AADAAC02}", AZ::Render::ILtcCommon);
@@ -37,8 +36,6 @@ namespace AZ::Render
         void LoadMatricesForSrg(Data::Instance<RPI::ShaderResourceGroup> srg) override;
 
     private:
-        AZStd::unordered_map<AZ::Uuid, AZStd::vector<RPI::AssetUtils::AsyncAssetLoader>> m_assetLoaders;
-
+        AZStd::unordered_map<AZ::Uuid, AZStd::vector<AZStd::shared_ptr<RPI::AssetUtils::AsyncAssetLoader>>> m_assetLoaders;
     };
-}
-
+} // namespace AZ::Render

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -176,6 +176,8 @@ namespace AZ
 
             //! Returns the masked occlusion culling interface
             MaskedOcclusionCulling* GetMaskedOcclusionCulling();
+            void SetMaskedOcclusionCullingDirty(bool dirty);
+            bool GetMaskedOcclusionCullingDirty() const;
 
             //! This is called by RenderPipeline when this view is added to the pipeline.
             void OnAddToRenderPipeline();
@@ -262,6 +264,7 @@ namespace AZ
 
             // Masked Occlusion Culling interface
             MaskedOcclusionCulling* m_maskedOcclusionCulling = nullptr;
+            AZStd::atomic_bool m_maskedOcclusionCullingDirty = true;
 
             AZStd::atomic_uint32_t m_andFlags{ 0xFFFFFFFF };
             AZStd::atomic_uint32_t m_orFlags { 0x00000000 };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
@@ -193,40 +193,39 @@ namespace AZ
             //! multiple ebus functions to handle callbacks. It will invoke the provided callback function when the
             //! asset loads or errors. It will stop listening on destruction, so it should be held onto until the
             //! callback fires.
-            class AsyncAssetLoader
-                : private Data::AssetBus::MultiHandler
+            class AsyncAssetLoader : private Data::AssetBus::Handler
             {
             public:
-                using AssetCallback = AZStd::function<void(Data::Asset<Data::AssetData>, bool /*success*/)>;
+                AZ_RTTI(AZ::RPI::AssetUtils::AsyncAssetLoader, "{E0FB5B08-B97D-40DF-8478-226249C0B654}");
+
+                using AssetCallback = AZStd::function<void(Data::Asset<Data::AssetData>)>;
 
                 AsyncAssetLoader() = default;
                 ~AsyncAssetLoader();
 
-                template <typename AssetDataT>
-                static AsyncAssetLoader Create(const AZStd::string& path, uint32_t subId, AssetCallback callback);
+                template<typename AssetDataT>
+                static AZStd::shared_ptr<AsyncAssetLoader> Create(const AZStd::string& path, uint32_t subId, AssetCallback callback);
 
-                template <typename AssetDataT>
-                static AsyncAssetLoader Create(Data::AssetId assetId, AssetCallback callback);
+                template<typename AssetDataT>
+                static AZStd::shared_ptr<AsyncAssetLoader> Create(Data::AssetId assetId, AssetCallback callback);
 
             private:
-
                 explicit AsyncAssetLoader(AssetCallback callback);
 
-                template <typename AssetDataT>
+                template<typename AssetDataT>
                 void StartLoad(Data::AssetId& assetId);
 
-                // Data::AssetBus::MultiHandler overrides..
+                // Data::AssetBus::Handler overrides..
                 void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
                 void OnAssetError(Data::Asset<Data::AssetData> asset) override;
 
-                void HandleCallback(Data::Asset<Data::AssetData> asset, bool isError);
+                void HandleCallback(Data::Asset<Data::AssetData> asset);
 
                 AssetCallback m_callback;
                 Data::Asset<Data::AssetData> m_asset;
             };
-        }
-    }
-}
+        } // namespace AssetUtils
+    } // namespace RPI
+} // namespace AZ
 
 #include <Atom/RPI.Reflect/Asset/AssetUtils.inl>
-

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.inl
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.inl
@@ -14,11 +14,10 @@ namespace AZ
         {
             // AsyncAssetLoader //
 
-            template <typename AssetDataT>
-            AsyncAssetLoader AsyncAssetLoader::Create(const AZStd::string& path, [[maybe_unused]] uint32_t subId, AssetCallback callback)
+            template<typename AssetDataT>
+            AZStd::shared_ptr<AsyncAssetLoader> AsyncAssetLoader::Create(
+                const AZStd::string& path, [[maybe_unused]] uint32_t subId, AssetCallback callback)
             {
-                AsyncAssetLoader loader(callback);
-
                 // Try to get an asset id for the requested path. Don't print an error yet if it isn't found though.
                 Data::AssetId assetId = GetAssetIdForProductPath(path.c_str(), TraceLevel::None, azrtti_typeid<AssetDataT>());
 
@@ -36,30 +35,30 @@ namespace AZ
 
                 // We'll start the load whether or not the asset id is valid. It will immediately call the callback with failure if
                 // the asset id is invalid.
-                loader.StartLoad<AssetDataT>(assetId);
-                return loader;
+                return Create<AssetDataT>(assetId, callback);
             }
 
-            template <typename AssetDataT>
-            AsyncAssetLoader AsyncAssetLoader::Create(Data::AssetId assetId, AssetCallback callback)
+            template<typename AssetDataT>
+            AZStd::shared_ptr<AsyncAssetLoader> AsyncAssetLoader::Create(Data::AssetId assetId, AssetCallback callback)
             {
-                AsyncAssetLoader loader(callback);
-                loader.StartLoad<AssetDataT>(assetId);
+                AZStd::shared_ptr<AsyncAssetLoader> loader(aznew AsyncAssetLoader(callback));
+                loader->StartLoad<AssetDataT>(assetId);
                 return loader;
             }
 
-            template <typename AssetDataT>
+            template<typename AssetDataT>
             void AsyncAssetLoader::StartLoad(Data::AssetId& assetId)
             {
                 if (!assetId.IsValid())
                 {
                     // Immediately call callback with empty asset and false for success.
-                    m_callback(Data::Asset<AssetDataT>(), false);
+                    HandleCallback(Data::Asset<AssetDataT>());
+                    return;
                 }
-                m_asset = AZ::Data::AssetManager::Instance().GetAsset<AssetDataT>(assetId, AZ::Data::AssetLoadBehavior::PreLoad);
-                m_asset.QueueLoad();
-                Data::AssetBus::MultiHandler::BusConnect(assetId);
+
+                m_asset.Create(assetId, AZ::Data::AssetLoadBehavior::PreLoad, true);
+                Data::AssetBus::Handler::BusConnect(assetId);
             }
-        }
-    }
-}
+        } // namespace AssetUtils
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.inl
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.inl
@@ -56,7 +56,8 @@ namespace AZ
                     return;
                 }
 
-                m_asset.Create(assetId, AZ::Data::AssetLoadBehavior::PreLoad, true);
+                m_asset = AZ::Data::AssetManager::Instance().GetAsset<AssetDataT>(assetId, AZ::Data::AssetLoadBehavior::PreLoad);
+                m_asset.QueueLoad();
                 Data::AssetBus::Handler::BusConnect(assetId);
             }
         } // namespace AssetUtils

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -647,14 +647,28 @@ namespace AZ
         void View::BeginCulling()
         {
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-            AZ_PROFILE_SCOPE(RPI, "View: ClearMaskedOcclusionBuffer");
-            m_maskedOcclusionCulling->ClearBuffer();
+            if (m_maskedOcclusionCullingDirty)
+            {
+                AZ_PROFILE_SCOPE(RPI, "View: ClearMaskedOcclusionBuffer");
+                m_maskedOcclusionCulling->ClearBuffer();
+                m_maskedOcclusionCullingDirty = false;
+            }
 #endif
         }
 
         MaskedOcclusionCulling* View::GetMaskedOcclusionCulling()
         {
             return m_maskedOcclusionCulling;
+        }
+
+        void View::SetMaskedOcclusionCullingDirty(bool dirty)
+        {
+            m_maskedOcclusionCullingDirty = dirty;
+        }
+
+        bool View::GetMaskedOcclusionCullingDirty() const
+        {
+            return m_maskedOcclusionCullingDirty;
         }
 
         void View::TryCreateShaderResourceGroup()

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Asset/AssetUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Asset/AssetUtils.cpp
@@ -88,23 +88,26 @@ namespace AZ
 
             AsyncAssetLoader::~AsyncAssetLoader()
             {
-                Data::AssetBus::MultiHandler::BusDisconnect();
+                Data::AssetBus::Handler::BusDisconnect();
             }
 
             void AsyncAssetLoader::OnAssetReady(Data::Asset<Data::AssetData> asset)
             {
-                HandleCallback(asset, true);
+                HandleCallback(asset);
             }
 
             void AsyncAssetLoader::OnAssetError(Data::Asset<Data::AssetData> asset)
             {
-                HandleCallback(asset, false);
+                HandleCallback(asset);
             }
 
-            void AsyncAssetLoader::HandleCallback(Data::Asset<Data::AssetData> asset, bool isSuccess)
+            void AsyncAssetLoader::HandleCallback(Data::Asset<Data::AssetData> asset)
             {
-                Data::AssetBus::MultiHandler::BusDisconnect();
-                m_callback(asset, isSuccess);
+                Data::AssetBus::Handler::BusDisconnect();
+                if (m_callback)
+                {
+                    m_callback(asset);
+                }
 
                 m_callback = {}; // Release the callback to avoid holding references to anything captured in the lambda.
                 m_asset = {}; // Release the asset in case this AsyncAssetLoader hangs around longer than the asset needs to.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -33,6 +33,7 @@ namespace AtomToolsFramework
     PreviewRenderer::PreviewRenderer(const AZStd::string& sceneName, const AZStd::string& pipelineName)
     {
         PreviewerFeatureProcessorProviderBus::Handler::BusConnect();
+        AZ::SystemTickBus::Handler::BusConnect();
 
         m_entityContext = AZStd::make_unique<AzFramework::EntityContext>();
         m_entityContext->InitContext();
@@ -79,13 +80,6 @@ namespace AtomToolsFramework
         m_view->SetViewToClipMatrix(viewToClipMatrix);
         m_renderPipeline->SetDefaultView(m_view);
 
-        // Run the pipeline once for complete initialization, else capturing will fail
-        // Todo: Investigate why RemoveFromRenderTick doesn't work here and what initialization
-        // steps are missing in that case (could be the target image/texture doesn't get setup)
-        // Without this line, pipeline default to render every frame until a capture is triggered
-        // This resulted in a ~0.5ms performance hit every frame
-        m_renderPipeline->AddToRenderTickOnce();
-
         m_state.reset(new PreviewRendererIdleState(this));
 
         AZ::Interface<PreviewRendererInterface>::Register(this);
@@ -93,6 +87,7 @@ namespace AtomToolsFramework
 
     PreviewRenderer::~PreviewRenderer()
     {
+        AZ::SystemTickBus::Handler::BusDisconnect();
         PreviewerFeatureProcessorProviderBus::Handler::BusDisconnect();
 
         m_state.reset();
@@ -159,12 +154,14 @@ namespace AtomToolsFramework
         {
             m_currentCaptureRequest.m_captureFailedCallback();
         }
+        EndCapture();
         m_state.reset();
         m_state.reset(new PreviewRendererIdleState(this));
     }
 
     void PreviewRenderer::CompleteCaptureRequest()
     {
+        EndCapture();
         m_state.reset();
         m_state.reset(new PreviewRendererIdleState(this));
     }
@@ -255,6 +252,14 @@ namespace AtomToolsFramework
     {
         m_currentCaptureRequest = {};
         m_renderPipeline->RemoveFromRenderTick();
+    }
+
+    void PreviewRenderer::OnSystemTick()
+    {
+        if (m_state)
+        {
+            m_state->Update();
+        }
     }
 
     void PreviewRenderer::GetRequiredFeatureProcessors(AZStd::vector<AZStd::string>& featureProcessors) const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
@@ -15,6 +15,7 @@
 #include <AtomToolsFramework/PreviewRenderer/PreviewRendererCaptureRequest.h>
 #include <AtomToolsFramework/PreviewRenderer/PreviewRendererInterface.h>
 #include <AtomToolsFramework/PreviewRenderer/PreviewerFeatureProcessorProviderBus.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzFramework/Entity/GameEntityContextComponent.h>
 #include <PreviewRenderer/PreviewRendererState.h>
 
@@ -24,6 +25,7 @@ namespace AtomToolsFramework
     class PreviewRenderer final
         : public PreviewRendererInterface
         , public PreviewerFeatureProcessorProviderBus::Handler
+        , public AZ::SystemTickBus::Handler
     {
     public:
         AZ_CLASS_ALLOCATOR(PreviewRenderer, AZ::SystemAllocator);
@@ -52,6 +54,9 @@ namespace AtomToolsFramework
         void EndCapture();
 
     private:
+        //! AZ::SystemTickBus::Handler interface overrides...
+        void OnSystemTick() override;
+
         //! AZ::Render::PreviewerFeatureProcessorProviderBus::Handler interface overrides...
         void GetRequiredFeatureProcessors(AZStd::vector<AZStd::string>& featureProcessors) const override;
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
@@ -29,7 +29,7 @@ namespace AtomToolsFramework
 
         //! Track the amount of time since the capture request was initiated
         AZStd::chrono::steady_clock::time_point m_startTime = AZStd::chrono::steady_clock::now();
-        AZStd::chrono::steady_clock::time_point m_captureTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(50);
+        AZStd::chrono::steady_clock::time_point m_captureTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5);
         AZStd::chrono::steady_clock::time_point m_abortTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5000);
         bool m_captureComplete = false;
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
-#include <AzCore/Component/TickBus.h>
 #include <PreviewRenderer/PreviewRendererState.h>
 
 namespace AtomToolsFramework
@@ -17,21 +16,21 @@ namespace AtomToolsFramework
     //! PreviewRendererCaptureState renders a preview to an image
     class PreviewRendererCaptureState final
         : public PreviewRendererState
-        , public AZ::SystemTickBus::Handler
         , public AZ::Render::FrameCaptureNotificationBus::Handler
     {
     public:
         PreviewRendererCaptureState(PreviewRenderer* renderer);
         ~PreviewRendererCaptureState();
+        void Update() override;
 
     private:
-        //! AZ::SystemTickBus::Handler interface overrides...
-        void OnSystemTick() override;
-
         //! AZ::Render::FrameCaptureNotificationBus::Handler overrides...
         void OnFrameCaptureFinished(AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
-        //! This is necessary to suspend capture until preview scene is ready
-        int m_ticksToCapture = 1;
+        //! Track the amount of time since the capture request was initiated
+        AZStd::chrono::steady_clock::time_point m_startTime = AZStd::chrono::steady_clock::now();
+        AZStd::chrono::steady_clock::time_point m_captureTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(50);
+        AZStd::chrono::steady_clock::time_point m_abortTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5000);
+        bool m_captureComplete = false;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.cpp
@@ -14,15 +14,13 @@ namespace AtomToolsFramework
     PreviewRendererIdleState::PreviewRendererIdleState(PreviewRenderer* renderer)
         : PreviewRendererState(renderer)
     {
-        AZ::SystemTickBus::Handler::BusConnect();
     }
 
     PreviewRendererIdleState::~PreviewRendererIdleState()
     {
-        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void PreviewRendererIdleState::OnSystemTick()
+    void PreviewRendererIdleState::Update()
     {
         m_renderer->ProcessCaptureRequests();
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererIdleState.h
@@ -8,22 +8,16 @@
 
 #pragma once
 
-#include <AzCore/Component/TickBus.h>
 #include <PreviewRenderer/PreviewRendererState.h>
 
 namespace AtomToolsFramework
 {
     //! PreviewRendererIdleState checks whether there are any new thumbnails that need to be rendered every tick
-    class PreviewRendererIdleState final
-        : public PreviewRendererState
-        , public AZ::SystemTickBus::Handler
+    class PreviewRendererIdleState final : public PreviewRendererState
     {
     public:
         PreviewRendererIdleState(PreviewRenderer* renderer);
         ~PreviewRendererIdleState();
-
-    private:
-        //! AZ::SystemTickBus::Handler interface overrides...
-        void OnSystemTick() override;
+        void Update() override;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.cpp
@@ -15,17 +15,15 @@ namespace AtomToolsFramework
         : PreviewRendererState(renderer)
     {
         m_renderer->LoadContent();
-        AZ::SystemTickBus::Handler::BusConnect();
     }
 
     PreviewRendererLoadState::~PreviewRendererLoadState()
     {
-        AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void PreviewRendererLoadState::OnSystemTick()
+    void PreviewRendererLoadState::Update()
     {
-        if (AZStd::chrono::steady_clock::now() > (m_startTime + AZStd::chrono::seconds(5)))
+        if (AZStd::chrono::steady_clock::now() > m_abortTime)
         {
             m_renderer->CancelLoadContent();
             return;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererLoadState.h
@@ -8,24 +8,20 @@
 
 #pragma once
 
-#include <AzCore/Component/TickBus.h>
 #include <PreviewRenderer/PreviewRendererState.h>
 
 namespace AtomToolsFramework
 {
     //! PreviewRendererLoadState pauses further rendering until all assets used for rendering a thumbnail have been loaded
-    class PreviewRendererLoadState final
-        : public PreviewRendererState
-        , public AZ::SystemTickBus::Handler
+    class PreviewRendererLoadState final : public PreviewRendererState
     {
     public:
         PreviewRendererLoadState(PreviewRenderer* renderer);
         ~PreviewRendererLoadState();
+        void Update() override;
 
     private:
-        //! AZ::SystemTickBus::Handler interface overrides...
-        void OnSystemTick() override;
-
         AZStd::chrono::steady_clock::time_point m_startTime = AZStd::chrono::steady_clock::now();
+        AZStd::chrono::steady_clock::time_point m_abortTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5000);
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererState.h
@@ -22,6 +22,7 @@ namespace AtomToolsFramework
         }
 
         virtual ~PreviewRendererState() = default;
+        virtual void Update() = 0;
 
     protected:
         PreviewRenderer* m_renderer = {};

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.cpp
@@ -52,34 +52,35 @@ namespace AtomToolsFramework
 
     void PreviewRendererSystemComponent::Activate()
     {
+        AZ::SystemTickBus::Handler::BusConnect();
         AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
         PreviewRendererSystemRequestBus::Handler::BusConnect();
-
-        AZ::TickBus::QueueFunction(
-            [this]()
-            {
-                // Only create a preview renderer if the RPI interface is fully initialized.  Otherwise the constructor will leave things
-                // in a bad state that can lead to crashing.
-                if (AZ::RPI::RPISystemInterface::Get()->IsInitialized())
-                {
-                    if (!m_previewRenderer)
-                    {
-                        m_previewRenderer.reset(aznew AtomToolsFramework::PreviewRenderer(
-                            "PreviewRendererSystemComponent Preview Scene", "PreviewRendererSystemComponent Preview Pipeline"));
-                    }
-                }
-            });
     }
 
     void PreviewRendererSystemComponent::Deactivate()
     {
         PreviewRendererSystemRequestBus::Handler::BusDisconnect();
         AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
+        AZ::SystemTickBus::Handler::BusDisconnect();
         m_previewRenderer.reset();
     }
 
     void PreviewRendererSystemComponent::OnApplicationAboutToStop()
     {
         m_previewRenderer.reset();
+    }
+
+    void PreviewRendererSystemComponent::OnSystemTick()
+    {
+        // Do not create the preview reader until the RPI has been initialized
+        if (AZ::RPI::RPISystemInterface::Get() && AZ::RPI::RPISystemInterface::Get()->IsInitialized())
+        {
+            if (!m_previewRenderer)
+            {
+                m_previewRenderer.reset(aznew AtomToolsFramework::PreviewRenderer(
+                    "PreviewRendererSystemComponent Preview Scene", "PreviewRendererSystemComponent Preview Pipeline"));
+            }
+            AZ::SystemTickBus::Handler::BusDisconnect();
+        }
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererSystemComponent.h
@@ -10,6 +10,7 @@
 
 #include <AtomToolsFramework/PreviewRenderer/PreviewRendererSystemRequestBus.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzFramework/Application/Application.h>
 #include <PreviewRenderer/PreviewRenderer.h>
 
@@ -19,6 +20,7 @@ namespace AtomToolsFramework
     class PreviewRendererSystemComponent final
         : public AZ::Component
         , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
+        , public AZ::SystemTickBus::Handler
         , public PreviewRendererSystemRequestBus::Handler
     {
     public:
@@ -39,6 +41,9 @@ namespace AtomToolsFramework
     private:
         // AzFramework::ApplicationLifecycleEvents overrides...
         void OnApplicationAboutToStop() override;
+
+        // AZ::SystemTickBus::Handler overrides...
+        void OnSystemTick() override;
 
         AZStd::unique_ptr<AtomToolsFramework::PreviewRenderer> m_previewRenderer;
     };

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/MaterialCanvasApplication.cpp
@@ -169,7 +169,7 @@ namespace MaterialCanvas
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("float4x4"), AZStd::array<AZ::Vector4, 4>{ AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 1.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f) }, "float4x4"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("color"), AZ::Color::CreateOne(), "color"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("string"), AZStd::string{}, "string"),
-            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("image"), AZ::Data::Asset<AZ::RPI::StreamingImageAsset>{}, "image"),
+            AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("image"), AZ::Data::Asset<AZ::RPI::StreamingImageAsset>{ AZ::Data::AssetLoadBehavior::NoLoad }, "image"),
             AZStd::make_shared<GraphModel::DataType>(AZ_CRC_CE("sampler"), defaultSamplerState, "sampler"),
         });
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
@@ -53,13 +53,13 @@ namespace AZ
         {
             m_pixmap = thumbnailImage;
             m_state = State::Ready;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         void SharedThumbnail::ThumbnailFailedToRender()
         {
             m_state = State::Failed;
-            Thumbnail::LoadComplete();
+            QueueThumbnailUpdated();
         }
 
         void SharedThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnail.cpp
@@ -64,7 +64,7 @@ namespace AZ
 
         void SharedThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)
         {
-            if (m_assetInfo.m_assetId == assetId && m_state == State::Ready)
+            if (m_assetInfo.m_assetId == assetId && (m_state == State::Ready || m_state == State::Failed))
             {
                 m_state = State::Unloaded;
                 Load();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.cpp
@@ -14,6 +14,7 @@
 #include <AtomToolsFramework/PreviewRenderer/PreviewRendererCaptureRequest.h>
 #include <AtomToolsFramework/PreviewRenderer/PreviewRendererInterface.h>
 #include <AtomToolsFramework/Util/Util.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 #include <SharedPreview/SharedPreviewContent.h>
@@ -27,9 +28,15 @@ namespace AZ
         template<typename T>
         void LoadPreviewAsset(AZ::Data::Asset<T>& asset, const AZ::Data::AssetId& assetId)
         {
-            if (assetId.IsValid())
+            if (!asset.IsReady() && !asset.IsLoading() && assetId.IsValid())
             {
-                asset.Create(assetId, true);
+                AZ::Data::AssetInfo assetInfo;
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                    assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, assetId);
+                if (assetInfo.m_assetId.IsValid())
+                {
+                    asset.Create(assetId, true);
+                }
             }
         }
 
@@ -41,26 +48,18 @@ namespace AZ
 
         SharedThumbnailRenderer::SharedThumbnailRenderer()
         {
-            //models/sphere.azmodel
-            m_defaultModelAsset.Create(AZ::Data::AssetId("{6DE0E9A8-A1C7-5D0F-9407-4E627C1F223C}", 284780167));
-            //lightingpresets/thumbnail.lightingpreset.azasset
-            m_defaultLightingPresetAsset.Create(AZ::Data::AssetId("{4F3761EF-E279-5FDD-98C3-EF90F924FBAC}", 0));
-            //materials/reflectionprobe/reflectionprobevisualization.azmaterial
-            m_reflectionMaterialAsset.Create(AZ::Data::AssetId("{4322FBCB-8916-5572-9CDA-18582E22D238}", 0));
-
             for (const AZ::Uuid& typeId : SharedPreviewUtils::GetSupportedAssetTypes())
             {
                 AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler::BusConnect(typeId);
             }
+
             SystemTickBus::Handler::BusConnect();
-            AzFramework::AssetCatalogEventBus::Handler::BusConnect();
         }
 
         SharedThumbnailRenderer::~SharedThumbnailRenderer()
         {
             AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler::BusDisconnect();
             SystemTickBus::Handler::BusDisconnect();
-            AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
         }
 
         bool SharedThumbnailRenderer::ThumbnailConfig::IsValid() const
@@ -167,39 +166,45 @@ namespace AZ
 
         void SharedThumbnailRenderer::RenderThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize)
         {
-            if (auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get())
+            auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get();
+            if (!previewRenderer)
             {
-                const auto& thumbnailConfig = GetThumbnailConfig(thumbnailKey);
-                if (thumbnailConfig.IsValid())
-                {
-                    previewRenderer->AddCaptureRequest(
-                        { thumbnailSize,
-                          AZStd::make_shared<SharedPreviewContent>(
-                              previewRenderer->GetScene(), previewRenderer->GetView(), previewRenderer->GetEntityContextId(),
-                              thumbnailConfig.m_modelAsset, thumbnailConfig.m_materialAsset, thumbnailConfig.m_lightingAsset,
-                              Render::MaterialPropertyOverrideMap()),
-                          [thumbnailKey]()
-                          {
-                              // Instead of sending the notification that the thumbnail render failed, we will allow it to succeed and
-                              // substitute it with a blank image. This will prevent the thumbnail system from getting stuck indefinitely
-                              // with a white file icon and allow the thumbnail to reload if the asset changes in the future. The thumbnail
-                              // system should be updated to support state management and recovery automatically.
-                              QPixmap pixmap(1, 1);
-                              pixmap.fill(Qt::black);
-                              AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                                  thumbnailKey,
-                                  &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
-                                  pixmap);
-                          },
-                          [thumbnailKey](const QPixmap& pixmap)
-                          {
-                              AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                                  thumbnailKey,
-                                  &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
-                                  pixmap);
-                          } });
-                }
+                AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                    thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                return;
             }
+
+            if (!m_defaultModelAsset.IsReady() || !m_defaultLightingPresetAsset.IsReady() || !m_reflectionMaterialAsset.IsReady())
+            {
+                AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                    thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                return;
+            }
+
+            const auto& thumbnailConfig = GetThumbnailConfig(thumbnailKey);
+            if (!thumbnailConfig.IsValid())
+            {
+                AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                    thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                return;
+            }
+
+            previewRenderer->AddCaptureRequest(
+                { thumbnailSize,
+                    AZStd::make_shared<SharedPreviewContent>(
+                        previewRenderer->GetScene(), previewRenderer->GetView(), previewRenderer->GetEntityContextId(),
+                        thumbnailConfig.m_modelAsset, thumbnailConfig.m_materialAsset, thumbnailConfig.m_lightingAsset,
+                        Render::MaterialPropertyOverrideMap()),
+                    [thumbnailKey]()
+                    {
+                      AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                          thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                    },
+                    [thumbnailKey](const QPixmap& pixmap)
+                    {
+                      AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                          thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered, pixmap);
+                    } });
         }
 
         bool SharedThumbnailRenderer::Installed() const
@@ -209,15 +214,14 @@ namespace AZ
 
         void SharedThumbnailRenderer::OnSystemTick()
         {
-            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::ExecuteQueuedEvents();
-        }
+            // models/sphere.azmodel
+            LoadPreviewAsset(m_defaultModelAsset, AZ::Data::AssetId("{6DE0E9A8-A1C7-5D0F-9407-4E627C1F223C}", 284780167));
+            // lightingpresets/thumbnail.lightingpreset.azasset
+            LoadPreviewAsset(m_defaultLightingPresetAsset, AZ::Data::AssetId("{4F3761EF-E279-5FDD-98C3-EF90F924FBAC}", 0));
+            // materials/reflectionprobe/reflectionprobevisualization.azmaterial
+            LoadPreviewAsset(m_reflectionMaterialAsset, AZ::Data::AssetId("{4322FBCB-8916-5572-9CDA-18582E22D238}", 0));
 
-        void SharedThumbnailRenderer::OnCatalogLoaded([[maybe_unused]] const char* catalogFile)
-        {
-            m_defaultMaterialAsset.QueueLoad();
-            m_defaultModelAsset.QueueLoad();
-            m_defaultLightingPresetAsset.QueueLoad();
-            m_reflectionMaterialAsset.QueueLoad();
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::ExecuteQueuedEvents();
         }
     } // namespace LyIntegration
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedThumbnailRenderer.h
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 #include <AzCore/Component/TickBus.h>
-#include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzToolsFramework/Thumbnails/Thumbnail.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 #include <Thumbnails/Thumbnail.h>
@@ -26,7 +25,6 @@ namespace AZ
         class SharedThumbnailRenderer final
             : public AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::MultiHandler
             , public SystemTickBus::Handler
-            , public AzFramework::AssetCatalogEventBus::Handler
         {
         public:
             AZ_CLASS_ALLOCATOR(SharedThumbnailRenderer, AZ::SystemAllocator);
@@ -51,9 +49,6 @@ namespace AZ
 
             //! SystemTickBus::Handler interface overrides...
             void OnSystemTick() override;
-
-            // AzFramework::AssetCatalogEventBus::Handler overrides...
-            void OnCatalogLoaded(const char* catalogFile) override;
 
             // Default assets to be kept loaded and used for rendering if not overridden
             Data::Asset<RPI::AnyAsset> m_defaultLightingPresetAsset;

--- a/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Model/Slot.h
@@ -67,6 +67,8 @@ namespace GraphModel
 
         AZStd::size_t GetHash() const;
 
+        AZStd::string ToString() const;
+
         SlotName m_name;
         SlotSubId m_subId = 0;
     };

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -46,6 +46,7 @@ namespace GraphModel
                 ->Attribute(AZ::Script::Attributes::Module, "editor.graph")
                 ->Constructor<const SlotName&>()
                 ->Constructor<const SlotName&, SlotSubId>()
+                ->Method("__repr__", &SlotId::ToString)
                 ->Method("IsValid", &SlotId::IsValid)
                 ->Method("GetHash", &SlotId::GetHash)
                 ->Property("name", BehaviorValueProperty(&SlotId::m_name))
@@ -116,6 +117,11 @@ namespace GraphModel
         AZStd::hash_combine(result, m_name);
         AZStd::hash_combine(result, m_subId);
         return result;
+    }
+
+    AZStd::string SlotId::ToString() const
+    {
+        return AZStd::string::format("GraphModelSlotId(%s,%d)", m_name.c_str(), m_subId);
     }
 
     /////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

- Rename LoadComplete function to QueueThumbnailUpdated.
- Removed the thumbnail loading animation. This was animating every tick, for every thumbnail context, sending multiple requests every frame to update thumbnails in the asset browser and repaint it. This is a massive drain on performance, startup times, and editor usability while thumbnails are loading or rendering. Before completely removing the animation, I attempted using a timer to send the updates at intervals of 250 milliseconds and 500 milliseconds. Both were performance improvements but not animating at all means that the asset browser does not need to be updated continuously. Changing the interval to 500 milliseconds or one second makes the animation look broken. Currently using a static black image. Will investigate better options, like a static image with a dial or three dots to signify processing.
- Remove the thumbnail job limit from the thumbnailer component. This is no longer required now that it is using the job system. Having the limit has the potential to keep thumbnails that were requested as part of a batch from updating. Between the job system and the preview renderer, nonimage thumbnails are still only processed one at a time.
- Updated the masked occlusion culling system with a dirty flag so that the occlusion buffer is only cleared if it was actually written to the previous frame. Clearing the occlusion buffer was always showing as the hot path in the profile even though there were no occlusion planes in my level and none in the thumbnail scenes either.

## How was this PR tested?

Launching the editor several times.
Scrolling and scrubbing through the asset browser in different views.
Confirming the increased frame rate and editor responsiveness.