### PR TITLE
Change output directory for Android builds to fix SO not included in APK

### DIFF
--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -8,6 +8,15 @@
 
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # With Android Studio, the CMAKE_RUNTIME_OUTPUT_DIRECTORY, CMAKE_LIBRARY_OUTPUT_DIRECTORY and CMAKE_RUNTIME_OUTPUT_DIRECTORY are
+    # already different per configuration. There's no need to do "CMAKE_RUNTIME_OUTPUT_DIRECTORY\Debug" as the output folder.
+    # Having this extra configuration folder creates issues when copying the "runtime dependencies" files into the APK.
+    foreach(conf IN LISTS CMAKE_CONFIGURATION_TYPES)
+        string(TOUPPER ${conf} UCONF)
+        unset(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${UCONF} CACHE)    # Just use the CMAKE_ARCHIVE_OUTPUT_DIRECTORY for all configurations
+        unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${UCONF} CACHE)    # Just use the CMAKE_LIBRARY_OUTPUT_DIRECTORY for all configurations
+        unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${UCONF} CACHE)    # Just use the CMAKE_ARCHIVE_OUTPUT_DIRECTORY for all configurations
+    endforeach()
 
     include(cmake/Platform/Common/Configurations_common.cmake)
     include(cmake/Platform/Common/Clang/Configurations_clang.cmake)

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -680,7 +680,7 @@ class AndroidSDKManager(object):
                                 capture_output=True,
                                 encoding=DEFAULT_READ_ENCODING,
                                 errors=ENCODING_ERROR_HANDLINGS,
-                                timeout=2)
+                                timeout=5)
         license_not_accepted_match = AndroidSDKManager.LICENSE_NOT_ACCEPTED_REGEX.search(result.stdout or result.stderr)
         if license_not_accepted_match:
             raise AndroidToolError(f"{license_not_accepted_match.group(1)}\n"


### PR DESCRIPTION
## What does this PR do?

Change output folder for Android so it doesn't include an extra folder for each configuration. The path generated by Android Studio is already different per configuration. Having this extra folder creates issues when copying the runtime dependencies into the APK (they are not copied).

## How was this PR tested?

Build an Android APK with the vulkan validation layer library included in the APK.