### PR TITLE
Fix validation layer initialization

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Loader/LoaderContext.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Loader/LoaderContext.h
@@ -57,7 +57,7 @@ namespace AZ
             //! Loads extensions from a layer.
             void LoadLayerExtensions(const Descriptor& descriptor);
             //! Removes layers that were not loaded correctly.
-            void FilterAvailableExtensions();
+            void FilterAvailableExtensions(const VkDevice device = VK_NULL_HANDLE);
 
             GladVulkanContext m_context = {};
         };

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Loader/LoaderContext.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Loader/LoaderContext.cpp
@@ -39,7 +39,7 @@ namespace AZ
             {
                 LoadLayerExtensions(descriptor);
             }
-            FilterAvailableExtensions();
+            FilterAvailableExtensions(descriptor.m_device);
             return result != 0;
         }
 
@@ -196,11 +196,13 @@ namespace AZ
             return m_context;
         }
 
-        void LoaderContext::FilterAvailableExtensions()
+        void LoaderContext::FilterAvailableExtensions(const VkDevice device)
         {
             // In some cases (like when running with the GPU profiler on Quest2) the extension is reported as available
             // but the function pointers do not load. Disable the extension if that's the case.
-            if (m_context.EXT_debug_utils && !m_context.CmdBeginDebugUtilsLabelEXT)
+            if (device != VK_NULL_HANDLE &&
+                m_context.EXT_debug_utils &&
+                m_context.CmdBeginDebugUtilsLabelEXT)
             {
                 m_context.EXT_debug_utils = 0;
             }


### PR DESCRIPTION
## What does this PR do?

The EXT_debug_utils extension was incorrectly being flag as not available in the function "LoaderContext::FilterAvailableExtensions" causing the validation layer to not being enabled.

## How was this PR tested?

Run Vulkan with -rhi-device-validation=enable