### PR TITLE
Update mesh feature processor so materials and event handlers are set up in the descriptor before acquire

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -92,14 +92,44 @@ namespace AZ
         struct MeshHandleDescriptor
         {
             using RequiresCloneCallback = AZStd::function<bool(const Data::Asset<RPI::ModelAsset>& modelAsset)>;
+            using ModelChangedEvent = Event<const Data::Instance<RPI::Model>&>;
+            using ObjectSrgCreatedEvent = Event<const Data::Instance<RPI::ShaderResourceGroup>&>;
+
+            MeshHandleDescriptor() = default;
+
+            MeshHandleDescriptor(const Data::Asset<RPI::ModelAsset>& modelAsset)
+                : m_modelAsset(modelAsset)
+            {
+            }
+
+            MeshHandleDescriptor(const Data::Asset<RPI::ModelAsset>& modelAsset, const CustomMaterialMap& customMaterials)
+                : m_modelAsset(modelAsset)
+                , m_customMaterials(customMaterials)
+            {
+            }
+
+            MeshHandleDescriptor(const Data::Asset<RPI::ModelAsset>& modelAsset, const Data::Instance<RPI::Material>& material)
+                : m_modelAsset(modelAsset)
+                , m_customMaterials({ { AZ::Render::DefaultCustomMaterialId, { material, {} } } })
+            {
+            }
 
             Data::Asset<RPI::ModelAsset> m_modelAsset;
-            RequiresCloneCallback m_requiresCloneCallback = {};
             bool m_isRayTracingEnabled = true;
             bool m_useForwardPassIblSpecular = false;
             bool m_isAlwaysDynamic = false;
             bool m_excludeFromReflectionCubeMaps = false;
             bool m_isSkinnedMesh = false;
+
+            CustomMaterialMap m_customMaterials;
+
+            RequiresCloneCallback m_requiresCloneCallback{};
+
+            //! Connects to an event that gets triggered whenever the model is changed, loaded, or reloaded.
+            ModelChangedEvent::Handler m_modelChangedEventHandler{ [](const Data::Instance<RPI::Model>&){} };
+
+            //! Connects to an event that triggers whenever the ObjectSrg is created.
+            ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler{ [](const Data::Instance<RPI::ShaderResourceGroup>&){} };
         };
 
         //! MeshFeatureProcessorInterface provides an interface to acquire and release a MeshHandle from the underlying
@@ -110,17 +140,12 @@ namespace AZ
             AZ_RTTI(AZ::Render::MeshFeatureProcessorInterface, "{975D7F0C-2E7E-4819-94D0-D3C4E2024721}", AZ::RPI::FeatureProcessor);
 
             using MeshHandle = StableDynamicArrayHandle<ModelDataInstance>;
-            using ModelChangedEvent = Event<const Data::Instance<RPI::Model>>;
-            using ObjectSrgCreatedEvent = Event<const Data::Instance<RPI::ShaderResourceGroup>&>;
 
             //! Returns the object id for a mesh handle.
             virtual TransformServiceFeatureProcessorInterface::ObjectId GetObjectId(const MeshHandle& meshHandle) const = 0;
 
-            //! Acquires a model with an optional collection of custom materials.
-            //! @param requiresCloneCallback The callback indicates whether cloning is required for a given model asset.
-            virtual MeshHandle AcquireMesh(const MeshHandleDescriptor& descriptor, const CustomMaterialMap& materials = {}) = 0;
-            //! Acquires a model with a single material applied to all its meshes.
-            virtual MeshHandle AcquireMesh(const MeshHandleDescriptor& descriptor, const Data::Instance<RPI::Material>& material) = 0;
+            //! Acquire a mesh handle for a model configured using the descriptor
+            virtual MeshHandle AcquireMesh(const MeshHandleDescriptor& descriptor) = 0;
             //! Releases the mesh handle
             virtual bool ReleaseMesh(MeshHandle& meshHandle) = 0;
             //! Creates a new instance and handle of a mesh using an existing MeshId. Currently, this will reset the new mesh to default materials.
@@ -151,11 +176,6 @@ namespace AZ
             virtual void SetCustomMaterials(const MeshHandle& meshHandle, const CustomMaterialMap& materials) = 0;
             //! Gets the CustomMaterialMap for a meshHandle.
             virtual const CustomMaterialMap& GetCustomMaterials(const MeshHandle& meshHandle) const = 0;
-            //! Connects a handler to any changes to an RPI::Model. Changes include loading and reloading.
-            virtual void ConnectModelChangeEventHandler(const MeshHandle& meshHandle, ModelChangedEvent::Handler& handler) = 0;
-
-            //! Connects a handler to ObjectSrg creation
-            virtual void ConnectObjectSrgCreatedEventHandler(const MeshHandle& meshHandle, ObjectSrgCreatedEvent::Handler& handler) = 0;
 
             //! Enables/Disables the mesh's DrawItem for the given drawListTag
             virtual void SetDrawItemEnabled(const MeshHandle& meshHandle, RHI::DrawListTag drawListTag, bool enabled) = 0;

--- a/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
@@ -38,8 +38,7 @@ namespace UnitTest
         MOCK_CONST_METHOD1(GetSortKey, AZ::RHI::DrawItemSortKey(const MeshHandle&));
         MOCK_METHOD2(SetMeshLodConfiguration, void(const MeshHandle&, const AZ::RPI::Cullable::LodConfiguration&));
         MOCK_CONST_METHOD1(GetMeshLodConfiguration, AZ::RPI::Cullable::LodConfiguration(const MeshHandle&));
-        MOCK_METHOD2(AcquireMesh, MeshHandle (const AZ::Render::MeshHandleDescriptor&, const AZ::Render::CustomMaterialMap&));
-        MOCK_METHOD2(AcquireMesh, MeshHandle (const AZ::Render::MeshHandleDescriptor&, const AZ::Data::Instance<AZ::RPI::Material>&));
+        MOCK_METHOD1(AcquireMesh, MeshHandle (const AZ::Render::MeshHandleDescriptor&));
         MOCK_METHOD2(SetRayTracingEnabled, void (const MeshHandle&, bool));
         MOCK_CONST_METHOD1(GetRayTracingEnabled, bool(const MeshHandle&));
         MOCK_METHOD2(SetExcludeFromReflectionCubeMaps, void(const MeshHandle&, bool));

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -956,8 +956,7 @@ namespace AZ
             }
         }
 
-        MeshFeatureProcessor::MeshHandle MeshFeatureProcessor::AcquireMesh(
-            const MeshHandleDescriptor& descriptor, const CustomMaterialMap& materials)
+        MeshFeatureProcessor::MeshHandle MeshFeatureProcessor::AcquireMesh(const MeshHandleDescriptor& descriptor)
         {
             AZ_PROFILE_SCOPE(AzRender, "MeshFeatureProcessor: AcquireMesh");
 
@@ -966,8 +965,9 @@ namespace AZ
             MeshHandle meshDataHandle = m_modelData.emplace();
 
             meshDataHandle->m_descriptor = descriptor;
+            meshDataHandle->m_descriptor.m_modelChangedEventHandler.Connect(meshDataHandle->m_modelChangedEvent);
+            meshDataHandle->m_descriptor.m_objectSrgCreatedHandler.Connect(meshDataHandle->m_objectSrgCreatedEvent);
             meshDataHandle->m_scene = GetParentScene();
-            meshDataHandle->m_customMaterials = materials;
             meshDataHandle->m_objectId = m_transformService->ReserveObjectId();
             meshDataHandle->m_rayTracingUuid = AZ::Uuid::CreateRandom();
             meshDataHandle->m_originalModelAsset = descriptor.m_modelAsset;
@@ -981,18 +981,6 @@ namespace AZ
             }
 
             return meshDataHandle;
-        }
-
-        MeshFeatureProcessor::MeshHandle MeshFeatureProcessor::AcquireMesh(
-            const MeshHandleDescriptor& descriptor, const Data::Instance<RPI::Material>& material)
-        {
-            Render::CustomMaterialMap materials;
-            if (material)
-            {
-                materials[AZ::Render::DefaultCustomMaterialId] = { material };
-            }
-
-            return AcquireMesh(descriptor, materials);
         }
 
         bool MeshFeatureProcessor::ReleaseMesh(MeshHandle& meshHandle)
@@ -1077,7 +1065,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return AcquireMesh(meshHandle->m_descriptor, meshHandle->m_customMaterials);
+                return AcquireMesh(meshHandle->m_descriptor);
             }
             return MeshFeatureProcessor::MeshHandle();
         }
@@ -1131,7 +1119,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_customMaterials = materials;
+                meshHandle->m_descriptor.m_customMaterials = materials;
                 if (meshHandle->m_model)
                 {
                     meshHandle->ReInit(this);
@@ -1143,23 +1131,7 @@ namespace AZ
 
         const CustomMaterialMap& MeshFeatureProcessor::GetCustomMaterials(const MeshHandle& meshHandle) const
         {
-            return meshHandle.IsValid() ? meshHandle->m_customMaterials : DefaultCustomMaterialMap;
-        }
-
-        void MeshFeatureProcessor::ConnectModelChangeEventHandler(const MeshHandle& meshHandle, ModelChangedEvent::Handler& handler)
-        {
-            if (meshHandle.IsValid())
-            {
-                handler.Connect(meshHandle->m_meshLoader->GetModelChangedEvent());
-            }
-        }
-
-        void MeshFeatureProcessor::ConnectObjectSrgCreatedEventHandler(const MeshHandle& meshHandle, ObjectSrgCreatedEvent::Handler& handler)
-        {
-            if (meshHandle.IsValid())
-            {
-                handler.Connect(meshHandle->GetObjectSrgCreatedEvent());
-            }
+            return meshHandle.IsValid() ? meshHandle->m_descriptor.m_customMaterials : DefaultCustomMaterialMap;
         }
 
         void MeshFeatureProcessor::SetTransform(const MeshHandle& meshHandle, const AZ::Transform& transform, const AZ::Vector3& nonUniformScale)
@@ -1566,12 +1538,6 @@ namespace AZ
         }
 
         // ModelDataInstance::MeshLoader...
-
-        MeshFeatureProcessorInterface::ModelChangedEvent& ModelDataInstance::MeshLoader::GetModelChangedEvent()
-        {
-            return m_modelChangedEvent;
-        }
-
         ModelDataInstance::MeshLoader::MeshLoader(const Data::Asset<RPI::ModelAsset>& modelAsset, ModelDataInstance* parent)
             : m_modelAsset(modelAsset)
             , m_parent(parent)
@@ -1582,12 +1548,8 @@ namespace AZ
                 return;
             }
 
-            if (!m_modelAsset.IsReady())
-            {
-                m_modelAsset.QueueLoad();
-            }
-
-            Data::AssetBus::Handler::BusConnect(modelAsset.GetId());
+            m_modelAsset.QueueLoad();
+            Data::AssetBus::Handler::BusConnect(m_modelAsset.GetId());
             AzFramework::AssetCatalogEventBus::Handler::BusConnect();
         }
 
@@ -1600,15 +1562,13 @@ namespace AZ
         //! AssetBus::Handler overrides...
         void ModelDataInstance::MeshLoader::OnAssetReady(Data::Asset<Data::AssetData> asset)
         {
-            Data::Asset<RPI::ModelAsset> modelAsset = asset;
-
             // Update our model asset reference to contain the latest loaded version.
             m_modelAsset = asset;
 
             // Assign the fully loaded asset back to the mesh handle to not only hold asset id, but the actual data as well.
             m_parent->m_originalModelAsset = asset;
 
-            if (const auto& modelTags = modelAsset->GetTags(); !modelTags.empty())
+            if (const auto& modelTags = m_modelAsset->GetTags(); !modelTags.empty())
             {
                 RPI::AssetQuality highestLodBias = RPI::AssetQualityLowest;
                 for (const AZ::Name& tag : modelTags)
@@ -1619,16 +1579,16 @@ namespace AZ
                     highestLodBias = AZStd::min(highestLodBias, tagQuality);
                 }
 
-                if (highestLodBias >= modelAsset->GetLodCount())
+                if (highestLodBias >= m_modelAsset->GetLodCount())
                 {
-                    highestLodBias = aznumeric_caster(modelAsset->GetLodCount() - 1);
+                    highestLodBias = aznumeric_caster(m_modelAsset->GetLodCount() - 1);
                 }
 
                 m_parent->m_lodBias = highestLodBias;
 
                 for (const AZ::Name& tag : modelTags)
                 {
-                    RPI::ModelTagBus::Broadcast(&RPI::ModelTagBus::Events::RegisterAsset, tag, modelAsset->GetId());
+                    RPI::ModelTagBus::Broadcast(&RPI::ModelTagBus::Events::RegisterAsset, tag, m_modelAsset->GetId());
                 }
             }
             else
@@ -1638,48 +1598,44 @@ namespace AZ
 
             Data::Instance<RPI::Model> model;
             // Check if a requires cloning callback got set and if so check if cloning the model asset is requested.
-            if (m_parent->m_descriptor.m_requiresCloneCallback &&
-                m_parent->m_descriptor.m_requiresCloneCallback(modelAsset))
+            if (m_parent->m_descriptor.m_requiresCloneCallback && m_parent->m_descriptor.m_requiresCloneCallback(m_modelAsset))
             {
                 // Clone the model asset to force create another model instance.
                 AZ::Data::AssetId newId(AZ::Uuid::CreateRandom(), /*subId=*/0);
                 Data::Asset<RPI::ModelAsset> clonedAsset;
                 // Assume cloned models will involve some kind of geometry deformation
                 m_parent->m_flags.m_isAlwaysDynamic = true;
-                if (AZ::RPI::ModelAssetCreator::Clone(modelAsset, clonedAsset, newId))
+                if (AZ::RPI::ModelAssetCreator::Clone(m_modelAsset, clonedAsset, newId))
                 {
                     model = RPI::Model::FindOrCreate(clonedAsset);
                 }
                 else
                 {
-                    AZ_Error("ModelDataInstance", false, "Cannot clone model for '%s'. Cloth simulation results won't be individual per entity.", modelAsset->GetName().GetCStr());
-                    model = RPI::Model::FindOrCreate(modelAsset);
+                    AZ_Error("ModelDataInstance", false, "Cannot clone model for '%s'. Cloth simulation results won't be individual per entity.", m_modelAsset->GetName().GetCStr());
+                    model = RPI::Model::FindOrCreate(m_modelAsset);
                 }
             }
             else
             {
                 // Static mesh, no cloth buffer present.
-                model = RPI::Model::FindOrCreate(modelAsset);
+                model = RPI::Model::FindOrCreate(m_modelAsset);
             }
-            
+
             if (model)
             {
                 RayTracingFeatureProcessor* rayTracingFeatureProcessor =
                     m_parent->m_scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
                 m_parent->RemoveRayTracingData(rayTracingFeatureProcessor);
                 m_parent->QueueInit(model);
-                m_modelChangedEvent.Signal(AZStd::move(model));
+                m_parent->m_modelChangedEvent.Signal(AZStd::move(model));
             }
             else
             {
-                //when running with null renderer, the RPI::Model::FindOrCreate(...) is expected to return nullptr, so suppress this error.
-                AZ_Error(
-                    "ModelDataInstance::OnAssetReady", RHI::IsNullRHI(), "Failed to create model instance for '%s'",
-                    asset.GetHint().c_str());
+                // when running with null renderer, the RPI::Model::FindOrCreate(...) is expected to return nullptr, so suppress this error.
+                AZ_Error("ModelDataInstance::OnAssetReady", RHI::IsNullRHI(), "Failed to create model instance for '%s'", asset.GetHint().c_str());
             }
         }
 
-        
         void ModelDataInstance::MeshLoader::OnModelReloaded(Data::Asset<Data::AssetData> asset)
         {
             OnAssetReady(asset);
@@ -1701,7 +1657,7 @@ namespace AZ
         {
             OnCatalogAssetChanged(assetId);
         }
-        
+
         void ModelDataInstance::MeshLoader::OnCatalogAssetAdded(const AZ::Data::AssetId& assetId)
         {
             // If the asset didn't exist in the catalog when it first attempted to load, we need to try loading it again
@@ -1755,7 +1711,8 @@ namespace AZ
 
             // We're intentionally using the MeshFeatureProcessor's value instead of using the cvar directly here,
             // because DeInit might be called after the cvar changes, but we want to do the de-initialization based
-            // on what the setting was before (when the resources were initialized). The MeshFeatureProcessor will still have the cached value in that case
+            // on what the setting was before (when the resources were initialized). The MeshFeatureProcessor will still have the cached
+            // value in that case
             if (!meshFeatureProcessor->IsMeshInstancingEnabled())
             {
                 m_drawPacketListsByLod.clear();
@@ -1783,7 +1740,7 @@ namespace AZ
                             AZStd::scoped_lock<AZStd::mutex> scopedLock(postCullingData.m_instanceGroupHandle->m_eventLock);
                             updateDrawPacketHandlers[meshIndex].Disconnect();
                         }
-                        
+
                         // Remove instance will decrement the use-count of the instance group, and only release the instance group
                         // if nothing else is referring to it.
                         meshInstanceManager.RemoveInstance(postCullingData.m_instanceGroupHandle);
@@ -1796,17 +1753,17 @@ namespace AZ
                 m_updateDrawPacketEventHandlersByLod.clear();
             }
 
-            m_customMaterials.clear();
+            m_descriptor.m_customMaterials.clear();
             m_objectSrgList = {};
             m_model = {};
         }
 
         void ModelDataInstance::ReInit(MeshFeatureProcessor* meshFeatureProcessor)
         {
-            CustomMaterialMap customMaterials = m_customMaterials;
+            CustomMaterialMap customMaterials = m_descriptor.m_customMaterials;
             const Data::Instance<RPI::Model> model = m_model;
             DeInit(meshFeatureProcessor);
-            m_customMaterials = customMaterials;
+            m_descriptor.m_customMaterials = customMaterials;
             m_model = model;
             QueueInit(m_model);
         }
@@ -1821,7 +1778,7 @@ namespace AZ
         void ModelDataInstance::Init(MeshFeatureProcessor* meshFeatureProcessor)
         {
             const size_t modelLodCount = m_model->GetLodCount();
-            
+
             if (!r_meshInstancingEnabled)
             {
                 m_drawPacketListsByLod.resize(modelLodCount);
@@ -1831,13 +1788,13 @@ namespace AZ
                 m_postCullingInstanceDataByLod.resize(modelLodCount);
                 m_updateDrawPacketEventHandlersByLod.resize(modelLodCount);
             }
-            
+
             for (size_t modelLodIndex = 0; modelLodIndex < modelLodCount; ++modelLodIndex)
             {
                 BuildDrawPacketList(meshFeatureProcessor, modelLodIndex);
             }
 
-            for(auto& objectSrg : m_objectSrgList)
+            for (auto& objectSrg : m_objectSrgList)
             {
                 // Set object Id once since it never changes
                 RHI::ShaderInputNameIndex objectIdIndex = "m_objectId";
@@ -1887,7 +1844,8 @@ namespace AZ
                 {
                     if (shaderItem.IsEnabled())
                     {
-                        // Check to see if the shaderItem has the o_meshInstancingEnabled option. All shader items in the draw packet must support this option
+                        // Check to see if the shaderItem has the o_meshInstancingEnabled option. All shader items in the draw packet must
+                        // support this option
                         RPI::ShaderOptionIndex index = shaderItem.GetShaderOptionGroup().GetShaderOptionLayout()->FindShaderOptionIndex(
                             s_o_meshInstancingIsEnabled_Name);
                         if (!index.IsValid())
@@ -1991,7 +1949,6 @@ namespace AZ
                     m_objectSrgList.push_back(meshObjectSrg);
                 }
 
-                
                 bool materialRequiresForwardPassIblSpecular = MaterialRequiresForwardPassIblSpecular(material);
 
                 // Track whether any materials in this mesh require ForwardPassIblSpecular, we need this information when the ObjectSrg is
@@ -2031,7 +1988,8 @@ namespace AZ
 
                         // We also use this path when r_meshInstancingDebugForceUniqueObjectsForProfiling is true, which makes meshes that
                         // would otherwise be instanced end up in a unique group. This is helpful for performance profiling to test the
-                        // worst case scenario of lots of objects that don't actually end up getting instanced but still go down the instancing path
+                        // worst case scenario of lots of objects that don't actually end up getting instanced but still go down the
+                        // instancing path
                         key.m_forceInstancingOff = Uuid::CreateRandom();
                     }
 
@@ -2045,11 +2003,10 @@ namespace AZ
                     m_postCullingInstanceDataByLod[modelLodIndex].push_back(postCullingData);
 
                     // Add an update draw packet event handler for the current mesh
-                    m_updateDrawPacketEventHandlersByLod[modelLodIndex].push_back(AZ::Event<>::Handler{
-                        [this]()
-                        {
-                            HandleDrawPacketUpdate();
-                        }});
+                    m_updateDrawPacketEventHandlersByLod[modelLodIndex].push_back(AZ::Event<>::Handler{ [this]()
+                                                                                                        {
+                                                                                                            HandleDrawPacketUpdate();
+                                                                                                        } });
                     // Connect to the update draw packet event
                     {
                         AZStd::scoped_lock<AZStd::mutex> scopedLock(instanceGroupInsertResult.m_handle->m_eventLock);
@@ -2063,12 +2020,7 @@ namespace AZ
                 if (!r_meshInstancingEnabled || instanceGroupInsertResult.m_instanceCount == 1)
                 {
                     // setup the mesh draw packet
-                    RPI::MeshDrawPacket drawPacket(
-                        modelLod,
-                        meshIndex,
-                        material,
-                        meshObjectSrg,
-                        customMaterialInfo.m_uvMapping);
+                    RPI::MeshDrawPacket drawPacket(modelLod, meshIndex, material, meshObjectSrg, customMaterialInfo.m_uvMapping);
 
                     // set the shader option to select forward pass IBL specular if necessary
                     if (!drawPacket.SetShaderOption(s_o_meshUseForwardPassIBLSpecular_Name, AZ::RPI::ShaderOptionValue{ m_descriptor.m_useForwardPassIblSpecular }))
@@ -2199,7 +2151,7 @@ namespace AZ
             shaderInputContract.m_streamChannels.emplace_back(bitangentStreamChannelInfo);
             shaderInputContract.m_streamChannels.emplace_back(uvStreamChannelInfo);
 
-            // setup the raytracing data for each sub-mesh 
+            // setup the raytracing data for each sub-mesh
             const size_t meshCount = modelLod->GetMeshes().size();
             RayTracingFeatureProcessor::SubMeshVector subMeshes;
             for (uint32_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
@@ -2461,8 +2413,9 @@ namespace AZ
             rayTracingMesh.m_transform = transformServiceFeatureProcessor->GetTransformForId(m_objectId);
             rayTracingMesh.m_nonUniformScale = transformServiceFeatureProcessor->GetNonUniformScaleForId(m_objectId);
             rayTracingMesh.m_isSkinnedMesh = m_descriptor.m_isSkinnedMesh;
-            rayTracingMesh.m_instanceMask |= (rayTracingMesh.m_isSkinnedMesh) ? static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::SKINNED_MESH) :
-                                                                                static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
+            rayTracingMesh.m_instanceMask |= (rayTracingMesh.m_isSkinnedMesh)
+                ? static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::SKINNED_MESH)
+                : static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
 
             // setup the reflection probe data, and track if this mesh is currently affected by a reflection probe
             SetRayTracingReflectionProbeData(meshFeatureProcessor, rayTracingMesh.m_reflectionProbe);
@@ -2723,7 +2676,7 @@ namespace AZ
             RPI::Cullable::LodData& lodData = m_cullable.m_lodData;
 
             const Aabb& localAabb = m_aabb;
-            lodData.m_lodSelectionRadius = 0.5f*localAabb.GetExtents().GetMaxElement();
+            lodData.m_lodSelectionRadius = 0.5f * localAabb.GetExtents().GetMaxElement();
 
             const size_t modelLodCount = m_model->GetLodCount();
             const auto& lodAssets = m_model->GetModelAsset()->GetLodAssets();
@@ -2977,7 +2930,7 @@ namespace AZ
             const CustomMaterialId ignoreLodId(DefaultCustomMaterialLodIndex, id.second);
             for (const auto& currentId : { id, ignoreLodId, DefaultCustomMaterialId })
             {
-                if (auto itr = m_customMaterials.find(currentId); itr != m_customMaterials.end() && itr->second.m_material)
+                if (auto itr = m_descriptor.m_customMaterials.find(currentId); itr != m_descriptor.m_customMaterials.end() && itr->second.m_material)
                 {
                     return itr->second;
                 }
@@ -2993,4 +2946,3 @@ namespace AZ
 
     } // namespace Render
 } // namespace AZ
-

--- a/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlane.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/OcclusionCullingPlane/OcclusionCullingPlane.cpp
@@ -33,7 +33,7 @@ namespace AZ
                 "Models/OcclusionCullingPlane.fbx.azmodel",
                 AZ::RPI::AssetUtils::TraceLevel::Assert);
 
-            m_visualizationMeshHandle = m_meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor{ m_visualizationModelAsset });
+            m_visualizationMeshHandle = m_meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor(m_visualizationModelAsset));
             m_meshFeatureProcessor->SetExcludeFromReflectionCubeMaps(m_visualizationMeshHandle, true);
             m_meshFeatureProcessor->SetRayTracingEnabled(m_visualizationMeshHandle, false);
             m_meshFeatureProcessor->SetTransform(m_visualizationMeshHandle, AZ::Transform::CreateIdentity());

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -23,7 +23,7 @@ namespace AZ
     {
         ReflectionProbe::~ReflectionProbe()
         {
-            Data::AssetBus::MultiHandler::BusDisconnect();
+            Data::AssetBus::Handler::BusDisconnect();
             m_scene->GetCullingScene()->UnregisterCullable(m_cullable);
             m_meshFeatureProcessor->ReleaseMesh(m_visualizationMeshHandle);
         }
@@ -33,7 +33,7 @@ namespace AZ
             if (m_visualizationMaterialAsset.GetId() == asset.GetId())
             {
                 m_visualizationMaterialAsset = asset;
-                Data::AssetBus::MultiHandler::BusDisconnect(asset.GetId());
+                Data::AssetBus::Handler::BusDisconnect();
 
                 m_meshFeatureProcessor->SetCustomMaterials(m_visualizationMeshHandle, AZ::RPI::Material::FindOrCreate(m_visualizationMaterialAsset));
             }
@@ -42,7 +42,7 @@ namespace AZ
         void ReflectionProbe::OnAssetError(Data::Asset<Data::AssetData> asset)
         {
             AZ_Error("ReflectionProbe", false, "Failed to load ReflectionProbe dependency asset %s", asset.ToString<AZStd::string>().c_str());
-            Data::AssetBus::MultiHandler::BusDisconnect(asset.GetId());
+            Data::AssetBus::Handler::BusDisconnect();
         }
 
         void ReflectionProbe::Init(RPI::Scene* scene, ReflectionRenderData* reflectionRenderData)
@@ -70,14 +70,14 @@ namespace AZ
             m_meshFeatureProcessor->SetExcludeFromReflectionCubeMaps(m_visualizationMeshHandle, true);
             m_meshFeatureProcessor->SetTransform(m_visualizationMeshHandle, AZ::Transform::CreateIdentity());
 
-            // We have to pre-load this asset before creating a Material instance because the InstanceDatabase will attempt a blocking load which could deadlock,
+            // We have to pre-load this asset before creating a material instance because the InstanceDatabase will attempt a blocking load which could deadlock,
             // particularly when slices are involved.
             // Note that m_visualizationMeshHandle had to be set up first, because AssetBus BusConnect() might call ReflectionProbe::OnAssetReady() immediately on this callstack.
             m_visualizationMaterialAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::MaterialAsset>(
                 "Materials/ReflectionProbe/ReflectionProbeVisualization.azmaterial",
                 AZ::RPI::AssetUtils::TraceLevel::Assert);
             m_visualizationMaterialAsset.QueueLoad();
-            Data::AssetBus::MultiHandler::BusConnect(m_visualizationMaterialAsset.GetId());
+            Data::AssetBus::Handler::BusConnect(m_visualizationMaterialAsset.GetId());
 
             // reflection render Srgs
             m_stencilSrg = RPI::ShaderResourceGroup::Create(

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.h
@@ -65,7 +65,7 @@ namespace AZ
 
         // ReflectionProbe manages all aspects of a single probe, including rendering, visualization, and cubemap generation
         class ReflectionProbe final
-            : public AZ::Data::AssetBus::MultiHandler
+            : public AZ::Data::AssetBus::Handler
             , private CubeMapRenderer
         {
         public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -85,9 +85,10 @@ namespace AZ::RHI
         /// Updates a Bottom Level Acceleration Structure (BLAS) for ray tracing operations, which is made up of RayTracingGeometry entries
         virtual void UpdateBottomLevelAccelerationStructure(const RHI::RayTracingBlas& rayTracingBlas) = 0;
 
-            /// Builds a Top Level Acceleration Structure (TLAS) for ray tracing operations, which is made up of RayTracingInstance entries that refer to a BLAS entry
-            virtual void BuildTopLevelAccelerationStructure(
-                const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) = 0;
+        /// Builds a Top Level Acceleration Structure (TLAS) for ray tracing operations, which is made up of RayTracingInstance entries that
+        /// refer to a BLAS entry
+        virtual void BuildTopLevelAccelerationStructure(
+            const RHI::RayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::RayTracingBlas*>& changedBlasList) = 0;
 
         /// Defines the submit range for a CommandList
         /// Note: the default is 0 items, which disables validation for items submitted outside of the framegraph

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -172,7 +172,7 @@ namespace AZ
             //! equal to the model asset that the model is linked to.
             static bool RequiresCloning(const Data::Asset<RPI::ModelAsset>& modelAsset);
 
-            void HandleModelChange(Data::Instance<RPI::Model> model);
+            void HandleModelChange(const Data::Instance<RPI::Model>& model);
             void HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg);
             void RegisterModel();
             void UnregisterModel();
@@ -194,12 +194,12 @@ namespace AZ
             //! Cached bus to use to notify RenderGeometry::Intersector the entity/component has changed.
             AzFramework::RenderGeometry::IntersectionNotificationBus::BusPtr m_intersectionNotificationBus;
 
-            MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_changeEventHandler
+            MeshHandleDescriptor::ModelChangedEvent::Handler m_modelChangedEventHandler
             {
-                [&](Data::Instance<RPI::Model> model) { HandleModelChange(model); }
+                [&](const Data::Instance<RPI::Model>& model) { HandleModelChange(model); }
             };
             
-            MeshFeatureProcessorInterface::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
+            MeshHandleDescriptor::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
             {
                 [&](const Data::Instance<RPI::ShaderResourceGroup>& objectSrg) { HandleObjectSrgCreate(objectSrg); }
             };

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -674,15 +674,13 @@ namespace AZ::Render
         {
             MeshHandleDescriptor meshDescriptor;
             meshDescriptor.m_modelAsset = m_skinnedMeshInstance->m_model->GetModelAsset();
-
+            meshDescriptor.m_customMaterials = ConvertToCustomMaterialMap(materials);
             meshDescriptor.m_isRayTracingEnabled = m_rayTracingEnabled;
             meshDescriptor.m_isAlwaysDynamic = true;
             meshDescriptor.m_excludeFromReflectionCubeMaps = true;
             meshDescriptor.m_isSkinnedMesh = true;
-
-            m_meshHandle = AZStd::make_shared<MeshFeatureProcessorInterface::MeshHandle>(
-                m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials)));
-            m_meshFeatureProcessor->ConnectObjectSrgCreatedEventHandler(*m_meshHandle, m_objectSrgCreatedHandler);
+            meshDescriptor.m_objectSrgCreatedHandler = m_objectSrgCreatedHandler;
+            m_meshHandle = AZStd::make_shared<MeshFeatureProcessorInterface::MeshHandle>(m_meshFeatureProcessor->AcquireMesh(meshDescriptor));
         }
 
         // If render proxies already exist, they will be auto-freed

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -228,7 +228,7 @@ namespace AZ
             AZStd::vector<Data::Instance<RPI::Image>> m_wrinkleMasks;
             AZStd::vector<float> m_wrinkleMaskWeights;
 
-            MeshFeatureProcessorInterface::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
+            MeshHandleDescriptor::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
             {
                 [&](const Data::Instance<RPI::ShaderResourceGroup>& objectSrg) { HandleObjectSrgCreate(objectSrg); }
             };

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -596,7 +596,7 @@ namespace EMotionFX
 
                 if (dependencyAsset && dependencyAsset.GetType() == azrtti_typeid<AZ::RPI::ModelAsset>())
                 {
-                    m_modelReloadedEventHandler = AZ::Render::ModelReloadedEvent::Handler(
+                     m_modelReloadedEventHandler = AZ::Render::ModelReloadedEvent::Handler(
                         [this](AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
                         {
                             m_actorAsset.QueueLoad();

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxAtomRenderMesh.cpp
@@ -199,7 +199,7 @@ namespace WhiteBox
         }
 
         m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
-        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_modelAsset }, m_materialInstance);
+        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor(m_modelAsset, m_materialInstance));
         AZ::Render::MeshHandleStateNotificationBus::Event(m_entityId, &AZ::Render::MeshHandleStateNotificationBus::Events::OnMeshHandleSet, &m_meshHandle);
 
         return true;


### PR DESCRIPTION
## What does this PR do?

This change resolves a problem with mesh feature processor, where event handlers are connected after the mesh handle has already been acquired and the model potentially already loaded. This issue forced callers to manually invoke the event handler function just in case the model was already loaded or potentially have it called twice if the model was reloaded. With this change, the event handlers are set up front on the descriptor before acquire is called to ensure that the handlers are available and called if the assets are already loaded. It reduces boilerplate code throughout samples and systems to handle the event manually.

Additionally common this change moves the custom materials container into the descriptor as primary storage, so that it can be set up front, stored in one place, simplifying the acquire interface.

Companion changes to ASV https://github.com/o3de/o3de-atom-sampleviewer/pull/656


## How was this PR tested?

Tested changes by loading the editor and other tools, levels in the editor from automated testing, multiplayer sample, and launching atom sample viewer which has companion changes.

There is a separate issue in the multiplayer sample where the editor gradient component needs to be removed in order to load the level.