### PR TITLE
Multi device rpi srg

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
@@ -402,7 +402,7 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
             drawPacketBuilder.SetDrawArguments(drawIndexed);
             drawPacketBuilder.SetIndexBufferView(group.m_indexBufferView);
-            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = m_shaderData.m_drawListTag;

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -1656,7 +1656,7 @@ namespace AZ
 
                 return BuildDrawPacket(
                     drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag,
-                    pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get(), sortKey);
+                    pipelineState->GetRHIPipelineState(), sortKey);
             }
             return nullptr;
         }
@@ -1750,7 +1750,7 @@ namespace AZ
             auto& drawListTag = shaderData.m_drawListTag;
 
             return BuildDrawPacket(
-                drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag, pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag, pipelineState->GetRHIPipelineState(),
                 sortKey);
         }
 
@@ -1761,7 +1761,7 @@ namespace AZ
             const RHI::SingleDeviceIndexBufferView& indexBufferView,
             const StreamBufferViewsForAllStreams& streamBufferViews,
             RHI::DrawListTag drawListTag,
-            const RHI::SingleDevicePipelineState* pipelineState,
+            const RHI::MultiDevicePipelineState* pipelineState,
             RHI::DrawItemSortKey sortKey)
         {
             RHI::DrawIndexed drawIndexed;
@@ -1776,7 +1776,7 @@ namespace AZ
 
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = drawListTag;
-            drawRequest.m_pipelineState = pipelineState;
+            drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
             drawRequest.m_streamBufferViews = streamBufferViews;
             drawRequest.m_sortKey = sortKey;
             drawPacketBuilder.AddDrawItem(drawRequest);

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -1656,7 +1656,7 @@ namespace AZ
 
                 return BuildDrawPacket(
                     drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag,
-                    pipelineState->GetRHIPipelineState(), sortKey);
+                    pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get(), sortKey);
             }
             return nullptr;
         }
@@ -1750,7 +1750,7 @@ namespace AZ
             auto& drawListTag = shaderData.m_drawListTag;
 
             return BuildDrawPacket(
-                drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag, pipelineState->GetRHIPipelineState(),
+                drawPacketBuilder, srg, indexCount, indexBufferView, streamBufferViews, drawListTag, pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get(),
                 sortKey);
         }
 
@@ -1761,7 +1761,7 @@ namespace AZ
             const RHI::SingleDeviceIndexBufferView& indexBufferView,
             const StreamBufferViewsForAllStreams& streamBufferViews,
             RHI::DrawListTag drawListTag,
-            const AZ::RHI::MultiDevicePipelineState* pipelineState,
+            const RHI::SingleDevicePipelineState* pipelineState,
             RHI::DrawItemSortKey sortKey)
         {
             RHI::DrawIndexed drawIndexed;
@@ -1772,11 +1772,11 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
             drawPacketBuilder.SetDrawArguments(drawIndexed);
             drawPacketBuilder.SetIndexBufferView(indexBufferView);
-            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = drawListTag;
-            drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = pipelineState;
             drawRequest.m_streamBufferViews = streamBufferViews;
             drawRequest.m_sortKey = sortKey;
             drawPacketBuilder.AddDrawItem(drawRequest);

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
@@ -173,8 +173,7 @@ namespace AZ
             void InitPipelineState(const PipelineStateOptions& options);
             RPI::Ptr<RPI::PipelineStateForDraw>& GetPipelineState(const PipelineStateOptions& pipelineStateOptions);
 
-            const RHI::SingleDeviceIndexBufferView& GetShapeIndexBufferView(
-                AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
+            const AZ::RHI::SingleDeviceIndexBufferView& GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
             const StreamBufferViewsForAllStreams& GetShapeStreamBufferViews(AuxGeomShapeType shapeType, LodIndex lodIndex, int drawStyle) const;
             uint32_t GetShapeIndexCount(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex);
 
@@ -188,7 +187,7 @@ namespace AZ
                 LodIndex lodIndex,
                 RHI::DrawItemSortKey sortKey = 0);
 
-            const RHI::SingleDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
+            const AZ::RHI::SingleDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
             const StreamBufferViewsForAllStreams& GetBoxStreamBufferViews(int drawStyle) const;
             uint32_t GetBoxIndexCount(int drawStyle);
 
@@ -209,7 +208,7 @@ namespace AZ
                 const RHI::SingleDeviceIndexBufferView& indexBufferView,
                 const StreamBufferViewsForAllStreams& streamBufferViews,
                 RHI::DrawListTag drawListTag,
-                const AZ::RHI::SingleDevicePipelineState* pipelineState,
+                const AZ::RHI::MultiDevicePipelineState* pipelineState,
                 RHI::DrawItemSortKey sortKey);
 
         private: // data

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
@@ -173,7 +173,8 @@ namespace AZ
             void InitPipelineState(const PipelineStateOptions& options);
             RPI::Ptr<RPI::PipelineStateForDraw>& GetPipelineState(const PipelineStateOptions& pipelineStateOptions);
 
-            const AZ::RHI::SingleDeviceIndexBufferView& GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
+            const RHI::SingleDeviceIndexBufferView& GetShapeIndexBufferView(
+                AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
             const StreamBufferViewsForAllStreams& GetShapeStreamBufferViews(AuxGeomShapeType shapeType, LodIndex lodIndex, int drawStyle) const;
             uint32_t GetShapeIndexCount(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex);
 
@@ -187,7 +188,7 @@ namespace AZ
                 LodIndex lodIndex,
                 RHI::DrawItemSortKey sortKey = 0);
 
-            const AZ::RHI::SingleDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
+            const RHI::SingleDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
             const StreamBufferViewsForAllStreams& GetBoxStreamBufferViews(int drawStyle) const;
             uint32_t GetBoxIndexCount(int drawStyle);
 
@@ -208,7 +209,7 @@ namespace AZ
                 const RHI::SingleDeviceIndexBufferView& indexBufferView,
                 const StreamBufferViewsForAllStreams& streamBufferViews,
                 RHI::DrawListTag drawListTag,
-                const AZ::RHI::MultiDevicePipelineState* pipelineState,
+                const AZ::RHI::SingleDevicePipelineState* pipelineState,
                 RHI::DrawItemSortKey sortKey);
 
         private: // data

--- a/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
@@ -46,7 +46,7 @@ namespace AZ
                             RPI::Image* image = azrtti_cast<RPI::Image*>(attachment->m_importedResource.get());
                             if (image)
                             {
-                                attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                                attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage());
                             }
                         }
                     }

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
@@ -59,8 +59,8 @@ namespace AZ
 
             // store the current exposure values
             Data::Instance<RPI::ShaderResourceGroup> sceneSrg = m_scene->GetShaderResourceGroup();
-            m_previousGlobalIblExposure = sceneSrg->GetConstant<float>(m_globalIblExposureConstantIndex);
-            m_previousSkyBoxExposure = sceneSrg->GetConstant<float>(m_skyBoxExposureConstantIndex);
+            m_previousGlobalIblExposure = sceneSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(0)->GetData().GetConstant<float>(m_globalIblExposureConstantIndex.GetConstantIndex());
+            m_previousSkyBoxExposure = sceneSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(0)->GetData().GetConstant<float>(m_skyBoxExposureConstantIndex.GetConstantIndex());
 
             // add the pipeline to the scene
             m_scene->AddRenderPipeline(environmentCubeMapPipeline);

--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
@@ -59,8 +59,8 @@ namespace AZ
 
             // store the current exposure values
             Data::Instance<RPI::ShaderResourceGroup> sceneSrg = m_scene->GetShaderResourceGroup();
-            m_previousGlobalIblExposure = sceneSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(0)->GetData().GetConstant<float>(m_globalIblExposureConstantIndex.GetConstantIndex());
-            m_previousSkyBoxExposure = sceneSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(0)->GetData().GetConstant<float>(m_skyBoxExposureConstantIndex.GetConstantIndex());
+            m_previousGlobalIblExposure = sceneSrg->GetConstant<float>(m_globalIblExposureConstantIndex.GetConstantIndex());
+            m_previousSkyBoxExposure = sceneSrg->GetConstant<float>(m_skyBoxExposureConstantIndex.GetConstantIndex());
 
             // add the pipeline to the scene
             m_scene->AddRenderPipeline(environmentCubeMapPipeline);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/AcesOutputTransformLutPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/AcesOutputTransformLutPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
             {
                 if (m_displayMapperLut.m_lutImageView != nullptr)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView.get());
                 }
 
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperBiasIndex, m_shaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/ApplyShaperLookupTablePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/ApplyShaperLookupTablePass.cpp
@@ -107,7 +107,7 @@ namespace AZ
             {
                 if (m_lutResource.m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_lutResource.m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_lutResource.m_lutStreamingImage->GetImageView());
 
                     m_shaderResourceGroup->SetConstant(m_shaderShaperTypeIndex, m_shaperParams.m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderShaperBiasIndex, m_shaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/BakeAcesOutputTransformLutPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/BakeAcesOutputTransformLutPass.cpp
@@ -67,7 +67,7 @@ namespace AZ
             AZ_Assert(m_displayMapperLut.m_lutImage != nullptr, "BakeAcesOutputTransformLutPass unable to acquire LUT image");
 
             AZ::RHI::AttachmentId imageAttachmentId = AZ::RHI::AttachmentId("DisplayMapperLutImageAttachmentId");
-            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_displayMapperLut.m_lutImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
+            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_displayMapperLut.m_lutImage.get());
             AZ_Error("BakeAcesOutputTransformLutPass", result == RHI::ResultCode::Success, "Failed to import compute buffer with error %d", result);
 
             RHI::ImageScopeAttachmentDescriptor desc;
@@ -92,7 +92,7 @@ namespace AZ
                 m_shaderResourceGroup->SetConstant(m_shaderInputSurroundGammaIndex, m_displayMapperParameters.m_surroundGamma);
                 m_shaderResourceGroup->SetConstant(m_shaderInputGammaIndex, m_displayMapperParameters.m_gamma);
 
-                m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_shaderResourceGroup->SetImageView(m_shaderInputLutImageIndex, m_displayMapperLut.m_lutImageView.get());
 
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperBiasIndex, m_shaperParams.m_bias);
                 m_shaderResourceGroup->SetConstant(m_shaderInputShaperScaleIndex, m_shaperParams.m_scale);

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -674,7 +674,7 @@ namespace AZ
             AZ_PROFILE_SCOPE(AzRender, "ImGuiPass: BuildCommandListInternal");
 
             context.GetCommandList()->SetViewport(m_viewportState);
-            context.GetCommandList()->SetShaderResourceGroupForDraw(*m_resourceGroup->GetRHIShaderResourceGroup());
+            context.GetCommandList()->SetShaderResourceGroupForDraw(*m_resourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
 
             for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
@@ -30,7 +30,8 @@ namespace AZ
             SkinnedMeshFeatureProcessor* skinnedMeshFeatureProcessor,
             MorphTargetInstanceMetaData morphInstanceMetaData,
             float morphDeltaIntegerEncoding)
-            : m_inputBuffers(inputBuffers)
+            : m_dispatchItem(RHI::MultiDevice::AllDevices)
+            , m_inputBuffers(inputBuffers)
             , m_morphTargetComputeMetaData(morphTargetComputeMetaData)
             , m_morphInstanceMetaData(morphInstanceMetaData)
             , m_accumulatedDeltaIntegerEncoding(morphDeltaIntegerEncoding)
@@ -76,19 +77,21 @@ namespace AZ
 
             InitRootConstants(pipelineStateDescriptor.m_pipelineLayoutDescriptor->GetRootConstantsLayout());
 
-            m_dispatchItem.m_pipelineState = m_morphTargetShader->AcquirePipelineState(pipelineStateDescriptor)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_dispatchItem.SetPipelineState(m_morphTargetShader->AcquirePipelineState(pipelineStateDescriptor));
 
             // Get the threads-per-group values from the compute shader [numthreads(x,y,z)]
-            auto& arguments = m_dispatchItem.m_arguments.m_direct;
-            const auto outcome = RPI::GetComputeShaderNumThreads(m_morphTargetShader->GetAsset(), arguments);
+            RHI::MultiDeviceDispatchArguments arguments;
+            const auto outcome = RPI::GetComputeShaderNumThreads(m_morphTargetShader->GetAsset(), arguments.m_direct);
             if (!outcome.IsSuccess())
             {
                 AZ_Error("MorphTargetDispatchItem", false, outcome.GetError().c_str());
             }
 
-            arguments.m_totalNumberOfThreadsX = m_morphTargetComputeMetaData.m_vertexCount;
-            arguments.m_totalNumberOfThreadsY = 1;
-            arguments.m_totalNumberOfThreadsZ = 1;
+            arguments.m_direct.m_totalNumberOfThreadsX = m_morphTargetComputeMetaData.m_vertexCount;
+            arguments.m_direct.m_totalNumberOfThreadsY = 1;
+            arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+
+            m_dispatchItem.SetArguments(arguments);
 
             return true;
         }
@@ -113,7 +116,7 @@ namespace AZ
 
             m_instanceSrg->Compile();
 
-            m_dispatchItem.m_uniqueShaderResourceGroup = m_instanceSrg->GetRHIShaderResourceGroup();
+            m_dispatchItem.SetUniqueShaderResourceGroup(m_instanceSrg->GetRHIShaderResourceGroup());
             return true;
         }
 
@@ -151,14 +154,14 @@ namespace AZ
             m_rootConstantData.SetConstant(tangentOffsetIndex, m_morphInstanceMetaData.m_accumulatedTangentDeltaOffsetInBytes / 4);
             m_rootConstantData.SetConstant(bitangentOffsetIndex, m_morphInstanceMetaData.m_accumulatedBitangentDeltaOffsetInBytes / 4);
 
-            m_dispatchItem.m_rootConstantSize = static_cast<uint8_t>(m_rootConstantData.GetConstantData().size());
-            m_dispatchItem.m_rootConstants = m_rootConstantData.GetConstantData().data();
+            m_dispatchItem.SetRootConstantSize(static_cast<uint8_t>(m_rootConstantData.GetConstantData().size()));
+            m_dispatchItem.SetRootConstants(m_rootConstantData.GetConstantData().data());
         }
 
         void MorphTargetDispatchItem::SetWeight(float weight)
         {
             m_rootConstantData.SetConstant(m_weightIndex, weight);
-            m_dispatchItem.m_rootConstants = m_rootConstantData.GetConstantData().data();
+            m_dispatchItem.SetRootConstants(m_rootConstantData.GetConstantData().data());
         }
 
         float MorphTargetDispatchItem::GetWeight() const
@@ -166,7 +169,7 @@ namespace AZ
             return m_rootConstantData.GetConstant<float>(m_weightIndex);
         }
 
-        const RHI::SingleDeviceDispatchItem& MorphTargetDispatchItem::GetRHIDispatchItem() const
+        const RHI::MultiDeviceDispatchItem& MorphTargetDispatchItem::GetRHIDispatchItem() const
         {
             return m_dispatchItem;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
@@ -11,7 +11,7 @@
 #include <Atom/Feature/MorphTargets/MorphTargetInputBuffers.h>
 
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
-#include <Atom/RHI/SingleDeviceDispatchItem.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
 #include <Atom/RHI/ConstantsData.h>
 #include <AtomCore/Instance/Instance.h>
 
@@ -58,7 +58,7 @@ namespace AZ
 
             bool Init();
 
-            const RHI::SingleDeviceDispatchItem& GetRHIDispatchItem() const;
+            const AZ::RHI::MultiDeviceDispatchItem& GetRHIDispatchItem() const;
 
             void SetWeight(float weight);
             float GetWeight() const;
@@ -71,7 +71,7 @@ namespace AZ
             void OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset) override;
             void OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant) override;
 
-            RHI::SingleDeviceDispatchItem m_dispatchItem;
+            RHI::MultiDeviceDispatchItem m_dispatchItem;
 
             // The morph target shader used for this instance
             Data::Instance<RPI::Shader> m_morphTargetShader;

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
@@ -58,7 +58,7 @@ namespace AZ
 
             bool Init();
 
-            const AZ::RHI::MultiDeviceDispatchItem& GetRHIDispatchItem() const;
+            const AZ::RHI::SingleDeviceDispatchItem& GetRHIDispatchItem() const;
 
             void SetWeight(float weight);
             float GetWeight() const;
@@ -71,7 +71,7 @@ namespace AZ
             void OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset) override;
             void OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant) override;
 
-            RHI::MultiDeviceDispatchItem m_dispatchItem;
+            RHI::SingleDeviceDispatchItem m_dispatchItem;
 
             // The morph target shader used for this instance
             Data::Instance<RPI::Shader> m_morphTargetShader;

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
@@ -29,8 +29,7 @@ namespace AZ
             m_vertexDeltaBuffer = RPI::Buffer::FindOrCreate(bufferAssetView.GetBufferAsset());
             if (m_vertexDeltaBuffer)
             {
-                m_vertexDeltaBufferView =
-                    aznew RHI::MultiDeviceBufferView{ m_vertexDeltaBuffer->GetRHIBuffer(), bufferAssetView.GetBufferViewDescriptor() };
+                m_vertexDeltaBufferView = m_vertexDeltaBuffer->GetRHIBuffer()->BuildBufferView(bufferAssetView.GetBufferViewDescriptor());
                 m_vertexDeltaBufferView->SetName(Name(bufferNamePrefix + "MorphTargetVertexDeltaView"));
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
@@ -41,7 +41,7 @@ namespace AZ
             AZ_Error("MorphTargetInputBuffers", srgIndex.IsValid(), "Failed to find shader input index for 'm_positionDeltas' in the skinning compute shader per-instance SRG.");
 
             [[maybe_unused]] bool success = perInstanceSRG->SetBufferView(
-                srgIndex, m_vertexDeltaBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                srgIndex, m_vertexDeltaBufferView.get());
             AZ_Error("MorphTargetInputBuffers", success, "Failed to bind buffer view for vertex deltas");
         }
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
@@ -10,7 +10,6 @@
 
 #include <PostProcess/PostProcessSettings.h>
 #include <Atom/Feature/PostProcess/PostProcessFeatureProcessorInterface.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Base.h>
 #include <AtomCore/std/containers/vector_set.h>

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -124,7 +124,7 @@ namespace AZ
             // import this attachment if it wasn't imported
             if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(imageAttachmentId))
             {
-                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_blendedLut.m_lutImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
+                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(imageAttachmentId, m_blendedLut.m_lutImage.get());
                 AZ_Error("BlendColorGradingLutsPass", result == RHI::ResultCode::Success, "Failed to import BlendColorGradingLutImageAttachmentId with error %d", result);
             }
 
@@ -153,7 +153,7 @@ namespace AZ
 
             if (m_shaderResourceGroup != nullptr)
             {
-                m_shaderResourceGroup->SetImageView(m_shaderInputBlendedLutImageIndex, m_blendedLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_shaderResourceGroup->SetImageView(m_shaderInputBlendedLutImageIndex, m_blendedLut.m_lutImageView.get());
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendedLutDimensionsIndex, m_blendedLutDimensions);
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendedLutShaperTypeIndex, m_blendedLutShaperParams.m_type);
                 m_shaderResourceGroup->SetConstant(m_shaderInputBlendededLutShaperBiasIndex, m_blendedLutShaperParams.m_bias);
@@ -166,7 +166,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[0].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut1ImageIndex, m_colorGradingLuts[0].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut1ImageIndex, m_colorGradingLuts[0].m_lutStreamingImage->GetImageView());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperTypeIndex, m_colorGradingShaperParams[0].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperBiasIndex, m_colorGradingShaperParams[0].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut1ShaperScaleIndex, m_colorGradingShaperParams[0].m_scale);
@@ -174,7 +174,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[1].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut2ImageIndex, m_colorGradingLuts[1].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut2ImageIndex, m_colorGradingLuts[1].m_lutStreamingImage->GetImageView());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperTypeIndex, m_colorGradingShaperParams[1].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperBiasIndex, m_colorGradingShaperParams[1].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut2ShaperScaleIndex, m_colorGradingShaperParams[1].m_scale);
@@ -182,7 +182,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[2].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut3ImageIndex, m_colorGradingLuts[2].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut3ImageIndex, m_colorGradingLuts[2].m_lutStreamingImage->GetImageView());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperTypeIndex, m_colorGradingShaperParams[2].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperBiasIndex, m_colorGradingShaperParams[2].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut3ShaperScaleIndex, m_colorGradingShaperParams[2].m_scale);
@@ -190,7 +190,7 @@ namespace AZ
 
                 if (m_colorGradingLuts[3].m_lutStreamingImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut4ImageIndex, m_colorGradingLuts[3].m_lutStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderInputSourceLut4ImageIndex, m_colorGradingLuts[3].m_lutStreamingImage->GetImageView());
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperTypeIndex, m_colorGradingShaperParams[3].m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperBiasIndex, m_colorGradingShaperParams[3].m_bias);
                     m_shaderResourceGroup->SetConstant(m_shaderInputSourceLut4ShaperScaleIndex, m_colorGradingShaperParams[3].m_scale);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -449,13 +449,13 @@ namespace AZ
             if (m_offsetBuffer)
             {
                 m_shaderResourceGroup->SetBufferView(
-                    m_offsetsInputIndex, m_offsetBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_offsetsInputIndex, m_offsetBuffer->GetBufferView());
             }
 
             if (m_weightBuffer)
             {
                 m_shaderResourceGroup->SetBufferView(
-                    m_weightsInputIndex, m_weightBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_weightsInputIndex, m_weightBuffer->GetBufferView());
             }
 
             SetTargetThreadCounts(m_sourceImageWidth, m_sourceImageHeight, 1);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
@@ -43,7 +43,7 @@ namespace AZ
 
             m_shaderResourceGroup->SetConstant(m_autoFocusScreenPositionIndex, m_autoFocusScreenPosition);
             m_shaderResourceGroup->SetBufferView(
-                m_autoFocusDataBufferIndex, m_bufferRef->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_autoFocusDataBufferIndex, m_bufferRef->GetBufferView());
 
             BindPassSrg(context, m_shaderResourceGroup);
             m_shaderResourceGroup->Compile();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
@@ -116,7 +116,7 @@ namespace AZ
                         if (settings)
                         {
                             settings->UpdateBuffer();
-                            view->GetShaderResourceGroup()->SetBufferView(m_exposureControlBufferInputIndex, settings->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                            view->GetShaderResourceGroup()->SetBufferView(m_exposureControlBufferInputIndex, settings->GetBufferView());
                         }
                     }
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -210,7 +210,7 @@ namespace AZ
             {
                 if (m_colorGradingLutEnabled == true && m_blendedColorGradingLut.m_lutImage)
                 {
-                    m_shaderResourceGroup->SetImageView(m_shaderColorGradingLutImageIndex, m_blendedColorGradingLut.m_lutImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_shaderResourceGroup->SetImageView(m_shaderColorGradingLutImageIndex, m_blendedColorGradingLut.m_lutImageView.get());
 
                     m_shaderResourceGroup->SetConstant(m_shaderColorGradingShaperTypeIndex, m_colorGradingShaperParams.m_type);
                     m_shaderResourceGroup->SetConstant(m_shaderColorGradingShaperBiasIndex, m_colorGradingShaperParams.m_bias);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -165,7 +165,7 @@ namespace AZ
                         AZ::RHI::AttachmentId tlasAttachmentId = rayTracingFeatureProcessor->GetTlasAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -684,14 +684,14 @@ namespace AZ
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_scene"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
 
             // directional lights
             const auto directionalLightFP = GetParentScene()->GetFeatureProcessor<DirectionalLightFeatureProcessor>();
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_directionalLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                directionalLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                directionalLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_directionalLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, directionalLightFP->GetLightCount());
@@ -701,7 +701,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_simplePointLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                simplePointLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                simplePointLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_simplePointLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, simplePointLightFP->GetLightCount());
@@ -711,7 +711,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_simpleSpotLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                simpleSpotLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                simpleSpotLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_simpleSpotLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, simpleSpotLightFP->GetLightCount());
@@ -721,7 +721,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_pointLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                pointLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                pointLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_pointLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, pointLightFP->GetLightCount());
@@ -731,7 +731,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_diskLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                diskLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                diskLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_diskLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, diskLightFP->GetLightCount());
@@ -741,7 +741,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_capsuleLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                capsuleLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                capsuleLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_capsuleLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, capsuleLightFP->GetLightCount());
@@ -751,7 +751,7 @@ namespace AZ
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_quadLights"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
-                quadLightFP->GetLightBuffer()->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                quadLightFP->GetLightBuffer()->GetBufferView());
 
             constantIndex = srgLayout->FindShaderInputConstantIndex(AZ::Name("m_quadLightCount"));
             m_rayTracingSceneSrg->SetConstant(constantIndex, quadLightFP->GetLightCount());
@@ -774,17 +774,13 @@ namespace AZ
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
                 m_meshInfoGpuBuffer[m_currentMeshInfoFrameIndex]
-                    ->GetBufferView()
-                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
-                    .get());
+                    ->GetBufferView());
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_meshBufferIndices"));
             m_rayTracingSceneSrg->SetBufferView(
                 bufferIndex,
                 m_meshBufferIndicesGpuBuffer[m_currentIndexListFrameIndex]
-                    ->GetBufferView()
-                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
-                    .get());
+                    ->GetBufferView());
 
 #if !USE_BINDLESS_SRG
             RHI::ShaderInputBufferUnboundedArrayIndex bufferUnboundedArrayIndex = srgLayout->FindShaderInputBufferUnboundedArrayIndex(AZ::Name("m_meshBuffers"));
@@ -802,17 +798,13 @@ namespace AZ
             m_rayTracingMaterialSrg->SetBufferView(
                 bufferIndex,
                 m_materialInfoGpuBuffer[m_currentMaterialInfoFrameIndex]
-                    ->GetBufferView()
-                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
-                    .get());
+                    ->GetBufferView());
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_materialTextureIndices"));
             m_rayTracingMaterialSrg->SetBufferView(
                 bufferIndex,
                 m_materialTextureIndicesGpuBuffer[m_currentIndexListFrameIndex]
-                    ->GetBufferView()
-                    ->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex)
-                    .get());
+                    ->GetBufferView());
 
 #if !USE_BINDLESS_SRG
             RHI::ShaderInputImageUnboundedArrayIndex textureUnboundedArrayIndex = srgLayout->FindShaderInputImageUnboundedArrayIndex(AZ::Name("m_materialTextures"));

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -258,7 +258,7 @@ namespace AZ
                     AZ::RHI::AttachmentId tlasAttachmentId = rayTracingFeatureProcessor->GetTlasAttachmentId();
                     if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId) == false)
                     {
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer);
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                     }
 
@@ -367,11 +367,11 @@ namespace AZ
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs
             // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
-            AZStd::vector<RHI::SingleDeviceShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+            AZStd::vector<RHI::SingleDeviceShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             if (m_requiresRayTracingSceneSrg)
             {
-                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup());
+                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
 
             if (m_requiresViewSrg)
@@ -379,18 +379,18 @@ namespace AZ
                 RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (view)
                 {
-                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup());
+                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
                 }
             }
 
             if (m_requiresSceneSrg)
             {
-                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup());
+                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
 
             if (m_requiresRayTracingMaterialSrg)
             {
-                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup());
+                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
 
             dispatchRaysItem.m_shaderResourceGroupCount = aznumeric_cast<uint32_t>(shaderResourceGroups.size());

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -301,7 +301,7 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
             drawPacketBuilder.SetDrawArguments(drawIndexed);
             drawPacketBuilder.SetIndexBufferView(m_reflectionRenderData->m_boxIndexBufferView);
-            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = drawListTag;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
@@ -36,8 +36,7 @@ namespace AZ
             SkinnedMeshFeatureProcessor* skinnedMeshFeatureProcessor,
             MorphTargetInstanceMetaData morphTargetInstanceMetaData,
             float morphTargetDeltaIntegerEncoding)
-            : m_dispatchItem(RHI::MultiDevice::AllDevices)
-            , m_inputBuffers(inputBuffers)
+            : m_inputBuffers(inputBuffers)
             , m_outputBufferOffsetsInBytes(outputBufferOffsetsInBytes)
             , m_positionHistoryBufferOffsetInBytes(positionHistoryOutputBufferOffsetInBytes)
             , m_lodIndex(lodIndex)
@@ -196,26 +195,24 @@ namespace AZ
             m_instanceSrg->SetConstant(totalNumberOfThreadsXIndex, xThreads);
 
             m_instanceSrg->Compile();
-            m_dispatchItem.SetUniqueShaderResourceGroup(m_instanceSrg->GetRHIShaderResourceGroup());
-            m_dispatchItem.SetPipelineState(m_skinningShader->AcquirePipelineState(pipelineStateDescriptor));
+            m_dispatchItem.m_uniqueShaderResourceGroup = m_instanceSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_dispatchItem.m_pipelineState = m_skinningShader->AcquirePipelineState(pipelineStateDescriptor)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
 
-            RHI::MultiDeviceDispatchArguments arguments;
-            const auto outcome = RPI::GetComputeShaderNumThreads(m_skinningShader->GetAsset(), arguments.m_direct);
+            auto& arguments = m_dispatchItem.m_arguments.m_direct;
+            const auto outcome = RPI::GetComputeShaderNumThreads(m_skinningShader->GetAsset(), arguments);
             if (!outcome.IsSuccess())
             {
                 AZ_Error("SkinnedMeshInputBuffers", false, outcome.GetError().c_str());
             }
  
-            arguments.m_direct.m_totalNumberOfThreadsX = xThreads;
-            arguments.m_direct.m_totalNumberOfThreadsY = yThreads;
-            arguments.m_direct.m_totalNumberOfThreadsZ = 1;
-
-            m_dispatchItem.SetArguments(arguments);
+            arguments.m_totalNumberOfThreadsX = xThreads;
+            arguments.m_totalNumberOfThreadsY = yThreads;
+            arguments.m_totalNumberOfThreadsZ = 1;
 
             return true;
         }
 
-        const RHI::MultiDeviceDispatchItem& SkinnedMeshDispatchItem::GetRHIDispatchItem() const
+        const RHI::SingleDeviceDispatchItem& SkinnedMeshDispatchItem::GetRHIDispatchItem() const
         {
             return m_dispatchItem;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.h
@@ -12,7 +12,7 @@
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h>
 #include <SkinnedMesh/SkinnedMeshShaderOptionsCache.h>
 
-#include <Atom/RHI/MultiDeviceDispatchItem.h>
+#include <Atom/RHI/SingleDeviceDispatchItem.h>
 #include <AtomCore/Instance/Instance.h>
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
 
@@ -64,7 +64,7 @@ namespace AZ
 
             bool Init();
 
-            const RHI::MultiDeviceDispatchItem& GetRHIDispatchItem() const;
+            const RHI::SingleDeviceDispatchItem& GetRHIDispatchItem() const;
 
             Data::Instance<RPI::Buffer> GetBoneTransforms() const;
             uint32_t GetVertexCount() const;
@@ -75,7 +75,7 @@ namespace AZ
             // SkinnedMeshShaderOptionNotificationBus::Handler
             void OnShaderReinitialized(const CachedSkinnedMeshShaderOptions* cachedShaderOptions) override;
 
-            RHI::MultiDeviceDispatchItem m_dispatchItem;
+            RHI::SingleDeviceDispatchItem m_dispatchItem;
 
             // The skinning shader used for this instance
             Data::Instance<RPI::Shader> m_skinningShader;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.h
@@ -12,7 +12,7 @@
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h>
 #include <SkinnedMesh/SkinnedMeshShaderOptionsCache.h>
 
-#include <Atom/RHI/SingleDeviceDispatchItem.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
 #include <AtomCore/Instance/Instance.h>
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
 
@@ -64,7 +64,7 @@ namespace AZ
 
             bool Init();
 
-            const RHI::SingleDeviceDispatchItem& GetRHIDispatchItem() const;
+            const RHI::MultiDeviceDispatchItem& GetRHIDispatchItem() const;
 
             Data::Instance<RPI::Buffer> GetBoneTransforms() const;
             uint32_t GetVertexCount() const;
@@ -75,7 +75,7 @@ namespace AZ
             // SkinnedMeshShaderOptionNotificationBus::Handler
             void OnShaderReinitialized(const CachedSkinnedMeshShaderOptions* cachedShaderOptions) override;
 
-            RHI::SingleDeviceDispatchItem m_dispatchItem;
+            RHI::MultiDeviceDispatchItem m_dispatchItem;
 
             // The skinning shader used for this instance
             Data::Instance<RPI::Shader> m_skinningShader;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -467,7 +467,7 @@ namespace AZ
             AZStd::advance(it, startIndex);
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
-                const RHI::SingleDeviceDispatchItem* dispatchItem =*it;
+                const RHI::SingleDeviceDispatchItem* dispatchItem = *it;
                 commandList->Submit(*dispatchItem, index);
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -450,12 +450,12 @@ namespace AZ
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
-            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*>::iterator it = m_skinningDispatches.begin();
+            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*>::iterator it = m_skinningDispatches.begin();
             AZStd::advance(it, startIndex);
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
-                const RHI::SingleDeviceDispatchItem& dispatchItem = (*it)->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex);
-                commandList->Submit(dispatchItem, index);
+                const RHI::SingleDeviceDispatchItem* dispatchItem = *it;
+                commandList->Submit(*dispatchItem, index);
             }
         }
 
@@ -463,12 +463,12 @@ namespace AZ
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
-            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*>::iterator it = m_morphTargetDispatches.begin();
+            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*>::iterator it = m_morphTargetDispatches.begin();
             AZStd::advance(it, startIndex);
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
-                const RHI::SingleDeviceDispatchItem& dispatchItem = (*it)->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex);
-                commandList->Submit(dispatchItem, index);
+                const RHI::SingleDeviceDispatchItem* dispatchItem =*it;
+                commandList->Submit(*dispatchItem, index);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -450,12 +450,12 @@ namespace AZ
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
-            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*>::iterator it = m_skinningDispatches.begin();
+            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*>::iterator it = m_skinningDispatches.begin();
             AZStd::advance(it, startIndex);
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
-                const RHI::SingleDeviceDispatchItem* dispatchItem = *it;
-                commandList->Submit(*dispatchItem, index);
+                const RHI::SingleDeviceDispatchItem& dispatchItem = (*it)->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex);
+                commandList->Submit(dispatchItem, index);
             }
         }
 
@@ -463,12 +463,12 @@ namespace AZ
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
-            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*>::iterator it = m_morphTargetDispatches.begin();
+            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*>::iterator it = m_morphTargetDispatches.begin();
             AZStd::advance(it, startIndex);
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
-                const RHI::SingleDeviceDispatchItem* dispatchItem = *it;
-                commandList->Submit(*dispatchItem, index);
+                const RHI::SingleDeviceDispatchItem& dispatchItem = (*it)->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex);
+                commandList->Submit(dispatchItem, index);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -89,10 +89,10 @@ namespace AZ
             StableDynamicArray<SkinnedMeshRenderProxy> m_renderProxies;
             AZStd::unique_ptr<SkinnedMeshStatsCollector> m_statsCollector;
 
-            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*> m_skinningDispatches;
+            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*> m_skinningDispatches;
             bool m_alreadyCreatedSkinningScopeThisFrame = false;
 
-            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*> m_morphTargetDispatches;
+            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*> m_morphTargetDispatches;
             bool m_alreadyCreatedMorphTargetScopeThisFrame = false;
 
             AZStd::mutex m_dispatchItemMutex;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -89,10 +89,10 @@ namespace AZ
             StableDynamicArray<SkinnedMeshRenderProxy> m_renderProxies;
             AZStd::unique_ptr<SkinnedMeshStatsCollector> m_statsCollector;
 
-            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*> m_skinningDispatches;
+            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*> m_skinningDispatches;
             bool m_alreadyCreatedSkinningScopeThisFrame = false;
 
-            AZStd::unordered_set<const RHI::MultiDeviceDispatchItem*> m_morphTargetDispatches;
+            AZStd::unordered_set<const RHI::SingleDeviceDispatchItem*> m_morphTargetDispatches;
             bool m_alreadyCreatedMorphTargetScopeThisFrame = false;
 
             AZStd::mutex m_dispatchItemMutex;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -434,7 +434,7 @@ namespace AZ
                     "Failed to find shader input index for '%s' in the skinning compute shader per-instance SRG.",
                     nameViewPair.m_srgName.GetCStr());
 
-                [[maybe_unused]] bool success = perInstanceSRG->SetBufferView(srgIndex, nameViewPair.m_bufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                [[maybe_unused]] bool success = perInstanceSRG->SetBufferView(srgIndex, nameViewPair.m_bufferView.get());
 
                 AZ_Error("SkinnedMeshInputBuffers", success, "Failed to bind buffer view for %s", nameViewPair.m_srgName.GetCStr());
             }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -113,7 +113,7 @@ namespace AZ
                     RHI::BufferViewDescriptor descriptor =
                         CreateInputViewDescriptor(streamInfo->m_enum, streamInfo->m_elementFormat, streamBufferView);
 
-                    AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> bufferView = aznew RHI::MultiDeviceBufferView(const_cast<RHI::MultiDeviceBuffer*>(streamBufferView.GetBuffer()), descriptor);
+                    AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> bufferView = const_cast<RHI::MultiDeviceBuffer*>(streamBufferView.GetBuffer())->BuildBufferView(descriptor);
                     {
                         // Initialize the buffer view
                         AZStd::string bufferViewName = AZStd::string::format(

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
@@ -90,7 +90,7 @@ namespace AZ
             if (m_buffer)
             {
                 m_sceneSrg->SetBufferView(
-                    m_physicalSkyBufferIndex, m_buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_physicalSkyBufferIndex, m_buffer->GetBufferView());
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
-
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Reflect/Image/Image.h>

--- a/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
@@ -135,13 +135,13 @@ namespace AZ
         {
             sceneSrg->SetBufferView(
                 m_objectToWorldBufferIndex,
-                m_objectToWorldBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_objectToWorldBuffer->GetBufferView());
             sceneSrg->SetBufferView(
                 m_objectToWorldInverseTransposeBufferIndex,
-                m_objectToWorldInverseTransposeBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_objectToWorldInverseTransposeBuffer->GetBufferView());
             sceneSrg->SetBufferView(
                 m_objectToWorldHistoryBufferIndex,
-                m_objectToWorldHistoryBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_objectToWorldHistoryBuffer->GetBufferView());
         }
 
         void TransformServiceFeatureProcessor::OnBeginPrepareRender()

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
@@ -90,7 +90,7 @@ namespace AZ
         {
             if (m_bufferIndex.IsValid())
             {
-                srg->SetBufferView(m_bufferIndex, m_buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                srg->SetBufferView(m_bufferIndex, m_buffer->GetBufferView());
             }
             if (m_elementCountIndex.IsValid())
             {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -10,7 +10,6 @@
 #include <Atom/RHI.Reflect/Size.h>
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
-#include <Atom/RHI/RHISystemInterface.h>
 
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -134,18 +133,7 @@ namespace AZ::RHI
 
         MultiDeviceImageSubresourceLayout() = default;
 
-        void Init(RHI::MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout& deviceLayout)
-        {
-            int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
-
-            for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
-            {
-                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
-                {
-                    m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
-                }
-            }
-        }
+        void Init(RHI::MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout& deviceLayout);
 
         SingleDeviceImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferFrameAttachment.h
@@ -9,7 +9,7 @@
 
 #include <Atom/RHI.Reflect/TransientBufferDescriptor.h>
 #include <Atom/RHI/FrameAttachment.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/ObjectCache.h>
 #include <AzCore/Memory/PoolAllocator.h>
 
@@ -28,7 +28,7 @@ namespace AZ::RHI
         virtual ~BufferFrameAttachment() override = default;
 
         /// Initialization for imported buffers.
-        BufferFrameAttachment(const AttachmentId& attachmentId, Ptr<SingleDeviceBuffer> buffer);
+        BufferFrameAttachment(const AttachmentId& attachmentId, Ptr<MultiDeviceBuffer> buffer);
 
         /// Initialization for transient buffers.
         BufferFrameAttachment(const TransientBufferDescriptor& descriptor);
@@ -43,8 +43,8 @@ namespace AZ::RHI
 
         /// Returns the buffer resource assigned to this attachment. This is not guaranteed to exist
         /// until after frame graph compilation.
-        const SingleDeviceBuffer* GetBuffer() const;
-        SingleDeviceBuffer* GetBuffer();
+        const MultiDeviceBuffer* GetBuffer() const;
+        MultiDeviceBuffer* GetBuffer();
 
         /// Returns the buffer descriptor assigned to this attachment.
         const BufferDescriptor& GetBufferDescriptor() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferScopeAttachment.h
@@ -13,7 +13,7 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceBufferView;
+    class MultiDeviceBufferView;
     class BufferFrameAttachment;
 
     //! A specialization of a scope attachment for buffers. Provides
@@ -47,10 +47,10 @@ namespace AZ::RHI
         BufferScopeAttachment* GetNext();
 
         /// Returns the buffer view set on the scope attachment.
-        const SingleDeviceBufferView* GetBufferView() const;
+        const AZ::RHI::MultiDeviceBufferView* GetBufferView() const;
 
         /// Assigns a buffer view to the scope attachment.
-        void SetBufferView(ConstPtr<SingleDeviceBufferView> bufferView);
+        void SetBufferView(ConstPtr<MultiDeviceBufferView> bufferView);
 
     private:
         BufferScopeAttachmentDescriptor m_descriptor;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandListValidator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandListValidator.h
@@ -16,7 +16,7 @@ namespace AZ::RHI
     class Scope;
     class SingleDeviceShaderResourceGroup;
     struct ShaderResourceGroupBindingInfo;
-    class SingleDeviceResource;
+    class MultiDeviceResource;
     class SingleDeviceResourceView;
     class ScopeAttachment;
     class FrameAttachment;
@@ -56,7 +56,7 @@ namespace AZ::RHI
         bool ValidateView(const ValidateViewContext& context, bool ignoreAttachmentValidation) const;
         bool ValidateAttachment(const ValidateViewContext& context, const FrameAttachment* frameAttachment) const;
             
-        AZStd::unordered_map<const SingleDeviceResource*, AZStd::vector<const ScopeAttachment*>> m_attachments;
+        AZStd::unordered_map<const MultiDeviceResource*, AZStd::vector<const ScopeAttachment*>> m_attachments;
         const Scope* m_scope = nullptr;
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     class Scope;
     class ScopeAttachment;
-    class SingleDeviceResource;
+    class MultiDeviceResource;
 
     //! FrameAttachment is the base class for all attachments stored in the frame graph. Attachments
     //! are "attached" to scopes via ScopeAttachment instances. These scope attachments form a linked list
@@ -33,8 +33,8 @@ namespace AZ::RHI
         const AttachmentId& GetId() const;
 
         /// Returns the resource associated with this frame attachment.
-        SingleDeviceResource* GetResource();
-        const SingleDeviceResource* GetResource() const;
+        MultiDeviceResource* GetResource();
+        const MultiDeviceResource* GetResource() const;
 
         /// Returns the attachment lifetime type.
         AttachmentLifetimeType GetLifetimeType() const;
@@ -61,7 +61,7 @@ namespace AZ::RHI
         HardwareQueueClassMask GetSupportedQueueMask() const;
 
         /// [Internal] Assigns the resource. This may only be done once.
-        void SetResource(Ptr<SingleDeviceResource> resource);
+        void SetResource(Ptr<MultiDeviceResource> resource);
 
     protected:
         FrameAttachment(
@@ -74,7 +74,7 @@ namespace AZ::RHI
 
     private:
         AttachmentId m_attachmentId;
-        Ptr<SingleDeviceResource> m_resource;
+        Ptr<MultiDeviceResource> m_resource;
         AttachmentLifetimeType m_lifetimeType;
         HardwareQueueClassMask m_usedQueueMask = HardwareQueueClassMask::None;
         HardwareQueueClassMask m_supportedQueueMask = HardwareQueueClassMask::None;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
@@ -21,14 +21,14 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceImage;
-    class SingleDeviceBuffer;
+    class MultiDeviceImage;
+    class MultiDeviceBuffer;
     class ImageFrameAttachment;
     class SwapChainFrameAttachment;
     class BufferFrameAttachment;
     class ImageScopeAttachment;
     class BufferScopeAttachment;
-    class SingleDeviceSwapChain;
+    class MultiDeviceSwapChain;
     struct TransientImageDescriptor;
     struct TransientBufferDescriptor;
     struct ResolveScopeAttachmentDescriptor;
@@ -42,13 +42,13 @@ namespace AZ::RHI
         void Clear();
 
         //! Imports an image into the database.
-        ResultCode ImportImage(const AttachmentId& attachmentId, Ptr<SingleDeviceImage> image);
+        ResultCode ImportImage(const AttachmentId& attachmentId, Ptr<MultiDeviceImage> image);
 
         //! Imports a swapchain into the database.
-        ResultCode ImportSwapChain(const AttachmentId& attachmentId, Ptr<SingleDeviceSwapChain> swapChain);
+        ResultCode ImportSwapChain(const AttachmentId& attachmentId, Ptr<MultiDeviceSwapChain> swapChain);
 
         //! Imports a buffer into the database.
-        ResultCode ImportBuffer(const AttachmentId& attachmentId, Ptr<SingleDeviceBuffer> buffer);
+        ResultCode ImportBuffer(const AttachmentId& attachmentId, Ptr<MultiDeviceBuffer> buffer);
 
         //! Creates a transient image and inserts it into the database.
         ResultCode CreateTransientImage(const TransientImageDescriptor& descriptor);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentInterface.h
@@ -8,7 +8,8 @@
 #pragma once
 
 #include <Atom/RHI/FrameGraphAttachmentDatabase.h>
-#include <Atom/RHI/SingleDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 
 #include <Atom/RHI.Reflect/TransientImageDescriptor.h>
 #include <Atom/RHI.Reflect/TransientBufferDescriptor.h>
@@ -16,8 +17,8 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceImage;
-    class SingleDeviceBuffer;
+    class MultiDeviceImage;
+    class MultiDeviceBuffer;
 
     //! This interface exposes FrameGraphAttachmentDatabase functionality to non-RHI systems (like the RPI). This is in order
     //! to reduce access to certain public functions in FrameGraphAttachmentDatabase that are intended for RHI use only.
@@ -46,21 +47,21 @@ namespace AZ::RHI
 
         //! Imports a persistent image as an attachment.
         //! \param imageAttachment The image attachment to import.
-        ResultCode ImportImage(const AttachmentId& attachmentId, Ptr<SingleDeviceImage> image)
+        ResultCode ImportImage(const AttachmentId& attachmentId, Ptr<MultiDeviceImage> image)
         {
             return m_attachmentDatabase.ImportImage(attachmentId, image);
         }
 
         //! Imports a swap chain image as an attachment.
         //! \param swapChainAttachment The swap chain attachment to import.
-        ResultCode ImportSwapChain(const AttachmentId& attachmentId, Ptr<SingleDeviceSwapChain> swapChain)
+        ResultCode ImportSwapChain(const AttachmentId& attachmentId, Ptr<MultiDeviceSwapChain> swapChain)
         {
             return m_attachmentDatabase.ImportSwapChain(attachmentId, swapChain);
         }
 
         //! Imports a persistent buffer as an attachment.
         //! \param bufferAttachment The buffer attachment to import.
-        ResultCode ImportBuffer(const AttachmentId& attachmentId, Ptr<SingleDeviceBuffer> buffer)
+        ResultCode ImportBuffer(const AttachmentId& attachmentId, Ptr<MultiDeviceBuffer> buffer)
         {
             return m_attachmentDatabase.ImportBuffer(attachmentId, buffer);
         }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompileContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompileContext.h
@@ -14,10 +14,10 @@
 namespace AZ::RHI
 {
     class FrameGraphAttachmentDatabase;
-    class SingleDeviceBuffer;
-    class SingleDeviceBufferView;
-    class SingleDeviceImage;
-    class SingleDeviceImageView;
+    class MultiDeviceBuffer;
+    class MultiDeviceBufferView;
+    class MultiDeviceImage;
+    class MultiDeviceImageView;
     class ScopeAttachment;
     struct BufferDescriptor;
     struct ImageDescriptor;
@@ -46,31 +46,31 @@ namespace AZ::RHI
         const size_t GetScopeAttachmentCount(const AttachmentId& attachmentId) const;
 
         //! Returns the buffer view associated with the scope attachment.
-        const SingleDeviceBufferView* GetBufferView(const ScopeAttachment* scopeAttachment) const;
+        const MultiDeviceBufferView* GetBufferView(const ScopeAttachment* scopeAttachment) const;
 
         //! Returns the buffer view associated with the attachmentId.
-        const SingleDeviceBufferView* GetBufferView(const AttachmentId& attachmentId) const;
+        const MultiDeviceBufferView* GetBufferView(const AttachmentId& attachmentId) const;
 
         //! Returns the buffer view associated with attachmentId and the attachmentUsage on the current scope.
-        const SingleDeviceBufferView* GetBufferView(const AttachmentId& attachmentId, RHI::ScopeAttachmentUsage attachmentUsage) const;
+        const MultiDeviceBufferView* GetBufferView(const AttachmentId& attachmentId, RHI::ScopeAttachmentUsage attachmentUsage) const;
 
         //! Returns the buffer associated with attachmentId.
-        const SingleDeviceBuffer* GetBuffer(const AttachmentId& attachmentId) const;
+        const MultiDeviceBuffer* GetBuffer(const AttachmentId& attachmentId) const;
 
         //! Returns the image view associated with the scope attachment
-        const SingleDeviceImageView* GetImageView(const ScopeAttachment* scopeAttacment) const;
+        const MultiDeviceImageView* GetImageView(const ScopeAttachment* scopeAttacment) const;
 
         //! Returns the image view associated with attachmentId, attachmentUsage and imageViewDescriptor on the current scope.
-        const SingleDeviceImageView* GetImageView(
+        const MultiDeviceImageView* GetImageView(
             const AttachmentId& attachmentId,
             const ImageViewDescriptor& imageViewDescriptor,
             const RHI::ScopeAttachmentUsage attachmentUsage) const;
 
         //! Returns the image view associated with the attachmentId.
-        const SingleDeviceImageView* GetImageView(const AttachmentId& attachmentId) const;
+        const MultiDeviceImageView* GetImageView(const AttachmentId& attachmentId) const;
 
         //! Returns the image associated with the attachmentId.
-        const SingleDeviceImage* GetImage(const AttachmentId& attachmentId) const;
+        const MultiDeviceImage* GetImage(const AttachmentId& attachmentId) const;
 
         //! Returns the buffer descriptor for the given attachment id.
         BufferDescriptor GetBufferDescriptor(const AttachmentId& attachmentId) const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
@@ -10,8 +10,8 @@
 #include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
 #include <Atom/RHI/Object.h>
 #include <Atom/RHI/ObjectCache.h>
-#include <Atom/RHI/SingleDeviceImageView.h>
-#include <Atom/RHI/SingleDeviceBufferView.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 
 //! Struct used as a key for m_imageReverseLookupHash map below. The reason for using a struct instead of a hash directly is
 //! so that the map can handle hash collision correctly by using the == operator. This struct contains
@@ -224,15 +224,15 @@ namespace AZ::RHI
         void RemoveFromCache(ReverseLookupObjectType objectToRemove,
                                 AZStd::unordered_map<ReverseLookupObjectType, HashValue64>& reverseHashLookupMap,
                                 ObjectCache<ObjectCacheType>& objectCache);
-            
+
         // Returns the resource from local cache if it exists within it or create one if it doesn't and add it to the cache
-        SingleDeviceImageView* GetImageViewFromLocalCache(SingleDeviceImage* image, const ImageViewDescriptor& imageViewDescriptor);
-        SingleDeviceBufferView* GetBufferViewFromLocalCache(SingleDeviceBuffer* buffer, const BufferViewDescriptor& bufferViewDescriptor);
+        AZ::RHI::MultiDeviceImageView* GetImageViewFromLocalCache(AZ::RHI::MultiDeviceImage* image, const ImageViewDescriptor& imageViewDescriptor);
+        AZ::RHI::MultiDeviceBufferView* GetBufferViewFromLocalCache(AZ::RHI::MultiDeviceBuffer* buffer, const BufferViewDescriptor& bufferViewDescriptor);
             
         // This cache is mainly for transient resources. It adds a dependency to the resource views and hence they wont be
         // deleted at the end of the frame and re-created at the start. Mainly used as an optimization.  
-        ObjectCache<SingleDeviceImageView> m_imageViewCache;
-        ObjectCache<SingleDeviceBufferView> m_bufferViewCache;
+        ObjectCache<MultiDeviceImageView> m_imageViewCache;
+        ObjectCache<MultiDeviceBufferView> m_bufferViewCache;
             
         // The maps below are used to reverse look up view hashes so we can clear them out of m_imageViewCache/m_bufferViewCache
         // once they have been replaced with a new view instance. 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
@@ -226,8 +226,8 @@ namespace AZ::RHI
                                 ObjectCache<ObjectCacheType>& objectCache);
 
         // Returns the resource from local cache if it exists within it or create one if it doesn't and add it to the cache
-        AZ::RHI::MultiDeviceImageView* GetImageViewFromLocalCache(AZ::RHI::MultiDeviceImage* image, const ImageViewDescriptor& imageViewDescriptor);
-        AZ::RHI::MultiDeviceBufferView* GetBufferViewFromLocalCache(AZ::RHI::MultiDeviceBuffer* buffer, const BufferViewDescriptor& bufferViewDescriptor);
+        MultiDeviceImageView* GetImageViewFromLocalCache(AZ::RHI::MultiDeviceImage* image, const ImageViewDescriptor& imageViewDescriptor);
+        MultiDeviceBufferView* GetBufferViewFromLocalCache(AZ::RHI::MultiDeviceBuffer* buffer, const BufferViewDescriptor& bufferViewDescriptor);
             
         // This cache is mainly for transient resources. It adds a dependency to the resource views and hence they wont be
         // deleted at the end of the frame and re-created at the start. Mainly used as an optimization.  

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -177,7 +177,7 @@ namespace AZ::RHI
         //! Returns the implicit root scope id.
         ScopeId GetRootScopeId() const;
 
-        //! Returns the descriptor which has information on the properties of a SingleDeviceTransientAttachmentPool.
+        //! Returns the descriptor which has information on the properties of a MultiDeviceTransientAttachmentPool.
         const TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const;
 
         //! Adds a SingleDeviceRayTracingShaderTable to be built this frame

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
         virtual ~ImageFrameAttachment() override = default;
 
         //! Initialization for imported images.
-        ImageFrameAttachment(const AttachmentId& attachmentId, Ptr<SingleDeviceImage> image);
+        ImageFrameAttachment(const AttachmentId& attachmentId, Ptr<MultiDeviceImage> image);
 
         //! Initialization for transient images.
         ImageFrameAttachment(const TransientImageDescriptor& descriptor);
@@ -42,8 +42,8 @@ namespace AZ::RHI
 
         //! Returns the image assigned to this attachment. This is not guaranteed to exist
         //! until after frame graph compilation.
-        const SingleDeviceImage* GetImage() const;
-        SingleDeviceImage* GetImage();
+        const MultiDeviceImage* GetImage() const;
+        MultiDeviceImage *GetImage();
 
         //! Returns the image descriptor for this attachment.
         const ImageDescriptor& GetImageDescriptor() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
@@ -8,13 +8,12 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/ScopeAttachment.h>
-#include <Atom/RHI/SingleDeviceImage.h>
 #include <AzCore/Memory/PoolAllocator.h>
 
 namespace AZ::RHI
 {
-    class MultiDeviceImageView;
     class ImageFrameAttachment;
 
     //! A specialization of a scope attachment for images. Provides

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
@@ -9,11 +9,12 @@
 
 #include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>
 #include <Atom/RHI/ScopeAttachment.h>
+#include <Atom/RHI/SingleDeviceImage.h>
 #include <AzCore/Memory/PoolAllocator.h>
 
 namespace AZ::RHI
 {
-    class SingleDeviceImageView;
+    class MultiDeviceImageView;
     class ImageFrameAttachment;
 
     //! A specialization of a scope attachment for images. Provides
@@ -47,10 +48,10 @@ namespace AZ::RHI
         ImageScopeAttachment* GetNext();
 
         //! Returns the image view set on the scope attachment.
-        const SingleDeviceImageView* GetImageView() const;
+        const AZ::RHI::MultiDeviceImageView* GetImageView() const;
 
         //! Assigns an image view to the scope attachment.
-        void SetImageView(ConstPtr<SingleDeviceImageView> imageView);
+        void SetImageView(ConstPtr<AZ::RHI::MultiDeviceImageView> imageView);
 
         bool IsBeingResolved() const;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -199,9 +199,6 @@ namespace AZ::RHI
         //! Enable compilation for a resourceType specified by resourceTypeMask
         void EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask);
 
-        //! Returns the mask that is suppose to indicate which resource type was updated
-        uint32_t GetUpdateMask() const;
-
         //! Update the indirect buffer view with the indices of all the image views which reside in the global gpu heap.
         void SetBindlessViews(
             ShaderInputBufferIndex indirectResourceBufferIndex,
@@ -250,10 +247,6 @@ namespace AZ::RHI
 
         //! The backing data store of constants used only for the getters, actual storage happens in the single device SRGs.
         ConstantsData m_constantsData;
-
-        //! Mask used to check whether to compile a specific resource type. This mask is managed by RPI and copied over to the RHI every
-        //! frame.
-        uint32_t m_updateMask = 0;
 
         //! A map of all device-specific ShaderResourceGroupDatas, indexed by the device index
         AZStd::unordered_map<int, SingleDeviceShaderResourceGroupData> m_deviceShaderResourceGroupDatas;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeAttachment.h
@@ -9,14 +9,13 @@
 
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
-#include <Atom/RHI/SingleDeviceResourceView.h>
+#include <Atom/RHI/MultiDeviceResource.h>
 #include <AzCore/RTTI/RTTI.h>
 
 namespace AZ::RHI
 {
     class Scope;
     class FrameAttachment;
-    class SingleDeviceSwapChain;
     
     struct ScopeAttachmentUsageAndAccess
     {
@@ -57,9 +56,9 @@ namespace AZ::RHI
             
         //! Returns a vector containing all usage/access data used by this scopeattachment.
         const AZStd::vector<ScopeAttachmentUsageAndAccess>& GetUsageAndAccess() const;
-            
+
         //! Returns the resource view.
-        const SingleDeviceResourceView* GetResourceView() const;
+        const MultiDeviceResourceView* GetResourceView() const;
 
         //! Returns the parent scope that this attachment is bound to.
         const Scope& GetScope() const;
@@ -91,7 +90,7 @@ namespace AZ::RHI
     protected:
 
         //! Assigns the resource view to this scope attachment.
-        void SetResourceView(ConstPtr<SingleDeviceResourceView> resourceView);
+        void SetResourceView(ConstPtr<MultiDeviceResourceView> resourceView);
 
     private:
             
@@ -102,7 +101,7 @@ namespace AZ::RHI
         ScopeAttachment* m_next = nullptr;
 
         /// The resource view declared for usage on this scope.
-        ConstPtr<SingleDeviceResourceView> m_resourceView;
+        ConstPtr<MultiDeviceResourceView> m_resourceView;
 
         /// The scope that the attachment is bound to.
         Scope* m_scope = nullptr;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceResource.h
@@ -30,7 +30,7 @@ namespace AZ::RHI
     class SingleDeviceResource
         : public DeviceObject
     {
-        friend class FrameAttachment;
+        friend class MultiDeviceResource;
         friend class SingleDeviceResourcePool;
     public:
         AZ_RTTI(SingleDeviceResource, "{9D02CDAC-80EB-4B77-8E62-849AC6E69206}", DeviceObject);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChainFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChainFrameAttachment.h
@@ -12,7 +12,7 @@
 
 namespace AZ::RHI
 {
-    class SingleDeviceSwapChain;
+    class MultiDeviceSwapChain;
 
     //! A swap chain registered into the frame scheduler.
     class SwapChainFrameAttachment final
@@ -24,13 +24,13 @@ namespace AZ::RHI
 
         SwapChainFrameAttachment(
             const AttachmentId& attachmentId,
-            Ptr<SingleDeviceSwapChain> swapChain);
+            Ptr<MultiDeviceSwapChain> swapChain);
 
         /// Returns the swap chain referenced by this attachment.
-        const SingleDeviceSwapChain* GetSwapChain() const;
-        SingleDeviceSwapChain* GetSwapChain();
+        const MultiDeviceSwapChain* GetSwapChain() const;
+        MultiDeviceSwapChain* GetSwapChain();
 
     private:
-        Ptr<SingleDeviceSwapChain> m_swapChain;
+        Ptr<MultiDeviceSwapChain> m_swapChain;
     };
 }

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ImageSubresource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ImageSubresource.cpp
@@ -375,17 +375,4 @@ namespace AZ::RHI
     {
         return GetImageSubresourceIndex(subresource.m_mipSlice, subresource.m_arraySlice, mipLevels);
     }
-
-    void MultiDeviceImageSubresourceLayout::Init(MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout &deviceLayout)
-    {
-        int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
-
-        for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
-        {
-            if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
-            {
-                m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
-            }
-        }
-    }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ImageSubresource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ImageSubresource.cpp
@@ -8,6 +8,7 @@
 #include <Atom/RHI.Reflect/ImageSubresource.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
 #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+#include <Atom/RHI/RHISystemInterface.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -373,5 +374,18 @@ namespace AZ::RHI
     uint32_t GetImageSubresourceIndex(ImageSubresource subresource, uint32_t mipLevels)
     {
         return GetImageSubresourceIndex(subresource.m_mipSlice, subresource.m_arraySlice, mipLevels);
+    }
+
+    void MultiDeviceImageSubresourceLayout::Init(MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout &deviceLayout)
+    {
+        int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+        for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+            {
+                m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
+            }
+        }
     }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferFrameAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferFrameAttachment.cpp
@@ -15,7 +15,7 @@ namespace AZ::RHI
 {
     BufferFrameAttachment::BufferFrameAttachment(
         const AttachmentId& attachmentId,
-        Ptr<SingleDeviceBuffer> buffer)
+        Ptr<MultiDeviceBuffer> buffer)
         : FrameAttachment(
             attachmentId,
             HardwareQueueClassMask::All,
@@ -58,13 +58,13 @@ namespace AZ::RHI
         return m_bufferDescriptor;
     }
 
-    const SingleDeviceBuffer* BufferFrameAttachment::GetBuffer() const
+    const MultiDeviceBuffer* BufferFrameAttachment::GetBuffer() const
     {
-        return static_cast<const SingleDeviceBuffer*>(GetResource());
+        return static_cast<const MultiDeviceBuffer*>(GetResource());
     }
 
-    SingleDeviceBuffer* BufferFrameAttachment::GetBuffer()
+    MultiDeviceBuffer* BufferFrameAttachment::GetBuffer()
     {
-        return static_cast<SingleDeviceBuffer*>(GetResource());
+        return static_cast<MultiDeviceBuffer*>(GetResource());
     }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
@@ -8,7 +8,7 @@
 
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
-#include <Atom/RHI/SingleDeviceBufferView.h>
+#include <Atom/RHI/SingleDeviceBuffer.h>
 
 namespace AZ::RHI
 {
@@ -37,12 +37,12 @@ namespace AZ::RHI
         return m_descriptor;
     }
 
-    const SingleDeviceBufferView* BufferScopeAttachment::GetBufferView() const
+    const MultiDeviceBufferView* BufferScopeAttachment::GetBufferView() const
     {
-        return static_cast<const SingleDeviceBufferView*>(ScopeAttachment::GetResourceView());
+        return static_cast<const MultiDeviceBufferView*>(ScopeAttachment::GetResourceView());
     }
 
-    void BufferScopeAttachment::SetBufferView(ConstPtr<SingleDeviceBufferView> bufferView)
+    void BufferScopeAttachment::SetBufferView(ConstPtr<MultiDeviceBufferView> bufferView)
     {
         SetResourceView(AZStd::move(bufferView));
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
@@ -12,6 +12,8 @@
 #include <Atom/RHI/SingleDeviceResourcePool.h>
 #include <Atom/RHI/SingleDeviceImagePoolBase.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/SingleDeviceResourceView.h>
 #include <Atom/RHI/SingleDeviceResource.h>
 #include <Atom/RHI/FrameGraph.h>
@@ -33,8 +35,8 @@ namespace AZ::RHI
 
         for (const ScopeAttachment* scopeAttachment : scope.GetAttachments())
         {
-            const SingleDeviceResourceView* resourceView = scopeAttachment->GetResourceView();
-            m_attachments[&resourceView->GetResource()].push_back(scopeAttachment);
+            auto resource = scopeAttachment->GetResourceView()->GetResource();
+            m_attachments[resource].push_back(scopeAttachment);
         }
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameAttachment.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <Atom/RHI/FrameAttachment.h>
-#include <Atom/RHI/SingleDeviceResource.h>
+#include <Atom/RHI/MultiDeviceResource.h>
 
 namespace AZ::RHI
 {
@@ -40,17 +40,17 @@ namespace AZ::RHI
         return m_lifetimeType;
     }
 
-    SingleDeviceResource* FrameAttachment::GetResource()
+    MultiDeviceResource* FrameAttachment::GetResource()
     {
         return m_resource.get();
     }
 
-    const SingleDeviceResource* FrameAttachment::GetResource() const
+    const MultiDeviceResource* FrameAttachment::GetResource() const
     {
         return m_resource.get();
     }
 
-    void FrameAttachment::SetResource(Ptr<SingleDeviceResource> resource)
+    void FrameAttachment::SetResource(Ptr<MultiDeviceResource> resource)
     {
         AZ_Assert(!m_resource, "A resource has already been assigned to this frame attachment.");
         AZ_Assert(resource, "Assigning a null resource to attachment %s.", m_attachmentId.GetCStr());

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -15,7 +15,7 @@
 #include <Atom/RHI/SingleDeviceQueryPool.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <Atom/RHI/Scope.h>
-#include <Atom/RHI/SingleDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
 
 namespace AZ::RHI
@@ -134,7 +134,7 @@ namespace AZ::RHI
         {
             if (auto* lastScope = attachment->GetLastScope())
             {
-                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain());
+                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain()->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex).get());
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphAttachmentDatabase.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphAttachmentDatabase.cpp
@@ -11,7 +11,7 @@
 #include <Atom/RHI/ImageFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
-#include <Atom/RHI/SingleDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 namespace AZ::RHI
 {
     size_t FrameGraphAttachmentDatabase::HashScopeAttachmentPair(const ScopeId& scopeId, const AttachmentId& attachmentId)
@@ -56,7 +56,7 @@ namespace AZ::RHI
 
     ResultCode FrameGraphAttachmentDatabase::ImportSwapChain(
         const AttachmentId& attachmentId,
-        Ptr<SingleDeviceSwapChain> swapChain)
+        Ptr<MultiDeviceSwapChain> swapChain)
     {
         if (!ValidateAttachmentIsUnregistered(attachmentId))
         {
@@ -71,7 +71,7 @@ namespace AZ::RHI
 
     ResultCode FrameGraphAttachmentDatabase::ImportImage(
         const AttachmentId& attachmentId,
-        Ptr<SingleDeviceImage> image)
+        Ptr<MultiDeviceImage> image)
     {
         // Only import the attachment if it hasn't already been imported
         if (FindAttachment(attachmentId) == nullptr)
@@ -85,7 +85,7 @@ namespace AZ::RHI
 
     ResultCode FrameGraphAttachmentDatabase::ImportBuffer(
         const AttachmentId& attachmentId,
-        Ptr<SingleDeviceBuffer> buffer)
+        Ptr<MultiDeviceBuffer> buffer)
     {
         // Only import the attachment if it hasn't already been imported
         if (FindAttachment(attachmentId) == nullptr)

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompileContext.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompileContext.cpp
@@ -7,11 +7,9 @@
  */
 #include <Atom/RHI/FrameGraphCompileContext.h>
 #include <Atom/RHI/FrameGraphAttachmentDatabase.h>
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferView.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
-#include <Atom/RHI/SingleDeviceImage.h>
-#include <Atom/RHI/SingleDeviceImageView.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
 
 namespace AZ::RHI
@@ -38,7 +36,7 @@ namespace AZ::RHI
         return 0;
     }
 
-    const SingleDeviceBufferView* FrameGraphCompileContext::GetBufferView(const ScopeAttachment* scopeAttacment) const
+    const MultiDeviceBufferView* FrameGraphCompileContext::GetBufferView(const ScopeAttachment* scopeAttacment) const
     {
         const BufferScopeAttachment* attachment = azrtti_cast<const BufferScopeAttachment*>(scopeAttacment);
         if (!attachment)
@@ -48,29 +46,29 @@ namespace AZ::RHI
         return attachment->GetBufferView();
     }
 
-    const SingleDeviceBufferView* FrameGraphCompileContext::GetBufferView(const AttachmentId& attachmentId) const
+    const MultiDeviceBufferView* FrameGraphCompileContext::GetBufferView(const AttachmentId& attachmentId) const
     {
         const ScopeAttachment* scopeAttacment = m_attachmentDatabase->FindScopeAttachment(m_scopeId, attachmentId);
         return GetBufferView(scopeAttacment);
     }
 
-    const SingleDeviceBufferView* FrameGraphCompileContext::GetBufferView(const AttachmentId& attachmentId, const RHI::ScopeAttachmentUsage attachmentUsage) const
+    const MultiDeviceBufferView* FrameGraphCompileContext::GetBufferView(const AttachmentId& attachmentId, const RHI::ScopeAttachmentUsage attachmentUsage) const
     {
         const ScopeAttachment* scopeAttacment = m_attachmentDatabase->FindScopeAttachment(m_scopeId, attachmentId, attachmentUsage);
         return GetBufferView(scopeAttacment);
     }
 
-    const SingleDeviceBuffer* FrameGraphCompileContext::GetBuffer(const AttachmentId& attachmentId) const
+    const MultiDeviceBuffer* FrameGraphCompileContext::GetBuffer(const AttachmentId& attachmentId) const
     {
-        const SingleDeviceBufferView* bufferView = GetBufferView(attachmentId);
+        const MultiDeviceBufferView* bufferView = GetBufferView(attachmentId);
         if (bufferView)
         {
-            return &bufferView->GetBuffer();
+            return bufferView->GetBuffer();
         }
         return nullptr;
     }
 
-    const SingleDeviceImageView* FrameGraphCompileContext::GetImageView(const ScopeAttachment* scopeAttacment) const
+    const MultiDeviceImageView* FrameGraphCompileContext::GetImageView(const ScopeAttachment* scopeAttacment) const
     {
         const ImageScopeAttachment* attachment = azrtti_cast<const ImageScopeAttachment*>(scopeAttacment);
         if (!attachment)
@@ -80,24 +78,24 @@ namespace AZ::RHI
         return attachment->GetImageView();
     }
 
-    const SingleDeviceImageView* FrameGraphCompileContext::GetImageView(const AttachmentId& attachmentId, const ImageViewDescriptor& imageViewDescriptor, RHI::ScopeAttachmentUsage attachmentUsage) const
+    const MultiDeviceImageView* FrameGraphCompileContext::GetImageView(const AttachmentId& attachmentId, const ImageViewDescriptor& imageViewDescriptor, RHI::ScopeAttachmentUsage attachmentUsage) const
     {
         const ScopeAttachment* scopeAttacment = m_attachmentDatabase->FindScopeAttachment(m_scopeId, attachmentId, imageViewDescriptor, attachmentUsage);
         return GetImageView(scopeAttacment);
     }
 
-    const SingleDeviceImageView* FrameGraphCompileContext::GetImageView(const AttachmentId& attachmentId) const
+    const MultiDeviceImageView* FrameGraphCompileContext::GetImageView(const AttachmentId& attachmentId) const
     {
         const ScopeAttachment* scopeAttacment = m_attachmentDatabase->FindScopeAttachment(m_scopeId, attachmentId);
         return GetImageView(scopeAttacment);
     }
 
-    const SingleDeviceImage* FrameGraphCompileContext::GetImage(const AttachmentId& attachmentId) const
+    const MultiDeviceImage* FrameGraphCompileContext::GetImage(const AttachmentId& attachmentId) const
     {
-        const SingleDeviceImageView* imageView = GetImageView(attachmentId);
+        const MultiDeviceImageView* imageView = GetImageView(attachmentId);
         if (imageView)
         {
-            return &imageView->GetImage();
+            return imageView->GetImage();
         }
         return nullptr;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageFrameAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageFrameAttachment.cpp
@@ -13,7 +13,7 @@ namespace AZ::RHI
 {
     ImageFrameAttachment::ImageFrameAttachment(
         const AttachmentId& attachmentId,
-        Ptr<SingleDeviceImage> image)
+        Ptr<MultiDeviceImage> image)
         : FrameAttachment(
             attachmentId,
             HardwareQueueClassMask::All,
@@ -62,14 +62,14 @@ namespace AZ::RHI
         return m_imageDescriptor;
     }
 
-    const SingleDeviceImage* ImageFrameAttachment::GetImage() const
+    const MultiDeviceImage* ImageFrameAttachment::GetImage() const
     {
-        return static_cast<const SingleDeviceImage*>(GetResource());
+        return static_cast<const MultiDeviceImage*>(GetResource());
     }
 
-    SingleDeviceImage* ImageFrameAttachment::GetImage()
+    MultiDeviceImage* ImageFrameAttachment::GetImage()
     {
-        return static_cast<SingleDeviceImage*>(GetResource());
+        return static_cast<MultiDeviceImage*>(GetResource());
     }
 
     ClearValue ImageFrameAttachment::GetOptimizedClearValue() const

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageScopeAttachment.cpp
@@ -35,12 +35,12 @@ namespace AZ::RHI
         return m_descriptor;
     }
 
-    const SingleDeviceImageView* ImageScopeAttachment::GetImageView() const
+    const MultiDeviceImageView* ImageScopeAttachment::GetImageView() const
     {
-        return static_cast<const SingleDeviceImageView*>(GetResourceView());
+        return static_cast<const MultiDeviceImageView*>(GetResourceView());
     }
 
-    void ImageScopeAttachment::SetImageView(ConstPtr<SingleDeviceImageView> imageView)
+    void ImageScopeAttachment::SetImageView(ConstPtr<MultiDeviceImageView> imageView)
     {
         SetResourceView(AZStd::move(imageView));
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
@@ -35,6 +35,5 @@ namespace AZ::RHI
         : m_deviceMask{ deviceMask }
         , m_deviceDrawItemPtrs{ deviceDrawItemPtrs }
     {
-
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI/ImageFrameAttachment.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
 #include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/RHISystemInterface.h>
 
 namespace AZ::RHI
 {
@@ -118,5 +119,18 @@ namespace AZ::RHI
         }
 
         return iterator->second;
+    }
+
+    void MultiDeviceImageSubresourceLayout::Init(MultiDevice::DeviceMask deviceMask, const SingleDeviceImageSubresourceLayout &deviceLayout)
+    {
+        int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+        for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+            {
+                m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
+            }
+        }
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
@@ -90,6 +90,11 @@ namespace AZ::RHI
         }
 
         m_frameAttachment = frameAttachment;
+
+        IterateObjects<SingleDeviceResource>([frameAttachment]([[maybe_unused]] auto deviceIndex, auto deviceResource)
+        {
+            deviceResource->SetFrameAttachment(frameAttachment);
+        });
     }
 
     const FrameAttachment* MultiDeviceResource::GetFrameAttachment() const

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
@@ -15,6 +15,8 @@ namespace AZ::RHI
     void MultiDeviceShaderResourceGroup::Compile(
         const MultiDeviceShaderResourceGroupData& groupData, CompileMode compileMode /*= CompileMode::Async*/)
     {
+        m_mdData = groupData;
+
         IterateObjects<SingleDeviceShaderResourceGroup>([&groupData, compileMode](auto deviceIndex, auto deviceShaderResourceGroup)
         {
             deviceShaderResourceGroup->Compile(groupData.GetDeviceShaderResourceGroupData(deviceIndex), compileMode);

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -49,6 +49,14 @@ namespace AZ::RHI
         }
     }
 
+    void MultiDeviceShaderResourceGroupData::ResetViews()
+    {
+        for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
+        {
+            deviceShaderResourceGroupData.ResetViews();
+        }
+    }
+
     const ShaderResourceGroupLayout* MultiDeviceShaderResourceGroupData::GetLayout() const
     {
         return m_shaderResourceGroupLayout.get();
@@ -94,7 +102,7 @@ namespace AZ::RHI
 
                 for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
                 {
-                    deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
+                    deviceImageViews[imageIndex] = imageViews[imageIndex] ? imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get() : nullptr;
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetImageViewArray(inputIndex, deviceImageViews, arrayIndex);
@@ -177,7 +185,7 @@ namespace AZ::RHI
 
                 for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
                 {
-                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
+                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex] ? bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get() : nullptr;
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetBufferViewArray(inputIndex, deviceBufferViews, arrayIndex);

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -141,7 +141,7 @@ namespace AZ::RHI
 
                 for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
                 {
-                    deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
+                    deviceImageViews[imageIndex] = imageViews[imageIndex] ? imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get() : nullptr;
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetImageViewUnboundedArray(inputIndex, deviceImageViews);
@@ -224,7 +224,7 @@ namespace AZ::RHI
 
                 for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
                 {
-                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
+                    deviceBufferViews[bufferIndex] = bufferViews[bufferIndex] ? bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get() : nullptr;
                 }
 
                 isValidAll &= deviceShaderResourceGroupData.SetBufferViewUnboundedArray(inputIndex, deviceBufferViews);
@@ -423,15 +423,8 @@ namespace AZ::RHI
         return m_samplers;
     }
 
-    uint32_t MultiDeviceShaderResourceGroupData::GetUpdateMask() const
-    {
-        return m_updateMask;
-    }
-
     void MultiDeviceShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask)
     {
-        m_updateMask = RHI::SetBits(m_updateMask, static_cast<uint32_t>(resourceTypeMask));
-
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
             deviceShaderResourceGroupData.EnableResourceTypeCompilation(resourceTypeMask);
@@ -440,8 +433,6 @@ namespace AZ::RHI
 
     void MultiDeviceShaderResourceGroupData::ResetUpdateMask()
     {
-        m_updateMask = 0;
-
         for (auto& [deviceIndex, deviceShaderResourceGroupData] : m_deviceShaderResourceGroupDatas)
         {
             deviceShaderResourceGroupData.ResetUpdateMask();
@@ -462,7 +453,7 @@ namespace AZ::RHI
 
             for (int imageIndex = 0; imageIndex < imageViews.size(); ++imageIndex)
             {
-                deviceImageViews[imageIndex] = imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get();
+                deviceImageViews[imageIndex] = imageViews[imageIndex] ? imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get() : nullptr;
             }
 
             deviceShaderResourceGroupData.SetBindlessViews(
@@ -515,7 +506,7 @@ namespace AZ::RHI
 
             for (int bufferIndex = 0; bufferIndex < bufferViews.size(); ++bufferIndex)
             {
-                deviceBufferViews[bufferIndex] = bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get();
+                deviceBufferViews[bufferIndex] = bufferViews[bufferIndex] ? bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get() : nullptr;
             }
 
             deviceShaderResourceGroupData.SetBindlessViews(

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -160,6 +160,14 @@ namespace AZ::RHI
                     image->m_deviceObjects[deviceIndex] = deviceImage;
                     image->SetDescriptor(deviceImage->GetDescriptor());
                 }
+                else
+                {
+                    if (auto potentialDeviceImage{ image->m_deviceObjects.find(deviceIndex) };
+                        potentialDeviceImage != image->m_deviceObjects.end())
+                    {
+                        image->m_deviceObjects.erase(potentialDeviceImage);
+                    }
+                }
             });
 
         if (image->m_deviceObjects.empty())
@@ -211,6 +219,14 @@ namespace AZ::RHI
                 {
                     buffer->m_deviceObjects[deviceIndex] = deviceBuffer;
                     buffer->SetDescriptor(deviceBuffer->GetDescriptor());
+                }
+                else
+                {
+                    if (auto potentialDeviceBuffer{ buffer->m_deviceObjects.find(deviceIndex) };
+                        potentialDeviceBuffer != buffer->m_deviceObjects.end())
+                    {
+                        buffer->m_deviceObjects.erase(potentialDeviceBuffer);
+                    }
                 }
             });
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ScopeAttachment.cpp
@@ -156,12 +156,12 @@ namespace AZ::RHI
         return "Unknown";
     }
     
-    const SingleDeviceResourceView* ScopeAttachment::GetResourceView() const
+    const MultiDeviceResourceView* ScopeAttachment::GetResourceView() const
     {
         return m_resourceView.get();
     }
 
-    void ScopeAttachment::SetResourceView(ConstPtr<SingleDeviceResourceView> resourceView)
+    void ScopeAttachment::SetResourceView(ConstPtr<MultiDeviceResourceView> resourceView)
     {
         m_resourceView = AZStd::move(resourceView);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChainFrameAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChainFrameAttachment.cpp
@@ -7,23 +7,21 @@
  */
 
 #include <Atom/RHI/SwapChainFrameAttachment.h>
-#include <Atom/RHI/SingleDeviceSwapChain.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 
 namespace AZ::RHI
 {
-    SwapChainFrameAttachment::SwapChainFrameAttachment(
-        const AttachmentId& attachmentId,
-        Ptr<SingleDeviceSwapChain> swapChain)
+    SwapChainFrameAttachment::SwapChainFrameAttachment(const AttachmentId& attachmentId, Ptr<MultiDeviceSwapChain> swapChain)
         : ImageFrameAttachment(attachmentId, swapChain->GetCurrentImage())
-        , m_swapChain{AZStd::move(swapChain)}
+        , m_swapChain{ AZStd::move(swapChain) }
     {}
 
-    SingleDeviceSwapChain* SwapChainFrameAttachment::GetSwapChain()
+    MultiDeviceSwapChain* SwapChainFrameAttachment::GetSwapChain()
     {
         return m_swapChain.get();
     }
 
-    const SingleDeviceSwapChain* SwapChainFrameAttachment::GetSwapChain() const
+    const MultiDeviceSwapChain* SwapChainFrameAttachment::GetSwapChain() const
     {
         return m_swapChain.get();
     }

--- a/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
@@ -22,13 +22,13 @@ namespace UnitTest
     struct ImportedImage
     {
         RHI::AttachmentId m_id;
-        RHI::Ptr<RHI::SingleDeviceImage> m_image;
+        RHI::Ptr<RHI::MultiDeviceImage> m_image;
     };
 
     struct ImportedBuffer
     {
         RHI::AttachmentId m_id;
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_buffer;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_buffer;
     };
 
     struct TransientImage
@@ -165,23 +165,23 @@ namespace UnitTest
             m_state.reset(new State);
 
             {
-                m_state->m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+                m_state->m_bufferPool = aznew RHI::MultiDeviceBufferPool;
 
                 RHI::BufferPoolDescriptor desc;
                 desc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
-                m_state->m_bufferPool->Init(*m_device, desc);
+                m_state->m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, desc);
             }
 
             for (uint32_t i = 0; i < ImportedBufferCount; ++i)
             {
-                RHI::Ptr<RHI::SingleDeviceBuffer> buffer;
-                buffer = RHI::Factory::Get().CreateBuffer();
+                RHI::Ptr<RHI::MultiDeviceBuffer> buffer;
+                buffer = aznew RHI::MultiDeviceBuffer;
 
                 RHI::BufferDescriptor desc;
                 desc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
                 desc.m_byteCount = BufferSize;
 
-                RHI::SingleDeviceBufferInitRequest request;
+                RHI::MultiDeviceBufferInitRequest request;
                 request.m_descriptor = desc;
                 request.m_buffer = buffer.get();
                 m_state->m_bufferPool->InitBuffer(request);
@@ -191,17 +191,17 @@ namespace UnitTest
             }
 
             {
-                m_state->m_imagePool = RHI::Factory::Get().CreateImagePool();
+                m_state->m_imagePool = aznew RHI::MultiDeviceImagePool();
 
                 RHI::ImagePoolDescriptor desc;
                 desc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
-                m_state->m_imagePool->Init(*m_device, desc);
+                m_state->m_imagePool->Init(RHI::MultiDevice::AllDevices, desc);
             }
 
             for (uint32_t i = 0; i < ImportedImageCount; ++i)
             {
-                RHI::Ptr<RHI::SingleDeviceImage> image;
-                image = RHI::Factory::Get().CreateImage();
+                RHI::Ptr<RHI::MultiDeviceImage> image;
+                image = aznew RHI::MultiDeviceImage();
 
                 RHI::ImageDescriptor desc = RHI::ImageDescriptor::Create2D(
                     RHI::ImageBindFlags::ShaderReadWrite,
@@ -209,7 +209,7 @@ namespace UnitTest
                     ImageSize,
                     RHI::Format::R8G8B8A8_UNORM);
 
-                RHI::SingleDeviceImageInitRequest request;
+                RHI::MultiDeviceImageInitRequest request;
                 request.m_descriptor = desc;
                 request.m_image = image.get();
                 m_state->m_imagePool->InitImage(request);
@@ -422,8 +422,8 @@ namespace UnitTest
 
         struct State
         {
-            RHI::Ptr<RHI::SingleDeviceBufferPool> m_bufferPool;
-            RHI::Ptr<RHI::SingleDeviceImagePool> m_imagePool;
+            RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
+            RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
             ImportedImage m_imageAttachments[ImportedImageCount];
             ImportedBuffer m_bufferAttachments[ImportedBufferCount];
             AZStd::vector<AZStd::unique_ptr<ScopeProducer>> m_producers;

--- a/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
@@ -12,6 +12,8 @@
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <AzCore/Math/Random.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
 

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -48,6 +48,7 @@ set(FILES
     Include/Atom/RHI/DrawFilterTagRegistry.h
     Include/Atom/RHI/SingleDeviceDrawItem.h
     Include/Atom/RHI/MultiDeviceDrawItem.h
+    Source/RHI/MultiDeviceDrawItem.cpp
     Include/Atom/RHI/DrawList.h
     Include/Atom/RHI/DrawListTagRegistry.h
     Include/Atom/RHI/DrawListContext.h

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -404,7 +404,7 @@ namespace AZ
             ResourceTransitionLoggerNull logger(bufferFrameAttachment.GetId());
 #endif
 
-            Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer());
+            Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
             RHI::BufferScopeAttachment* scopeAttachment = bufferFrameAttachment.GetFirstScopeAttachment();
 
             if (scopeAttachment == nullptr)
@@ -477,7 +477,7 @@ namespace AZ
             ResourceTransitionLoggerNull logger(imageFrameAttachment.GetId());
 #endif
 
-            Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage());
+            Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
             RHI::ImageScopeAttachment* scopeAttachment = imageFrameAttachment.GetFirstScopeAttachment();
 
             if (scopeAttachment == nullptr)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -166,7 +166,7 @@ namespace AZ
     
         bool Scope::IsResourceDiscarded(const RHI::ImageScopeAttachment& scopeAttachment) const
         {
-            const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView());
+            const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
             return IsInDiscardResourceRequests(imageView->GetMemory());
         }
 
@@ -207,7 +207,7 @@ namespace AZ
             for (const RHI::ImageScopeAttachment* scopeAttachment : GetImageAttachments())
             {
                 const AZStd::vector<RHI::ScopeAttachmentUsageAndAccess>& usagesAndAccesses = scopeAttachment->GetUsageAndAccess();
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView());
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
 
                 const bool isFullView           = imageView->IsFullView();
@@ -411,8 +411,8 @@ namespace AZ
                     {
                         if (imageAttachment->GetDescriptor().m_attachmentId == resolveAttachment->GetDescriptor().m_resolveAttachmentId)
                         {
-                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView());
-                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView());
+                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
                             commandList.GetCommandList()->ResolveSubresource(
                                 dstImageView->GetMemory(),
                                 0, 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -166,13 +166,13 @@ namespace AZ
     
         bool Scope::IsResourceDiscarded(const RHI::ImageScopeAttachment& scopeAttachment) const
         {
-            const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+            const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
             return IsInDiscardResourceRequests(imageView->GetMemory());
         }
 
         bool Scope::IsResourceDiscarded(const RHI::BufferScopeAttachment& scopeAttachment) const
         {
-            const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment.GetBufferView());
+            const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment.GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
             return IsInDiscardResourceRequests(bufferView->GetMemory());
         }
 
@@ -207,7 +207,7 @@ namespace AZ
             for (const RHI::ImageScopeAttachment* scopeAttachment : GetImageAttachments())
             {
                 const AZStd::vector<RHI::ScopeAttachmentUsageAndAccess>& usagesAndAccesses = scopeAttachment->GetUsageAndAccess();
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
 
                 const bool isFullView           = imageView->IsFullView();
@@ -281,7 +281,7 @@ namespace AZ
             for (const RHI::BufferScopeAttachment* scopeAttachment : GetBufferAttachments())
             {
                 const AZStd::vector<RHI::ScopeAttachmentUsageAndAccess>& usagesAndAccesses = scopeAttachment->GetUsageAndAccess();
-                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView());
+                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 const RHI::BufferScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
 
                 const bool isClearAction = bindingDescriptor.m_loadStoreAction.m_loadAction == RHI::AttachmentLoadAction::Clear;
@@ -411,8 +411,8 @@ namespace AZ
                     {
                         if (imageAttachment->GetDescriptor().m_attachmentId == resolveAttachment->GetDescriptor().m_resolveAttachmentId)
                         {
-                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
-                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                             commandList.GetCommandList()->ResolveSubresource(
                                 dstImageView->GetMemory(),
                                 0, 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 #include <RHI/CommandList.h>
 #include <RHI/Conversions.h>
 #include <RHI/Device.h>
@@ -119,7 +120,7 @@ namespace AZ
                     m_swapChainAttachment = scopeAttachment;
                 }
                 
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView());
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
                 id<MTLTexture> imageViewMtlTexture = imageView->GetMemoryView().GetGpuAddress<id<MTLTexture>>();
                 
@@ -289,7 +290,7 @@ namespace AZ
                 //here and attach it directly to the colorAttachment. The assumption here is that this scope should be the
                 //CopyToSwapChain scope. With this way if the internal resolution differs from the window resolution the compositer
                 //within the metal driver will perform the appropriate upscale/downscale at the end.
-                const RHI::SingleDeviceSwapChain* swapChain = (azrtti_cast<const RHI::SwapChainFrameAttachment*>(&m_swapChainAttachment->GetFrameAttachment()))->GetSwapChain();
+                const RHI::SingleDeviceSwapChain* swapChain = (azrtti_cast<const RHI::SwapChainFrameAttachment*>(&m_swapChainAttachment->GetFrameAttachment()))->GetSwapChain()->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex).get();
                 SwapChain* metalSwapChain = static_cast<SwapChain*>(const_cast<RHI::SingleDeviceSwapChain*>(swapChain));
                 m_renderPassDescriptor.colorAttachments[0].texture = metalSwapChain->RequestDrawable(m_isSwapChainAndFrameCaptureEnabled);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -120,7 +120,7 @@ namespace AZ
                     m_swapChainAttachment = scopeAttachment;
                 }
                 
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
                 id<MTLTexture> imageViewMtlTexture = imageView->GetMemoryView().GetGpuAddress<id<MTLTexture>>();
                 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -1239,7 +1239,7 @@ namespace AZ
 
         void CommandList::ClearImage(const ResourceClearRequest& request)
         {
-            const ImageView& imageView = static_cast<const ImageView&>(*request.m_resourceView);
+            const ImageView& imageView = static_cast<const ImageView&>(*request.m_resourceView->GetDeviceResourceView(RHI::MultiDevice::DefaultDeviceIndex));
             const Image& image = static_cast<const Image&>(imageView.GetImage());
             const VkImageSubresourceRange& range = imageView.GetVkImageSubresourceRange();
 
@@ -1272,7 +1272,7 @@ namespace AZ
 
         void CommandList::ClearBuffer(const ResourceClearRequest& request)
         {
-            const BufferView& bufferView = static_cast<const BufferView&>(*request.m_resourceView);
+            const BufferView& bufferView = static_cast<const BufferView&>(*request.m_resourceView->GetDeviceResourceView(RHI::MultiDevice::DefaultDeviceIndex));
             const RHI::BufferViewDescriptor& bufferViewDesc = bufferView.GetDescriptor();
             const Buffer& buffer = static_cast<const Buffer&>(bufferView.GetBuffer());
             union

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -12,6 +12,7 @@
 #include <Atom/RHI/CommandListStates.h>
 #include <Atom/RHI/DeviceObject.h>
 #include <Atom/RHI/PipelineStateDescriptor.h>
+#include <Atom/RHI/MultiDeviceResource.h>
 #include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
 #include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>
 #include <Atom/RHI.Reflect/Limits.h>
@@ -66,7 +67,7 @@ namespace AZ
             struct ResourceClearRequest
             {
                 RHI::ClearValue m_clearValue;
-                const RHI::SingleDeviceResourceView* m_resourceView = nullptr;
+                const RHI::MultiDeviceResourceView* m_resourceView = nullptr;
             };
 
             ~CommandList() = default;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -9,7 +9,8 @@
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/Scope.h>
 #include <Atom/RHI/ScopeAttachment.h>
-#include <Atom/RHI/SingleDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceResource.h>
 #include <Atom/RHI/SingleDeviceImageView.h>
 #include <RHI/Conversion.h>
 #include <RHI/Image.h>
@@ -91,7 +92,7 @@ namespace AZ
                 case RHI::ScopeAttachmentUsage::ShadingRate:
                     {
                         const Image& image =
-                            static_cast<const Image&>((static_cast<const RHI::SingleDeviceImageView*>(scopeAttachment.GetResourceView()))->GetImage());
+                            static_cast<const Image&>(*(static_cast<const RHI::MultiDeviceImageView*>(scopeAttachment.GetResourceView()))->GetImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         mergedStateFlags |=
                             RHI::CheckBitsAll(
                                 image.GetUsageFlags(), static_cast<VkImageUsageFlags>(VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT))
@@ -262,7 +263,7 @@ namespace AZ
                 case RHI::ScopeAttachmentUsage::ShadingRate:
                     {
                         const Image& image =
-                            static_cast<const Image&>((static_cast<const RHI::SingleDeviceImageView*>(scopeAttachment.GetResourceView()))->GetImage());
+                            static_cast<const Image&>(*(static_cast<const RHI::MultiDeviceImageView*>(scopeAttachment.GetResourceView()))->GetImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                         accessFlags |=
                             RHI::CheckBitsAll(
                                 image.GetUsageFlags(), static_cast<VkImageUsageFlags>(VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT))
@@ -393,7 +394,7 @@ namespace AZ
                 }
             }
 
-            const RHI::SingleDeviceImageView* imageView = imageAttachment.GetImageView();
+            const RHI::SingleDeviceImageView* imageView = imageAttachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get();
             auto imageAspects = RHI::FilterBits(imageView->GetImage().GetAspectFlags(), imageView->GetDescriptor().m_aspectFlags);
             switch (usagesAndAccesses.front().m_usage)
             {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/SingleDeviceBufferView.h>
+#include <Atom/RHI/MultiDeviceSwapChain.h>
 #include <Atom/RHI/FrameGraphAttachmentDatabase.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
@@ -105,7 +106,7 @@ namespace AZ
             auto& queueContext = device.GetCommandQueueContext();
 
             RHI::BufferScopeAttachment* scopeAttachment = frameGraphAttachment.GetFirstScopeAttachment();
-            Buffer& buffer = static_cast<Buffer&>(*frameGraphAttachment.GetBuffer());
+            Buffer& buffer = static_cast<Buffer&>(*frameGraphAttachment.GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
             while (scopeAttachment)
             {
                 Scope& scope = static_cast<Scope&>(scopeAttachment->GetScope());
@@ -143,7 +144,7 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
             auto& queueContext = device.GetCommandQueueContext();
 
-            Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage());
+            Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
             RHI::ImageScopeAttachment* scopeAttachment = imageFrameAttachment.GetFirstScopeAttachment();
             while (scopeAttachment)
             {
@@ -165,7 +166,7 @@ namespace AZ
                         scope,
                         clearAttachment,
                         image,
-                        static_cast<const ImageView*>(scopeAttachment->GetImageView())->GetImageSubresourceRange(),
+                        static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get())->GetImageSubresourceRange(),
                         Scope::BarrierSlot::Clear,
                         GetResourcePipelineStateFlags(*scopeAttachment),
                         GetResourceAccessFlags(*scopeAttachment),
@@ -197,7 +198,7 @@ namespace AZ
                         scope,
                         resolveSourceAttachment,
                         image,
-                        static_cast<const ImageView*>(scopeAttachment->GetImageView())->GetImageSubresourceRange(),
+                        static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get())->GetImageSubresourceRange(),
                         Scope::BarrierSlot::Resolve,
                         GetResourcePipelineStateFlags(*scopeAttachment),
                         GetResourceAccessFlags(*scopeAttachment),
@@ -210,7 +211,7 @@ namespace AZ
             // If this is the last usage of a swap chain, we require that it be in the common state for presentation.
             if (auto swapchainAttachment = azrtti_cast<RHI::SwapChainFrameAttachment*>(&imageFrameAttachment))
             {
-                SwapChain* swapChain = static_cast<SwapChain*>(swapchainAttachment->GetSwapChain());
+                SwapChain* swapChain = static_cast<SwapChain*>(swapchainAttachment->GetSwapChain()->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                 // Skip adding synchronization constructs for XR swapchain as that is managed by OpenXr api
                 if (swapChain->GetDescriptor().m_isXrSwapChain)
@@ -397,7 +398,7 @@ namespace AZ
         RHI::ImageSubresourceRange FrameGraphCompiler::GetSubresourceRange(const RHI::ImageScopeAttachment& scopeAttachment) const
         {
             auto &physicalDevice = static_cast<const PhysicalDevice&>(GetDevice().GetPhysicalDevice());
-            const auto* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView());
+            const auto* imageView = static_cast<const ImageView*>(scopeAttachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
             auto range = RHI::ImageSubresourceRange(imageView->GetDescriptor());
             RHI::ImageAspectFlags imageAspectFlags = imageView->GetImage().GetAspectFlags();
             // If separate depth/stencil is not supported, then the barrier must ALWAYS include both image aspects (depth and stencil).

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPassBuilder.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPassBuilder.cpp
@@ -8,6 +8,7 @@
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <RHI/BufferView.h>
 #include <RHI/Conversion.h>
@@ -120,7 +121,7 @@ namespace AZ
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
                 const RHI::ImageFrameAttachment& imageFrameAttachment = scopeAttachment->GetFrameAttachment();
                 const RHI::ImageDescriptor& imageDescriptor = imageFrameAttachment.GetImageDescriptor();
-                const ImageView* attachmentImageView = static_cast<const ImageView*>(scopeAttachment->GetImageView());
+                const ImageView* attachmentImageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 const RHI::Format imageViewFormat = attachmentImageView->GetFormat();
                 auto scopeAttachmentId = scopeAttachment->GetDescriptor().m_attachmentId;
                 AZ_Assert(imageViewFormat != RHI::Format::Unknown, "Invalid image view format.");
@@ -145,7 +146,7 @@ namespace AZ
                         attachmentBinding.m_initialLayout = GetInitialLayout(scope, *scopeAttachment);
                         attachmentBinding.m_finalLayout = finalLayout;
                         attachmentBinding.m_multisampleState = imageDescriptor.m_multisampleState;
-                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()));
+                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()));
                         m_clearValues.push_back(bindingDescriptor.m_loadStoreAction.m_clearValue);
                     }
                     else
@@ -187,7 +188,7 @@ namespace AZ
                         attachmentBinding.m_initialLayout = GetInitialLayout(scope, *scopeAttachment);
                         attachmentBinding.m_finalLayout = finalLayout;
                         attachmentBinding.m_multisampleState = imageDescriptor.m_multisampleState;
-                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()));
+                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()));
                         m_clearValues.push_back(bindingDescriptor.m_loadStoreAction.m_clearValue);
                     }
                     else
@@ -222,7 +223,7 @@ namespace AZ
                         attachmentBinding.m_finalLayout = finalLayout;
                         attachmentBinding.m_multisampleState = imageDescriptor.m_multisampleState;
 
-                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()));
+                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()));
                         m_clearValues.push_back(bindingDescriptor.m_loadStoreAction.m_clearValue);
                     }
                     else
@@ -270,7 +271,7 @@ namespace AZ
                         attachmentBinding.m_initialLayout = GetInitialLayout(scope, *scopeAttachment);
                         attachmentBinding.m_finalLayout = finalLayout;
                         attachmentBinding.m_multisampleState = imageDescriptor.m_multisampleState;
-                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()));
+                        m_framebufferDesc.m_attachmentImageViews.push_back(static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()));
                     }
                     else
                     {
@@ -299,7 +300,7 @@ namespace AZ
             for (size_t index = 0; index < scope.GetBufferAttachments().size(); ++index)
             {
                 const RHI::BufferScopeAttachment* scopeAttachment = scope.GetBufferAttachments()[index];
-                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView());
+                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
                 AddResourceDependency(subpassIndex, scope, bufferView);
             }
         }
@@ -379,7 +380,7 @@ namespace AZ
             // Calculate the initial layout of an image attachment from a list of barriers.
             // The initial layout is the old layout of the first barrier of the image (it's the layout
             // that the image will be before starting the renderpass).
-            const ImageView* imageView = static_cast<const ImageView*>(attachment.GetImageView());
+            const ImageView* imageView = static_cast<const ImageView*>(attachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
             auto& barriers = scope.m_subpassBarriers[static_cast<uint32_t>(Scope::BarrierSlot::Prologue)];
 
             auto findIt = AZStd::find_if(barriers.begin(), barriers.end(), [imageView](const Scope::Barrier& barrier)
@@ -397,7 +398,7 @@ namespace AZ
             // Calculate the final layout of an image attachment from a list of barriers.
             // The final layout is the new layout of the last barrier of the image (it's the layout
             // that the image will transition before ending the renderpass).
-            const ImageView* imageView = static_cast<const ImageView*>(attachment.GetImageView());
+            const ImageView* imageView = static_cast<const ImageView*>(attachment.GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
             auto& barriers = scope.m_subpassBarriers[static_cast<uint32_t>(Scope::BarrierSlot::Epilogue)];
 
             auto findIt = AZStd::find_if(barriers.rbegin(), barriers.rend(), [imageView](const Scope::Barrier& barrier)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -550,8 +550,8 @@ namespace AZ
                     {
                         if (imageAttachment->GetDescriptor().m_attachmentId == resolveAttachment->GetDescriptor().m_resolveAttachmentId)
                         {
-                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView());
-                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView());
+                            auto srcImageView = static_cast<const ImageView*>(imageAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                            auto dstImageView = static_cast<const ImageView*>(resolveAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
                             auto srcImageSubresourceRange = srcImageView->GetVkImageSubresourceRange();
                             auto dstImageSubresourceRange = dstImageView->GetVkImageSubresourceRange();
                             auto& srcImage = static_cast<const Image&>(srcImageView->GetImage());

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Base.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Base.h
@@ -29,7 +29,7 @@ namespace AZ
 
     namespace RHI
     {
-        class SingleDeviceShaderResourceGroup;
+        class MultiDeviceShaderResourceGroup;
     }
 
     namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -131,7 +131,7 @@ namespace AZ
             //! Do not set this in the shipping runtime unless you know what you are doing.
             void SetPsoHandlingOverride(MaterialPropertyPsoHandling psoHandlingOverride);
 
-            const RHI::SingleDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
+            const RHI::MultiDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
 
             const Data::Asset<MaterialAsset>& GetAsset() const;
 
@@ -198,7 +198,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> m_shaderResourceGroup;
 
             //! The RHI shader resource group owned by m_shaderResourceGroup. Held locally to avoid an indirection.
-            const RHI::SingleDeviceShaderResourceGroup* m_rhiShaderResourceGroup = nullptr;
+            const RHI::MultiDeviceShaderResourceGroup* m_rhiShaderResourceGroup = nullptr;
 
             //! These the main material properties, exposed in the Material Editor, and configured directly by users.
             MaterialPropertyCollection m_materialProperties;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
@@ -73,6 +73,7 @@ namespace AZ
             {
                 RHI::SingleDeviceDrawArguments m_drawArguments;
                 RHI::MultiDeviceIndexBufferView m_indexBufferView;
+                RHI::SingleDeviceIndexBufferView m_sdIndexBufferView; // TODO: Remove once IndexBufferViews have been converted to multi device
 
                 StreamInfoList m_streamInfo;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -60,7 +60,7 @@ namespace AZ
             ViewPtr GetView() const;
 
             // Add a srg to srg list to be bound for this pass
-            void BindSrg(const RHI::SingleDeviceShaderResourceGroup* srg);
+            void BindSrg(const RHI::MultiDeviceShaderResourceGroup* srg);
             
 
         protected:
@@ -150,7 +150,7 @@ namespace AZ
 
             // List of all ShaderResourceGroups to be bound during rendering or computing
             // Derived classed may call BindSrg function to add other srgs the list
-            AZStd::unordered_map<uint8_t, const RHI::SingleDeviceShaderResourceGroup*> m_shaderResourceGroupsToBind;
+            AZStd::unordered_map<uint8_t, const RHI::MultiDeviceShaderResourceGroup*> m_shaderResourceGroupsToBind;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
+#include <Atom/RHI/MultiDeviceImage.h>
 #include <Atom/RPI.Reflect/Pass/PassDescriptor.h>
 
 namespace AZ::RPI
@@ -85,7 +86,7 @@ namespace AZ::RPI
         Ptr<PassAttachment> m_counterPassAttachment;
 
         // Retainer of image views for each mip level of in/out image.
-        AZStd::array<Ptr<RHI::SingleDeviceImageView>, SpdMipLevelCountMax> m_imageViews;
+        AZStd::array<Ptr<RHI::MultiDeviceImageView>, SpdMipLevelCountMax> m_imageViews;
 
         Data::Instance<Buffer> m_globalAtomicBuffer;
     };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
@@ -12,7 +12,6 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
 #include <Atom/RPI.Public/Pass/AttachmentReadback.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SelectorPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SelectorPass.h
@@ -11,7 +11,6 @@
 
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/SwapChainDescriptor.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SwapChainPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/SwapChainPass.h
@@ -11,7 +11,6 @@
 
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/SwapChainDescriptor.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -136,7 +136,7 @@ namespace AZ
 
             void RemoveRenderPipeline(const RenderPipelineId& pipelineId);
 
-            const RHI::SingleDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
+            const RHI::MultiDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
             Data::Instance<ShaderResourceGroup> GetShaderResourceGroup() const;
 
             const SceneId& GetId() const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -16,7 +16,7 @@
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 
 #include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
 
 #include <AzCore/std/containers/span.h>
 #include <AtomCore/Instance/InstanceId.h>
@@ -88,7 +88,7 @@ namespace AZ
             const RHI::ShaderResourceGroupLayout* GetLayout() const;
 
             /// Returns the underlying RHI shader resource group.
-            RHI::SingleDeviceShaderResourceGroup* GetRHIShaderResourceGroup();
+            RHI::MultiDeviceShaderResourceGroup* GetRHIShaderResourceGroup();
 
             //////////////////////////////////////////////////////////////////////////
             // Methods for assignment / access of RPI Image types.
@@ -141,64 +141,65 @@ namespace AZ
             // Methods for assignment / access of RHI Image types.
                                     
             /// Sets one image view for the given shader input index.
-            bool SetImageView(RHI::ShaderInputNameIndex& inputIndex, const RHI::SingleDeviceImageView* imageView, uint32_t arrayIndex = 0);
-            bool SetImageView(RHI::ShaderInputImageIndex inputIndex, const RHI::SingleDeviceImageView* imageView, uint32_t arrayIndex = 0);
+            bool SetImageView(RHI::ShaderInputNameIndex& inputIndex, const RHI::MultiDeviceImageView *imageView, uint32_t arrayIndex = 0);
+            bool SetImageView(RHI::ShaderInputImageIndex inputIndex, const RHI::MultiDeviceImageView* imageView, uint32_t arrayIndex = 0);
 
             /// Sets an array of image view for the given shader input index.
-            bool SetImageViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews, uint32_t arrayIndex = 0);
-            bool SetImageViewArray(RHI::ShaderInputImageIndex inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews, uint32_t arrayIndex = 0);
+            bool SetImageViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::MultiDeviceImageView* const> imageViews, uint32_t arrayIndex = 0);
+            bool SetImageViewArray(RHI::ShaderInputImageIndex inputIndex, AZStd::span<const RHI::MultiDeviceImageView* const> imageViews, uint32_t arrayIndex = 0);
 
             /// Sets an unbounded array of image views for the given shader input index.
-            bool SetImageViewUnboundedArray(RHI::ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews);
+            bool SetImageViewUnboundedArray(RHI::ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const RHI::MultiDeviceImageView * const> imageViews);
 
             /// Update the indirect buffer view with the indices of all the image views which reside in the global gpu heap.
             void SetBindlessViews(
                 RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
-                const RHI::SingleDeviceBufferView* indirectResourceBuffer,
-                AZStd::span<const RHI::SingleDeviceImageView* const> imageViews,
+                const RHI::MultiDeviceBufferView* indirectResourceBuffer,
+                AZStd::span<const RHI::MultiDeviceImageView* const> imageViews,
                 uint32_t* outIndices,
                 AZStd::span<bool> isViewReadOnly,
                 uint32_t arrayIndex = 0);
-            
+
             /// Returns a single image view associated with the image shader input index and array offset.
-            const RHI::ConstPtr<RHI::SingleDeviceImageView>& GetImageView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex = 0) const;
-            const RHI::ConstPtr<RHI::SingleDeviceImageView>& GetImageView(RHI::ShaderInputImageIndex inputIndex, uint32_t arrayIndex = 0) const;
+            const RHI::ConstPtr<RHI::MultiDeviceImageView>& GetImageView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex = 0) const;
+            const RHI::ConstPtr<RHI::MultiDeviceImageView>& GetImageView(
+                RHI::ShaderInputImageIndex inputIndex, uint32_t arrayIndex = 0) const;
 
             /// Returns a span of image views associated with the given image shader input index.
-            AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceImageView>> GetImageViewArray(RHI::ShaderInputNameIndex& inputIndex) const;
-            AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceImageView>> GetImageViewArray(RHI::ShaderInputImageIndex inputIndex) const;
+            AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> GetImageViewArray(RHI::ShaderInputNameIndex& inputIndex) const;
+            AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> GetImageViewArray(RHI::ShaderInputImageIndex inputIndex) const;
 
             //////////////////////////////////////////////////////////////////////////
             // Methods for assignment / access of RHI Buffer types.
 
             /// Sets one buffer view for the given shader input index.
-            bool SetBufferView(RHI::ShaderInputNameIndex& inputIndex, const RHI::SingleDeviceBufferView* bufferView, uint32_t arrayIndex = 0);
-            bool SetBufferView(RHI::ShaderInputBufferIndex inputIndex, const RHI::SingleDeviceBufferView* bufferView, uint32_t arrayIndex = 0);
+            bool SetBufferView(RHI::ShaderInputNameIndex& inputIndex, const RHI::MultiDeviceBufferView* bufferView, uint32_t arrayIndex = 0);
+            bool SetBufferView(RHI::ShaderInputBufferIndex inputIndex, const RHI::MultiDeviceBufferView* bufferView, uint32_t arrayIndex = 0);
 
             /// Sets an array of buffer view for the given shader input index.
-            bool SetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews, uint32_t arrayIndex = 0);
-            bool SetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews, uint32_t arrayIndex = 0);
+            bool SetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::MultiDeviceBufferView * const> bufferViews, uint32_t arrayIndex = 0);
+            bool SetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex, AZStd::span<const RHI::MultiDeviceBufferView* const> bufferViews, uint32_t arrayIndex = 0);
 
             /// Sets an unbounded array of buffer views for the given shader input index.
-            bool SetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews);
+            bool SetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const RHI::MultiDeviceBufferView* const> bufferViews);
 
             /// Update the indirect buffer view with the indices of all the buffer views which reside in the global gpu heap.
-            void SetBindlessViews(
-                RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
-                const RHI::SingleDeviceBufferView* indirectResourceBuffer,
-                AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews,
+            void SetBindlessViews(RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
+                const RHI::MultiDeviceBufferView* indirectResourceBuffer,
+                AZStd::span<const RHI::MultiDeviceBufferView* const> bufferViews,
                 uint32_t* outIndices,
                 AZStd::span<bool> isViewReadOnly,
                 uint32_t arrayIndex = 0);
             
             /// Returns a single buffer view associated with the buffer shader input index and array offset.
-            const RHI::ConstPtr<RHI::SingleDeviceBufferView>& GetBufferView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex = 0) const;
-            const RHI::ConstPtr<RHI::SingleDeviceBufferView>& GetBufferView(RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex = 0) const;
+            const RHI::ConstPtr<RHI::MultiDeviceBufferView>& GetBufferView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex = 0) const;
+            const RHI::ConstPtr<RHI::MultiDeviceBufferView>& GetBufferView(
+                RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex = 0) const;
 
             /// Returns a span of buffer views associated with the given buffer shader input index.
-            AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceBufferView>> GetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex) const;
-            AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceBufferView>> GetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex) const;
-            
+            AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> GetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex) const;
+            AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> GetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex) const;
+
             //////////////////////////////////////////////////////////////////////////
             // Methods for assignment / access of RHI Sampler types.
 
@@ -342,14 +343,14 @@ namespace AZ
             /// If true, Init() was called and was successful.
             bool m_isInitialized = false;
 
-            /// Pool for allocating RHI::SingleDeviceShaderResourceGroup objects
+            /// Pool for allocating RHI::MultiDeviceShaderResourceGroup objects
             Data::Instance<ShaderResourceGroupPool> m_pool;
 
             /// The shader resource group data that is manipulated by this class
-            RHI::SingleDeviceShaderResourceGroupData m_data;
+            RHI::MultiDeviceShaderResourceGroupData m_data;
 
             /// The shader resource group that can be submitted to the renderer
-            RHI::Ptr<RHI::SingleDeviceShaderResourceGroup> m_shaderResourceGroup;
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> m_shaderResourceGroup;
 
             /// A reference to the SRG asset used to initialize and manipulate this group.
             AZ::Data::Asset<ShaderAsset> m_asset;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroupPool.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceShaderResourceGroupPool.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
 #include <AtomCore/Instance/InstanceData.h>
 #include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
 
@@ -49,10 +49,10 @@ namespace AZ
             static Data::Instance<ShaderResourceGroupPool> FindOrCreate(
                 const Data::Asset<ShaderAsset>& shaderAsset, const SupervariantIndex& supervariantIndex, const AZ::Name& srgName);
             
-            RHI::Ptr<RHI::SingleDeviceShaderResourceGroup> CreateRHIShaderResourceGroup();
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroup> CreateRHIShaderResourceGroup();
 
-            RHI::SingleDeviceShaderResourceGroupPool* GetRHIPool();
-            const RHI::SingleDeviceShaderResourceGroupPool* GetRHIPool() const;
+            RHI::MultiDeviceShaderResourceGroupPool* GetRHIPool();
+            const RHI::MultiDeviceShaderResourceGroupPool* GetRHIPool() const;
 
         private:
             ShaderResourceGroupPool() = default;
@@ -63,7 +63,7 @@ namespace AZ
 
             RHI::ResultCode Init(ShaderAsset& shaderAsset, const SupervariantIndex& supervariantIndex, const AZ::Name& srgName);
 
-            RHI::Ptr<RHI::SingleDeviceShaderResourceGroupPool> m_pool;
+            RHI::Ptr<RHI::MultiDeviceShaderResourceGroupPool> m_pool;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroup.h>
 #include <Atom/RHI/DrawListContext.h>
 
 #include <Atom/RPI.Public/Base.h>
@@ -66,7 +66,7 @@ namespace AZ
             RHI::DrawListMask GetDrawListMask() const { return m_drawListMask; }
             void Reset();
 
-            RHI::SingleDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
+            RHI::MultiDeviceShaderResourceGroup* GetRHIShaderResourceGroup() const;
 
             Data::Instance<RPI::ShaderResourceGroup> GetShaderResourceGroup();
             

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -208,7 +208,7 @@ namespace AZ
                 return;
             }
 
-            m_bufferView = aznew RHI::MultiDeviceBufferView{ m_rhiBuffer.get(), m_bufferViewDescriptor };
+            m_bufferView = m_rhiBuffer.get()->BuildBufferView(m_bufferViewDescriptor);
 
             if(!m_bufferView.get())
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -208,7 +208,7 @@ namespace AZ
                 return;
             }
 
-            m_bufferView = m_rhiBuffer.get()->BuildBufferView(m_bufferViewDescriptor);
+            m_bufferView = m_rhiBuffer->BuildBufferView(m_bufferViewDescriptor);
 
             if(!m_bufferView.get())
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -130,7 +130,7 @@ namespace AZ
             {
                 m_srgPerContext = AZ::RPI::ShaderResourceGroup::Create(
                     m_shader->GetAsset(), m_shader->GetSupervariantIndex(), Name { PerContextSrgName });
-                m_srgGroups[0] = m_srgPerContext->GetRHIShaderResourceGroup();
+                m_srgGroups[0] = m_srgPerContext->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
 
             // Save per draw srg asset which can be used to create draw srg later
@@ -525,7 +525,7 @@ namespace AZ
             // Setup per draw srg
             if (drawSrg)
             {
-                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
 
             // Set scissor per draw if scissor is enabled.
@@ -614,7 +614,7 @@ namespace AZ
             // Setup per draw srg
             if (drawSrg)
             {
-                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
 
             // Set scissor per draw if scissor is enabled.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -283,7 +283,7 @@ namespace AZ
             m_psoHandling = psoHandlingOverride;
         }
 
-        const RHI::SingleDeviceShaderResourceGroup* Material::GetRHIShaderResourceGroup() const
+        const RHI::MultiDeviceShaderResourceGroup* Material::GetRHIShaderResourceGroup() const
         {
             return m_rhiShaderResourceGroup;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -231,8 +231,8 @@ namespace AZ
 
             drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
             drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
-            drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
-            drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+            drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             // We build the list of used shaders in a local list rather than m_activeShaders so that
             // if DoUpdate() fails it won't modify any member data.
@@ -418,7 +418,7 @@ namespace AZ
                 drawRequest.m_sortKey = m_sortKey;
                 if (drawSrg)
                 {
-                    drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                    drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                     // Hold on to a reference to the drawSrg so the refcount doesn't drop to zero
                     m_perDrawSrgs.push_back(drawSrg);
                 }
@@ -469,7 +469,7 @@ namespace AZ
             if (m_drawPacket)
             {
                 m_activeShaders = shaderList;
-                m_materialSrg = m_material->GetRHIShaderResourceGroup();
+                m_materialSrg = m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex);
                 return true;
             }
             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -231,8 +231,14 @@ namespace AZ
 
             drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
             drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
-            drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
-            drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+            drawPacketBuilder.AddShaderResourceGroup(
+                m_objectSrg->GetRHIShaderResourceGroup()
+                    ? m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                    : nullptr);
+            drawPacketBuilder.AddShaderResourceGroup(
+                m_material->GetRHIShaderResourceGroup()
+                    ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                    : nullptr);
 
             // We build the list of used shaders in a local list rather than m_activeShaders so that
             // if DoUpdate() fails it won't modify any member data.
@@ -469,7 +475,7 @@ namespace AZ
             if (m_drawPacket)
             {
                 m_activeShaders = shaderList;
-                m_materialSrg = m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex);
+                m_materialSrg = m_material->GetRHIShaderResourceGroup() ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex): nullptr;
                 return true;
             }
             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -87,6 +87,7 @@ namespace AZ
                         bufferViewDescriptor.m_elementOffset * bufferViewDescriptor.m_elementSize,
                         bufferViewDescriptor.m_elementCount * bufferViewDescriptor.m_elementSize,
                         indexFormat);
+                    meshInstance.m_sdIndexBufferView = meshInstance.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
 
                     RHI::DrawIndexed drawIndexed;
                     drawIndexed.m_indexCount = bufferViewDescriptor.m_elementCount;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -412,10 +412,11 @@ namespace AZ
                         range.m_aspectFlags = RHI::ImageAspectFlags::Depth;
                     }
 
-                    AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts(1);
+                    AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
                     imageSubresourceLayouts.resize_no_construct(m_imageDescriptor.m_mipLevels);
                     size_t totalSizeInBytes = 0;
-                    image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), nullptr);
+                    image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)
+                        ->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), &totalSizeInBytes);
                     AZ::u64 byteCount = totalSizeInBytes;
 
                     RPI::CommonBufferDescriptor desc;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -155,7 +155,7 @@ namespace AZ
             m_dispatchItem.m_pipelineState = m_decomposeShader->AcquirePipelineState(pipelineStateDescriptor)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             m_dispatchItem.m_shaderResourceGroupCount = 1;
-            m_dispatchItem.m_shaderResourceGroups[0] = m_decomposeSrg->GetRHIShaderResourceGroup();
+            m_dispatchItem.m_shaderResourceGroups[0] = m_decomposeSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             // find srg input indexes
             m_decomposeInputImageIndex = m_decomposeSrg->FindShaderInputImageIndex(Name("m_msImage"));
@@ -289,9 +289,8 @@ namespace AZ
 
             m_dispatchItem.m_arguments = dispatchArgs;
 
-            const RHI::SingleDeviceImageView* imageView = context.GetImageView(m_attachmentId);
+            const RHI::MultiDeviceImageView* imageView = context.GetImageView(m_attachmentId);
             m_decomposeSrg->SetImageView(m_decomposeInputImageIndex, imageView);
-
             imageView = context.GetImageView(m_copyAttachmentId);
             m_decomposeSrg->SetImageView(m_decomposeOutputImageIndex, imageView);
 
@@ -367,7 +366,7 @@ namespace AZ
         {
             if (m_attachmentType == RHI::AttachmentType::Buffer)
             {
-                const AZ::RHI::SingleDeviceBuffer* buffer = context.GetBuffer(m_copyAttachmentId);
+                const AZ::RHI::MultiDeviceBuffer* buffer = context.GetBuffer(m_copyAttachmentId);
 
                 RPI::CommonBufferDescriptor desc;
                 desc.m_poolType = RPI::CommonBufferPoolType::ReadBack;
@@ -378,7 +377,7 @@ namespace AZ
 
                 // copy buffer
                 RHI::SingleDeviceCopyBufferDescriptor copyBuffer;
-                copyBuffer.m_sourceBuffer = buffer;
+                copyBuffer.m_sourceBuffer = buffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
                 copyBuffer.m_destinationBuffer = m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
                 copyBuffer.m_size = aznumeric_cast<uint32_t>(desc.m_byteCount);
 
@@ -386,8 +385,8 @@ namespace AZ
             }
             else if (m_attachmentType == RHI::AttachmentType::Image)
             {
-                // copy image to a read back buffer since only a buffer can be accessed by the host.
-                const AZ::RHI::SingleDeviceImage* image = context.GetImage(m_copyAttachmentId);
+                // copy image to read back buffer since only buffer can be accessed by host
+                const AZ::RHI::MultiDeviceImage* image = context.GetImage(m_copyAttachmentId);
                 if (!image)
                 {
                     AZ_Warning("AttachmentReadback", false, "Failed to find attachment image %s for copy to buffer", m_copyAttachmentId.GetCStr());
@@ -413,10 +412,10 @@ namespace AZ
                         range.m_aspectFlags = RHI::ImageAspectFlags::Depth;
                     }
 
-                    AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
+                    AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts(1);
                     imageSubresourceLayouts.resize_no_construct(m_imageDescriptor.m_mipLevels);
                     size_t totalSizeInBytes = 0;
-                    image->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), &totalSizeInBytes);
+                    image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), nullptr);
                     AZ::u64 byteCount = totalSizeInBytes;
 
                     RPI::CommonBufferDescriptor desc;
@@ -431,7 +430,7 @@ namespace AZ
 
                     // copy descriptor for copying image to buffer
                     RHI::SingleDeviceCopyImageToBufferDescriptor copyImageToBuffer;
-                    copyImageToBuffer.m_sourceImage = image;
+                    copyImageToBuffer.m_sourceImage = image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
                     copyImageToBuffer.m_sourceSize = imageSubresourceLayouts[mipSlice].m_size;
                     copyImageToBuffer.m_sourceSubresource = RHI::ImageSubresource(mipSlice, 0 /*arraySlice*/, imageAspect);
                     copyImageToBuffer.m_destinationOffset = 0;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
@@ -155,14 +154,14 @@ namespace AZ
 
             // Source Buffer
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId());
+            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_sourceBuffer = sourceBuffer;
             copyDesc.m_size = static_cast<uint32_t>(sourceBuffer->GetDescriptor().m_byteCount);
             copyDesc.m_sourceOffset = m_data.m_bufferSourceOffset;
 
             // Destination Buffer
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId());
+            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_destinationOffset = m_data.m_bufferDestinationOffset;
 
             m_copyItem = copyDesc;
@@ -174,7 +173,7 @@ namespace AZ
 
             // Source Image
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId());
+            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_sourceImage = sourceImage;
             copyDesc.m_sourceSize = sourceImage->GetDescriptor().m_size;
             copyDesc.m_sourceOrigin = m_data.m_imageSourceOrigin;
@@ -182,7 +181,7 @@ namespace AZ
 
             // Destination Image
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId());
+            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_destinationOrigin = m_data.m_imageDestinationOrigin;
             copyDesc.m_destinationSubresource = m_data.m_imageDestinationSubresource;
 
@@ -195,7 +194,7 @@ namespace AZ
 
             // Source Buffer
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId());
+            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_sourceBuffer = sourceBuffer;
             copyDesc.m_sourceSize = m_data.m_sourceSize;
             copyDesc.m_sourceOffset = m_data.m_bufferSourceOffset;
@@ -204,7 +203,7 @@ namespace AZ
 
             // Destination Image
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId());
+            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_destinationOrigin = m_data.m_imageDestinationOrigin;
             copyDesc.m_destinationSubresource = m_data.m_imageDestinationSubresource;
 
@@ -217,7 +216,7 @@ namespace AZ
 
             // Source Image
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId());
+            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_sourceImage = sourceImage;
             copyDesc.m_sourceSize = sourceImage->GetDescriptor().m_size;
             copyDesc.m_sourceOrigin = m_data.m_imageSourceOrigin;
@@ -225,7 +224,7 @@ namespace AZ
 
             // Destination Buffer
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId());
+            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             copyDesc.m_destinationOffset = m_data.m_bufferDestinationOffset;
             copyDesc.m_destinationBytesPerRow = m_data.m_bufferDestinationBytesPerRow;
             copyDesc.m_destinationBytesPerImage = m_data.m_bufferDestinationBytesPerImage;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -935,11 +935,11 @@ namespace AZ
                         Image* image = static_cast<Image*>(attachment->m_importedResource.get());
                         if (currentAttachment == nullptr)
                         {
-                            attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get());
+                            attachmentDatabase.ImportImage(attachmentId, image->GetRHIImage());
                         }
                         else
                         {
-                            AZ_Assert(currentAttachment->GetResource() == image->GetRHIImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                            AZ_Assert(currentAttachment->GetResource() == image->GetRHIImage(),
                                 "Importing image attachment named \"%s\" but a different attachment with the "
                                 "same name already exists in the database.\n", attachmentId.GetCStr());
                         }
@@ -949,11 +949,11 @@ namespace AZ
                         Buffer* buffer = static_cast<Buffer*>(attachment->m_importedResource.get());
                         if (currentAttachment == nullptr)
                         {
-                            attachmentDatabase.ImportBuffer(attachmentId, buffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get());
+                            attachmentDatabase.ImportBuffer(attachmentId, buffer->GetRHIBuffer());
                         }
                         else
                         {
-                            AZ_Assert(currentAttachment->GetResource() == buffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                            AZ_Assert(currentAttachment->GetResource() == buffer->GetRHIBuffer(),
                                 "Importing buffer attachment named \"%s\" but a different attachment with the "
                                 "same name already exists in the database.\n", attachmentId.GetCStr());
                         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -9,7 +9,6 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
 #include <Atom/RHI/RHISystemInterface.h>
-#include <Atom/RHI/SingleDeviceShaderResourceGroup.h>
 
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
 #include <Atom/RPI.Public/Pass/RasterPass.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -284,7 +284,7 @@ namespace AZ
                     {
                         inputIndex = imageIndex;
                     }
-                    const RHI::SingleDeviceImageView* imageView =
+                    const RHI::MultiDeviceImageView* imageView =
                         context.GetImageView(attachment->GetAttachmentId(), binding.m_unifiedScopeDesc.GetImageViewDescriptor(), binding.m_scopeAttachmentUsage);
 
                     if (binding.m_shaderImageDimensionsNameIndex.HasName())
@@ -324,7 +324,7 @@ namespace AZ
                     {
                         inputIndex = bufferIndex;
                     }
-                    const RHI::SingleDeviceBufferView* bufferView = context.GetBufferView(attachment->GetAttachmentId(), binding.m_scopeAttachmentUsage);
+                    const RHI::MultiDeviceBufferView* bufferView = context.GetBufferView(attachment->GetAttachmentId(), binding.m_scopeAttachmentUsage);
                     m_shaderResourceGroup->SetBufferView(RHI::ShaderInputBufferIndex(inputIndex), bufferView, arrayIndex);
                     ++bufferIndex;
                 }
@@ -378,7 +378,7 @@ namespace AZ
         void RenderPass::CollectSrgs()
         {
             // Scene srg
-            const RHI::SingleDeviceShaderResourceGroup* sceneSrg = m_pipeline->GetScene()->GetRHIShaderResourceGroup();
+            const RHI::MultiDeviceShaderResourceGroup* sceneSrg = m_pipeline->GetScene()->GetRHIShaderResourceGroup();
             BindSrg(sceneSrg);
 
             // View srg
@@ -402,7 +402,7 @@ namespace AZ
             m_shaderResourceGroupsToBind.clear();
         }
 
-        void RenderPass::BindSrg(const RHI::SingleDeviceShaderResourceGroup* srg)
+        void RenderPass::BindSrg(const RHI::MultiDeviceShaderResourceGroup* srg)
         {
             if (srg)
             {
@@ -414,7 +414,7 @@ namespace AZ
         {
             for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDraw(*(itr.second));
+                commandList->SetShaderResourceGroupForDraw(*(itr.second->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex)));
             }
         }
 
@@ -422,7 +422,7 @@ namespace AZ
         {
             for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDispatch(*(itr.second));
+                commandList->SetShaderResourceGroupForDispatch(*(itr.second->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex)));
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -195,7 +195,7 @@ namespace AZ
 
             // Import the SwapChain
             attachmentDatabase.ImportSwapChain(
-                m_windowContext->GetSwapChainAttachmentId(m_viewType), m_windowContext->GetSwapChain(m_viewType)->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex));
+                m_windowContext->GetSwapChainAttachmentId(m_viewType), m_windowContext->GetSwapChain(m_viewType));
 
             ParentPass::FrameBeginInternal(params);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -931,7 +931,7 @@ namespace AZ
             }
         }
 
-        const RHI::SingleDeviceShaderResourceGroup* Scene::GetRHIShaderResourceGroup() const
+        const RHI::MultiDeviceShaderResourceGroup* Scene::GetRHIShaderResourceGroup() const
         {
             if (m_srg.get())
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -636,7 +636,19 @@ namespace AZ
         {
             return m_data.GetConstantRaw(inputIndex);
         }
-    
+
+        void ShaderResourceGroup::SetBindlessViews(
+            RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
+            const RHI::MultiDeviceBufferView* indirectResourceBuffer,
+            AZStd::span<const RHI::MultiDeviceImageView* const> imageViews,
+            uint32_t* outIndices,
+            AZStd::span<bool> isViewReadOnly,
+            uint32_t arrayIndex)
+        {
+            m_data.SetBindlessViews(
+                indirectResourceBufferIndex, indirectResourceBuffer, imageViews, outIndices, isViewReadOnly, arrayIndex);
+        }
+
         void ShaderResourceGroup::SetBindlessViews(
             RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
             const RHI::MultiDeviceBufferView* indirectResourceBuffer,

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -115,7 +115,7 @@ namespace AZ
                 return RHI::ResultCode::Fail;
             }
             m_shaderResourceGroup->SetName(m_pool->GetRHIPool()->GetName());
-            m_data = RHI::SingleDeviceShaderResourceGroupData(m_layout);
+            m_data = RHI::MultiDeviceShaderResourceGroupData(RHI::MultiDevice::AllDevices, m_layout);
             m_asset = { &shaderAsset, AZ::Data::AssetLoadBehavior::PreLoad };
 
             // The RPI groups match the same dimensions as the RHI group.
@@ -175,7 +175,7 @@ namespace AZ
             return m_layout;
         }
 
-        RHI::SingleDeviceShaderResourceGroup* ShaderResourceGroup::GetRHIShaderResourceGroup()
+        RHI::MultiDeviceShaderResourceGroup* ShaderResourceGroup::GetRHIShaderResourceGroup()
         {
             return m_shaderResourceGroup.get();
         }
@@ -213,7 +213,7 @@ namespace AZ
 
         bool ShaderResourceGroup::SetImage(RHI::ShaderInputImageIndex inputIndex, const Data::Instance<Image>& image, uint32_t arrayIndex)
         {
-            const auto imageView = image ? image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get() : nullptr;
+            const RHI::MultiDeviceImageView* imageView = image ? image->GetImageView() : nullptr;
 
             if (m_data.SetImageView(inputIndex, imageView, arrayIndex))
             {
@@ -289,7 +289,7 @@ namespace AZ
             return {};
         }
 
-        bool ShaderResourceGroup::SetImageView(RHI::ShaderInputNameIndex& inputIndex, const RHI::SingleDeviceImageView* imageView, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetImageView(RHI::ShaderInputNameIndex& inputIndex, const RHI::MultiDeviceImageView* imageView, uint32_t arrayIndex)
         {
             if (inputIndex.ValidateOrFindImageIndex(GetLayout()))
             {
@@ -298,7 +298,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetImageView(RHI::ShaderInputImageIndex inputIndex, const RHI::SingleDeviceImageView* imageView, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetImageView(RHI::ShaderInputImageIndex inputIndex, const RHI::MultiDeviceImageView* imageView, uint32_t arrayIndex)
         {
             if (m_data.SetImageView(inputIndex, imageView, arrayIndex))
             {
@@ -312,7 +312,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetImageViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetImageViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::MultiDeviceImageView* const> imageViews, uint32_t arrayIndex)
         {
             if (inputIndex.ValidateOrFindImageIndex(GetLayout()))
             {
@@ -321,7 +321,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetImageViewArray(RHI::ShaderInputImageIndex inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetImageViewArray(RHI::ShaderInputImageIndex inputIndex, AZStd::span<const RHI::MultiDeviceImageView * const> imageViews, uint32_t arrayIndex)
         {
             if (GetLayout()->ValidateAccess(inputIndex, arrayIndex + static_cast<uint32_t>(imageViews.size()) - 1))
             {
@@ -335,12 +335,12 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetImageViewUnboundedArray(RHI::ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const RHI::SingleDeviceImageView* const> imageViews)
+        bool ShaderResourceGroup::SetImageViewUnboundedArray(RHI::ShaderInputImageUnboundedArrayIndex inputIndex, AZStd::span<const RHI::MultiDeviceImageView* const> imageViews)
         {
             return m_data.SetImageViewUnboundedArray(inputIndex, imageViews);
         }
 
-        bool ShaderResourceGroup::SetBufferView(RHI::ShaderInputNameIndex& inputIndex, const RHI::SingleDeviceBufferView* bufferView, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetBufferView(RHI::ShaderInputNameIndex& inputIndex, const RHI::MultiDeviceBufferView *bufferView, uint32_t arrayIndex)
         {
             if (inputIndex.ValidateOrFindBufferIndex(GetLayout()))
             {
@@ -349,7 +349,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetBufferView(RHI::ShaderInputBufferIndex inputIndex, const RHI::SingleDeviceBufferView* bufferView, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetBufferView(RHI::ShaderInputBufferIndex inputIndex, const RHI::MultiDeviceBufferView *bufferView, uint32_t arrayIndex)
         {
             if (m_data.SetBufferView(inputIndex, bufferView, arrayIndex))
             {
@@ -363,7 +363,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex, AZStd::span<const RHI::MultiDeviceBufferView* const> bufferViews, uint32_t arrayIndex)
         {
             if (inputIndex.ValidateOrFindBufferIndex(GetLayout()))
             {
@@ -372,7 +372,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews, uint32_t arrayIndex)
+        bool ShaderResourceGroup::SetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex, AZStd::span<const RHI::MultiDeviceBufferView * const> bufferViews, uint32_t arrayIndex)
         {
             if (GetLayout()->ValidateAccess(inputIndex, arrayIndex + static_cast<uint32_t>(bufferViews.size()) - 1))
             {
@@ -386,7 +386,7 @@ namespace AZ
             return false;
         }
 
-        bool ShaderResourceGroup::SetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews)
+        bool ShaderResourceGroup::SetBufferViewUnboundedArray(RHI::ShaderInputBufferUnboundedArrayIndex inputIndex, AZStd::span<const RHI::MultiDeviceBufferView * const> bufferViews)
         {
             return m_data.SetBufferViewUnboundedArray(inputIndex, bufferViews);
         }
@@ -463,46 +463,50 @@ namespace AZ
             return success;
         }
 
-        const RHI::ConstPtr<RHI::SingleDeviceImageView>& ShaderResourceGroup::GetImageView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex) const
+        const RHI::ConstPtr<RHI::MultiDeviceImageView>& ShaderResourceGroup::GetImageView(
+            RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex) const
         {
             inputIndex.ValidateOrFindImageIndex(GetLayout());
             return GetImageView(inputIndex.GetImageIndex(), arrayIndex);
         }
 
-        const RHI::ConstPtr<RHI::SingleDeviceImageView>& ShaderResourceGroup::GetImageView(RHI::ShaderInputImageIndex inputIndex, uint32_t arrayIndex) const
+        const RHI::ConstPtr<RHI::MultiDeviceImageView>& ShaderResourceGroup::GetImageView(RHI::ShaderInputImageIndex inputIndex, uint32_t arrayIndex) const
         {
             return m_data.GetImageView(inputIndex, arrayIndex);
         }
 
-        AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceImageView>> ShaderResourceGroup::GetImageViewArray(RHI::ShaderInputNameIndex& inputIndex) const
+        AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> ShaderResourceGroup::GetImageViewArray(
+            RHI::ShaderInputNameIndex& inputIndex) const
         {
             inputIndex.ValidateOrFindImageIndex(GetLayout());
             return GetImageViewArray(inputIndex.GetImageIndex());
         }
 
-        AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceImageView>> ShaderResourceGroup::GetImageViewArray(RHI::ShaderInputImageIndex inputIndex) const
+        AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceImageView>> ShaderResourceGroup::GetImageViewArray(RHI::ShaderInputImageIndex inputIndex) const
         {
             return m_data.GetImageViewArray(inputIndex);
         }
 
-        const RHI::ConstPtr<RHI::SingleDeviceBufferView>& ShaderResourceGroup::GetBufferView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex) const
+        const RHI::ConstPtr<RHI::MultiDeviceBufferView>& ShaderResourceGroup::GetBufferView(
+            RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex) const
         {
             inputIndex.ValidateOrFindBufferIndex(GetLayout());
             return GetBufferView(inputIndex.GetBufferIndex(), arrayIndex);
         }
 
-        const RHI::ConstPtr<RHI::SingleDeviceBufferView>& ShaderResourceGroup::GetBufferView(RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex) const
+        const RHI::ConstPtr<RHI::MultiDeviceBufferView>& ShaderResourceGroup::GetBufferView(RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex) const
         {
             return m_data.GetBufferView(inputIndex, arrayIndex);
         }
 
-        AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceBufferView>> ShaderResourceGroup::GetBufferViewArray(RHI::ShaderInputNameIndex& inputIndex) const
+        AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> ShaderResourceGroup::GetBufferViewArray(
+            RHI::ShaderInputNameIndex& inputIndex) const
         {
             inputIndex.ValidateOrFindBufferIndex(GetLayout());
             return GetBufferViewArray(inputIndex.GetBufferIndex());
         }
 
-        AZStd::span<const RHI::ConstPtr<RHI::SingleDeviceBufferView>> ShaderResourceGroup::GetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex) const
+        AZStd::span<const RHI::ConstPtr<RHI::MultiDeviceBufferView>> ShaderResourceGroup::GetBufferViewArray(RHI::ShaderInputBufferIndex inputIndex) const
         {
             return m_data.GetBufferViewArray(inputIndex);
         }
@@ -519,9 +523,9 @@ namespace AZ
         bool ShaderResourceGroup::SetBuffer(RHI::ShaderInputBufferIndex inputIndex, const Data::Instance<Buffer>& buffer, uint32_t arrayIndex)
         {
             const auto bufferView =
-                buffer ? buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex) : nullptr;
+                buffer ? buffer->GetBufferView() : nullptr;
 
-            if (m_data.SetBufferView(inputIndex, bufferView.get(), arrayIndex))
+            if (m_data.SetBufferView(inputIndex, bufferView, arrayIndex))
             {
                 const RHI::Interval interval = m_layout->GetGroupInterval(inputIndex);
 
@@ -635,20 +639,8 @@ namespace AZ
     
         void ShaderResourceGroup::SetBindlessViews(
             RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
-            const RHI::SingleDeviceBufferView* indirectResourceBuffer,
-            AZStd::span<const RHI::SingleDeviceImageView* const> imageViews,
-            uint32_t* outIndices,
-            AZStd::span<bool> isViewReadOnly,
-            uint32_t arrayIndex)
-        {
-            m_data.SetBindlessViews(indirectResourceBufferIndex, indirectResourceBuffer,
-                                    imageViews, outIndices, isViewReadOnly, arrayIndex);
-        }
-    
-        void ShaderResourceGroup::SetBindlessViews(
-            RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
-            const RHI::SingleDeviceBufferView* indirectResourceBuffer,
-            AZStd::span<const RHI::SingleDeviceBufferView* const> bufferViews,
+            const RHI::MultiDeviceBufferView* indirectResourceBuffer,
+            AZStd::span<const RHI::MultiDeviceBufferView* const> bufferViews,
             uint32_t* outIndices,
             AZStd::span<bool> isViewReadOnly,
             uint32_t arrayIndex)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -98,7 +98,7 @@ namespace AZ
             m_passesByDrawList = nullptr;
         }
 
-        RHI::SingleDeviceShaderResourceGroup* View::GetRHIShaderResourceGroup() const
+        RHI::MultiDeviceShaderResourceGroup* View::GetRHIShaderResourceGroup() const
         {
             return m_shaderResourceGroup->GetRHIShaderResourceGroup();
         }

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialTests.cpp
@@ -151,8 +151,8 @@ namespace UnitTest
 
             // Dig in to the SRG to make sure the values were applied there as well...
 
-            const RHI::SingleDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
-            const RHI::SingleDeviceShaderResourceGroupData& srgData = srg->GetData();
+            const RHI::MultiDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
+            const RHI::MultiDeviceShaderResourceGroupData& srgData = srg->GetData();
 
             EXPECT_EQ(srgData.GetConstant<bool>(srgData.FindShaderInputConstantIndex(Name{ "m_bool" })), false);
             EXPECT_EQ(srgData.GetConstant<int32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_int" })), -12);
@@ -189,8 +189,8 @@ namespace UnitTest
 
             // Dig in to the SRG to make sure the values were applied there as well...
 
-            const RHI::SingleDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
-            const RHI::SingleDeviceShaderResourceGroupData& srgData = srg->GetData();
+            const RHI::MultiDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
+            const RHI::MultiDeviceShaderResourceGroupData& srgData = srg->GetData();
 
             EXPECT_EQ(srgData.GetConstant<bool>(srgData.FindShaderInputConstantIndex(Name{ "m_bool" })), true);
             EXPECT_EQ(srgData.GetConstant<int32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_int" })), -2);
@@ -204,9 +204,9 @@ namespace UnitTest
             EXPECT_EQ(srgData.GetConstant<Vector4>(srgData.FindShaderInputConstantIndex(Name{ "m_float4" })), Vector4(2.1f, 2.2f, 2.3f, 2.4f));
             EXPECT_EQ(srgData.GetConstant<Color>(srgData.FindShaderInputConstantIndex(Name{ "m_color" })), TransformColor(Color(1.0f, 1.0f, 1.0f, 1.0f), ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg));
 
-            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), m_testImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), m_testImage->GetImageView());
             EXPECT_EQ(srgData.GetConstant<uint32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_enum" })), 2u);
-            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_attachmentImage" }), 0), m_testAttachmentImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+            EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_attachmentImage" }), 0), m_testAttachmentImage->GetImageView());
         }
 
         //! Provides write access to private material asset property values, primarily for simulating
@@ -361,8 +361,8 @@ namespace UnitTest
 
         // Dig in to the SRG to make sure the values were applied there as well...
 
-        const RHI::SingleDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
-        const RHI::SingleDeviceShaderResourceGroupData& srgData = srg->GetData();
+        const RHI::MultiDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
+        const RHI::MultiDeviceShaderResourceGroupData& srgData = srg->GetData();
 
         EXPECT_EQ(srgData.GetConstant<bool>(srgData.FindShaderInputConstantIndex(Name{ "m_bool" })), false);
         EXPECT_EQ(srgData.GetConstant<int32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_int" })), -5);
@@ -376,7 +376,7 @@ namespace UnitTest
         EXPECT_EQ(srgData.GetConstant<Vector4>(srgData.FindShaderInputConstantIndex(Name{ "m_float4" })), Vector4(12.1f, 12.2f, 12.3f, 12.4f));
         EXPECT_EQ(srgData.GetConstant<Color>(srgData.FindShaderInputConstantIndex(Name{ "m_color" })), TransformColor(Color(0.1f, 0.2f, 0.3f, 0.4f), ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg));
 
-        EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), otherTestImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex));
+        EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{ "m_image" }), 0), otherTestImage->GetImageView());
         EXPECT_EQ(srgData.GetConstant<uint32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_enum" })), 3u);
     }
 
@@ -411,8 +411,8 @@ namespace UnitTest
 
         // Dig in to the SRG to make sure the values were applied to both shader constants...
 
-        const RHI::SingleDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
-        const RHI::SingleDeviceShaderResourceGroupData& srgData = srg->GetData();
+        const RHI::MultiDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
+        const RHI::MultiDeviceShaderResourceGroupData& srgData = srg->GetData();
 
         EXPECT_EQ(srgData.GetConstant<int32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_int" })), 42);
         EXPECT_EQ(srgData.GetConstant<uint32_t>(srgData.FindShaderInputConstantIndex(Name{ "m_uint" })), 42u);
@@ -428,9 +428,9 @@ namespace UnitTest
         EXPECT_TRUE(material->Compile());
 
         // Taint the SRG so we can check whether it was set by the SetPropertyValue() calls below.
-        const RHI::SingleDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
-        const RHI::SingleDeviceShaderResourceGroupData& srgData = srg->GetData();
-        const_cast<RHI::SingleDeviceShaderResourceGroupData*>(&srgData)->SetConstant(m_testMaterialSrgLayout->FindShaderInputConstantIndex(Name{"m_float"}), 0.0f);
+        const RHI::MultiDeviceShaderResourceGroup* srg = material->GetRHIShaderResourceGroup();
+        const RHI::MultiDeviceShaderResourceGroupData& srgData = srg->GetData();
+        const_cast<RHI::MultiDeviceShaderResourceGroupData*>(&srgData)->SetConstant(m_testMaterialSrgLayout->FindShaderInputConstantIndex(Name{"m_float"}), 0.0f);
 
         // Set the properties to the same values as before
         EXPECT_FALSE(material->SetPropertyValue<float>(material->FindPropertyIndex(Name{ "MyFloat" }), 2.5f));
@@ -468,7 +468,7 @@ namespace UnitTest
         ProcessQueuedSrgCompilations(m_testMaterialShaderAsset, m_testMaterialSrgLayout->GetName());
         material->Compile();
 
-        const RHI::SingleDeviceShaderResourceGroupData& srgData = material->GetRHIShaderResourceGroup()->GetData();
+        const RHI::MultiDeviceShaderResourceGroupData& srgData = material->GetRHIShaderResourceGroup()->GetData();
 
         EXPECT_EQ(srgData.GetImageView(srgData.FindShaderInputImageIndex(Name{"m_image"}), 0), nullptr);
     }

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
@@ -34,11 +34,11 @@ namespace UnitTest
         Data::Instance<Buffer> m_shortBuffer;
         Data::Instance<Buffer> m_mediumBuffer;
         Data::Instance<Buffer> m_longBuffer;
-        Ptr<RHI::SingleDeviceBufferView> m_bufferViewA;
-        Ptr<RHI::SingleDeviceBufferView> m_bufferViewB;
-        Ptr<RHI::SingleDeviceBufferView> m_bufferViewC;
+        Ptr<RHI::MultiDeviceBufferView> m_bufferViewA;
+        Ptr<RHI::MultiDeviceBufferView> m_bufferViewB;
+        Ptr<RHI::MultiDeviceBufferView> m_bufferViewC;
         AZStd::vector<Data::Instance<Buffer>> m_threeBuffers;
-        AZStd::vector<const RHI::SingleDeviceBufferView*> m_threeBufferViews;
+        AZStd::vector<const RHI::MultiDeviceBufferView*> m_threeBufferViews;
         const RHI::ShaderInputBufferIndex m_indexOfBufferA{ 0 };
         const RHI::ShaderInputBufferIndex m_indexOfBufferB{ 1 };
         const RHI::ShaderInputBufferIndex m_indexOfBufferArray{ 2 };
@@ -109,9 +109,9 @@ namespace UnitTest
             m_longBuffer = Buffer::FindOrCreate(m_longBufferAsset);
 
             m_threeBuffers = { m_shortBuffer, m_mediumBuffer, m_longBuffer };
-            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
-            m_bufferViewB = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
-            m_bufferViewC = m_longBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
+            m_bufferViewA = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
+            m_bufferViewB = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
+            m_bufferViewC = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
 
             m_threeBufferViews = { m_bufferViewA.get(), m_bufferViewB.get(), m_bufferViewC.get() };
         }
@@ -127,7 +127,7 @@ namespace UnitTest
             m_bufferPoolAsset.Reset();
 
             m_threeBuffers = AZStd::vector<Data::Instance<Buffer>>();
-            m_threeBufferViews = AZStd::vector<const RHI::SingleDeviceBufferView*>();
+            m_threeBufferViews = AZStd::vector<const RHI::MultiDeviceBufferView*>();
             m_bufferViewA = nullptr;
             m_bufferViewB = nullptr;
             m_bufferViewC = nullptr;
@@ -189,8 +189,8 @@ namespace UnitTest
         EXPECT_EQ(m_mediumBuffer, m_testSrg->GetBuffer(m_indexOfBufferB));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_shortBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferA, 0));
-        EXPECT_EQ(m_mediumBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferB, 0));
+        EXPECT_EQ(m_shortBuffer->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferA, 0));
+        EXPECT_EQ(m_mediumBuffer->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferB, 0));
 
         // Test changing back to null...
 
@@ -199,7 +199,7 @@ namespace UnitTest
         EXPECT_TRUE(m_testSrg->SetBuffer(m_indexOfBufferA, nullptr));
         m_testSrg->Compile();
         EXPECT_EQ(nullptr, m_testSrg->GetBuffer(m_indexOfBufferA));
-        EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferA, 0));
+        EXPECT_EQ(nullptr, m_testSrg->GetBufferView(m_indexOfBufferA, 0));
     }
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetGetBufferAtOffset)
@@ -214,9 +214,9 @@ namespace UnitTest
         EXPECT_EQ(m_longBuffer, m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
 
         m_testSrg->Compile();
-        EXPECT_EQ(m_shortBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_mediumBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_longBuffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_shortBuffer->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_mediumBuffer->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_longBuffer->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
 
         // Test changing back to null...
 
@@ -225,7 +225,7 @@ namespace UnitTest
         EXPECT_TRUE(m_testSrg->SetBuffer(m_indexOfBufferArray, nullptr, 1));
         m_testSrg->Compile();
         EXPECT_EQ(nullptr, m_testSrg->GetBuffer(m_indexOfBufferArray, 1));
-        EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(nullptr, m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
     }
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetGetBufferArray)
@@ -242,9 +242,9 @@ namespace UnitTest
         EXPECT_EQ(m_threeBuffers[0], m_testSrg->GetBuffer(m_indexOfBufferArray, 0));
         EXPECT_EQ(m_threeBuffers[1], m_testSrg->GetBuffer(m_indexOfBufferArray, 1));
         EXPECT_EQ(m_threeBuffers[2], m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
-        EXPECT_EQ(m_threeBuffers[0]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_threeBuffers[1]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_threeBuffers[2]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_threeBuffers[0]->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_threeBuffers[1]->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_threeBuffers[2]->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
 
         // Test replacing just two buffers including changing one buffer back to null...
 
@@ -296,9 +296,9 @@ namespace UnitTest
         EXPECT_EQ(nullptr, m_testSrg->GetBuffer(m_indexOfBufferArray, 0));
         EXPECT_EQ(twoBuffers[0], m_testSrg->GetBuffer(m_indexOfBufferArray, 1));
         EXPECT_EQ(twoBuffers[1], m_testSrg->GetBuffer(m_indexOfBufferArray, 2));
-        EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(twoBuffers[0]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(twoBuffers[1]->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex), m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(nullptr, m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(twoBuffers[0]->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(twoBuffers[1]->GetBufferView(), m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
     }
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetBufferArrayAtOffset_ValidationFailure)
@@ -337,8 +337,8 @@ namespace UnitTest
 
         EXPECT_EQ(m_bufferViewA, m_testSrg->GetBufferView(m_indexOfBufferA));
         EXPECT_EQ(m_bufferViewB, m_testSrg->GetBufferView(m_indexOfBufferB));
-        EXPECT_EQ(m_bufferViewA, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferA, 0));
-        EXPECT_EQ(m_bufferViewB, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferB, 0));
+        EXPECT_EQ(m_bufferViewA, m_testSrg->GetBufferView(m_indexOfBufferA, 0));
+        EXPECT_EQ(m_bufferViewB, m_testSrg->GetBufferView(m_indexOfBufferB, 0));
 
         // The RPI::Buffer should get cleared when you set a RHI::SingleDeviceBufferView directly
         EXPECT_EQ(nullptr, m_testSrg->GetBuffer(m_indexOfBufferA));
@@ -364,9 +364,9 @@ namespace UnitTest
         EXPECT_EQ(m_bufferViewA, m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
         EXPECT_EQ(m_bufferViewB, m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
         EXPECT_EQ(m_bufferViewC, m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
-        EXPECT_EQ(m_bufferViewA, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_bufferViewB, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_bufferViewC, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_bufferViewA, m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_bufferViewB, m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_bufferViewC, m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
 
         // The RPI::Buffer should get cleared when you set a RHI::SingleDeviceBufferView directly
         EXPECT_EQ(nullptr, m_testSrg->GetBuffer(m_indexOfBufferArray, 0));
@@ -388,15 +388,15 @@ namespace UnitTest
         EXPECT_EQ(m_threeBufferViews[0], m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
         EXPECT_EQ(m_threeBufferViews[1], m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
         EXPECT_EQ(m_threeBufferViews[2], m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
-        EXPECT_EQ(m_threeBufferViews[0], m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(m_threeBufferViews[1], m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(m_threeBufferViews[2], m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(m_threeBufferViews[0], m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(m_threeBufferViews[1], m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(m_threeBufferViews[2], m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
 
         // Test replacing just two buffer views including changing one back to null...
 
         ProcessQueuedSrgCompilations(m_testSrgShaderAsset, m_testSrgLayout->GetName());
 
-        AZStd::vector<const RHI::SingleDeviceBufferView*> alternateBufferViews = { m_bufferViewB.get(), nullptr };
+        AZStd::vector<const RHI::MultiDeviceBufferView*> alternateBufferViews = { m_bufferViewB.get(), nullptr };
 
         EXPECT_TRUE(m_testSrg->SetBufferViewArray(m_indexOfBufferArray, alternateBufferViews));
         m_testSrg->Compile();
@@ -410,7 +410,7 @@ namespace UnitTest
     {
         // Make sure the no changes are made when a validation failure is detected
 
-        AZStd::vector<const RHI::SingleDeviceBufferView*> tooManyBufferViews{ 4, m_bufferViewA.get() };
+        AZStd::vector<const RHI::MultiDeviceBufferView*> tooManyBufferViews{ 4, m_bufferViewA.get() };
 
         AZ_TEST_START_ASSERTTEST;
         EXPECT_FALSE(m_testSrg->SetBufferViewArray(m_indexOfBufferArray, tooManyBufferViews));
@@ -424,7 +424,7 @@ namespace UnitTest
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetBufferViewArrayAtOffset)
     {
-        AZStd::vector<const RHI::SingleDeviceBufferView*> twoBufferViews = { m_bufferViewA.get(), m_bufferViewB.get() };
+        AZStd::vector<const RHI::MultiDeviceBufferView*> twoBufferViews = { m_bufferViewA.get(), m_bufferViewB.get() };
 
         // Test set operation, skipping the first element...
 
@@ -438,16 +438,16 @@ namespace UnitTest
         EXPECT_EQ(nullptr, m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
         EXPECT_EQ(twoBufferViews[0], m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
         EXPECT_EQ(twoBufferViews[1], m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
-        EXPECT_EQ(nullptr, m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 0));
-        EXPECT_EQ(twoBufferViews[0], m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 1));
-        EXPECT_EQ(twoBufferViews[1], m_testSrg->GetRHIShaderResourceGroup()->GetData().GetBufferView(m_indexOfBufferArray, 2));
+        EXPECT_EQ(nullptr, m_testSrg->GetBufferView(m_indexOfBufferArray, 0));
+        EXPECT_EQ(twoBufferViews[0], m_testSrg->GetBufferView(m_indexOfBufferArray, 1));
+        EXPECT_EQ(twoBufferViews[1], m_testSrg->GetBufferView(m_indexOfBufferArray, 2));
     }
 
     TEST_F(ShaderResourceGroupBufferTests, TestSetBufferViewArrayAtOffset_ValidationFailure)
     {
         // Make sure the no changes are made when a validation failure is detected
 
-        AZStd::vector<const RHI::SingleDeviceBufferView*> tooManyBufferViews{ 3, m_bufferViewA.get() };
+        AZStd::vector<const RHI::MultiDeviceBufferView*> tooManyBufferViews{ 3, m_bufferViewA.get() };
 
         AZ_TEST_START_ASSERTTEST;
         EXPECT_FALSE(m_testSrg->SetBufferViewArray(m_indexOfBufferArray, tooManyBufferViews, 1));

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupConstantBufferTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupConstantBufferTests.cpp
@@ -389,7 +389,7 @@ namespace UnitTest
             // MyFloat2
             EXPECT_FALSE(m_srg->SetConstantArray<float>(RHI::ShaderInputConstantIndex(13), AZStd::array<float, 3>({ 0.1f, 0.2f, 0.3f })));
 
-            AZ_TEST_STOP_ASSERTTEST(1);
+            AZ_TEST_STOP_ASSERTTEST(2);
         }
     }
 
@@ -417,7 +417,7 @@ namespace UnitTest
             // MyBool2
             EXPECT_FALSE(m_srg->SetConstant<bool>(RHI::ShaderInputConstantIndex(1), false));
 
-            AZ_TEST_STOP_ASSERTTEST(1);
+            AZ_TEST_STOP_ASSERTTEST(2);
         }
     }
 

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -344,7 +344,7 @@ void AZ::FFont::DrawStringUInternal(
             //setup per draw srg
             auto drawSrg = dynamicDraw->NewDrawSrg();
             drawSrg->SetConstant(m_fontShaderData.m_viewProjInputIndex, modelViewProjMat);
-            drawSrg->SetImageView(m_fontShaderData.m_imageInputIndex, m_fontStreamingImage->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            drawSrg->SetImageView(m_fontShaderData.m_imageInputIndex, m_fontStreamingImage->GetImageView());
             drawSrg->Compile();
 
             dynamicDraw->DrawIndexed(m_vertexBuffer, m_vertexCount, m_indexBuffer, m_indexCount, RHI::IndexFormat::Uint16, drawSrg);

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -151,7 +151,7 @@ namespace AZ::Render
         // Initialize our shader
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
         drawSrg->SetConstant(m_viewportSizeIndex, AzFramework::Vector2FromScreenSize(viewportSize));
-        drawSrg->SetImageView(m_textureParameterIndex, image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+        drawSrg->SetImageView(m_textureParameterIndex, image->GetImageView());
         drawSrg->Compile();
 
         // Scale icons by screen DPI

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -129,8 +129,14 @@ namespace AZ::Render
 
         drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
         drawPacketBuilder.SetIndexBufferView(mesh.m_sdIndexBufferView);
-        drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
-        drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+        drawPacketBuilder.AddShaderResourceGroup(
+            m_objectSrg->GetRHIShaderResourceGroup()
+                ? m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                : nullptr);
+        drawPacketBuilder.AddShaderResourceGroup(
+            m_material->GetRHIShaderResourceGroup()
+                ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                : nullptr);
 
         // We build the list of used shaders in a local list rather than m_activeShaders so that
         // if DoUpdate() fails it won't modify any member data.

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -128,9 +128,9 @@ namespace AZ::Render
         drawPacketBuilder.Begin(nullptr);
 
         drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-        drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
-        drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
-        drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
+        drawPacketBuilder.SetIndexBufferView(mesh.m_sdIndexBufferView);
+        drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+        drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
         // We build the list of used shaders in a local list rather than m_activeShaders so that
         // if DoUpdate() fails it won't modify any member data.
@@ -257,7 +257,7 @@ namespace AZ::Render
             drawRequest.m_sortKey = m_sortKey;
             if (drawSrg)
             {
-                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                 m_perDrawSrgs.push_back(drawSrg);
             }
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
@@ -73,9 +73,9 @@ namespace AZ::Render
         // The per-object shader resource group
         Data::Instance<RPI::ShaderResourceGroup> m_objectSrg;
 
-        // We hold ConstPtr<RHI::SingleDeviceShaderResourceGroup> instead of Instance<RPI::ShaderResourceGroup> because the Material class
+        // We hold ConstPtr<RHI::MultiDeviceShaderResourceGroup> instead of Instance<RPI::ShaderResourceGroup> because the Material class
         // does not allow public access to its Instance<RPI::ShaderResourceGroup>.
-        RPI::ConstPtr<RHI::SingleDeviceShaderResourceGroup> m_materialSrg;
+        RPI::ConstPtr<RHI::MultiDeviceShaderResourceGroup> m_materialSrg;
 
         AZStd::fixed_vector<Data::Instance<RPI::ShaderResourceGroup>, RHI::DrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
 

--- a/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
@@ -104,7 +104,7 @@ namespace AZ
                     return false;
                 }
 
-                if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()))
                 {
                     AZ_Error(warningHeader, false, "Failed to bind buffer view for [%s]", bufferDesc.m_bufferName.GetCStr());
                     return false;

--- a/Gems/AtomTressFX/Code/Rendering/HairDispatchItem.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairDispatchItem.cpp
@@ -51,8 +51,8 @@ namespace AZ
                 m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                 m_dispatchItem.m_shaderResourceGroupCount = 2;      // the per pass will be added by each pass.
                 m_dispatchItem.m_shaderResourceGroups = {
-                    hairGenerationSrg->GetRHIShaderResourceGroup(), // Static generation data
-                    hairSimSrg->GetRHIShaderResourceGroup()         // Dynamic data changed between passes
+                    hairGenerationSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(), // Static generation data
+                    hairSimSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()         // Dynamic data changed between passes
                 };
             }
 

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
@@ -124,7 +124,7 @@ namespace AZ
                         streamDesc.m_elementFormat, RHI::BufferBindFlags::ShaderRead    // No need for ReadWrite in the raster fill
                     );
 
-                    m_readBuffersViews[index] = aznew RHI::MultiDeviceBufferView{ rhiBuffer, viewDescriptor };
+                    m_readBuffersViews[index] = rhiBuffer->BuildBufferView(viewDescriptor);
 
                     // Buffer binding into the raster srg
                     RHI::ShaderInputBufferIndex indexHandle = m_simSrgForRaster->FindShaderInputBufferIndex(streamDesc.m_paramNameInSrg);
@@ -253,7 +253,7 @@ namespace AZ
                         streamDesc.m_elementFormat, RHI::BufferBindFlags::ShaderReadWrite
                     );
 
-                    m_dynamicBuffersViews[stream] = aznew RHI::MultiDeviceBufferView{ rhiBuffer, viewDescriptor };
+                    m_dynamicBuffersViews[stream] = rhiBuffer->BuildBufferView(viewDescriptor);
                 }
 
                 m_initialized = true;

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
@@ -128,7 +128,7 @@ namespace AZ
 
                     // Buffer binding into the raster srg
                     RHI::ShaderInputBufferIndex indexHandle = m_simSrgForRaster->FindShaderInputBufferIndex(streamDesc.m_paramNameInSrg);
-                    if (!m_simSrgForRaster->SetBufferView(indexHandle, m_readBuffersViews[index]->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                    if (!m_simSrgForRaster->SetBufferView(indexHandle, m_readBuffersViews[index].get()))
                     {
                         AZ_Error("Hair Gem", false, "Failed to bind raster buffer view for %s", streamDesc.m_bufferName.GetCStr());
                         return false;
@@ -170,7 +170,7 @@ namespace AZ
                     RHI::ShaderInputBufferIndex indexHandle = m_simSrgForCompute->FindShaderInputBufferIndex(streamDesc.m_paramNameInSrg);
                     streamDesc.m_resourceShaderIndex = indexHandle.GetIndex();
 
-                    if (!m_simSrgForCompute->SetBufferView(indexHandle, m_dynamicBuffersViews[buffer]->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                    if (!m_simSrgForCompute->SetBufferView(indexHandle, m_dynamicBuffersViews[buffer].get()))
                     {
                         AZ_Error("Hair Gem", false, "Failed to bind compute buffer view for %s", streamDesc.m_bufferName.GetCStr());
                         return false;
@@ -497,13 +497,13 @@ namespace AZ
 
                 // Vertex streams: thickness and texture coordinates
                 desc = &m_hairRenderDescriptors[uint8_t(HairRenderBuffersSemantics::HairVertexRenderParams)];
-                if (!m_hairRenderSrg->SetBufferView(RHI::ShaderInputBufferIndex(desc->m_resourceShaderIndex), m_hairVertexRenderParams->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                if (!m_hairRenderSrg->SetBufferView(RHI::ShaderInputBufferIndex(desc->m_resourceShaderIndex), m_hairVertexRenderParams->GetBufferView()))
                 {
                     bindSuccess = false;
                     AZ_Error("Hair Gem", false, "Failed to bind buffer view for [%s]", desc->m_bufferName.GetCStr());
                 }
                 desc = &m_hairRenderDescriptors[uint8_t(HairRenderBuffersSemantics::HairTexCoords)];
-                if (!m_hairRenderSrg->SetBufferView(RHI::ShaderInputBufferIndex(desc->m_resourceShaderIndex), m_hairTexCoords->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                if (!m_hairRenderSrg->SetBufferView(RHI::ShaderInputBufferIndex(desc->m_resourceShaderIndex), m_hairTexCoords->GetBufferView()))
                 {
                     AZ_Error("Hair Gem", false, "Failed to bind buffer view for [%s]", desc->m_bufferName.GetCStr());
                     bindSuccess = false;
@@ -585,8 +585,8 @@ namespace AZ
                 AZ_Error("Hair Gem", result == RHI::ResultCode::Success, "Failed to initialize index buffer - error [%d]", result);
 
                 // create index buffer view
-                m_indexBufferView = RHI::SingleDeviceIndexBufferView(*m_indexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get(), 0, indexBufferSize, RHI::IndexFormat::Uint32 );
- 
+                m_indexBufferView = RHI::SingleDeviceIndexBufferView(*m_indexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, indexBufferSize, RHI::IndexFormat::Uint32 );
+
                 return true;
             }
 
@@ -1145,8 +1145,8 @@ namespace AZ
                     return false;
                 }
                 // No need to compile the simSrg since it was compiled already by the Compute pass this frame
-                drawPacketBuilder.AddShaderResourceGroup(renderMaterialSrg->GetRHIShaderResourceGroup());
-                drawPacketBuilder.AddShaderResourceGroup(simSrg->GetRHIShaderResourceGroup());
+                drawPacketBuilder.AddShaderResourceGroup(renderMaterialSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                drawPacketBuilder.AddShaderResourceGroup(simSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
                 drawPacketBuilder.AddDrawItem(drawRequest);
 
                 const RHI::DrawPacket* drawPacket = drawPacketBuilder.End();

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -93,7 +93,7 @@ namespace AZ
                         drawPacketBuilder.Begin(nullptr);
                         drawPacketBuilder.SetDrawArguments(drawIndexed);
                         drawPacketBuilder.SetIndexBufferView(m_renderData->m_boxIndexBufferView);
-                        drawPacketBuilder.AddShaderResourceGroup(m_renderObjectSrg->GetRHIShaderResourceGroup());
+                        drawPacketBuilder.AddShaderResourceGroup(m_renderObjectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                         RHI::DrawPacketBuilder::DrawRequest drawRequest;
                         drawRequest.m_listTag = m_renderData->m_drawListTag;
@@ -484,7 +484,7 @@ namespace AZ
             uint32_t packed3 = 0;
             uint32_t packed4 = (m_scrolling << 16) | (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20); // scrolling, rayFormat, irradianceFormat, relocation, classification
 
-            m_prepareSrg->SetBufferView(m_renderData->m_prepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_prepareSrg->SetBufferView(m_renderData->m_prepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgGridDataInitializedNameIndex, m_gridDataInitialized);
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridOriginNameIndex, m_transform.GetTranslation());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridProbeHysteresisNameIndex, m_probeHysteresis);
@@ -516,11 +516,11 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_rayTraceSrg.get(), "Failed to create RayTrace shader resource group");
             }
 
-            m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgGiShadowsNameIndex, m_giShadows);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgUseDiffuseIblNameIndex, m_useDiffuseIbl);
@@ -538,10 +538,10 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendIrradianceSrg.get(), "Failed to create BlendIrradiance shader resource group");
             }
 
-            m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -554,10 +554,10 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendDistanceSrg.get(), "Failed to create BlendDistance shader resource group");
             }
 
-            m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -574,7 +574,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowIrradianceSrg.get(), "Failed to create BorderUpdateRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateRowIrradianceSrg->SetImageView(m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateRowIrradianceSrg->SetImageView(m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateRowIrradianceSrg->SetConstant(m_renderData->m_borderUpdateRowIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -586,7 +586,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnIrradianceSrg.get(), "Failed to create BorderUpdateColumnRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateColumnIrradianceSrg->SetImageView(m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateColumnIrradianceSrg->SetImageView(m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateColumnIrradianceSrg->SetConstant(m_renderData->m_borderUpdateColumnIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -598,7 +598,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowDistanceSrg.get(), "Failed to create BorderUpdateRowDistance shader resource group");
                 }
 
-                m_borderUpdateRowDistanceSrg->SetImageView(m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateRowDistanceSrg->SetImageView(m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateRowDistanceSrg->SetConstant(m_renderData->m_borderUpdateRowDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
 
@@ -610,7 +610,7 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnDistanceSrg.get(), "Failed to create BorderUpdateColumnRowDistance shader resource group");
                 }
 
-                m_borderUpdateColumnDistanceSrg->SetImageView(m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateColumnDistanceSrg->SetImageView(m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateColumnDistanceSrg->SetConstant(m_renderData->m_borderUpdateColumnDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
         }
@@ -623,9 +623,9 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_relocationSrg.get(), "Failed to create Relocation shader resource group");
             }
 
-            m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -638,9 +638,9 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_classificationSrg.get(), "Failed to create Classification shader resource group");
             }
 
-            m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -658,7 +658,7 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_renderObjectSrg.get(), "Failed to create render shader resource group");
             }
 
-            m_renderObjectSrg->SetBufferView(m_renderData->m_renderSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_renderObjectSrg->SetBufferView(m_renderData->m_renderSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
 
             AZ::Matrix3x4 modelToWorld = AZ::Matrix3x4::CreateFromTransform(m_transform) * AZ::Matrix3x4::CreateScale(m_renderExtents);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgModelToWorldNameIndex, modelToWorld);
@@ -670,9 +670,9 @@ namespace AZ
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEnableDiffuseGiNameIndex, m_enabled);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEdgeBlendIblNameIndex, m_edgeBlendIbl);
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
 
             m_updateRenderObjectSrg = false;
 
@@ -690,14 +690,14 @@ namespace AZ
 
             uint32_t tlasInstancesBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasInstancesBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, tlasInstancesBufferByteCount / RayTracingTlasInstanceElementSize, RayTracingTlasInstanceElementSize);
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->BuildBufferView(bufferViewDescriptor).get());
 
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationPrepareSrg->SetConstant(m_renderData->m_visualizationPrepareSrgProbeSphereRadiusNameIndex, m_visualizationSphereRadius);
         }
 
-        void DiffuseProbeGrid::UpdateVisualizationRayTraceSrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& layout, const RHI::SingleDeviceImageView* outputImageView)
+        void DiffuseProbeGrid::UpdateVisualizationRayTraceSrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& layout, const RHI::MultiDeviceImageView* outputImageView)
         {
             if (!m_visualizationRayTraceSrg)
             {
@@ -707,12 +707,12 @@ namespace AZ
 
             uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
 
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationRayTraceSrg->SetConstant(m_renderData->m_visualizationRayTraceSrgShowInactiveProbesNameIndex, m_visualizationShowInactiveProbes);
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgOutputNameIndex, outputImageView);
         }
@@ -725,10 +725,10 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_querySrg.get(), "Failed to create Query shader resource group");
             }
 
-            m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex)->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_querySrg->SetConstant(m_renderData->m_querySrgAmbientMultiplierNameIndex, m_ambientMultiplier);
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
@@ -269,7 +269,10 @@ namespace AZ
             void UpdateClassificationSrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout);
             void UpdateRenderObjectSrg();
             void UpdateVisualizationPrepareSrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout);
-            void UpdateVisualizationRayTraceSrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout, const RHI::SingleDeviceImageView* outputImageView);
+            void UpdateVisualizationRayTraceSrg(
+                const Data::Instance<RPI::Shader>& shader,
+                const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout,
+                const RHI::MultiDeviceImageView* outputImageView);
             void UpdateQuerySrg(const Data::Instance<RPI::Shader>& shader, const RHI::Ptr<RHI::ShaderResourceGroupLayout>& srgLayout);
 
             // textures

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
@@ -186,8 +186,8 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendDistanceSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendDistanceSrg()->GetRHIShaderResourceGroup();
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
 
                 uint32_t probeCountX;
                 uint32_t probeCountY;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
@@ -176,8 +176,8 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendIrradianceSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendIrradianceSrg()->GetRHIShaderResourceGroup();
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                 uint32_t probeCountX;
                 uint32_t probeCountY;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
@@ -226,7 +226,7 @@ namespace AZ
             {
                 SubmitItem& submitItem = m_submitItems[index];
 
-                commandList->SetShaderResourceGroupForDispatch(*submitItem.m_shaderResourceGroup);
+                commandList->SetShaderResourceGroupForDispatch(*submitItem.m_shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
                 commandList->Submit(submitItem.m_dispatchItem, index++);
             }
         }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.h
@@ -49,7 +49,7 @@ namespace AZ
             // the data for submits in this pass are pre-built to properly handle submitting on multiple threads
             struct SubmitItem
             {
-                RHI::SingleDeviceShaderResourceGroup* m_shaderResourceGroup = nullptr;
+                RHI::MultiDeviceShaderResourceGroup* m_shaderResourceGroup = nullptr;
                 RHI::SingleDeviceDispatchItem m_dispatchItem;
             };
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
@@ -178,8 +178,8 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetClassificationSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetClassificationSrg()->GetRHIShaderResourceGroup();
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = shader.m_dispatchArgs;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
@@ -110,7 +110,7 @@ namespace AZ
             {
                 // grid data buffer
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(diffuseProbeGrid->GetGridDataBufferAttachmentId(), diffuseProbeGrid->GetGridDataBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(diffuseProbeGrid->GetGridDataBufferAttachmentId(), diffuseProbeGrid->GetGridDataBuffer());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import grid data buffer");
 
                     RHI::BufferScopeAttachmentDescriptor desc;
@@ -147,8 +147,8 @@ namespace AZ
             {
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleProbeGrids()[index];
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetPrepareSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetPrepareSrg()->GetRHIShaderResourceGroup();
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
@@ -220,9 +220,9 @@ namespace AZ
                 const uint8_t srgCount = 3;
                 AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups =
                 {
-                    diffuseProbeGrid->GetQuerySrg()->GetRHIShaderResourceGroup(),
-                    m_shaderResourceGroup->GetRHIShaderResourceGroup(),
-                    views[0]->GetRHIShaderResourceGroup()
+                    diffuseProbeGrid->GetQuerySrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                 };
 
                 RHI::SingleDeviceDispatchItem dispatchItem;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -184,7 +184,7 @@ namespace AZ
                     const RHI::Ptr<RHI::MultiDeviceBuffer>& rayTracingTlasBuffer = rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer();
                     if (rayTracingTlasBuffer)
                     {
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, rayTracingTlasBuffer);
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
 
                         uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(rayTracingTlasBuffer->GetDescriptor().m_byteCount);
@@ -211,7 +211,7 @@ namespace AZ
 
                 // probe raytrace
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetRayTraceImageAttachmentId(), diffuseProbeGrid->GetRayTraceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetRayTraceImageAttachmentId(), diffuseProbeGrid->GetRayTraceImage());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeRayTraceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -231,7 +231,7 @@ namespace AZ
 
                 // probe irradiance
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetIrradianceImageAttachmentId(), diffuseProbeGrid->GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetIrradianceImageAttachmentId(), diffuseProbeGrid->GetIrradianceImage());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeIrradianceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -252,7 +252,7 @@ namespace AZ
 
                 // probe distance
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetDistanceImageAttachmentId(), diffuseProbeGrid->GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetDistanceImageAttachmentId(), diffuseProbeGrid->GetDistanceImage());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeDistanceImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -273,7 +273,7 @@ namespace AZ
 
                 // probe data
                 {
-                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetProbeDataImageAttachmentId(), diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetProbeDataImageAttachmentId(), diffuseProbeGrid->GetProbeDataImage());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ProbeDataImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;
@@ -358,9 +358,9 @@ namespace AZ
                     AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
 
                     const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                        diffuseProbeGrid->GetRayTraceSrg()->GetRHIShaderResourceGroup(),
-                        rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup(),
-                        rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()
+                        diffuseProbeGrid->GetRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                     };
 
                     RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
@@ -209,8 +209,8 @@ namespace AZ
             {
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetRelocationSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
+                const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetRelocationSrg()->GetRHIShaderResourceGroup();
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
@@ -131,7 +131,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the irradiance image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetIrradianceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetIrradianceImage());
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeIrradianceImage");
                     }
 
@@ -149,7 +149,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the distance image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetDistanceImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetDistanceImage());
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeDistanceImage");
                     }
 
@@ -167,7 +167,7 @@ namespace AZ
                     if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked && !frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId))
                     {
                         // import the probe data image now, since it is baked and therefore was not imported during the raytracing pass
-                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                        [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage());
                         AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ProbeDataImage");
                     }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -106,7 +106,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS buffer with error %d", result);
                         }
 
@@ -126,7 +126,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasInstancesAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS Instances buffer with error %d", result);
                         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -168,7 +168,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS buffer with error %d", result);
                         }
 
@@ -188,7 +188,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeVisualizationTlasInstancesAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(attachmentId, tlasInstancesBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid visualization TLAS Instances buffer with error %d", result);
                         }
 
@@ -218,7 +218,7 @@ namespace AZ
                         AZ::RHI::AttachmentId attachmentId = diffuseProbeGrid->GetProbeDataImageAttachmentId();
                         if (frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentId) == false)
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage()->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(attachmentId, diffuseProbeGrid->GetProbeDataImage());
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import DiffuseProbeGrid probe data buffer with error %d", result);
                         }
 
@@ -268,7 +268,7 @@ namespace AZ
                     continue;
                 }
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetVisualizationPrepareSrg()->GetRHIShaderResourceGroup();
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetVisualizationPrepareSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                 commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
 
                 RHI::SingleDeviceDispatchItem dispatchItem;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -187,7 +187,7 @@ namespace AZ
                     {
                         if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(tlasAttachmentId))
                         {
-                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, visualizationTlasBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(tlasAttachmentId, visualizationTlasBuffer);
                             AZ_Assert(result == RHI::ResultCode::Success, "Failed to import ray tracing TLAS buffer with error %d", result);
                         }
 
@@ -251,8 +251,8 @@ namespace AZ
         }
 
         void DiffuseProbeGridVisualizationRayTracingPass::CompileResources([[maybe_unused]] const RHI::FrameGraphCompileContext& context)
-        {           
-            const RHI::SingleDeviceImageView* outputImageView = context.GetImageView(GetOutputBinding(0).GetAttachment()->GetAttachmentId());
+        {
+            const RHI::MultiDeviceImageView* outputImageView = context.GetImageView(GetOutputBinding(0).GetAttachment()->GetAttachmentId());
             AZ_Assert(outputImageView, "Failed to retrieve output ImageView");
 
             RPI::Scene* scene = m_pipeline->GetScene();
@@ -296,9 +296,9 @@ namespace AZ
                 }
 
                 const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    diffuseProbeGrid->GetVisualizationRayTraceSrg()->GetRHIShaderResourceGroup(),
-                    rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup(),
-                    views[0]->GetRHIShaderResourceGroup(),
+                    diffuseProbeGrid->GetVisualizationRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
                 };
 
                 RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -766,7 +766,7 @@ void CDraw2d::DeferredQuad::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
     }
 
     // Set projection matrix
@@ -827,7 +827,7 @@ void CDraw2d::DeferredLine::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> dynam
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
     }
 
     // Set projection matrix
@@ -903,7 +903,7 @@ void CDraw2d::DeferredRectOutline::Draw(AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext
 
     if (imageView)
     {
-        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
+        drawSrg->SetImageView(shaderData.m_imageInputIndex, imageView, 0);
     }
 
     // Set projection matrix

--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -173,7 +173,7 @@ namespace LyShine
             auto attachmentImageId = attachmentImage->GetAttachmentId();
             if (!frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentImageId))
             {
-                frameGraph.GetAttachmentDatabase().ImportImage(attachmentImageId, attachmentImage->GetRHIImage()->GetDeviceImage(AZ::RHI::MultiDevice::DefaultDeviceIndex));
+                frameGraph.GetAttachmentDatabase().ImportImage(attachmentImageId, attachmentImage->GetRHIImage());
             }
 
             AZ::RHI::ImageScopeAttachmentDescriptor desc;

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -126,7 +126,7 @@ namespace LyShine
             // Default to white texture
             const AZ::Data::Instance<AZ::RPI::Image>& image = m_textures[i].m_texture ? m_textures[i].m_texture
                 : AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
-            const auto imageView = image->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
+            const auto imageView = image->GetImageView();
 
             if (imageView)
             {

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
@@ -173,7 +173,7 @@ namespace AZ
             viewDescriptor.m_ignoreFrameAttachmentValidation = true;
 
             RHI::MultiDeviceBuffer* rhiBuffer = Meshlets::SharedBufferInterface::Get()->GetBuffer()->GetRHIBuffer();
-            Data::Instance<RHI::MultiDeviceBufferView> bufferView = aznew RHI::MultiDeviceBufferView(rhiBuffer, viewDescriptor);
+            Data::Instance<RHI::MultiDeviceBufferView> bufferView = rhiBuffer->BuildBufferView(viewDescriptor);
             RHI::ResultCode resultCode = bufferView->Init(*rhiBuffer, viewDescriptor);
 
             if (resultCode != RHI::ResultCode::Success)

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
@@ -173,16 +173,7 @@ namespace AZ
             viewDescriptor.m_ignoreFrameAttachmentValidation = true;
 
             RHI::MultiDeviceBuffer* rhiBuffer = Meshlets::SharedBufferInterface::Get()->GetBuffer()->GetRHIBuffer();
-            Data::Instance<RHI::MultiDeviceBufferView> bufferView = rhiBuffer->BuildBufferView(viewDescriptor);
-            RHI::ResultCode resultCode = bufferView->Init(*rhiBuffer, viewDescriptor);
-
-            if (resultCode != RHI::ResultCode::Success)
-            {
-                AZ_Error(warningHeader, false, "BufferView could not be retrieved for [%s]", bufferDesc.m_bufferName.GetCStr());
-                return Data::Instance<RHI::SingleDeviceBufferView>();
-            }
-
-            return bufferView;
+            return rhiBuffer->BuildBufferView(viewDescriptor);
         }
 
         bool UtilityClass::BindBufferViewToSrg(

--- a/Gems/Meshlets/Code/Source/Meshlets/MultiDispatchComputePass.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MultiDispatchComputePass.cpp
@@ -80,7 +80,7 @@ namespace AZ
             {
                 if (dispatchItem)
                 {
-                    for (RHI::SingleDeviceShaderResourceGroup* srgInDispatch : dispatchItem->m_shaderResourceGroups)
+                    for (RHI::MultiDeviceShaderResourceGroup* srgInDispatch : dispatchItem->m_shaderResourceGroups)
                     {
                         srgInDispatch->Compile()
                     }
@@ -122,7 +122,7 @@ namespace AZ
                 // In a similar way, add the dispatch high frequencies srgs.
                 for (uint32_t srg = 0; srg < dispatchItem->m_shaderResourceGroupCount; ++srg)
                 {
-                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = dispatchItem->m_shaderResourceGroups[srg];
+                    const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = dispatchItem->m_shaderResourceGroups[srg];
                     commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
                 }
 

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
@@ -292,7 +292,7 @@ namespace AZ::Render
         RHI::DrawPacketBuilder drawPacketBuilder;
         drawPacketBuilder.Begin(nullptr);
         drawPacketBuilder.SetDrawArguments(drawLinear);
-        drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
+        drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
         RHI::DrawPacketBuilder::DrawRequest drawRequest;
         drawRequest.m_listTag = drawListTag;

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.h
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.h
@@ -71,7 +71,7 @@ namespace AZ::Render
             const Data::Instance<RPI::ShaderResourceGroup>& srg,
             const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
             const RHI::DrawListTag& drawListTag,
-            const AZStd::span<const AZ::RHI::SingleDeviceStreamBufferView>& streamBufferViews,
+            const AZStd::span<const RHI::SingleDeviceStreamBufferView>& streamBufferViews,
             uint32_t vertexCount);
 
         RPI::Ptr<RPI::PipelineStateForDraw> m_meshPipelineState;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainClipmapManager.cpp
@@ -316,7 +316,7 @@ namespace Terrain
     void TerrainClipmapManager::ImportClipmap(ClipmapName clipmapName, AZ::RHI::FrameGraphAttachmentInterface attachmentDatabase) const
     {
         auto clipmap = m_clipmaps[clipmapName];
-        attachmentDatabase.ImportImage(clipmap->GetAttachmentId(), clipmap->GetRHIImage()->GetDeviceImage(AZ::RHI::MultiDevice::DefaultDeviceIndex));
+        attachmentDatabase.ImportImage(clipmap->GetAttachmentId(), clipmap->GetRHIImage());
     }
 
     void TerrainClipmapManager::UseClipmap(ClipmapName clipmapName, AZ::RHI::ScopeAttachmentAccess access, AZ::RHI::FrameGraphInterface frameGraph) const

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -290,7 +290,8 @@ namespace Terrain
 
     }
 
-    AZ::RHI::SingleDeviceStreamBufferView TerrainMeshManager::CreateStreamBufferView(AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset)
+    AZ::RHI::SingleDeviceStreamBufferView TerrainMeshManager::CreateStreamBufferView(
+        AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset)
     {
         return
         {
@@ -308,8 +309,8 @@ namespace Terrain
         drawPacketBuilder.Begin(nullptr);
         drawPacketBuilder.SetDrawArguments(AZ::RHI::DrawIndexed(1, 0, 0, indexCount, 0));
         drawPacketBuilder.SetIndexBufferView(m_indexBufferView);
-        drawPacketBuilder.AddShaderResourceGroup(sector.m_srg->GetRHIShaderResourceGroup());
-        drawPacketBuilder.AddShaderResourceGroup(m_materialInstance->GetRHIShaderResourceGroup());
+        drawPacketBuilder.AddShaderResourceGroup(sector.m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get());
+        drawPacketBuilder.AddShaderResourceGroup(m_materialInstance->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get());
 
         sector.m_perDrawSrgs.clear();
 
@@ -319,7 +320,7 @@ namespace Terrain
 
             AZ::RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = drawData.m_drawListTag;
-            drawRequest.m_pipelineState = drawData.m_pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = drawData.m_pipelineState;
             drawRequest.m_streamBufferViews = sector.m_streamBufferViews;
             drawRequest.m_stencilRef = AZ::Render::StencilRefs::UseDiffuseGIPass | AZ::Render::StencilRefs::UseIBLSpecularPass;
 
@@ -344,7 +345,7 @@ namespace Terrain
 
             if (drawSrg)
             {
-                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
                 sector.m_perDrawSrgs.push_back(drawSrg);
             }
             drawPacketBuilder.AddDrawItem(drawRequest);
@@ -640,7 +641,7 @@ namespace Terrain
 
                 auto drawSrgLayout = shader->GetAsset()->GetDrawSrgLayout(shader->GetSupervariantIndex());
 
-                m_cachedDrawData.push_back({ shader, shaderOptions, pipelineState, drawListTag, drawSrgLayout, variant, materialPipelineName });
+                m_cachedDrawData.push_back({ shader, shaderOptions, pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), drawListTag, drawSrgLayout, variant, materialPipelineName });
                 return true;
             });
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -290,8 +290,7 @@ namespace Terrain
 
     }
 
-    AZ::RHI::SingleDeviceStreamBufferView TerrainMeshManager::CreateStreamBufferView(
-        AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset)
+    AZ::RHI::SingleDeviceStreamBufferView TerrainMeshManager::CreateStreamBufferView(AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset)
     {
         return
         {
@@ -320,7 +319,7 @@ namespace Terrain
 
             AZ::RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = drawData.m_drawListTag;
-            drawRequest.m_pipelineState = drawData.m_pipelineState;
+            drawRequest.m_pipelineState = drawData.m_pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
             drawRequest.m_streamBufferViews = sector.m_streamBufferViews;
             drawRequest.m_stencilRef = AZ::Render::StencilRefs::UseDiffuseGIPass | AZ::Render::StencilRefs::UseIBLSpecularPass;
 
@@ -641,7 +640,7 @@ namespace Terrain
 
                 auto drawSrgLayout = shader->GetAsset()->GetDrawSrgLayout(shader->GetSupervariantIndex());
 
-                m_cachedDrawData.push_back({ shader, shaderOptions, pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get(), drawListTag, drawSrgLayout, variant, materialPipelineName });
+                m_cachedDrawData.push_back({ shader, shaderOptions, pipelineState, drawListTag, drawSrgLayout, variant, materialPipelineName });
                 return true;
             });
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -215,7 +215,7 @@ namespace Terrain
         {
             AZ::Data::Instance<AZ::RPI::Shader> m_shader;
             AZ::RPI::ShaderOptionGroup m_shaderOptions;
-            const AZ::RHI::SingleDevicePipelineState* m_pipelineState;
+            const AZ::RHI::MultiDevicePipelineState* m_pipelineState;
             AZ::RHI::DrawListTag m_drawListTag;
             AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_drawSrgLayout;
             AZ::RPI::ShaderVariant m_shaderVariant;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -215,7 +215,7 @@ namespace Terrain
         {
             AZ::Data::Instance<AZ::RPI::Shader> m_shader;
             AZ::RPI::ShaderOptionGroup m_shaderOptions;
-            const AZ::RHI::MultiDevicePipelineState* m_pipelineState;
+            const AZ::RHI::SingleDevicePipelineState* m_pipelineState;
             AZ::RHI::DrawListTag m_drawListTag;
             AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_drawSrgLayout;
             AZ::RPI::ShaderVariant m_shaderVariant;


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

This specific PR transitions RPI::ShaderResourceGroup to use MultiDeviceShaderResourceGroup. It is not a small change and thus this is one of the bigger PRs in this set of PRs.

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`
