### PR TITLE
Asset browser: fixing filters and performance part 2

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -40,7 +40,6 @@ namespace AzToolsFramework
             , m_isTableView(isTableView)
         {
             setDynamicSortFilter(true);
-            setRecursiveFilteringEnabled(true);
             m_shownColumns.insert(aznumeric_cast<int>(AssetBrowserEntry::Column::DisplayName));
             if (ed_useNewAssetBrowserListView)
             {
@@ -156,7 +155,7 @@ namespace AzToolsFramework
                 return true;
             }
 
-            return !m_filter || m_filter->MatchWithoutPropagation(entry);
+            return !m_filter || m_filter->Match(entry);
         }
 
         bool AssetBrowserFilterModel::filterAcceptsColumn(int source_column, const QModelIndex&) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
@@ -259,15 +259,10 @@ namespace AzToolsFramework
         {
             auto selectedAssets = m_ui->m_assetBrowserTreeViewWidget->isVisible() ? m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets()
                                                                                   : m_ui->m_assetBrowserListViewWidget->GetSelectedAssets();
-            // exactly one item must be selected, even if multi-select option is disabled, still good practice to check
-            if (selectedAssets.empty())
-            {
-                return false;
-            }
 
             m_selection.GetResults().clear();
-
             AZStd::unordered_set<const AssetBrowserEntry*> entries;
+
             for (auto entry : selectedAssets)
             {
                 m_selection.GetSelectionFilter()->Filter(entries, entry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -22,26 +22,63 @@ namespace AzToolsFramework
     {
         namespace
         {
-            FilterConstType EntryTypeNoFoldersFilter(AssetBrowserEntry::AssetEntryType entryType = AssetBrowserEntry::AssetEntryType::Product)
+            QSharedPointer<AssetBrowserEntryFilter> CreateCompositeFilter_And(
+                const AZStd::vector<QSharedPointer<AssetBrowserEntryFilter>>& filters,
+                AssetBrowserEntryFilter::PropagateDirection direction = AssetBrowserEntryFilter::PropagateDirection::None)
             {
-                EntryTypeFilter* entryTypeFilter = new EntryTypeFilter();
-                entryTypeFilter->SetEntryType(entryType);
-                // in case entry is a source or folder, it may still contain relevant product
-                entryTypeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-
-                EntryTypeFilter* foldersFilter = new EntryTypeFilter();
-                foldersFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Folder);
-
-                InverseFilter* noFoldersFilter = new InverseFilter();
-                noFoldersFilter->SetFilter(FilterConstType(foldersFilter));
-
-                CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
-                compFilter->AddFilter(FilterConstType(entryTypeFilter));
-                compFilter->AddFilter(FilterConstType(noFoldersFilter));
-
-                return FilterConstType(compFilter);
+                QSharedPointer<CompositeFilter> compositeFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND));
+                for (const auto& filter : filters)
+                {
+                    compositeFilter->AddFilter(filter);
+                }
+                compositeFilter->SetFilterPropagation(direction);
+                return compositeFilter;
             }
-        }
+
+            QSharedPointer<AssetBrowserEntryFilter> CreateCompositeFilter_Or(
+                const AZStd::vector<QSharedPointer<AssetBrowserEntryFilter>>& filters,
+                AssetBrowserEntryFilter::PropagateDirection direction = AssetBrowserEntryFilter::PropagateDirection::None)
+            {
+                QSharedPointer<CompositeFilter> compositeFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR));
+                for (const auto& filter : filters)
+                {
+                    compositeFilter->AddFilter(filter);
+                }
+                compositeFilter->SetFilterPropagation(direction);
+                return compositeFilter;
+            }
+
+            QSharedPointer<AssetBrowserEntryFilter> CreateEntryTypeFilter(
+                const AZStd::vector<AssetBrowserEntry::AssetEntryType>& entryTypes,
+                AssetBrowserEntryFilter::PropagateDirection direction = AssetBrowserEntryFilter::PropagateDirection::None)
+            {
+                QSharedPointer<CustomFilter> entryTypeFilter(new CustomFilter(
+                    [entryTypes](const AssetBrowserEntry* entry)
+                    {
+                        return entryTypes.empty() ||
+                            (entry && AZStd::find(entryTypes.begin(), entryTypes.end(), entry->GetEntryType()) != entryTypes.end());
+                    }));
+                entryTypeFilter->SetFilterPropagation(direction);
+                return entryTypeFilter;
+            }
+
+            QSharedPointer<AssetBrowserEntryFilter> CreateAssetTypeFilter(
+                const AZStd::vector<AZ::Data::AssetType>& assetTypes,
+                AssetBrowserEntryFilter::PropagateDirection direction = AssetBrowserEntryFilter::PropagateDirection::None)
+            {
+                QSharedPointer<CustomFilter> assetTypeFilter(new CustomFilter(
+                    [assetTypes](const AssetBrowserEntry* entry)
+                    {
+                        const ProductAssetBrowserEntry* product = entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product
+                            ? static_cast<const ProductAssetBrowserEntry*>(entry)
+                            : nullptr;
+                        return assetTypes.empty() ||
+                            (product && AZStd::find(assetTypes.begin(), assetTypes.end(), product->GetAssetType()) != assetTypes.end());
+                    }));
+                assetTypeFilter->SetFilterPropagation(direction);
+                return assetTypeFilter;
+            }
+        } // namespace
 
         AssetSelectionModel::AssetSelectionModel()
             : m_multiselect(false)
@@ -86,14 +123,12 @@ namespace AzToolsFramework
         void AssetSelectionModel::SetSelectedAssetIds(const AZStd::vector<AZ::Data::AssetId>& selectedAssetIds)
         {
             m_selectedFilePaths.clear();
-
             m_selectedAssetIds = selectedAssetIds;
         }
 
         void AssetSelectionModel::SetSelectedAssetId(const AZ::Data::AssetId& selectedAssetId)
         {
             m_selectedFilePaths.clear();
-
             m_selectedAssetIds.clear();
             m_selectedAssetIds.push_back(selectedAssetId);
         }
@@ -106,14 +141,12 @@ namespace AzToolsFramework
         void AssetSelectionModel::SetSelectedFilePaths(const AZStd::vector<AZStd::string>& selectedFilePaths)
         {
             m_selectedAssetIds.clear();
-
             m_selectedFilePaths = selectedFilePaths;
         }
 
         void AssetSelectionModel::SetSelectedFilePath(const AZStd::string& selectedFilePath)
         {
             m_selectedAssetIds.clear();
-
             m_selectedFilePaths.clear();
             m_selectedFilePaths.push_back(selectedFilePath);
         }
@@ -135,7 +168,7 @@ namespace AzToolsFramework
 
         const AssetBrowserEntry* AssetSelectionModel::GetResult()
         {
-            return m_results.front();
+            return !m_results.empty() ? m_results.front() : nullptr;
         }
 
         bool AssetSelectionModel::IsValid() const
@@ -164,100 +197,61 @@ namespace AzToolsFramework
             return "Asset";
         }
 
-        AssetSelectionModel AssetSelectionModel::AssetTypeSelection(const AZ::Data::AssetType& assetType, bool multiselect)
+        AssetSelectionModel AssetSelectionModel::AssetTypeSelection(
+            const AZ::Data::AssetType& assetType, bool multiselect, bool supportSelectingSources)
         {
-            return AssetTypesSelection({ assetType }, multiselect);
+            return AssetTypeSelection(AZStd::vector<AZ::Data::AssetType>{ assetType }, multiselect, supportSelectingSources);
         }
 
-        AssetSelectionModel AssetSelectionModel::AssetTypeSelection(const char* assetTypeName, bool multiselect)
+        AssetSelectionModel AssetSelectionModel::AssetTypeSelection(
+            const char* assetTypeName, bool multiselect, bool supportSelectingSources)
         {
             EBusFindAssetTypeByName result(assetTypeName);
             AZ::AssetTypeInfoBus::BroadcastResult(result, &AZ::AssetTypeInfo::GetAssetType);
-            return AssetTypeSelection(result.GetAssetType(), multiselect);
+            return AssetTypeSelection(result.GetAssetType(), multiselect, supportSelectingSources);
         }
 
-        AssetSelectionModel AssetSelectionModel::AssetTypesSelection(const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect) 
+        AssetSelectionModel AssetSelectionModel::AssetTypeSelection(
+            const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect, bool supportSelectingSources)
         {
-            // If no asset types were specified then allow unfiltered asset selection.
-            if (assetTypes.empty())
-            {
-                return EverythingSelection(multiselect);
-            }
+            auto entryTypeFilter = supportSelectingSources
+                ? CreateEntryTypeFilter({ AssetBrowserEntry::AssetEntryType::Product, AssetBrowserEntry::AssetEntryType::Source })
+                : CreateEntryTypeFilter({ AssetBrowserEntry::AssetEntryType::Product });
+
+            auto assetTypeFilter = supportSelectingSources
+                ? CreateAssetTypeFilter(assetTypes, AssetBrowserEntryFilter::PropagateDirection::Down)
+                : CreateAssetTypeFilter(assetTypes, AssetBrowserEntryFilter::PropagateDirection::None);
+
+            auto selectionFilter = CreateCompositeFilter_And({ assetTypeFilter, entryTypeFilter });
 
             AssetSelectionModel selection;
-
-            CompositeFilter* anyAssetTypeFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::OR);
-            anyAssetTypeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-            auto anyAssetTypeFilterPtr = FilterConstType(anyAssetTypeFilter);
-
-            for (const auto& assetType : assetTypes)
-            {
-                AssetTypeFilter* assetTypeFilter = new AssetTypeFilter();
-                assetTypeFilter->SetAssetType(assetType);
-                anyAssetTypeFilter->AddFilter(FilterConstType(assetTypeFilter));
-            }
-
-            CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
-            compFilter->AddFilter(anyAssetTypeFilterPtr);
-            compFilter->AddFilter(EntryTypeNoFoldersFilter());
-
-            selection.SetSelectionFilter(FilterConstType(compFilter));
-            selection.SetDisplayFilter(anyAssetTypeFilterPtr);
+            selection.SetDisplayFilter(assetTypeFilter);
+            selection.SetSelectionFilter(selectionFilter);
             selection.SetMultiselect(multiselect);
-            return selection;
-        }
-
-        AssetSelectionModel AssetSelectionModel::AssetGroupSelection(const char* group, bool multiselect)
-        {
-            AssetSelectionModel selection;
-
-            AssetGroupFilter* assetGroupFilter = new AssetGroupFilter();
-            assetGroupFilter->SetAssetGroup(group);
-            assetGroupFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-            auto assetGroupFilterPtr = FilterConstType(assetGroupFilter);
-
-            selection.SetDisplayFilter(assetGroupFilterPtr);
-
-            CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
-            compFilter->AddFilter(assetGroupFilterPtr);
-            compFilter->AddFilter(EntryTypeNoFoldersFilter());
-
-            selection.SetSelectionFilter(FilterConstType(compFilter));
-            selection.SetMultiselect(multiselect);
-
             return selection;
         }
 
         AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect)
         {
-            AssetSelectionModel selection;
-
-            RegExpFilter* patternFilter = new RegExpFilter();
+            QSharedPointer<RegExpFilter> patternFilter(new RegExpFilter());
             patternFilter->SetFilterPattern(pattern);
-            patternFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-            auto patternFilterPtr = FilterConstType(patternFilter);
 
-            selection.SetDisplayFilter(patternFilterPtr);
+            QSharedPointer<AssetBrowserEntryFilter> compositeFilter(
+                CreateCompositeFilter_And({ CreateEntryTypeFilter({ AssetBrowserEntry::AssetEntryType::Source }), patternFilter }));
 
-            CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
-            compFilter->AddFilter(patternFilterPtr);
-            compFilter->AddFilter(EntryTypeNoFoldersFilter(AssetBrowserEntry::AssetEntryType::Source));
-
-            selection.SetSelectionFilter(FilterConstType(compFilter));
+            AssetSelectionModel selection;
+            selection.SetDisplayFilter(compositeFilter);
+            selection.SetSelectionFilter(compositeFilter);
             selection.SetMultiselect(multiselect);
-
             return selection;
         }
 
-        AssetSelectionModel AssetSelectionModel::EverythingSelection(bool multiselect) 
+        AssetSelectionModel AssetSelectionModel::EverythingSelection(bool multiselect)
         {
             AssetSelectionModel selection;
-         
-            CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::OR);
-            selection.SetDisplayFilter(FilterConstType(compFilter));
-            selection.SetSelectionFilter(EntryTypeNoFoldersFilter());
+            selection.SetDisplayFilter(CreateCompositeFilter_Or({}));
+            selection.SetSelectionFilter(CreateEntryTypeFilter({}));
             selection.SetMultiselect(multiselect);
-
             return selection;
         }
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
@@ -60,10 +60,12 @@ namespace AzToolsFramework
 
             QString GetTitle() const;
 
-            static AssetSelectionModel AssetTypeSelection(const AZ::Data::AssetType& assetType, bool multiselect = false);
-            static AssetSelectionModel AssetTypeSelection(const char* assetTypeName, bool multiselect = false);
-            static AssetSelectionModel AssetTypesSelection(const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect = false);
-            static AssetSelectionModel AssetGroupSelection(const char* group, bool multiselect = false);
+            static AssetSelectionModel AssetTypeSelection(
+                const AZ::Data::AssetType& assetType, bool multiselect = false, bool supportSelectingSources = false);
+            static AssetSelectionModel AssetTypeSelection(
+                const char* assetTypeName, bool multiselect = false, bool supportSelectingSources = false);
+            static AssetSelectionModel AssetTypeSelection(
+                const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect = false, bool supportSelectingSources = false);
             static AssetSelectionModel SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect = false);
             static AssetSelectionModel EverythingSelection(bool multiselect = false);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -200,16 +200,8 @@ namespace AzToolsFramework
             return m_visiblePath.Native();
         }
 
-        const AZStd::string AssetBrowserEntry::GetFullPath() const
+        const AZStd::string& AssetBrowserEntry::GetFullPath() const
         {
-            // the full path could use a decoding:
-            if (AZ::IO::FileIOBase* instance = AZ::IO::FileIOBase::GetInstance())
-            {
-                char resolvedPath[AZ_MAX_PATH_LEN] = { 0 };
-                instance->ResolvePath(m_fullPath.Native().c_str(), resolvedPath, AZ_MAX_PATH_LEN);
-                return AZStd::string(resolvedPath);
-            }
-
             return m_fullPath.Native();
         }
 
@@ -237,9 +229,17 @@ namespace AzToolsFramework
         {
             m_fullPath = fullPath;
 
-            // Update the entryType string.
-            m_entryType = "";
+            // the full path could use a decoding:
+            if (AZ::IO::FileIOBase* instance = AZ::IO::FileIOBase::GetInstance())
+            {
+                char resolvedPath[AZ_MAX_PATH_LEN] = { 0 };
+                if (instance->ResolvePath(fullPath.Native().c_str(), resolvedPath, AZ_MAX_PATH_LEN))
+                {
+                    m_fullPath = resolvedPath;
+                }
+            }
 
+            // Update the entryType string.
             switch (GetEntryType())
             {
             case AssetBrowserEntry::AssetEntryType::Root:
@@ -253,6 +253,9 @@ namespace AzToolsFramework
                 break;
             case AssetBrowserEntry::AssetEntryType::Product:
                 m_entryType = tr("Product");
+                break;
+            default:
+                m_entryType = "";
                 break;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h
@@ -128,7 +128,7 @@ namespace AzToolsFramework
             const AZStd::string& GetVisiblePath() const;
             //! Return absolute path to this file. Note that this decodes it to native slashes and resolves
             //! any aliases.
-            const AZStd::string GetFullPath() const;
+            const AZStd::string& GetFullPath() const;
             //! Return the size on disk of the asset
             const size_t GetDiskSize() const;
             //! Return the time the file was last modified.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -271,6 +271,7 @@ namespace AzToolsFramework
         void AssetBrowserTableView::OnAssetBrowserComponentReady()
         {
             m_treeToTableProxyModel->setSourceModel(m_assetBrowserModel);
+            UpdateFilterInLocalFilterModel();
         }
 
         AzQtComponents::AssetFolderTableView* AssetBrowserTableView::GetTableViewWidget() const
@@ -564,7 +565,7 @@ namespace AzToolsFramework
             bool hasString{ false };
             const QString tagString("String");
             const QString tagFolder("Folder");
-            auto filterCopy = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
+            auto clonedFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             for (const auto& subFilter : filter->GetSubFilters())
             {
                 if (subFilter->GetTag() == tagString)
@@ -576,7 +577,7 @@ namespace AzToolsFramework
                 // Skip the folder filter on the table view so that we can see files
                 if (subFilter->GetTag() != tagFolder)
                 {
-                    filterCopy->AddFilter(FilterConstType(subFilter->Clone()));
+                    clonedFilter->AddFilter(FilterConstType(subFilter->Clone()));
                 }
             }
 
@@ -588,41 +589,41 @@ namespace AzToolsFramework
 
             if (hasString)
             {
-                for (auto& subFilter : filterCopy->GetSubFilters())
+                // With string searches enabled we disable filter propagation to only show exact mattress.
+                for (auto subFilter : clonedFilter->GetSubFilters())
                 {
-                    auto anyCompFilter = qobject_cast<const CompositeFilter*>(subFilter.get());
-                    if (anyCompFilter)
+                    if (auto clonedCompositeFilter = qobject_cast<const CompositeFilter*>(subFilter.get()); clonedCompositeFilter)
                     {
-                        auto myCompFilter = const_cast<CompositeFilter*>(anyCompFilter);
-                        myCompFilter->SetFilterPropagation(AssetBrowserEntryFilter::None);
+                        auto modifiedCompositeFilter = const_cast<CompositeFilter*>(clonedCompositeFilter);
+                        modifiedCompositeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
                     }
                 }
 
-                auto productFilter = new CustomFilter([](const AssetBrowserEntry* entry) {
-                    return entry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Product;
-                });
-                productFilter->SetName("NoProduct");
-                productFilter->SetFilterPropagation(AssetBrowserEntryFilter::None);
+                // With string searches enabled we only want to show sources and products in this view.
+                auto customTypeFilter = new CustomFilter(
+                    [](const AssetBrowserEntry* entry)
+                    {
+                        switch (entry->GetEntryType())
+                        {
+                        case AssetBrowserEntry::AssetEntryType::Product:
+                        case AssetBrowserEntry::AssetEntryType::Source:
+                            return true;
+                        }
+                        return false;
+                    });
+                clonedFilter->AddFilter(FilterConstType(customTypeFilter));
 
-                filterCopy->AddFilter(FilterConstType(productFilter));
-                filterCopy->SetFilterPropagation(AssetBrowserEntryFilter::None);
-            }
-            else
-            {
-                filterCopy->SetFilterPropagation(AssetBrowserEntryFilter::Up | AssetBrowserEntryFilter::Down);
-            }
-
-            m_assetFilterModel->SetFilter(FilterConstType(filterCopy));
-
-            if (hasString)
-            {
-                m_tableViewWidget->expandAll();
+                clonedFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
                 m_assetFilterModel->setSourceModel(m_treeToTableProxyModel);
+                m_assetFilterModel->SetFilter(FilterConstType(clonedFilter));
+                m_tableViewWidget->expandAll();
             }
             else
             {
-                m_tableViewWidget->collapseAll();
+                clonedFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
                 m_assetFilterModel->setSourceModel(m_assetBrowserModel);
+                m_assetFilterModel->SetFilter(FilterConstType(clonedFilter));
+                m_tableViewWidget->collapseAll();
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -472,7 +472,7 @@ namespace AzToolsFramework
             bool hasString{ false };
             const QString tagString("String");
             const QString tagFolder("Folder");
-            auto filterCopy = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
+            auto clonedFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             for (const auto& subFilter : filter->GetSubFilters())
             {
                 if (subFilter->GetTag() == tagString)
@@ -484,7 +484,7 @@ namespace AzToolsFramework
                 // Skip the folder filter on the thumbnail view so that we can see files
                 if (subFilter->GetTag() != tagFolder)
                 {
-                    filterCopy->AddFilter(FilterConstType(subFilter->Clone()));
+                    clonedFilter->AddFilter(FilterConstType(subFilter->Clone()));
                 }
             }
 
@@ -494,9 +494,35 @@ namespace AzToolsFramework
             m_thumbnailViewProxyModel->SetShowSearchResultsMode(hasString);
             m_thumbnailViewWidget->SetShowSearchResultsMode(hasString);
 
-            filterCopy->SetFilterPropagation(AssetBrowserEntryFilter::Down);
+            if (hasString)
+            {
+                // With string searches enabled we disable filter propagation to only show exact mattress.
+                for (auto subFilter : clonedFilter->GetSubFilters())
+                {
+                    if (auto clonedCompositeFilter = qobject_cast<const CompositeFilter*>(subFilter.get()); clonedCompositeFilter)
+                    {
+                        auto modifiedCompositeFilter = const_cast<CompositeFilter*>(clonedCompositeFilter);
+                        modifiedCompositeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
+                    }
+                }
 
-            m_assetFilterModel->SetFilter(FilterConstType(filterCopy));
+                // With string searches enabled we only want to show sources and products in this view.
+                auto customTypeFilter = new CustomFilter(
+                    [](const AssetBrowserEntry* entry)
+                    {
+                        switch (entry->GetEntryType())
+                        {
+                        case AssetBrowserEntry::AssetEntryType::Product:
+                        case AssetBrowserEntry::AssetEntryType::Source:
+                            return true;
+                        }
+                        return false;
+                    });
+                clonedFilter->AddFilter(FilterConstType(customTypeFilter));
+            }
+
+            clonedFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            m_assetFilterModel->SetFilter(FilterConstType(clonedFilter));
         }
 
         void AssetBrowserThumbnailView::SetSortMode(const AssetBrowserEntry::AssetEntrySortMode mode)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -377,16 +377,15 @@ namespace AzToolsFramework
             // If we're filtering for a valid entry, select the first valid entry
             if (hasFilter && selectFirstValidEntry)
             {
-                QModelIndex curIndex = m_assetBrowserSortFilterProxyModel->index(0, 0);
-                while (curIndex.isValid())
+                bool selected = false;
+                const QModelIndex firstIndex = m_assetBrowserSortFilterProxyModel->index(0, 0);
+                for (QModelIndex curIndex = firstIndex; curIndex.isValid() && !selected; curIndex = indexBelow(curIndex))
                 {
                     if (GetEntryFromIndex<SourceAssetBrowserEntry>(curIndex))
                     {
                         setCurrentIndex(curIndex);
-                        break;
+                        selected = true;
                     }
-
-                    curIndex = indexBelow(curIndex);
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -346,7 +346,7 @@ namespace AzToolsFramework
 
         void AssetEditorWidget::OpenAssetWithDialog()
         {
-            AssetSelectionModel selection = AssetSelectionModel::AssetTypesSelection(m_genericAssetTypes);
+            AssetSelectionModel selection = AssetSelectionModel::AssetTypeSelection(m_genericAssetTypes);
             EditorRequests::Bus::Broadcast(&EditorRequests::BrowseForAssets, selection);
             if (selection.IsValid())
             {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -375,7 +375,6 @@ namespace LUAEditor
         entryTypeFilter->SetFilterPropagation(AssetTypeFilter::PropagateDirection::None);
 
         // Add in a string filter that comes from user input
-        // Propagate this up so that if we match a folder, it will show everything under that folder
         StringFilter* stringFilter = new StringFilter();
         stringFilter->SetFilterPropagation(AssetTypeFilter::PropagateDirection::Up);
 

--- a/Gems/LyShine/Code/Editor/AssetTreeEntry.cpp
+++ b/Gems/LyShine/Code/Editor/AssetTreeEntry.cpp
@@ -24,7 +24,7 @@ UISliceLibraryFilter::UISliceLibraryFilter(const AZ::Data::AssetType& assetType,
 {
     // propagation = Down means the filter will examine all children recursively until it satisfies or no more children are left
     // in our case we start from root entry and examine everything underneath it
-    SetFilterPropagation(AzToolsFramework::AssetBrowser::AssetBrowserEntryFilter::Down);
+    SetFilterPropagation(AzToolsFramework::AssetBrowser::AssetBrowserEntryFilter::PropagateDirection::Down);
 }
 
 AzToolsFramework::AssetBrowser::AssetBrowserEntryFilter* UISliceLibraryFilter::Clone() const


### PR DESCRIPTION
## What does this PR do?

Reverted changes to the asset browser filter model that had filtering auto recurse and use partial asset browser entry matching.

Cleaned up asset picker dialog selection model utility functions and propagation settings.

Always clearing selection model results when the selection changes in case nothing was selected.

Optimized asset browser entry path functions so the path is resolved when set instead of get. Returning string reference.

Deleted unused asset browser entry filter utility functions.

Improved asset browser table and thumbnail view filters.

Updated property asset control to allow assigning, dragging, and dropping source asset browser entries, resolving compatible product assets.

## How was this PR tested?

- Confirmed that filtering by asset type does not lock up the editor.
- Confirmed that model assets can be dragged from the asset browser to the viewport creating expected entities.
- Confirmed that model and material assets can be dragged from the asset browser and assigned to asset properties in the inspector.
- Confirmed that source and product assets can be dragged from the browser views to the property asset control.
- Confirmed that source and product assets can be selected from the asset picker and assigned to the property asset control.
- Confirmed that performance has restored in SMC, ME, MC due to exhaustive asset browser filters.
- Confirmed that asset browser tree view reflects search results when using table to thumbnail view.
- Confirmed that assets can still be opened in the asset editor using the asset picker.
- Confirmed that asset picker still works correctly in SMC, MC, ME for opening documents and assigning properties.