### PR TITLE
Abstract an UpdateImportedAttachmentImage function in Pass.h

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.h
@@ -77,7 +77,6 @@ namespace AZ::Render
         RHI::ShaderInputNameIndex m_constantDataIndex = "m_constantData";
 
         AZStd::array<Data::Instance<RPI::PassAttachment>, 2> m_accumulationAttachments;
-        AZStd::array<Data::Instance<RPI::AttachmentImage>, 2> m_attachmentImages;
 
         RPI::PassAttachmentBinding* m_inputColorBinding = nullptr;
         RPI::PassAttachmentBinding* m_lastFrameAccumulationBinding = nullptr;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -399,6 +399,11 @@ namespace AZ
             // Setup ImageAttachmentCopy
             void UpdateAttachmentCopy(FramePrepareParams params);
 
+            // Update Imported Attachment
+            bool UpdateImportedAttachmentImage(Ptr<PassAttachment>& attachment, 
+                RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite,
+                RHI::ImageAspectFlags aspectFlags = RHI::ImageAspectFlags::Color);
+
             // --- Protected Members ---
 
             const Name PassNameThis{"This"};

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -29,13 +29,14 @@
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 #include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
+#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 
 #include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 #include <Atom/RPI.Reflect/Pass/PassRequest.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 #include <Atom/RPI.Reflect/Pass/PassName.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
-
 
 namespace AZ
 {
@@ -1547,6 +1548,56 @@ namespace AZ
             {
                 m_attachmentCopy.lock()->FrameBegin(params);
             }
+        }
+
+        bool Pass::UpdateImportedAttachmentImage(Ptr<PassAttachment>& attachment, RHI::ImageBindFlags bindFlags, RHI::ImageAspectFlags aspectFlags)
+        {
+            if (!attachment)
+            {
+                return false;
+            }
+
+            // update the image attachment descriptor to sync up size and format
+            attachment->Update(true);
+            RHI::ImageDescriptor& imageDesc = attachment->m_descriptor.m_image;
+
+            // The Format Source had no valid attachment
+            if (imageDesc.m_format == RHI::Format::Unknown)
+            {
+                return false;
+            }
+
+            RPI::AttachmentImage* currentImage = azrtti_cast<RPI::AttachmentImage*>(attachment->m_importedResource.get());
+
+            if (attachment->m_importedResource && imageDesc.m_size == currentImage->GetDescriptor().m_size)
+            {
+                // If there's a resource already and the size didn't change, just keep using the old AttachmentImage.
+                return true;
+            }
+            
+            Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+
+            // set the bind flags
+            imageDesc.m_bindFlags |= bindFlags;
+            
+            // The ImageViewDescriptor must be specified to make sure the frame graph compiler doesn't treat this as a transient image.
+            RHI::ImageViewDescriptor viewDesc = RHI::ImageViewDescriptor::Create(imageDesc.m_format, 0, 0);
+            viewDesc.m_aspectFlags = aspectFlags;
+
+            // The full path name is needed for the attachment image so it's not deduplicated from accumulation images in different pipelines.
+            AZStd::string imageName = RPI::ConcatPassString(GetPathName(), attachment->m_path);
+            auto attachmentImage = RPI::AttachmentImage::Create(*pool.get(), imageDesc, Name(imageName), nullptr, &viewDesc);
+
+            if (attachmentImage)
+            {
+                attachment->m_path = attachmentImage->GetAttachmentId();
+                attachment->m_importedResource = attachmentImage;
+                return true;
+            }else
+            {
+                AZ_Error("Pass", false, "UpdateImportedAttachmentImage failed because it is unable to create an attachment image.");
+            }
+            return false;
         }
 
         void Pass::PrintIndent(AZStd::string& stringOutput, uint32_t indent) const


### PR DESCRIPTION
## What does this PR do?

I think updating an imported attachment image is a **commonly used** functionality, it is currently already  being used in TaaPass.cpp.

According to our real Gem developing experiences, we have quite a lot situations where we need this feature. But currently we don't have a common one in the Pass class. So I think it should be reasonable to implement one in the Pass class.

This PR moves most of the logic inside the `TaaPass::UpdateAttachmentImage` into a new function named `UpdateImportedAttachmentImage`, and putting this function in Pass class, so that the future developers can use this feature for their purpose.

## How was this PR tested?

Self tested, and commonly used in our real projects.
