### PR TITLE
Fix mini audio release

### DIFF
--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioModule.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioModule.cpp
@@ -21,8 +21,4 @@ namespace MiniAudio
 }// namespace MiniAudio
 
 
-#if defined(O3DE_GEM_NAME)
-AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), MiniAudio::MiniAudioModule)
-#else
 AZ_DECLARE_MODULE_CLASS(Gem_MiniAudio, MiniAudio::MiniAudioModule)
-#endif


### PR DESCRIPTION
## What does this PR do?

Fixing compile issue with monolithic release.  Point release branch does not have the macro changes development has for supporting gem renaming, so I've reverted that code here.

## How was this PR tested?

-configured and build monolithic MiniAudio library
