### PR TITLE
Fix MiniAudio compile issue in SDK (Installer buillds)

### DIFF
--- a/Gems/Achievements/CMakeLists.txt
+++ b/Gems/Achievements/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #
 
-o3de_gem_setup("Acheivements")
+o3de_gem_setup("Achievements")
 
 ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 

--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+get_property(miniaudio_gem_root GLOBAL PROPERTY "@GEMROOT:MiniAudio@")
+ly_add_external_target(
+    NAME miniaudio 
+    3RDPARTY_ROOT_DIRECTORY "${miniaudio_gem_root}/3rdParty/miniaudio"
+    VERSION
+)
+
+ly_add_external_target(
+    NAME stb_vorbis 
+    3RDPARTY_ROOT_DIRECTORY "${miniaudio_gem_root}/3rdParty/stb_vorbis"
+    VERSION
+)
+

--- a/Gems/MiniAudio/CMakeLists.txt
+++ b/Gems/MiniAudio/CMakeLists.txt
@@ -10,4 +10,6 @@ o3de_gem_setup("MiniAudio")
 
 add_subdirectory(3rdParty)
 
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
+
 add_subdirectory(Code)


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/o3de/o3de/issues/17327 by declaring external targets for SDK builds.  The `miniaudio.h` and `stb_vorbis.c` files are not needed by the SDK but `permutations.cmake` CMake still refers to those targets.
- Fixes the default gem name for the Achievments gem in cmake

## How was this PR tested?

- Created a local O3DE SDK
- Created a project with MiniAudio, configured, built and opened the Editor and verified I could play audio
