### PR TITLE
Fix hard-coded multi sample setting for animation viewport renderer 

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -85,6 +85,10 @@ namespace EMStudio
         AZStd::optional<AZ::RPI::RenderPipelineDescriptor> renderPipelineDesc =
             AZ::RPI::GetRenderPipelineDescriptorFromAsset(pipelineAssetPath.c_str(), AZStd::string::format("_%i", viewportContext->GetId()));
         AZ_Assert(renderPipelineDesc.has_value(), "Invalid render pipeline descriptor from asset %s", pipelineAssetPath.c_str());
+
+        const AZ::RHI::MultisampleState multiSampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
+        renderPipelineDesc.value().m_renderSettings.m_multisampleState = multiSampleState;
+        AZ_Printf("AnimViewportRenderer", "Animation viewport renderer starting with multi sample %d", multiSampleState.m_samples);
         
         m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(renderPipelineDesc.value(), *m_windowContext.get());
         m_scene->AddRenderPipeline(m_renderPipeline);


### PR DESCRIPTION
This PR fixes #17217 

What does this PR do?

This PR fix the hard coded animation editor's multi sample settings, use the main editor's multi sample setting instead.

In Bug #17217 , it is because the shaders are compiled according to the multi sample state from the render pipeline loaded to the main editor, but the animation editor is hard coded to read the multi sample state  in `MainRenderPipeline.azasset`, so if the engine is not started with main render pipeline, there is a chance that the multi sample state is mismatch.

Here I fix the multi sample state for the render pipeline in animation editor, at least load the same multi sample state from the activated application, to ensure the multi sample state matches the shaders'.

## How was this PR tested?

Self tested, it works for me.
