### PR TITLE
Updating material editor, canvas, and other atom tools to reference docs URLs

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -56,8 +56,8 @@ namespace AtomToolsFramework
         virtual void OpenSettingsDialog();
         virtual void OnSettingsDialogClosed();
 
-        virtual AZStd::string GetHelpDialogText() const;
-        virtual void OpenHelpDialog();
+        virtual AZStd::string GetHelpUrl() const;
+        virtual void OpenHelpUrl();
 
         virtual void OpenAboutDialog();
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -19,12 +19,13 @@
 
 #include <QClipboard>
 #include <QCloseEvent>
-#include <QFileDialog>
+#include <QDesktopServices>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QStatusBar>
+#include <QUrlQuery>
 #include <QVBoxLayout>
 
 namespace AtomToolsFramework
@@ -263,7 +264,7 @@ namespace AtomToolsFramework
         }, QKeySequence::Preferences);
 
         m_menuHelp->addAction(tr("&Help..."), [this]() {
-            OpenHelpDialog();
+            OpenHelpUrl();
         }, QKeySequence::HelpContents);
 
         m_menuHelp->addAction(tr("&About..."), [this]() {
@@ -377,19 +378,22 @@ namespace AtomToolsFramework
     {
     }
 
-    AZStd::string AtomToolsMainWindow::GetHelpDialogText() const
+    AZStd::string AtomToolsMainWindow::GetHelpUrl() const
     {
-        return AZStd::string();
+        return "https://docs.o3de.org/docs/atom-guide/look-dev/tools/";
     }
 
-    void AtomToolsMainWindow::OpenHelpDialog()
+    void AtomToolsMainWindow::OpenHelpUrl()
     {
-        QMessageBox::information(this, windowTitle(), GetHelpDialogText().c_str());
+        QDesktopServices::openUrl(QUrl(GetHelpUrl().c_str()));
     }
 
     void AtomToolsMainWindow::OpenAboutDialog()
     {
-        QMessageBox::about(this, windowTitle(), QApplication::applicationName());
+        const QString text = tr("<html><head/><body><p><b><u>%1</u></b></p><p><a href=\"%2\">Terms of Use</a></p></body></html>")
+                                 .arg(QApplication::applicationName())
+                                 .arg("https://www.o3debinaries.org/license");
+        QMessageBox::about(this, windowTitle(), text);
     }
 
     void AtomToolsMainWindow::showEvent(QShowEvent* showEvent)

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -260,23 +260,9 @@ namespace MaterialCanvas
         Base::OnSettingsDialogClosed();
     }
 
-    AZStd::string MaterialCanvasMainWindow::GetHelpDialogText() const
+    AZStd::string MaterialCanvasMainWindow::GetHelpUrl() const
     {
-        return R"(<html><head/><body>
-            <p><h3><u>Shader Build Settings</u></h3></p>
-            <p>Shaders, materials, and other assets will be generated as changes are applied to the graph.
-            The viewport will update and display the generated materials and shaders once they have been
-            compiled by the Asset Processor. This can take a few seconds. Compilation times and preview
-            responsiveness can be improved by enabling the Minimal Shader Build settings in the Tools->Settings
-            menu. Changing the settings will require restarting Material Canvas and the Asset Processor.</p>
-            <p><h3><u>Camera Controls</u></h3></p>
-            <p><b>LMB</b> - rotate camera</p>
-            <p><b>RMB</b> or <b>Alt+LMB</b> - orbit camera around target</p>
-            <p><b>MMB</b> - pan camera on its xy plane</p>
-            <p><b>Alt+RMB</b> or <b>LMB+RMB</b> - dolly camera on its z axis</p>
-            <p><b>Ctrl+LMB</b> - rotate model</p>
-            <p><b>Shift+LMB</b> - rotate environment</p>
-            </body></html>)";
+        return "https://docs.o3de.org/docs/atom-guide/look-dev/tools/material-canvas/";
     }
 } // namespace MaterialCanvas
 

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.h
@@ -52,7 +52,7 @@ namespace MaterialCanvas
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void PopulateSettingsInspector(AtomToolsFramework::InspectorWidget* inspector) const override;
         void OnSettingsDialogClosed() override;
-        AZStd::string GetHelpDialogText() const override;
+        AZStd::string GetHelpUrl() const override;
 
     private:
         AtomToolsFramework::AtomToolsDocumentInspector* m_documentInspector = {};

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.cpp
@@ -96,17 +96,9 @@ namespace MaterialEditor
         m_materialViewport->UnlockRenderTargetSize();
     }
 
-    AZStd::string MaterialEditorMainWindow::GetHelpDialogText() const
+    AZStd::string MaterialEditorMainWindow::GetHelpUrl() const
     {
-        return R"(<html><head/><body>
-            <p><h3><u>Camera Controls</u></h3></p>
-            <p><b>LMB</b> - rotate camera</p>
-            <p><b>RMB</b> or <b>Alt+LMB</b> - orbit camera around target</p>
-            <p><b>MMB</b> - pan camera on its xy plane</p>
-            <p><b>Alt+RMB</b> or <b>LMB+RMB</b> - dolly camera on its z axis</p>
-            <p><b>Ctrl+LMB</b> - rotate model</p>
-            <p><b>Shift+LMB</b> - rotate environment</p>
-            </body></html>)";
+        return "https://docs.o3de.org/docs/atom-guide/look-dev/tools/material-editor/";
     }
 } // namespace MaterialEditor
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorMainWindow.h
@@ -43,7 +43,7 @@ namespace MaterialEditor
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
 
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
-        AZStd::string GetHelpDialogText() const override;
+        AZStd::string GetHelpUrl() const override;
 
         AtomToolsFramework::AtomToolsDocumentInspector* m_documentInspector = {};
         AtomToolsFramework::EntityPreviewViewportSettingsInspector* m_viewportSettingsInspector = {};

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
@@ -180,17 +180,9 @@ namespace PassCanvas
         Base::OnSettingsDialogClosed();
     }
 
-    AZStd::string PassCanvasMainWindow::GetHelpDialogText() const
+    AZStd::string PassCanvasMainWindow::GetHelpUrl() const
     {
-        return R"(<html><head/><body>
-            <p><h3><u>Camera Controls</u></h3></p>
-            <p><b>LMB</b> - rotate camera</p>
-            <p><b>RMB</b> or <b>Alt+LMB</b> - orbit camera around target</p>
-            <p><b>MMB</b> - pan camera on its xy plane</p>
-            <p><b>Alt+RMB</b> or <b>LMB+RMB</b> - dolly camera on its z axis</p>
-            <p><b>Ctrl+LMB</b> - rotate model</p>
-            <p><b>Shift+LMB</b> - rotate environment</p>
-            </body></html>)";
+        return "https://docs.o3de.org/docs/atom-guide/look-dev/tools/";
     }
 } // namespace PassCanvas
 

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.h
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.h
@@ -52,7 +52,7 @@ namespace PassCanvas
         // AtomToolsFramework::AtomToolsDocumentMainWindow overrides...
         void PopulateSettingsInspector(AtomToolsFramework::InspectorWidget* inspector) const override;
         void OnSettingsDialogClosed() override;
-        AZStd::string GetHelpDialogText() const override;
+        AZStd::string GetHelpUrl() const override;
 
     private:
         AtomToolsFramework::AtomToolsDocumentInspector* m_documentInspector = {};


### PR DESCRIPTION
## What does this PR do?

Changing material editor and other tools to open documentation links instead of having dedicated help dialogs.

Add in terms of use and other details to about dialogs.

Resolves https://github.com/o3de/o3de/issues/8638

## How was this PR tested?

Confirmed that pressing F1 or clicking the help menu action opens the designated url in the browser instead of opening a help dialog