### PR TITLE
Fix Android Pak loading inside an APK

### DIFF
--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/io/APKHandler.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/io/APKHandler.java
@@ -29,6 +29,8 @@ public class APKHandler
 
         try
         {
+            // Asset manager doesn't handle '.' as a directory expression, so replace it with '' if it is encountered
+            path = (path.equals( ".")) ? "" : path;
             filelist = s_assetManager.list(path);
         }
         catch (IOException e)

--- a/Code/Framework/AzCore/Platform/Android/AzCore/Android/Utils.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Android/Utils.cpp
@@ -136,11 +136,17 @@ namespace AZ
                 AAssetManager* mgr = GetAssetManager();
                 if (mgr)
                 {
-                    AAsset* asset = AAssetManager_open(mgr, "engine.json", AASSET_MODE_UNKNOWN);
-                    if (asset)
+                    // The assets folder in an APK will have either 'engine.json' (LOOSE mode) or 'engine_android.pak' (PAK Mode)
+                    const char* asset_marker_files[] = { "engine.json", "engine_android.pak" };
+                    AAsset* asset = nullptr;
+                    for (const char* asset_marker : asset_marker_files)
                     {
-                        AAsset_close(asset);
-                        return GetApkAssetsPrefix();
+                        asset = AAssetManager_open(mgr, asset_marker, AASSET_MODE_UNKNOWN);
+                        if (asset)
+                        {
+                            AAsset_close(asset);
+                            return GetApkAssetsPrefix();
+                        }
                     }
                 }
 

--- a/Gems/Atom/Bootstrap/Assets/seedList.seed
+++ b/Gems/Atom/Bootstrap/Assets/seedList.seed
@@ -7,7 +7,7 @@
             "assetId": {
                 "guid": "{3C004E81-244A-51C1-B3BB-50EFFD1373C9}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/mainrenderpipeline.azasset"
         }
     ]

--- a/Gems/Atom/Feature/Common/Assets/seedList.seed
+++ b/Gems/Atom/Feature/Common/Assets/seedList.seed
@@ -7,133 +7,133 @@
             "assetId": {
                 "guid": "{88B442CC-1F5B-5B8A-BC10-EDEB9998BEF9}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/passtemplates.azasset"
         },
         {
             "assetId": {
                 "guid": "{6B01EDAB-1951-5588-AB7B-DF2F703950D4}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/smaaconfiguration.azasset"
         },
         {
             "assetId": {
                 "guid": "{0302DBFA-309B-50F9-912A-F5EB9A3FFC89}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaderlib/atom/features/raytracing/raytracingsrgs.azshader"
         },
         {
             "assetId": {
                 "guid": "{558ADDDC-9CF3-5EE9-9FE2-288A1F404072}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/auxgeom/auxgeomworld.azshader"
         },
         {
             "assetId": {
                 "guid": "{920D0051-A477-555A-BA28-441D779DF7FE}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/auxgeom/auxgeomobject.azshader"
         },
         {
             "assetId": {
                 "guid": "{7DB9C0CD-EE20-5B1D-92E0-423B4832461E}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/auxgeom/auxgeomobjectlit.azshader"
         },
         {
             "assetId": {
                 "guid": "{B1E8CBB8-00F8-552B-AA3F-07F3DAA9C79C}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/imgui/imgui.azshader"
         },
         {
             "assetId": {
                 "guid": "{72B3ED19-D85C-5674-B331-F1D8758EBC83}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/displaymapper.azshader"
         },
         {
             "assetId": {
                 "guid": "{AAC80DB3-C758-5B36-864A-9AD9923387E1}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/acesoutputtransformlut.azshader"
         },
         {
             "assetId": {
                 "guid": "{91F6209C-D41E-5F6A-9070-EEED973ED34A}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/bakeacesoutputtransformlutcs.azshader"
         },
         {
             "assetId": {
                 "guid": "{BF6EC912-C8EB-56AF-A3A7-5FE2570465B9}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/fullscreencopy.azshader"
         },
         {
             "assetId": {
                 "guid": "{CC4B44B0-1DCB-5A50-B2C0-6C8D778D60C6}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/applyshaperlookuptable.azshader"
         },
         {
             "assetId": {
                 "guid": "{D24FDB86-AE3A-5AF3-8CF2-A398A7DE7ECD}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/outputtransform.azshader"
         },
         {
             "assetId": {
                 "guid": "{45485BD7-DFDD-5B8D-99C7-2464D2FEF506}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionprobestencil.azshader"
         },
         {
             "assetId": {
                 "guid": "{2173DB42-64C3-5AB3-B394-CBC093258D01}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionprobeblendweight.azshader"
         },
         {
             "assetId": {
                 "guid": "{6FD5B51E-51D8-54C2-B8B1-914C4D33950D}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionproberenderouter.azshader"
         },
         {
             "assetId": {
                 "guid": "{7C15D605-EAAD-5AF4-A5F7-AF2781156064}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionproberenderinner.azshader"
         },
         {
             "assetId": {
                 "guid": "{FE7E2F65-2F34-5231-AF26-D0D836668294}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionscreenspaceblurvertical.azshader"
         },
         {
             "assetId": {
                 "guid": "{27A231B1-F585-5D0E-AD1F-AD08D9C1E8F2}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/reflections/reflectionscreenspaceblurhorizontal.azshader"
         },
         {
@@ -141,7 +141,7 @@
                 "guid": "{1AA24D31-66E5-52B6-8F21-ABADFECE661D}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/cloudnoise_01.jpg.streamingimage"
         },
         {
@@ -149,7 +149,7 @@
                 "guid": "{49F60E08-3BAF-5132-B6E7-0F4A32310B12}",
                 "subId": 3000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/default/default_iblglobalcm_ibldiffuse.dds.streamingimage"
         },
         {
@@ -157,7 +157,7 @@
                 "guid": "{49F60E08-3BAF-5132-B6E7-0F4A32310B12}",
                 "subId": 2000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/default/default_iblglobalcm_iblspecular.dds.streamingimage"
         },
         {
@@ -165,7 +165,7 @@
                 "guid": "{FDC3F4B9-5C6C-5D85-9628-892826185D85}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/default/default_skyboxcm.dds.streamingimage"
         },
         {
@@ -173,7 +173,7 @@
                 "guid": "{2BD005F4-D37A-59DD-9DDE-F5ADD4668B9B}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/ltc/ltc_mat_lutrgba32f.dds.streamingimage"
         },
         {
@@ -181,7 +181,7 @@
                 "guid": "{F9E4A926-0E27-595A-B147-69822B4E1F98}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/ltc/ltc_amp_lutrg32f.dds.streamingimage"
         },
         {
@@ -189,7 +189,7 @@
                 "guid": "{8ECFB722-130A-55F8-9FD0-428ACEEA1EAF}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/postprocessing/depthoffield_pencilmap_35mmfilm.bmp.streamingimage"
         },
         {
@@ -197,7 +197,7 @@
                 "guid": "{54023EDC-B393-544A-9C80-E8E2ACB1BE53}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/postprocessing/areatex.dds.streamingimage"
         },
         {
@@ -205,28 +205,28 @@
                 "guid": "{1553E50C-D99C-5CD1-BB5C-747FD47C354B}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/postprocessing/searchtex.dds.streamingimage"
         },
         {
             "assetId": {
                 "guid": "{3C004E81-244A-51C1-B3BB-50EFFD1373C9}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/mainrenderpipeline.azasset"
         },
         {
             "assetId": {
                 "guid": "{06E16462-E7A0-5780-A87D-BA165F18C297}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/postprocessing/displaymappersrgb.azshader"
         },
         {
             "assetId": {
                 "guid": "{3ED0319F-603A-59E3-83C7-3183649A9A94}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/shadow/clearshadow.azshader"
         },
         {
@@ -234,21 +234,21 @@
                 "guid": "{7F053C3F-A21C-5801-88EE-56C62A4752E2}",
                 "subId": 278992749
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "models/occlusioncullingplane.azmodel"
         },
         {
             "assetId": {
                 "guid": "{C84BC230-53BF-53BB-A18D-060B6DDBDFE6}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "materials/occlusioncullingplane/occlusioncullingplanevisualization.azmaterial"
         },
         {
             "assetId": {
                 "guid": "{3F28138D-27D7-5B62-977E-F49C08B77B7D}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "materials/occlusioncullingplane/occlusioncullingplanetransparentvisualization.azmaterial"
         },
         {
@@ -256,7 +256,7 @@
                 "guid": "{8CC9B575-39D7-5914-AC42-92A77833E63A}",
                 "subId": 268692035
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "models/diffuseprobesphere.azmodel"
         },
         {

--- a/Gems/Atom/RPI/Assets/seedList.seed
+++ b/Gems/Atom/RPI/Assets/seedList.seed
@@ -7,21 +7,21 @@
             "assetId": {
                 "guid": "{AC37FCC4-ACF3-5EB7-B66E-D552DB55BA43}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/decomposemsimage.azshader"
         },
         {
             "assetId": {
                 "guid": "{624D96E2-CB87-5105-991E-01C17C9BCD20}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/imagepreview.azshader"
         },
         {
             "assetId": {
                 "guid": "{DECFE8B1-6410-513D-902E-4601CB425B53}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/sceneandviewsrgs.azshader"
         },
         {
@@ -29,7 +29,7 @@
                 "guid": "{FFF65E99-3A75-5734-BC40-E7D6796B1789}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/defaults/defaultfallback.png.streamingimage"
         },
         {
@@ -37,7 +37,7 @@
                 "guid": "{BBA1FB65-974C-55D2-B549-806FA42A2115}",
                 "subId": 1000
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "textures/defaults/missing.png.streamingimage"
         }
     ]

--- a/Gems/AtomLyIntegration/AtomFont/Assets/seedList.seed
+++ b/Gems/AtomLyIntegration/AtomFont/Assets/seedList.seed
@@ -7,7 +7,7 @@
             "assetId": {
                 "guid": "{400C0F36-1069-5F0E-8E55-87123BA075CD}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/simpletextured.azshader"
         }
     ]

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Assets/seedList.seed
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Assets/seedList.seed
@@ -7,7 +7,7 @@
             "assetId": {
                 "guid": "{7B093FA3-A834-5061-9ADD-C6DCA97A4B60}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/texturedicon.azshader"
         }
     ]

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/seedList.seed
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/seedList.seed
@@ -7,7 +7,7 @@
             "assetId": {
                 "guid": "{4F3761EF-E279-5FDD-98C3-EF90F924FBAC}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "lightingpresets/thumbnail.lightingpreset.azasset"
         },
         {
@@ -15,28 +15,28 @@
                 "guid": "{6DE0E9A8-A1C7-5D0F-9407-4E627C1F223C}",
                 "subId": 284780167
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "models/sphere.azmodel"
         },
         {
             "assetId": {
                 "guid": "{CF91AE08-8FD5-538B-A5F2-427DFA9D5E1C}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "materials/basic_grey.azmaterial"
         },
         {
             "assetId": {
                 "guid": "{DCE9A5B2-1907-5A0D-8A96-5ABF608D103B}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/mainpipeline.pass"
         },
         {
             "assetId": {
                 "guid": "{6B01EDAB-1951-5588-AB7B-DF2F703950D4}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/smaaconfiguration.azasset"
         }
     ]

--- a/Gems/DiffuseProbeGrid/Assets/seedList.seed
+++ b/Gems/DiffuseProbeGrid/Assets/seedList.seed
@@ -7,140 +7,140 @@
             "assetId": {
                 "guid": "{34E20A18-CB2E-5D93-84CF-C2B9E144DA75}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridblenddistance.azshader"
         },
         {
             "assetId": {
                 "guid": "{F70A2001-CC2C-5DFE-BC87-B98A4E0E57EB}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridblendirradiance.azshader"
         },
         {
             "assetId": {
                 "guid": "{44260D05-99D8-5A86-83E7-B7C5EC48F297}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridborderupdaterow.azshader"
         },
         {
             "assetId": {
                 "guid": "{F60AFD1E-1CED-5E33-930E-17DB4EAA1F81}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridborderupdatecolumn.azshader"
         },
         {
             "assetId": {
                 "guid": "{7547FD2E-1630-58B1-9293-F4C9F33E0D72}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridclassification.azshader"
         },
         {
             "assetId": {
                 "guid": "{5A28BC26-22C8-5DC2-870B-3EE03A6DC723}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridrender.azshader"
         },
         {
             "assetId": {
                 "guid": "{55BDC206-9859-52D8-AE08-457F5664F509}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracing.azshader"
         },
         {
             "assetId": {
                 "guid": "{3E4941A5-56BF-5ECD-95B3-64E6D6803159}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracingclosesthit.azshader"
         },
         {
             "assetId": {
                 "guid": "{EB5538D4-1028-534C-9FC0-1421E0926E31}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracingmiss.azshader"
         },
         {
             "assetId": {
                 "guid": "{582D6038-5953-585B-8840-CA5B993B5B08}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridrelocation.azshader"
         },
         {
             "assetId": {
                 "guid": "{E1A185DF-DC80-58B1-B77B-CE8BEDB61D3B}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridupdatepassrequest.azasset"
         },
         {
             "assetId": {
                 "guid": "{522C32A8-CB02-51CE-B450-C4B8E38C084D}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridrenderpassrequest.azasset"
         },
         {
             "assetId": {
                 "guid": "{B428ED95-3E5F-50D5-98A7-A2AECEAA1898}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridvisualizationpassrequest.azasset"
         },
         {
             "assetId": {
                 "guid": "{A6F9D127-D963-5D78-B19F-A31E73C5C2B5}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridtemplates.azasset"
         },
         {
             "assetId": {
                 "guid": "{49D6CA83-7AE4-5BF5-9428-636B9EB6DCC7}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridprepare.azshader"
         },
         {
             "assetId": {
                 "guid": "{D20ADC05-ECF9-5305-93FC-F0A88AB2072D}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridquery.azshader"
         },
         {
             "assetId": {
                 "guid": "{B3B664B6-4340-5A35-9A67-DC00A5361D62}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationprepare.azshader"
         },
         {
             "assetId": {
                 "guid": "{82253586-BC83-5289-8E14-4DF83E7032D2}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridscreenspacereflectionsquerypassrequest.azasset"
         },
         {
             "assetId": {
                 "guid": "{2AAC574D-E80D-5D41-BE12-32B192306FD1}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridqueryfullscreenwithalbedo.azshader"
         },
         {
             "assetId": {
                 "guid": "{8BC56BD7-1477-5396-A410-D8A36D4DDB25}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridpreparepassrequest.azasset"
         }
     ]

--- a/Gems/LyShine/Assets/seedList.seed
+++ b/Gems/LyShine/Assets/seedList.seed
@@ -22,7 +22,7 @@
             "assetId": {
                 "guid": "{C7BCB5E8-3E6B-5531-A3D9-CEE93E103F69}"
             },
-            "platformFlags": 3,
+            "platformFlags": 255,
             "pathHint": "lyshine/shaders/lyshineui.azshader"
         },
         {


### PR DESCRIPTION
## What does this PR do?
This fixes an issue where Pak files are not being loaded when the pak priority indicates that pak files should be included during asset loading in an Android APK File.

**Root Cause**
- Locating the assets directory early on relied on the location of 'engine.json', which is valid for LOOSE asset mode. But for APKs that only contain PAK files, this file is not present, so it will be unable to locate the assets folder.
- When searching for the @product@/*.pak, the archive system normalizes the a 'current path' to '.', which is valid for normal file systems. However, using the Android Asset Manager's list method, it does not recognize this as the current folder.
- Even after the paks are finally loaded, a lot of the current seedlist files did not have android enabled as a platform, so they were not part of the final bundle.
-
**Fix Details**
- Update AzCore::Android::Utils::FindAssetsDirectory to use both 'engine.json' and 'engine_android.pak' as marker files to locate the asset folder
- Update call to `GetFilesAndDirectoriesInPath` to handle path '.', which is supported by local file systems, but is not recognized by the android asset manager's [list](https://developer.android.com/reference/android/content/res/AssetManager#list(java.lang.String)) method.
- Enable all the assets in the seedlist files for O3DE to turn on all platforms by default.

## How was this PR tested?

Was able to confirm through logcat for android that assets inside the APK were located and loaded for the newpaperdelivery game.


