### PR TITLE
Create utility functions for asset browser highlighting and item flags

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -12,18 +12,17 @@
 
 #include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
 
-#include <AzToolsFramework/Editor/RichTextHighlighter.h>
-
 #include <AzCore/Console/IConsole.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 
+#include <QCollator>
 #include <QSharedPointer>
 #include <QTimer>
-#include <QCollator>
 AZ_POP_DISABLE_WARNING
 
 AZ_CVAR(
@@ -70,8 +69,10 @@ namespace AzToolsFramework
                 disconnect(m_filter.data(), &AssetBrowserEntryFilter::updatedSignal, this, &AssetBrowserFilterModel::filterUpdatedSlot);
             }
             connect(filter.data(), &AssetBrowserEntryFilter::updatedSignal, this, &AssetBrowserFilterModel::filterUpdatedSlot);
+
             m_filter = filter;
             m_invalidateFilter = true;
+
             // asset browser entries are not guaranteed to have populated when the filter is set, delay filtering until they are
             bool isAssetBrowserComponentReady = false;
             AssetBrowserComponentRequestBus::BroadcastResult(isAssetBrowserComponentReady, &AssetBrowserComponentRequests::AreEntriesReady);
@@ -108,13 +109,7 @@ namespace AzToolsFramework
             {
                 if (index.column() == aznumeric_cast<int>(AssetBrowserEntry::Column::Name))
                 {
-                    const QString name = assetBrowserEntry->GetName().c_str();
-                    if (!m_searchString.isEmpty())
-                    {
-                        // highlight characters in filter
-                        return AzToolsFramework::RichTextHighlighter::HighlightText(name, m_searchString);
-                    }
-                    return name;
+                    return AssetBrowserViewUtils::GetAssetBrowserEntryNameWithHighlighting(assetBrowserEntry, m_searchString);
                 }
                 
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.cpp
@@ -214,22 +214,10 @@ namespace AzToolsFramework
 
             if (index.isValid())
             {
-                // We can only drop items onto folders so set flags accordingly
-                const AssetBrowserEntry* item =
-                    mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                if (item)
-                {
-                    if (item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product ||
-                        item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
-                    {
-                        return Qt::ItemIsDragEnabled | defaultFlags;
-                    }
-                    if (item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
-                    {
-                        return Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | defaultFlags;
-                    }
-                }
+                return AssetBrowserViewUtils::GetAssetBrowserEntryCommonItemFlags(
+                    mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>(), defaultFlags);
             }
+
             return defaultFlags;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -220,22 +220,13 @@ namespace AzToolsFramework
         Qt::ItemFlags AssetBrowserModel::flags(const QModelIndex& index) const
         {
             Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
+
             if (index.isValid())
             {
-                // We can only drop items onto folders so set flags accordingly
-                AssetBrowserEntry* item = static_cast<AssetBrowserEntry*>(index.internalPointer());
-                if (item)
-                {
-                    if (item->RTTI_IsTypeOf(ProductAssetBrowserEntry::RTTI_Type()) || item->RTTI_IsTypeOf(SourceAssetBrowserEntry::RTTI_Type()))
-                    {
-                        return Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | defaultFlags;
-                    }
-                    if (item->RTTI_IsTypeOf(FolderAssetBrowserEntry::RTTI_Type()))
-                    {
-                        return Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | defaultFlags;
-                    }
-                }
+                return AssetBrowserViewUtils::GetAssetBrowserEntryCommonItemFlags(
+                    static_cast<AssetBrowserEntry*>(index.internalPointer()), defaultFlags);
             }
+
             return defaultFlags;
         }
         QStringList AssetBrowserModel::mimeTypes() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
@@ -12,7 +12,6 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
-#include <AzToolsFramework/Editor/RichTextHighlighter.h>
 
 namespace AzToolsFramework
 {
@@ -42,13 +41,7 @@ namespace AzToolsFramework
                     {
                     case Name:
                         {
-                            const QString name = assetBrowserEntry->GetName().c_str();
-                            if (!m_searchString.isEmpty())
-                            {
-                                // highlight characters in filter
-                                return AzToolsFramework::RichTextHighlighter::HighlightText(name, m_searchString);
-                            }
-                            return name;
+                            return AssetBrowserViewUtils::GetAssetBrowserEntryNameWithHighlighting(assetBrowserEntry, m_searchString);
                         }
                     case Type:
                         {
@@ -145,11 +138,7 @@ namespace AzToolsFramework
             {
                 return (rowCount(parent) > 0) && (columnCount(parent) > 0);
             }
-            if (parent != m_rootIndex)
-            {
-                return false;
-            }
-            return true;
+            return parent == m_rootIndex;
         }
 
         int AssetBrowserTableViewProxyModel::columnCount([[maybe_unused]]const QModelIndex& parent) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.h
@@ -50,7 +50,7 @@ namespace AzToolsFramework
             void SetSearchString(const QString& searchString);
         private:
             QPersistentModelIndex m_rootIndex;
-            bool m_searchResultsMode;
+            bool m_searchResultsMode{ false };
             QString m_searchString;
         };
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
@@ -16,8 +16,6 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 
 #include <AzQtComponents/Components/Widgets/AssetFolderThumbnailView.h>
-#include <AzToolsFramework/Editor/RichTextHighlighter.h>
-
 
 namespace AzToolsFramework
 {
@@ -43,13 +41,7 @@ namespace AzToolsFramework
             {
             case Qt::DisplayRole:
                 {
-                    const QString name = assetBrowserEntry->GetName().c_str();
-                    if (!m_searchString.isEmpty())
-                    {
-                        // highlight characters in filter
-                        return AzToolsFramework::RichTextHighlighter::HighlightText(name, m_searchString);
-                    }
-                    return name;
+                    return AssetBrowserViewUtils::GetAssetBrowserEntryNameWithHighlighting(assetBrowserEntry, m_searchString);
                 }
             case Qt::DecorationRole:
                 {
@@ -61,13 +53,8 @@ namespace AzToolsFramework
                 }
             case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExpandable):
                 {
-                    // We don't want to see children on folders in the thumbnail view
-                    if (assetBrowserEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
-                    {
-                        return false;
-                    }
-
-                    return rowCount(index) > 0;
+                    // In thumbnail mode, folders are not expandable, only source assets with products beneath them.
+                    return rowCount(index) > 0 && assetBrowserEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source;
                 }
             case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsTopLevel):
                 {
@@ -77,23 +64,14 @@ namespace AzToolsFramework
                             index.data(static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExactMatch)).value<bool>();
                         return isExactMatch;
                     }
-                    else
-                    {
-                        if (m_rootIndex.isValid())
-                        {
-                            return index.parent() == m_rootIndex;
-                        }
-                        else
-                        {
-                            return index.parent().isValid() && !index.parent().parent().isValid();
-                        }
-                    }
+
+                    return index.parent().isValid() && (index.parent() == m_rootIndex || !index.parent().parent().isValid());
                 }
             case static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsVisible):
                 {
                     auto isExactMatch =
                         index.data(static_cast<int>(AzQtComponents::AssetFolderThumbnailView::Role::IsExactMatch)).value<bool>();
-                    return !m_searchResultsMode || (m_searchResultsMode && isExactMatch);
+                    return !m_searchResultsMode || isExactMatch;
                 }
             }
 
@@ -137,24 +115,14 @@ namespace AzToolsFramework
 
         Qt::ItemFlags AssetBrowserThumbnailViewProxyModel::flags(const QModelIndex& index) const
         {
-            Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
+            const Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
 
             if (index.isValid())
             {
-                // We can only drop items onto folders so set flags accordingly
-                const AssetBrowserEntry* item = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                if (item)
-                {
-                    if (item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product || item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
-                    {
-                        return Qt::ItemIsDragEnabled | defaultFlags;
-                    }
-                    if (item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
-                    {
-                        return Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled | defaultFlags;
-                    }
-                }
+                return AssetBrowserViewUtils::GetAssetBrowserEntryCommonItemFlags(
+                    mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>(), defaultFlags);
             }
+
             return defaultFlags;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.h
@@ -45,7 +45,7 @@ namespace AzToolsFramework
             QStringList mimeTypes() const override;
         private:
             QPersistentModelIndex m_rootIndex;
-            bool m_searchResultsMode;
+            bool m_searchResultsMode{ false };
             QString m_searchString;
         };
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -186,6 +186,7 @@ namespace AzToolsFramework
         {
             const QModelIndexList& selectedIndexes = selectionModel()->selectedRows();
             QModelIndexList sourceIndexes;
+            sourceIndexes.reserve(selectedIndexes.size());
             for (const auto& index : selectedIndexes)
             {
                 sourceIndexes.push_back(m_assetBrowserSortFilterProxyModel->mapToSource(index));
@@ -398,8 +399,9 @@ namespace AzToolsFramework
             if (!m_fileToSelectAfterUpdate.empty())
             {
                 SelectFileAtPath(m_fileToSelectAfterUpdate);
-                m_fileToSelectAfterUpdate = "";
+                m_fileToSelectAfterUpdate.clear();
             }
+
             m_applySnapshot = true;
         }
 
@@ -435,13 +437,7 @@ namespace AzToolsFramework
 
         bool AssetBrowserTreeView::IsIndexExpandedByDefault(const QModelIndex& index) const
         {
-            if (!m_expandToEntriesByDefault)
-            {
-                return false;
-            }
-
-            // Expand until we get to source entries, we don't want to go beyond that
-            return GetEntryFromIndex<SourceAssetBrowserEntry>(index) == nullptr;
+            return m_expandToEntriesByDefault && (GetEntryFromIndex<SourceAssetBrowserEntry>(index) == nullptr);
         }
 
         void AssetBrowserTreeView::OpenItemForEditing(const QModelIndex& index)
@@ -484,7 +480,7 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::SelectFolderFromBreadcrumbsPath(AZStd::string_view folderPath)
         {
-            if (folderPath.size() == 0)
+            if (folderPath.empty())
             {
                 return;
             }
@@ -498,7 +494,7 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::SelectFolder(AZStd::string_view folderPath)
         {
-            if (folderPath.size() == 0)
+            if (folderPath.empty())
             {
                 return;
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -161,7 +161,7 @@ namespace AzToolsFramework
             QString m_name;
 
             QModelIndex m_indexToSelectAfterUpdate;
-            AZStd::string m_fileToSelectAfterUpdate = "";
+            AZStd::string m_fileToSelectAfterUpdate;
 
             bool SelectProduct(const QModelIndex& idxParent, AZ::Data::AssetId assetID);
             bool SelectEntry(const QModelIndex& idxParent, const AZStd::vector<AZStd::string>& entryPathTokens, const uint32_t lastFolderIndex = 0, const uint32_t entryPathIndex = 0, bool useDisplayName = false);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
@@ -9,22 +9,21 @@
 
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
-
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzFramework/Network/AssetProcessorConnection.h>
 #include <AzFramework/StringFunc/StringFunc.h>
+#include <AzQtComponents/Components/Widgets/MessageBox.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
-#include <AzToolsFramework/AssetBrowser/Previewer/PreviewerBus.h>
-#include <AzToolsFramework/AssetBrowser/Previewer/PreviewerFactory.h>
+#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h>
+#include <AzToolsFramework/AssetBrowser/Previewer/PreviewerBus.h>
+#include <AzToolsFramework/AssetBrowser/Previewer/PreviewerFactory.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeViewDialog.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
-#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
+#include <AzToolsFramework/Editor/RichTextHighlighter.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
-
-#include <AzQtComponents/Components/Widgets/MessageBox.h>
 
 #include <QDir>
 #include <QPushButton>
@@ -545,7 +544,6 @@ namespace AzToolsFramework
             {
                 QFile::copy(oldPath.c_str(), newPath.c_str());
             }
-
         }
 
         QVariant AssetBrowserViewUtils::GetThumbnail(const AssetBrowserEntry* entry, bool returnIcon, bool isFavorite)
@@ -668,6 +666,44 @@ namespace AzToolsFramework
                 iconPathToUse = (engineRoot / DefaultFileIconPath).c_str();
             }
             return iconPathToUse;
+        }
+
+        Qt::ItemFlags AssetBrowserViewUtils::GetAssetBrowserEntryCommonItemFlags(const AssetBrowserEntry* entry, Qt::ItemFlags defaultFlags)
+        {
+            if (entry)
+            {
+                switch (entry->GetEntryType())
+                {
+                case AssetBrowserEntry::AssetEntryType::Product:
+                case AssetBrowserEntry::AssetEntryType::Source:
+                    {
+                        return defaultFlags | Qt::ItemIsDragEnabled;
+                    }
+                case AssetBrowserEntry::AssetEntryType::Folder:
+                    {
+                        return defaultFlags | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+                    }
+                }
+            }
+
+            return defaultFlags;
+        }
+
+        QString AssetBrowserViewUtils::GetAssetBrowserEntryNameWithHighlighting(
+            const AssetBrowserEntry* entry, const QString& highlightedText)
+        {
+            if (entry)
+            {
+                const QString name = entry->GetName().c_str();
+                if (!highlightedText.isEmpty())
+                {
+                    // highlight characters in filter
+                    return AzToolsFramework::RichTextHighlighter::HighlightText(name, highlightedText);
+                }
+                return name;
+            }
+
+            return {};
         }
 
         Qt::DropAction AssetBrowserViewUtils::SelectDropActionForEntries(const AZStd::vector<const AssetBrowserEntry*>& entries)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
@@ -37,6 +37,12 @@ namespace AzToolsFramework
             // @param returnIcon - when set to true, always returns the default icon for a given entry
             // @param isFavorite - used for folders in the AssetBrowser, will return the favoriteFolder ison rather than a standard folder.
             static QVariant GetThumbnail(const AssetBrowserEntry* entry, bool returnIcon = false, bool isFavorite = false);
+
+            //! @return the most common flags for an asset browser entry, included drag and drop.
+            static Qt::ItemFlags GetAssetBrowserEntryCommonItemFlags(const AssetBrowserEntry* entry, Qt::ItemFlags defaultFlags);
+
+            //! @return the asset browser entry name with highlighted text
+            static QString GetAssetBrowserEntryNameWithHighlighting(const AssetBrowserEntry* entry, const QString& highlightedText);
         };
     } // namespace AssetBrowser
 


### PR DESCRIPTION
## What does this PR do?

Consolidate some duplicated asset browser view code by adding utility functions for highlighting text and setting asset browser entry item drag and drop flags.

Performed brother cleanup, like variable initialization.

## How was this PR tested?

Tested dragging and dropping files and folders and thumbnail view.
The function disables dragging folders but allows files to be dropped onto them.
Dragging folders was supported in one location but the drop handling code ignored it.
Search filter colors highlight in all tested asset browser and asset picker views.