### PR TITLE
Fix crash when right-clicking on log messages in scene setting view

### DIFF
--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.cpp
@@ -171,7 +171,7 @@ void SceneSettingsCard::AddLogEntry(const AzToolsFramework::Logging::LogEntry& l
         }
     }
 
-    m_additionalLogDetails.push_back(detailsForLogLine);
+    m_additionalLogDetails[m_reportModel->rowCount()] = detailsForLogLine;
     
     if (logEntry.GetSeverity() == AzToolsFramework::Logging::LogEntry::Severity::Error)
     {
@@ -438,12 +438,8 @@ void SceneSettingsCard::ShowLogContextMenu(const QPoint& pos)
     }
     
     int logRow = selectedIndex.row();
-    if (logRow <= 0)
-    {
-        return;
-    }
 
-    if (logRow > m_additionalLogDetails.count())
+    if (!m_additionalLogDetails.contains(logRow))
     {
         return;
     }

--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
@@ -17,6 +17,7 @@
 #include <AzQtComponents/Components/Widgets/Card.h>
 #include <AzQtComponents/Components/Widgets/CardHeader.h>
 #include <SceneAPI/SceneUI/SceneUIConfiguration.h>
+#include <QMap>
 #include <QPair>
 #include <QString>
 #include <QVector>
@@ -128,7 +129,7 @@ private:
     void AddLogTableEntry(AzQtComponents::StyledDetailsTableModel::TableEntry& entry);
 
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-    QVector<QVector<QPair<QString, QString>>> m_additionalLogDetails;
+    QMap<int, QVector<QPair<QString, QString>>> m_additionalLogDetails;
     
     AzToolsFramework::Debug::TraceContextMultiStackHandler m_traceStackHandler;
     AZ::Uuid m_traceTag;


### PR DESCRIPTION
## What does this PR do?

When changing the scene settings for eg. a FBX file, and then right-clicking on some of the log messages to show additional data, the editor crashes in some cases.
This happens because the vector `m_additionalLogDetails` in `SceneSettingsCard` is not appended to for each log message, just for some warnings and errors, but it is later queried by the line number of the right-clicked log message, which leads to wrong messages being shown if there are info-messages at the start of the list and crashes due to out-of-bounds access of the array when right-clicking on entries further down the list.

I changed the data type of `m_additionalLogDetails` to use a `QMap` with the line number as key, such that both cases work correctly.

## How was this PR tested?

I was not able to test this with the latest development version, since the editor always crashes when I try to open the "FBX settings" tab of the inspector due to a unrelated Qt crash.
With an internal version of O3DE, which is based on 2305, this fixes the crashes and wrong messages; and since the two changed files were basically not modified since then I assume it would also work in the latest version.