### PR TITLE
new: Allow to browse to asset in the dependency tree view

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -1301,6 +1301,22 @@ bool AzAssetBrowserRequestHandler::OpenWithOS(const AZStd::string& fullEntryPath
     return openedSuccessfully;
 }
 
+AzAssetBrowserWindow* AzAssetBrowserRequestHandler::FindAzAssetBrowserWindow(QWidget* widgetToStartSearchFrom)
+{
+    AzAssetBrowserWindow* assetBrowserWindow = nullptr;
+    if (widgetToStartSearchFrom)
+    {
+        assetBrowserWindow = FindAzAssetBrowserWindowThatContainsWidget(widgetToStartSearchFrom);
+    }
+
+    if (!assetBrowserWindow)
+    {
+        assetBrowserWindow = AzToolsFramework::GetViewPaneWidget<AzAssetBrowserWindow>(LyViewPane::AssetBrowser);
+    }
+
+    return assetBrowserWindow;
+}
+
 AzAssetBrowserWindow* AzAssetBrowserRequestHandler::FindAzAssetBrowserWindowThatContainsWidget(QWidget* widget)
 {
     AzAssetBrowserWindow* targetAssetBrowserWindow = nullptr;
@@ -1326,24 +1342,16 @@ AzAssetBrowserWindow* AzAssetBrowserRequestHandler::FindAzAssetBrowserWindowThat
 
 void AzAssetBrowserRequestHandler::SelectAsset(QWidget* caller, const AZStd::string& fullFilePath)
 {
-    AzAssetBrowserWindow* assetBrowserWindow = FindAzAssetBrowserWindowThatContainsWidget(caller);
-
-    if (!assetBrowserWindow)
+    if (AzAssetBrowserWindow* assetBrowserWindow = FindAzAssetBrowserWindow(caller))
     {
-        return;
+        assetBrowserWindow->SelectAsset(fullFilePath.c_str(), false);
     }
-
-    assetBrowserWindow->SelectAsset(fullFilePath.c_str(), false);
 }
 
 void AzAssetBrowserRequestHandler::SelectFolderAsset([[maybe_unused]] QWidget* caller, [[maybe_unused]] const AZStd::string& fullFolderPath)
 {
-    AzAssetBrowserWindow* assetBrowserWindow = FindAzAssetBrowserWindowThatContainsWidget(caller);
-
-    if (!assetBrowserWindow)
+    if (AzAssetBrowserWindow* assetBrowserWindow = FindAzAssetBrowserWindow(caller))
     {
-        return;
+        assetBrowserWindow->SelectAsset(fullFolderPath.c_str(), true);
     }
-
-    assetBrowserWindow->SelectAsset(fullFolderPath.c_str(), true);
 }

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
@@ -100,6 +100,7 @@ protected:
 
     bool DecodeDragMimeData(const QMimeData* mimeData,
                             AZStd::vector<const AzToolsFramework::AssetBrowser::ProductAssetBrowserEntry*>* outVector = nullptr) const;
+    AzAssetBrowserWindow* FindAzAssetBrowserWindow(QWidget* widgetToStartSearchFrom);
     AzAssetBrowserWindow* FindAzAssetBrowserWindowThatContainsWidget(QWidget* widget);
 };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -92,10 +92,22 @@ namespace AzToolsFramework
 
             static void BrowseToAsset(const DependentAssetTreeWidgetItem& assetItem)
             {
+                // Product asset path is located in the cached folder not discoverable by asset browser
+                // so we resolve the source path instead
+                auto path = assetItem.m_assetBrowserEntry->GetFullPath();
+                if (assetItem.m_assetBrowserEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)
+                {
+                    const auto* productItem = static_cast<const ProductAssetBrowserEntry*>(assetItem.m_assetBrowserEntry);
+                    if (const SourceAssetBrowserEntry* source = SourceAssetBrowserEntry::GetSourceByUuid(productItem->GetAssetId().m_guid))
+                    {
+                        path = source->GetFullPath();
+                    }
+                }
+
                 AssetBrowserInteractionNotificationBus::Broadcast(
                         &AssetBrowserInteractionNotificationBus::Events::SelectAsset,
                         nullptr,
-                        assetItem.m_assetBrowserEntry->GetFullPath());
+                        path);
             }
         };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.h
@@ -29,6 +29,8 @@ namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
+        class DependentAssetTreeWidgetItem;
+
         class AssetBrowserEntityInspectorWidget
             : public QWidget
             , public AssetBrowserPreviewRequestBus::Handler
@@ -57,7 +59,7 @@ namespace AzToolsFramework
             // Create an incoming or outgoing dependency QTreeWidgetItem for each valid AssetId
             void CreateProductDependencyTree(const AZStd::set<AZ::Data::AssetId> dependencyUuids, bool isOutgoing);
             // Adds the name and icon of an asset browser entry under a QTreeWidgetItem
-            void AddAssetBrowserEntryToTree(const AssetBrowserEntry* entry, QTreeWidgetItem* headerItem);
+            void AddAssetBrowserEntryToTree(const AssetBrowserEntry* entry, DependentAssetTreeWidgetItem* headerItem);
             // Processses the source asset and populates the FBX settings
             void HandleSourceAsset(const AssetBrowserEntry* entry, const SourceAssetBrowserEntry* sourceEntry);
             // Processes the product asset


### PR DESCRIPTION
## What does this PR do?

On the entity inspector widget, allow to browse to asset dependency via right-click menu or on double click on the item.

![inaction](https://github.com/o3de/o3de/assets/19243508/af890f65-dcc7-4bfe-bf3d-4b91341b6738)

Changes:
- New private class in Entity Inspector to handle dependent assets tree view
- The call to `AssetBrowserInteractionNotificationBus::SelectAsset` will no longer fail if the caller widget is not a child of the asset browser (new fallback to get the asset browser directly if not found in caller widget hierarchy)

## How was this PR tested?

Selected multiple asset types, deleted the entry while entity was selected and re-browsed to the dependency
