### PR TITLE
Fixes for some minor issues/warnings.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -61,7 +61,8 @@ namespace AZ
 
         private:
             class MeshLoader
-                : private Data::AssetBus::Handler
+                : private SystemTickBus::Handler
+                , private Data::AssetBus::Handler
                 , private AzFramework::AssetCatalogEventBus::Handler
             {
             public:
@@ -69,6 +70,9 @@ namespace AZ
                 ~MeshLoader();
 
             private:
+                // SystemTickBus::Handler overrides...
+                void OnSystemTick() override;
+
                 // AssetBus::Handler overrides...
                 void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
                 void OnAssetError(Data::Asset<Data::AssetData> asset) override;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -50,8 +50,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        void InvalidateViews() override final;
-
         //! Returns true if the SingleDeviceResourceView is in the cache of all single device buffers
         bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -86,7 +86,7 @@ namespace AZ::RHI
         //! Return the contained multi-device buffer
         const RHI::MultiDeviceBuffer* GetBuffer() const
         {
-            return m_buffer;
+            return m_buffer.get();
         }
 
         //! Return the contained BufferViewDescriptor
@@ -97,7 +97,7 @@ namespace AZ::RHI
 
         const MultiDeviceResource* GetResource() const override
         {
-            return m_buffer;
+            return m_buffer.get();
         }
 
         const SingleDeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
@@ -107,7 +107,7 @@ namespace AZ::RHI
 
     private:
         //! A raw pointer to a multi-device buffer
-        const RHI::MultiDeviceBuffer* m_buffer;
+        ConstPtr<RHI::MultiDeviceBuffer> m_buffer;
         //! The corresponding BufferViewDescriptor for this view.
         BufferViewDescriptor m_descriptor;
         //! SingleDeviceBufferView cache

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -93,9 +93,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Invalidate all device-specific views by setting off events on all corresponding ResourceInvalidateBusses
-        void InvalidateViews() override final;
-
         //! Returns true if the SingleDeviceResourceView is in the cache of all single device images
         bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -134,7 +134,7 @@ namespace AZ::RHI
         //! Return the contained multi-device image
         const RHI::MultiDeviceImage* GetImage() const
         {
-            return m_image;
+            return m_image.get();
         }
 
         //! Return the contained ImageViewDescriptor
@@ -145,7 +145,7 @@ namespace AZ::RHI
 
         const MultiDeviceResource* GetResource() const override
         {
-            return m_image;
+            return m_image.get();
         }
 
         const SingleDeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
@@ -155,7 +155,7 @@ namespace AZ::RHI
 
     private:
         //! A raw pointer to a multi-device image
-        const RHI::MultiDeviceImage* m_image;
+        ConstPtr<RHI::MultiDeviceImage> m_image;
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
         //! SingleDeviceImageView cache

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
@@ -41,8 +41,5 @@ namespace AZ::RHI
 
         //! Shuts down the device-specific resources by detaching them from their parent pool.
         void Shutdown() override final;
-
-        //! Invalidates all views by setting off events on all device-specific ResourceInvalidateBusses
-        void InvalidateViews() override final;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -60,7 +60,7 @@ namespace AZ::RHI
         //!
         //! Platform back-ends which invalidate GPU-specific data on the resource without an explicit
         //! shutdown / re-initialization will need to call this method explicitly.
-        virtual void InvalidateViews() = 0;
+        void InvalidateViews();
 
     protected:
         MultiDeviceResource() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
@@ -49,9 +49,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Invalidate all views by setting off events on all device-specific ResourceInvalidateBusses
-        void InvalidateViews() override final;
-
     private:
         MultiDeviceShaderResourceGroupData m_mdData;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceRayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SingleDeviceRayTracingPipelineState.h
@@ -73,6 +73,8 @@ namespace AZ::RHI
     //!
     class SingleDeviceRayTracingPipelineStateDescriptor final
     {
+        friend class MultiDeviceRayTracingPipelineStateDescriptor;
+
     public:
         SingleDeviceRayTracingPipelineStateDescriptor() = default;
         ~SingleDeviceRayTracingPipelineStateDescriptor() = default;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -53,14 +53,6 @@ namespace AZ::RHI
         MultiDeviceResource::Shutdown();
     }
 
-    void MultiDeviceBuffer::InvalidateViews()
-    {
-        IterateObjects<SingleDeviceBuffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
-        {
-            deviceBuffer->InvalidateViews();
-                                           });
-    }
-
     bool MultiDeviceBuffer::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor)
     {
         bool isInResourceCache{true};

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -92,14 +92,6 @@ namespace AZ::RHI
         MultiDeviceResource::Shutdown();
     }
 
-    void MultiDeviceImage::InvalidateViews()
-    {
-        IterateObjects<SingleDeviceImage>([]([[maybe_unused]] auto deviceIndex, auto deviceImage)
-        {
-            deviceImage->InvalidateViews();
-        });
-    }
-
     bool MultiDeviceImage::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor)
     {
         bool isInResourceCache{true};

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
@@ -29,12 +29,4 @@ namespace AZ::RHI
 
         MultiDeviceResource::Shutdown();
     }
-
-    void MultiDeviceQuery::InvalidateViews()
-    {
-        IterateObjects<SingleDeviceQuery>([]([[maybe_unused]] auto deviceIndex, auto deviceQuery)
-        {
-            deviceQuery->InvalidateViews();
-        });
-    }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -234,22 +234,19 @@ namespace AZ::RHI
         const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
     {
         m_mdDescriptor = *descriptor;
-        ResultCode resultCode{ ResultCode::Success };
 
         MultiDeviceObject::Init(deviceMask);
 
-        IterateObjects<SingleDeviceRayTracingTlas>(
-            [this, &resultCode, &descriptor, &rayTracingBufferPools](int deviceIndex, auto deviceRayTracingTlas)
+        ResultCode resultCode = IterateObjects<SingleDeviceRayTracingTlas>(
+            [this, &descriptor, &rayTracingBufferPools](int deviceIndex, auto deviceRayTracingTlas)
             {
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingTlas();
 
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
 
-                resultCode = deviceRayTracingTlas->CreateBuffers(
+                return deviceRayTracingTlas->CreateBuffers(
                     *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
-
-                return resultCode == ResultCode::Success;
             });
 
         if (resultCode != ResultCode::Success)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
@@ -21,7 +21,7 @@ namespace AZ::RHI
 
         if (m_mdPipelineState)
         {
-            descriptor.PipelineState(m_mdPipelineState->GetDevicePipelineState(deviceIndex).get());
+            descriptor.m_pipelineState = m_mdPipelineState->GetDevicePipelineState(deviceIndex).get();
         }
 
         return descriptor;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
@@ -42,6 +42,15 @@ namespace AZ::RHI
         return m_version == 0;
     }
 
+    void MultiDeviceResource::InvalidateViews()
+    {
+        IterateObjects<SingleDeviceResource>(
+            []([[maybe_unused]] auto deviceIndex, auto deviceResource)
+            {
+                deviceResource->InvalidateViews();
+            });
+    }
+
     void MultiDeviceResource::SetPool(MultiDeviceResourcePool* bufferPool)
     {
         m_mdPool = bufferPool;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
@@ -63,12 +63,4 @@ namespace AZ::RHI
 
         MultiDeviceResource::Shutdown();
     }
-
-    void MultiDeviceShaderResourceGroup::InvalidateViews()
-    {
-        IterateObjects<SingleDeviceShaderResourceGroup>([]([[maybe_unused]] auto deviceIndex, auto deviceShaderResourceGroup)
-        {
-            deviceShaderResourceGroup->InvalidateViews();
-        });
-    }
 } // namespace AZ::RHI

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -409,7 +409,7 @@ namespace AZ
         void MeshComponentController::HandleModelChange(const AZ::Data::Instance<AZ::RPI::Model>& model)
         {
             Data::Asset<RPI::ModelAsset> modelAsset = m_meshFeatureProcessor->GetModelAsset(m_meshHandle);
-            if (model && modelAsset)
+            if (model && modelAsset.IsReady())
             {
                 const AZ::EntityId entityId = m_entityComponentIdPair.GetEntityId();
                 m_configuration.m_modelAsset = modelAsset;


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

This specific PR transitions RPI::ShaderResourceGroup to use MultiDeviceShaderResourceGroup. It is not a small change and thus this is one of the bigger PRs in this set of PRs.

## How was this PR tested?

Automated testing CI script.
