### PR TITLE
quick fix for truncation warning

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -68,7 +68,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), deviceIndex))
+                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), static_cast<AZ::u8>(deviceIndex)))
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -68,6 +68,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
+                // cast to u8 to prevent warning
                 if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), static_cast<AZ::u8>(deviceIndex)))
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());


### PR DESCRIPTION
## What does this PR do?
fixes truncation warning when mixing u8s and ints. Technically dangerous if the deviceIndex can exceed 256...

## How was this PR tested?
locally, in the Editor project
