### PR TITLE
SwapChain-related resources

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
@@ -10,7 +10,7 @@
 
 #include <Atom/RPI.Public/Base.h>
 
-#include <Atom/RHI/SingleDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 
 #include <Atom/RHI.Reflect/Scissor.h>
 #include <Atom/RHI.Reflect/Viewport.h>
@@ -57,7 +57,7 @@ namespace AZ
             const RHI::AttachmentId& GetSwapChainAttachmentId(ViewType viewType = ViewType::Default) const;
 
             //! Retrieves the underlying SwapChain created by this WindowContext
-            const RHI::Ptr<RHI::SingleDeviceSwapChain>& GetSwapChain(ViewType viewType = ViewType::Default) const;
+            const RHI::Ptr<RHI::MultiDeviceSwapChain>& GetSwapChain(ViewType viewType = ViewType::Default) const;
 
             //! Retrieves the default ViewportState for the WindowContext
             const RHI::Viewport& GetViewport(ViewType viewType = ViewType::Default) const;
@@ -119,7 +119,7 @@ namespace AZ
             struct SwapChainData
             {
                 // RHI SwapChain object itself
-                RHI::Ptr<RHI::SingleDeviceSwapChain> m_swapChain;
+                RHI::Ptr<RHI::MultiDeviceSwapChain> m_swapChain;
 
                 // The default viewport that covers the entire surface
                 RHI::Viewport m_viewport;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -195,7 +195,7 @@ namespace AZ
 
             // Import the SwapChain
             attachmentDatabase.ImportSwapChain(
-                m_windowContext->GetSwapChainAttachmentId(m_viewType), m_windowContext->GetSwapChain(m_viewType));
+                m_windowContext->GetSwapChainAttachmentId(m_viewType), m_windowContext->GetSwapChain(m_viewType)->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex));
 
             ParentPass::FrameBeginInternal(params);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -79,7 +79,7 @@ namespace AZ
             return GetSwapChain(viewType)->GetAttachmentId();
         }
 
-        const RHI::Ptr<RHI::SingleDeviceSwapChain>& WindowContext::GetSwapChain(ViewType viewType) const
+        const RHI::Ptr<RHI::MultiDeviceSwapChain>& WindowContext::GetSwapChain(ViewType viewType) const
         {
             uint32_t swapChainIndex = static_cast<uint32_t>(viewType);
             AZ_Assert(swapChainIndex < GetSwapChainsSize(), "Swapchain with index %i does not exist", swapChainIndex);
@@ -122,7 +122,7 @@ namespace AZ
 
         bool WindowContext::CheckResizeSwapChain()
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
+            RHI::Ptr<RHI::MultiDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             const AZ::RHI::SwapChainDimensions& currentDimensions = defaultSwapChain->GetDescriptor().m_dimensions;
             AzFramework::WindowSize renderSize = ResolveSwapchainSize();
             if (renderSize.m_width != currentDimensions.m_imageWidth || renderSize.m_height != currentDimensions.m_imageHeight)
@@ -131,7 +131,7 @@ namespace AZ
                 RHI::SwapChainDimensions dimensions = defaultSwapChain->GetDescriptor().m_dimensions;
                 dimensions.m_imageWidth = renderSize.m_width;
                 dimensions.m_imageHeight = renderSize.m_height;
-                dimensions.m_imageFormat = GetSwapChainFormat(defaultSwapChain->GetDevice());
+                dimensions.m_imageFormat = GetSwapChainFormat(*RHI::RHISystemInterface::Get()->GetDevice(static_cast<int>(log2(static_cast<float>(defaultSwapChain->GetDeviceMask())))));
 
                 FillWindowState(dimensions.m_imageWidth, dimensions.m_imageHeight);
 
@@ -155,7 +155,7 @@ namespace AZ
 
         void WindowContext::OnVsyncIntervalChanged(uint32_t interval)
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
+            RHI::Ptr<RHI::MultiDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             if (defaultSwapChain->GetDescriptor().m_verticalSyncInterval != interval)
             {
                 defaultSwapChain->SetVerticalSyncInterval(interval);
@@ -164,19 +164,19 @@ namespace AZ
 
         bool WindowContext::IsExclusiveFullScreenPreferred() const
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
+            RHI::Ptr<RHI::MultiDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             return defaultSwapChain->IsExclusiveFullScreenPreferred();
         }
 
         bool WindowContext::GetExclusiveFullScreenState() const
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
+            RHI::Ptr<RHI::MultiDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             return defaultSwapChain->GetExclusiveFullScreenState();
         }
 
         bool WindowContext::SetExclusiveFullScreenState(bool fullScreenState)
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
+            RHI::Ptr<RHI::MultiDeviceSwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             return defaultSwapChain->SetExclusiveFullScreenState(fullScreenState);
         }
 
@@ -206,7 +206,7 @@ namespace AZ
 
         void WindowContext::CreateSwapChains(RHI::Device& device)
         {
-            RHI::Ptr<RHI::SingleDeviceSwapChain> swapChain = RHI::Factory::Get().CreateSwapChain();
+            RHI::Ptr<RHI::MultiDeviceSwapChain> swapChain = aznew RHI::MultiDeviceSwapChain;
 
             RHI::SwapChainDescriptor descriptor;
 
@@ -228,7 +228,7 @@ namespace AZ
 
             AZStd::string attachmentName = AZStd::string::format("WindowContextAttachment_%p", m_windowHandle);
             descriptor.m_attachmentId = RHI::AttachmentId{ attachmentName.c_str() };
-            swapChain->Init(device, descriptor);
+            swapChain->Init(device.GetDeviceIndex(), descriptor);
             descriptor = swapChain->GetDescriptor(); // Get descriptor from swapchain because it can set different values during initialization
 
             RHI::Viewport viewport;
@@ -260,7 +260,7 @@ namespace AZ
                 AZ_Assert(numXrViews <= 2, "Atom only supports two XR views");
                 for (AZ::u32 i = 0; i < numXrViews; i++)
                 {
-                    RHI::Ptr<RHI::SingleDeviceSwapChain> xrSwapChain = RHI::Factory::Get().CreateSwapChain();
+                    RHI::Ptr<RHI::MultiDeviceSwapChain> xrSwapChain = aznew RHI::MultiDeviceSwapChain;
                     RHI::SwapChainDescriptor xrDescriptor;
                     xrDescriptor.m_dimensions.m_imageWidth = xrSystem->GetSwapChainWidth(i);
                     xrDescriptor.m_dimensions.m_imageHeight = xrSystem->GetSwapChainHeight(i);
@@ -272,7 +272,7 @@ namespace AZ
 
                     const AZStd::string xrAttachmentName = AZStd::string::format("XRSwapChain_View_%i", i);
                     xrDescriptor.m_attachmentId = RHI::AttachmentId{ xrAttachmentName.c_str() };
-                    xrSwapChain->Init(device, xrDescriptor);
+                    xrSwapChain->Init(device.GetDeviceIndex(), xrDescriptor);
                     xrDescriptor = xrSwapChain->GetDescriptor(); // Get descriptor from swapchain because it can set different values during initialization
 
                     RHI::Viewport xrViewport;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -131,6 +131,7 @@ namespace AZ
                 RHI::SwapChainDimensions dimensions = defaultSwapChain->GetDescriptor().m_dimensions;
                 dimensions.m_imageWidth = renderSize.m_width;
                 dimensions.m_imageHeight = renderSize.m_height;
+                // Note: there is only one bit set in the mask, so we simply get the device index with log2
                 dimensions.m_imageFormat = GetSwapChainFormat(*RHI::RHISystemInterface::Get()->GetDevice(static_cast<int>(log2(static_cast<float>(defaultSwapChain->GetDeviceMask())))));
 
                 FillWindowState(dimensions.m_imageWidth, dimensions.m_imageHeight);


### PR DESCRIPTION
## What does this PR do?
This specific PR transitions resources related to `SwapChain*` to `MultiDeviceSwapChain*`.
### General Idea
This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a https://github.com/o3de/o3de/pull/14079, however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of ->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex) to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using RHI::MultiDevice::DefaultDeviceIndex everywhere because it simplifies the transition.
## How was this PR tested?
- `Gem::Atom_RPI.Tests.main`

