### PR TITLE
Fix expansion state saving/restoring for PrefabOverrideLabelHandler

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ExpanderSettings.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ExpanderSettings.cpp
@@ -187,9 +187,10 @@ namespace AZ::DocumentPropertyEditor
             for (auto arrayIter = rowValue.ArrayBegin(), endIter = rowValue.ArrayEnd(); arrayIter != endIter; ++arrayIter)
             {
                 auto& currChild = *arrayIter;
-                if (currChild.GetNodeName() == AZ::Dpe::GetNodeName<AZ::Dpe::Nodes::Label>())
+                auto valueMember = currChild.FindMember("Value");
+                if (valueMember != currChild.MemberEnd() && valueMember->second.IsString())
                 {
-                    subString = AZ::Dpe::Nodes::Label::Value.ExtractFromDomNode(currChild).value_or("");
+                    subString = valueMember->second.GetString();
                     break;
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -73,7 +73,7 @@ namespace AzToolsFramework::Prefab
         AZ_Assert(adapterBuilder != nullptr, "PrefabComponentAdapter: CreateLabel called with null adapterBuilder!");
 
         adapterBuilder->BeginPropertyEditor<PrefabOverrideLabel>();
-        adapterBuilder->Attribute(PrefabOverrideLabel::Text, labelText);
+        adapterBuilder->Attribute(PrefabOverrideLabel::Value, labelText);
 
         AZ::Dom::Path relativePathFromEntity;
         if (!m_componentAlias.empty() && !serializedPath.empty())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -39,7 +39,7 @@ namespace AzToolsFramework::Prefab
         m_overridden = PrefabOverrideLabel::IsOverridden.ExtractFromDomNode(domValue).value_or(false);
 
         // Set up label
-        AZStd::string_view labelText = PrefabOverrideLabel::Text.ExtractFromDomNode(domValue).value_or("");
+        AZStd::string_view labelText = PrefabOverrideLabel::Value.ExtractFromDomNode(domValue).value_or("");
         m_textLabel->setText(QString::fromUtf8(labelText.data(), aznumeric_cast<int>(labelText.size())));
 
         m_textLabel->setProperty(OverriddenPropertyName, QVariant(m_overridden));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabPropertyEditorNodes.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabPropertyEditorNodes.h
@@ -15,7 +15,7 @@ namespace AzToolsFramework::Prefab::PrefabPropertyEditorNodes
     struct PrefabOverrideLabel : AZ::DocumentPropertyEditor::NodeDefinition
     {
         static constexpr AZStd::string_view Name = "PrefabOverrideLabel";
-        static constexpr auto Text = AZ::DocumentPropertyEditor::AttributeDefinition<AZStd::string_view>("Text");
+        static constexpr auto Value = AZ::DocumentPropertyEditor::AttributeDefinition<AZStd::string_view>("Value");
         static constexpr auto IsOverridden = AZ::DocumentPropertyEditor::AttributeDefinition<bool>("IsOverridden");
         static constexpr auto RelativePath = AZ::DocumentPropertyEditor::AttributeDefinition<AZStd::string_view>("RelativePath");
         static constexpr auto RevertOverride =

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Overrides/PrefabInspectorOverrideTests.cpp
@@ -43,7 +43,7 @@ namespace UnitTest
 
             AZ::Dom::Value labelPropertyEditor = translateRow[0];
             EXPECT_EQ(labelPropertyEditor[PropertyEditor::Type.GetName()].GetString(), PrefabOverrideLabel::Name);
-            EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Text.GetName()].GetString(), "Translate");
+            EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Value.GetName()].GetString(), "Translate");
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RelativePath.GetName()].GetString().empty());
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RevertOverride.GetName()].IsNull());
 
@@ -81,7 +81,7 @@ namespace UnitTest
 
             AZ::Dom::Value labelPropertyEditor = translateRow[0];
             EXPECT_EQ(labelPropertyEditor[PropertyEditor::Type.GetName()].GetString(), PrefabOverrideLabel::Name);
-            EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Text.GetName()].GetString(), "Translate");
+            EXPECT_EQ(labelPropertyEditor[PrefabOverrideLabel::Value.GetName()].GetString(), "Translate");
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RelativePath.GetName()].GetString().empty());
             EXPECT_FALSE(labelPropertyEditor[PrefabOverrideLabel::RevertOverride.GetName()].IsNull());
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -68,7 +68,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), deviceIndex))
+                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), static_cast<AZ::u8>(deviceIndex)))
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());
                 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -68,6 +68,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
+                // cast to u8 to prevent warning
                 if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), static_cast<AZ::u8>(deviceIndex)))
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DrawPacketBuilder());


### PR DESCRIPTION
## What does this PR do?
- changes DPE expansion state saving to use the first column entry with a string as its path value, instead of exclusively requiring Labels. This is useful for adapters (like the prefab override adapter) that want to use node types other than generic Labels for their first column text
- fixes #17333 

## How was this PR tested?
locally, in the Editor project