### PR TITLE
RaytracingAccelerationStructurePass: Fixed barriers for non-animated meshes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -244,6 +244,7 @@ namespace AZ
                     for (auto submeshIndex = 0; submeshIndex < blasInstance.second.m_subMeshes.size(); ++submeshIndex)
                     {
                         auto& submeshBlasInstance = blasInstance.second.m_subMeshes[submeshIndex];
+                        changedBlasList.push_back(submeshBlasInstance.m_blas.get());
                         if (blasInstance.second.m_blasBuilt == false)
                         {
                             // Always build the BLAS, if it has not previously been built
@@ -266,7 +267,6 @@ namespace AZ
                             // Fall back to building the BLAS in any case
                             context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas);
                         }
-                        changedBlasList.push_back(submeshBlasInstance.m_blas.get());
                     }
 
                     blasInstance.second.m_blasBuilt = true;


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/17156
The BLAS of non-animated meshes where not added to the changedBlasList, resulting in missing barriers for these meshes, or no barriers at all if no animated meshes are present in the scene.

## How was this PR tested?

Windows and Vulkan/DX12
