### PR TITLE
Removed blur from highlights, it degraded performance significantly

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GlowOutlineGraphicsItem.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/GraphicsItems/GlowOutlineGraphicsItem.h
@@ -30,7 +30,7 @@ namespace GraphCanvas
     class GlowOutlineConfiguration
     {
     public:
-        qreal m_blurRadius;
+        qreal m_blurRadius = 0; // #17174 using blur degrades performance
         QPen m_pen;
 
         AZStd::chrono::milliseconds m_pulseRate = AZStd::chrono::milliseconds(0);

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1542,7 +1542,7 @@ namespace ScriptCanvasEditor
     {
         GraphCanvas::SceneMemberGlowOutlineConfiguration glowConfiguration;
 
-        glowConfiguration.m_blurRadius = 5;
+        glowConfiguration.m_blurRadius = 0; // #17174 using blur degrades performance
 
         glowConfiguration.m_pen = QPen();
         glowConfiguration.m_pen.setBrush(QColor(243,129,29));

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -420,7 +420,7 @@ namespace ScriptCanvasEditor
 
             glowConfiguration.m_sceneMember = graphCanvasNodeId;
 
-            glowConfiguration.m_blurRadius = 5;
+            glowConfiguration.m_blurRadius = 0; // #17174 using blur degrades performance
 
             glowConfiguration.m_pen = QPen();
             glowConfiguration.m_pen.setBrush(QColor(243, 129, 29));

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.cpp
@@ -47,7 +47,7 @@ namespace ScriptCanvasEditor
 
     HighlightElementValidationEffect::HighlightElementValidationEffect()
     {
-        m_templateConfiguration.m_blurRadius = 5;
+        m_templateConfiguration.m_blurRadius = 0; // #17174 using blur degrades performance
 
         m_templateConfiguration.m_pen = QPen();
         m_templateConfiguration.m_pen.setBrush(Qt::red);


### PR DESCRIPTION
Remove the blur from the Script Canvas highlight nodes function as it was identified to degrade performance significantly.

Closes #17174




https://github.com/o3de/o3de/assets/58790905/5bcf6220-a6cd-4287-8f90-3ef1a839f12a




