### PR TITLE
Fix debug labels on Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Loader/LoaderContext.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Loader/LoaderContext.cpp
@@ -202,7 +202,7 @@ namespace AZ
             // but the function pointers do not load. Disable the extension if that's the case.
             if (device != VK_NULL_HANDLE &&
                 m_context.EXT_debug_utils &&
-                m_context.CmdBeginDebugUtilsLabelEXT)
+                !m_context.CmdBeginDebugUtilsLabelEXT)
             {
                 m_context.EXT_debug_utils = 0;
             }


### PR DESCRIPTION
## What does this PR do?

Fix debug labels on Vulkan (the ones that appear on Renderdoc)

## How was this PR tested?

Did a capture with Renderdoc when running on Vulkan