### PR TITLE
Atom Image Builder Respects Platform Settings

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
@@ -41,9 +41,6 @@
                 "Enable": false
             },
             "server": {
-                "GlossScale": 16.0,
-                "GlossBias": 0.0,
-                "Streaming": false,
                 "Enable": false
             }
         },

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -700,8 +700,12 @@ namespace ImageProcessingAtom
 
     bool BuilderSettingManager::DoesSupportPlatform(AZStd::string_view platformId)
     {
-        bool rv = m_builderSettings.find(platformId) != m_builderSettings.end();
-        return rv;
+        if (const auto& itr = m_builderSettings.find(platformId); itr != m_builderSettings.end())
+        {
+            return itr->second.m_enablePlatform;
+        }
+
+        return false;
     }
     
     void BuilderSettingManager::SavePresets(AZStd::string_view outputFolder)


### PR DESCRIPTION
Disable image builder platform support if the setting is marked Enabled=false

**Tested by:**
1) Ran AssetProcessor with pc and server enabled, and see that Cache/pc contains images, but Cache/server no longer generates images.
2) Open image settings in Editor.exe and server still hidden

Fixes #17334 