### PR TITLE
Material Canvas: Negate surface normals when rendering back faces

### DIFF
--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -55,6 +55,7 @@ Surface EvaluateSurface_MaterialGraphName(
     surface.position = positionWS;
     surface.vertexNormal = normalWS;
     surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((real2)inNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
+    surface.normal *= real(mad(isFrontFace, 2.0, -1.0));
 
     surface.roughnessLinear = inRoughness;
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -67,6 +67,7 @@ Surface EvaluateSurface_MaterialGraphName(
     surface.position = positionWS;
     surface.vertexNormal = normalWS;
     surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((real2)inNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
+    surface.normal *= real(mad(isFrontFace, 2.0, -1.0));
     surface.roughnessLinear = inRoughness;
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);
     surface.CalculateRoughnessA();


### PR DESCRIPTION
## What does this PR do?

This change updates material canvas shaders to invert the surface normal when rendering back faces. The original PBR material types handled this deep inside common functions that expected standardized material SRG properties, textures, options, and other parameters. Material canvas does not produce a standard material SRG or properties and cannot use these functions because everything is dynamically defined by the the graph.

Resolves https://github.com/o3de/o3de/issues/17254

## How was this PR tested?

<img width="407" alt="image" src="https://github.com/o3de/o3de/assets/82461473/14743de3-f049-4cee-b557-0cf809c1886a">
