### PR TITLE
Introduce multi-device DrawPacket-related resources

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -726,8 +726,7 @@ namespace AZ
                 // Since there is only one task that will operate both on this view index and on the bucket with this instance group,
                 // there is no need to lock here.
                 RHI::DrawPacketBuilder drawPacketBuilder;
-                instanceGroup.m_perViewDrawPackets[viewIndex] =
-                    const_cast<RHI::DrawPacket*>(drawPacketBuilder.Clone(instanceGroup.m_drawPacket.GetRHIDrawPacket()));
+                instanceGroup.m_perViewDrawPackets[viewIndex] = drawPacketBuilder.Clone(instanceGroup.m_drawPacket.GetRHIDrawPacket());
             }
 
             // Now that we have a valid cloned draw packet, update it with the latest offset + count

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
@@ -15,6 +15,7 @@
 namespace UnitTest
 {
     class DrawPacketTest;
+    class MultiDeviceDrawPacketTest;
 }
 
 namespace AZ
@@ -45,6 +46,8 @@ namespace AZ::RHI
     {
         friend class DrawPacketBuilder;
         friend class UnitTest::DrawPacketTest;
+        friend class UnitTest::MultiDeviceDrawPacketTest;
+
     public:
         using DrawItemVisitor = AZStd::function<void(DrawListTag, DrawItemProperties)>;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
@@ -79,7 +79,7 @@ namespace AZ::RHI
         //! Note: the copy will reference the same DrawSrg as the original, so it is not possible to vary the DrawSrg values between the
         //! original draw packet and the cloned one. Only settings that can be modified via the DrawPacket interface can be changed
         //! after cloning, such as SetRootConstant and SetInstanceCount
-        const DrawPacket* Clone(const DrawPacket* original);
+        DrawPacket* Clone(const DrawPacket* original);
 
     private:
         void ClearData();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -83,19 +83,23 @@ namespace AZ::RHI
 
     class MultiDeviceDrawItem
     {
+        friend class MultiDeviceDrawPacketBuilder;
+
     public:
         MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask);
+
+        MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask, AZStd::unordered_map<int, DrawItem*>&& deviceDrawItemPtrs);
 
         //! Returns the device-specific DrawItem for the given index
         const DrawItem& GetDeviceDrawItem(int deviceIndex) const
         {
             AZ_Error(
                 "MultiDeviceDrawItem",
-                m_deviceDrawItems.find(deviceIndex) != m_deviceDrawItems.end(),
+                m_deviceDrawItemPtrs.find(deviceIndex) != m_deviceDrawItemPtrs.end(),
                 "No DeviceDrawItem found for device index %d\n",
                 deviceIndex);
 
-            return m_deviceDrawItems.at(deviceIndex);
+            return *m_deviceDrawItemPtrs.at(deviceIndex);
         }
 
         bool GetEnabled() const
@@ -107,65 +111,65 @@ namespace AZ::RHI
         {
             m_enabled = enabled;
 
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_enabled = enabled;
+                drawItem->m_enabled = enabled;
             }
         }
 
         void SetArguments(const MultiDeviceDrawArguments& arguments)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_arguments = arguments.GetDeviceDrawArguments(deviceIndex);
+                drawItem->m_arguments = arguments.GetDeviceDrawArguments(deviceIndex);
             }
         }
 
         void SetIndexedArgumentsInstanceCount(uint32_t instanceCount)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_arguments.m_indexed.m_instanceCount = instanceCount;
+                drawItem->m_arguments.m_indexed.m_instanceCount = instanceCount;
             }
         }
 
         void SetStencilRef(uint8_t stencilRef)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_stencilRef = stencilRef;
+                drawItem->m_stencilRef = stencilRef;
             }
         }
 
         void SetPipelineState(const MultiDevicePipelineState* pipelineState)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
+                drawItem->m_pipelineState = pipelineState->GetDevicePipelineState(deviceIndex).get();
             }
         }
 
         //! The index buffer used when drawing with an indexed draw call.
         void SetIndexBufferView(const MultiDeviceIndexBufferView* indexBufferView)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
                 m_deviceIndexBufferView.emplace(deviceIndex, indexBufferView->GetDeviceIndexBufferView(deviceIndex));
             }
 
             // Done extra so memory is not moved around any more during map resize
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_indexBufferView = &m_deviceIndexBufferView[deviceIndex];
+                drawItem->m_indexBufferView = &m_deviceIndexBufferView[deviceIndex];
             }
         }
 
         //! Array of stream buffers to bind (count must match m_streamBufferViewCount).
         void SetStreamBufferViews(const MultiDeviceStreamBufferView* streamBufferViews, uint32_t streamBufferViewCount)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(streamBufferViewCount);
+                drawItem->m_streamBufferViewCount = static_cast<uint8_t>(streamBufferViewCount);
 
                 auto [it, insertOK]{ m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::vector<StreamBufferView>{}) };
 
@@ -176,16 +180,16 @@ namespace AZ::RHI
                     deviceStreamBufferView.emplace_back(streamBufferViews[i].GetDeviceStreamBufferView(deviceIndex));
                 }
 
-                drawItem.m_streamBufferViews = deviceStreamBufferView.data();
+                drawItem->m_streamBufferViews = deviceStreamBufferView.data();
             }
         }
 
         //! Shader Resource Groups
         void SetShaderResourceGroups(const MultiDeviceShaderResourceGroup* const* shaderResourceGroups, uint32_t shaderResourceGroupCount)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(shaderResourceGroupCount);
+                drawItem->m_shaderResourceGroupCount = static_cast<uint8_t>(shaderResourceGroupCount);
 
                 auto [it, insertOK]{ m_deviceShaderResourceGroups.emplace(
                     deviceIndex, AZStd::vector<ShaderResourceGroup*>(shaderResourceGroupCount)) };
@@ -197,7 +201,7 @@ namespace AZ::RHI
                     deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
                 }
 
-                drawItem.m_shaderResourceGroups = deviceShaderResourceGroup.data();
+                drawItem->m_shaderResourceGroups = deviceShaderResourceGroup.data();
             }
         }
 
@@ -205,19 +209,19 @@ namespace AZ::RHI
         //! key
         void SetUniqueShaderResourceGroup(const MultiDeviceShaderResourceGroup* uniqueShaderResourceGroup)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
+                drawItem->m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
             }
         }
 
         //! Array of root constants to bind (count must match m_rootConstantSize).
         void SetRootConstants(const uint8_t* rootConstants, uint8_t rootConstantSize)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_rootConstantSize = rootConstantSize;
-                drawItem.m_rootConstants = rootConstants;
+                drawItem->m_rootConstantSize = rootConstantSize;
+                drawItem->m_rootConstants = rootConstants;
             }
         }
 
@@ -225,10 +229,10 @@ namespace AZ::RHI
         //! after the MultiDeviceDrawItem has been processed.
         void SetScissors(const Scissor* scissors, uint8_t scissorsCount)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_scissorsCount = scissorsCount;
-                drawItem.m_scissors = scissors;
+                drawItem->m_scissorsCount = scissorsCount;
+                drawItem->m_scissors = scissors;
             }
         }
 
@@ -236,10 +240,10 @@ namespace AZ::RHI
         //! after the MultiDeviceDrawItem has been processed.
         void SetViewports(const Viewport* viewports, uint8_t viewportCount)
         {
-            for (auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+            for (auto& [deviceIndex, drawItem] : m_deviceDrawItemPtrs)
             {
-                drawItem.m_viewportsCount = viewportCount;
-                drawItem.m_viewports = viewports;
+                drawItem->m_viewportsCount = viewportCount;
+                drawItem->m_viewports = viewports;
             }
         }
 
@@ -248,6 +252,10 @@ namespace AZ::RHI
         MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
         //! A map of all device-specific DrawItems, indexed by the device index
         AZStd::unordered_map<int, DrawItem> m_deviceDrawItems;
+        //! A map of pointers to device-specific DrawItems, indexed by the device index
+        //! These pointers may point to m_deviceDrawItems (in case of direct usage of a DrawItem)
+        //! or may point to DrawItems in linear memory (when allocated via a DrawPacket)
+        AZStd::unordered_map<int, DrawItem*> m_deviceDrawItemPtrs;
         //! A map of all device-specific IndexBufferViews, indexed by the device index
         //! This additional cache is needed since device-specific IndexBufferViews are returned as objects
         //! and the device-specific DrawItem holds a pointer to it.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacket.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RHI/DrawList.h>
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <AzCore/std/smart_ptr/intrusive_base.h>
+
+// Predefinition for unit test friend class
+namespace UnitTest
+{
+    class MultiDeviceDrawPacketTest;
+}
+
+namespace AZ::RHI
+{
+    class MultiDeviceDrawPacket final : public AZStd::intrusive_base
+    {
+        friend class MultiDeviceDrawPacketBuilder;
+        friend class UnitTest::MultiDeviceDrawPacketTest;
+
+    public:
+        using DrawItemVisitor = AZStd::function<void(DrawListTag, MultiDeviceDrawItemProperties)>;
+
+        //! Draw packets cannot be move constructed or copied, as they contain an additional memory payload.
+        //! Use DrawPacketBuilder::Clone to copy a draw packet.
+        AZ_DISABLE_COPY_MOVE(MultiDeviceDrawPacket);
+
+        //! Returns the mask representing all the draw lists affected by the packet.
+        DrawListMask GetDrawListMask() const;
+
+        //! Returns the number of draw items stored in the packet.
+        size_t GetDrawItemCount() const;
+
+        //! Returns the index associated with the given DrawListTag
+        s32 GetDrawListIndex(DrawListTag drawListTag) const;
+
+        //! Returns the DrawItem at the given index
+        MultiDeviceDrawItem* GetDrawItem(size_t index);
+
+        //! Returns the DrawItem associated with the given DrawListTag
+        MultiDeviceDrawItem* GetDrawItem(DrawListTag drawListTag);
+
+        //! Returns the draw item and its properties associated with the provided index.
+        MultiDeviceDrawItemProperties GetDrawItemProperties(size_t index) const;
+
+        //! Returns the draw list tag associated with the provided index, used to filter the draw item into an appropriate pass.
+        DrawListTag GetDrawListTag(size_t index) const;
+
+        //! Returns the draw filter mask associated with the provided index, used to filter the draw item into an appropriate render
+        //! pipeline.
+        DrawFilterMask GetDrawFilterMask(size_t index) const;
+
+        //! Update the root constant at the specified interval. The same root constants are shared by all draw items in the draw packet
+        void SetRootConstant(uint32_t offset, const AZStd::span<uint8_t>& data);
+
+        //! Set the instance count in all draw items.
+        void SetInstanceCount(uint32_t instanceCount);
+
+        const DrawPacket* GetDeviceDrawPacket(int deviceIndex) const
+        {
+            AZ_Error(
+                "MultiDeviceDrawPacket",
+                m_deviceDrawPackets.find(deviceIndex) != m_deviceDrawPackets.end(),
+                "No DrawPacket found for device index %d\n",
+                deviceIndex);
+
+            return m_deviceDrawPackets.at(deviceIndex).get();
+        }
+
+    private:
+        /// Use DrawPacketBuilder to construct an instance.
+        MultiDeviceDrawPacket() = default;
+
+        // The bit-mask of all active filter tags.
+        DrawListMask m_drawListMask{};
+
+        // List of draw items.
+        AZStd::vector<MultiDeviceDrawItem> m_drawItems;
+
+        // List of draw item sort keys associated with the draw item index.
+        AZStd::vector<DrawItemSortKey> m_drawItemSortKeys;
+
+        // List of draw list tags associated with the draw item index.
+        AZStd::vector<DrawListTag> m_drawListTags;
+
+        // List of draw filter masks associated with the draw item index.
+        AZStd::vector<DrawFilterMask> m_drawFilterMasks;
+
+        //! A map of single-device DrawPackets, index by the device index
+        AZStd::unordered_map<int, RHI::Ptr<DrawPacket>> m_deviceDrawPackets;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacket.h
@@ -21,6 +21,11 @@ namespace UnitTest
 
 namespace AZ::RHI
 {
+    //! MultiDeviceDrawPacket is a multi-device class that holds a map of device-specific DrawPackets as well as
+    //! a vector of MultiDeviceDrawItems, corresponding SortKeys, DrawListTags and DrawListMasks.
+    //! A MultiDeviceDrawPacket is only intened to be contructed via the MultiDeviceDrawPacketBuilder.
+    //! Individual device-specific DrawPackets are allocated as packed data structures, referenced via RHI::Ptrs
+    //! in a map, indexed by the device-index.
     class MultiDeviceDrawPacket final : public AZStd::intrusive_base
     {
         friend class MultiDeviceDrawPacketBuilder;
@@ -76,22 +81,22 @@ namespace AZ::RHI
         }
 
     private:
-        /// Use DrawPacketBuilder to construct an instance.
+        //! Use DrawPacketBuilder to construct an instance.
         MultiDeviceDrawPacket() = default;
 
-        // The bit-mask of all active filter tags.
+        //! The bit-mask of all active filter tags.
         DrawListMask m_drawListMask{};
 
-        // List of draw items.
+        //! List of draw items.
         AZStd::vector<MultiDeviceDrawItem> m_drawItems;
 
-        // List of draw item sort keys associated with the draw item index.
+        //! List of draw item sort keys associated with the draw item index.
         AZStd::vector<DrawItemSortKey> m_drawItemSortKeys;
 
-        // List of draw list tags associated with the draw item index.
+        //! List of draw list tags associated with the draw item index.
         AZStd::vector<DrawListTag> m_drawListTags;
 
-        // List of draw filter masks associated with the draw item index.
+        //! List of draw filter masks associated with the draw item index.
         AZStd::vector<DrawFilterMask> m_drawFilterMasks;
 
         //! A map of single-device DrawPackets, index by the device index

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RHI.Reflect/Scissor.h>
+#include <Atom/RHI.Reflect/Viewport.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/StreamBufferView.h>
+
+namespace AZ
+{
+    class IAllocator;
+} // namespace AZ
+
+namespace AZ::RHI
+{
+    class MultiDeviceDrawPacketBuilder
+    {
+    public:
+        struct MultiDeviceDrawRequest
+        {
+            MultiDeviceDrawRequest() = default;
+
+            //! Returns the device-specific RayTracingTlasDescriptor for the given index
+            DrawPacketBuilder::DrawRequest GetDeviceDrawRequest(int deviceIndex);
+
+            //! The filter tag used to direct the draw item.
+            DrawListTag m_listTag;
+
+            //! The stencil ref value used for this draw item.
+            uint8_t m_stencilRef{};
+
+            //! The array of stream buffers to bind for this draw item.
+            AZStd::span<const MultiDeviceStreamBufferView> m_streamBufferViews;
+
+            //! Shader resource group unique for this draw request
+            const MultiDeviceShaderResourceGroup* m_uniqueShaderResourceGroup{};
+
+            //! The pipeline state assigned to this draw item.
+            const MultiDevicePipelineState* m_pipelineState{};
+
+            //! The sort key assigned to this draw item.
+            DrawItemSortKey m_sortKey{};
+
+            //! Mask for filtering the draw item into specific render pipelines.
+            //! We use a mask because the same item could be reused in multiple pipelines. For example, a simple
+            //! depth pre-pass could be present in multiple pipelines.
+            DrawFilterMask m_drawFilterMask = DrawFilterMaskDefaultValue;
+
+            //! A map of all device-specific StreamBufferViews, indexed by the device index
+            //! This additional cache is needed since device-specific StreamBufferViews are returned as objects
+            //! and the device-specific DrawItem holds a pointer to it.
+            AZStd::unordered_map<int, AZStd::vector<StreamBufferView>> m_deviceStreamBufferViews;
+        };
+
+        explicit MultiDeviceDrawPacketBuilder(RHI::MultiDevice::DeviceMask deviceMask)
+            : m_deviceMask{ deviceMask }
+        {
+            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+
+            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                {
+                    m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());
+                }
+            }
+        }
+
+        // NOTE: This is configurable; just used to control the amount of memory held by the builder.
+        static const size_t DrawItemCountMax = 16;
+
+        void Begin(IAllocator* allocator);
+
+        void SetDrawArguments(const MultiDeviceDrawArguments& drawArguments);
+
+        void SetIndexBufferView(const MultiDeviceIndexBufferView& indexBufferView);
+
+        void SetRootConstants(AZStd::span<const uint8_t> rootConstants);
+
+        void SetScissors(AZStd::span<const Scissor> scissors);
+
+        void SetScissor(const Scissor& scissor);
+
+        void SetViewports(AZStd::span<const Viewport> viewports);
+
+        void SetViewport(const Viewport& viewport);
+
+        void AddShaderResourceGroup(const MultiDeviceShaderResourceGroup* shaderResourceGroup);
+
+        void AddDrawItem(MultiDeviceDrawRequest& request);
+
+        RHI::Ptr<MultiDeviceDrawPacket> End();
+
+        //! Make a copy of an existing DrawPacket.
+        //! Note: the copy will reference the same DrawSrg as the original, so it is not possible to vary the DrawSrg values between the
+        //! original draw packet and the cloned one. Only settings that can be modified via the DrawPacket interface can be changed
+        //! after cloning, such as SetRootConstant and SetInstanceCount
+        RHI::Ptr<MultiDeviceDrawPacket> Clone(const MultiDeviceDrawPacket* original);
+
+    private:
+        void ClearData();
+
+        RHI::MultiDevice::DeviceMask m_deviceMask{ 0u };
+        AZStd::fixed_vector<MultiDeviceDrawRequest, DrawPacketBuilder::DrawItemCountMax> m_drawRequests;
+
+        RHI::Ptr<MultiDeviceDrawPacket> m_drawPacketInFlight;
+        // MultiDeviceDrawArguments m_drawArguments;
+        // size_t m_streamBufferViewCount{};
+        // MultiDeviceIndexBufferView m_indexBufferView;
+        // AZStd::vector<MultiDeviceStreamBufferView> m_streamBufferViews;
+        // AZStd::fixed_vector<const MultiDeviceShaderResourceGroup*, Limits::Pipeline::ShaderResourceGroupCountMax> m_shaderResourceGroups;
+        // AZStd::span<const uint8_t> m_rootConstants;
+        // AZStd::fixed_vector<Scissor, Limits::Pipeline::AttachmentColorCountMax> m_scissors;
+        // AZStd::fixed_vector<Viewport, Limits::Pipeline::AttachmentColorCountMax> m_viewports;
+
+        //! A map of single-device DrawPacketBuilder, indexed by the device index
+        AZStd::unordered_map<int, DrawPacketBuilder> m_deviceDrawPacketBuilders;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -78,49 +78,53 @@ namespace AZ::RHI
         // NOTE: This is configurable; just used to control the amount of memory held by the builder.
         static const size_t DrawItemCountMax = 16;
 
+        //! Passes the linear allocator to all single-device DrawPacketBuilders and
+        //! initializes the multi-device DrawPacket which will be returned after calling End()
         void Begin(IAllocator* allocator);
 
+        //! Passes the DrawArguments to all single-device DrawPacketBuilders
         void SetDrawArguments(const MultiDeviceDrawArguments& drawArguments);
 
+        //! Passes the IndexBufferViews to all single-device DrawPacketBuilders
         void SetIndexBufferView(const MultiDeviceIndexBufferView& indexBufferView);
 
+        //! Passes the RootConstants to all single-device DrawPacketBuilders
         void SetRootConstants(AZStd::span<const uint8_t> rootConstants);
 
+        //! Passes the Scissors to all single-device DrawPacketBuilders
         void SetScissors(AZStd::span<const Scissor> scissors);
 
+        //! Passes a Scissor to all single-device DrawPacketBuilders
         void SetScissor(const Scissor& scissor);
 
+        //! Passes the Viewports to all single-device DrawPacketBuilders
         void SetViewports(AZStd::span<const Viewport> viewports);
 
+        //! Passes a Viewport to all singl-device DrawPacketBuilders
         void SetViewport(const Viewport& viewport);
 
+        //! Passes the ShaderResourceGroup to all single-device DrawPacketBuilders
         void AddShaderResourceGroup(const MultiDeviceShaderResourceGroup* shaderResourceGroup);
 
+        //! Passes the single-device DrawRequests to all single-device DrawPacketBuilders,
+        //! keeps the multi-device DrawRequest and sets the DrawListMask in the current
+        //! multi-device DrawPacket
         void AddDrawItem(MultiDeviceDrawRequest& request);
 
+        //! Builds all single-device DrawPackets linearly in memory using their allocator
+        //! and captures them in the multi-device DrawPacket, correctly linking the
+        //! single-device DrawItems with the corresponding multi-device DrawItem as well
         RHI::Ptr<MultiDeviceDrawPacket> End();
 
-        //! Make a copy of an existing DrawPacket.
-        //! Note: the copy will reference the same DrawSrg as the original, so it is not possible to vary the DrawSrg values between the
-        //! original draw packet and the cloned one. Only settings that can be modified via the DrawPacket interface can be changed
-        //! after cloning, such as SetRootConstant and SetInstanceCount
+        //! Clones all single-device DrawPackets and then sets all corresponding pointers
+        //! in the multi-device DrawPacket and DrawItem objects
         RHI::Ptr<MultiDeviceDrawPacket> Clone(const MultiDeviceDrawPacket* original);
 
     private:
-        void ClearData();
-
         RHI::MultiDevice::DeviceMask m_deviceMask{ 0u };
         AZStd::fixed_vector<MultiDeviceDrawRequest, DrawPacketBuilder::DrawItemCountMax> m_drawRequests;
 
         RHI::Ptr<MultiDeviceDrawPacket> m_drawPacketInFlight;
-        // MultiDeviceDrawArguments m_drawArguments;
-        // size_t m_streamBufferViewCount{};
-        // MultiDeviceIndexBufferView m_indexBufferView;
-        // AZStd::vector<MultiDeviceStreamBufferView> m_streamBufferViews;
-        // AZStd::fixed_vector<const MultiDeviceShaderResourceGroup*, Limits::Pipeline::ShaderResourceGroupCountMax> m_shaderResourceGroups;
-        // AZStd::span<const uint8_t> m_rootConstants;
-        // AZStd::fixed_vector<Scissor, Limits::Pipeline::AttachmentColorCountMax> m_scissors;
-        // AZStd::fixed_vector<Viewport, Limits::Pipeline::AttachmentColorCountMax> m_viewports;
 
         //! A map of single-device DrawPacketBuilder, indexed by the device index
         AZStd::unordered_map<int, DrawPacketBuilder> m_deviceDrawPacketBuilders;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -29,8 +29,8 @@ namespace AZ::RHI
         {
             MultiDeviceDrawRequest() = default;
 
-            //! Returns the device-specific RayTracingTlasDescriptor for the given index
-            DrawPacketBuilder::DrawRequest GetDeviceDrawRequest(int deviceIndex);
+            //! Returns the device-specific DrawRequest for the given index
+            DrawPacketBuilder::DrawRequest BuildDeviceDrawRequest(int deviceIndex);
 
             //! The filter tag used to direct the draw item.
             DrawListTag m_listTag;
@@ -68,7 +68,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), deviceIndex))
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());
                 }

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawPacketBuilder.cpp
@@ -301,7 +301,7 @@ namespace AZ::RHI
         m_viewports.clear();
     }
 
-    const DrawPacket* DrawPacketBuilder::Clone(const DrawPacket* original)
+    DrawPacket* DrawPacketBuilder::Clone(const DrawPacket* original)
     {
         Begin(original->m_allocator);
         SetDrawArguments(original->GetDrawItemProperties(0).m_item->m_arguments);

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawItem.cpp
@@ -24,5 +24,17 @@ namespace AZ::RHI
                 m_deviceDrawItems.emplace(deviceIndex, DrawItem{});
             }
         }
+
+        for(auto& [deviceIndex, drawItem] : m_deviceDrawItems)
+        {
+            m_deviceDrawItemPtrs.emplace(deviceIndex, &drawItem);
+        }
+    }
+
+    MultiDeviceDrawItem::MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask, AZStd::unordered_map<int, DrawItem*>&& deviceDrawItemPtrs)
+        : m_deviceMask{ deviceMask }
+        , m_deviceDrawItemPtrs{ deviceDrawItemPtrs }
+    {
+
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacket.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacket.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/Scissor.h>
+#include <Atom/RHI.Reflect/Viewport.h>
+#include <Atom/RHI/ConstantsData.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+
+#include <AzCore/Memory/Memory.h>
+
+namespace AZ::RHI
+{
+    size_t MultiDeviceDrawPacket::GetDrawItemCount() const
+    {
+        return m_drawItems.size();
+    }
+
+    s32 MultiDeviceDrawPacket::GetDrawListIndex(DrawListTag drawListTag) const
+    {
+        for (size_t i = 0; i < m_drawItems.size(); ++i)
+        {
+            if (GetDrawListTag(i) == drawListTag)
+            {
+                return s32(i);
+            }
+        }
+        return -1;
+    }
+
+    MultiDeviceDrawItem* MultiDeviceDrawPacket::GetDrawItem(size_t index)
+    {
+        return (index < m_drawItems.size()) ? &m_drawItems[index] : nullptr;
+    }
+
+    MultiDeviceDrawItem* MultiDeviceDrawPacket::GetDrawItem(DrawListTag drawListTag)
+    {
+        s32 index = GetDrawListIndex(drawListTag);
+        if (index > -1)
+        {
+            return GetDrawItem(index);
+        }
+        return nullptr;
+    }
+
+    MultiDeviceDrawItemProperties MultiDeviceDrawPacket::GetDrawItemProperties(size_t index) const
+    {
+        AZ_Assert(index < GetDrawItemCount(), "Out of bounds array access!");
+        return MultiDeviceDrawItemProperties{&m_drawItems[index], m_drawItemSortKeys[index], m_drawFilterMasks[index]};
+    }
+
+    DrawListTag MultiDeviceDrawPacket::GetDrawListTag(size_t index) const
+    {
+        AZ_Assert(index < GetDrawItemCount(), "Out of bounds array access!");
+        return m_drawListTags[index];
+    }
+
+    DrawFilterMask MultiDeviceDrawPacket::GetDrawFilterMask(size_t index) const
+    {
+        AZ_Assert(index < GetDrawItemCount(), "Out of bounds array access!");
+        return m_drawFilterMasks[index];
+    }
+
+    DrawListMask MultiDeviceDrawPacket::GetDrawListMask() const
+    {
+        return m_drawListMask;
+    }
+
+    void MultiDeviceDrawPacket::SetRootConstant(uint32_t offset, const AZStd::span<uint8_t>& data)
+    {
+        for(auto&[_, deviceDrawPacket] : m_deviceDrawPackets)
+        {
+            deviceDrawPacket->SetRootConstant(offset, data);
+        }
+    }
+
+    void MultiDeviceDrawPacket::SetInstanceCount(uint32_t instanceCount)
+    {
+        for (auto& drawItem : m_drawItems)
+        {
+            drawItem.SetIndexedArgumentsInstanceCount(instanceCount);
+        }
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -178,14 +178,9 @@ namespace AZ::RHI
             drawItem.SetEnabled(!drawListTagDisabled);
         }
 
-        ClearData();
+        m_drawRequests.clear();
 
         return AZStd::move(m_drawPacketInFlight);
-    }
-
-    void MultiDeviceDrawPacketBuilder::ClearData()
-    {
-        m_drawRequests.clear();
     }
 
     RHI::Ptr<MultiDeviceDrawPacket> MultiDeviceDrawPacketBuilder::Clone(const MultiDeviceDrawPacket* original)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -16,7 +16,7 @@
 
 namespace AZ::RHI
 {
-    DrawPacketBuilder::DrawRequest MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::GetDeviceDrawRequest(int deviceIndex)
+    DrawPacketBuilder::DrawRequest MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::BuildDeviceDrawRequest(int deviceIndex)
     {
         if (!m_deviceStreamBufferViews.contains(deviceIndex))
         {
@@ -122,7 +122,7 @@ namespace AZ::RHI
             m_drawPacketInFlight->m_drawListMask.set(request.m_listTag.GetIndex());
             for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
             {
-                deviceDrawPacketBuilder.AddDrawItem(request.GetDeviceDrawRequest(deviceIndex));
+                deviceDrawPacketBuilder.AddDrawItem(request.BuildDeviceDrawRequest(deviceIndex));
             }
         }
         else

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI/LinearAllocator.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+namespace AZ::RHI
+{
+    DrawPacketBuilder::DrawRequest MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::GetDeviceDrawRequest(int deviceIndex)
+    {
+        if (!m_deviceStreamBufferViews.contains(deviceIndex))
+        {
+            // We need to hold the memory for the single-device StreamBufferViews
+            AZStd::vector<StreamBufferView> deviceStreamBufferView;
+            for (auto& mdStreamBufferView : m_streamBufferViews)
+            {
+                deviceStreamBufferView.emplace_back(mdStreamBufferView.GetDeviceStreamBufferView(deviceIndex));
+            }
+            m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::move(deviceStreamBufferView));
+        }
+
+        return { m_listTag,
+                 m_stencilRef,
+                 m_deviceStreamBufferViews.at(deviceIndex),
+                 m_uniqueShaderResourceGroup ? m_uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get() : nullptr,
+                 m_pipelineState ? m_pipelineState->GetDevicePipelineState(deviceIndex).get() : nullptr,
+                 m_sortKey,
+                 m_drawFilterMask };
+    }
+
+    void MultiDeviceDrawPacketBuilder::Begin(IAllocator* allocator)
+    {
+        AZ_Error(
+            "MultiDeviceDrawPacketBuilder",
+            m_deviceMask != MultiDevice::DeviceMask{ 0u },
+            "MultiDeviceDrawPacketBuilder not initialized");
+
+        m_drawPacketInFlight = aznew MultiDeviceDrawPacket;
+
+        for (auto& [_, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.Begin(allocator);
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetDrawArguments(const MultiDeviceDrawArguments& drawArguments)
+    {
+        for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.SetDrawArguments(drawArguments.GetDeviceDrawArguments(deviceIndex));
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetIndexBufferView(const MultiDeviceIndexBufferView& indexBufferView)
+    {
+        for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.SetIndexBufferView(indexBufferView.GetDeviceIndexBufferView(deviceIndex));
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetRootConstants(AZStd::span<const uint8_t> rootConstants)
+    {
+        for (auto& [_, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.SetRootConstants(rootConstants);
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetScissors(AZStd::span<const Scissor> scissors)
+    {
+        for (auto& [_, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.SetScissors(scissors);
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetScissor(const Scissor& scissor)
+    {
+        SetScissors(AZStd::span<const Scissor>(&scissor, 1));
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetViewports(AZStd::span<const Viewport> viewports)
+    {
+        for (auto& [_, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            deviceDrawPacketBuilder.SetViewports(viewports);
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::SetViewport(const Viewport& viewport)
+    {
+        SetViewports(AZStd::span<const Viewport>(&viewport, 1));
+    }
+
+    void MultiDeviceDrawPacketBuilder::AddShaderResourceGroup(const MultiDeviceShaderResourceGroup* shaderResourceGroup)
+    {
+        if (shaderResourceGroup)
+        {
+            for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+            {
+                deviceDrawPacketBuilder.AddShaderResourceGroup(shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+            }
+        }
+    }
+
+    void MultiDeviceDrawPacketBuilder::AddDrawItem(MultiDeviceDrawRequest& request)
+    {
+        if (request.m_listTag.IsValid())
+        {
+            m_drawRequests.push_back(request);
+            m_drawPacketInFlight->m_drawListMask.set(request.m_listTag.GetIndex());
+            for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+            {
+                deviceDrawPacketBuilder.AddDrawItem(request.GetDeviceDrawRequest(deviceIndex));
+            }
+        }
+        else
+        {
+            AZ_Warning("DrawPacketBuilder", false, "Attempted to add a draw item to draw packet with no draw list tag assigned. Skipping.");
+        }
+    }
+
+    RHI::Ptr<MultiDeviceDrawPacket> MultiDeviceDrawPacketBuilder::End()
+    {
+        if (m_drawRequests.empty())
+        {
+            return nullptr;
+        }
+
+        for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex] = deviceDrawPacketBuilder.End();
+        }
+
+        m_drawPacketInFlight->m_drawListTags.resize_no_construct(m_drawRequests.size());
+        m_drawPacketInFlight->m_drawFilterMasks.resize_no_construct(m_drawRequests.size());
+        m_drawPacketInFlight->m_drawItemSortKeys.resize_no_construct(m_drawRequests.size());
+        m_drawPacketInFlight->m_drawItems.reserve(m_drawRequests.size());
+
+        // Setup single-device DrawItems
+        for (auto i{ 0 }; i < m_drawRequests.size(); ++i)
+        {
+            AZStd::unordered_map<int, DrawItem*> deviceDrawItemPtrs;
+            for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+            {
+                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(0));
+            }
+            m_drawPacketInFlight->m_drawItems.emplace_back(MultiDeviceDrawItem{ m_deviceMask, AZStd::move(deviceDrawItemPtrs) });
+        }
+
+        const AZStd::vector<DrawListTag>& disabledTags = RHISystemInterface::Get()->GetDrawListTagsDisabledByDefault();
+        for (size_t i = 0; i < m_drawRequests.size(); ++i)
+        {
+            const auto& drawRequest = m_drawRequests[i];
+
+            m_drawPacketInFlight->m_drawListTags[i] = drawRequest.m_listTag;
+            m_drawPacketInFlight->m_drawFilterMasks[i] = drawRequest.m_drawFilterMask;
+            m_drawPacketInFlight->m_drawItemSortKeys[i] = drawRequest.m_sortKey;
+
+            bool drawListTagDisabled = false;
+            for (const DrawListTag& disabledTag : disabledTags)
+            {
+                drawListTagDisabled = drawListTagDisabled || (drawRequest.m_listTag == disabledTag);
+            }
+
+            auto& drawItem = m_drawPacketInFlight->m_drawItems[i];
+            drawItem.SetEnabled(!drawListTagDisabled);
+        }
+
+        ClearData();
+
+        return AZStd::move(m_drawPacketInFlight);
+    }
+
+    void MultiDeviceDrawPacketBuilder::ClearData()
+    {
+        m_drawRequests.clear();
+    }
+
+    RHI::Ptr<MultiDeviceDrawPacket> MultiDeviceDrawPacketBuilder::Clone(const MultiDeviceDrawPacket* original)
+    {
+        m_drawPacketInFlight = aznew MultiDeviceDrawPacket;
+
+        auto drawRequestCount{ original->m_drawListTags.size() };
+        m_drawPacketInFlight->m_drawListTags.resize_no_construct(drawRequestCount);
+        m_drawPacketInFlight->m_drawFilterMasks.resize_no_construct(drawRequestCount);
+        m_drawPacketInFlight->m_drawItemSortKeys.resize_no_construct(drawRequestCount);
+        m_drawPacketInFlight->m_drawItems.reserve(drawRequestCount);
+
+        for (auto i{ 0 }; i < drawRequestCount; ++i)
+        {
+            m_drawPacketInFlight->m_drawListTags[i] = original->m_drawListTags[i];
+            m_drawPacketInFlight->m_drawFilterMasks[i] = original->m_drawFilterMasks[i];
+            m_drawPacketInFlight->m_drawItemSortKeys[i] = original->m_drawItemSortKeys[i];
+        }
+
+        for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+        {
+            m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex] =
+                deviceDrawPacketBuilder.Clone(original->m_deviceDrawPackets.at(deviceIndex).get());
+        }
+
+        // Setup single-device DrawItems
+        for (auto i{ 0 }; i < drawRequestCount; ++i)
+        {
+            AZStd::unordered_map<int, DrawItem*> deviceDrawItemPtrs;
+            for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
+            {
+                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(0));
+            }
+            m_drawPacketInFlight->m_drawItems.emplace_back(MultiDeviceDrawItem{ m_deviceMask, AZStd::move(deviceDrawItemPtrs) });
+        }
+
+        return AZStd::move(m_drawPacketInFlight);
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
@@ -1,0 +1,615 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RHITestFixture.h"
+
+#include <Atom/RHI.Reflect/RenderAttachmentLayout.h>
+#include <Atom/RHI/DrawListContext.h>
+#include <Atom/RHI/DrawListTagRegistry.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+
+#include <AzCore/Math/Random.h>
+#include <AzCore/std/sort.h>
+
+#include <Tests/Device.h>
+#include <Tests/Factory.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    //? TODO: May revert back to normal deviceCount and Mask
+    static constexpr auto LocalDeviceCount{1};
+    static constexpr auto LocalDeviceMask{RHI::MultiDevice::DefaultDevice};
+
+    struct MultiDeviceDrawItemData
+    {
+        MultiDeviceDrawItemData(SimpleLcgRandom& random, const RHI::MultiDeviceBuffer* bufferEmpty, const RHI::MultiDevicePipelineState* psoEmpty)
+        {
+            m_pipelineState = psoEmpty;
+
+            // Fill with deterministic random data to compare against.
+            for (auto& streamBufferView : m_streamBufferViews)
+            {
+                streamBufferView =
+                    RHI::MultiDeviceStreamBufferView{ *bufferEmpty, random.GetRandom(), random.GetRandom(), random.GetRandom() };
+            }
+
+            m_tag = RHI::DrawListTag(random.GetRandom() % RHI::Limits::Pipeline::DrawListTagCountMax);
+            m_stencilRef = static_cast<uint8_t>(random.GetRandom());
+            m_sortKey = random.GetRandom();
+        }
+
+        AZStd::array<RHI::MultiDeviceStreamBufferView, RHI::Limits::Pipeline::StreamCountMax> m_streamBufferViews;
+
+        const RHI::MultiDevicePipelineState* m_pipelineState;
+        RHI::DrawListTag m_tag;
+        RHI::DrawItemSortKey m_sortKey;
+        uint8_t m_stencilRef;
+    };
+
+    struct MultiDeviceDrawPacketData
+    {
+        const size_t DrawItemCountMax = 8;
+
+        MultiDeviceDrawPacketData(SimpleLcgRandom& random)
+        {
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            m_bufferPool = aznew RHI::MultiDeviceBufferPool;
+            m_bufferEmpty = aznew RHI::MultiDeviceBuffer;
+            m_bufferPool->Init(LocalDeviceMask, bufferPoolDesc);
+            RHI::MultiDeviceBufferInitRequest request;
+            request.m_buffer = m_bufferEmpty.get();
+            request.m_descriptor = RHI::BufferDescriptor{};
+            m_bufferPool->InitBuffer(request);
+            m_psoEmpty = aznew RHI::MultiDevicePipelineState;
+            m_psoEmpty->TestInitialize(
+                LocalDeviceMask,
+                []()
+                {
+                    return RHI::Factory::Get().CreatePipelineState();
+                });
+
+            for (auto& srg : m_srgs)
+            {
+                srg = aznew RHI::MultiDeviceShaderResourceGroup;
+                srg->TestInitialize(
+                    LocalDeviceMask,
+                    []()
+                    {
+                        return RHI::Factory::Get().CreateShaderResourceGroup();
+                    });
+            }
+
+            unsigned int* data = reinterpret_cast<unsigned int*>(m_rootConstants.data());
+            for (uint32_t i = 0; i < m_rootConstants.size() / sizeof(unsigned int); ++i)
+            {
+                data[i] = random.GetRandom();
+            }
+
+            for (size_t i = 0; i < DrawItemCountMax; ++i)
+            {
+                m_drawItemDatas.emplace_back(random, m_bufferEmpty.get(), m_psoEmpty.get());
+            }
+
+            m_indexBufferView =
+                RHI::MultiDeviceIndexBufferView(*m_bufferEmpty, random.GetRandom(), random.GetRandom(), RHI::IndexFormat::Uint16);
+        }
+
+        ~MultiDeviceDrawPacketData()
+        {
+            m_psoEmpty->TestClear();
+            for (auto& srg : m_srgs)
+            {
+                srg->TestClear();
+            }
+        }
+
+        const auto Build(RHI::MultiDeviceDrawPacketBuilder& builder)
+        {
+            builder.Begin(nullptr);
+
+            for (auto& srgPtr : m_srgs)
+            {
+                builder.AddShaderResourceGroup(srgPtr.get());
+            }
+
+            builder.SetRootConstants(m_rootConstants);
+            builder.SetIndexBufferView(m_indexBufferView);
+
+            RHI::DrawListMask drawListMask;
+
+            for (size_t i = 0; i < DrawItemCountMax; ++i)
+            {
+                const MultiDeviceDrawItemData& drawItemData = m_drawItemDatas[i];
+                drawListMask[drawItemData.m_tag.GetIndex()] = true;
+
+                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+                drawRequest.m_listTag = drawItemData.m_tag;
+                drawRequest.m_sortKey = drawItemData.m_sortKey;
+                drawRequest.m_stencilRef = drawItemData.m_stencilRef;
+                drawRequest.m_streamBufferViews = drawItemData.m_streamBufferViews;
+                drawRequest.m_pipelineState = drawItemData.m_pipelineState;
+                builder.AddDrawItem(drawRequest);
+            }
+
+            const auto drawPacket = builder.End();
+
+            EXPECT_NE(drawPacket, nullptr);
+            EXPECT_EQ(drawPacket->GetDrawListMask(), drawListMask);
+            EXPECT_EQ(drawPacket->GetDrawItemCount(), m_drawItemDatas.size());
+
+            return drawPacket;
+        }
+
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_bufferEmpty;
+        RHI::Ptr<RHI::MultiDevicePipelineState> m_psoEmpty;
+
+        RHI::Ptr<RHI::MultiDeviceShaderResourceGroupPool> m_srgPool;
+        AZStd::array<RHI::Ptr<RHI::MultiDeviceShaderResourceGroup>, RHI::Limits::Pipeline::ShaderResourceGroupCountMax> m_srgs;
+        AZStd::array<uint8_t, sizeof(unsigned int) * 4> m_rootConstants;
+        RHI::MultiDeviceIndexBufferView m_indexBufferView;
+
+        AZStd::vector<MultiDeviceDrawItemData> m_drawItemDatas;
+    };
+
+    class MultiDeviceDrawPacketTest : public MultiDeviceRHITestFixture
+    {
+    protected:
+        static const uint32_t s_randomSeed = 1234;
+
+        RHI::DrawListContext m_drawListContext;
+
+        AZStd::unique_ptr<AZ::RHI::RHISystem> m_rhiSystem;
+        AZStd::unique_ptr<Factory> m_factory;
+
+    public:
+        void SetUp() override
+        {
+            MultiDeviceRHITestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            MultiDeviceRHITestFixture::TearDown();
+        }
+
+        void DrawPacketEmpty()
+        {
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            builder.Begin(nullptr);
+
+            const auto drawPacket = builder.End();
+            EXPECT_EQ(drawPacket, nullptr);
+        }
+
+        void DrawPacketNullItem()
+        {
+            RHI::DrawPacketBuilder builder;
+            builder.Begin(nullptr);
+
+            RHI::DrawPacketBuilder::DrawRequest drawRequest;
+            builder.AddDrawItem(drawRequest);
+
+            const RHI::DrawPacket* drawPacket = builder.End();
+            EXPECT_EQ(drawPacket, nullptr);
+        }
+
+        void DrawPacketBuild()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+
+            const auto drawPacket = drawPacketData.Build(builder);
+        }
+
+        void DrawPacketBuildClearBuildNull()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            auto drawPacket = drawPacketData.Build(builder);
+
+            // Try to build a 'null' packet. This should result in a null pointer.
+            builder.Begin(nullptr);
+            drawPacket = builder.End();
+            EXPECT_EQ(drawPacket.get(), nullptr);
+        }
+
+        //! Add these tests once DrawListContext takes MultiDeviceDrawPackets
+        /*
+        void DrawListContextFilter()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            const auto drawPacket = drawPacketData.Build(builder);
+
+            RHI::DrawListContext drawListContext;
+            drawListContext.Init(RHI::DrawListMask{}.set());
+            drawListContext.AddDrawPacket(drawPacket);
+
+            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
+            {
+                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
+
+                RHI::DrawListView drawList = drawListContext.GetList(tag);
+                EXPECT_TRUE(drawList.empty());
+            }
+
+            drawListContext.FinalizeLists();
+
+            RHI::DrawListsByTag listsByTag;
+            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
+            {
+                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
+
+                listsByTag[tag.GetIndex()].push_back(drawPacket->GetDrawItemProperties(i));
+            }
+
+            size_t tagIndex = 0;
+            for (auto& drawList : listsByTag)
+            {
+                SortDrawList(drawList, RHI::DrawListSortType::KeyThenDepth);
+
+                RHI::DrawListTag tag(tagIndex);
+
+                RHI::DrawListView drawListView = drawListContext.GetList(tag);
+                EXPECT_EQ(drawListView.size(), drawList.size());
+
+                for (size_t i = 0; i < drawList.size(); ++i)
+                {
+                    EXPECT_EQ(drawList[i], drawListView[i]);
+                }
+
+                tagIndex++;
+            }
+
+            drawListContext.Shutdown();
+        }
+
+        void DrawListContextNullFilter()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+            DrawPacketData drawPacketData(random);
+
+            RHI::DrawPacketBuilder builder;
+            const RHI::DrawPacket* drawPacket = drawPacketData.Build(builder);
+
+            RHI::DrawListContext drawListContext;
+            drawListContext.Init(RHI::DrawListMask{}); // Mask set to not contain any draw lists.
+            drawListContext.AddDrawPacket(drawPacket);
+            drawListContext.FinalizeLists();
+
+            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
+            {
+                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
+                RHI::DrawListView drawList = drawListContext.GetList(tag);
+                EXPECT_TRUE(drawList.empty());
+            }
+
+            drawListContext.Shutdown();
+
+            delete drawPacket;
+        }
+        */
+
+        void DrawPacketClone()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            const auto drawPacket = drawPacketData.Build(builder);
+
+            RHI::MultiDeviceDrawPacketBuilder builder2(LocalDeviceMask);
+            const auto drawPacketClone = builder2.Clone(drawPacket.get());
+
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacket{ drawPacket->GetDeviceDrawPacket(deviceIndex) };
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+
+                EXPECT_EQ(deviceDrawPacket->m_drawItemCount, deviceDrawPacketClone->m_drawItemCount);
+                EXPECT_EQ(deviceDrawPacket->m_streamBufferViewCount, deviceDrawPacketClone->m_streamBufferViewCount);
+                EXPECT_EQ(deviceDrawPacket->m_shaderResourceGroupCount, deviceDrawPacketClone->m_shaderResourceGroupCount);
+                EXPECT_EQ(deviceDrawPacket->m_uniqueShaderResourceGroupCount, deviceDrawPacketClone->m_uniqueShaderResourceGroupCount);
+                EXPECT_EQ(deviceDrawPacket->m_rootConstantSize, deviceDrawPacketClone->m_rootConstantSize);
+                EXPECT_EQ(deviceDrawPacket->m_scissorsCount, deviceDrawPacketClone->m_scissorsCount);
+                EXPECT_EQ(deviceDrawPacket->m_viewportsCount, deviceDrawPacketClone->m_viewportsCount);
+            }
+
+            auto drawItemCount = drawPacket->GetDrawItemCount();
+
+            for (uint8_t i = 0; i < drawItemCount; ++i)
+            {
+                EXPECT_EQ(drawPacket->GetDrawListTag(i), drawPacketClone->GetDrawListTag(i));
+                EXPECT_EQ(drawPacket->GetDrawFilterMask(i), drawPacketClone->GetDrawFilterMask(i));
+
+                const auto* drawItem = drawPacket->GetDrawItem(i);
+                const RHI::MultiDeviceDrawItem* drawItemClone = drawPacketClone->GetDrawItem(i);
+
+                // Check the clone is an actual copy not an identical pointer.
+                EXPECT_NE(drawItem, drawItemClone);
+
+                for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+                {
+                    auto deviceDrawPacket{ drawPacket->GetDeviceDrawPacket(deviceIndex) };
+                    auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+                    auto& deviceDrawItem{ drawItem->GetDeviceDrawItem(deviceIndex) };
+                    auto& deviceDrawItemClone{ drawItemClone->GetDeviceDrawItem(deviceIndex) };
+
+                    EXPECT_EQ(deviceDrawItem.m_arguments.m_type, deviceDrawItemClone.m_arguments.m_type);
+                    EXPECT_EQ(deviceDrawItem.m_pipelineState->GetType(), deviceDrawItemClone.m_pipelineState->GetType());
+                    EXPECT_EQ(deviceDrawItem.m_stencilRef, deviceDrawItemClone.m_stencilRef);
+                    EXPECT_EQ(deviceDrawItem.m_streamBufferViewCount, deviceDrawItemClone.m_streamBufferViewCount);
+                    EXPECT_EQ(deviceDrawItem.m_shaderResourceGroupCount, deviceDrawItemClone.m_shaderResourceGroupCount);
+                    EXPECT_EQ(deviceDrawItem.m_rootConstantSize, deviceDrawItemClone.m_rootConstantSize);
+                    EXPECT_EQ(deviceDrawItem.m_scissorsCount, deviceDrawItemClone.m_scissorsCount);
+                    EXPECT_EQ(deviceDrawItem.m_viewportsCount, deviceDrawItemClone.m_viewportsCount);
+
+                    uint8_t streamBufferViewCount = deviceDrawItem.m_streamBufferViewCount;
+                    uint8_t shaderResourceGroupCount = deviceDrawItem.m_shaderResourceGroupCount;
+                    uint8_t rootConstantSize = deviceDrawItem.m_rootConstantSize;
+                    uint8_t scissorsCount = deviceDrawItem.m_scissorsCount;
+                    uint8_t viewportsCount = deviceDrawItem.m_viewportsCount;
+
+                    for (uint8_t j = 0; j < streamBufferViewCount; ++j)
+                    {
+                        const RHI::StreamBufferView* streamBufferView = deviceDrawPacket->m_streamBufferViews + j;
+                        const RHI::StreamBufferView* streamBufferViewClone = deviceDrawPacketClone->m_streamBufferViews + j;
+                        EXPECT_EQ(streamBufferView->GetByteCount(), streamBufferViewClone->GetByteCount());
+                        EXPECT_EQ(streamBufferView->GetByteOffset(), streamBufferViewClone->GetByteOffset());
+                        EXPECT_EQ(streamBufferView->GetByteStride(), streamBufferViewClone->GetByteStride());
+                        EXPECT_EQ(streamBufferView->GetHash(), streamBufferViewClone->GetHash());
+                    }
+
+                    for (uint8_t j = 0; j < shaderResourceGroupCount; ++j)
+                    {
+                        EXPECT_EQ(*(deviceDrawItem.m_shaderResourceGroups + j), *(deviceDrawItemClone.m_shaderResourceGroups + j));
+                    }
+
+                    for (uint8_t j = 0; j < rootConstantSize; ++j)
+                    {
+                        EXPECT_EQ(*(deviceDrawItem.m_rootConstants + j), *(deviceDrawItemClone.m_rootConstants + j));
+                    }
+
+                    for (uint8_t j = 0; j < scissorsCount; ++j)
+                    {
+                        EXPECT_EQ(deviceDrawItem.m_scissors + j, deviceDrawItemClone.m_scissors + j);
+                    }
+
+                    for (uint8_t j = 0; j < viewportsCount; ++j)
+                    {
+                        EXPECT_EQ(deviceDrawItem.m_viewports + j, deviceDrawItemClone.m_viewports + j);
+                    }
+                }
+            }
+
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacket{ drawPacket->GetDeviceDrawPacket(deviceIndex) };
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+
+                uint8_t streamBufferViewCount = deviceDrawPacket->m_streamBufferViewCount;
+                uint8_t shaderResourceGroupCount = deviceDrawPacket->m_shaderResourceGroupCount;
+                uint8_t uniqueShaderResourceGroupCount = deviceDrawPacket->m_uniqueShaderResourceGroupCount;
+                uint8_t rootConstantSize = deviceDrawPacket->m_rootConstantSize;
+                uint8_t scissorsCount = deviceDrawPacket->m_scissorsCount;
+                uint8_t viewportsCount = deviceDrawPacket->m_viewportsCount;
+
+                for (uint8_t i = 0; i < streamBufferViewCount; ++i)
+                {
+                    const RHI::StreamBufferView* streamBufferView = deviceDrawPacket->m_streamBufferViews + i;
+                    const RHI::StreamBufferView* streamBufferViewClone = deviceDrawPacketClone->m_streamBufferViews + i;
+                    EXPECT_EQ(streamBufferView->GetByteCount(), streamBufferViewClone->GetByteCount());
+                    EXPECT_EQ(streamBufferView->GetByteOffset(), streamBufferViewClone->GetByteOffset());
+                    EXPECT_EQ(streamBufferView->GetByteStride(), streamBufferViewClone->GetByteStride());
+                    EXPECT_EQ(streamBufferView->GetHash(), streamBufferViewClone->GetHash());
+                }
+
+                for (uint8_t i = 0; i < shaderResourceGroupCount; ++i)
+                {
+                    EXPECT_EQ(*(deviceDrawPacket->m_shaderResourceGroups + i), *(deviceDrawPacketClone->m_shaderResourceGroups + i));
+                }
+
+                for (uint8_t i = 0; i < uniqueShaderResourceGroupCount; ++i)
+                {
+                    EXPECT_EQ(
+                        *(deviceDrawPacket->m_uniqueShaderResourceGroups + i), *(deviceDrawPacketClone->m_uniqueShaderResourceGroups + i));
+                }
+
+                for (uint8_t i = 0; i < rootConstantSize; ++i)
+                {
+                    EXPECT_EQ(*(deviceDrawPacket->m_rootConstants + i), *(deviceDrawPacketClone->m_rootConstants + i));
+                }
+
+                for (uint8_t i = 0; i < scissorsCount; ++i)
+                {
+                    EXPECT_EQ(deviceDrawPacket->m_scissors + i, deviceDrawPacketClone->m_scissors + i);
+                }
+
+                for (uint8_t i = 0; i < viewportsCount; ++i)
+                {
+                    EXPECT_EQ(deviceDrawPacket->m_viewports + i, deviceDrawPacketClone->m_viewports + i);
+                }
+            }
+        }
+
+        void TestSetInstanceCount()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            const auto drawPacket = drawPacketData.Build(builder);
+            RHI::MultiDeviceDrawPacketBuilder builder2(LocalDeviceMask);
+            auto drawPacketClone = builder2.Clone(drawPacket.get());
+
+            uint8_t drawItemCount = drawPacketClone->GetDrawItemCount();
+
+            // Test default value
+            for (uint8_t i = 0; i < drawItemCount; ++i)
+            {
+                for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+                {
+                    const auto& drawItemClone = drawPacketClone->m_drawItems[i].GetDeviceDrawItem(deviceIndex);
+                    EXPECT_EQ(drawItemClone.m_arguments.m_type, RHI::DrawType::Indexed);
+                    EXPECT_EQ(drawItemClone.m_arguments.m_indexed.m_instanceCount, 1);
+                }
+            }
+
+            drawPacketClone->SetInstanceCount(12);
+
+            for (uint8_t i = 0; i < drawItemCount; ++i)
+            {
+                for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+                {
+                    const auto& drawItemClone = drawPacketClone->m_drawItems[i].GetDeviceDrawItem(deviceIndex);
+                    EXPECT_EQ(drawItemClone.m_arguments.m_indexed.m_instanceCount, 12);
+
+                    // Check that the original draw packet is not affected
+                    const auto& drawItem = drawPacket->m_drawItems[i].GetDeviceDrawItem(deviceIndex);
+                    EXPECT_EQ(drawItem.m_arguments.m_indexed.m_instanceCount, 1);
+                }
+            }
+        }
+
+        void TestSetRootConstants()
+        {
+            AZ::SimpleLcgRandom random(s_randomSeed);
+
+            MultiDeviceDrawPacketData drawPacketData(random);
+
+            RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
+            const auto drawPacket = drawPacketData.Build(builder);
+            RHI::MultiDeviceDrawPacketBuilder builder2(LocalDeviceMask);
+            RHI::Ptr<RHI::MultiDeviceDrawPacket> drawPacketClone = builder2.Clone(drawPacket.get());
+
+            AZStd::vector<AZStd::array<uint8_t, sizeof(unsigned int) * 4>> rootConstantOld(LocalDeviceCount);
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+                EXPECT_EQ(sizeof(unsigned int) * 4, deviceDrawPacketClone->m_rootConstantSize);
+            }
+
+            // Keep a copy of old root constant for later verification
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+                for (uint8_t i = 0; i < deviceDrawPacketClone->m_rootConstantSize; ++i)
+                {
+                    rootConstantOld[deviceIndex][i] = deviceDrawPacketClone->m_rootConstants[i];
+                }
+            }
+
+            // Root constant data to be set, partial size as of the full root constant size.
+            AZStd::array<uint8_t, sizeof(unsigned int)* 2> rootConstantNew = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            // Attempt to set beyond the array
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            drawPacketClone->SetRootConstant(9, rootConstantNew);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+            // Nothing will be set if it triggers the assert
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+                for (uint8_t i = 0; i < deviceDrawPacketClone->m_rootConstantSize; ++i)
+                {
+                    EXPECT_EQ(rootConstantOld[deviceIndex][i], deviceDrawPacketClone->m_rootConstants[i]);
+                }
+            }
+
+            drawPacketClone->SetRootConstant(8, rootConstantNew);
+
+            for (auto deviceIndex{ 0 }; deviceIndex < LocalDeviceCount; ++deviceIndex)
+            {
+                auto deviceDrawPacket{ drawPacket->GetDeviceDrawPacket(deviceIndex) };
+                auto deviceDrawPacketClone{ drawPacketClone->GetDeviceDrawPacket(deviceIndex) };
+            
+                // Compare the part staying the same.
+                for (uint8_t i = 0; i < deviceDrawPacketClone->m_rootConstantSize - 8; ++i)
+                {
+                    EXPECT_EQ(rootConstantOld[deviceIndex][i], deviceDrawPacketClone->m_rootConstants[i]);
+                }
+
+                // Compare the part being set
+                for (uint8_t i = deviceDrawPacketClone->m_rootConstantSize - 8; i < deviceDrawPacketClone->m_rootConstantSize; ++i)
+                {
+                    EXPECT_EQ(rootConstantNew[i - (deviceDrawPacketClone->m_rootConstantSize - 8)], deviceDrawPacketClone->m_rootConstants[i]);
+                }
+
+                // Compare the origin which shouldn't be affected.
+                for (uint8_t i = 0; i < deviceDrawPacket->m_rootConstantSize; ++i)
+                {
+                    EXPECT_EQ(rootConstantOld[deviceIndex][i], deviceDrawPacket->m_rootConstants[i]);
+                }
+            }
+        }
+    };
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawPacketEmpty)
+    {
+        DrawPacketEmpty();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawPacketNullItem)
+    {
+        DrawPacketNullItem();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawPacketBuild)
+    {
+        DrawPacketBuild();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawPacketBuildClearBuildNull)
+    {
+        DrawPacketBuildClearBuildNull();
+    }
+
+    //! Add these tests once DrawListContext takes MultiDeviceDrawPackets
+    /*
+    TEST_F(MultiDeviceDrawPacketTest, DrawListContextFilter)
+    {
+        DrawListContextFilter();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawListContextNullFilter)
+    {
+        DrawListContextNullFilter();
+    }
+    */
+
+    TEST_F(MultiDeviceDrawPacketTest, DrawPacketClone)
+    {
+        DrawPacketClone();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, TestSetInstanceCount)
+    {
+        TestSetInstanceCount();
+    }
+
+    TEST_F(MultiDeviceDrawPacketTest, TestSetRootConstants)
+    {
+        TestSetRootConstants();
+    }
+} // namespace UnitTest

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -52,7 +52,9 @@ set(FILES
     Include/Atom/RHI/DrawListTagRegistry.h
     Include/Atom/RHI/DrawListContext.h
     Include/Atom/RHI/DrawPacket.h
+    Include/Atom/RHI/MultiDeviceDrawPacket.h
     Include/Atom/RHI/DrawPacketBuilder.h
+    Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
     Include/Atom/RHI/IndirectArguments.h
     Include/Atom/RHI/MultiDeviceIndirectArguments.h
     Source/RHI/CommandList.cpp
@@ -61,7 +63,9 @@ set(FILES
     Source/RHI/DrawList.cpp
     Source/RHI/DrawListContext.cpp
     Source/RHI/DrawPacket.cpp
+    Source/RHI/MultiDeviceDrawPacket.cpp
     Source/RHI/DrawPacketBuilder.cpp
+    Source/RHI/MultiDeviceDrawPacketBuilder.cpp
     Source/RHI/MultiDeviceDrawItem.cpp
     Include/Atom/RHI/Device.h
     Include/Atom/RHI/DeviceBusTraits.h

--- a/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_tests_files.cmake
@@ -58,6 +58,7 @@ set(FILES
     Tests/MultiDeviceImageTests.cpp
     Tests/MultiDeviceIndirectBufferTests.cpp
     Tests/MultiDeviceShaderResourceGroupTests.cpp
+    Tests/MultiDeviceDrawPacketTests.cpp
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES


### PR DESCRIPTION
## What does this PR do?

This PR is part of https://github.com/o3de/sig-graphics-audio/pull/137 (original proposal including discussion in https://github.com/o3de/sig-graphics-audio/issues/120, there referred to as (part of) commit 3 in the Planned git history sub-section) and introduces multi-device resource classes, including:

- `MultiDeviceDrawPacket`
- `MultiDeviceDrawPacketBuilder`

It is important to note that this PR only introduces these resource classes, but does not call them currently on either the RHI or RPI level (this will happen after all multi-device resources have been properly introduces into the code base).

## How was this PR tested?
- `Gem::Atom_RHI.Tests.main`
- Added a new test `MultiDeviceDrawPacketTests`
