### PR TITLE
Cherry pick MiniAudio gem and bump engine version

### DIFF
--- a/Gems/MiniAudio/3rdParty/CMakeLists.txt
+++ b/Gems/MiniAudio/3rdParty/CMakeLists.txt
@@ -1,0 +1,45 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# this file makes sure that the 3rd party components miniaudio and stb_vorbis are available to use.
+
+# for licenses of the sub-parts, please see their repos in github, or, licenses.txt in this folder.
+
+include(FetchContent)
+
+FetchContent_Declare(
+    stb_vorbis
+    URL          https://raw.githubusercontent.com/nothings/stb/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb_vorbis.c
+    URL_HASH     MD5=36713ac98e445271e29547cc2d90b01f # from the main branch @ Jan 29 2023
+    DOWNLOAD_NO_EXTRACT TRUE
+    DOWNLOAD_NO_PROGRESS TRUE
+    TLS_VERIFY TRUE
+)
+
+FetchContent_Declare(
+    miniaudio
+    URL         https://raw.githubusercontent.com/mackron/miniaudio/0.11.17/miniaudio.h
+    URL_HASH    MD5=7233fe13f5d42c4df37acff873c72bf5 # from tag 0.11.17
+    DOWNLOAD_NO_EXTRACT TRUE
+    DOWNLOAD_NO_PROGRESS TRUE
+    TLS_VERIFY TRUE
+)
+
+FetchContent_MakeAvailable(stb_vorbis miniaudio)
+
+FetchContent_GetProperties(stb_vorbis SOURCE_DIR STB_VORBIS_SOURCE_DIR)
+FetchContent_GetProperties(miniaudio SOURCE_DIR MINIAUDIO_SOURCE_DIR)
+
+add_library(3rdParty::miniaudio IMPORTED INTERFACE GLOBAL ${MINIAUDIO_SOURCE_DIR}/miniaudio.h)
+target_include_directories(3rdParty::miniaudio SYSTEM INTERFACE ${MINIAUDIO_SOURCE_DIR})
+
+add_library(3rdParty::stb_vorbis IMPORTED INTERFACE GLOBAL ${STB_VORBIS_SOURCE_DIR}/stb_vorbis.c)
+target_include_directories(3rdParty::stb_vorbis SYSTEM INTERFACE ${STB_VORBIS_SOURCE_DIR})
+
+message(STATUS "Using miniaudio ${MINIAUDIO_SOURCE_DIR}/miniaudio.h - see ${CMAKE_CURRENT_LIST_DIR}/miniaudio/LICENSE.TXT")
+message(STATUS "Using stb_vorbis ${STB_VORBIS_SOURCE_DIR}/stb_vorbis.c - see ${CMAKE_CURRENT_LIST_DIR}/stb_vorbis/LICENSE.TXT")

--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+get_property(miniaudio_gem_root GLOBAL PROPERTY "@GEMROOT:MiniAudio@")
+ly_add_external_target(
+    NAME miniaudio 
+    3RDPARTY_ROOT_DIRECTORY "${miniaudio_gem_root}/3rdParty/miniaudio"
+    VERSION
+)
+
+ly_add_external_target(
+    NAME stb_vorbis 
+    3RDPARTY_ROOT_DIRECTORY "${miniaudio_gem_root}/3rdParty/stb_vorbis"
+    VERSION
+)
+

--- a/Gems/MiniAudio/3rdParty/miniaudio/LICENSE.TXT
+++ b/Gems/MiniAudio/3rdParty/miniaudio/LICENSE.TXT
@@ -1,0 +1,53 @@
+From https://github.com/mackron/miniaudio/blob/master/LICENSE, 
+this is the license that applies to miniaudio:
+
+/*
+This software is available as a choice of the following licenses. Choose
+whichever you prefer.
+
+===============================================================================
+ALTERNATIVE 1 - Public Domain (www.unlicense.org)
+===============================================================================
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+
+===============================================================================
+ALTERNATIVE 2 - MIT No Attribution
+===============================================================================
+Copyright 2023 David Reid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/

--- a/Gems/MiniAudio/3rdParty/readme.md
+++ b/Gems/MiniAudio/3rdParty/readme.md
@@ -1,0 +1,5 @@
+This folder contains a script to grab and verify the 3rd party libraries miniaudio and stb_vorbis.
+
+The license files for those libraries are present for your convenience (And the convenience of any license scanning tools you use), in subfolders of this folder.
+
+During the build process, the downloaded libraries will be copied into the build folder, under _deps, so as not to pollute your source tree.  

--- a/Gems/MiniAudio/3rdParty/stb_vorbis/LICENSE.TXT
+++ b/Gems/MiniAudio/3rdParty/stb_vorbis/LICENSE.TXT
@@ -1,0 +1,43 @@
+This is the license that applies to https://github.com/nothings/stb/blob/master/stb_vorbis.c
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/Gems/MiniAudio/CMakeLists.txt
+++ b/Gems/MiniAudio/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+o3de_gem_setup("MiniAudio")
+
+add_subdirectory(3rdParty)
+
+add_subdirectory(Code)

--- a/Gems/MiniAudio/CMakeLists.txt
+++ b/Gems/MiniAudio/CMakeLists.txt
@@ -10,4 +10,6 @@ o3de_gem_setup("MiniAudio")
 
 add_subdirectory(3rdParty)
 
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
+
 add_subdirectory(Code)

--- a/Gems/MiniAudio/CMakeLists.txt
+++ b/Gems/MiniAudio/CMakeLists.txt
@@ -6,7 +6,27 @@
 #
 #
 
-o3de_gem_setup("MiniAudio")
+# Query the gem name from the gem.json file if possible
+# otherwise fallback to using the default gem name argument
+o3de_find_ancestor_gem_root(gem_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
+if (NOT gem_name)
+    set(gem_name "MiniAudio")
+endif()
+
+# Fallback to using the current source CMakeLists.txt directory as the gem root path
+if (NOT gem_path)
+    set(gem_path ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+set(gem_json ${gem_path}/gem.json)
+
+# Read the version field from the gem.json
+set(gem_version, "0.0.0")
+o3de_read_json_key(gem_version ${gem_json} "version")
+
+o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
+
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 add_subdirectory(3rdParty)
 

--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -1,0 +1,168 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Currently we are in the Code folder: ${CMAKE_CURRENT_LIST_DIR}
+# Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
+# Note: o3de_pal_dir will take care of the details for us, as this may be a restricted platform
+#       in which case it will see if that platform is present here or in the restricted folder.
+#       i.e. It could here in our gem : Gems/MiniAudio/Code/Platform/<platorm_name>  or
+#            <restricted_folder>/<platform_name>/Gems/MiniAudio/Code
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
+
+# Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
+# traits for this platform. Traits for a platform are defines for things like whether or not something in this gem
+# is supported by this platform.
+include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
+
+# The MiniAudio.API target declares the common interface that users of this gem should depend on in their targets
+ly_add_target(
+    NAME ${gem_name}.API INTERFACE
+    NAMESPACE Gem
+    FILES_CMAKE
+        miniaudio_api_files.cmake
+        ${pal_dir}/miniaudio_api_files.cmake
+    INCLUDE_DIRECTORIES
+        INTERFACE
+            Include
+    BUILD_DEPENDENCIES
+        INTERFACE
+           AZ::AzCore
+)
+
+# The MiniAudio.Private.Object target is an internal target
+# It should not be used outside of this Gems CMakeLists.txt
+ly_add_target(
+    NAME ${gem_name}.Private.Object STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        miniaudio_private_files.cmake
+        ${pal_dir}/miniaudio_private_files.cmake
+    TARGET_PROPERTIES
+        O3DE_PRIVATE_TARGET TRUE
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            Include
+            Source
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::AzCore
+            AZ::AzFramework
+        PRIVATE
+            3rdParty::miniaudio
+            3rdParty::stb_vorbis
+)
+
+# Here add MiniAudio target, it depends on the Private Object library and Public API interface
+ly_add_target(
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAMESPACE Gem
+    FILES_CMAKE
+        miniaudio_shared_files.cmake
+        ${pal_dir}/miniaudio_shared_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include
+        PRIVATE
+            Source
+    BUILD_DEPENDENCIES
+        PUBLIC
+            Gem::${gem_name}.API
+        PRIVATE
+            Gem::${gem_name}.Private.Object
+)
+
+# Inject the gem name into the Module source file
+ly_add_source_properties(
+    SOURCES
+        Source/Clients/MiniAudioModule.cpp
+    PROPERTY COMPILE_DEFINITIONS
+        VALUES
+            O3DE_GEM_NAME=${gem_name}
+            O3DE_GEM_VERSION=${gem_version})
+
+# By default, we will specify that the above target MiniAudio would be used by
+# Client and Server type targets when this gem is enabled.  If you don't want it
+# active in Clients or Servers by default, delete one of both of the following lines:
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
+
+# For the Client and Server variants of MiniAudio Gem, an alias to the MiniAudio.API target will be made
+ly_create_alias(NAME ${gem_name}.Clients.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Servers.API NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+
+# If we are on a host platform, we want to add the host tools targets like the MiniAudio.Editor MODULE target
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    # The MiniAudio.Editor.API target can be used by other gems that want to interact with the MiniAudio.Editor module
+    ly_add_target(
+        NAME ${gem_name}.Editor.API INTERFACE
+        NAMESPACE Gem
+        FILES_CMAKE
+            miniaudio_editor_api_files.cmake
+            ${pal_dir}/miniaudio_editor_api_files.cmake
+        INCLUDE_DIRECTORIES
+            INTERFACE
+                Include
+        BUILD_DEPENDENCIES
+            INTERFACE
+                AZ::AzToolsFramework
+    )
+
+    # The MiniAudio.Editor.Private.Object target is an internal target
+    # which is only to be used by this gems CMakeLists.txt and any subdirectories
+    # Other gems should not use this target
+    ly_add_target(
+        NAME ${gem_name}.Editor.Private.Object STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            miniaudio_editor_private_files.cmake
+        TARGET_PROPERTIES
+            O3DE_PRIVATE_TARGET TRUE
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Include
+                Source
+        BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzToolsFramework
+                AZ::AssetBuilderSDK
+                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+            PRIVATE
+                 3rdParty::miniaudio
+                 3rdParty::stb_vorbis
+    )
+
+    ly_add_target(
+        NAME ${gem_name}.Editor GEM_MODULE
+        NAMESPACE Gem
+        AUTOMOC
+        FILES_CMAKE
+            miniaudio_editor_shared_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::${gem_name}.Editor.API
+            PRIVATE
+                Gem::${gem_name}.Editor.Private.Object
+    )
+
+    # By default, we will specify that the above target MiniAudio would be used by
+    # Tool and Builder type targets when this gem is enabled.  If you don't want it
+    # active in Tools or Builders by default, delete one of both of the following lines:
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+
+    # For the Tools and Builders variants of MiniAudio Gem, an alias to the MiniAudio.Editor API target will be made
+    ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+    ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+
+endif()
+

--- a/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioBus.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioBus.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/RTTI/TypeSafeIntegral.h>
+
+struct ma_engine;
+
+namespace MiniAudio
+{
+    class MiniAudioRequests
+    {
+    public:
+        AZ_RTTI(MiniAudioRequests, "{3726A215-EF3D-44E0-8847-FBA15A8B1F84}");
+        virtual ~MiniAudioRequests() = default;
+
+        virtual ma_engine* GetSoundEngine() = 0;
+
+        //! Sets the volume for the entire sound engine.
+        //! @param scale 0 resulting in silence and anything above 1 resulting in amplification 
+        virtual void SetGlobalVolume(float scale) = 0;
+        
+        //! @return the current volume set for the whole sound engine
+        virtual float GetGlobalVolume() const = 0;
+
+        //! Sets the volume for the entire sound engine using decibel scale.
+        //! @param decibels gain in decibels
+        virtual void SetGlobalVolumeInDecibels(float decibels) = 0;
+    };
+
+    class MiniAudioBusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using MiniAudioRequestBus = AZ::EBus<MiniAudioRequests, MiniAudioBusTraits>;
+    using MiniAudioInterface = AZ::Interface<MiniAudioRequests>;
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioConstants.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioConstants.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace MiniAudio
+{
+    inline constexpr const char* const MiniAudioPlaybackComponentTypeId = "{9eaa86ef-5371-4a6a-b218-ea3b733fafe5}";
+    inline constexpr const char* const EditorMiniAudioPlaybackComponentTypeId = "{183c6195-647d-4958-9eb0-5823dfe88ef3}";
+
+    inline constexpr const char* const MiniAudioListenerComponentTypeId = "{ee70666a-971c-4cff-856e-645621d38906}";
+    inline constexpr const char* const EditorMiniAudioListenerComponentTypeId = "{a033d461-0fcb-4301-a7cc-01e989b0d616}";
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioListenerBus.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioListenerBus.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace MiniAudio
+{
+    class MiniAudioListenerRequests : public AZ::ComponentBus
+    {
+    public:
+        ~MiniAudioListenerRequests() override = default;
+
+        virtual void SetFollowEntity(AZ::EntityId followEntity) = 0;
+        virtual void SetPosition(const AZ::Vector3& position) = 0;
+    };
+
+    using MiniAudioListenerRequestBus = AZ::EBus<MiniAudioListenerRequests>;
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioPlaybackBus.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioPlaybackBus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <MiniAudio/SoundAsset.h>
+#include <MiniAudio/SoundAssetRef.h>
+
+namespace MiniAudio
+{
+    class MiniAudioPlaybackRequests : public AZ::ComponentBus
+    {
+    public:
+        ~MiniAudioPlaybackRequests() override = default;
+
+        virtual void Play() = 0;
+        virtual void Stop() = 0;
+        virtual void SetVolume(float volume) = 0;
+        virtual void SetLooping(bool loop) = 0;
+        virtual bool IsLooping() const = 0;
+        virtual void SetSoundAsset(AZ::Data::Asset<SoundAsset> soundAsset) = 0;
+        virtual AZ::Data::Asset<SoundAsset> GetSoundAsset() const = 0;
+
+        //! Custom setter for scripting
+        virtual void SetSoundAssetRef(const SoundAssetRef& soundAssetRef) = 0;
+        //! Custom getter for scripting
+        virtual SoundAssetRef GetSoundAssetRef() const = 0;
+    };
+
+    using MiniAudioPlaybackRequestBus = AZ::EBus<MiniAudioPlaybackRequests>;
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Include/MiniAudio/SoundAsset.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/SoundAsset.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace MiniAudio
+{
+    class SoundAsset
+        : public AZ::Data::AssetData
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(SoundAsset, AZ::SystemAllocator, 0);
+        AZ_RTTI(SoundAsset, "{7fef8671-760f-4ebd-91e7-57aaf3eef1ca}", AZ::Data::AssetData);
+
+        static constexpr const char* FileExtension = "miniaudio";
+        static constexpr const char* AssetGroup = "Sound";
+        static constexpr AZ::u32 AssetSubId = 1;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        SoundAsset() = default;
+        ~SoundAsset() override = default;
+
+        AZStd::vector<AZ::u8> m_data;
+    };
+
+    using SoundDataAsset = AZ::Data::Asset<SoundAsset>;
+    using SoundDataAssetVector = AZStd::vector<AZ::Data::Asset<SoundAsset>>;
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Include/MiniAudio/SoundAssetRef.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/SoundAssetRef.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/std/containers/vector.h>
+#include <MiniAudio/SoundAsset.h>
+
+namespace MiniAudio
+{
+    //! A wrapper around SoundAsset that can be used by Script Canvas and Lua
+    class SoundAssetRef final
+        : private AZ::Data::AssetBus::Handler
+    {
+    public:
+        AZ_RTTI(SoundAssetRef, "{1edba837-5590-4f2c-a61c-9001eb18505b}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        SoundAssetRef() = default;
+        ~SoundAssetRef();
+        SoundAssetRef(const SoundAssetRef& rhs);
+        SoundAssetRef(SoundAssetRef&& rhs);
+        SoundAssetRef& operator=(const SoundAssetRef& rhs);
+        SoundAssetRef& operator=(SoundAssetRef&& rhs);
+
+        void SetAsset(const AZ::Data::Asset<SoundAsset>& asset);
+        AZ::Data::Asset<SoundAsset> GetAsset() const;
+
+    private:
+        class SerializationEvents : public AZ::SerializeContext::IEventHandler
+        {
+            void OnReadEnd(void* classPtr) override
+            {
+                SoundAssetRef* SoundAssetRef = reinterpret_cast<class SoundAssetRef*>(classPtr);
+                // Call SetAsset to connect AssetBus handler as soon as m_asset field is set
+                SoundAssetRef->SetAsset(SoundAssetRef->m_asset);
+            }
+        };
+
+        void OnSpawnAssetChanged();
+        void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+
+        AZ::Data::Asset<SoundAsset> m_asset;
+    };
+}

--- a/Gems/MiniAudio/Code/Platform/Android/PAL_android.cmake
+++ b/Gems/MiniAudio/Code/Platform/Android/PAL_android.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_MINIAUDIO_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_EDITOR_TEST_SUPPORTED FALSE)

--- a/Gems/MiniAudio/Code/Platform/Android/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Android/miniaudio_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Android/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Android/miniaudio_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Android
+# i.e. ../Source/Android/MiniAudioAndroid.cpp
+#      ../Source/Android/MiniAudioAndroid.h
+#      ../Include/Android/MiniAudioAndroid.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Android/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Android/miniaudio_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Android
+# i.e. ../Source/Android/MiniAudioAndroid.cpp
+#      ../Source/Android/MiniAudioAndroid.h
+#      ../Include/Android/MiniAudioAndroid.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/PAL_linux.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_MINIAUDIO_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_EDITOR_TEST_SUPPORTED TRUE)

--- a/Gems/MiniAudio/Code/Platform/Linux/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/miniaudio_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Linux/miniaudio_editor_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/miniaudio_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Linux/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/miniaudio_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Linux
+# i.e. ../Source/Linux/MiniAudioLinux.cpp
+#      ../Source/Linux/MiniAudioLinux.h
+#      ../Include/Linux/MiniAudioLinux.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Linux/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/miniaudio_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Linux
+# i.e. ../Source/Linux/MiniAudioLinux.cpp
+#      ../Source/Linux/MiniAudioLinux.h
+#      ../Include/Linux/MiniAudioLinux.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Mac/PAL_mac.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/PAL_mac.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_MINIAUDIO_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_EDITOR_TEST_SUPPORTED TRUE)

--- a/Gems/MiniAudio/Code/Platform/Mac/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/miniaudio_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Mac/miniaudio_editor_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/miniaudio_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Mac/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/miniaudio_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Mac
+# i.e. ../Source/Mac/MiniAudioMac.cpp
+#      ../Source/Mac/MiniAudioMac.h
+#      ../Include/Mac/MiniAudioMac.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Mac/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/miniaudio_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Mac
+# i.e. ../Source/Mac/MiniAudioMac.cpp
+#      ../Source/Mac/MiniAudioMac.h
+#      ../Include/Mac/MiniAudioMac.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Windows/PAL_windows.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/PAL_windows.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_MINIAUDIO_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_EDITOR_TEST_SUPPORTED TRUE)

--- a/Gems/MiniAudio/Code/Platform/Windows/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/miniaudio_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Windows/miniaudio_editor_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/miniaudio_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Windows/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/miniaudio_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Windows
+# i.e. ../Source/Windows/MiniAudioWindows.cpp
+#      ../Source/Windows/MiniAudioWindows.h
+#      ../Include/Windows/MiniAudioWindows.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/Windows/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/miniaudio_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Windows
+# i.e. ../Source/Windows/MiniAudioWindows.cpp
+#      ../Source/Windows/MiniAudioWindows.h
+#      ../Include/Windows/MiniAudioWindows.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/iOS/PAL_ios.cmake
+++ b/Gems/MiniAudio/Code/Platform/iOS/PAL_ios.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_MINIAUDIO_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_MINIAUDIO_EDITOR_TEST_SUPPORTED FALSE)

--- a/Gems/MiniAudio/Code/Platform/iOS/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/iOS/miniaudio_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/iOS/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/iOS/miniaudio_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for iOS
+# i.e. ../Source/iOS/MiniAudioiOS.cpp
+#      ../Source/iOS/MiniAudioiOS.h
+#      ../Include/iOS/MiniAudioiOS.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Platform/iOS/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/Platform/iOS/miniaudio_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for iOS
+# i.e. ../Source/iOS/MiniAudioiOS.cpp
+#      ../Source/iOS/MiniAudioiOS.h
+#      ../Include/iOS/MiniAudioiOS.h
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/PlatformDef.h>
+
+AZ_PUSH_DISABLE_WARNING(4701, "-Wuninitialized") //  warning C4701: potentially uninitialized local variable 'mid' used in vorbis
+
+extern "C" {
+
+#define STB_VORBIS_HEADER_ONLY
+#include <stb_vorbis.c>    // Enables Vorbis decoding.
+
+#define MINIAUDIO_IMPLEMENTATION
+#include <miniaudio.h>
+
+// The stb_vorbis implementation must come after the implementation of miniaudio.
+#undef STB_VORBIS_HEADER_ONLY
+#include <stb_vorbis.c>
+
+}
+
+AZ_POP_DISABLE_WARNING

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioIncludes.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioIncludes.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// This file exists to allow any preprocessor directives to be applied
+// before including miniaudio.h, if necessary.  Note that the header is very large and contains the entirety
+// of miniaudio, so care should be taken not to actually use this in header files that themselves are included by
+// other header files, if at all possible.
+
+#pragma once
+
+extern "C" {
+
+#define STB_VORBIS_HEADER_ONLY
+#include <stb_vorbis.c>    // Enables Vorbis decoding.
+
+#include <miniaudio.h>
+
+}

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponent.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioListenerComponent.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* MiniAudioListenerComponent_CreateDescriptor()
+    {
+        return MiniAudioListenerComponent::CreateDescriptor();
+    }
+
+    MiniAudioListenerComponent::MiniAudioListenerComponent(const MiniAudioListenerComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void MiniAudioListenerComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MiniAudioListenerComponent, BaseClass>()
+                ->Version(1);
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->ConstantProperty("MiniAudioListenerComponentTypeId",
+                BehaviorConstant(AZ::Uuid(MiniAudioListenerComponentTypeId)))
+                ->Attribute(AZ::Script::Attributes::Module, "MiniAudio")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common);
+
+            behaviorContext->EBus<MiniAudioListenerRequestBus>("MiniAudioListenerRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "audio")
+                ->Attribute(AZ::Script::Attributes::Category, "MiniAudio Listener")
+                ->Event("SetPosition", &MiniAudioListenerRequests::SetPosition)
+                ->Event("SetFollowEntity", &MiniAudioListenerRequests::SetFollowEntity)
+                ;
+
+            behaviorContext->Class<MiniAudioListenerComponent>()->RequestBus("MiniAudioListenerRequestBus");
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponent.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponent.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <MiniAudio/MiniAudioConstants.h>
+#include <MiniAudio/MiniAudioListenerBus.h>
+
+#include "MiniAudioListenerComponentController.h"
+#include "MiniAudioListenerComponentConfig.h"
+
+namespace MiniAudio
+{
+    class MiniAudioListenerComponent final
+        : public AzFramework::Components::ComponentAdapter<MiniAudioListenerComponentController, MiniAudioListenerComponentConfig>
+    {
+        using BaseClass = AzFramework::Components::ComponentAdapter<MiniAudioListenerComponentController, MiniAudioListenerComponentConfig>;
+    public:
+        AZ_COMPONENT(MiniAudioListenerComponent, MiniAudioListenerComponentTypeId, BaseClass);
+        MiniAudioListenerComponent() = default;
+        explicit MiniAudioListenerComponent(const MiniAudioListenerComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentConfig.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentConfig.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioListenerComponentConfig.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+
+namespace MiniAudio
+{
+    void MiniAudioListenerComponentConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MiniAudioListenerComponentConfig>()
+                ->Version(1)
+                ->Field("Follow Entity", &MiniAudioListenerComponentConfig::m_followEntity)
+                ->Field("Listener Index", &MiniAudioListenerComponentConfig::m_listenerIndex)
+                ;
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentConfig.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentConfig.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+
+namespace MiniAudio
+{
+    class MiniAudioListenerComponentConfig final
+        : public AZ::ComponentConfig
+    {
+    public:
+        AZ_RTTI(MiniAudioListenerComponentConfig, "{7987E444-3A98-469C-B38B-EDD9C247D7F1}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Listener follows the specified entity.
+        AZ::EntityId m_followEntity;
+
+        AZ::u32 m_listenerIndex = 0;
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentController.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentController.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioListenerComponentController.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include "MiniAudioIncludes.h"
+
+namespace MiniAudio
+{
+    MiniAudioListenerComponentController::MiniAudioListenerComponentController()
+    {
+    }
+
+    MiniAudioListenerComponentController::MiniAudioListenerComponentController(
+        const MiniAudioListenerComponentConfig& config)
+    {
+        m_config = config;
+    }
+
+    void MiniAudioListenerComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        MiniAudioListenerComponentConfig::Reflect(context);
+
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<MiniAudioListenerComponentController>()
+                ->Field("Config", &MiniAudioListenerComponentController::m_config)
+                ->Version(1);
+        }
+    }
+
+    void MiniAudioListenerComponentController::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("MiniAudioListenerComponent"));
+    }
+
+    void MiniAudioListenerComponentController::Activate(const AZ::EntityComponentIdPair& entityComponentIdPair)
+    {
+        m_entityComponentIdPair = entityComponentIdPair;
+
+        MiniAudioListenerRequestBus::Handler::BusConnect(m_entityComponentIdPair.GetEntityId());
+        OnConfigurationUpdated();
+    }
+
+    void MiniAudioListenerComponentController::SetConfiguration(const MiniAudioListenerComponentConfig& config)
+    {
+        m_config = config;
+        OnConfigurationUpdated();
+    }
+
+    const MiniAudioListenerComponentConfig& MiniAudioListenerComponentController::GetConfiguration() const
+    {
+        return m_config;
+    }
+
+    void MiniAudioListenerComponentController::SetFollowEntity(AZ::EntityId followEntity)
+    {
+        m_config.m_followEntity = followEntity;
+        OnConfigurationUpdated();
+    }
+
+    void MiniAudioListenerComponentController::SetPosition(const AZ::Vector3& position)
+    {
+        if (ma_engine* engine = MiniAudioInterface::Get()->GetSoundEngine())
+        {
+            ma_engine_listener_set_position(engine, m_config.m_listenerIndex, position.GetX(), position.GetY(), position.GetZ());
+        }
+    }
+
+    void MiniAudioListenerComponentController::Deactivate()
+    {
+        m_entityMovedHandler.Disconnect();
+
+        MiniAudioListenerRequestBus::Handler::BusDisconnect();
+    }
+
+    void MiniAudioListenerComponentController::OnWorldTransformChanged(const AZ::Transform& world)
+    {
+        if (ma_engine* engine = MiniAudioInterface::Get()->GetSoundEngine())
+        {
+            ma_engine_listener_set_position(engine, m_config.m_listenerIndex, world.GetTranslation().GetX(), world.GetTranslation().GetY(), world.GetTranslation().GetZ());
+
+            const AZ::Vector3 forward = world.TransformVector(AZ::Vector3::CreateAxisY(-1.f));
+            ma_engine_listener_set_direction(engine, m_config.m_listenerIndex, forward.GetX(), forward.GetY(), forward.GetZ());
+
+            ma_engine_listener_set_world_up(engine, m_config.m_listenerIndex, 0.f, 0.f, 1.f);
+        }
+    }
+
+    void MiniAudioListenerComponentController::OnConfigurationUpdated()
+    {
+        if (m_config.m_followEntity.IsValid())
+        {
+            m_entityMovedHandler.Disconnect();
+            AZ::TransformBus::Event(m_config.m_followEntity, &AZ::TransformBus::Events::BindTransformChangedEventHandler, m_entityMovedHandler);
+
+            AZ::Transform worldTm = AZ::Transform::CreateIdentity();
+            AZ::TransformBus::EventResult(worldTm, m_entityComponentIdPair.GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+            OnWorldTransformChanged(worldTm);
+        }
+        else
+        {
+            m_entityMovedHandler.Disconnect();
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentController.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioListenerComponentController.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Component/TransformBus.h>
+#include <MiniAudio/MiniAudioBus.h>
+#include <MiniAudio/MiniAudioListenerBus.h>
+
+#include "MiniAudioListenerComponentConfig.h"
+
+namespace MiniAudio
+{
+    class MiniAudioListenerComponentController
+        : public MiniAudioListenerRequestBus::Handler
+    {
+        friend class EditorMiniAudioListenerComponent;
+    public:
+        AZ_CLASS_ALLOCATOR(MiniAudioListenerComponentController, AZ::SystemAllocator, 0);
+        AZ_RTTI(MiniAudioListenerComponentController, "{59297F11-FE85-421E-A3D6-BF58A7BCFD92}");
+
+        MiniAudioListenerComponentController();
+        explicit MiniAudioListenerComponentController(const MiniAudioListenerComponentConfig& config);
+        ~MiniAudioListenerComponentController() override = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+
+        void Activate(const AZ::EntityComponentIdPair& entityComponentIdPair);
+        void Deactivate();
+        void SetConfiguration(const MiniAudioListenerComponentConfig& config);
+        const MiniAudioListenerComponentConfig& GetConfiguration() const;
+
+        // MiniAudioListenerRequestBus
+        void SetFollowEntity(AZ::EntityId followEntity) override;
+        void SetPosition(const AZ::Vector3& position) override;
+
+    private:
+        AZ::EntityComponentIdPair m_entityComponentIdPair;
+
+        void OnWorldTransformChanged(const AZ::Transform& world);
+        AZ::TransformChangedEvent::Handler m_entityMovedHandler{[this](
+            [[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
+        {
+            OnWorldTransformChanged(world);
+        }};
+
+        MiniAudioListenerComponentConfig m_config;
+        void OnConfigurationUpdated();
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioModule.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioModule.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+
+#include <MiniAudioModuleInterface.h>
+
+namespace MiniAudio
+{
+    class MiniAudioModule
+        : public MiniAudioModuleInterface
+    {
+    public:
+        AZ_RTTI(MiniAudioModule, "{501C94A1-993A-4203-9720-D43D6C1DDB7A}", MiniAudioModuleInterface);
+        AZ_CLASS_ALLOCATOR(MiniAudioModule, AZ::SystemAllocator, 0);
+    };
+}// namespace MiniAudio
+
+
+#if defined(O3DE_GEM_NAME)
+AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), MiniAudio::MiniAudioModule)
+#else
+AZ_DECLARE_MODULE_CLASS(Gem_MiniAudio, MiniAudio::MiniAudioModule)
+#endif

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioPlaybackComponent.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <MiniAudio/SoundAssetRef.h>
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* MiniAudioPlaybackComponent_CreateDescriptor()
+    {
+        return MiniAudioPlaybackComponent::CreateDescriptor();
+    }
+
+    AZ::TypeId MiniAudioPlaybackComponent_GetUUID()
+    {
+        return azrtti_typeid<MiniAudioPlaybackComponent>();
+    }
+
+    MiniAudioPlaybackComponent::MiniAudioPlaybackComponent(const MiniAudioPlaybackComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void MiniAudioPlaybackComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MiniAudioPlaybackComponent, BaseClass>()
+                ->Version(1);
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->ConstantProperty("MiniAudioPlaybackComponentTypeId",
+                BehaviorConstant(AZ::Uuid(MiniAudioPlaybackComponentTypeId)))
+                ->Attribute(AZ::Script::Attributes::Module, "MiniAudio")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common);
+
+            behaviorContext->EBus<MiniAudioPlaybackRequestBus>("MiniAudioPlaybackRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "audio")
+                ->Attribute(AZ::Script::Attributes::Category, "MiniAudio Playback")
+                ->Event("Play", &MiniAudioPlaybackRequests::Play)
+                ->Event("Stop", &MiniAudioPlaybackRequests::Stop)
+                ->Event("SetVolume", &MiniAudioPlaybackRequests::SetVolume)
+                ->Event("SetLooping", &MiniAudioPlaybackRequests::SetLooping)
+                ->Event("IsLooping", &MiniAudioPlaybackRequests::IsLooping)
+                ->Event("SetSoundAsset", &MiniAudioPlaybackRequests::SetSoundAssetRef)
+                ->Event("GetSoundAsset", &MiniAudioPlaybackRequests::GetSoundAssetRef)
+            ;
+
+            behaviorContext->Class<MiniAudioPlaybackComponentController>()->RequestBus("MiniAudioPlaybackRequestBus");
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <MiniAudio/MiniAudioConstants.h>
+#include <MiniAudio/MiniAudioPlaybackBus.h>
+
+#include "MiniAudioPlaybackComponentController.h"
+#include "MiniAudioPlaybackComponentConfig.h"
+
+namespace MiniAudio
+{
+    class MiniAudioPlaybackComponent final
+        : public AzFramework::Components::ComponentAdapter<MiniAudioPlaybackComponentController, MiniAudioPlaybackComponentConfig>
+    {
+        using BaseClass = AzFramework::Components::ComponentAdapter<MiniAudioPlaybackComponentController, MiniAudioPlaybackComponentConfig>;
+    public:
+        AZ_COMPONENT(MiniAudioPlaybackComponent, MiniAudioPlaybackComponentTypeId, BaseClass);
+        MiniAudioPlaybackComponent() = default;
+        explicit MiniAudioPlaybackComponent(const MiniAudioPlaybackComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioPlaybackComponentConfig.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+
+namespace MiniAudio
+{
+    void MiniAudioPlaybackComponentConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MiniAudioPlaybackComponentConfig>()
+                ->Version(4)
+                ->Field("Autoplay", &MiniAudioPlaybackComponentConfig::m_autoplayOnActivate)
+                ->Field("Sound", &MiniAudioPlaybackComponentConfig::m_sound)
+                ->Field("Volume", &MiniAudioPlaybackComponentConfig::m_volume)
+                ->Field("Auto-follow", &MiniAudioPlaybackComponentConfig::m_autoFollowEntity)
+                ->Field("Loop", &MiniAudioPlaybackComponentConfig::m_loop)
+                ->Field("Spatialization", &MiniAudioPlaybackComponentConfig::m_enableSpatialization)
+                ->Field("Attenuation Model", &MiniAudioPlaybackComponentConfig::m_attenuationModel)
+                ->Field("Min Distance", &MiniAudioPlaybackComponentConfig::m_minimumDistance)
+                ->Field("Max Distance", &MiniAudioPlaybackComponentConfig::m_maximumDistance)
+                ;
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <MiniAudio/SoundAsset.h>
+
+namespace MiniAudio
+{
+    // AttenuationModel hidden here to prevent needing to include miniaudio.h here.
+    enum class AttenuationModel  // must match ma_attenuation_model from miniaudio.   
+    {
+        Inverse = 1, //ma_attenuation_model_inverse,
+        Linear = 2, // ma_attenuation_model_linear,
+        Exponential = 3, //= ma_attenuation_model_exponential
+    };
+
+    class MiniAudioPlaybackComponentConfig final
+        : public AZ::ComponentConfig
+    {
+    public:
+        AZ_RTTI(MiniAudioPlaybackComponentConfig, "{b829e7ae-690f-4cf4-a350-e39929f206c2}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::Data::Asset<SoundAsset> m_sound;
+
+        //! If true, automatically play when the entity activates, useful for
+        //! environment audio.
+        bool m_autoplayOnActivate = false;
+
+        float m_volume = 1.f;
+
+        //! If true, follow the position of the entity.
+        bool m_autoFollowEntity = false;
+
+        //! If true, loops the sound.
+        bool m_loop = false;
+
+        bool m_enableSpatialization = false;
+        AttenuationModel m_attenuationModel = AttenuationModel::Inverse;
+        float m_minimumDistance = 3.f;        
+        float m_maximumDistance = 30.f;
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.cpp
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioPlaybackComponentController.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include "MiniAudioIncludes.h"
+
+namespace MiniAudio
+{
+    MiniAudioPlaybackComponentController::MiniAudioPlaybackComponentController()
+    {
+    }
+
+    // placement of this destructor is intentional.  It forces unique_ptr<ma_sound> to declare its destructor here
+    // instead of in the header before inclusion of the giant MiniAudioIncludes.h file
+    MiniAudioPlaybackComponentController::~MiniAudioPlaybackComponentController() 
+    {
+    }
+
+    MiniAudioPlaybackComponentController::MiniAudioPlaybackComponentController(
+        const MiniAudioPlaybackComponentConfig& config)
+    {
+        m_config = config;
+    }
+
+    void MiniAudioPlaybackComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        MiniAudioPlaybackComponentConfig::Reflect(context);
+
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<MiniAudioPlaybackComponentController>()
+                ->Field("Config", &MiniAudioPlaybackComponentController::m_config)
+                ->Version(1);
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("MiniAudioPlaybackComponent"));
+    }
+
+    void MiniAudioPlaybackComponentController::Activate(const AZ::EntityComponentIdPair& entityComponentIdPair)
+    {
+        m_entityComponentIdPair = entityComponentIdPair;
+
+        MiniAudioPlaybackRequestBus::Handler::BusConnect(m_entityComponentIdPair.GetEntityId());
+        OnConfigurationUpdated();
+    }
+
+    void MiniAudioPlaybackComponentController::SetConfiguration(const MiniAudioPlaybackComponentConfig& config)
+    {
+        m_config = config;
+        OnConfigurationUpdated();
+    }
+
+    const MiniAudioPlaybackComponentConfig& MiniAudioPlaybackComponentController::GetConfiguration() const
+    {
+        return m_config;
+    }
+
+    void MiniAudioPlaybackComponentController::Deactivate()
+    {
+        m_entityMovedHandler.Disconnect();
+        UnloadSound();
+        m_config.m_sound.Release();
+
+        MiniAudioPlaybackRequestBus::Handler::BusDisconnect();
+        AZ::Data::AssetBus::MultiHandler::BusDisconnect();
+    }
+
+    void MiniAudioPlaybackComponentController::Play()
+    {
+        if (m_sound)
+        {
+            ma_sound_seek_to_pcm_frame(m_sound.get(), 0);
+            ma_sound_start(m_sound.get());
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::Stop()
+    {
+        if (m_sound)
+        {
+            ma_sound_stop(m_sound.get());
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::SetVolume(float volume)
+    {
+        if (m_sound)
+        {
+            ma_sound_set_volume(m_sound.get(), volume);
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::SetLooping(bool loop)
+    {
+        m_config.m_loop = loop;
+        if (m_sound)
+        {
+            ma_sound_set_looping(m_sound.get(), loop);
+        }
+    }
+
+    bool MiniAudioPlaybackComponentController::IsLooping() const
+    {
+        if (m_sound)
+        {
+            return ma_sound_is_looping(m_sound.get());
+        }
+
+        return false;
+    }
+
+    AZ::Data::Asset<SoundAsset> MiniAudioPlaybackComponentController::GetSoundAsset() const
+    {
+        return m_config.m_sound;
+    }
+
+    void MiniAudioPlaybackComponentController::SetSoundAsset(AZ::Data::Asset<SoundAsset> soundAsset)
+    {
+        if (m_config.m_sound.GetId() != soundAsset.GetId())
+        {
+            m_config.m_sound = soundAsset;
+            OnConfigurationUpdated();
+        }
+    }
+
+    SoundAssetRef MiniAudioPlaybackComponentController::GetSoundAssetRef() const
+    {
+        SoundAssetRef ref;
+        ref.SetAsset(GetSoundAsset());
+        return ref;
+    }
+
+    void MiniAudioPlaybackComponentController::SetSoundAssetRef(const SoundAssetRef& soundAssetRef)
+    {
+        SetSoundAsset(soundAssetRef.GetAsset());
+    }
+
+    void MiniAudioPlaybackComponentController::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        AZ::Data::AssetBus::MultiHandler::BusDisconnect(asset.GetId());
+
+        // Re-assign the sound before attempting to load it if it was
+        // released and the asset is now ready.
+        // This can happen in the Editor when returning from game mode
+        if (!m_config.m_sound.IsReady())
+        {
+            m_config.m_sound = asset;
+        }
+
+        LoadSound();
+    }
+
+    void MiniAudioPlaybackComponentController::OnWorldTransformChanged(const AZ::Transform& world)
+    {
+        if (m_sound)
+        {
+            ma_sound_set_position(m_sound.get(), world.GetTranslation().GetX(), world.GetTranslation().GetY(), world.GetTranslation().GetZ());
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::OnConfigurationUpdated()
+    {
+        if (m_config.m_sound.IsReady() == false)
+        {
+            AZ::Data::AssetBus::MultiHandler::BusConnect(m_config.m_sound.GetId());
+            m_config.m_sound.QueueLoad();
+        }
+        else
+        {
+            LoadSound();
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::LoadSound()
+    {
+        UnloadSound();
+
+        if (ma_engine* engine = MiniAudioInterface::Get()->GetSoundEngine())
+        {
+            if (GetConfiguration().m_sound.IsReady())
+            {
+                m_soundName = GetConfiguration().m_sound.GetHint();
+
+                const auto& assetBuffer = GetConfiguration().m_sound->m_data;
+                if (assetBuffer.empty())
+                {
+                    return;
+                }
+
+                ma_result result = ma_resource_manager_register_encoded_data(ma_engine_get_resource_manager(engine),
+                    m_soundName.c_str(), assetBuffer.data(), assetBuffer.size());
+                if (result != MA_SUCCESS)
+                {
+                    // An error occurred.
+                    return;
+                }
+
+                if (m_sound)
+                {
+                    ma_sound_uninit(m_sound.get());
+                    m_sound.reset();
+                }
+                m_sound = AZStd::make_unique<ma_sound>();
+
+                const ma_uint32 flags = MA_SOUND_FLAG_DECODE;
+                result = ma_sound_init_from_file(engine, m_soundName.c_str(), flags, nullptr, nullptr, m_sound.get());
+                if (result != MA_SUCCESS)
+                {
+                    // An error occurred.
+                    return;
+                }
+
+                ma_sound_set_volume(m_sound.get(), m_config.m_volume);
+                ma_sound_set_looping(m_sound.get(), m_config.m_loop);
+
+                ma_sound_set_spatialization_enabled(m_sound.get(), m_config.m_enableSpatialization);
+                if (m_config.m_enableSpatialization)
+                {
+                    ma_sound_set_min_distance(m_sound.get(), m_config.m_minimumDistance);
+                    ma_sound_set_max_distance(m_sound.get(), m_config.m_maximumDistance);
+                    ma_sound_set_attenuation_model(m_sound.get(), static_cast<ma_attenuation_model>(m_config.m_attenuationModel));
+                }
+
+                if (m_config.m_autoFollowEntity)
+                {
+                    m_entityMovedHandler.Disconnect();
+                    AZ::TransformBus::Event(m_entityComponentIdPair.GetEntityId(), &AZ::TransformBus::Events::BindTransformChangedEventHandler, m_entityMovedHandler);
+
+                    AZ::Transform worldTm = AZ::Transform::CreateIdentity();
+                    AZ::TransformBus::EventResult(worldTm, m_entityComponentIdPair.GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+                    OnWorldTransformChanged(worldTm);
+                }
+                else
+                {
+                    m_entityMovedHandler.Disconnect();
+                }
+
+                // Automatically play after the sound loads if requested
+                // This will play automatically in Editor and Game
+                if (m_config.m_autoplayOnActivate)
+                {
+                    Play();
+                }
+            }
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::UnloadSound()
+    {
+        if (ma_engine* engine = MiniAudioInterface::Get()->GetSoundEngine())
+        {
+            if (m_sound)
+            {
+                ma_sound_stop(m_sound.get());
+                ma_sound_uninit(m_sound.get());
+                m_sound.reset();
+            }
+
+            if (m_soundName.empty() == false)
+            {
+                ma_resource_manager_unregister_data(ma_engine_get_resource_manager(engine), m_soundName.c_str());
+                m_soundName.clear();
+            }
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Component/TransformBus.h>
+#include <MiniAudio/MiniAudioBus.h>
+#include <MiniAudio/MiniAudioPlaybackBus.h>
+#include "MiniAudioPlaybackComponentConfig.h"
+
+struct ma_sound;
+
+namespace MiniAudio
+{
+    class MiniAudioPlaybackComponentController
+        : public MiniAudioPlaybackRequestBus::Handler
+        , public AZ::Data::AssetBus::MultiHandler
+    {
+        friend class EditorMiniAudioPlaybackComponent;
+    public:
+        AZ_CLASS_ALLOCATOR(MiniAudioPlaybackComponentController, AZ::SystemAllocator, 0);
+        AZ_RTTI(MiniAudioPlaybackComponentController, "{1c3f1578-b190-4b49-a0c6-223f40bd9fe5}");
+
+        MiniAudioPlaybackComponentController();
+        explicit MiniAudioPlaybackComponentController(const MiniAudioPlaybackComponentConfig& config);
+        ~MiniAudioPlaybackComponentController() override;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+
+        void Activate(const AZ::EntityComponentIdPair& entityComponentIdPair);
+        void Deactivate();
+        void SetConfiguration(const MiniAudioPlaybackComponentConfig& config);
+        const MiniAudioPlaybackComponentConfig& GetConfiguration() const;
+
+        // MiniAudioPlaybackRequestBus
+        void Play() override;
+        void Stop() override;
+        void SetVolume(float volume) override;
+        void SetLooping(bool loop) override;
+        bool IsLooping() const override;
+        AZ::Data::Asset<SoundAsset> GetSoundAsset() const override;
+        void SetSoundAsset(AZ::Data::Asset<SoundAsset> soundAsset) override;
+        SoundAssetRef GetSoundAssetRef() const override;
+        void SetSoundAssetRef(const SoundAssetRef& soundAssetRef) override;
+
+        // MultiHandler
+        void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+
+    private:
+        AZ::EntityComponentIdPair m_entityComponentIdPair;
+
+        void OnWorldTransformChanged(const AZ::Transform& world);
+        AZ::TransformChangedEvent::Handler m_entityMovedHandler{[this](
+            [[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
+        {
+            OnWorldTransformChanged(world);
+        }};
+
+        MiniAudioPlaybackComponentConfig m_config;
+        void OnConfigurationUpdated();
+
+        void LoadSound();
+        void UnloadSound();
+
+        AZStd::unique_ptr<ma_sound> m_sound;
+        AZStd::string m_soundName;
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioSystemComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioSystemComponent.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "MiniAudioSystemComponent.h"
+
+#include <AzCore/Serialization/EditContext.h>
+#include <MiniAudio/SoundAsset.h>
+#include <MiniAudio/SoundAssetRef.h>
+
+#include "SoundAssetHandler.h"
+#include "MiniAudioIncludes.h"
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* MiniAudioSystemComponent_CreateDescriptor()
+    {
+        return MiniAudioSystemComponent::CreateDescriptor();
+    }
+
+    AZ::TypeId MiniAudioSystemComponent_GetTypeId()
+    {
+        return azrtti_typeid<MiniAudioSystemComponent>();
+    }
+
+    void MiniAudioSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        SoundAsset::Reflect(context);
+        SoundAssetRef::Reflect(context);
+
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<MiniAudioSystemComponent, AZ::Component>()
+                ->Version(0)
+                ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<MiniAudioSystemComponent>("MiniAudio", "[Description of functionality provided by this System Component]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ;
+            }
+        }
+    }
+
+    void MiniAudioSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("MiniAudioService"));
+    }
+
+    void MiniAudioSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("MiniAudioService"));
+    }
+
+    void MiniAudioSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+    }
+
+    void MiniAudioSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+    MiniAudioSystemComponent::MiniAudioSystemComponent()
+    {
+        if (MiniAudioInterface::Get() == nullptr)
+        {
+            MiniAudioInterface::Register(this);
+        }
+    }
+
+    MiniAudioSystemComponent::~MiniAudioSystemComponent()
+    {
+        if (MiniAudioInterface::Get() == this)
+        {
+            MiniAudioInterface::Unregister(this);
+        }
+    }
+
+    void MiniAudioSystemComponent::Init()
+    {
+    }
+
+    void MiniAudioSystemComponent::Activate()
+    {
+        m_engine = AZStd::make_unique<ma_engine>();
+        const ma_result result = ma_engine_init(nullptr, m_engine.get());
+        if (result != MA_SUCCESS)
+        {
+            AZ_Error("MiniAudio", false, "Failed to initialize audio engine, error %d", result);
+        }
+
+        MiniAudioRequestBus::Handler::BusConnect();
+
+        {
+            SoundAssetHandler* handler = aznew SoundAssetHandler();
+            AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequests::EnableCatalogForAsset, AZ::AzTypeInfo<SoundAsset>::Uuid());
+            AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequests::AddExtension, SoundAsset::FileExtension);
+            m_assetHandlers.emplace_back(handler);
+        }
+    }
+
+    void MiniAudioSystemComponent::Deactivate()
+    {
+        m_assetHandlers.clear();
+        ma_engine_uninit(m_engine.get());
+        m_engine.reset();
+        MiniAudioRequestBus::Handler::BusDisconnect();
+    }
+
+    ma_engine* MiniAudioSystemComponent::GetSoundEngine()
+    {
+        return m_engine.get();
+    }
+
+    void MiniAudioSystemComponent::SetGlobalVolume(float scale)
+    {
+        m_globalVolume = scale;
+        ma_engine_set_volume(m_engine.get(), m_globalVolume);
+    }
+
+    float MiniAudioSystemComponent::GetGlobalVolume() const
+    {
+        return m_globalVolume;
+    }
+
+    void MiniAudioSystemComponent::SetGlobalVolumeInDecibels(float decibels)
+    {
+        m_globalVolume = ma_volume_db_to_linear(decibels);
+        SetGlobalVolume(m_globalVolume);
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioSystemComponent.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioSystemComponent.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/Asset/AssetManager.h>
+#include <MiniAudio/MiniAudioBus.h>
+
+// avoid including MiniAudioIncludes here to speed up compilation
+
+struct ma_engine;
+
+namespace MiniAudio
+{
+    class MiniAudioSystemComponent
+        : public AZ::Component
+        , public MiniAudioRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(MiniAudioSystemComponent, "{9F15877E-3FC6-4479-867F-A31883DFC945}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        MiniAudioSystemComponent();
+        MiniAudioSystemComponent(const MiniAudioSystemComponent&) = delete;
+        MiniAudioSystemComponent& operator=(const MiniAudioSystemComponent&) = delete;
+        virtual ~MiniAudioSystemComponent() override;
+
+        // AZ::Component interface implementation
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        // MiniAudioRequestBus interface implementation
+        ma_engine* GetSoundEngine() override;
+        void SetGlobalVolume(float scale) override;
+        float GetGlobalVolume() const override;
+        void SetGlobalVolumeInDecibels(float decibels) override;
+
+    private:
+        std::unique_ptr<ma_engine> m_engine;
+
+        float m_globalVolume = 1.f;
+
+        // Assets related data
+        AZStd::vector<AZStd::unique_ptr<AZ::Data::AssetHandler>> m_assetHandlers;
+    };
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/SoundAsset.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/SoundAsset.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <MiniAudio/SoundAsset.h>
+
+namespace MiniAudio
+{
+    void SoundAsset::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SoundAsset, AZ::Data::AssetData>()
+                ->Version(1)
+                ->Field("Data", &SoundAsset::m_data)
+                ;
+
+            serializeContext->RegisterGenericType<AZ::Data::Asset<SoundAsset>>();
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<SoundAsset>("MiniSound SoundAsset", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "");
+            }
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/SoundAssetHandler.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/SoundAssetHandler.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/Utils.h>
+#include <Clients/MiniAudioPlaybackComponent.h>
+#include <Clients/SoundAssetHandler.h>
+#include <MiniAudio/SoundAsset.h>
+
+namespace MiniAudio
+{
+    SoundAssetHandler::SoundAssetHandler()
+    {
+        Register();
+    }
+
+    SoundAssetHandler::~SoundAssetHandler()
+    {
+        Unregister();
+    }
+
+    void SoundAssetHandler::Register()
+    {
+        const bool assetManagerReady = AZ::Data::AssetManager::IsReady();
+        AZ_Error("SoundAssetHandler", assetManagerReady, "Asset manager isn't ready.");
+        if (assetManagerReady)
+        {
+            AZ::Data::AssetManager::Instance().RegisterHandler(this, AZ::AzTypeInfo<SoundAsset>::Uuid());
+        }
+
+        AZ::AssetTypeInfoBus::Handler::BusConnect(AZ::AzTypeInfo<SoundAsset>::Uuid());
+    }
+
+    void SoundAssetHandler::Unregister()
+    {
+        AZ::AssetTypeInfoBus::Handler::BusDisconnect();
+
+        if (AZ::Data::AssetManager::IsReady())
+        {
+            AZ::Data::AssetManager::Instance().UnregisterHandler(this);
+        }
+    }
+
+    // AZ::AssetTypeInfoBus
+    AZ::Data::AssetType SoundAssetHandler::GetAssetType() const
+    {
+        return AZ::AzTypeInfo<SoundAsset>::Uuid();
+    }
+
+    void SoundAssetHandler::GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions)
+    {
+        extensions.push_back(SoundAsset::FileExtension);
+    }
+
+    const char* SoundAssetHandler::GetAssetTypeDisplayName() const
+    {
+        return "Sound Asset (MiniAudio Gem)";
+    }
+
+    const char* SoundAssetHandler::GetBrowserIcon() const
+    {
+        return "Icons/Components/ColliderMesh.svg";
+    }
+
+    const char* SoundAssetHandler::GetGroup() const
+    {
+        return "Sound";
+    }
+
+    // Disable spawning of physics asset entities on drag and drop
+    AZ::Uuid SoundAssetHandler::GetComponentTypeId() const
+    {
+        // NOTE: This doesn't do anything when CanCreateComponent returns false
+        return AZ::Uuid(EditorMiniAudioPlaybackComponentTypeId);
+    }
+
+    bool SoundAssetHandler::CanCreateComponent([[maybe_unused]] const AZ::Data::AssetId& assetId) const
+    {
+        return false;
+    }
+
+    // AZ::Data::AssetHandler
+    AZ::Data::AssetPtr SoundAssetHandler::CreateAsset([[maybe_unused]] const AZ::Data::AssetId& id, const AZ::Data::AssetType& type)
+    {
+        if (type == AZ::AzTypeInfo<SoundAsset>::Uuid())
+        {
+            return aznew SoundAsset();
+        }
+
+        AZ_Error("SoundAssetHandler", false, "This handler deals only with SoundAsset type.");
+        return nullptr;
+    }
+
+    AZ::Data::AssetHandler::LoadResult SoundAssetHandler::LoadAssetData(
+        const AZ::Data::Asset<AZ::Data::AssetData>& asset,
+        AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
+        [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB)
+    {
+        const bool result = AZ::Utils::LoadObjectFromStreamInPlace<SoundAsset>(*stream, *asset.GetAs<SoundAsset>());
+        if (result == false)
+        {
+            AZ_Error(__FUNCTION__, false, "Failed to load asset");
+            return AssetHandler::LoadResult::Error;
+        }
+
+        return AssetHandler::LoadResult::LoadComplete;
+    }
+
+    void SoundAssetHandler::DestroyAsset(AZ::Data::AssetPtr ptr)
+    {
+        delete ptr;
+    }
+
+    void SoundAssetHandler::GetHandledAssetTypes(AZStd::vector<AZ::Data::AssetType>& assetTypes)
+    {
+        assetTypes.push_back(AZ::AzTypeInfo<SoundAsset>::Uuid());
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/SoundAssetHandler.h
+++ b/Gems/MiniAudio/Code/Source/Clients/SoundAssetHandler.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Asset/AssetTypeInfoBus.h>
+#include <AzCore/Asset/AssetManager.h> // this is where AssetHandler is defined
+
+namespace MiniAudio
+{
+    class SoundAssetHandler
+        : public AZ::Data::AssetHandler
+        , public AZ::AssetTypeInfoBus::Handler
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(SoundAssetHandler, AZ::SystemAllocator, 0);
+
+        SoundAssetHandler();
+        ~SoundAssetHandler();
+
+        void Register();
+        void Unregister();
+
+        // AZ::Data::AssetHandler
+        AZ::Data::AssetPtr CreateAsset(const AZ::Data::AssetId& id, const AZ::Data::AssetType& type) override;
+        AZ::Data::AssetHandler::LoadResult LoadAssetData(
+            const AZ::Data::Asset<AZ::Data::AssetData>& asset,
+            AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
+            const AZ::Data::AssetFilterCB& assetLoadFilterCB) override;
+        void DestroyAsset(AZ::Data::AssetPtr ptr) override;
+        void GetHandledAssetTypes(AZStd::vector<AZ::Data::AssetType>& assetTypes) override;
+
+        // AZ::AssetTypeInfoBus
+        AZ::Data::AssetType GetAssetType() const override;
+        void GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions) override;
+        const char* GetAssetTypeDisplayName() const override;
+        const char* GetBrowserIcon() const override;
+        const char* GetGroup() const override;
+        AZ::Uuid GetComponentTypeId() const override;
+        bool CanCreateComponent(const AZ::Data::AssetId& assetId) const override;
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Clients/SoundAssetRef.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/SoundAssetRef.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <MiniAudio/SoundAssetRef.h>
+
+namespace MiniAudio
+{
+    void SoundAssetRef::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext
+                ->Class<SoundAssetRef>()
+                ->Version(0)
+                ->EventHandler<SerializationEvents>()
+                ->Field("asset", &SoundAssetRef::m_asset)
+            ;
+
+            serializeContext->RegisterGenericType<AZStd::vector<SoundAssetRef>>();
+            serializeContext->RegisterGenericType<AZStd::unordered_map<AZStd::string, SoundAssetRef>>();
+            serializeContext->RegisterGenericType<AZStd::unordered_map<double, SoundAssetRef>>(); // required to support Map<Number, SoundAssetRef> in Script Canvas
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext
+                    ->Class<SoundAssetRef>("SoundAssetRef", "A wrapper around MiniAudio SoundAsset to be used as a variable in Script Canvas.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    // m_asset
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SoundAssetRef::m_asset, "asset", "")
+                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, false)
+                    ->Attribute(AZ::Edit::Attributes::HideProductFilesInAssetPicker, true)
+                    ->Attribute(AZ::Edit::Attributes::AssetPickerTitle, "MiniAudio Sound Asset")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SoundAssetRef::OnSpawnAssetChanged);
+            }
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<SoundAssetRef>("SoundAssetRef")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::EnableAsScriptEventParamType, true)
+                ->Attribute(AZ::Script::Attributes::Category, "MiniAudio")
+                ->Attribute(AZ::Script::Attributes::Module, "miniaudio")
+                ->Constructor()
+                ->Method("GetAsset", &SoundAssetRef::GetAsset)
+                ->Method("SetAsset", &SoundAssetRef::SetAsset);
+        }
+    }
+
+    SoundAssetRef::~SoundAssetRef()
+    {
+        AZ::Data::AssetBus::Handler::BusDisconnect();
+    }
+
+    SoundAssetRef::SoundAssetRef(const SoundAssetRef& rhs)
+    {
+        SetAsset(rhs.m_asset);
+    }
+
+    SoundAssetRef::SoundAssetRef(SoundAssetRef&& rhs)
+    {
+        SetAsset(AZStd::move(rhs.m_asset));
+    }
+
+    SoundAssetRef& SoundAssetRef::operator=(const SoundAssetRef& rhs)
+    {
+        if (this != &rhs)
+        {
+            SetAsset(rhs.m_asset);
+        }
+        return *this;
+    }
+
+    SoundAssetRef& SoundAssetRef::operator=(SoundAssetRef&& rhs)
+    {
+        if (this != &rhs)
+        {
+            SetAsset(AZStd::move(rhs.m_asset));
+        }
+        return *this;
+    }
+
+    void SoundAssetRef::SetAsset(const AZ::Data::Asset<SoundAsset>& asset)
+    {
+        AZ::Data::AssetBus::Handler::BusDisconnect();
+        m_asset = asset;
+        if (m_asset.GetId().IsValid())
+        {
+            AZ::Data::AssetBus::Handler::BusConnect(m_asset.GetId());
+        }
+    }
+
+    AZ::Data::Asset<SoundAsset> SoundAssetRef::GetAsset() const
+    {
+        return m_asset;
+    }
+
+    void SoundAssetRef::OnSpawnAssetChanged()
+    {
+        SetAsset(m_asset);
+    }
+
+    void SoundAssetRef::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        m_asset = asset;
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/MiniAudioModuleInterface.h
+++ b/Gems/MiniAudio/Code/Source/MiniAudioModuleInterface.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Module/Module.h>
+
+namespace MiniAudio
+{
+    // forwarded here to avoid leaking miniaudio.h into shared files.
+    extern AZ::ComponentDescriptor* MiniAudioSystemComponent_CreateDescriptor();
+    extern AZ::TypeId MiniAudioSystemComponent_GetTypeId();
+    extern AZ::ComponentDescriptor* MiniAudioPlaybackComponent_CreateDescriptor();
+    extern AZ::ComponentDescriptor* MiniAudioListenerComponent_CreateDescriptor();
+
+    class MiniAudioModuleInterface
+        : public AZ::Module
+    {
+    public:
+        AZ_RTTI(MiniAudioModuleInterface, "{290D3CED-B418-46E5-88A4-69EBF7DFC32C}", AZ::Module);
+        AZ_CLASS_ALLOCATOR(MiniAudioModuleInterface, AZ::SystemAllocator, 0);
+
+        MiniAudioModuleInterface()
+        {
+            // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
+            // Add ALL components descriptors associated with this gem to m_descriptors.
+            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+            // This happens through the [MyComponent]::Reflect() function.
+            m_descriptors.insert(m_descriptors.end(), {
+                MiniAudioSystemComponent_CreateDescriptor(),
+                MiniAudioPlaybackComponent_CreateDescriptor(),
+                MiniAudioListenerComponent_CreateDescriptor(),
+                });
+        }
+
+        /**
+         * Add required SystemComponents to the SystemEntity.
+         */
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+        {
+            return AZ::ComponentTypeList{
+                MiniAudioSystemComponent_GetTypeId(),
+            };
+        }
+    };
+}// namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioListenerComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioListenerComponent.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorMiniAudioListenerComponent.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* EditorMiniAudioListenerComponent_CreateDescriptor()
+    {
+        return EditorMiniAudioListenerComponent::CreateDescriptor();
+    }
+
+    void EditorMiniAudioListenerComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<EditorMiniAudioListenerComponent, BaseClass>()
+                ->Version(2);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<EditorMiniAudioListenerComponent>("MiniAudio Listener",
+                    "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "MiniAudio")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                editContext->Class<MiniAudioListenerComponentController>(
+                    "MiniAudioListenerComponentController", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioListenerComponentController::m_config, "Configuration", "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                editContext->Class<MiniAudioListenerComponentConfig>("MiniAudioListenerComponent Config",
+                    "[Configuration for MiniAudioListenerComponent]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioListenerComponentConfig::m_followEntity, "Follow Entity", "The listener will follow the position and orientation of the specified entity.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioListenerComponentConfig::m_listenerIndex, "Listener Index", "MiniAudio listener index to control.")
+                    ;
+            }
+        }
+    }
+
+    EditorMiniAudioListenerComponent::EditorMiniAudioListenerComponent(const MiniAudioListenerComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void EditorMiniAudioListenerComponent::Activate()
+    {
+        BaseClass::Activate();
+    }
+
+    void EditorMiniAudioListenerComponent::Deactivate()
+    {
+        BaseClass::Deactivate();
+    }
+
+    AZ::u32 EditorMiniAudioListenerComponent::OnConfigurationChanged()
+    {
+        m_controller.OnConfigurationUpdated();
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioListenerComponent.h
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioListenerComponent.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <Clients/MiniAudioListenerComponent.h>
+#include <Clients/MiniAudioListenerComponentController.h>
+#include <ToolsComponents/EditorComponentAdapter.h>
+
+namespace MiniAudio
+{
+    class EditorMiniAudioListenerComponent
+        : public AzToolsFramework::Components::EditorComponentAdapter<MiniAudioListenerComponentController,
+            MiniAudioListenerComponent, MiniAudioListenerComponentConfig>
+    {
+    public:
+        using BaseClass = AzToolsFramework::Components::EditorComponentAdapter<MiniAudioListenerComponentController, MiniAudioListenerComponent, MiniAudioListenerComponentConfig>;
+        AZ_EDITOR_COMPONENT(EditorMiniAudioListenerComponent, EditorMiniAudioListenerComponentTypeId, BaseClass);
+        static void Reflect(AZ::ReflectContext* context);
+
+        EditorMiniAudioListenerComponent() = default;
+        explicit EditorMiniAudioListenerComponent(const MiniAudioListenerComponentConfig& config);
+
+        void Activate() override;
+        void Deactivate() override;
+
+        AZ::u32 OnConfigurationChanged() override;
+    };
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorMiniAudioPlaybackComponent.h"
+
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* EditorMiniAudioPlaybackComponent_CreateDescriptor()
+    {
+        return EditorMiniAudioPlaybackComponent::CreateDescriptor();
+    }
+
+    void EditorMiniAudioPlaybackComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<EditorMiniAudioPlaybackComponent, BaseClass>()
+                ->Version(4);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<EditorMiniAudioPlaybackComponent>("MiniAudio Playback",
+                    "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "MiniAudio")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "Play Sound", "Plays the assigned sound")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                    ->Attribute(AZ::Edit::Attributes::ButtonText, "Play Sound")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMiniAudioPlaybackComponent::PlaySoundInEditor)
+
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "Stop Sound", "Stops playing the sound")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                    ->Attribute(AZ::Edit::Attributes::ButtonText, "Stop Sound")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMiniAudioPlaybackComponent::StopSoundInEditor)
+                    ;
+
+                editContext->Class<MiniAudioPlaybackComponentController>(
+                    "MiniAudioPlaybackComponentController", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentController::m_config, "Configuration", "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                editContext->Class<MiniAudioPlaybackComponentConfig>("MiniAudioPlaybackComponent Config",
+                    "[Configuration for MiniAudioPlaybackComponent]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_sound, "Sound Asset", "Sound asset to play")
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Configuration")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_autoplayOnActivate, "Autoplay", "Plays the sound on activation of the component.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_loop, "Loop", "Loops the sound.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_volume, "Volume", "The volume of the sound when played.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->Attribute(AZ::Edit::Attributes::SoftMax, 10.f)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_autoFollowEntity, "Auto-follow",
+                        "The sound's position is updated to match the entity's position.")
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Spatialization")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_enableSpatialization, "Spatialization", "If true the sound will have 3D position in the world and will have effects applied to it based on the distance from a sound listener.")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &MiniAudioPlaybackComponentConfig::m_attenuationModel, "Attenuation", "Attenuation model.")
+                    ->EnumAttribute(AttenuationModel::Inverse, "Inverse")
+                    ->EnumAttribute(AttenuationModel::Exponential, "Exponential")
+                    ->EnumAttribute(AttenuationModel::Linear, "Linear")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_minimumDistance, "Min Distance", "Minimum distance for attenuation.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MiniAudioPlaybackComponentConfig::m_maximumDistance, "Max Distance", "Maximum distance for attenuation.")
+
+                    ;
+            }
+        }
+    }
+
+    EditorMiniAudioPlaybackComponent::EditorMiniAudioPlaybackComponent(const MiniAudioPlaybackComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void EditorMiniAudioPlaybackComponent::Activate()
+    {
+        BaseClass::Activate();
+    }
+
+    void EditorMiniAudioPlaybackComponent::Deactivate()
+    {
+        BaseClass::Deactivate();
+    }
+
+    AZ::u32 EditorMiniAudioPlaybackComponent::OnConfigurationChanged()
+    {
+        m_controller.OnConfigurationUpdated();
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+
+    AZ::Crc32 EditorMiniAudioPlaybackComponent::PlaySoundInEditor()
+    {
+        m_controller.Stop();
+        m_controller.Play();
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+
+    AZ::Crc32 EditorMiniAudioPlaybackComponent::StopSoundInEditor()
+    {
+        m_controller.Stop();
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+
+    AZ::Crc32 EditorMiniAudioPlaybackComponent::OnVolumeChanged()
+    {
+        m_controller.SetVolume(m_controller.GetConfiguration().m_volume);
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.h
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <Clients/MiniAudioPlaybackComponent.h>
+#include <Clients/MiniAudioPlaybackComponentController.h>
+#include <ToolsComponents/EditorComponentAdapter.h>
+
+namespace MiniAudio
+{
+    class EditorMiniAudioPlaybackComponent
+        : public AzToolsFramework::Components::EditorComponentAdapter<MiniAudioPlaybackComponentController,
+            MiniAudioPlaybackComponent, MiniAudioPlaybackComponentConfig>
+    {
+    public:
+        using BaseClass = AzToolsFramework::Components::EditorComponentAdapter<MiniAudioPlaybackComponentController, MiniAudioPlaybackComponent, MiniAudioPlaybackComponentConfig>;
+        AZ_EDITOR_COMPONENT(EditorMiniAudioPlaybackComponent, EditorMiniAudioPlaybackComponentTypeId, BaseClass);
+        static void Reflect(AZ::ReflectContext* context);
+
+        EditorMiniAudioPlaybackComponent() = default;
+        explicit EditorMiniAudioPlaybackComponent(const MiniAudioPlaybackComponentConfig& config);
+
+        void Activate() override;
+        void Deactivate() override;
+
+        AZ::u32 OnConfigurationChanged() override;
+
+        AZ::Crc32 PlaySoundInEditor();
+        AZ::Crc32 StopSoundInEditor();
+        AZ::Crc32 OnVolumeChanged();
+    };
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorModule.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorModule.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <MiniAudioModuleInterface.h>
+
+namespace MiniAudio
+{
+    extern AZ::TypeId MiniAudioEditorSystemComponent_GetTypeId();
+    extern AZ::ComponentDescriptor* MiniAudioEditorSystemComponent_CreateDescriptor();
+    extern AZ::ComponentDescriptor* EditorMiniAudioListenerComponent_CreateDescriptor();
+    extern AZ::ComponentDescriptor* EditorMiniAudioPlaybackComponent_CreateDescriptor();
+
+    class MiniAudioEditorModule
+        : public MiniAudioModuleInterface
+    {
+    public:
+        AZ_RTTI(MiniAudioEditorModule, "{501C94A1-993A-4203-9720-D43D6C1DDB7A}", MiniAudioModuleInterface);
+        AZ_CLASS_ALLOCATOR(MiniAudioEditorModule, AZ::SystemAllocator, 0);
+
+        MiniAudioEditorModule()
+        {
+            // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
+            // Add ALL components descriptors associated with this gem to m_descriptors.
+            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+            // This happens through the [MyComponent]::Reflect() function.
+            m_descriptors.insert(m_descriptors.end(), {
+                MiniAudioEditorSystemComponent_CreateDescriptor(),
+                EditorMiniAudioListenerComponent_CreateDescriptor(),
+                EditorMiniAudioPlaybackComponent_CreateDescriptor(),
+            });
+        }
+
+        /**
+         * Add required SystemComponents to the SystemEntity.
+         * Non-SystemComponents should not be added here
+         */
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+        {
+            return AZ::ComponentTypeList {
+                MiniAudioEditorSystemComponent_GetTypeId(),
+            };
+        }
+    };
+}// namespace MiniAudio
+
+AZ_DECLARE_MODULE_CLASS(Gem_MiniAudio, MiniAudio::MiniAudioEditorModule)

--- a/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include "MiniAudioEditorSystemComponent.h"
+
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AzFramework/Asset/GenericAssetHandler.h>
+#include <MiniAudio/SoundAsset.h>
+
+namespace MiniAudio
+{
+    AZ::ComponentDescriptor* MiniAudioEditorSystemComponent_CreateDescriptor()
+    {
+        return MiniAudioEditorSystemComponent::CreateDescriptor();
+    }
+
+    AZ::TypeId MiniAudioEditorSystemComponent_GetTypeId()
+    {
+        return azrtti_typeid<MiniAudioEditorSystemComponent>();
+    }
+
+    void MiniAudioEditorSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MiniAudioEditorSystemComponent, AZ::Component>()
+                ->Version(1)
+                ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("AssetBuilder") }))
+                ;
+        }
+    }
+
+    void MiniAudioEditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        BaseSystemComponent::GetProvidedServices(provided);
+        provided.push_back(AZ_CRC_CE("MiniAudioEditorService"));
+    }
+
+    void MiniAudioEditorSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        BaseSystemComponent::GetIncompatibleServices(incompatible);
+        incompatible.push_back(AZ_CRC_CE("MiniAudioEditorService"));
+    }
+
+    void MiniAudioEditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        BaseSystemComponent::GetRequiredServices(required);
+    }
+
+    void MiniAudioEditorSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        dependent.push_back(AZ_CRC_CE("AssetDatabaseService"));
+        dependent.push_back(AZ_CRC_CE("AssetCatalogService"));
+        BaseSystemComponent::GetDependentServices(dependent);
+    }
+
+    void MiniAudioEditorSystemComponent::Activate()
+    {
+        MiniAudioSystemComponent::Activate();
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+
+        // Register MiniSound Asset
+        auto* materialAsset = aznew AzFramework::GenericAssetHandler<SoundAsset>("MiniSound Asset", SoundAsset::AssetGroup, SoundAsset::FileExtension);
+        materialAsset->Register();
+        m_assetHandlers.emplace_back(materialAsset);
+
+        // Register MiniSound Asset Builder
+        AssetBuilderSDK::AssetBuilderDesc materialAssetBuilderDescriptor;
+        materialAssetBuilderDescriptor.m_name = "MiniSound Asset Builder";
+        materialAssetBuilderDescriptor.m_version = 3; // bump this to rebuild all sound files
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.ogg",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.flac",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.mp3",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.wav",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_busId = azrtti_typeid<SoundAssetBuilder>();
+        materialAssetBuilderDescriptor.m_createJobFunction = [this](const AssetBuilderSDK::CreateJobsRequest& request,
+            AssetBuilderSDK::CreateJobsResponse& response)
+        {
+            m_soundAssetBuilder.CreateJobs(request, response);
+        };
+        materialAssetBuilderDescriptor.m_processJobFunction = [this](const AssetBuilderSDK::ProcessJobRequest& request,
+            AssetBuilderSDK::ProcessJobResponse& response)
+        {
+            m_soundAssetBuilder.ProcessJob(request, response);
+        };
+        m_soundAssetBuilder.BusConnect(materialAssetBuilderDescriptor.m_busId);
+        AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBus::Handler::RegisterBuilderInformation,
+            materialAssetBuilderDescriptor);
+
+    }
+
+    void MiniAudioEditorSystemComponent::Deactivate()
+    {
+        m_assetHandlers.clear();
+
+        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
+        MiniAudioSystemComponent::Deactivate();
+    }
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.h
+++ b/Gems/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <Clients/MiniAudioSystemComponent.h>
+#include <Tools/SoundAssetBuilder.h>
+#include <Clients/MiniAudioSystemComponent.h>
+
+namespace MiniAudio
+{
+    /// System component for MiniAudio editor
+    class MiniAudioEditorSystemComponent
+        : public MiniAudioSystemComponent
+        , protected AzToolsFramework::EditorEvents::Bus::Handler
+    {
+        using BaseSystemComponent = MiniAudioSystemComponent;
+    public:
+        AZ_COMPONENT(MiniAudioEditorSystemComponent, "{C221724F-CCA2-454E-97A9-E418A91CB072}", BaseSystemComponent);
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        MiniAudioEditorSystemComponent() = default;
+        MiniAudioEditorSystemComponent(const MiniAudioEditorSystemComponent&) = delete;
+        MiniAudioEditorSystemComponent& operator=(const MiniAudioEditorSystemComponent&) = delete;
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        SoundAssetBuilder m_soundAssetBuilder;
+
+        // Assets related data
+        AZStd::vector<AZStd::unique_ptr<AZ::Data::AssetHandler>> m_assetHandlers;
+    };
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/SoundAssetBuilder.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/SoundAssetBuilder.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AssetBuilderSDK/SerializationDependencies.h>
+#include <AzCore/Asset/AssetDataStream.h>
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/IOUtils.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <MiniAudio/SoundAsset.h>
+#include <Tools/SoundAssetBuilder.h>
+
+namespace MiniAudio
+{
+    void SoundAssetBuilder::CreateJobs(
+        const AssetBuilderSDK::CreateJobsRequest& request,
+        AssetBuilderSDK::CreateJobsResponse& response) const
+    {
+        for (const AssetBuilderSDK::PlatformInfo& platformInfo : request.m_enabledPlatforms)
+        {
+            AssetBuilderSDK::JobDescriptor jobDescriptor;
+            jobDescriptor.m_critical = true;
+            jobDescriptor.m_jobKey = "MiniSound Asset";
+            jobDescriptor.SetPlatformIdentifier(platformInfo.m_identifier.c_str());
+
+            response.m_createJobOutputs.push_back(jobDescriptor);
+        }
+
+        response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
+    }
+
+    void SoundAssetBuilder::ProcessJob(
+        [[maybe_unused]] const AssetBuilderSDK::ProcessJobRequest& request,
+        AssetBuilderSDK::ProcessJobResponse& response) const
+    {
+        const AZStd::string& fromFile = request.m_fullPath;
+
+        AZ::Data::Asset<SoundAsset> soundAsset;
+        soundAsset.Create(AZ::Data::AssetId(AZ::Uuid::CreateRandom()));
+
+        auto assetDataStream = AZStd::make_shared<AZ::Data::AssetDataStream>();
+        // Read in the data from a file to a buffer, then hand ownership of the buffer over to the assetDataStream
+        {
+            AZ::IO::FileIOStream stream(fromFile.c_str(), AZ::IO::OpenMode::ModeRead);
+            if (!AZ::IO::RetryOpenStream(stream))
+            {
+                AZ_Error("SoundAssetBuilder", false, "Source file '%s' could not be opened.", fromFile.c_str());
+                return;
+            }
+
+            AZStd::vector<AZ::u8> fileBuffer(stream.GetLength());
+            const size_t bytesRead = stream.Read(fileBuffer.size(), fileBuffer.data());
+            if (bytesRead != stream.GetLength())
+            {
+                AZ_Error("SoundAssetBuilder", false, "Source file '%s' could not be read.", fromFile.c_str());
+                return;
+            }
+
+            soundAsset->m_data.swap(fileBuffer);
+        }
+
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFileName(request.m_sourceFile.c_str(), filename);
+
+        AZStd::string currentExtension;
+        AzFramework::StringFunc::Path::GetExtension(request.m_sourceFile.c_str(), currentExtension);
+        AZStd::string outputExtension = currentExtension + "." + SoundAsset::FileExtension;
+
+        AzFramework::StringFunc::Path::ReplaceExtension(filename, outputExtension.c_str());
+
+        AZStd::string outputPath;
+        AzFramework::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), filename.c_str(), outputPath, true);
+
+        if (!AZ::Utils::SaveObjectToFile(outputPath, AZ::DataStream::ST_BINARY, soundAsset.Get()))
+        {
+            AZ_Error(__FUNCTION__, false, "Failed to save material type to file '%s'!", outputPath.c_str());
+            return;
+        }
+
+        AssetBuilderSDK::JobProduct soundJobProduct;
+        if (!AssetBuilderSDK::OutputObject(
+            soundAsset.Get(),
+            outputPath,
+            azrtti_typeid<SoundAsset>(),
+            SoundAsset::AssetSubId,
+            soundJobProduct))
+        {
+            AZ_Error("SoundAssetBuilder", false, "Failed to output product dependencies.");
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+        }
+        else
+        {
+            response.m_outputProducts.push_back(AZStd::move(soundJobProduct));
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
+        }
+    }
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/Source/Tools/SoundAssetBuilder.h
+++ b/Gems/MiniAudio/Code/Source/Tools/SoundAssetBuilder.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AssetBuilderSDK/AssetBuilderBusses.h>
+
+namespace MiniAudio
+{
+    class SoundAssetBuilder
+        : public AssetBuilderSDK::AssetBuilderCommandBus::Handler
+    {
+    public:
+        AZ_RTTI(SoundAssetBuilder, "{b7db2037-18c7-4bc7-9434-7cd5523d6649}");
+
+        SoundAssetBuilder() = default;
+
+        //! AssetBuilderCommandBus overrides ...
+        void CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response) const;
+        void ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const;
+        void ShutDown() override {}
+    };
+
+} // namespace MiniAudio

--- a/Gems/MiniAudio/Code/miniaudio_api_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_api_files.cmake
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Include/MiniAudio/MiniAudioBus.h
+    Include/MiniAudio/MiniAudioConstants.h
+    Include/MiniAudio/MiniAudioListenerBus.h
+    Include/MiniAudio/MiniAudioPlaybackBus.h
+    Include/MiniAudio/SoundAsset.h
+    Include/MiniAudio/SoundAssetRef.h
+)

--- a/Gems/MiniAudio/Code/miniaudio_editor_api_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_editor_api_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+
+set(FILES
+)

--- a/Gems/MiniAudio/Code/miniaudio_editor_private_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_editor_private_files.cmake
@@ -1,0 +1,18 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/Tools/EditorMiniAudioListenerComponent.cpp
+    Source/Tools/EditorMiniAudioListenerComponent.h
+    Source/Tools/EditorMiniAudioPlaybackComponent.cpp
+    Source/Tools/EditorMiniAudioPlaybackComponent.h
+    Source/Tools/MiniAudioEditorSystemComponent.cpp
+    Source/Tools/MiniAudioEditorSystemComponent.h
+    Source/Tools/SoundAssetBuilder.cpp
+    Source/Tools/SoundAssetBuilder.h
+)

--- a/Gems/MiniAudio/Code/miniaudio_editor_shared_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_editor_shared_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/Tools/MiniAudioEditorModule.cpp
+)

--- a/Gems/MiniAudio/Code/miniaudio_private_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_private_files.cmake
@@ -1,0 +1,40 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/MiniAudioModuleInterface.h
+    Source/Clients/MiniAudioImplementation.cpp
+    Source/Clients/MiniAudioIncludes.h
+    Source/Clients/MiniAudioListenerComponent.cpp
+    Source/Clients/MiniAudioListenerComponent.h
+
+    Source/Clients/MiniAudioListenerComponent.cpp
+    Source/Clients/MiniAudioListenerComponent.h
+    Source/Clients/MiniAudioListenerComponentConfig.cpp
+    Source/Clients/MiniAudioListenerComponentConfig.h
+    Source/Clients/MiniAudioListenerComponentController.cpp
+    Source/Clients/MiniAudioListenerComponentController.h
+
+    Source/Clients/MiniAudioPlaybackComponent.cpp
+    Source/Clients/MiniAudioPlaybackComponent.h
+    Source/Clients/MiniAudioPlaybackComponentConfig.cpp
+    Source/Clients/MiniAudioPlaybackComponentConfig.h
+    Source/Clients/MiniAudioPlaybackComponentController.cpp
+    Source/Clients/MiniAudioPlaybackComponentController.h
+
+    Source/Clients/MiniAudioSystemComponent.cpp
+    Source/Clients/MiniAudioSystemComponent.h
+    Source/Clients/SoundAssetHandler.cpp
+    Source/Clients/SoundAssetHandler.h
+    Source/Clients/SoundAsset.cpp
+    Source/Clients/SoundAssetRef.cpp
+)
+
+set(SKIP_UNITY_BUILD_INCLUSION_FILES
+    Source/Clients/MiniAudioImplementation.cpp
+)

--- a/Gems/MiniAudio/Code/miniaudio_shared_files.cmake
+++ b/Gems/MiniAudio/Code/miniaudio_shared_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/Clients/MiniAudioModule.cpp
+)

--- a/Gems/MiniAudio/README.md
+++ b/Gems/MiniAudio/README.md
@@ -1,0 +1,73 @@
+# MiniAudioO3DE
+This is an integration of https://miniaud.io/ into Open 3D Engine as a Gem. It has the most fundamental features working already: sound playback, sound positioning, and listener positioning. One can test the sounds in the Editor viewport without entering game mode.
+
+# Supported Sound Formats
+- .wav 
+- .ogg 
+- .mp3
+- .flac
+
+MiniAudio supports more formats, but not all are supported in this Gem yet.
+
+# Components
+- MiniAudio Playback Component
+
+![image](https://user-images.githubusercontent.com/5432499/184503877-e9d1d3ec-4520-48eb-9bc2-bff25ab47709.png)
+
+- MiniAudio Listener Component
+
+![image](https://user-images.githubusercontent.com/5432499/184503840-0ac54dd6-66e8-400b-bc68-8ac16f839c1f.png)
+
+# How-To in Scripting 
+
+The following nodes are exposed to scripting.
+
+![image](https://user-images.githubusercontent.com/5432499/197317433-18b16407-2bd8-4deb-abf1-53dd67f1d831.png)
+
+For the playback component:
+![image](https://user-images.githubusercontent.com/5432499/197317353-60f694af-4a30-46d8-bb85-89519f9e87de.png)
+
+For the listener component:
+![image](https://user-images.githubusercontent.com/5432499/197317439-5cf7eaad-b5ab-4fb1-86ac-c6d2fb75a4cd.png)
+
+
+# How-To Guide in C++
+
+1. Declare a dependency in your cmake target on `Gem::MiniAudio.API`:
+    ```
+    BUILD_DEPENDENCIES
+        PUBLIC
+            ...
+            Gem::MiniAudio.API
+    ```
+2. Include the header file, for example
+    ```cpp
+    #include <MiniAudio/MiniAudioPlaybackBus.h>
+    ```
+3. Invoke MiniAudioPlaybackRequestBus interface
+    ```cpp
+    MiniAudio::MiniAudioPlaybackRequestBus::Event(GetEntityId(), &MiniAudio::MiniAudioPlaybackRequestBus::Events::Play);
+    ```
+4. Or get a direct pointer to the interface:
+    ```cpp    
+    if (auto bus = MiniAudio::MiniAudioPlaybackRequestBus::FindFirstHandler(GetEntityId()))
+    {
+        bus->Play();
+    }
+    ```
+5. You can also declare a dependency of a component on a particular component of MiniAudio, such as:
+    ```cpp
+    static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("MiniAudioPlaybackComponent"));
+    }
+    ```
+
+# License
+
+See the LICENSE files at the root of the engine.
+
+Uses 3rd party components under their own license:
+ * MiniAudio:  See ./3rdParty/miniaudio/LICENSE.TXT  - choose between either Public Domain (www.unlicense.org) or MIT No Attribution
+ * stb_vorbis: See ./3rdParty/stb_vorbis/LICENSE.TXT - choose between either Public Domain (www.unlicense.org) or MIT
+ 

--- a/Gems/MiniAudio/Registry/assetprocessor_settings.setreg
+++ b/Gems/MiniAudio/Registry/assetprocessor_settings.setreg
@@ -1,0 +1,18 @@
+{
+    "Amazon": {
+        "AssetProcessor": {
+            "Settings": {
+                "ScanFolder MiniAudio/Assets": {
+                    "watch": "@GEMROOT:MiniAudio@/Assets",
+                    "recursive": 1,
+                    "order": 101
+                },
+                "ScanFolder MiniAudio/Registry": {
+                    "watch": "@GEMROOT:MiniAudio@/Registry",
+                    "recursive": 1,
+                    "order": 102
+                }
+            }
+        }
+    }
+}

--- a/Gems/MiniAudio/gem.json
+++ b/Gems/MiniAudio/gem.json
@@ -1,0 +1,25 @@
+{
+    "gem_name": "MiniAudio",
+    "version": "0.1.0",
+    "display_name": "MiniAudio",
+    "license": "Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "origin": "Open 3D Engine - o3de.org",
+    "origin_url": "https://github.com/o3de/o3de",
+    "type": "Code",
+    "summary": "The MiniAudio Gem provides support for audio playback using MiniAudio (https://miniaud.io)",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "MiniAudio",
+        "Audio",
+        "Utility",
+        "Tools"
+    ],
+    "icon_path": "preview.png",
+    "requirements": "",
+    "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/audio/miniaudio/",
+    "dependencies": [],
+    "restricted": "MiniAudio"
+}

--- a/Gems/MiniAudio/preview.png
+++ b/Gems/MiniAudio/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:248e3ffe1fc9ffc02afb2ba8914e222a5a5d13ac45a48b98c95ee062e959a94c
+size 4475

--- a/engine.json
+++ b/engine.json
@@ -60,6 +60,7 @@
         "Gems/MessagePopup",
         "Gems/Metastream",
         "Gems/Microphone",
+        "Gems/MiniAudio",
         "Gems/MotionMatching",
         "Gems/Multiplayer",
         "Gems/MultiplayerCompression",

--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.1.0",


### PR DESCRIPTION
## What does this PR do?

1. Cherry pick MiniAudio Gem from https://github.com/o3de/o3de/pull/17328 and https://github.com/o3de/o3de/pull/17302
2. Bump engine version from `2.2.0` to `2.2.1`

## How was this PR tested?

- added MiniAudio gem to AutomatedTesting, configured and built AutomatedTesting project Editor, opened a level and verified MiniAudio component could play audio.
