### PR TITLE
Fix AWS Native SDK CMake Typo

### DIFF
--- a/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
+++ b/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
@@ -21,7 +21,7 @@ ly_add_target(
             ${pal_dir}
     BUILD_DEPENDENCIES
         PRIVATE
-            3rdParty::AWSNativeSDK::Core
+            3rdParty::AWSNativeSDK::AWSCore
             AZ::AzCore
 )
 


### PR DESCRIPTION
Cherry pick development branch fix for an AWS Native SDK CMake typo (commit 6710afd3e005e6a68a0baca3a3f50fdb4fabff77)

Fixes #17368 