### PR TITLE
Add support for custom draw srg for potential deferred rendering implementation with multiple material types

### DIFF
--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
@@ -10,6 +10,12 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#ifndef USE_CUSTOM_DRAW_SRG
+#define USE_CUSTOM_DRAW_SRG 0
+#endif
+
+#if USE_CUSTOM_DRAW_SRG
+#else
 ShaderResourceGroup DrawSrg : SRG_PerDraw
 {
     // This SRG is unique per draw packet
@@ -20,4 +26,5 @@ ShaderResourceGroup DrawSrg : SRG_PerDraw
         return (m_uvStreamTangentBitmask >> (4 * uvIndex)) & 0xF;
     }
 }
+#endif
 


### PR DESCRIPTION
## What does this PR do?

Consider implementing a deferred rendering pipeline, we would need to send a full-screen draw with the a material index so that the shading pass can know what exactly the material instance is, therefore we may need to customize the draw srg, but in the current settings, all material types are sharing the same draw srg and there is no space for the developers to customize it.

So this PR introduce a macro to distinguish whether or not using the customized draw srg, one can define this when necessary in a Gem outside the engine.

Also, since the standard multilayer pbr and standard pbr material types are sharing the same lighting model, in the shaders inside the deferred shading pass we may not be able to distinguish them between each other, here I add a macro to tell that.

These few lines of code changes are the minimum and necessary changes to the engine to support deferred rendering, they won't affect the current rendering things at all but granting flexibility and possibility for implementing a deferred rendering pipeline inside the engine or in a separated Gem.

## How was this PR tested?

Self tested.
