### PR TITLE
fix string constructible types failing conversion when not implicitly strings

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.h
@@ -217,12 +217,15 @@ namespace AZ::Dom::Utils
         {
             return value.IsNumber();
         }
-        else if constexpr (AZStd::is_constructible_v<WrapperType, AZStd::string_view>)
-        {
-            return value.IsString();
-        }
         else
         {
+            if constexpr (AZStd::is_constructible_v<WrapperType, AZStd::string_view>)
+            {
+                if (value.IsString())
+                {
+                    return true;
+                }
+            }
             // For pointer types, the pointer marshaling logic is used
             // to extract a pointer address from the Object with the Dom::Value
             if constexpr (AZStd::is_pointer_v<WrapperType>)


### PR DESCRIPTION
## What does this PR do?
- fixes string constructible types failing conversion when not implicitly strings, which especially caused certain opaque types to fail
- fixes https://github.com/o3de/o3de/issues/17287

## How was this PR tested?
- locally in the Editor and DPEStandalone projects