### PR TITLE
Fix Linux/Mac errors for the android generation scripts

### DIFF
--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -52,7 +52,7 @@ elif platform.system() == 'Linux':
     EXE_EXTENSION = ''
     O3DE_SCRIPT_EXTENSION = '.sh'
     SDKMANAGER_EXTENSION = ''
-    GRADLE_EXTENSION = '.sh'
+    GRADLE_EXTENSION = ''
     DEFAULT_ANDROID_SDK_PATH = f"{os.getenv('HOME')}/Android/Sdk"
     PYTHON_SCRIPT = 'python.sh'
 else:
@@ -475,7 +475,7 @@ class AndroidSDKManager(object):
                                    f"Make sure that it is installed at {android_sdk_command_line_tools_root}.")
 
         # Retrieve the version if possible to validate it can be used
-        command_arg = [android_sdk_command_line_tool.name, '--version']
+        command_arg = [android_sdk_command_line_tool, '--version']
         logging.debug("Validating tool version exec: (%s)", subprocess.list2cmdline(command_arg))
         result = subprocess.run(command_arg,
                                 shell=(platform.system() == 'Windows'),
@@ -675,8 +675,8 @@ class AndroidSDKManager(object):
         that provides information on how to accept them.
         """
         logger.info("Checking Android SDK Package licenses state..")
-        result = subprocess.run(['echo' , 'Y' , '|', self._android_command_line_tools_sdkmanager_path, '--licenses'],
-                                shell=(platform.system() == 'Windows'),
+        result = subprocess.run(f"echo 'Y' | \"{self._android_command_line_tools_sdkmanager_path}\" --licenses",
+                                shell=True,
                                 capture_output=True,
                                 encoding=DEFAULT_READ_ENCODING,
                                 errors=ENCODING_ERROR_HANDLINGS,
@@ -689,6 +689,7 @@ class AndroidSDKManager(object):
         if license_accepted_match:
             logger.info(license_accepted_match.group(1))
         else:
+            print(result.stdout)
             raise AndroidToolError("Unable to determine the Android SDK Package license state. \n"
                                    f"Please run '{self._android_command_line_tools_sdkmanager_path} --licenses' to troubleshoot the issue.\n")
 

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -689,7 +689,6 @@ class AndroidSDKManager(object):
         if license_accepted_match:
             logger.info(license_accepted_match.group(1))
         else:
-            print(result.stdout)
             raise AndroidToolError("Unable to determine the Android SDK Package license state. \n"
                                    f"Please run '{self._android_command_line_tools_sdkmanager_path} --licenses' to troubleshoot the issue.\n")
 


### PR DESCRIPTION
## What does this PR do?

Fixes various issues around tool detection for the android generation scripts that only occur on Linux/Mac

## How was this PR tested?

Ran `o3de.sh android-configure --list --validate` on both Linux and Mac
Ran `o3de.sh android-generate -B build/android` on both Linux and Mac
Ran `gradlew assembleProfile` on o3de-atomsampleviewer on Linux and Mac

