### PR TITLE
Add splash on black background to game launcher

### DIFF
--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -9,6 +9,7 @@
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Windows.h>
 #include <AzFramework/Windowing/NativeWindow.h>
 #include <AzFramework/Windowing/NativeWindow_Windows.h>
+#include <AzFramework/Windowing/Resources.h>
 
 #include <AzCore/Module/DynamicModuleHandle.h>
 #include <AzCore/PlatformIncl.h>
@@ -40,6 +41,31 @@ namespace AzFramework
         m_win32Handle = nullptr;
     }
 
+    void DrawSplash(HWND hWnd)
+    {
+        const HINSTANCE hInstance = GetModuleHandle(0);
+        auto hImage = (HBITMAP)LoadImageA(hInstance, MAKEINTRESOURCEA(IDB_SPLASH1), IMAGE_BITMAP, 0, 0, 0);
+        if (hImage)
+        {
+            HDC hDC = GetDC(hWnd);
+            HDC hDCBitmap = CreateCompatibleDC(hDC);
+            BITMAP bm;
+
+            GetObjectA(hImage, sizeof(bm), &bm);
+            SelectObject(hDCBitmap, hImage);
+
+            RECT Rect;
+            GetWindowRect(hWnd, &Rect);
+
+            DWORD x = ((Rect.right - Rect.left) - bm.bmWidth) >> 1;
+            DWORD y = ((Rect.bottom - Rect.top) - bm.bmHeight) >> 1;
+            BitBlt(hDC, x, y, bm.bmWidth, bm.bmHeight, hDCBitmap, 0, 0, SRCCOPY);
+
+            DeleteObject(hImage);
+            DeleteDC(hDCBitmap);
+        }
+    }
+
     void NativeWindowImpl_Win32::InitWindow(const AZStd::string& title,
                                             const WindowGeometry& geometry,
                                             const WindowStyleMasks& styleMasks)
@@ -58,7 +84,7 @@ namespace AzFramework
             windowClass.hInstance = hInstance;
             windowClass.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
             windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-            windowClass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+            windowClass.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
             windowClass.lpszMenuName = NULL;
             windowClass.lpszClassName = s_defaultClassName;
             windowClass.hIconSm = LoadIcon(hInstance, IDI_APPLICATION);
@@ -118,6 +144,7 @@ namespace AzFramework
             // This will result in a WM_SIZE message which will send the OnWindowResized notification
             ShowWindow(m_win32Handle, SW_SHOW);
             UpdateWindow(m_win32Handle);
+            DrawSplash(m_win32Handle);
         }
     }
 
@@ -376,6 +403,8 @@ namespace AzFramework
         {
             m_width = width;
             m_height = height;
+
+            DrawSplash(m_win32Handle);
 
             if (m_activated)
             {

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/Resources.h
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/Resources.h
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AzFramework/Windowing/Resources.h>
+#pragma once
 
-IDI_ICON1 ICON DISCARDABLE "@ICON_FILE@"
-IDB_SPLASH1 BITMAP DISCARDABLE "@SPLASH_FILE@"
+#define IDB_SPLASH1 101

--- a/Code/Framework/AzFramework/Platform/Windows/platform_nativeui_windows_files.cmake
+++ b/Code/Framework/AzFramework/Platform/Windows/platform_nativeui_windows_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     AzFramework/Application/Application_Windows.h
     AzFramework/Windowing/NativeWindow_Windows.cpp
     AzFramework/Windowing/NativeWindow_Windows.h
+    AzFramework/Windowing/Resources.h
     AzFramework/Input/Devices/Gamepad/InputDeviceGamepad_Windows.cpp
     AzFramework/Input/Devices/Gamepad/InputDeviceGamepad_Windows.h
     AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Windows.cpp

--- a/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
+++ b/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
@@ -17,7 +17,13 @@ if(NOT EXISTS ${ICON_FILE})
     set(ICON_FILE Resources/GameSDK.ico)
 endif()
 
-if(EXISTS ${ICON_FILE})
+set(SPLASH_FILE ${project_real_path}/Resources/Splash.bmp)
+if(NOT EXISTS ${SPLASH_FILE})
+    # Try legacy splash
+    set(SPLASH_FILE ${project_real_path}/Resources/LegacyLogoLauncher.bmp)
+endif()
+
+if(EXISTS ${ICON_FILE} OR EXISTS ${SPLASH_FILE})
     set(target_file ${CMAKE_CURRENT_BINARY_DIR}/${project_name}.GameLauncher.rc)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/Launcher.rc.in
         ${target_file}

--- a/Templates/DefaultProject/Template/Resources/LegacyLogoLauncher.bmp
+++ b/Templates/DefaultProject/Template/Resources/LegacyLogoLauncher.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3584c695998fd5f2d137148a11f68602523c817af5d18fdd6c56b0b5278a6c
-size 462760

--- a/Templates/DefaultProject/Template/Resources/Splash.bmp
+++ b/Templates/DefaultProject/Template/Resources/Splash.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd314f41b90bc9cba384d86eed865568343cbd332568f74c8ca39a08bc43836
+size 1200056

--- a/Templates/DefaultProject/template.json
+++ b/Templates/DefaultProject/template.json
@@ -207,7 +207,7 @@
             "isTemplated": false
         },
         {
-            "file": "Resources/LegacyLogoLauncher.bmp",
+            "file": "Resources/Splash.bmp",
             "isTemplated": false
         },
         {

--- a/Templates/MinimalProject/Template/Resources/LegacyLogoLauncher.bmp
+++ b/Templates/MinimalProject/Template/Resources/LegacyLogoLauncher.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3584c695998fd5f2d137148a11f68602523c817af5d18fdd6c56b0b5278a6c
-size 462760

--- a/Templates/MinimalProject/Template/Resources/Splash.bmp
+++ b/Templates/MinimalProject/Template/Resources/Splash.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd314f41b90bc9cba384d86eed865568343cbd332568f74c8ca39a08bc43836
+size 1200056

--- a/Templates/MinimalProject/template.json
+++ b/Templates/MinimalProject/template.json
@@ -191,7 +191,7 @@
             "isTemplated": true
         },
         {
-            "file": "Resources/LegacyLogoLauncher.bmp",
+            "file": "Resources/Splash.bmp",
             "isTemplated": false
         },
         {


### PR DESCRIPTION
## What does this PR do?

- changes the game launcher background from windows default (bright white) to black
- draws a splash bitmap centered in the window (windows only for now) - splash comes from [o3de logo pack ](https://github.com/o3de/artwork)
![image](https://github.com/o3de/o3de/assets/3628857/15443eb7-538b-49df-9a0f-d97cf71224fb)
- replaces `LegacyLauncherLogo.bmp` with `Splash.bmp`

This is still in draft, need to fix coding style, c-style casting, and hopefully add the splash to Linux and Mac launchers.

## How was this PR tested?

- ran the profile game launcher on Windows and verified the splash screen is shown before the renderer starts drawing

