### PR TITLE
Update lighting channel config ui to remove extra groups and add labels each channel

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
@@ -22,14 +22,18 @@ namespace AZ
         {
             AZ_TYPE_INFO(LightingChannelConfiguration, "{7FFD6D01-BABE-FE35-612F-63A30925E5F7}");
 
-            AZStd::array<bool, LightingChannelsCount> m_lightingChannelFlags {true, false, false, false, false};
+            static void Reflect(AZ::ReflectContext* context);
 
             LightingChannelConfiguration() = default;
 
-            static void Reflect(AZ::ReflectContext* context);
+            void SetLightingChannelMask(const uint32_t mask);
 
             uint32_t GetLightingChannelMask() const;
-            void SetLightingChannelMask(const uint32_t mask);
+
+            AZStd::array<bool, LightingChannelsCount> m_lightingChannelFlags{ true, false, false, false, false };
+
+        private:
+            AZStd::string GetLabelForIndex(int index) const;
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
@@ -26,14 +26,27 @@ namespace AZ
                 
                 if (auto* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<AZ::Render::LightingChannelConfiguration>("Lighting Channels Config", "")
+                    editContext->Class<AZ::Render::LightingChannelConfiguration>("Lighting Channel Config", "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                            ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &AZ::Render::LightingChannelConfiguration::m_lightingChannelFlags,
-                                        "Lighting Channels", "Lights can only shine the objects in the same lighting channel with the light.")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
-                    ;
+                            "Lighting Channels", "Lights can only shine the objects in the same lighting channel with the light.")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                            ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                            ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
+                            ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                            ->Attribute(AZ::Edit::Attributes::IndexedChildNameLabelOverride, &LightingChannelConfiguration::GetLabelForIndex)
+                     ;
                 }
+            }
+        }
+
+        void LightingChannelConfiguration::SetLightingChannelMask(const uint32_t mask)
+        {
+            for (uint32_t index = 0; index < m_lightingChannelFlags.size(); ++index)
+            {
+                m_lightingChannelFlags[index] = (static_cast<bool>(mask >> index) & 0x01);
             }
         }
 
@@ -47,12 +60,9 @@ namespace AZ
             return mask;
         }
 
-        void LightingChannelConfiguration::SetLightingChannelMask(const uint32_t mask)
+        AZStd::string LightingChannelConfiguration::GetLabelForIndex(int index) const
         {
-            for (uint32_t index = 0; index < m_lightingChannelFlags.size(); ++index)
-            {
-                m_lightingChannelFlags[index] = (static_cast<bool>(mask >> index) & 0x01);
-            }
+            return AZStd::string::format("Lighting Channel %d", index);
         }
-    }
-}
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -102,11 +102,8 @@ namespace AZ
                             ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsAttenuationRadiusModeAutomatic)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)
                         
-                        ->ClassElement(Edit::ClassElements::Group, "Lighting Channels")
-                        ->DataElement(0, &AreaLightComponentConfig::m_lightingChannelConfig, "Lighting channel configuration", "")
-                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                            ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &AreaLightComponentConfig::m_lightingChannelConfig, "Lighting Channels", "")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
 
                         ->ClassElement(Edit::ClassElements::Group, "Shutters")
                             ->Attribute(Edit::Attributes::AutoExpand, true)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -76,11 +76,8 @@ namespace AZ
                             ->Attribute(Edit::Attributes::SoftMax, 1.0f)
                             ->Attribute(Edit::Attributes::Suffix, " deg")
                             
-                        ->ClassElement(Edit::ClassElements::Group, "Lighting Channels")
-                            ->DataElement(0, &DirectionalLightComponentConfig::m_lightingChannelConfig, "Lighting channel configuration", "")
-                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                            ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &DirectionalLightComponentConfig::m_lightingChannelConfig, "Lighting Channels", "")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                             
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Shadow")
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -89,6 +89,8 @@ namespace AZ
                                 ->EnumAttribute(RPI::Cullable::LodType::ScreenCoverage, "Screen Coverage")
                                 ->EnumAttribute(RPI::Cullable::LodType::SpecificLod, "Specific LOD")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::EntireTree)
+                            ->DataElement(AZ::Edit::UIHandlers::Default, &MeshComponentConfig::m_lightingChannelConfig, "Lighting Channels", "")
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Lod Configuration")
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "LOD Configuration")
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
@@ -107,11 +109,6 @@ namespace AZ
                                 ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                                 ->Attribute(AZ::Edit::Attributes::Max, 1.f)
                                 ->Attribute(AZ::Edit::Attributes::Visibility, &MeshComponentConfig::LodTypeIsScreenCoverage)
-                        ->ClassElement(Edit::ClassElements::Group, "Lighting Channels")
-                            ->DataElement(0, &MeshComponentConfig::m_lightingChannelConfig, "Lighting channel configuration", "")
-                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                                ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
-                                ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                         ;
                 }
             }

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -124,12 +124,10 @@ namespace EMotionFX
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Render options")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
 
-                        ->DataElement(0, &EditorActorComponent::m_lightingChannelConfig,
-                                      "Lighting channel configuration", "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorActorComponent::m_lightingChannelConfig,
+                                      "Lighting Channels", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::LightingChannelMaskChanged)
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                        ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
 
                         ->DataElement(0, &EditorActorComponent::m_renderCharacter,
                             "Draw character", "Toggles rendering of character mesh.")


### PR DESCRIPTION
## What does this PR do?

Cleans up lighting channel config UI.
Removes extra group surrounding each lighting channel config entry.
Adds labels with indices to each lighting channel in the container instead of printing the data type.

## How was this PR tested?

<img width="341" alt="image" src="https://github.com/o3de/o3de/assets/82461473/3defff77-21f3-4cc0-83d0-257a68986984">
