### PR TITLE
fix: Do not use dangling ptr for EditorTransform when echap key is hit

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -208,7 +208,6 @@ namespace AzToolsFramework
 
         bool IsEntitySelected(AZ::EntityId entityId) const;
         void SetSelectedEntities(const EntityIdList& entityIds);
-        void DeselectEntities();
         bool SelectDeselect(AZ::EntityId entityId);
         void ChangeSelectedEntity(AZ::EntityId entityId);
 
@@ -258,6 +257,7 @@ namespace AzToolsFramework
         void CopyScaleToSelectedEntitiesIndividualWorld(float scale) override;
         void SnapSelectedEntitiesToWorldGrid(float gridSize) override;
         void OverrideComponentModeSwitcher(AZStd::shared_ptr<ComponentModeFramework::ComponentModeSwitcher>) override;
+        void DeselectEntities() override;
 
         // EditorManipulatorCommandUndoRedoRequestBus overrides ...
         void UndoRedoEntityManipulatorCommand(AZ::u8 pivotOverride, const AZ::Transform& transform) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h
@@ -135,6 +135,9 @@ namespace AzToolsFramework
         //! Replace ComponentModeSwitcher with overridden ComponentModeSwitcher
         virtual void OverrideComponentModeSwitcher(AZStd::shared_ptr<ComponentModeFramework::ComponentModeSwitcher>) = 0;
 
+        //! Deselect all entities
+        virtual void DeselectEntities() = 0;
+
     protected:
         ~EditorTransformComponentSelectionRequests() = default;
     };


### PR DESCRIPTION
## What does this PR do?

Fix #17264.

Issue occured because the Action callback for `o3de.action.edit.deselectAll` was capturing a pointer of the current `EditorTransformComponentSelection`. Problem is that this class is destroyed and re-created anytime `PropertyEntityIdCtrl::StartEntityPickMode()` is called, thus the dangling pointer.

The fix proposal is to rely on the EditorTransform event bus, which will call the last valid instance of the class. There might be a better approach to prevent this problem that I'm not aware of.

If this is the way to go, I'll update the PR to add the unit test for the new command.
I believe that I should also update the other action callbacks in this class that are also capturing `this`.

## How was this PR tested?

1. Open a level with some content
2. Select an entity
3. Pick the reparent icon on the transform component
4. Press the "echap" key on your keyboard

![image](https://github.com/o3de/o3de/assets/19243508/612dbcf6-45fa-4064-8fbb-e2d07795e3c9)

