### PR TITLE
[SMC] shadervariantlist init from asset crawling python script: do no…

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
@@ -48,6 +48,7 @@ namespace AZ
                     ->Method("GetValueByOptionName", static_cast<ShaderOptionValue (ShaderOptionGroup::*)(const Name&) const>(&ShaderOptionGroup::GetValue))
                     ->Method("GetShaderOptionDescriptors", &ShaderOptionGroup::GetShaderOptionDescriptors)
                     ->Method("GetShaderVariantId", &ShaderOptionGroup::GetShaderVariantId)
+                    ->Method("ClearValue", static_cast<bool (ShaderOptionGroup::*)(const Name&)>(&ShaderOptionGroup::ClearValue))
                     ;
             }
         }


### PR DESCRIPTION
This PR makes the material crawler script generate "lean" variants (no extremely constrained default values everywhere).

Result:
![image](https://github.com/o3de/o3de/assets/25970839/ef127e77-2f6b-4ea1-b1b2-62dd97365031)
