### PR TITLE
[Smc] variantlist invariants verifier feature

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -581,6 +581,17 @@ namespace ShaderManagementConsole
 
     bool ShaderManagementConsoleDocument::SaveSourceData()
     {
+        auto verification = Verify();
+        //ErrorMessageBoxesForDocumentVerification(verification); // can't display message boxes from the document
+        if (!verification.AllGood())
+        {
+            AZ_TracePrintf("ShaderManagementConsoleDocument", "Verification reported: redundant variants: %s | stable id jumps: %s | root-like found: %s",
+                           verification.m_hasRedundantVariants ? "yes" : "no",
+                           verification.m_hasStableIdJump ? "yes" : "no",
+                           verification.m_hasRootLike ? "yes" : "no");
+            return SaveFailed();
+        }
+
         if (!AZ::RPI::JsonUtils::SaveObjectToFile(m_savePathNormalized, m_shaderVariantListSourceData))
         {
             AZ_Error("ShaderManagementConsoleDocument", false, "Document could not be saved: '%s'.", m_savePathNormalized.c_str());

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -187,49 +187,64 @@ namespace ShaderManagementConsole
         SetShaderVariantListSourceData(newSourceData);
     }
 
+    enum InfoConstness {ConstInfo, MutableInfo};
+
+    template<InfoConstness Constness> // configure whether the m_info field is const or not
+    struct VariantCompacterKey
+    {
+        using VariantInfo = AZ::RPI::ShaderVariantListSourceData::VariantInfo;
+        using VariantInfo_MaybeConst = AZStd::conditional_t<Constness == ConstInfo, AZStd::add_const_t<VariantInfo>, VariantInfo>;
+
+        VariantInfo_MaybeConst* m_info{};
+        size_t m_hash{};
+
+        bool operator==(const VariantCompacterKey& rhs) const
+        {
+            return m_hash == rhs.m_hash && m_info->m_options == rhs.m_info->m_options; // first part of expression for short circuit
+        }
+
+        static VariantCompacterKey Make(VariantInfo_MaybeConst* source)
+        {
+            VariantCompacterKey newKey;
+            newKey.m_info = source;
+            newKey.m_hash = AZ::ShaderBuilder::HashedVariantInfoSourceData::HashCombineShaderOptionValues(0, source->m_options);
+            return newKey;
+        }
+    };
+
+    template<InfoConstness Constness>
+    struct KeyHasher
+    {
+        std::size_t operator()(const VariantCompacterKey<Constness>& key) const
+        {
+            return key.m_hash;
+        }
+    };
+
+    template<InfoConstness Constness, typename VariantInfoIterable>
+    auto CompactVariants(VariantInfoIterable& variants)
+    {
+        // Use a set for uniquification process
+        AZStd::unordered_set<VariantCompacterKey<Constness>, KeyHasher<Constness>> compacter;
+        compacter.reserve(variants.size());
+        for (auto& variantInfo : variants)
+        {
+            compacter.insert(VariantCompacterKey<Constness>::Make(&variantInfo));
+        }
+        return compacter;
+    }
+
     void ShaderManagementConsoleDocument::DefragmentVariantList()
     {
-        struct VariantCompacterKey
-        {
-            AZ::RPI::ShaderVariantListSourceData::VariantInfo* m_info{};
-            size_t m_hash{};
-
-            bool operator==(const VariantCompacterKey& rhs) const
-            {
-                return m_hash == rhs.m_hash && m_info->m_options == rhs.m_info->m_options;  // first part of expression for short circuit
-            }
-
-            static VariantCompacterKey Make(AZ::RPI::ShaderVariantListSourceData::VariantInfo* source)
-            {
-                VariantCompacterKey newKey;
-                newKey.m_info = source;
-                newKey.m_hash = AZ::ShaderBuilder::HashedVariantInfoSourceData::HashCombineShaderOptionValues(0, source->m_options);
-                return newKey;
-            }
-        };
-
-        struct KeyHasher
-        {
-            std::size_t operator()(const VariantCompacterKey& key) const
-            {
-                return key.m_hash;
-            }
-        };
-        // Use a set for uniquification process
-        AZStd::unordered_set<VariantCompacterKey, KeyHasher> compacter;
-        compacter.reserve(m_shaderVariantListSourceData.m_shaderVariants.size());
-        for (auto& variantInfo : m_shaderVariantListSourceData.m_shaderVariants)
-        {
-            compacter.insert(VariantCompacterKey::Make(&variantInfo));
-        }
+        auto compactVariants = CompactVariants<MutableInfo>(m_shaderVariantListSourceData.m_shaderVariants);
         // Prepare a whole new source data
         AZ::RPI::ShaderVariantListSourceData newSourceData;
         // partial copy
         newSourceData.m_materialOptionsHint = m_shaderVariantListSourceData.m_materialOptionsHint;
         newSourceData.m_shaderFilePath = m_shaderVariantListSourceData.m_shaderFilePath;
         // variants are prepared from the compacted set
-        newSourceData.m_shaderVariants.reserve(compacter.size());
-        for (VariantCompacterKey& compactedKey : compacter)
+        newSourceData.m_shaderVariants.reserve(compactVariants.size());
+        for (VariantCompacterKey<MutableInfo>& compactedKey : compactVariants)
         {
             newSourceData.m_shaderVariants.emplace_back(std::move(*compactedKey.m_info));
         }
@@ -385,6 +400,32 @@ namespace ShaderManagementConsole
         }
         AZ_Error("ShaderManagementConsoleDocument", false, "GetShaderOptionDescriptor no asset ready");
         return m_invalidDescriptor;
+    }
+
+    DocumentVerificationResult ShaderManagementConsoleDocument::Verify() const
+    {
+        // verify compactness: (i.e. no duplicates)
+        auto compactVariants = CompactVariants<ConstInfo>(m_shaderVariantListSourceData.m_shaderVariants);
+        if (compactVariants.size() < m_shaderVariantListSourceData.m_shaderVariants.size())
+        {
+            return {/*m_hasRedundantVariants*/true};
+        }
+        // verify that the stableIDs "space" is dense:
+        AZ::u32 check = 1;
+        for (auto& variantInfo : m_shaderVariantListSourceData.m_shaderVariants)
+        {
+            if (variantInfo.m_stableId != check)
+            {
+                return {/*m_hasRedundantVariants*/false, /*m_hasRootLike*/false, /*m_rootLikeStableId*/0, /*m_hasStableIdJump*/true, /*faultyId*/variantInfo.m_stableId};
+            }
+            ++check;
+            // while we're looping, we can also check that no variant is root-like:
+            if (variantInfo.m_options.empty())
+            {
+                return {/*m_hasRedundantVariants*/false, /*m_hasRootLike*/true, /*m_rootLikeStableId*/variantInfo.m_stableId};
+            }
+        }
+        return {}; // no issue
     }
 
     AtomToolsFramework::DocumentTypeInfo ShaderManagementConsoleDocument::BuildDocumentTypeInfo()

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -246,7 +246,10 @@ namespace ShaderManagementConsole
         newSourceData.m_shaderVariants.reserve(compactVariants.size());
         for (VariantCompacterKey<MutableInfo>& compactedKey : compactVariants)
         {
-            newSourceData.m_shaderVariants.emplace_back(std::move(*compactedKey.m_info));
+            if (!compactedKey.m_info->m_options.empty()) // don't preserve root-like variants
+            {
+                newSourceData.m_shaderVariants.emplace_back(std::move(*compactedKey.m_info));
+            }
         }
         // sort by old stable id
         AZStd::sort(newSourceData.m_shaderVariants.begin(),
@@ -582,13 +585,13 @@ namespace ShaderManagementConsole
     bool ShaderManagementConsoleDocument::SaveSourceData()
     {
         auto verification = Verify();
-        //ErrorMessageBoxesForDocumentVerification(verification); // can't display message boxes from the document
         if (!verification.AllGood())
         {
-            AZ_TracePrintf("ShaderManagementConsoleDocument", "Verification reported: redundant variants: %s | stable id jumps: %s | root-like found: %s",
-                           verification.m_hasRedundantVariants ? "yes" : "no",
-                           verification.m_hasStableIdJump ? "yes" : "no",
-                           verification.m_hasRootLike ? "yes" : "no");
+            // can't display message boxes from the document, use a trace:
+            AZ_TracePrintf("ShaderManagementConsoleDocument", "Verification reported: %s%s%s",
+                           verification.m_hasRedundantVariants ? "Redundant variants. " : "",
+                           verification.m_hasRootLike ? "Root-like found. " : "",
+                           verification.m_hasStableIdJump ? "Stable id jumps." : "");
             return SaveFailed();
         }
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.h
@@ -60,6 +60,7 @@ namespace ShaderManagementConsole
         const AZ::RPI::ShaderVariantListSourceData& GetShaderVariantListSourceData() const override;
         size_t GetShaderOptionDescriptorCount() const override;
         const AZ::RPI::ShaderOptionDescriptor& GetShaderOptionDescriptor(size_t index) const override;
+        DocumentVerificationResult Verify() const override;
 
     private:
         // AtomToolsFramework::AtomToolsDocument overrides...

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocumentRequestBus.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocumentRequestBus.h
@@ -15,6 +15,17 @@
 
 namespace ShaderManagementConsole
 {
+    struct DocumentVerificationResult
+    {
+        bool AllGood() const { return !m_hasRedundantVariants && !m_hasRootLike && !m_hasStableIdJump; }
+
+        bool m_hasRedundantVariants = false;
+        bool m_hasRootLike = false;
+        AZ::u32 m_rootLikeStableId{};
+        bool m_hasStableIdJump = false;
+        AZ::u32 faultyId{};
+    };
+
     class ShaderManagementConsoleDocumentRequests : public AZ::EBusTraits
     {
     public:
@@ -66,6 +77,9 @@ namespace ShaderManagementConsole
         //! Get the shader option descriptor from the shader asset.
         //! Note that the shader asset can contain more descriptors than are stored in the shader variant list source data.
         virtual const AZ::RPI::ShaderOptionDescriptor& GetShaderOptionDescriptor(size_t index) const = 0;
+
+        //! Verify before save that some guarantees are respected (like contiguous stableids)
+        virtual DocumentVerificationResult Verify() const = 0;
     };
 
     using ShaderManagementConsoleDocumentRequestBus = AZ::EBus<ShaderManagementConsoleDocumentRequests>;

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -164,6 +164,13 @@ namespace ShaderManagementConsole
             });
         m_menuFile->insertAction(m_menuFile->actions().back(), verifyAction);
 
+        QAction* compactAction = new QAction(tr("Run compaction (undoable)"), m_menuFile);
+        QObject::connect(verifyAction, &QAction::triggered, this, [this](){
+            ShaderManagementConsoleDocumentRequestBus::Event(
+                GetCurrentDocumentId(), &ShaderManagementConsoleDocumentRequestBus::Events::DefragmentVariantList);
+        });
+        m_menuFile->insertAction(m_menuFile->actions().back(), compactAction);
+
         // Add statistics button
         QAction* action = new QAction(tr("Generate Shader Variant Statistics..."), m_menuFile);
         QObject::connect(action, &QAction::triggered, this, &ShaderManagementConsoleWindow::GenerateStatisticView);

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -27,6 +27,7 @@
 #include <QUrl>
 #include <QWindow>
 #include <QMessageBox>
+#include <QMenuBar>
 
 namespace ShaderManagementConsole
 {
@@ -122,6 +123,37 @@ namespace ShaderManagementConsole
     void ShaderManagementConsoleWindow::CreateMenus(QMenuBar* menuBar)
     {
         Base::CreateMenus(menuBar);
+
+        QAction* verifyAction = new QAction(tr("Verify Variantlist invariants"), m_menuFile);
+        QObject::connect(verifyAction, &QAction::triggered, this, [this](){
+            DocumentVerificationResult verification;
+            ShaderManagementConsoleDocumentRequestBus::EventResult(
+                verification, GetCurrentDocumentId(), &ShaderManagementConsoleDocumentRequestBus::Events::Verify);
+            if (verification.m_hasRedundantVariants)
+            {
+                QMessageBox::critical(
+                    this, tr("QC fail"), tr("Some variants are redundant. Use the recompaction feature before saving."), QMessageBox::Ok);
+            }
+            if (verification.m_hasRootLike)
+            {
+                QMessageBox::critical(
+                    this,
+                    tr("QC fail"),
+                    tr("Variant with id %1 is root-like (all options dynamic). Remove it or use recompaction feature before saving.").arg(verification.m_rootLikeStableId),
+                    QMessageBox::Ok);
+            }
+            if (verification.m_hasStableIdJump)
+            {
+                QMessageBox::critical(
+                    this, tr("QC fail"), tr("Stable id %1 isn't compact. Use the recompaction feature before saving.").arg(verification.faultyId), QMessageBox::Ok);
+            }
+            if (verification.AllGood())
+            {
+                QMessageBox::information(
+                    this, tr("QC pass"), tr("All good"), QMessageBox::Ok);
+            }
+            });
+        m_menuFile->insertAction(m_menuFile->actions().back(), verifyAction);
 
         // Add statistics button
         QAction* action = new QAction(tr("Generate Shader Variant Statistics..."), m_menuFile);

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -120,6 +120,32 @@ namespace ShaderManagementConsole
         return result.Native();
     }
 
+    void ShaderManagementConsoleWindow::ErrorMessageBoxesForDocumentVerification(const DocumentVerificationResult& verification)
+    {
+        if (verification.m_hasRedundantVariants)
+        {
+            QMessageBox::critical(
+                this, tr("QC fail"), tr("Some variants are redundant. Use the recompaction feature before saving."), QMessageBox::Ok);
+        }
+        if (verification.m_hasRootLike)
+        {
+            QMessageBox::critical(
+                this,
+                tr("QC fail"),
+                tr("Variant with id %1 is root-like (all options dynamic). Remove it or use recompaction feature before saving.")
+                    .arg(verification.m_rootLikeStableId),
+                QMessageBox::Ok);
+        }
+        if (verification.m_hasStableIdJump)
+        {
+            QMessageBox::critical(
+                this,
+                tr("QC fail"),
+                tr("Stable id %1 isn't compact. Use the recompaction feature before saving.").arg(verification.faultyId),
+                QMessageBox::Ok);
+        }
+    }
+
     void ShaderManagementConsoleWindow::CreateMenus(QMenuBar* menuBar)
     {
         Base::CreateMenus(menuBar);
@@ -129,24 +155,7 @@ namespace ShaderManagementConsole
             DocumentVerificationResult verification;
             ShaderManagementConsoleDocumentRequestBus::EventResult(
                 verification, GetCurrentDocumentId(), &ShaderManagementConsoleDocumentRequestBus::Events::Verify);
-            if (verification.m_hasRedundantVariants)
-            {
-                QMessageBox::critical(
-                    this, tr("QC fail"), tr("Some variants are redundant. Use the recompaction feature before saving."), QMessageBox::Ok);
-            }
-            if (verification.m_hasRootLike)
-            {
-                QMessageBox::critical(
-                    this,
-                    tr("QC fail"),
-                    tr("Variant with id %1 is root-like (all options dynamic). Remove it or use recompaction feature before saving.").arg(verification.m_rootLikeStableId),
-                    QMessageBox::Ok);
-            }
-            if (verification.m_hasStableIdJump)
-            {
-                QMessageBox::critical(
-                    this, tr("QC fail"), tr("Stable id %1 isn't compact. Use the recompaction feature before saving.").arg(verification.faultyId), QMessageBox::Ok);
-            }
+            ErrorMessageBoxesForDocumentVerification(verification);
             if (verification.AllGood())
             {
                 QMessageBox::information(

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -13,6 +13,8 @@
 
 namespace ShaderManagementConsole
 {
+    struct DocumentVerificationResult;
+
     //! ShaderManagementConsoleWindow is the main class. Its responsibility is limited to initializing and connecting
     //! its panels, managing selection of assets, and performing high-level actions like saving. It contains...
     class ShaderManagementConsoleWindow : public AtomToolsFramework::AtomToolsDocumentMainWindow

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -39,6 +39,8 @@ namespace ShaderManagementConsole
 
         void ShowContextMenu(const QPoint& pos);
 
+        void ErrorMessageBoxesForDocumentVerification(const DocumentVerificationResult& verification);
+
     private:
         void closeEvent(QCloseEvent* closeEvent) override;
 


### PR DESCRIPTION
This is a check system that verifies a few conditions before allowing a variantlist file to be saved.
This way we enforce a few invariants that are helpful, even possibly necessary, for correct runtime behavior.
those are:

- no duplicated variants (same option choices on multiple rows)
- no root-like variants (**that's the same as a duplicate**, but the root is hidden in a variantlist, it's "inherited from the system" (in a way) but present)
- no jumps in stable id count space (I think the variant selector algorithm relies on compactness, but not certain).

Those are reflected in a new aggregate struct called DocumentVerificationResult, and the function is callable on SMCDocumentRequestsBus.

In the SMCDocument.cpp file there is a small refactoring works that extracts the hasher/variantkey structures that were function local to the defragmenter feature before. Now both verify & defrag share the code. It looks like it's new in the diff but it is not, it's just migrated a bit upward in the file. (+ Const configuration in an enum template that is new from this PR)

There is a direct call to the verification feature in the smcdocument::save function. I couldn't easily engineer a way to request the smcwindow to show up messagebox dialogs, so the report is conveyed through a "save failure" + formatted trace.

I could verify partially the correction of this change because it was working prior to a merge with latest, but now the SMC doesn't really work anymore because of an infinite busy work under OnIdle message pump doing asset filter string compares.