### PR TITLE
android-generate runs from project root

### DIFF
--- a/Code/Tools/Android/ProjectGenerator/project_generator.py
+++ b/Code/Tools/Android/ProjectGenerator/project_generator.py
@@ -95,7 +95,11 @@ class ProjectGenerator(ThreadedLambda):
             arg_list.extend(["--oculus-project"])
         self._generate_project_cmd = SubprocessRunner(
             arg_list,
-            timeOutSeconds=60
+            timeOutSeconds=60,
+            # The "android-generate" subcommand requires to be run from the project root directory,
+            # otherwise it won't find the settings we previously defined with the multiple calls
+            # to "android-configure" subcommand.
+            cwd=config.project_path
         )
 
 

--- a/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
+++ b/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
@@ -14,7 +14,7 @@ class SubprocessRunner:
     and capture the errorCode, stdout and stderr
     """
 
-    def __init__(self, argList: list[str], timeOutSeconds: int):
+    def __init__(self, argList: list[str], timeOutSeconds: int, cwd: str = ".") :
         self._name = self.__class__.__name__
         self._argList = argList
         self._arg_list_str = ""  # Becomes the command string when executed.
@@ -22,6 +22,7 @@ class SubprocessRunner:
         self._error_code = -1
         self._error_message = ""
         self._success_message = ""
+        self._cwd = cwd
 
 
     def run(self) -> bool:
@@ -32,7 +33,7 @@ class SubprocessRunner:
         self._arg_list_str = " ".join(self._argList)
         print(f"{self._name} will run command:\n{self._arg_list_str}\n")
         self._subprocess = subprocess.Popen(
-            self._argList, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            self._argList, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._cwd
         )
         try:
             outs, errs = self._subprocess.communicate(timeout=self._timeOut)


### PR DESCRIPTION
## What does this PR do?

It was found that the "android-generate" subcommand only finds the project config settings if the
working directory is the project root directory.

## How was this PR tested?

Validated with a project, for which the `build dir` and `root dir` where in completely different locations of the file system and was able to compile and deploy to a Meta Quest Pro devices using Android Studio. 
