### PR TITLE
Fix hardcoded path in the template export

### DIFF
--- a/Templates/DefaultProject/Template/export.bat
+++ b/Templates/DefaultProject/Template/export.bat
@@ -34,7 +34,7 @@ REM
 REM Note: The location of the engine (O3DE_PATH) is hardcoded to the location of the engine that was used to generate 
 REM       this project. The engine path must reflect the path to the engine on the local machine.
 
-set O3DE_PATH=D:/github/o3de
+set O3DE_PATH=${EnginePath}
 set O3DE_PROJECT_PATH=%~dp0
 
 IF "%1" == "-h" (

--- a/Templates/MinimalProject/Template/export.bat
+++ b/Templates/MinimalProject/Template/export.bat
@@ -34,7 +34,7 @@ REM
 REM Note: The location of the engine (O3DE_PATH) is hardcoded to the location of the engine that was used to generate 
 REM       this project. The engine path must reflect the path to the engine on the local machine.
 
-set O3DE_PATH=D:/github/o3de
+set O3DE_PATH=${EnginePath}
 set O3DE_PROJECT_PATH=%~dp0
 
 IF "%1" == "-h" (


### PR DESCRIPTION
## What does this PR do?

Fix hardcoded path in the template export

## How was this tested?

Created a new project (DefaultProject) with the Project Exporter, verified the engine path was substituted correctly


**Note** Will bypass AR since there are no AR tests that invokes the project creation + export at this time.

