### PR TITLE
Support for geometry shader

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
@@ -225,10 +225,6 @@ namespace AZ
                     return RHI::ShaderHardwareStage::Fragment;
                 case RPI::ShaderStageType::Geometry:
                     return RHI::ShaderHardwareStage::Geometry;
-                case RPI::ShaderStageType::TessellationControl:
-                    return RHI::ShaderHardwareStage::TessellationControl;
-                case RPI::ShaderStageType::TessellationEvaluation:
-                    return RHI::ShaderHardwareStage::TessellationEvaluation;
                 case RPI::ShaderStageType::Vertex:
                     return RHI::ShaderHardwareStage::Vertex;
                 case RPI::ShaderStageType::RayTracing:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/ShaderPlatformInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/ShaderPlatformInterface.h
@@ -40,8 +40,6 @@ namespace AZ::RHI
         Invalid = static_cast<uint32_t>(-1),
         Vertex = 0,
         Geometry,
-        TessellationControl,
-        TessellationEvaluation,
         Fragment,
         Compute,
         RayTracing,

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
@@ -20,9 +20,6 @@ namespace AZ::RHI
 {
     struct DeviceFeatures
     {
-        //! Whether the adapter supports tessellation shaders.
-        bool m_tessellationShader;
-
         //! Whether the adapter supports geometry shaders.
         bool m_geometryShader;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
@@ -32,6 +32,10 @@ namespace AZ::RHI
         //! a vertex. On certain platforms like Metal, this stage may occur after tessellation.
         Vertex = 0,
 
+        //! This virtual stage contains shader stages that expand an input assembly stream and manipulate
+        //! a vertex.
+        Geometry,
+
         //! This virtual stage contains platform-specific stages for hardware tessellation. The specifics
         //! of how tessellation is achieved varies per platform. PC platforms have dedicated stages to handle this,
         //! while others utilize compute.
@@ -47,10 +51,6 @@ namespace AZ::RHI
 
         // This virtual stage represents ray tracing shaders.  On DXIL platforms this is implemented with a DXIL Library.
         RayTracing,
-        
-        //! This virtual stage contains shader stages that expand an input assembly stream and manipulate
-        //! a vertex.
-        Geometry,
 
         Count,
         GraphicsCount = Compute,
@@ -70,11 +70,11 @@ namespace AZ::RHI
     {
         None = 0,
         Vertex = AZ_BIT(static_cast<uint32_t>(ShaderStage::Vertex)),
+        Geometry = AZ_BIT(static_cast<uint32_t>(ShaderStage::Geometry)),
         Tessellation = AZ_BIT(static_cast<uint32_t>(ShaderStage::Tessellation)),
         Fragment = AZ_BIT(static_cast<uint32_t>(ShaderStage::Fragment)),
         Compute = AZ_BIT(static_cast<uint32_t>(ShaderStage::Compute)),
         RayTracing = AZ_BIT(static_cast<uint32_t>(ShaderStage::RayTracing)),
-        Geometry = AZ_BIT(static_cast<uint32_t>(ShaderStage::Geometry)),
         All = Vertex | Tessellation | Fragment | Compute | RayTracing | Geometry
     };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
@@ -47,6 +47,10 @@ namespace AZ::RHI
 
         // This virtual stage represents ray tracing shaders.  On DXIL platforms this is implemented with a DXIL Library.
         RayTracing,
+        
+        //! This virtual stage contains shader stages that expand an input assembly stream and manipulate
+        //! a vertex.
+        Geometry,
 
         Count,
         GraphicsCount = Compute,
@@ -70,7 +74,8 @@ namespace AZ::RHI
         Fragment = AZ_BIT(static_cast<uint32_t>(ShaderStage::Fragment)),
         Compute = AZ_BIT(static_cast<uint32_t>(ShaderStage::Compute)),
         RayTracing = AZ_BIT(static_cast<uint32_t>(ShaderStage::RayTracing)),
-        All = Vertex | Tessellation | Fragment | Compute | RayTracing
+        Geometry = AZ_BIT(static_cast<uint32_t>(ShaderStage::Geometry)),
+        All = Vertex | Tessellation | Fragment | Compute | RayTracing | Geometry
     };
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ShaderStageMask)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStages.h
@@ -33,13 +33,8 @@ namespace AZ::RHI
         Vertex = 0,
 
         //! This virtual stage contains shader stages that expand an input assembly stream and manipulate
-        //! a vertex.
+        //! a vertex Note: Not supported on metal.
         Geometry,
-
-        //! This virtual stage contains platform-specific stages for hardware tessellation. The specifics
-        //! of how tessellation is achieved varies per platform. PC platforms have dedicated stages to handle this,
-        //! while others utilize compute.
-        Tessellation,
 
         //! This virtual stage contains the platform-specific stages necessary to process screen space fragments.
         //! Currently, on all supported platforms, this maps 1-to-1 with a hardware shader stage.
@@ -71,11 +66,10 @@ namespace AZ::RHI
         None = 0,
         Vertex = AZ_BIT(static_cast<uint32_t>(ShaderStage::Vertex)),
         Geometry = AZ_BIT(static_cast<uint32_t>(ShaderStage::Geometry)),
-        Tessellation = AZ_BIT(static_cast<uint32_t>(ShaderStage::Tessellation)),
         Fragment = AZ_BIT(static_cast<uint32_t>(ShaderStage::Fragment)),
         Compute = AZ_BIT(static_cast<uint32_t>(ShaderStage::Compute)),
         RayTracing = AZ_BIT(static_cast<uint32_t>(ShaderStage::RayTracing)),
-        All = Vertex | Tessellation | Fragment | Compute | RayTracing | Geometry
+        All = Vertex | Geometry | Fragment | Compute | RayTracing
     };
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ShaderStageMask)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
@@ -99,6 +99,9 @@ namespace AZ::RHI
         ConstPtr<ShaderStageFunction> m_vertexFunction;
 
         /// [Optional] The tessellation function to compile.
+        ConstPtr<ShaderStageFunction> m_geometryFunction;
+        
+        /// [Optional] The tessellation function to compile.
         ConstPtr<ShaderStageFunction> m_tessellationFunction;
 
         /// [Required] The fragment function used to compile.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
@@ -98,11 +98,8 @@ namespace AZ::RHI
         /// [Required] The vertex function to compile.
         ConstPtr<ShaderStageFunction> m_vertexFunction;
 
-        /// [Optional] The tessellation function to compile.
+        /// [Optional] The geometry function to compile.
         ConstPtr<ShaderStageFunction> m_geometryFunction;
-        
-        /// [Optional] The tessellation function to compile.
-        ConstPtr<ShaderStageFunction> m_tessellationFunction;
 
         /// [Required] The fragment function used to compile.
         ConstPtr<ShaderStageFunction> m_fragmentFunction;

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -413,8 +413,7 @@ namespace AZ::RHI
         case ShaderHardwareStage::Fragment:
             return RHI::ShaderStage::Fragment;
         case ShaderHardwareStage::Geometry:
-            AZ_Assert(false, "RHI currently does not support geometry shaders");
-            return RHI::ShaderStage::Unknown;
+            return RHI::ShaderStage::Geometry;
         case ShaderHardwareStage::TessellationControl:
         case ShaderHardwareStage::TessellationEvaluation:
             return RHI::ShaderStage::Tessellation;

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -414,9 +414,6 @@ namespace AZ::RHI
             return RHI::ShaderStage::Fragment;
         case ShaderHardwareStage::Geometry:
             return RHI::ShaderStage::Geometry;
-        case ShaderHardwareStage::TessellationControl:
-        case ShaderHardwareStage::TessellationEvaluation:
-            return RHI::ShaderStage::Tessellation;
         case ShaderHardwareStage::Vertex:
             return RHI::ShaderStage::Vertex;
         case ShaderHardwareStage::RayTracing:

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
@@ -64,10 +64,6 @@ namespace AZ::RHI
         {
             seed = TypeHash64(m_geometryFunction->GetHash(), seed);
         }
-        if (m_tessellationFunction)
-        {
-            seed = TypeHash64(m_tessellationFunction->GetHash(), seed);
-        }
         if (m_fragmentFunction)
         {
             seed = TypeHash64(m_fragmentFunction->GetHash(), seed);
@@ -96,8 +92,8 @@ namespace AZ::RHI
     {
         return m_fragmentFunction == rhs.m_fragmentFunction && m_pipelineLayoutDescriptor == rhs.m_pipelineLayoutDescriptor &&
             m_renderStates == rhs.m_renderStates && m_vertexFunction == rhs.m_vertexFunction &&
-            m_geometryFunction == rhs.m_geometryFunction && m_tessellationFunction == rhs.m_tessellationFunction &&
-            m_inputStreamLayout == rhs.m_inputStreamLayout && m_renderAttachmentConfiguration == rhs.m_renderAttachmentConfiguration;
+            m_geometryFunction == rhs.m_geometryFunction && m_inputStreamLayout == rhs.m_inputStreamLayout && 
+            m_renderAttachmentConfiguration == rhs.m_renderAttachmentConfiguration;
     }
 
     bool PipelineStateDescriptorForDispatch::operator == (const PipelineStateDescriptorForDispatch& rhs) const

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
@@ -60,6 +60,10 @@ namespace AZ::RHI
         {
             seed = TypeHash64(m_vertexFunction->GetHash(), seed);
         }
+        if (m_geometryFunction)
+        {
+            seed = TypeHash64(m_geometryFunction->GetHash(), seed);
+        }
         if (m_tessellationFunction)
         {
             seed = TypeHash64(m_tessellationFunction->GetHash(), seed);
@@ -90,13 +94,10 @@ namespace AZ::RHI
 
     bool PipelineStateDescriptorForDraw::operator == (const PipelineStateDescriptorForDraw& rhs) const
     {
-        return m_fragmentFunction == rhs.m_fragmentFunction &&
-            m_pipelineLayoutDescriptor == rhs.m_pipelineLayoutDescriptor &&
-            m_renderStates == rhs.m_renderStates &&
-            m_vertexFunction == rhs.m_vertexFunction &&
-            m_tessellationFunction == rhs.m_tessellationFunction &&
-            m_inputStreamLayout == rhs.m_inputStreamLayout &&
-            m_renderAttachmentConfiguration == rhs.m_renderAttachmentConfiguration;
+        return m_fragmentFunction == rhs.m_fragmentFunction && m_pipelineLayoutDescriptor == rhs.m_pipelineLayoutDescriptor &&
+            m_renderStates == rhs.m_renderStates && m_vertexFunction == rhs.m_vertexFunction &&
+            m_geometryFunction == rhs.m_geometryFunction && m_tessellationFunction == rhs.m_tessellationFunction &&
+            m_inputStreamLayout == rhs.m_inputStreamLayout && m_renderAttachmentConfiguration == rhs.m_renderAttachmentConfiguration;
     }
 
     bool PipelineStateDescriptorForDispatch::operator == (const PipelineStateDescriptorForDispatch& rhs) const

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/ShaderStageFunction.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/ShaderStageFunction.h
@@ -40,13 +40,9 @@ namespace AZ
         {
             /// Used when the sub-stage is 1-to-1 with the virtual stage.
             const uint32_t Default = 0;
-
-            /// Tessellation is composed of two physical stages in HLSL.
-            const uint32_t TessellationHull = 0;
-            const uint32_t TessellationDomain = 1;
         }
 
-        const uint32_t ShaderSubStageCountMax = 2;
+        const uint32_t ShaderSubStageCountMax = 1;
 
         class ShaderStageFunction
             : public RHI::ShaderStageFunction

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/ShaderStageFunction.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/ShaderStageFunction.h
@@ -42,7 +42,7 @@ namespace AZ
             const uint32_t Default = 0;
         }
 
-        const uint32_t ShaderSubStageCountMax = 1;
+        const uint32_t ShaderSubStageCountMax = 2;
 
         class ShaderStageFunction
             : public RHI::ShaderStageFunction

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -61,6 +61,7 @@ namespace AZ
 
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Vertex;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Fragment;
+            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Geometry;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationControl;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationEvaluation;
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -47,7 +47,7 @@ namespace AZ
             RHI::Ptr<ShaderStageFunction> newShaderStageFunction =  ShaderStageFunction::Create(RHI::ToRHIShaderStage(stageDescriptor.m_stageType));
 
             const DX12::ShaderByteCode& byteCode = stageDescriptor.m_byteCode;
-            const int byteCodeIndex = (stageDescriptor.m_stageType == RHI::ShaderHardwareStage::TessellationEvaluation) ? 1 : 0;
+            const int byteCodeIndex = 0;
             newShaderStageFunction->SetByteCode(byteCodeIndex, byteCode);
 
             newShaderStageFunction->Finalize();
@@ -62,8 +62,6 @@ namespace AZ
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Vertex;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Fragment;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Geometry;
-            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationControl;
-            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationEvaluation;
 
             return hasRasterProgram;
         }
@@ -230,8 +228,6 @@ namespace AZ
                 {RHI::ShaderHardwareStage::Fragment,               "ps_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::Compute,                "cs_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::Geometry,               "gs_" + shaderModelVersion},
-                {RHI::ShaderHardwareStage::TessellationControl,    "hs_" + shaderModelVersion},
-                {RHI::ShaderHardwareStage::TessellationEvaluation, "ds_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::RayTracing,             "lib_6_3"}
             };
             auto profileIt = stageToProfileName.find(shaderStageType);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
@@ -1195,8 +1195,6 @@ namespace AZ
                 return D3D12_SHADER_VISIBILITY_VERTEX;
             case RHI::ShaderStageMask::Geometry:
                 return D3D12_SHADER_VISIBILITY_GEOMETRY;
-            case RHI::ShaderStageMask::Tessellation:
-                return D3D12_SHADER_VISIBILITY_ALL;
             case RHI::ShaderStageMask::Fragment:
                 return D3D12_SHADER_VISIBILITY_PIXEL;
             case RHI::ShaderStageMask::Compute:

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
@@ -1193,6 +1193,8 @@ namespace AZ
                 return D3D12_SHADER_VISIBILITY_ALL;
             case RHI::ShaderStageMask::Vertex:
                 return D3D12_SHADER_VISIBILITY_VERTEX;
+            case RHI::ShaderStageMask::Geometry:
+                return D3D12_SHADER_VISIBILITY_GEOMETRY;
             case RHI::ShaderStageMask::Tessellation:
                 return D3D12_SHADER_VISIBILITY_ALL;
             case RHI::ShaderStageMask::Fragment:

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -208,7 +208,6 @@ namespace AZ
 
         void Device::InitFeatures()
         {
-            m_features.m_tessellationShader = true;
             m_features.m_geometryShader = true;
             m_features.m_computeShader = true;
             m_features.m_independentBlend = true;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
@@ -66,12 +66,6 @@ namespace AZ
                 pipelineStateDesc.GS = D3D12BytecodeFromView(geometryFunction->GetByteCode());
             }
 
-            if (const ShaderStageFunction* tessellationFunction = azrtti_cast<const ShaderStageFunction*>(descriptor.m_tessellationFunction.get()))
-            {
-                pipelineStateDesc.HS = D3D12BytecodeFromView(tessellationFunction->GetByteCode(ShaderSubStage::TessellationHull));
-                pipelineStateDesc.DS = D3D12BytecodeFromView(tessellationFunction->GetByteCode(ShaderSubStage::TessellationDomain));
-            }
-
             if (const ShaderStageFunction* fragmentFunction = azrtti_cast<const ShaderStageFunction*>(descriptor.m_fragmentFunction.get()))
             {
                 pipelineStateDesc.PS = D3D12BytecodeFromView(fragmentFunction->GetByteCode());

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineState.cpp
@@ -61,6 +61,11 @@ namespace AZ
                 pipelineStateDesc.VS = D3D12BytecodeFromView(vertexFunction->GetByteCode());
             }
 
+            if (const ShaderStageFunction* geometryFunction = azrtti_cast<const ShaderStageFunction*>(descriptor.m_geometryFunction.get()))
+            {
+                pipelineStateDesc.GS = D3D12BytecodeFromView(geometryFunction->GetByteCode());
+            }
+
             if (const ShaderStageFunction* tessellationFunction = azrtti_cast<const ShaderStageFunction*>(descriptor.m_tessellationFunction.get()))
             {
                 pipelineStateDesc.HS = D3D12BytecodeFromView(tessellationFunction->GetByteCode(ShaderSubStage::TessellationHull));

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h
@@ -44,7 +44,7 @@ namespace AZ
             const uint32_t Default = 0;
         }
 
-        const uint32_t ShaderSubStageCountMax = 1;
+        const uint32_t ShaderSubStageCountMax = 2;
 
         class ShaderStageFunction
             : public RHI::ShaderStageFunction

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h
@@ -42,13 +42,9 @@ namespace AZ
         {
             /// Used when the sub-stage is 1-to-1 with the virtual stage.
             const uint32_t Default = 0;
-
-            /// Tessellation is composed of two physical stages in Vulkan.
-            const uint32_t TesselationControl = 0;
-            const uint32_t TesselationEvaluattion = 1;
         }
 
-        const uint32_t ShaderSubStageCountMax = 2;
+        const uint32_t ShaderSubStageCountMax = 1;
 
         class ShaderStageFunction
             : public RHI::ShaderStageFunction

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -55,6 +55,7 @@ namespace AZ
             bool hasRasterProgram = false;
 
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Vertex;
+            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Geometry;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Fragment;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationControl;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationEvaluation;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -42,7 +42,7 @@ namespace AZ
 
             const Vulkan::ShaderByteCode& byteCode = stageDescriptor.m_byteCode;
             const AZStd::string& entryFunctionName = stageDescriptor.m_entryFunctionName;
-            const int byteCodeIndex = (stageDescriptor.m_stageType == RHI::ShaderHardwareStage::TessellationEvaluation) ? 1 : 0;
+            const int byteCodeIndex = 0;
             newShaderStageFunction->SetByteCode(byteCodeIndex, byteCode, entryFunctionName);
 
             newShaderStageFunction->Finalize();
@@ -57,8 +57,6 @@ namespace AZ
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Vertex;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Geometry;
             hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::Fragment;
-            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationControl;
-            hasRasterProgram |= shaderStageType == RHI::ShaderHardwareStage::TessellationEvaluation;
 
             return hasRasterProgram;
         }
@@ -186,8 +184,6 @@ namespace AZ
                 {RHI::ShaderHardwareStage::Fragment,               "ps_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::Compute,                "cs_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::Geometry,               "gs_" + shaderModelVersion},
-                {RHI::ShaderHardwareStage::TessellationControl,    "hs_" + shaderModelVersion},
-                {RHI::ShaderHardwareStage::TessellationEvaluation, "ds_" + shaderModelVersion},
                 {RHI::ShaderHardwareStage::RayTracing,             "lib_6_3"}
             };
             auto profileIt = stageToProfileName.find(shaderStageType);
@@ -225,7 +221,6 @@ namespace AZ
             {
             case RHI::ShaderHardwareStage::Vertex:
             case RHI::ShaderHardwareStage::Geometry:
-            case RHI::ShaderHardwareStage::TessellationEvaluation:
                 RHI::ShaderBuildArguments::AppendArguments(dxcArguments, { "-fvk-invert-y" });
                 break;
             case RHI::ShaderHardwareStage::Fragment:
@@ -233,7 +228,6 @@ namespace AZ
                 // when compiling a shader stage that is not the fragment shader (even if it's not being used).
                 RHI::ShaderBuildArguments::AppendArguments(dxcArguments, { "-DAZ_USE_SUBPASSINPUT", "-fvk-use-dx-position-w"});
                 break;
-            case RHI::ShaderHardwareStage::TessellationControl:
             case RHI::ShaderHardwareStage::Compute:
             case RHI::ShaderHardwareStage::RayTracing:
                 break;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -569,6 +569,8 @@ namespace AZ
                 return VK_SHADER_STAGE_FRAGMENT_BIT;
             case RHI::ShaderStage::Compute:
                 return VK_SHADER_STAGE_COMPUTE_BIT;
+            case RHI::ShaderStage::Geometry:
+                return VK_SHADER_STAGE_GEOMETRY_BIT;
             case RHI::ShaderStage::Tessellation:
                 return subStageIndex == 0 ? VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT : VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
             default:

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -559,7 +559,7 @@ namespace AZ
             return flags;
         }
 
-        VkShaderStageFlagBits ConvertShaderStage(RHI::ShaderStage stage, uint32_t subStageIndex /* = 0 */)
+        VkShaderStageFlagBits ConvertShaderStage(RHI::ShaderStage stage, [[maybe_unused]] uint32_t subStageIndex /* = 0 */)
         {
             switch (stage)
             {
@@ -571,8 +571,6 @@ namespace AZ
                 return VK_SHADER_STAGE_COMPUTE_BIT;
             case RHI::ShaderStage::Geometry:
                 return VK_SHADER_STAGE_GEOMETRY_BIT;
-            case RHI::ShaderStage::Tessellation:
-                return subStageIndex == 0 ? VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT : VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
             default:
                 AZ_Assert(false, "Invalid shader stage %d", stage);
                 return VkShaderStageFlagBits(0);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1064,7 +1064,6 @@ namespace AZ
 
         void Device::InitFeaturesAndLimits(const PhysicalDevice& physicalDevice)
         {
-            m_features.m_tessellationShader = (m_enabledDeviceFeatures.tessellationShader == VK_TRUE);
             m_features.m_geometryShader = (m_enabledDeviceFeatures.geometryShader == VK_TRUE);
             m_features.m_computeShader = true;
             m_features.m_independentBlend = (m_enabledDeviceFeatures.independentBlend == VK_TRUE);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -271,6 +271,9 @@ namespace AZ
                 vulkan12Features.descriptorBindingStorageBufferUpdateAfterBind = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingStorageBufferUpdateAfterBind;
                 vulkan12Features.descriptorBindingPartiallyBound = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingPartiallyBound;
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
+                vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
+                vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
+                shaderImageAtomicInt64.pNext = &vulkan12Features;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
@@ -123,19 +123,6 @@ namespace AZ
             m_pipelineShaderStageCreateInfos.emplace_back();
             FillPipelineShaderStageCreateInfo(*func, RHI::ShaderStage::Vertex, ShaderSubStage::Default, *m_pipelineShaderStageCreateInfos.rbegin());
 
-            if (GetDevice().GetFeatures().m_tessellationShader)
-            {
-                func = static_cast<ShaderStageFunction const*>(descriptor.m_tessellationFunction.get());
-                if (func)
-                {
-                    for (uint32_t subStageIndex = 0; subStageIndex < ShaderSubStageCountMax; ++subStageIndex)
-                    {
-                        m_pipelineShaderStageCreateInfos.emplace_back();
-                        FillPipelineShaderStageCreateInfo(*func, RHI::ShaderStage::Tessellation, subStageIndex, *m_pipelineShaderStageCreateInfos.rbegin());
-                    }
-                }
-            }
-
             if (GetDevice().GetFeatures().m_geometryShader)
             {
                 func = static_cast<ShaderStageFunction const*>(descriptor.m_geometryFunction.get());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/GraphicsPipeline.cpp
@@ -136,6 +136,17 @@ namespace AZ
                 }
             }
 
+            if (GetDevice().GetFeatures().m_geometryShader)
+            {
+                func = static_cast<ShaderStageFunction const*>(descriptor.m_geometryFunction.get());
+                if (func)
+                {
+                    m_pipelineShaderStageCreateInfos.emplace_back();
+                    FillPipelineShaderStageCreateInfo(
+                        *func, RHI::ShaderStage::Geometry, ShaderSubStage::Default, *m_pipelineShaderStageCreateInfos.rbegin());
+                }
+            }
+
             func = static_cast<ShaderStageFunction const*>(descriptor.m_fragmentFunction.get());
             if (func)
             {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
@@ -109,19 +109,6 @@ namespace AZ
             case RHI::ShaderStage::Geometry:
                 stageBits = VK_SHADER_STAGE_GEOMETRY_BIT;
                 break;
-            case RHI::ShaderStage::Tessellation:
-                switch (subStageIndex)
-                {
-                case ShaderSubStage::TesselationControl:
-                    stageBits = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-                    break;
-                case ShaderSubStage::TesselationEvaluattion:
-                    stageBits = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
-                    break;
-                default:
-                    AZ_Assert(false, "Shader Sub Stage is wrong.");
-                }
-                break;
             case RHI::ShaderStage::Fragment:
                 stageBits = VK_SHADER_STAGE_FRAGMENT_BIT;
                 break;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
@@ -106,6 +106,9 @@ namespace AZ
             case RHI::ShaderStage::Vertex:
                 stageBits = VK_SHADER_STAGE_VERTEX_BIT;
                 break;
+            case RHI::ShaderStage::Geometry:
+                stageBits = VK_SHADER_STAGE_GEOMETRY_BIT;
+                break;
             case RHI::ShaderStage::Tessellation:
                 switch (subStageIndex)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
@@ -45,7 +45,6 @@ namespace AZ
 
             if (m_asset->GetShaderStageFunction(RHI::ShaderStage::Vertex) ||
                 m_asset->GetShaderStageFunction(RHI::ShaderStage::Geometry) ||
-                m_asset->GetShaderStageFunction(RHI::ShaderStage::Tessellation) ||
                 m_asset->GetShaderStageFunction(RHI::ShaderStage::Fragment))
             {
                 foundDrawFunctions = true;
@@ -67,13 +66,6 @@ namespace AZ
                 !m_asset->GetShaderStageFunction(RHI::ShaderStage::Vertex))
             {
                 ReportError("Shader Variant with StableId '%u' has a fragment function but no vertex function.", m_asset->m_stableId);
-                return false;
-            }
-
-            if (m_asset->GetShaderStageFunction(RHI::ShaderStage::Tessellation) &&
-                !m_asset->GetShaderStageFunction(RHI::ShaderStage::Vertex))
-            {
-                ReportError("Shader Variant with StableId '%u' has a tessellation function but no vertex function.", m_asset->m_stableId);
                 return false;
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantAssetCreator.cpp
@@ -44,6 +44,7 @@ namespace AZ
             bool foundDispatchFunctions = false;
 
             if (m_asset->GetShaderStageFunction(RHI::ShaderStage::Vertex) ||
+                m_asset->GetShaderStageFunction(RHI::ShaderStage::Geometry) ||
                 m_asset->GetShaderStageFunction(RHI::ShaderStage::Tessellation) ||
                 m_asset->GetShaderStageFunction(RHI::ShaderStage::Fragment))
             {
@@ -76,7 +77,12 @@ namespace AZ
                 return false;
             }
 
-
+            if (m_asset->GetShaderStageFunction(RHI::ShaderStage::Geometry) &&
+                !m_asset->GetShaderStageFunction(RHI::ShaderStage::Vertex))
+            {
+                ReportError("Shader Variant with StableId '%u' has a geometry function but no vertex function.", m_asset->m_stableId);
+                return false;
+            }
 
             m_asset->SetReady();
             return EndCommon(result);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariant.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariant.cpp
@@ -51,7 +51,6 @@ namespace AZ
                 RHI::PipelineStateDescriptorForDraw& descriptorForDraw = static_cast<RHI::PipelineStateDescriptorForDraw&>(descriptor);
                 descriptorForDraw.m_vertexFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Vertex);
                 descriptorForDraw.m_geometryFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Geometry);
-                descriptorForDraw.m_tessellationFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Tessellation);
                 descriptorForDraw.m_fragmentFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Fragment);
                 descriptorForDraw.m_renderStates = *m_renderStates;
                 break;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariant.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariant.cpp
@@ -50,6 +50,7 @@ namespace AZ
                 AZ_Assert(m_renderStates, "Invalid RenderStates");
                 RHI::PipelineStateDescriptorForDraw& descriptorForDraw = static_cast<RHI::PipelineStateDescriptorForDraw&>(descriptor);
                 descriptorForDraw.m_vertexFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Vertex);
+                descriptorForDraw.m_geometryFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Geometry);
                 descriptorForDraw.m_tessellationFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Tessellation);
                 descriptorForDraw.m_fragmentFunction = m_shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Fragment);
                 descriptorForDraw.m_renderStates = *m_renderStates;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
@@ -242,7 +242,6 @@ namespace AZ
         {
             if (shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Vertex) ||
                 shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Geometry) ||
-                shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Tessellation) ||
                 shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Fragment))
             {
                 return RHI::PipelineStateType::Draw;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
@@ -241,6 +241,7 @@ namespace AZ
         static RHI::PipelineStateType GetPipelineStateType(const Data::Asset<ShaderVariantAsset>& shaderVariantAsset)
         {
             if (shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Vertex) ||
+                shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Geometry) ||
                 shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Tessellation) ||
                 shaderVariantAsset->GetShaderStageFunction(RHI::ShaderStage::Fragment))
             {

--- a/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
@@ -1229,6 +1229,22 @@ namespace UnitTest
         EXPECT_FALSE(shaderAsset);
     }
 
+    TEST_F(ShaderTests, ShaderAsset_Error_GeometryFunctionRequiresVertexFunction)
+    {
+        ErrorMessageFinder messageFinder("geometry function but no vertex function");
+        messageFinder.AddExpectedErrorMessage("Invalid root variant");
+        messageFinder.AddExpectedErrorMessage("Cannot continue building ShaderAsset because 1 error(s) reported");
+
+        AZ::RPI::ShaderAssetCreator creator;
+        BeginCreatingTestShaderAsset(creator, { AZ::RHI::ShaderStage::Geometry });
+
+        AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
+
+        messageFinder.CheckExpectedErrorsFound();
+
+        EXPECT_FALSE(shaderAsset);
+    }
+
     TEST_F(ShaderTests, ShaderAsset_Error_TessellationFunctionRequiresVertexFunction)
     {
         ErrorMessageFinder messageFinder("tessellation function but no vertex function");

--- a/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Shader/ShaderTests.cpp
@@ -1245,22 +1245,6 @@ namespace UnitTest
         EXPECT_FALSE(shaderAsset);
     }
 
-    TEST_F(ShaderTests, ShaderAsset_Error_TessellationFunctionRequiresVertexFunction)
-    {
-        ErrorMessageFinder messageFinder("tessellation function but no vertex function");
-        messageFinder.AddExpectedErrorMessage("Invalid root variant");
-        messageFinder.AddExpectedErrorMessage("Cannot continue building ShaderAsset because 1 error(s) reported");
-
-        AZ::RPI::ShaderAssetCreator creator;
-        BeginCreatingTestShaderAsset(creator, { AZ::RHI::ShaderStage::Tessellation });
-
-        AZ::Data::Asset<AZ::RPI::ShaderAsset> shaderAsset = EndCreatingTestShaderAsset(creator);
-
-        messageFinder.CheckExpectedErrorsFound();
-
-        EXPECT_FALSE(shaderAsset);
-    }
-
     TEST_F(ShaderTests, ShaderAsset_Serialize_Test)
     {
         using namespace AZ;


### PR DESCRIPTION
## What does this PR do?

Adds support for geometry shaders for Vulkan and DX12 Backends.

Note, this PR breaks DDGI gem and DDGI gem needs to be recompiled.

## How was this PR tested?

Ran on Windows with Dx12 and Vulkan RHI