### PR TITLE
DPE | Fix grouping issue where properties would not be shown if registered after a group.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -975,11 +975,6 @@ namespace AZ::Reflection
                 {
                     StackEntry& nodeData = m_stack.back();
 
-                    if (!nodeData.m_entryClosed)
-                    {
-                        m_visitor->VisitObjectEnd(*this, *this);
-                    }
-
                     // Handle groups
                     if (nodeData.m_groups.size() > 0)
                     {
@@ -1029,6 +1024,11 @@ namespace AZ::Reflection
 
                         nodeData.m_propertyToGroupMap.clear();
                         nodeData.m_groupEntries.clear();
+                    }
+
+                    if (!nodeData.m_entryClosed)
+                    {
+                        m_visitor->VisitObjectEnd(*this, *this);
                     }
 
                     auto nodePath = nodeData.m_path;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -975,6 +975,8 @@ namespace AZ::Reflection
                 {
                     StackEntry& nodeData = m_stack.back();
 
+                    AZ_Assert(nodeData != nullptr, "LegacyReflectionBridge: Unable to retrieve nodeData in EndNode");
+
                     // Handle groups
                     if (nodeData.m_groups.size() > 0)
                     {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -975,8 +975,6 @@ namespace AZ::Reflection
                 {
                     StackEntry& nodeData = m_stack.back();
 
-                    AZ_Assert(nodeData != nullptr, "LegacyReflectionBridge: Unable to retrieve nodeData in EndNode");
-
                     // Handle groups
                     if (nodeData.m_groups.size() > 0)
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -70,6 +70,8 @@ namespace AzToolsFramework::Prefab
     {
         using PrefabPropertyEditorNodes::PrefabOverrideLabel;
 
+        AZ_Assert(adapterBuilder != nullptr, "PrefabComponentAdapter: CreateLabel called with null adapterBuilder!");
+
         adapterBuilder->BeginPropertyEditor<PrefabOverrideLabel>();
         adapterBuilder->Attribute(PrefabOverrideLabel::Text, labelText);
 


### PR DESCRIPTION
## What does this PR do?

Fixes an edge case where properties would not appear in the DPE if registered after a group was manually closed.
For an example of the issue, see attached GHI.

Fixes #17242 

## How was this PR tested?

Manual testing.
