### PR TITLE
new: Allow contextual menu on asset browser when no selection

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -102,6 +102,18 @@ namespace AzToolsFramework
                 [this]()
                 {
                     AZStd::vector<const AssetBrowserEntry*> entries = AZStd::move(GetSelectedAssets());
+                    if (entries.empty() && m_assetTreeView)
+                    {
+                        // Tree has the current open folder selected if context is valid (not searching, etc)
+                        const auto treeSelection = m_assetTreeView->selectionModel()->selectedIndexes();
+                        if (!treeSelection.empty())
+                        {
+                            m_thumbnailViewWidget->selectionModel()->select(
+                                treeSelection.first(), QItemSelectionModel::SelectionFlag::ClearAndSelect);
+                            entries = AZStd::move(GetSelectedAssets());
+                        }
+                    }
+
                     QMenu menu(this);
 
                     if (entries.size() == 1)
@@ -122,7 +134,7 @@ namespace AzToolsFramework
                             menu.addSeparator();
                         }
                     }
-                    
+
                     AssetBrowserInteractionNotificationBus::Broadcast(
                         &AssetBrowserInteractionNotificationBus::Events::AddContextMenuActions, this, &menu, entries);
 


### PR DESCRIPTION
## What does this PR do?

Allow the right click contextual menu to show up in the Asset Browser in thumbnail view if you click on an empty area (create new asset, change sort type, etc).

![inaction](https://github.com/o3de/o3de/assets/19243508/a4461905-32f7-42d5-b794-5b7756e47e0e)

Notes:
- `AzAssetBrowserRequestHandler::AddContextMenuActions()` will only work if there is an entry selected, thus if selection is empty on rclick, I select the current folder
- The menu is disabled in search mode or in root folder as these contexts are invalid (cannot create a new asset outside of the project)
- The folder rename option is the only one not usuable. Should be either supported in the future or the folder edit option should be hidden in this context

## How was this PR tested?

Open a project, put the asset browser in thumbnail view, right click in empty area. Check that asset creation is working, sort types, folder move and delete
