### PR TITLE
Adding launcher setregpatch generation for profile builds

### DIFF
--- a/scripts/o3de/ExportScripts/IgnoreAssetProcessor.profile.setregpatch
+++ b/scripts/o3de/ExportScripts/IgnoreAssetProcessor.profile.setregpatch
@@ -1,4 +1,6 @@
 [
+    // This file is intended to be included in exported projects to prevent the asset processor 
+    // from launching from the exported location. 
     {
         "op": "add",
         "path": "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor",

--- a/scripts/o3de/ExportScripts/IgnoreAssetProcessor.profile.setregpatch
+++ b/scripts/o3de/ExportScripts/IgnoreAssetProcessor.profile.setregpatch
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "add",
+        "path": "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor",
+        "value": false
+    }
+]

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -200,17 +200,21 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
     if should_build_game_launcher:
         export_layouts.append(exp.ExportLayoutConfig(output_path=output_path / f'{ctx.project_name}GamePackage',
                                                      project_file_patterns=project_file_patterns_to_copy + game_project_file_patterns_to_copy,
-                                                     ignore_file_patterns=[f'*.ServerLauncher{exp.EXECUTABLE_EXTENSION}', f'*.UnifiedLauncher{exp.EXECUTABLE_EXTENSION}']))
+                                                     ignore_file_patterns=[f'*.ServerLauncher{exp.EXECUTABLE_EXTENSION}', f'*.UnifiedLauncher{exp.EXECUTABLE_EXTENSION}'],
+                                                     launcher_type=exp.LauncherType.GAME,
+                                                     launch_flags=['-bg_ConnectToAssetProcessor=0', '-sys_PakPriority=2']))
 
     if should_build_server_launcher:
         export_layouts.append(exp.ExportLayoutConfig(output_path=output_path / f'{ctx.project_name}ServerPackage',
                                                      project_file_patterns=project_file_patterns_to_copy + server_project_file_patterns_to_copy,
-                                                     ignore_file_patterns=[f'*.GameLauncher{exp.EXECUTABLE_EXTENSION}', f'*.UnifiedLauncher{exp.EXECUTABLE_EXTENSION}']))
+                                                     ignore_file_patterns=[f'*.GameLauncher{exp.EXECUTABLE_EXTENSION}', f'*.UnifiedLauncher{exp.EXECUTABLE_EXTENSION}'],
+                                                     launcher_type=exp.LauncherType.SERVER))
 
     if should_build_unified_launcher:
         export_layouts.append(exp.ExportLayoutConfig(output_path=output_path / f'{ctx.project_name}UnifiedPackage',
                                                      project_file_patterns=project_file_patterns_to_copy + game_project_file_patterns_to_copy + server_project_file_patterns_to_copy,
-                                                     ignore_file_patterns=[f'*.ServerLauncher{exp.EXECUTABLE_EXTENSION}', f'*.GameLauncher{exp.EXECUTABLE_EXTENSION}']))
+                                                     ignore_file_patterns=[f'*.ServerLauncher{exp.EXECUTABLE_EXTENSION}', f'*.GameLauncher{exp.EXECUTABLE_EXTENSION}'],
+                                                     launcher_type=exp.LauncherType.UNIFIED))
 
     # Generate the layouts and archive the packages based on the desired launcher types
     for export_layout in export_layouts:
@@ -224,7 +228,30 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                             export_layout=export_layout,
                                             archive_output_format=archive_output_format,
                                             logger=logger)
+        if build_config == 'profile':
+            generate_launcher_startup_script(selected_platform, ctx.project_name, export_layout.launcher_type, export_layout.launch_flags, export_layout.output_path)
 
+def generate_launcher_startup_script(platform, project_name, launcher_type, launch_flags, output_path):
+    launcher_name = 'GameLauncher' if launcher_type == exp.LauncherType.GAME else \
+                    ('ServerLauncher' if launcher_type == exp.LauncherType.SERVER else 'UnifiedLauncher')
+    slash = '.\\' if platform == 'pc' else './'
+
+    # We do not use pathlib in this specific instance b/c its string conversion removes the initial './', which can trip up the shell script
+    exec_path = f"{slash}{project_name}.{launcher_name}{'.exe' if platform == 'pc' else ''}"
+    script_extension = 'cmd' if platform == 'pc' else 'sh'
+    comment_type = 'REM' if platform == 'pc' else '#'
+    cmd_text = f"""
+{comment_type} This game was exported using profile mode.
+{comment_type} Profile games try to open the AssetProcessor by default, but PAK files must be used for portability, so disable connecting to asset processor
+{comment_type} Use a release mode configuration to avoid having to use this script
+
+{str(exec_path)}  {' '.join(launch_flags)}
+"""
+    output_path.mkdir(parents = True, exist_ok=True)
+    script_path = output_path / f'{project_name}.{launcher_name}.START_GAME.{script_extension}'
+    
+    with open(script_path, 'w+') as cmd_file:
+        cmd_file.write(cmd_text)
 
 def export_standalone_parse_args(o3de_context: exp.O3DEScriptExportContext, export_config: command_utils.O3DEConfig):
 

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -9,7 +9,6 @@
 import argparse
 import glob
 import logging
-import json
 import os
 import sys
 
@@ -225,14 +224,6 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                             export_layout=export_layout,
                                             archive_output_format=archive_output_format,
                                             logger=logger)
-        if build_config == 'profile':
-            generate_launcher_startup_setreg_patch(ctx.project_name, export_layout.output_path / 'Registry')
-
-def generate_launcher_startup_setreg_patch(project_name, output_path):
-    setregpatch = [{ "op": "add", "path": "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor", "value": False }]
-    output_path.mkdir(parents=True, exist_ok=True)
-    with open(output_path / f'{project_name.lower()}_export.setregpatch', 'w+') as patch_file:
-        json.dump(setregpatch, patch_file, indent=4)
 
 def export_standalone_parse_args(o3de_context: exp.O3DEScriptExportContext, export_config: command_utils.O3DEConfig):
 

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -178,10 +178,14 @@ class ExportLayoutConfig(object):
     def __init__(self,
                  output_path: pathlib.Path,
                  project_file_patterns: List[str],
-                 ignore_file_patterns: List[str]):
+                 ignore_file_patterns: List[str],
+                 launcher_type: int = 0,
+                 launch_flags: List[str] = []):
         self.output_path = output_path
         self.project_file_patterns = project_file_patterns
         self.ignore_file_patterns = ignore_file_patterns
+        self.launcher_type = launcher_type
+        self.launch_flags = launch_flags
 
 
 class LauncherType(IntEnum):

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -946,6 +946,16 @@ def setup_launcher_layout_directory(project_path: pathlib.Path,
     
     with open(export_layout.output_path / 'project.json', 'w') as project_json_file:
         json.dump({"project_name": project_name}, project_json_file, ensure_ascii=True)
+    
+    if build_config == 'profile':
+        # This file is intended to be included in exported projects to prevent the asset processor from
+        # launching from the exported location. If you want to launch the asset processor anyways from an exported project,
+        # delete the copy of this file in the `Registry` subfolder found in the exported location.
+
+        setregpatch_file = pathlib.Path(__file__).parent.parent / 'ExportScripts/IgnoreAssetProcessor.profile.setregpatch'
+        (export_layout.output_path / 'Registry').mkdir(exist_ok=True) 
+        shutil.copy(setregpatch_file, export_layout.output_path / 'Registry')
+
 
     # Optionally compress the layout directory into an archive if the user requests
     if archive_output_format != "none":

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -178,14 +178,10 @@ class ExportLayoutConfig(object):
     def __init__(self,
                  output_path: pathlib.Path,
                  project_file_patterns: List[str],
-                 ignore_file_patterns: List[str],
-                 launcher_type: int = 0,
-                 launch_flags: List[str] = []):
+                 ignore_file_patterns: List[str]):
         self.output_path = output_path
         self.project_file_patterns = project_file_patterns
         self.ignore_file_patterns = ignore_file_patterns
-        self.launcher_type = launcher_type
-        self.launch_flags = launch_flags
 
 
 class LauncherType(IntEnum):

--- a/scripts/o3de/tests/ExportScripts/test_export_source_built_project.py
+++ b/scripts/o3de/tests/ExportScripts/test_export_source_built_project.py
@@ -10,7 +10,6 @@ import pytest
 import pathlib
 from unittest.mock import patch, create_autospec, MagicMock, Mock, PropertyMock
 from o3de.export_project import O3DEScriptExportContext, LauncherType
-import json
 import logging
 import configparser
 
@@ -18,8 +17,7 @@ import configparser
 import o3de.utils as utils
 from o3de import command_utils
 utils.prepend_to_system_path(pathlib.Path(__file__).parent.parent.parent / 'ExportScripts')
-from export_source_built_project import export_standalone_project, export_standalone_parse_args, export_standalone_run_command,\
-                                        generate_launcher_startup_setreg_patch
+from export_source_built_project import export_standalone_project, export_standalone_parse_args, export_standalone_run_command
 
 def test_should_fail_immediately_for_installer_mono_build_with_no_artifacts(tmp_path):
     test_project_name = "TestProject"
@@ -33,8 +31,7 @@ def test_should_fail_immediately_for_installer_mono_build_with_no_artifacts(tmp_
     with patch('o3de.manifest.is_sdk_engine', return_value=True) as mock_is_sdk_engine,\
         patch('o3de.export_project.has_monolithic_artifacts', return_value=False) as mock_has_mono_artifacts,\
         patch('o3de.export_project.kill_existing_processes') as mock_kill_processes,\
-        pytest.raises(exp.ExportProjectError),\
-        patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+        pytest.raises(exp.ExportProjectError):
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
         mock_ctx.project_path = test_project_path
@@ -55,7 +52,6 @@ def test_should_fail_immediately_for_installer_mono_build_with_no_artifacts(tmp_
         mock_is_sdk_engine.assert_called_once_with(engine_path=mock_ctx.engine_path)
         mock_has_mono_artifacts.assert_called_once_with(mock_ctx)
         mock_kill_processes.assert_not_called()
-        mock_launch_script.assert_not_called()
 
 
 @pytest.mark.parametrize("is_engine_centric, use_sdk, should_build_tools_flag, has_monolithic, use_monolithic, expect_toolchain_build_called", [
@@ -121,8 +117,7 @@ def test_build_tools_combinations(tmp_path, is_engine_centric, use_sdk, should_b
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets') as mock_bundle_assets,\
          patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
-         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
         mock_ctx.project_path = test_project_path
@@ -179,7 +174,6 @@ def test_build_tools_combinations(tmp_path, is_engine_centric, use_sdk, should_b
                                                                         engine_centric=is_engine_centric,
                                                                         tool_config="profile",
                                                                         logger=mock_logger)
-                    
                 else:
                     mock_build_export_toolchain.assert_not_called()
             
@@ -230,8 +224,7 @@ def test_asset_bundler_combinations(tmp_path, is_engine_centric, use_sdk, has_mo
          patch('o3de.export_project.build_assets') as mock_build_assets,\
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets') as mock_bundle_assets,\
-         patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+         patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
         mock_ctx.project_path = test_project_path
@@ -356,8 +349,7 @@ def test_asset_bundler_seed_combinations(tmp_path, test_seedlists, test_seedfile
          patch('o3de.export_project.build_assets') as mock_build_assets,\
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets') as mock_bundle_assets,\
-         patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+         patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
         mock_ctx.project_path = test_project_path
@@ -437,8 +429,7 @@ def test_asset_processor_combinations(tmp_path, is_engine_centric, use_sdk, has_
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets') as mock_bundle_assets,\
          patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
-         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
 
 
         mock_ctx = create_autospec(O3DEScriptExportContext)
@@ -594,8 +585,7 @@ def test_build_game_targets_combinations(tmp_path, is_engine_centric, use_sdk, h
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets') as mock_bundle_assets,\
          patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
-         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch') as mock_launch_script:
+         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
 
         mock_ctx = create_autospec(O3DEScriptExportContext)
@@ -725,15 +715,6 @@ def test_setup_launcher_layout_directory(tmp_path, is_engine_centric, use_sdk, h
     def reset_cache():
         nonlocal setup_dir_cache
         setup_dir_cache = []
-    
-    gen_setregpatch_cache = []
-    def cache_gen_params(*args):
-        nonlocal gen_setregpatch_cache
-        gen_setregpatch_cache.append(args)
-    
-    def reset_gen_cache():
-        nonlocal gen_setregpatch_cache
-        gen_setregpatch_cache = []
 
     test_project_name = "TestProject"
     test_project_path = tmp_path / "project"
@@ -763,8 +744,7 @@ def test_setup_launcher_layout_directory(tmp_path, is_engine_centric, use_sdk, h
          patch('o3de.export_project.get_asset_bundler_batch_path') as mock_get_asset_bundler_path,\
          patch('o3de.export_project.bundle_assets', return_value=bundle_output_path) as mock_bundle_assets,\
          patch('o3de.export_project.setup_launcher_layout_directory', side_effect=cache_params) as mock_setup_launcher_layout_directory,\
-         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger,\
-         patch('export_source_built_project.generate_launcher_startup_setreg_patch', side_effect=cache_gen_params) as mock_launch_script:
+         patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
         mock_ctx.project_path = test_project_path
@@ -887,42 +867,9 @@ def test_setup_launcher_layout_directory(tmp_path, is_engine_centric, use_sdk, h
                         
                         assert settings_remaining == 0
 
-                        if buildconf == 'profile':
-                            # test the setregpatch
-                            settings_remaining = settings_count
-                            for argset in gen_setregpatch_cache:
-                                assert argset[0] == mock_ctx.project_name
-                                output_path = argset[1]
-                                
-                                registry_folder_name = output_path.name
-                                assert registry_folder_name == 'Registry'
-
-                                package_folder_name = output_path.parent.name
-                                for stub in launcher_stubs:
-                                    if package_folder_name == f'{mock_ctx.project_name}{stub}' and launcher_map[stub] & check_launcher_type > 0:
-                                        settings_remaining -= 1
-                                        break
-                            assert settings_remaining == 0
-
                     reset_cache()
-                    reset_gen_cache()
                     mock_setup_launcher_layout_directory.reset_mock()
 
-
-def test_generate_launcher_startup_setreg_patch(tmp_path):
-    
-    generate_launcher_startup_setreg_patch("TestProject", tmp_path / 'game_output/Registry')
-    output_file = tmp_path / 'game_output/Registry/TestProject_export.setregpatch'
-    
-    assert output_file.exists()
-        
-    with open(output_file, 'r') as sf:
-        patch_list = json.load(sf)
-        assert len(patch_list) == 1
-        patch = patch_list[0]
-        assert patch['op'] == 'add'
-        assert patch['path'] == "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor"
-        assert patch['value'] == False
 
 #helper to generate settings file
 def create_dummy_commands_settings_file(build_config='profile', tool_config='profile', archive_format='none',

--- a/scripts/o3de/tests/test_export_project.py
+++ b/scripts/o3de/tests/test_export_project.py
@@ -6,6 +6,7 @@
 #
 #
 
+import json
 import pytest
 import pathlib
 import unittest.mock as mock
@@ -544,6 +545,18 @@ def test_setup_launcher_layout_directory(tmp_path, build_config, asset_platform,
         result_archive_file = tmp_path / f"output.{test_archive_output_format}"
         assert result_archive_file.is_file(), f"Missing <output>.{test_archive_output_format}"
 
+    setregpatch_file = test_output_path / 'Registry/IgnoreAssetProcessor.profile.setregpatch'
+    if build_config == 'profile':
+        assert (test_output_path / 'Registry').exists()
+        assert setregpatch_file.is_file()
+        with open(setregpatch_file,'r') as pf:
+            patch_data = json.load(pf)
+            assert len(patch_data) == 1
+            assert patch_data[0]['op'] == 'add'
+            assert patch_data[0]['value'] == False
+            assert patch_data[0]['path'] == "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor"
+    else:
+        assert not setregpatch_file.is_file()
 
 @pytest.mark.parametrize("project_path, create_files, check_abs_files, check_rel_files, expect_error",[
     pytest.param("project", ["project/SeedLists/seed1", "project/SeedLists/seed2"], ["project/SeedLists/seed1", "project/SeedLists/seed2"], [], False),

--- a/scripts/o3de/tests/test_export_project.py
+++ b/scripts/o3de/tests/test_export_project.py
@@ -550,11 +550,7 @@ def test_setup_launcher_layout_directory(tmp_path, build_config, asset_platform,
         assert (test_output_path / 'Registry').exists()
         assert setregpatch_file.is_file()
         with open(setregpatch_file,'r') as pf:
-            patch_data = json.load(pf)
-            assert len(patch_data) == 1
-            assert patch_data[0]['op'] == 'add'
-            assert patch_data[0]['value'] == False
-            assert patch_data[0]['path'] == "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor"
+            assert 'bg_ConnectToAssetProcessor' in pf.read()
     else:
         assert not setregpatch_file.is_file()
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes the issue found in https://github.com/o3de/o3de/issues/17222. The PR fixes the processor by preventing connecting to the asset processor via a setregpatch file. The file looks like this:

```
[
    {
        "op": "add",
        "path": "/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor",
        "value": false
    }
]
```

## How was this PR tested?
The script generation was tested from an O3DE Installer SDK and minimal game project template. Unit tests have also been added to ensure accuracy with patch generation.
