### PR TITLE
[Vulkan] Add AppendVkStruct function

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -144,8 +144,6 @@ namespace AZ
             AZStd::vector<VkDeviceQueueCreateInfo> queueCreationInfo;
             VkDeviceQueueCreateInfo queueCreateInfo = {};
             queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-            queueCreateInfo.pNext = nullptr;
-            queueCreateInfo.flags = 0;
 
             for (size_t familyIndex = 0; familyIndex < m_queueFamilyProperties.size(); ++familyIndex)
             {
@@ -171,6 +169,7 @@ namespace AZ
 
             // unbounded array functionality
             VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptorIndexingFeatures = {};
+            VkBaseOutStructure& chainInit = reinterpret_cast<VkBaseOutStructure&>(descriptorIndexingFeatures);
             descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
             const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& physicalDeviceDescriptorIndexingFeatures =
                 physicalDevice.GetPhysicalDeviceDescriptorIndexingFeatures();
@@ -195,46 +194,54 @@ namespace AZ
                 physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind;
 
             auto bufferDeviceAddressFeatures = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures();
-            descriptorIndexingFeatures.pNext = &bufferDeviceAddressFeatures;
-
-            auto depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();
-            bufferDeviceAddressFeatures.pNext = &depthClipEnabled;
-
-            auto fragmenDensityMapFeatures = physicalDevice.GetPhysicalDeviceFragmentDensityMapFeatures();
-            depthClipEnabled.pNext = &fragmenDensityMapFeatures;
-
-            auto fragmenShadingRateFeatures = physicalDevice.GetPhysicalDeviceFragmentShadingRateFeatures();
-            fragmenDensityMapFeatures.pNext = &fragmenShadingRateFeatures;
-
-            if (fragmenShadingRateFeatures.attachmentFragmentShadingRate)
-            {
-                // Must disable the "fragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
-                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
-                fragmenDensityMapFeatures.fragmentDensityMap = false;
-            }
-            else if (fragmenDensityMapFeatures.fragmentDensityMap)
-            {
-                // Must disable the "pipelineFragmentShadingRate" and "primitiveFragmentShadingRate" usage if "fragmentDensityMap" is enabled.
-                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentShadingRate);
-                fragmenShadingRateFeatures.pipelineFragmentShadingRate = false;
-                fragmenShadingRateFeatures.primitiveFragmentShadingRate = false;
-            }
+            auto depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();            
+            auto rayQueryFeatures = physicalDevice.GetRayQueryFeatures();            
+            auto shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();            
 
             VkPhysicalDeviceRobustness2FeaturesEXT robustness2 = {};
             robustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
             robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobutness2Features().nullDescriptor;
-            fragmenShadingRateFeatures.pNext = &robustness2;
 
-            VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
-            robustness2.pNext = &rayQueryFeatures;
+            bufferDeviceAddressFeatures.pNext = nullptr;
+            depthClipEnabled.pNext = nullptr;
+            rayQueryFeatures.pNext = nullptr;
+            shaderImageAtomicInt64.pNext = nullptr;
+            robustness2.pNext = nullptr;
 
-            VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();
-            rayQueryFeatures.pNext = &shaderImageAtomicInt64;
+            AppendVkStruct(
+                chainInit,
+                {
+                    &bufferDeviceAddressFeatures,
+                    &depthClipEnabled,
+                    &rayQueryFeatures,
+                    &shaderImageAtomicInt64,
+                    &robustness2
+                });
+
+            auto fragmenDensityMapFeatures = physicalDevice.GetPhysicalDeviceFragmentDensityMapFeatures();
+            auto fragmenShadingRateFeatures = physicalDevice.GetPhysicalDeviceFragmentShadingRateFeatures();
+
+            if (fragmenShadingRateFeatures.attachmentFragmentShadingRate)
+            {
+                // Must disable the "FragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
+                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
+                fragmenShadingRateFeatures.pNext = nullptr;
+                AppendVkStruct(chainInit, &fragmenShadingRateFeatures);
+            }
+            else if (fragmenDensityMapFeatures.fragmentDensityMap)
+            {
+                // Must disable the "FragmentShadingRate" usage if "fragmentDensityMap" is enabled.
+                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentShadingRate);
+                fragmenDensityMapFeatures.pNext = nullptr;
+                AppendVkStruct(chainInit, &fragmenDensityMapFeatures);
+            }
 
             VkPhysicalDeviceVulkan12Features vulkan12Features = {};
             VkPhysicalDeviceShaderFloat16Int8FeaturesKHR float16Int8 = {};
             VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separateDepthStencil = {};
             VkPhysicalDeviceShaderAtomicInt64Features shaderAtomicInt64 = {};
+            VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {};
+            VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {};
 
             VkDeviceCreateInfo deviceInfo = {};
             deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
@@ -264,7 +271,16 @@ namespace AZ
                 vulkan12Features.descriptorBindingStorageBufferUpdateAfterBind = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingStorageBufferUpdateAfterBind;
                 vulkan12Features.descriptorBindingPartiallyBound = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingPartiallyBound;
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
-                shaderImageAtomicInt64.pNext = &vulkan12Features;
+
+                accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
+                accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
+
+                rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
+                rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
+                rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
+
+                AppendVkStruct(chainInit, { &vulkan12Features, &accelerationStructureFeatures, &rayTracingPipelineFeatures });
+                // Do not start from the chainInit, but from the depthClipEnabled struct
                 deviceInfo.pNext = &depthClipEnabled;
             }
             else
@@ -274,15 +290,13 @@ namespace AZ
 
                 separateDepthStencil.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
                 separateDepthStencil.separateDepthStencilLayouts = physicalDevice.GetPhysicalDeviceSeparateDepthStencilFeatures().separateDepthStencilLayouts;
-                float16Int8.pNext = &separateDepthStencil;
 
                 shaderAtomicInt64.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
                 shaderAtomicInt64.shaderBufferInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderBufferInt64Atomics;
                 shaderAtomicInt64.shaderSharedInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderSharedInt64Atomics;
-                separateDepthStencil.pNext = &shaderAtomicInt64;
 
-                shaderImageAtomicInt64.pNext = &float16Int8;
-                deviceInfo.pNext = &descriptorIndexingFeatures;
+                AppendVkStruct(chainInit, { &float16Int8, &separateDepthStencil, &shaderAtomicInt64 });
+                deviceInfo.pNext = &chainInit;
             }
 
 #if defined(USE_NSIGHT_AFTERMATH)
@@ -301,22 +315,6 @@ namespace AZ
             aftermathInfo.pNext = deviceInfo.pNext;
             deviceInfo.pNext = &aftermathInfo;
 #endif
-
-            // set raytracing features if we are running Vulkan >= 1.2
-            VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {};
-            VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {};
-
-            if (majorVersion >= 1 && minorVersion >= 2)
-            {
-                accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
-                accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
-                vulkan12Features.pNext = &accelerationStructureFeatures;
-
-                rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
-                rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
-                rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
-                accelerationStructureFeatures.pNext = &rayTracingPipelineFeatures;
-            }
 
             deviceInfo.flags = 0;
             deviceInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreationInfo.size());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -359,100 +359,60 @@ namespace AZ
 
             if (VK_INSTANCE_EXTENSION_SUPPORTED(context, KHR_get_physical_device_properties2))
             {
-                // features
-                VkPhysicalDeviceDescriptorIndexingFeaturesEXT& descriptorIndexingFeatures = m_descriptorIndexingFeatures;
-                descriptorIndexingFeatures = {};
-                descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
-
-                VkPhysicalDeviceBufferDeviceAddressFeaturesEXT& bufferDeviceAddressFeatures = m_bufferDeviceAddressFeatures;
-                bufferDeviceAddressFeatures = {};
-                bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT;
-                descriptorIndexingFeatures.pNext = &bufferDeviceAddressFeatures;
-
-                VkPhysicalDeviceDepthClipEnableFeaturesEXT& dephClipEnableFeatures = m_dephClipEnableFeatures;
-                dephClipEnableFeatures = {};
-                dephClipEnableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
-                bufferDeviceAddressFeatures.pNext = &dephClipEnableFeatures;
-
-                VkPhysicalDeviceShaderAtomicInt64Features& shaderAtomicInt64Features = m_shaderAtomicInt64Features;
-                shaderAtomicInt64Features = {};
-                shaderAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
-                dephClipEnableFeatures.pNext = &shaderAtomicInt64Features;
-
-                VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& shaderImageAtomicInt64Features = m_shaderImageAtomicInt64Features;
-                shaderImageAtomicInt64Features = {};
-                shaderImageAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
-                shaderAtomicInt64Features.pNext = &shaderImageAtomicInt64Features;
-
-                VkPhysicalDeviceRayQueryFeaturesKHR& rayQueryFeatures = m_rayQueryFeatures;
-                rayQueryFeatures = {};
-                rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
-                shaderImageAtomicInt64Features.pNext = &rayQueryFeatures;
-
-                VkPhysicalDeviceRobustness2FeaturesEXT& robustness2Feature = m_robutness2Features;
-                robustness2Feature = {};
-                robustness2Feature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
-                rayQueryFeatures.pNext = &robustness2Feature;
-
-                VkPhysicalDeviceShaderFloat16Int8FeaturesKHR& float16Int8Features = m_float16Int8Features;
-                float16Int8Features = {};
-                float16Int8Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
-                robustness2Feature.pNext = &float16Int8Features;
-
-                VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR& separateDepthStencilFeatures = m_separateDepthStencilFeatures;
-                separateDepthStencilFeatures = {};
-                separateDepthStencilFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
-                float16Int8Features.pNext = &separateDepthStencilFeatures;
-
-                VkPhysicalDeviceVulkan12Features& vulkan12Features = m_vulkan12Features;
-                vulkan12Features = {};
-                vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-                separateDepthStencilFeatures.pNext = &vulkan12Features;
-
-                VkPhysicalDeviceAccelerationStructureFeaturesKHR& accelerationStructureFeatures = m_accelerationStructureFeatures;
-                accelerationStructureFeatures = {};
-                accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
-                vulkan12Features.pNext = &accelerationStructureFeatures;
-
-                VkPhysicalDeviceRayTracingPipelineFeaturesKHR& rayTracingPipelineFeatures = m_rayTracingPipelineFeatures;
-                rayTracingPipelineFeatures = {};
-                rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
-                accelerationStructureFeatures.pNext = &rayTracingPipelineFeatures;
-
-                VkPhysicalDeviceFragmentShadingRateFeaturesKHR& shadingRateFeatures = m_shadingRateFeatures;
-                shadingRateFeatures = {};
-                shadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
-                rayTracingPipelineFeatures.pNext = &shadingRateFeatures;
-
-                VkPhysicalDeviceFragmentDensityMapFeaturesEXT& densityMapFeatures = m_fragmentDensityMapFeatures;
-                densityMapFeatures = {};
-                densityMapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT;
-                shadingRateFeatures.pNext = &densityMapFeatures;
+                // Features
+                m_descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+                m_bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT;
+                m_dephClipEnableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
+                m_shaderAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
+                m_shaderImageAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
+                m_rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
+                m_robutness2Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
+                m_float16Int8Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
+                m_separateDepthStencilFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
+                m_vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+                m_accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
+                m_rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
+                m_shadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
+                m_fragmentDensityMapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT;
 
                 VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
                 deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-                deviceFeatures2.pNext = &descriptorIndexingFeatures;
+                AppendVkStruct(
+                    deviceFeatures2,
+                    { &m_descriptorIndexingFeatures,
+                      &m_bufferDeviceAddressFeatures,
+                      &m_dephClipEnableFeatures,
+                      &m_shaderAtomicInt64Features,
+                      &m_shaderImageAtomicInt64Features,
+                      &m_rayQueryFeatures,
+                      &m_robutness2Features,
+                      &m_float16Int8Features,
+                      &m_separateDepthStencilFeatures,
+                      &m_vulkan12Features ,
+                      &m_accelerationStructureFeatures,
+                      &m_rayTracingPipelineFeatures,
+                      &m_shadingRateFeatures,
+                      &m_fragmentDensityMapFeatures});
 
                 context.GetPhysicalDeviceFeatures2KHR(vkPhysicalDevice, &deviceFeatures2);
                 m_deviceFeatures = deviceFeatures2.features;
 
-                // properties
-                VkPhysicalDeviceProperties2 deviceProps2 = {};
+                // Properties
                 m_conservativeRasterProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT;
-                deviceProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
-                deviceProps2.pNext = &m_conservativeRasterProperties;
-
                 m_rayTracingPipelineProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
-                m_conservativeRasterProperties.pNext = &m_rayTracingPipelineProperties;
-
                 m_accelerationStructureProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
-                m_rayTracingPipelineProperties.pNext = &m_accelerationStructureProperties;
-
                 m_fragmentDensityMapProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT;
-                m_accelerationStructureProperties.pNext = &m_fragmentDensityMapProperties;
-
                 m_fragmentShadingRateProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR;
-                m_fragmentDensityMapProperties.pNext = &m_fragmentShadingRateProperties;
+                
+                VkPhysicalDeviceProperties2 deviceProps2 = {};
+                deviceProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+                AppendVkStruct(
+                    deviceProps2,
+                    { &m_conservativeRasterProperties,
+                      &m_rayTracingPipelineProperties,
+                      &m_accelerationStructureProperties,
+                      &m_fragmentDensityMapProperties,
+                      &m_fragmentShadingRateProperties });
 
                 context.GetPhysicalDeviceProperties2KHR(vkPhysicalDevice, &deviceProps2);
                 m_deviceProperties = deviceProps2.properties;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -129,6 +129,32 @@ namespace AZ
 
         bool operator==(const VkImageSubresourceRange& lhs, const VkImageSubresourceRange& rhs);
 
+        /// Appends a list of Vulkan structs to end of the "next" chain
+        template<class T>
+        void AppendVkStruct(T& init, const AZStd::vector<void*>& nextStructs)
+        {
+            VkBaseOutStructure* baseStruct = reinterpret_cast<VkBaseOutStructure*>(&init);
+            // Find the last struct in the chain
+            while (baseStruct->pNext)
+            {
+                baseStruct = baseStruct->pNext;
+            }
+
+            // Add the new structs to the chain
+            for (void* nextStruct : nextStructs)
+            {
+                baseStruct->pNext = reinterpret_cast<VkBaseOutStructure*>(nextStruct);
+                baseStruct = baseStruct->pNext;
+            }
+        }
+
+        /// Appends a Vulkan struct to end of the "next" chain
+        template<class T>
+        void AppendVkStruct(T& init, void* nextStruct)
+        {
+            AppendVkStruct(init, AZStd::vector<void*>{ nextStruct });
+        }
+
         AZ_DEFINE_ENUM_BITWISE_OPERATORS(VkImageLayout);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Refactor the chaining of Vulkan structs when creating a VkPhysicalDevice and VkDevice object. It was getting really hard to keep track the chain of vulkan structs that were involved in the creation of a physical device and device. Added an utility function to keep the process cleaner.

## How was this PR tested?

Run Vulkan on Windows and Android