### PR TITLE
Fix Android Project Generation with Pak mode

### DIFF
--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1598,7 +1598,7 @@ class AndroidProjectGenerator(object):
                 cmake_argument_list.append('"-DLY_STRIP_DEBUG_SYMBOLS=ON"')
 
             if self._asset_mode == ASSET_MODE_PAK:
-                cmake_argument_list.append('"-DLY_ARCHIVE_FILE_SEARCH_MODE=2"')
+                cmake_argument_list.append('"-DLY_ARCHIVE_FILE_SEARCH_MODE=1"')
 
             cmake_argument_list.extend([
                 f'"-DANDROID_NATIVE_API_LEVEL={self._android_platform_sdk_api_level}"',

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -992,7 +992,7 @@ CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR = """
         tasks.findAll {{ task->task.name.contains('strip{config}DebugSymbols') }}
     }}
     
-    mergeProfileAssets.dependsOn syncLYLayoutMode{config}
+    merge{config}Assets.dependsOn syncLYLayoutMode{config}
 """
 
 DEFAULT_CONFIG_CHANGES = [

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1597,6 +1597,9 @@ class AndroidProjectGenerator(object):
             if self._strip_debug_symbols:
                 cmake_argument_list.append('"-DLY_STRIP_DEBUG_SYMBOLS=ON"')
 
+            if self._asset_mode == ASSET_MODE_PAK:
+                cmake_argument_list.append('"-DLY_ARCHIVE_FILE_SEARCH_MODE=2"')
+
             cmake_argument_list.extend([
                 f'"-DANDROID_NATIVE_API_LEVEL={self._android_platform_sdk_api_level}"',
                 f'"-DLY_NDK_DIR={template_ndk_path}"',


### PR DESCRIPTION
## What does this PR do?

When generating android projects for O3DE, you can set the asset mode to 'PAK' mode. This is not enough, however, since by default only release builds use pak files. In order to search for Pak files in non-release configurations, the [LY_ARCHIVE_FILE_SEARCH_MODE](https://github.com/o3de/o3de/blob/development/Code/Framework/AzFramework/AzFramework/feature_options.cmake) needs to be set to search for Pak files as well as loose assets. 

This also fixes gradle dependency issue for merge{config}Assets

## How was this PR tested?

The android generation script was ran to generate the NewpaperDelivery project with bundled android assets. Validated the generated build.gradle for `app` contains the additional cmake variable. Ran `gradlew.bat assembleProfile` and verified the pak files are located within the APK under the assets subfolder.

This is a partial fix for pak mode. Unable to verify that this fixes pak mode yet.

