### PR TITLE
Add MiniAudio Gem to DefaultProject template

### DIFF
--- a/Templates/DefaultProject/Template/project.json
+++ b/Templates/DefaultProject/Template/project.json
@@ -32,6 +32,7 @@
         "ImGui",
         "LandscapeCanvas",
         "LyShine",
+        "MiniAudio",
         "PhysX",
         "PrimitiveAssets",
         "PrefabBuilder",


### PR DESCRIPTION
## What does this PR do?

- Add MiniAudio Gem to the DefaultProject template

## How was this PR tested?

- created a project with DefaultProject template, built it, opened the editor and verified the components could be added and play audio.
