### PR TITLE
The Android Project Generator tool.

### DIFF
--- a/Code/Tools/Android/ProjectGenerator/README.md
+++ b/Code/Tools/Android/ProjectGenerator/README.md
@@ -1,0 +1,29 @@
+# About The Android Project Generator
+This is a standalone tool that works as an extension of the O3DE ProjectManager.  
+  
+The purpose of this tool is to expedite and automate the creation of an Android Project
+that can be compiled and built with Android Studio, or from the command line terminal
+with the help of commands like `gradlew assembleProfile`.  
+  
+With this tool the user can easily create a Keystore file, and/or create an Android Project. 
+  
+This tool can be spawned manually from the terminal, but its usefulness becomes
+more aparent when started from the ProjectManager per-project menu because the
+input arguments (like `engine path`, `project path`, etc) required by `main.py`
+are automatically inferred by using internal O3DE APIs.  
+  
+# How To Use The Android Project Generator
+
+## TL;DR
+1. Push the `Create Keystore` button (only required if the keystore file has not been created before).
+2. Push the `Generate Project` button.
+3. Open the project with Android Studio.
+  
+## More details. 
+As soon as the tool is executed by the ProjectManager, the user will be presented
+with a window. The window is made of 4 sections:
+1. Options to load/save settings from/to user preferred locations on disk. The default settings will be stored
+in a file with path `<Project>/apg_config.json`.  
+2. The `Keystore Settings` section. In this section, the user customizes the arguments required to create an android keystore for signing the application.
+3. The `Android SDK/NDK Settings` section. In this section, the user customizes the arguments required to generate the android project.
+4. The `Operations Report` section. This is just a scrollable widget that shows all the applications that are being invoked by this tool, which can help the user visualize details of each command argument, etc.

--- a/Code/Tools/Android/ProjectGenerator/config_data.py
+++ b/Code/Tools/Android/ProjectGenerator/config_data.py
@@ -1,0 +1,101 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import os
+import json
+import platform
+
+from keystore_settings import KeystoreSettings
+
+class ConfigData:
+    """
+    This class contains all the configuration parameters that are required
+    to create a keystore for android applications and the configuration
+    data that is required to create an android project for O3DE.
+    """
+    ASSET_MODE_LOOSE = "LOOSE"
+    DEFAULT_NDK_VERSION = "25*"
+    DEFAULT_API_LEVEL = "31" # The API level for Android 12.
+    def __init__(self):
+        self.engine_path = "" # Not serialized.
+        self.project_path = "" # Not serialized.
+        self.build_path = "" # Not serialized.
+        self.third_party_path = "" # Not serialized.
+        self.keystore_settings = KeystoreSettings()
+        self.android_sdk_path = ""
+        self.android_ndk_version = self.DEFAULT_NDK_VERSION
+        self.android_sdk_api_level = self.DEFAULT_API_LEVEL
+        self.asset_mode = self.ASSET_MODE_LOOSE
+        self.is_meta_quest_project = False
+
+
+    def as_dictionary(self) -> dict:
+        d = { "keystore_settings" : self.keystore_settings.as_dictionary(),
+              "android_sdk_path" : self.android_sdk_path,
+              "android_ndk_version" : self.android_ndk_version,
+              "android_sdk_api_level" : self.android_sdk_api_level,
+              "asset_mode":  self.asset_mode,
+              "is_meta_quest_project": self.is_meta_quest_project,
+              }
+        return d
+
+
+    def update_from_dictionary(self, d: dict):
+        """
+        Partially updates this object from a dictionary
+        """
+        self.keystore_settings = KeystoreSettings.from_dictionary(d["keystore_settings"])
+        self.android_sdk_path = d.get("android_sdk_path", "")
+        self.android_ndk_version = d.get("android_ndk_version", self.DEFAULT_NDK_VERSION)
+        self.android_sdk_api_level = d.get("android_sdk_api_level", self.DEFAULT_API_LEVEL)
+        self.asset_mode = d.get("asset_mode", self.ASSET_MODE_LOOSE)
+        self.is_meta_quest_project = d.get("is_meta_quest_project", False)
+
+
+    def save_to_json_file(self, filePath: str) -> bool:
+        """
+        @returns True if successful
+        """
+        try:
+            with open(filePath, "w") as f:
+                json.dump(self.as_dictionary(), f, indent=4)
+        except Exception as err:
+            print(f"ConfigData.save_to_json_file failed for file {filePath}.\nException: {err}")
+            return False
+        return True
+
+
+    def load_from_json_file(self, filePath: str) -> bool:
+        """
+        Partially updates this object from a json file
+        """
+        try:
+            with open(filePath, "r") as f:
+                loaded_dict = json.load(f)
+                self.update_from_dictionary(loaded_dict)
+        except Exception as err:
+            print(f"ConfigData.load_from_json_file failed for file {filePath}.\nException: {err}")
+            return False
+        return True
+
+
+    def get_o3de_cmd(self) -> str:
+        if platform.system() == "Windows":
+            return os.path.join(self.engine_path, "scripts", "o3de.bat")
+        else:
+            return os.path.join(self.engine_path, "scripts", "o3de.sh")
+
+
+    def get_project_name(self) -> str:
+        return os.path.basename(self.project_path)
+    
+
+    def get_android_build_dir(self) -> str:
+        return os.path.join(self.build_path, "android")
+    
+# class ConfigData END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/discovery.py
+++ b/Code/Tools/Android/ProjectGenerator/discovery.py
@@ -1,0 +1,54 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+# Utility functions to discover system settings like Android SDK location, etc.
+import os
+import platform
+
+def could_be_android_sdk_directory(sdk_path: str) -> bool:
+    """
+    @returns True if the provided @sdk_path could be an Android SDK directory.
+             Will check for existence of a few directories that are typically located
+             inside an Android SDK directory.
+    """
+    if not os.path.isdir(sdk_path):
+        return False
+    test_dir = os.path.join(sdk_path, "ndk")
+    if os.path.isdir(test_dir):
+        return True
+    test_dir = os.path.join(sdk_path, "platform-tools")
+    if os.path.isdir(test_dir):
+        return True
+    return False
+
+
+def discover_android_sdk_path() -> str:
+    """
+    Follows common sense heuristic to find the location of the Android SDK.
+    @returns absolute path as a string to the Android SDK directory.
+    """
+    var = os.getenv('ANDROID_HOME')
+    if var and os.path.isdir(var):
+        return var
+    var = os.getenv('ANDROID_SDK_ROOT')
+    if var and os.path.isdir(var):
+        return var
+    user_home_dir = os.path.expanduser("~")
+    if platform.system() == "Windows":
+        sdk_path = f"{user_home_dir}\\AppData\\Local\\Android\\Sdk"
+        if os.path.isdir(sdk_path):
+            return sdk_path
+        sdk_system_path = "C:\\Program Files (x86)\\Android\\android-sdk"
+        if os.path.isdir(sdk_system_path):
+            return sdk_system_path
+    else:
+        # Linux or MacOS
+        sdk_path = f"{user_home_dir}/Library/Android/sdk"
+        if os.path.isdir(sdk_path):
+            return sdk_path
+    return ""
+

--- a/Code/Tools/Android/ProjectGenerator/keystore_generator.py
+++ b/Code/Tools/Android/ProjectGenerator/keystore_generator.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import os
+
+from config_data import ConfigData
+from threaded_lambda import ThreadedLambda
+from subprocess_runner import SubprocessRunner
+
+class KeystoreGenerator(ThreadedLambda):
+    """
+    This class knows how to use the keytool JAVA command to create
+    a new keystore. It also uses o3de.bat/o3de.sh to store configuration
+    data for the current project.
+    """
+
+    def __init__(self, config: ConfigData):
+        def _job_func():
+            self._run_commands()
+        super().__init__("Keystore Generator", _job_func)
+        ks = config.keystore_settings
+        o3de_cmd = config.get_o3de_cmd()
+        self._keystoreFileConfigureCmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"signconfig.store.file={ks.keystore_file}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+
+        self._keystoreKeyAliasConfigureCmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"signconfig.key.alias={ks.key_alias}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+
+        self._keystoreStorePasswordConfigureCmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"signconfig.store.password={ks.keystore_password}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+
+        self._keystoreKeyPasswordConfigureCmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"signconfig.key.password={ks.key_password}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+
+        self._keystoreCreateCmd = SubprocessRunner(
+            [
+                "keytool",
+                "-genkey",
+                "-keystore",
+                ks.keystore_file,
+                "-storepass",
+                ks.keystore_password,
+                "-alias",
+                ks.key_alias,
+                "-keypass",
+                ks.key_password,
+                "-keyalg",
+                "RSA",
+                "-keysize",
+                ks.key_size,
+                "-validity",
+                ks.validity_days,
+                "-dname",
+                ks.get_distinguished_name(),
+            ],
+            timeOutSeconds=10,
+            )
+
+    def _run_commands(self):
+        """
+        This is a "protected" function. It is invoked when super().start() is called.
+        """
+        if self._is_cancelled:
+            self._is_finished = True
+            self._is_success = False
+            return
+        commands = [
+            self._keystoreFileConfigureCmd,
+            self._keystoreKeyAliasConfigureCmd,
+            self._keystoreStorePasswordConfigureCmd,
+            self._keystoreKeyPasswordConfigureCmd,
+            self._keystoreCreateCmd,
+        ]
+        for command in commands:
+            if self._is_cancelled:
+                self._is_finished = True
+                self._is_success = False
+                return
+            if not command.run():
+                self._record_command_error(command)
+                return
+            else:
+                self._record_command_results(command)
+        self._is_finished = True
+        self._is_success = True
+        self._report_msg += f"Next Steps:\nYou can now generate the android project by pushing the `Generate Project` button.\n"
+
+
+    def _record_command_error(self, command: SubprocessRunner):
+        self._is_finished = True
+        self._is_success = False
+        self._record_command_results(command)
+
+
+    def _record_command_results(self, command: SubprocessRunner):
+        self._report_msg += f"Command:\n{command.get_command_str()}\nCompleted with status code {command.get_error_code()}.\n"
+        self._report_msg += command.get_stdall()
+
+# class KeystoreGenerator END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/keystore_settings.py
+++ b/Code/Tools/Android/ProjectGenerator/keystore_settings.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+class KeystoreSettings:
+    """
+    This class contains all the configuration parameters that are required
+    to create a keystore for android applications.
+    """
+    DEFAULT_PASSWORD = "password"
+    DEFAULT_KEY_ALIAS = "app_key_alias"
+    DEFAULT_KEY_SIZE = "2048"
+    DEFAULT_VALIDITY_DAYS = "10000"
+    DEFAULT_CN = "MyAppName"
+    DEFAULT_OU = "MyOrganizationalUnit"
+    DEFAULT_O = "MyCompany"
+    DEFAULT_C = "US"
+
+    def __init__(self):
+        self.keystore_file = ""
+        self.keystore_password = self.DEFAULT_PASSWORD
+        self.key_alias = self.DEFAULT_KEY_ALIAS
+        self.key_password = (
+            self.keystore_password
+        )  # Must be same as store password.
+        self.key_size = self.DEFAULT_KEY_SIZE
+        self.validity_days = self.DEFAULT_VALIDITY_DAYS
+        # Parts of a distiguished name string:
+        self.dn_common_name = self.DEFAULT_CN
+        self.dn_organizational_unit = self.DEFAULT_OU
+        self.dn_organization = self.DEFAULT_O
+        self.dn_country_code = self.DEFAULT_C
+
+
+    def get_distinguished_name(self) -> str:
+        return f"cn={self.dn_common_name}, ou={self.dn_organizational_unit}, o={self.dn_organization}, c={self.dn_country_code}"
+
+
+    def configure_distinguished_name(self,
+        app_name: str, organizational_unit: str,
+        company_name: str, country_code: str):
+        self.dn_common_name = app_name
+        self.dn_organizational_unit = organizational_unit
+        self.dn_organization = company_name
+        self.dn_country_code = country_code
+
+
+    @classmethod
+    def from_dictionary(cls, d: dict) -> "KeystoreSettings":
+        ks = KeystoreSettings()
+        ks.keystore_file = d.get("keystore_file", "")
+        ks.keystore_password = d.get("keystore_password", cls.DEFAULT_PASSWORD)
+        ks.key_alias =  d.get("key_alias", cls.DEFAULT_KEY_ALIAS)
+        ks.key_password = d.get("key_password", cls.DEFAULT_PASSWORD)
+        ks.key_size = d.get("key_size", cls.DEFAULT_KEY_SIZE)
+        ks.validity_days = d.get("validity_days", cls.DEFAULT_VALIDITY_DAYS)
+        # Parts of a distiguished name string:
+        ks.dn_common_name = d.get("dn_common_name", cls.DEFAULT_CN)
+        ks.dn_organizational_unit = d.get("dn_organizational_unit", cls.DEFAULT_OU)
+        ks.dn_organization = d.get("dn_organization", cls.DEFAULT_O)
+        ks.dn_country_code = d.get("dn_country_code", cls.DEFAULT_C)
+        return ks
+
+
+    def as_dictionary(self) -> dict:
+        d = {
+            "keystore_file" : self.keystore_file,
+            "keystore_password" : self.keystore_password,
+            "key_alias" : self.key_alias,
+            "key_password" : self.key_password,
+            "validity_days" : self.validity_days,
+            "dn_common_name" : self.dn_common_name,
+            "dn_organizational_unit" : self.dn_organizational_unit,
+            "dn_organization" : self.dn_organization,
+            "dn_country_code" : self.dn_country_code,
+        }
+        return d
+
+# class KeystoreSettings END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/main.py
+++ b/Code/Tools/Android/ProjectGenerator/main.py
@@ -1,0 +1,491 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import os
+import argparse
+import copy
+import time
+
+import tkinter as tk
+from tkinter import messagebox
+from tkinter import filedialog
+
+from config_data import ConfigData
+from keystore_settings import KeystoreSettings
+import discovery
+from wait_dialog import WaitDialog
+from keystore_generator import KeystoreGenerator
+from project_generator import ProjectGenerator
+
+DEFAULT_APG_CONFIG_FILE="apg_config.json"
+
+class TkApp(tk.Tk):
+    """
+    This is the main UI of the Android Project Generator, known as APG for short.
+    """
+    def __init__(self, config: ConfigData, config_file_path: str = ""):
+        super().__init__()
+        self.title("Android Project Generator")
+        # Display the main window wherever the mouse is located.
+        x, y = self.winfo_pointerx(), self.winfo_pointery()
+        self.geometry(f"+{x}+{y}")
+
+        self._config = config
+        self._config_file_path_var = tk.StringVar()
+        self._config_file_path_var.set(config_file_path)
+
+        self._init_load_save_ui()
+        self._init_keystore_settings_ui()
+        self._init_sdk_settings_ui()
+        self._init_report_ui()
+
+
+    def _init_load_save_ui(self):
+        frame = tk.Frame(self)
+        frame.pack()
+
+        buttons_frame = tk.Frame(frame)
+        buttons_frame.pack()
+        btn = tk.Button(buttons_frame, text="Load Settings", command=self.on_load_settings_button)
+        btn.pack(padx=20, side=tk.LEFT)
+        btn = tk.Button(buttons_frame, text="Save Settings", command=self.on_save_settings_button)
+        btn.pack(padx=20, side=tk.RIGHT)
+        lbl = tk.Label(frame, textvariable=self._config_file_path_var)
+        lbl.pack()
+
+
+    def _init_keystore_settings_ui(self):
+        # Create a button widget with an event handler.
+        keystore_frame = tk.Frame(self)
+        keystore_frame.pack(expand=False, fill=tk.X)
+
+        lbl = tk.Label(keystore_frame, text="============ Keystore Settings ============")
+        lbl.pack()
+
+        # Let's add the fields that make the Distinguished Name.
+        dn_frame = tk.Frame(keystore_frame)
+        dn_frame.pack(expand=True, fill=tk.X)
+        self._init_keystore_distinguished_name_ui(dn_frame)
+
+        # Now let's add the rest of the keystore fields.
+        ks_data = self._config.keystore_settings
+        self._keystore_validity_days_var = self._add_label_entry(keystore_frame, "Validity Days", ks_data.validity_days)[0]
+        self._keystore_key_size_var = self._add_label_entry(keystore_frame, "Key Size", ks_data.key_size)[0]
+        self._keystore_app_key_alias_var = self._add_label_entry(keystore_frame, "App Key Alias", ks_data.key_alias)[0]
+        self._keystore_app_key_password_var = self._add_label_entry(keystore_frame, "App Key Password", ks_data.key_password)[0]
+        self._keystore_keystore_password_var = self._add_label_entry(keystore_frame, "Keystore Password", ks_data.keystore_password)[0]
+        self._keystore_file_var, _, row_frame =  self._add_label_entry(keystore_frame, "Keystore File", ks_data.keystore_file)
+        btn = tk.Button(row_frame, text="...", command=self.on_select_keystore_file_button)
+        btn.pack(side=tk.LEFT)
+
+        btn = tk.Button(keystore_frame, text="Create Keystore", command=self.on_create_keystore_button)
+        btn.pack()
+
+
+    def _init_keystore_distinguished_name_ui(self, parent_frame: tk.Frame):
+        tk.Label(parent_frame, text="Distinguished Name Settings:").pack(anchor=tk.W)
+        spaceStr = "        "
+        ks_data = self._config.keystore_settings
+        self._dn_country_code_var = self._add_label_entry(parent_frame, f"{spaceStr}Country Code", ks_data.dn_country_code)[0]
+        self._dn_company_var = self._add_label_entry(parent_frame, f"{spaceStr}Company (aka Organization)", ks_data.dn_organization)[0]
+        self._dn_organizational_unit_var = self._add_label_entry(parent_frame, f"{spaceStr}Organizational Unit", ks_data.dn_organizational_unit)[0]
+        self._dn_app_name_var = self._add_label_entry(parent_frame, f"{spaceStr}App Name (aka Common Name)", ks_data.dn_common_name)[0]
+
+
+    def _init_sdk_settings_ui(self):
+        sdk_frame = tk.Frame(self)
+        sdk_frame.pack(expand=False, fill=tk.X)
+        lbl = tk.Label(sdk_frame, text="========= Android SDK/NDK Settings ========")
+        lbl.pack()
+        cf = self._config
+        self._android_ndk_version_var = self._add_label_entry(sdk_frame, "NDK Version", cf.android_ndk_version)[0]
+        self._android_sdk_api_level_var = self._add_label_entry(sdk_frame, "SDK API Level", cf.android_sdk_api_level)[0]
+        self._android_sdk_path_var, _, row_frame = self._add_label_entry(sdk_frame, "SDK Path", cf.android_sdk_path)
+        btn = tk.Button(row_frame, text="...", command=self.on_select_sdk_path_button)
+        btn.pack(side=tk.LEFT)
+        # Add the meta quest project checkbox
+        self._android_quest_flag_var = self._add_checkbox(sdk_frame, "This is a Meta Quest project", cf.is_meta_quest_project)[0]
+        # Add the project generation button.
+        btn = tk.Button(sdk_frame, text="Generate Project", command=self.on_generate_project_button)
+        btn.pack()
+
+
+    def _add_label_entry(self, parent_frame: tk.Frame, lbl_name: str, default_value: str = "") -> tuple[tk.StringVar, tk.Entry, tk.Frame]:
+        """
+        Returns the tuple (string_var, entry, row_frame),
+        where  @string_var is the TK StringVar bound to the Entry widget,
+               @entry is the Entry widget,
+               @row_frame is the parent Frame that owns @entry widget.
+        """
+        row_frame = tk.Frame(parent_frame)
+        row_frame.pack(padx=5, pady=2, expand=True, fill=tk.X)
+        lbl = tk.Label(row_frame, text=lbl_name)
+        lbl.pack(side=tk.LEFT, anchor=tk.W)
+        entry = tk.Entry(row_frame, justify='right')
+        entry.pack(side=tk.LEFT, expand=True, fill=tk.X)
+        string_var = tk.StringVar()
+        string_var.set(default_value)
+        entry["textvariable"] = string_var
+        return string_var, entry, row_frame
+
+
+    def _add_checkbox(self, parent_frame: tk.Frame, lbl_name: str, default_value: bool = False) -> tuple[tk.BooleanVar, tk.Checkbutton, tk.Frame]:
+        """
+        Returns the tuple (BooleanVar, check_box, row_frame),
+        where  @BooleanVar is the TK BooleanVar bound to the CheckBox widget,
+               @check_box is the Checkbutton widget,
+               @row_frame is the parent Frame that owns @check_box widget.
+        """
+        row_frame = tk.Frame(parent_frame)
+        row_frame.pack(padx=5, pady=2, expand=True, fill=tk.X)
+        bool_var = tk.BooleanVar()
+        bool_var.set(default_value)
+        # Create a Checkbutton widget and bind it to the variable.
+        checkbutton = tk.Checkbutton(row_frame, text=lbl_name, variable=bool_var)
+        checkbutton.pack(side=tk.LEFT, anchor=tk.W)
+        return bool_var, checkbutton, row_frame
+
+
+    def _init_report_ui(self):
+        """
+        Instanties the scrollable text widget where this app will report
+        all the stdout and stderr string produced by all subprocess invoked
+        by this application.
+        """
+        lbl = tk.Label(self, text="============ Operations Report ============")
+        lbl.pack()
+        self._report_text_widget = tk.Text(self, wrap=tk.WORD, borderwidth=2, relief=tk.SUNKEN)
+        self._report_scrollbar_widget = tk.Scrollbar(self, orient=tk.VERTICAL, command=self._report_text_widget.yview)
+        # Configure the Text widget and the Scrollbar widget.
+        self._report_text_widget.configure(yscrollcommand=self._report_scrollbar_widget.set)
+        self._report_text_widget.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self._report_scrollbar_widget.pack(side=tk.RIGHT, fill=tk.Y)
+
+
+    def _get_time_now_str(self) -> str:
+        """
+        @returns The current local time as a formatted string. 
+        """
+        time_secs = time.time()
+        time_st = time.localtime(time_secs)
+        no_millis_str = time.strftime("%H:%M:%S", time_st)
+        fractional_secs = int(str(time_secs).split(".")[1])
+        return f"{no_millis_str}.{fractional_secs}"
+
+
+    def _append_log_message(self, msg: str):
+        """
+        Append the msg with a timestamp to the report widget, and automatically scrolls to
+        the bottom of the report.
+        """
+        timestamp_str = self._get_time_now_str()
+        self._report_text_widget.insert(tk.END, f">>{timestamp_str}>>\n{msg}\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n")
+        self._report_text_widget.see(tk.END) #scroll to the end.
+
+
+    def create_keystore_settings_from_widgets(self) -> KeystoreSettings:
+        """
+        @returns A new KeystoreSettings object, where all the values are read from the
+        current content in the UI text/entry fields.
+        """
+        ks = KeystoreSettings()
+        ks.keystore_file = self._keystore_file_var.get()
+        ks.keystore_password = self._keystore_keystore_password_var.get()
+        ks.key_alias = self._keystore_app_key_alias_var.get()
+        ks.key_password = self._keystore_app_key_password_var.get()
+        ks.key_size = self._keystore_key_size_var.get()
+        ks.validity_days = self._keystore_validity_days_var.get()
+        ks.dn_common_name = self._dn_app_name_var.get()
+        ks.dn_organizational_unit = self._dn_organizational_unit_var.get()
+        ks.dn_organization = self._dn_company_var.get()
+        ks.dn_country_code = self._dn_country_code_var.get()
+        return ks
+
+
+    def create_config_data_from_widgets(self) -> ConfigData:
+        """
+        @returns A new ConfigData object, where all the values are read from the
+        current content in the UI text/entry fields.
+        """
+        config = copy.deepcopy(self._config)
+        config.android_sdk_path = self._android_sdk_path_var.get()
+        config.android_ndk_version = self._android_ndk_version_var.get()
+        config.android_sdk_api_level = self._android_sdk_api_level_var.get()
+        config.is_meta_quest_project = self._android_quest_flag_var.get()
+        config.keystore_settings = self.create_keystore_settings_from_widgets()
+        return config
+
+
+    def update_widgets_from_keystore_settings(self, ks: KeystoreSettings):
+        self._keystore_file_var.set(ks.keystore_file)
+        self._keystore_keystore_password_var.set(ks.keystore_password)
+        self._keystore_app_key_alias_var.set(ks.key_alias)
+        self._keystore_app_key_password_var.set(ks.key_password)
+        self._keystore_key_size_var.set(ks.key_size)
+        self._keystore_validity_days_var.set(ks.validity_days)
+        self._dn_app_name_var.set(ks.dn_common_name)
+        self._dn_organizational_unit_var.set(ks.dn_organizational_unit)
+        self._dn_company_var.set(ks.dn_organization)
+        self._dn_country_code_var.set(ks.dn_country_code)
+
+
+    def update_widgets_from_config(self, config: ConfigData):
+        self._android_sdk_path_var.set(config.android_sdk_path)
+        self._android_ndk_version_var.set(config.android_ndk_version)
+        self._android_sdk_api_level_var.set(config.android_sdk_api_level)
+        self._android_quest_flag_var.set(config.is_meta_quest_project)
+        self.update_widgets_from_keystore_settings(config.keystore_settings)
+
+
+    def on_load_settings_button(self):
+        """
+        Invoked when the user clicks the `Load Settings` button.
+        """
+        suggested_file_path = self._config_file_path_var.get()
+        if suggested_file_path == "":
+            suggested_file_path = os.path.join(self._config.project_path, DEFAULT_APG_CONFIG_FILE)
+        initial_dir, initial_file = os.path.split(suggested_file_path)
+        filename = filedialog.askopenfilename(
+            initialdir=initial_dir,
+            initialfile=initial_file,
+            title="Load Settings",
+            filetypes=[("JSON files", "*.json"), ("All files", "*")],
+            defaultextension=".json",
+            parent=self
+            )
+        if (not filename) or (not os.path.isfile(filename)):
+            messagebox.showinfo("Invalid Settings File Path", f"The path {filename} is invalid!")
+            return
+        if not self._config.load_from_json_file(filename):
+            messagebox.showerror("File I/O Error", f"Failed to read settings from file:\n{filename}")
+            return
+        self._config_file_path_var.set(filename)
+        messagebox.showinfo("Success!", f"Current settings were loaded from file:\n{filename}")
+        self.update_widgets_from_config(self._config)
+
+
+    def on_save_settings_button(self):
+        """
+        Invoked when the user clicks the `Save Settings` button.
+        """
+        configData = self.create_config_data_from_widgets()
+        suggested_file_path = self._config_file_path_var.get()
+        if suggested_file_path == "":
+            suggested_file_path = os.path.join(configData.project_path, DEFAULT_APG_CONFIG_FILE)
+        initial_dir, initial_file = os.path.split(suggested_file_path)
+        filename = filedialog.asksaveasfilename(
+            initialdir=initial_dir,
+            initialfile=initial_file,
+            title="Save Settings",
+            filetypes=[("JSON files", "*.json"), ("All files", "*")],
+            defaultextension=".json",
+            parent=self
+            )
+        if (filename is None) or (filename == ""):
+            return # Cancelled by user.
+        if not configData.save_to_json_file(filename):
+            messagebox.showerror("File I/O Error", f"Failed to save settings to file {filename}")
+        self._config = configData
+        self._config_file_path_var.set(filename)
+        messagebox.showinfo("Success!", f"Current settings were saved as file:\n{filename}")
+
+
+    def _on_user_cancel_task(self):
+        """
+        This is a callback invoked by self._wait_dialog when the user
+        decides to cancel the current operation.
+        """
+        self._wait_dialog = None
+        self._cancel_current_operation()
+        self._current_operation = None # Doesn't hurt to force this to None.
+
+
+    def _tick_operation(self):
+        """
+        This function will be called periodically while there's an operation running in the background.
+        """
+        if self._current_operation and self._current_operation.is_finished():
+            # The operation completed. Time to close the progress dialog
+            # and report the results.
+            if self._wait_dialog:
+                 self._wait_dialog.close()
+                 self._wait_dialog = None
+            self._on_current_operation_finished()
+            return
+        # Keep ticking, until next time if the operation is finished or the user
+        # decides to cancel the current operation.
+        if self._wait_dialog:
+            self._wait_dialog.on_tick(float(self._tick_delta_ms)/1000.0)
+            self.after(self._tick_delta_ms, self._tick_operation)
+
+
+    def _cancel_current_operation(self):
+        """
+        This one is called upon user request.
+        """
+        self._current_operation.cancel()
+        report_msg = self._current_operation.get_report_msg()
+        self._append_log_message(report_msg)
+        messagebox.showinfo("Cancelled By User", f"{self._current_operation.get_basic_description()}\nwas cancelled by user!")
+        self._current_operation = None
+
+
+    def _on_current_operation_finished(self):
+        # The current operation is finished. But it could have
+        # finished with error or success. Let the user know the outcome.
+        report_msg = self._current_operation.get_report_msg()
+        self._append_log_message(report_msg)
+        if self._current_operation.is_success():
+            messagebox.showinfo("Success", f"{self._current_operation.get_basic_description()}\ncompleted succesfully!")
+        else:
+            messagebox.showerror("Error", f"{self._current_operation.get_basic_description()}\ncompleted with errors!")
+        self._current_operation = None
+
+
+    def on_select_keystore_file_button(self):
+        """
+        The user clicked the "..." button next to the `Keystore File` field, with the purpose
+        of selecting a different keystore file.
+        """
+        suggested_file_path = self._keystore_file_var.get()
+        if suggested_file_path == "":
+            # If the user input data is empty, try the cached data.
+            suggested_file_path = self._config.keystore_settings.keystore_file
+        if suggested_file_path == "":
+            # If the cached data is empty, let's try a default
+            suggested_file_path = os.path.join(self._config.project_path, "app.keystore")
+
+        initial_dir, initial_file = os.path.split(suggested_file_path)
+        filename = filedialog.asksaveasfilename(
+            initialdir=initial_dir,
+            initialfile=initial_file,
+            title="Select Keystore File",
+            filetypes=[("keystore files", "*.keystore"), ("All files", "*")],
+            defaultextension=".json",
+            parent=self
+            )
+        if (not filename) or (filename == ""):
+            messagebox.showerror("Error", f"Invalid Keystore File Path!")
+            return
+        self._keystore_file_var.set(filename)
+        self._config.keystore_settings.keystore_file = filename
+
+
+    def on_select_sdk_path_button(self):
+        """
+        The user clicked the "..." button next to the  `SDK Path` field, with the purpose
+        of selecting a different Android SDK path.
+        """
+        configData = self.create_config_data_from_widgets()
+        initial_dir = configData.android_sdk_path
+        directory  = filedialog.askdirectory(
+            initialdir=initial_dir,
+            title="Pick Android SDK Location",
+            parent=self
+            )
+        if (not directory ) or (directory == "") or (not os.path.isdir(directory)):
+            messagebox.showerror("Invalid SDK Path", f"The path {directory} is invalid!")
+            return
+        if not discovery.could_be_android_sdk_directory(directory):
+            messagebox.showwarning("Warning", f"The directory:\n{directory}\nDoesn't appear to be an Android SDK directory.")
+        configData.android_sdk_path = directory
+        self._config = configData 
+        self.update_widgets_from_config(self._config)
+
+
+    def on_create_keystore_button(self):
+        """
+        The user clicked the `Create Keystore` button. Will spawn the required tools to create the keystore.
+        """
+        ks = self.create_keystore_settings_from_widgets()
+        if (not ks.keystore_file) or (ks.keystore_file == ""):
+            messagebox.showerror("Error", f"A vaid `Keystore File` is required.")
+            return
+        if os.path.isfile(ks.keystore_file):
+            result = messagebox.askyesno("Attention!", f"Do you want to replace the Keystore File:\n{ks.keystore_file}?")
+            if not result:
+                return
+            else:
+                # It's important to delete the existing keystore file, otherwise the java keytool will fail to replace it.
+                try:
+                    os.remove(ks.keystore_file)
+                except Exception as err:
+                    messagebox.showerror("Error", f"Failed to delete keystore file {ks.keystore_file}. Got Exception:\n{err}")
+                    return
+        self._config.keystore_settings = ks
+        # Start the in-progress modal dialog.
+        def _inner_cancel_cb():
+            self._on_user_cancel_task()
+        self._wait_dialog = WaitDialog(self, "Creating Keystore.\nThis operation takes around 5 seconds.", _inner_cancel_cb)
+        self._tick_delta_ms = 250
+        self.after(self._tick_delta_ms, self._tick_operation)
+        # Instantiate and start the job.
+        self._current_operation = KeystoreGenerator(self._config)
+        self._current_operation.start()
+
+
+    def on_generate_project_button(self):
+        """
+        The user clicked the `Generate Project` button. Will spawn the required tools to create the android project.
+        """
+        configData = self.create_config_data_from_widgets()
+        # Make sure the keystore file exist.
+        ks = configData.keystore_settings
+        if (not ks.keystore_file) or (ks.keystore_file == ""):
+            messagebox.showerror("Error", f"Can not generate an android project without a valid `Keystore File`.")
+            return
+        if not os.path.isfile(ks.keystore_file):
+            messagebox.showerror("Error", f"The keystore file {ks.keystore_file} doesn't exist.\nPush the `Create Keystore` button to create it.")
+            return
+        # Start the in-progress modal dialog.
+        def _inner_cancel_cb():
+            self._on_user_cancel_task()
+        self._wait_dialog = WaitDialog(self, "Generating the android project.\nThis operation takes around 30 seconds.", _inner_cancel_cb)
+        self._tick_delta_ms = 250
+        self.after(self._tick_delta_ms, self._tick_operation)
+        # Instantiate and start the job.
+        self._config = configData
+        self._current_operation = ProjectGenerator(configData)
+        self._current_operation.start()
+
+# class TkApp END
+######################################################
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Presents a UI that automates the generation of an Android Project and its keystore.')
+    parser.add_argument('--engine', '--e', required=True,
+                    help='Path to the engine root directory.')
+    parser.add_argument('--project', '--p', required=True,
+                    help='Path to the project root directory.')
+    parser.add_argument('--build', '--b', required=True,
+                    help='Path to the build directory.')
+    parser.add_argument('--third_party', '--t', required=True,
+                    help='Path to the 3rd Party root folder.')
+
+    args = parser.parse_args()
+
+    # Check if the project directory contains a json file with configuration data.
+    configPath = os.path.join(args.project, DEFAULT_APG_CONFIG_FILE)
+    config_data = ConfigData()
+    config_data.load_from_json_file(configPath)
+
+    # Discover the location of the keystore file if not defined yet.
+    ks = config_data.keystore_settings
+    if (not ks.keystore_file) or (ks.keystore_file == ""):
+        ks.keystore_file = os.path.join(args.project, "app.keystore")
+
+    # Discover the android sdk path if empty.
+    if (config_data.android_sdk_path is None) or (config_data.android_sdk_path == ""):
+        config_data.android_sdk_path = discovery.discover_android_sdk_path()
+
+    config_data.engine_path = args.engine
+    config_data.project_path = args.project
+    config_data.build_path = args.build
+    config_data.third_party_path = args.third_party
+
+    app = TkApp(config_data, configPath)
+    app.mainloop()

--- a/Code/Tools/Android/ProjectGenerator/project_generator.py
+++ b/Code/Tools/Android/ProjectGenerator/project_generator.py
@@ -1,0 +1,146 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import os
+
+from config_data import ConfigData
+from threaded_lambda import ThreadedLambda
+from subprocess_runner import SubprocessRunner
+
+class ProjectGenerator(ThreadedLambda):
+    """
+    This class knows how to create an Android project.
+    It first runs the configuration commands supported by o3de.bat/o3de.sh,
+    validates the configuration and generates the project.
+    """
+
+    def __init__(self, config: ConfigData):
+        def _job_func():
+            self._run_commands()
+        super().__init__("Android Project Generator", _job_func)
+        self._config = config
+        o3de_cmd = config.get_o3de_cmd()
+        self._sdk_root_configure_cmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"sdk.root={config.android_sdk_path}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+        self._api_level_configure_cmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"platform.sdk.api={config.android_sdk_api_level}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+        self._ndk_configure_cmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                f"ndk.version={config.android_ndk_version}",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+        # agp is Android Gradle Plugin. FIXME: Make it a variable.
+        self._agp_configure_cmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--set-value",
+                "android.gradle.plugin=8.1.0",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=10,
+        )
+
+        self._validate_configuration_cmd = SubprocessRunner(
+            [
+                o3de_cmd,
+                "android-configure",
+                "--validate",
+                "--project",
+                config.project_path,
+            ],
+            timeOutSeconds=60
+        )
+
+        arg_list = [
+            o3de_cmd,
+            "android-generate",
+            "-p",
+            config.get_project_name(),
+            "-B",
+            config.get_android_build_dir(),
+            "--asset-mode",
+            config.asset_mode,
+            ]
+        if config.is_meta_quest_project:
+            arg_list.extend(["--oculus-project"])
+        self._generate_project_cmd = SubprocessRunner(
+            arg_list,
+            timeOutSeconds=60
+        )
+
+
+    def _run_commands(self):
+        """
+        This is a "protected" function. It is invoked when super().start() is called.
+        """
+        if self._is_cancelled:
+            self._is_finished = True
+            self._is_success = False
+            return
+        commands = [
+            self._sdk_root_configure_cmd,
+            self._api_level_configure_cmd,
+            self._ndk_configure_cmd,
+            self._agp_configure_cmd,
+            self._validate_configuration_cmd,
+            self._generate_project_cmd,
+        ]
+        for command in commands:
+            if self._is_cancelled:
+                self._is_finished = True
+                self._is_success = False
+                return
+            if not command.run():
+                self._record_command_error(command)
+                return
+            else:
+                self._record_command_results(command)
+        self._is_finished = True
+        self._is_success = True
+        self._report_msg += f"Next Steps:\nYou can compile, deploy and execute the android application with Android Studio by opening the project:\n{self._config.get_android_build_dir()}.\n"
+        self._report_msg += "Alternatively, you can compile the project from the command line with the following commands:\n"
+        self._report_msg += f"$ cd {self._config.get_android_build_dir()}\n$ .\\gradlew assembleProfile\nOr if interested in compiling for debugging:\n$ .\\gradlew assembleDebug\n"
+
+
+    def _record_command_error(self, command: SubprocessRunner):
+        self._is_finished = True
+        self._is_success = False
+        self._record_command_results(command)
+
+
+    def _record_command_results(self, command: SubprocessRunner):
+        self._report_msg += f"Command:\n{command.get_command_str()}\nCompleted with status code {command.get_error_code()}.\n"
+        self._report_msg += command.get_stdall()
+
+# class ProjectGenerator END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
+++ b/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
@@ -1,0 +1,74 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import subprocess
+
+class SubprocessRunner:
+    """
+    Class for common methods and properties
+    required to dispatch a shell/system/python application
+    and capture the errorCode, stdout and stderr
+    """
+
+    def __init__(self, argList: list[str], timeOutSeconds: int):
+        self._name = self.__class__.__name__
+        self._argList = argList
+        self._arg_list_str = ""  # Becomes the command string when executed.
+        self._timeOut = timeOutSeconds
+        self._error_code = -1
+        self._error_message = ""
+        self._success_message = ""
+
+
+    def run(self) -> bool:
+        """
+        This is a blocking call that returns when the subprocess is finished.
+        @returns True if the system error code is 0 (success).
+        """
+        self._arg_list_str = " ".join(self._argList)
+        print(f"{self._name} will run command:\n{self._arg_list_str}\n")
+        self._subprocess = subprocess.Popen(
+            self._argList, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        try:
+            outs, errs = self._subprocess.communicate(timeout=self._timeOut)
+            self._success_message = outs.decode("utf-8")
+            self._error_message = errs.decode("utf-8")
+            print(f"ok:<{self._success_message}>, err:<{self._error_message}>")
+            self._error_code = self._subprocess.returncode
+            return self._subprocess.returncode == 0
+        except subprocess.TimeoutExpired:
+            self._subprocess.kill()
+            outs, errs = self._subprocess.communicate()
+            self._success_message = outs.decode("utf-8")
+            self._error_message = errs.decode("utf-8")
+            print(f"ok:<{self._success_message}>, err:<{self._error_message}>")
+            self._error_code = -1
+            return False
+
+
+    def get_error_code(self):
+        return self._error_code
+
+
+    def get_stderr(self) -> str:
+        return self._error_message
+
+
+    def get_stdout(self) -> str:
+        return self._success_message
+
+
+    def get_stdall(self) -> str:
+        return f"{self._success_message}\n{self._error_message}"
+
+
+    def get_command_str(self) -> str:
+        return self._arg_list_str
+
+# class SubprocessRunner END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/threaded_lambda.py
+++ b/Code/Tools/Android/ProjectGenerator/threaded_lambda.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import threading
+
+class ThreadedLambda:
+    """
+    A base class that encapsulates a long operation
+    via a lambda function that runs on a thread. Typically
+    the long operation is a subprocess or a series of subprocesses.
+    """
+    def __init__(self, basic_description: str, job_func):
+        """
+        @param job_func The function that will do the work. It should check the state of
+                        self._is_cancelled and other member variables and cancel pending work
+                        if needed.
+        """
+        self._basic_description = basic_description
+        self._is_finished = False
+        self._is_success = False
+        # The job_func should check for the status of this variable and exit immediately if needed.
+        self._is_cancelled = False
+        # Subclasses should store here the result of stdout+stderr.
+        self._report_msg = ""
+        self._thread = threading.Thread(target=job_func)
+
+
+    def start(self):
+        """
+        Do not override.
+        """
+        self._thread.start()
+
+
+    def is_finished(self) -> bool:
+        return self._is_finished
+
+
+    def is_success(self) -> bool:
+        return self._is_success
+
+
+    def cancel(self):
+        if self._is_cancelled:
+            print(f"Job <{self._basic_description}> is already cancelled!")
+            return
+        self._is_cancelled = True
+        self._cancel_internal()
+        self._thread.join()
+
+
+    def get_report_msg(self) -> str:
+        return self._report_msg
+
+
+    def get_basic_description(self) -> str:
+        return self._basic_description
+
+
+    def _cancel_internal(self):
+        """
+        A protected method that gives the chance to the subclass
+        to do something when the operation is being cancelled.
+        """
+        pass
+
+# class ThreadedLambda END
+######################################################

--- a/Code/Tools/Android/ProjectGenerator/wait_dialog.py
+++ b/Code/Tools/Android/ProjectGenerator/wait_dialog.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import tkinter as tk
+
+class WaitDialog:
+    """
+    A cancelable modal dialog that can be helpful to
+    notify the user that some work is being done
+    in the background.
+    """
+    MAX_DOTS = 4
+    def __init__(self, tk_parent, work_message: str, cancel_cb):
+        self._tk_parent = tk_parent
+        self._dialog = tk.Toplevel(tk_parent)
+
+        # Display the dialog at the center of its parent.
+        w = 340
+        h = 100
+        self._dialog.wait_visibility()
+        x = tk_parent.winfo_x() + tk_parent.winfo_width()//2 - w//2
+        y = tk_parent.winfo_y() + tk_parent.winfo_height()//2 - h//2
+
+        self._dialog.geometry(f"{w}x{h}+{x}+{y}")
+        self._dialog.title("Operation In Progress...")
+        self._dialog.grab_set()  # Make the dialog modal.
+        self._cancel_cb = cancel_cb
+        lbl = tk.Label(self._dialog, text=work_message)
+        lbl.pack()
+        # This is a simple string that will be updated periodically
+        # and its value will be bound to a tk Label widget.
+        self._progress_string_var = tk.StringVar()
+        self._progress_string_var.set("")
+        self._progress_sign = 1 # Start positive
+        lbl = tk.Label(self._dialog, textvariable=self._progress_string_var)
+        lbl.pack()
+        # The Cancel button
+        button = tk.Button(self._dialog, text="Cancel", command=self._on_cancel_button)
+        button.pack()
+
+    def _on_cancel_button(self):
+        self.close()
+        self._cancel_cb()
+
+    def close(self):
+        """
+        Call this function when the job is done. Will close
+        and destroy this dialog
+        """
+        self._dialog.destroy()
+        self._tk_parent.focus_set()
+
+    def on_tick(self, delta_seconds: float):
+        progress = self._progress_string_var.get()
+        if self._progress_sign > 0:
+            progress = f"{progress}*"
+            if len(progress) >= self.MAX_DOTS:
+                self._progress_sign = -1
+        else:
+            num_dots = len(progress)
+            if num_dots < 1:
+                self._progress_sign = 1
+            else:
+                progress = "*" * (num_dots - 1)
+        self._progress_string_var.set(progress)
+
+# class WaitDialog END
+######################################################

--- a/Code/Tools/ProjectManager/Platform/Linux/Python_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/Python_linux.cpp
@@ -41,4 +41,13 @@ namespace Platform
         libPath = libPath.LexicallyNormal();
         return libPath.String();
     }
+
+    AZStd::string GetPythonExecutablePath(const char* engineRoot)
+    {
+        // append lib path to Python paths
+        AZ::IO::FixedMaxPath libPath = engineRoot;
+        libPath /= AZ::IO::FixedMaxPathString("python/python.sh");
+        libPath = libPath.LexicallyNormal();
+        return libPath.String();
+    }
 }

--- a/Code/Tools/ProjectManager/Platform/Mac/Python_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/Python_mac.cpp
@@ -41,4 +41,13 @@ namespace Platform
         libPath = libPath.LexicallyNormal();
         return libPath.String();
     }
+
+    AZStd::string GetPythonExecutablePath(const char* engineRoot)
+    {
+        // append lib path to Python paths
+        AZ::IO::FixedMaxPath libPath = engineRoot;
+        libPath /= AZ::IO::FixedMaxPathString("python/python.sh");
+        libPath = libPath.LexicallyNormal();
+        return libPath.String();
+    }
 }

--- a/Code/Tools/ProjectManager/Platform/Windows/Python_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/Python_windows.cpp
@@ -36,4 +36,13 @@ namespace Platform
         libPath = libPath.LexicallyNormal();
         return libPath.String();
     }
+
+    AZStd::string GetPythonExecutablePath(const char* engineRoot)
+    {
+        // append lib path to Python paths
+        AZ::IO::FixedMaxPath libPath = engineRoot;
+        libPath /= AZ::IO::FixedMaxPathString("python/python.cmd");
+        libPath = libPath.LexicallyNormal();
+        return libPath.String();
+    }
 }

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -362,6 +362,8 @@ namespace O3DE::ProjectManager
         menu->addAction(tr("Configure Gems..."), this, [this]() { emit EditProjectGems(m_projectInfo.m_path); });
         menu->addAction(tr("Build"), this, [this]() { emit BuildProject(m_projectInfo); });
         menu->addAction(tr("Open CMake GUI..."), this, [this]() { emit OpenCMakeGUI(m_projectInfo); });
+        menu->addAction(tr("Open Android Project Generator..."), this, [this]() { emit OpenAndroidProjectGenerator(m_projectInfo.m_path); });
+
         menu->addSeparator();
         menu->addAction(tr("Open Project folder..."), this, [this]()
         { 

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -142,6 +142,7 @@ namespace O3DE::ProjectManager
         void DeleteProject(const QString& projectName);
         void BuildProject(const ProjectInfo& projectInfo, bool skipDialogBox = false);
         void OpenCMakeGUI(const ProjectInfo& projectInfo);
+        void OpenAndroidProjectGenerator(const QString& projectPath);
 
     private:
         void enterEvent(QEvent* event) override;

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -75,6 +75,7 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> GetProjectBuildPath(const QString& projectPath);
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath);
         AZ::Outcome<QString, QString> RunGetPythonScript(const QString& enginePath);
+        QString GetPythonExecutablePath(const QString& enginePath);
 
         QString GetDefaultProjectPath();
         QString GetDefaultTemplatePath();

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -11,6 +11,7 @@
 #include <ProjectManagerDefs.h>
 #include <ProjectButtonWidget.h>
 #include <PythonBindingsInterface.h>
+#include <PythonBindings.h>
 #include <ProjectUtils.h>
 #include <ProjectBuilderController.h>
 #include <ScreensCtrl.h>
@@ -49,6 +50,7 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QFileSystemWatcher>
+#include <QProcess>
 
 namespace O3DE::ProjectManager
 {
@@ -201,6 +203,7 @@ namespace O3DE::ProjectManager
                     QMessageBox::critical(this, tr("Failed to open CMake GUI"), result.GetError(), QMessageBox::Ok);
                 }
             });
+        connect(projectButton, &ProjectButton::OpenAndroidProjectGenerator, this, &ProjectsScreen::HandleOpenAndroidProjectGenerator);
 
         return projectButton;
     }
@@ -621,6 +624,61 @@ namespace O3DE::ProjectManager
                 emit NotifyProjectRemoved(projectPath);
             }
         }
+    }
+
+    void ProjectsScreen::HandleOpenAndroidProjectGenerator(const QString& projectPath)
+    {
+        AZ::Outcome<EngineInfo> engineInfoResult = PythonBindingsInterface::Get()->GetProjectEngine(projectPath);
+        AZ::Outcome projectBuildPathResult = ProjectUtils::GetProjectBuildPath(projectPath);
+
+        auto engineInfo = engineInfoResult.TakeValue();
+        auto buildPath = projectBuildPathResult.TakeValue();
+
+        QString projectName = tr("Project");
+        auto getProjectResult = PythonBindingsInterface::Get()->GetProject(projectPath);
+        if (getProjectResult)
+        {
+            projectName = getProjectResult.GetValue().m_displayName;
+        }
+
+        const QString pythonPath = GetPythonExecutablePath(engineInfo.m_path);
+        const QString apgPath = QString("%1/Code/Tools/Android/ProjectGenerator/main.py").arg(engineInfo.m_path);
+
+
+        AZ_Printf("ProjectManager", "APG Info:\nProject Name: %s\nProject Path: %s\nEngine Path: %s\n3rdParty Path: %s\nBuild Path: %s\nPython Path: %s\nAPG path: %s\n",
+            projectName.toUtf8().constData(),
+            projectPath.toUtf8().constData(),
+            engineInfo.m_path.toUtf8().constData(),
+            engineInfo.m_thirdPartyPath.toUtf8().constData(),
+            buildPath.toUtf8().constData(),
+            pythonPath.toUtf8().constData(),
+            apgPath.toUtf8().constData());
+
+        // Let's start the python script.
+        QProcess process;        
+        process.setProgram(pythonPath);
+        const QStringList commandArgs { apgPath,
+                                        "--e", engineInfo.m_path,
+                                        "--p", projectPath,
+                                        "--b", buildPath,
+                                        "--t", engineInfo.m_thirdPartyPath };
+        process.setArguments(commandArgs);
+
+        // It's important to dump the command details in the application log so the user
+        // would know how to spawn the Android Project Generator from the command terminal
+        // in case of errors and debugging is required.
+        const QString commandArgsStr = QString("%1 %2").arg(pythonPath, commandArgs.join(" "));
+        AZ_Printf("ProjectManager", "Will start the Android Project Generator with the following command:\n%s\n", commandArgsStr.toUtf8().constData()); 
+
+        if (!process.startDetached())
+        {
+            QMessageBox::warning(
+                this,
+                tr("Tool Error"),
+                tr("Failed to start Android Project Generator from path %1").arg(apgPath),
+                QMessageBox::Ok);
+        }
+        
     }
 
     void ProjectsScreen::SuggestBuildProjectMsg(const ProjectInfo& projectInfo, bool showMessage)

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.h
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.h
@@ -59,6 +59,7 @@ namespace O3DE::ProjectManager
         void HandleCopyProject(const ProjectInfo& projectInfo);
         void HandleRemoveProject(const QString& projectPath);
         void HandleDeleteProject(const QString& projectPath);
+        void HandleOpenAndroidProjectGenerator(const QString& projectPath);
 
         void SuggestBuildProject(const ProjectInfo& projectInfo);
         void QueueBuildProject(const ProjectInfo& projectInfo, bool skipDialogBox = false);

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -51,7 +51,11 @@ namespace Platform
     // Implemented in each different platform's PAL implementation files, as it differs per platform.
     AZStd::string GetPythonHomePath(const char* pythonPackage, const char* engineRoot);
 
+    // Per platform information.
+    AZStd::string GetPythonExecutablePath(const char* engineRoot);
+
 } // namespace Platform
+
 
 #define Py_To_String(obj) pybind11::str(obj).cast<std::string>().c_str()
 #define Py_To_String_Optional(dict, key, default_string) dict.contains(key) ? Py_To_String(dict[key]) : default_string
@@ -235,6 +239,11 @@ namespace RedirectOutput
 
 namespace O3DE::ProjectManager
 {
+    QString GetPythonExecutablePath(const QString& enginePath)
+    {
+        return QString(Platform::GetPythonExecutablePath(enginePath.toUtf8().constData()).c_str());
+    }
+
     PythonBindings::PythonBindings(const AZ::IO::PathView& enginePath)
         : m_enginePath(enginePath)
     {

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -21,6 +21,8 @@
 
 namespace O3DE::ProjectManager
 {
+    QString GetPythonExecutablePath(const QString& enginePath);
+
     class PythonBindings
         : public PythonBindingsInterface::Registrar
     {

--- a/scripts/o3de/o3de/command_utils.py
+++ b/scripts/o3de/o3de/command_utils.py
@@ -84,7 +84,7 @@ class SettingsDescription(object):
 
     def validate_value(self, input):
         if self._is_password:
-            raise O3DEConfigError(f"Input value for '{self._key}' must be set through the password setting argument.")
+            logger.debug(f"Input value for '{self._key}' is a password. If extra security is required, use the --set-password setting argument.")
         if self._is_boolean:
             evaluate_boolean_from_setting(input)
         if self._restricted_regex and not self._restricted_regex.match(input):


### PR DESCRIPTION
## What does this PR do?
The Android Project Generator tool.

This PR adds a new feature to the ProjectManager (**o3de.exe**), by means of a set of python scripts, that automate the creation of Keystore files and the generation of an Android Project.

The following picture show the location of the menu option `Open Android Project Generator...`:  
<img src="https://github.com/o3de/o3de/assets/66021303/64caba4c-e94c-49e0-83ef-a7c3b07b993f" alt="alt text" width="300" height="300">
  
And this is how the APG UI looks like:  
![image](https://github.com/o3de/o3de/assets/66021303/d0656f1b-adb0-4abd-9b2a-e3ea40502b38)
  
The UI was developed with the `tkinter` python module because it facilitates manual execution of this tool from the terminal using the python version that ships with O3DE.  The initial iteration of this UI was developed with PySide2, but it required to run from the Editor and made it impossible to run from the terminal.

What used to be a runtime exception for `o3de.bat android-configue --set-value` for Keystore passwords has been changed to an informational message. Otherwise this tool would be more complicated to implement as it would require the usage of a module like `pexpect` (Which is not part of the O3DE python distribution) to emulate TTY input.

A `README.md` file was added to explains how to use the tool.

## How was this PR tested?

This tool was tested on a Windows10 Host machine. Android pojects were generated with this tool and compiled and deployed to Meta Quest Pro device for OpenXRTest and a custom O3DE project.
