### PR TITLE
Fix hard-coded multi sample settings for UI renderer

### DIFF
--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -117,6 +117,10 @@ AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportCon
         AZ::RPI::GetRenderPipelineDescriptorFromAsset(pipelineAssetPath, AZStd::string::format("_%i", viewportContext->GetId()));
     AZ_Assert(renderPipelineDesc.has_value(), "Invalid render pipeline descriptor from asset %s", pipelineAssetPath);
 
+    const AZ::RHI::MultisampleState multiSampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
+    renderPipelineDesc.value().m_renderSettings.m_multisampleState = multiSampleState;
+    AZ_Printf("UiRenderer", "UI renderer starting with multi sample %d", multiSampleState.m_samples);
+
     auto renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(renderPipelineDesc.value(), *viewportContext->GetWindowContext().get());
     atomScene->AddRenderPipeline(renderPipeline);
 


### PR DESCRIPTION
## What does this PR do?

This is similar to #17218, after that PR, I happen to found that the UI editor has the same issue. This PR fixes #17295, i.e., the same hard-coded multi sample setting in the UI renderer.

When the main editor starts with pipelines with multi sample 1 (e.g., low end pipeline etc.), and launch the UI editor, the UI editor by default hard-coded to read the multi sample from main pipeline, but the shaders are compiled with multi sample 1, then we will get a lot of console errors complaining about the mismatch multi sample between pass and shaders.

This time I also checked the other editors in the engine (I checked  script canvas, track view editor, material editor and material canvas editor), it seems that these editors are not starting any render pipeline or they are already handling the multi sample setting well [like this](https://github.com/o3de/o3de/blob/e92fd03ac3ce808c33dc14afd3bff8e50089f4a1/Gems/Atom/Tools/AtomToolsFramework/Code/Source/EntityPreviewViewport/EntityPreviewViewportScene.cpp#L151) except for the UI renderer, now this PR fixes the UI editor.

## How was this PR tested?

Self tested in Windows Server 2019 edition.
