### PR TITLE
Add missing m_preferredTabOrder values

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Behaviors/AnimationGroup.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/AnimationGroup.h
@@ -49,7 +49,7 @@ namespace AZ
 
                 bool SceneHasAnimationGroup(const Containers::Scene& scene) const;
 
-                static const int s_animationsPreferredTabOrder;
+                static constexpr int s_animationsPreferredTabOrder{ 2 };
             };
         } // namespace Behaviors
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsAnimationGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsAnimationGroup.cpp
@@ -27,8 +27,6 @@ namespace AZ
     {
         namespace Behaviors
         {
-            const int AnimationGroup::s_animationsPreferredTabOrder = 2;
-
             void AnimationGroup::Activate()
             {       
             }

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsMeshGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsMeshGroup.cpp
@@ -30,8 +30,6 @@ namespace AZ
     {
         namespace Behaviors
         {
-            const int MeshGroup::s_meshGroupPreferredTabOrder = 0;
-
             void MeshGroup::Activate()
             {
                 Events::ManifestMetaInfoBus::Handler::BusConnect();

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkeletonGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkeletonGroup.cpp
@@ -28,8 +28,6 @@ namespace AZ
     {
         namespace Behaviors
         {
-            const int SkeletonGroup::s_rigsPreferredTabOrder = 1;
-
             void SkeletonGroup::Activate()
             {
             }

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkinGroup.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/BehaviorsSkinGroup.cpp
@@ -30,7 +30,6 @@ namespace AZ
         {
             const char* SkinGroup::s_skinVirtualTypeName = "Skin";
             Crc32 SkinGroup::s_skinVirtualType = AZ_CRC(SkinGroup::s_skinVirtualTypeName, 0x0279681e);
-            const int SkinGroup::s_rigsPreferredTabOrder = 1;
 
             void SkinGroup::Activate()
             {

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/MeshGroup.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/MeshGroup.h
@@ -47,7 +47,7 @@ namespace AZ
 
                 bool SceneHasMeshGroup(const Containers::Scene& scene) const;
 
-                static const int s_meshGroupPreferredTabOrder;
+                static constexpr int s_meshGroupPreferredTabOrder{ 0 };
             };
         } // Behaviors
     } // SceneAPI

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/SkeletonGroup.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/SkeletonGroup.h
@@ -46,8 +46,8 @@ namespace AZ
                 Events::ProcessingResult UpdateSkeletonGroups(Containers::Scene& scene) const;
 
                 bool SceneHasSkeletonGroup(const Containers::Scene& scene) const;
-                
-                static const int s_rigsPreferredTabOrder;
+
+                static constexpr int s_rigsPreferredTabOrder{ 1 };
                 bool m_isDefaultConstructing{ false };
             };
         } // namespace Behaviors

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/SkinGroup.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/SkinGroup.h
@@ -58,7 +58,7 @@ namespace AZ
 
                 bool SceneHasSkinGroup(const Containers::Scene& scene) const;
 
-                static const int s_rigsPreferredTabOrder;
+                static constexpr int s_rigsPreferredTabOrder{ 1 };
             };
         } // namespace Behaviors
     } // namespace SceneAPI

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
@@ -43,8 +43,6 @@ namespace EMotionFX
     {
         namespace Behavior
         {
-            const int ActorGroupBehavior::s_animationsPreferredTabOrder = 3;
-
             void ActorGroupBehavior::Reflect(AZ::ReflectContext* context)
             {
                 Group::ActorGroup::Reflect(context);
@@ -81,7 +79,7 @@ namespace EMotionFX
                 const bool hasRequiredData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBoneData>(scene, false);
                 if (SceneHasActorGroup(scene) || hasRequiredData)
                 {
-                    categories.emplace_back("Actors", Group::ActorGroup::TYPEINFO_Uuid(), s_animationsPreferredTabOrder);
+                    categories.emplace_back("Actors", Group::ActorGroup::TYPEINFO_Uuid(), s_actorsPreferredTabOrder);
                 }
             }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.h
@@ -58,7 +58,7 @@ namespace EMotionFX
 
                 bool SceneHasActorGroup(const AZ::SceneAPI::Containers::Scene& scene) const;
 
-                static const int s_animationsPreferredTabOrder;
+                static constexpr int s_actorsPreferredTabOrder{ 3 };
             };
         } // Behavior
     } // Pipeline

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/MotionGroupBehavior.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/MotionGroupBehavior.cpp
@@ -32,8 +32,6 @@ namespace EMotionFX
     {
         namespace Behavior
         {
-            const int MotionGroupBehavior::s_preferredTabOrder = 2;
-
             void MotionGroupBehavior::Reflect(AZ::ReflectContext* context)
             {
                 Group::MotionGroup::Reflect(context);
@@ -67,7 +65,7 @@ namespace EMotionFX
             {
                 if (SceneHasMotionGroup(scene) || AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IAnimationData>(scene, false))
                 {
-                    categories.emplace_back("Motions", Group::MotionGroup::TYPEINFO_Uuid(), s_preferredTabOrder);
+                    categories.emplace_back("Motions", Group::MotionGroup::TYPEINFO_Uuid(), s_motionGroupPreferredTabOrder);
                 }
             }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/MotionGroupBehavior.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/MotionGroupBehavior.h
@@ -53,7 +53,7 @@ namespace EMotionFX
 
                 bool SceneHasMotionGroup(const AZ::SceneAPI::Containers::Scene& scene) const;
 
-                static const int s_preferredTabOrder;
+                static constexpr int s_motionGroupPreferredTabOrder{ 2 };
             };
         } // Behavior
     } // Pipeline

--- a/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.cpp
@@ -59,7 +59,7 @@ namespace PhysX
         {
             if (AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IMeshData>(scene, false))
             {
-                categories.emplace_back("PhysX", MeshGroup::TYPEINFO_Uuid());
+                categories.emplace_back("PhysX", MeshGroup::TYPEINFO_Uuid(), s_meshBehaviorPreferredTabOrder);
             }
         }
 

--- a/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshBehavior.h
@@ -50,6 +50,8 @@ namespace PhysX
         private:
             AZ::SceneAPI::Events::ProcessingResult BuildDefault(AZ::SceneAPI::Containers::Scene& scene) const;
             AZ::SceneAPI::Events::ProcessingResult UpdatePhysXMeshGroups(AZ::SceneAPI::Containers::Scene& scene) const;
+
+            static constexpr int s_meshBehaviorPreferredTabOrder{ 5 };
         };
     } // Pipeline
 } // PhysX

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -126,7 +126,7 @@ namespace AZ::SceneAPI::Behaviors
 
     void PrefabGroupBehavior::ExportEventHandler::GetCategoryAssignments(CategoryRegistrationList& categories, const Containers::Scene&)
     {
-        categories.emplace_back("Procedural Prefab", SceneData::PrefabGroup::TYPEINFO_Uuid());
+        categories.emplace_back("Procedural Prefab", SceneData::PrefabGroup::TYPEINFO_Uuid(), s_prefabGroupPreferredTabOrder);
     }
 
     Events::ProcessingResult PrefabGroupBehavior::ExportEventHandler::UpdateSceneForPrefabGroup(

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.h
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.h
@@ -59,6 +59,8 @@ namespace AZ::SceneAPI::Behaviors
 
         struct ExportEventHandler;
         AZStd::shared_ptr<ExportEventHandler> m_exportEventHandler;
+
+        static constexpr int s_prefabGroupPreferredTabOrder{ 6 };
     };
 }
 

--- a/Gems/SceneLoggingExample/Code/Behaviors/LoggingGroupBehavior.cpp
+++ b/Gems/SceneLoggingExample/Code/Behaviors/LoggingGroupBehavior.cpp
@@ -61,7 +61,7 @@ namespace SceneLoggingExample
     // users from adding groups that have no effect.
     void LoggingGroupBehavior::GetCategoryAssignments(CategoryRegistrationList& categories, [[maybe_unused]] const AZ::SceneAPI::Containers::Scene& scene)
     {
-        categories.emplace_back("Logging", LoggingGroup::TYPEINFO_Uuid());
+        categories.emplace_back("Logging", LoggingGroup::TYPEINFO_Uuid(), s_loggingPreferredTabOrder);
     }
 
     // When a scene is loaded for the first time (for example, from an .fbx file), there won't be a manifest (.assetinfo file).

--- a/Gems/SceneLoggingExample/Code/Behaviors/LoggingGroupBehavior.h
+++ b/Gems/SceneLoggingExample/Code/Behaviors/LoggingGroupBehavior.h
@@ -40,5 +40,8 @@ namespace SceneLoggingExample
         {
             result = "LoggingGroupBehavior";
         }
+
+    private:
+        static constexpr int s_loggingPreferredTabOrder{ 10 };
     };
 } // namespace SceneLoggingExample


### PR DESCRIPTION
## What does this PR do?


This PR fixes some missing `m_preferredOrder` values which are used for the order of the tabs in the Asset Inspector window:
![image](https://github.com/o3de/o3de/assets/113582781/a00c6687-9341-4371-bee9-3ba4e55d1bf6)
The following values are now used (the ones marked with * were added by me), I did not resolve existing duplicate values:
* MeshGroup: 0
* SkeletonGroup: 1
* SkinGroup: 1
* AnimationGroup: 2
* MotionGroup: 2
* ActorGroup: 3
* MeshBehavior (PhysX): 5 *
* PrefabGroupBehavior: 6 *
* LoggingBehavior: 10 *

I chose 5 and 6 for Mesh/PrefabGroup behaviour since they used to use INT_MAX and were displayed to the right of the ones with smaller numbers, so their order remains unchanged. Without this change, all entries which dont explicitly specify the tab order (MeshBehavior, PrefabGroupBehavior, LoggingBehavior) are shown in implementation-specific order, since they are sorted with `AZStd::sort` with `m_preferredOrder` as sort criteria.
(The reason for this PR is that I want to be able to add a new tab from an external gem to the right of the existing tabs, which is not be possible if INT_MAX is already used as sort index.)

## How was this PR tested?

Looking at the Inspector before and after the change, the order of tabs was unchanged.
