### PR TITLE
Fix skip debug symbols stripping for Android

### DIFF
--- a/cmake/Platform/Android/LYWrappers_android.cmake
+++ b/cmake/Platform/Android/LYWrappers_android.cmake
@@ -48,7 +48,7 @@ function(ly_apply_debug_strip_options target)
         return()
     endif()
 
-    if (NOT ${LY_STRIP_DEBUG_SYMBOLS})
+    if (NOT LY_STRIP_DEBUG_SYMBOLS)
         return()
     endif()
 


### PR DESCRIPTION
## What does this PR do?

Android was always stripping the debug symbols even if the strip.debug was false.

## How was this PR tested?

Build an Android APK with debug symbols stripping on and off.