### PR TITLE
make sure cached attributes are removed before they are re-added

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1019,6 +1019,7 @@ namespace AzToolsFramework
                         else
                         {
                             // handler is the same, set the existing handler with the new value
+                            RemoveCachedAttributes(childIndex);
                             SetPropertyEditorAttributes(childIndex, valueAtSubPath, childWidget);
                             handlerInfo.handlerInterface->SetValueFromDom(valueAtSubPath);
                         }


### PR DESCRIPTION
## What does this PR do?
fixes "share prior column" error where updated widgets were adding duplicate attributes when being reset by the handler, because their prior cached attributes hadn't been removed.

![image](https://github.com/o3de/o3de/assets/85521892/92c4be49-abe0-4f54-91d1-d61b8f8ed022)

fixes main bug reported here:
https://github.com/o3de/o3de/issues/17208

If other issues mentioned in that GHI still exist, please separate those out into different bug reports.

## How was this PR tested?
locally, in the Editor and DPEStandalone apps

_Please describe any testing performed._
