### PR TITLE
fix: "LegacyAssetConverter" to export assets lumberyard to o3de

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
@@ -25,7 +25,7 @@ PREFERRED_IMAGE_FORMAT = '.tif'
 
 TRANSFER_EXTENSIONS = ['.fbx', '.assetinfo']
 
-IMAGE_KEYS = {
+FILE_MASKS = {
     'ddn': ['ddn'],
     'ddna': ['ddna'],
     'diffuse': ['diffuse', 'diff', 'dif', 'd'],

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
@@ -19,7 +19,7 @@ DIRECTORY_EXCLUSION_LIST = ['.mayaSwatches']
 
 LUMBERYARD_DATA_FILES = ['.mtl', '.assetinfo', '.material']
 
-EXPORT_MATERIAL_TYPES = ['Illum', 'Vegetation']
+EXPORT_MATERIAL_TYPES = ['Illum', 'Vegetation', 'Glass']
 
 PREFERRED_IMAGE_FORMAT = '.tif'
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/constants.py
@@ -19,7 +19,7 @@ DIRECTORY_EXCLUSION_LIST = ['.mayaSwatches']
 
 LUMBERYARD_DATA_FILES = ['.mtl', '.assetinfo', '.material']
 
-EXPORT_MATERIAL_TYPES = ['Illum']
+EXPORT_MATERIAL_TYPES = ['Illum', 'Vegetation']
 
 PREFERRED_IMAGE_FORMAT = '.tif'
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/create_maya_files.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/create_maya_files.py
@@ -48,7 +48,7 @@ class CreateMayaFiles(QtCore.QObject):
         self.destination_directory = destination_directory
         self.modify_naming = modify_naming
         self.scene_shader_info = None
-        self.materials_db = shelve.open('materialsdb', protocol=2)
+        self.materials_db = {} #shelve.open('materialsdb', protocol=2)
         self.new_file = True
         self.file_name = None
         self.target_database_listing = None
@@ -107,7 +107,7 @@ class CreateMayaFiles(QtCore.QObject):
         try:
             return_dictionary = {self.target_database_listing: self.transfer_data}
             json.dump(return_dictionary, sys.stdout)
-            self.materials_db.close()
+            #self.materials_db.close()
         except Exception as e:
             _LOGGER.info('Error: {} -- {}'.format(e, self.transfer_data))
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
@@ -28,7 +28,7 @@ module_name = 'legacy_asset_converter.main.image_conversion'
 _LOGGER = _logging.getLogger(module_name)
 
 
-def get_pbr_textures(legacy_textures, destination_directory, base_directory, shader_name):
+def get_pbr_textures(legacy_textures, destination_directory, base_directory, uses_alpha):
     pbr_textures = {}
     for texture_type, texture_path in legacy_textures.items():
         _LOGGER.info(f'TEXTURETYPE::> {texture_type}  TEXTUREPATH::> {texture_path}')
@@ -40,7 +40,7 @@ def get_pbr_textures(legacy_textures, destination_directory, base_directory, sha
             _LOGGER.info(f'Found texture [{existing_path}]. Continuing...')
             texture_path = Path(existing_path)
         if texture_type == 'diffuse':
-            filemask = 'BaseColorA' if shader_uses_alpha(shader_name) else 'BaseColor'
+            filemask = 'BaseColorA' if uses_alpha else 'BaseColor'
             dst = get_converted_filename(texture_path, destination_directory, filemask)
             pbr_textures['BaseColor'] = transfer_texture(dst, texture_path) if not os.path.isfile(dst) else dst
         elif texture_type == 'specular':
@@ -92,10 +92,6 @@ def resolve_path(texture_path, base_directory):
             if target_file == texture_path.stem.lower():
                 return os.path.abspath(os.path.join(root, file))
     return None
-
-
-def shader_uses_alpha(shader_name):
-    return shader_name.lower() == 'vegetation'
 
 
 def transfer_texture(dst, src, overwrite=False):

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
@@ -39,8 +39,9 @@ def get_pbr_textures(legacy_textures, destination_directory, base_directory, use
             # Fallback on tiff texture as it might exist like this on disk
             if not existing_path and texture_path.suffix == '.dds':
                 existing_path = resolve_path(texture_path.with_suffix('.tif'), base_directory)
-                if not existing_path:
-                    continue
+
+            if not existing_path:
+                continue
 
             _LOGGER.info(f'Found texture [{existing_path}]. Continuing...')
             texture_path = Path(existing_path)
@@ -99,12 +100,26 @@ def resolve_path(texture_path, base_directory):
         if os.path.exists(resolved_path):
             return resolved_path
 
-    for (root, dirs, files) in os.walk(base_directory.parent, topdown=True):
+    cache_dir(base_directory)
+    for (root, dirs, files) in os_walk_cache(base_directory):
         for file in files:
             if Path(file).name.lower() == texture_path.name.lower():
                 return os.path.abspath(os.path.join(root, file))
     return None
 
+cache = {}
+def cache_dir(dir):
+    if dir in cache:
+        return
+    else:
+        cache[dir] = []
+        for x in os.walk(dir, topdown=True):
+            cache[dir].append(x)
+
+def os_walk_cache(dir):
+    if dir in cache:
+        for x in cache[dir]:
+            yield x
 
 def transfer_texture(dst, src, overwrite=False):
     if not os.path.exists(dst) or overwrite:

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
@@ -238,17 +238,16 @@ def find_min_max(buf):
 
 def get_converted_filename(src, dst, texture_type):
     """
-    Takes the structure of an existing filename extracted from the legacy mtl files, and renames it, base on the
-    texture type argument that is passed to it
+    Append the texture type to the texture name
     :param src: The legacy filename to be manipulated
     :param dst: The destination directory that the new file will be saved to
     :param texture_type: PBR texture type
-    :return:
+    :return: filepath
     """
     if src.is_file():
-        filename = src.name.replace(get_texture_type(src), texture_type)
+        filename = f'{src.stem}_{texture_type}{src.suffix}'
         dst = os.path.normpath(dst / filename)
-        _LOGGER.info(f'+=+=+=+=+=+=+=+=+=+=+=+ {dst}  -- {os.path.isfile(dst)}')
+        _LOGGER.info(f'+=+=+=+=+=+=+=+=+=+=+=+ {dst} -- overwriting {os.path.isfile(dst)}')
     return dst
 
 
@@ -289,7 +288,7 @@ def get_texture_basename(image_path):
 
 def get_texture_type(image_path):
     """
-    Gets the PBR texture type from the filename.
+    Returns the string after the last '_' from filename
     :param image_path: Path to the image from which to extract pbr type
     :return:
     """

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
@@ -86,10 +86,17 @@ def get_pbr_textures(legacy_textures, destination_directory, base_directory, use
 
 def resolve_path(texture_path, base_directory):
     _LOGGER.info(f'Resolving Path... Filename[{texture_path.name}: {base_directory}')
+    
+    # Try to match path via topmost assets folder
+    split_dir = base_directory.as_posix().lower().split('/assets/')
+    if len(split_dir) > 1:
+        resolved_path = os.path.abspath(os.path.join(split_dir[0], 'assets', texture_path))
+        if os.path.exists(resolved_path):
+            return resolved_path
+
     for (root, dirs, files) in os.walk(base_directory.parent, topdown=True):
         for file in files:
-            target_file = file.split('.')[0].lower()
-            if target_file == texture_path.stem.lower():
+            if Path(file).name.lower() == texture_path.name.lower():
                 return os.path.abspath(os.path.join(root, file))
     return None
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/image_conversion.py
@@ -35,8 +35,13 @@ def get_pbr_textures(legacy_textures, destination_directory, base_directory, use
         if not texture_path.is_file():
             _LOGGER.info(f'(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((( Missing:::: {texture_path}')
             existing_path = resolve_path(texture_path, base_directory)
-            if not existing_path:
-                continue
+
+            # Fallback on tiff texture as it might exist like this on disk
+            if not existing_path and texture_path.suffix == '.dds':
+                existing_path = resolve_path(texture_path.with_suffix('.tif'), base_directory)
+                if not existing_path:
+                    continue
+
             _LOGGER.info(f'Found texture [{existing_path}]. Continuing...')
             texture_path = Path(existing_path)
         if texture_type == 'diffuse':

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/lumberyard_data.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/lumberyard_data.py
@@ -120,7 +120,9 @@ def get_material_info(target_directory, filename):
                     map_name = texture.get('Map')
                     file_path = texture.get('File')
                     material_textures[map_name.lower()] = Path(file_path)
-                    if texture.findall('TexMod'):
+                    # As Standard PBR shader uses same UV set for all textures,
+                    # we only want to carry over changes made to the main texture
+                    if map_name.lower() == 'diffuse' and texture.findall('TexMod'):
                         listing = texture.findall('TexMod')
                         for child in listing:
                             texture_modifications[material_attributes['Name']] = child.attrib

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -24,7 +24,7 @@
 #  built-ins
 import collections
 from collections import abc
-# import subprocess
+import subprocess
 import logging as _logging
 try:
     import pathlib
@@ -1039,7 +1039,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                     fbx_name = key
                     destination_directory = self.set_destination_directory(target_dictionary[constants.FBX_DIRECTORY_NAME])
 
-                    for material_name, texture_set in values['materials'].items():
+                    for material_name, texture_set in values[constants.FBX_MATERIALS].items():
                         checklist = collections.OrderedDict()
                         checklist['fbxname'] = fbx_name
                         checklist['materialname'] = material_name
@@ -1423,7 +1423,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
             for key, values in self.materials_db.items():
                 directory_items.append(values[constants.FBX_DIRECTORY_NAME])
             self.asset_directory_combobox.addItems(directory_items)
-            current_directory = section_data.directoryname
+            current_directory = section_data[constants.FBX_DIRECTORY_NAME]
             index = self.asset_directory_combobox.findText(current_directory, QtCore.Qt.MatchFixedString)
             self.asset_directory_combobox.setCurrentIndex(index)
             self.asset_directory_combobox.blockSignals(False)
@@ -1507,12 +1507,13 @@ class LegacyFilesConverter(QtWidgets.QDialog):
             for key, values in self.materials_db.items():
                 if values:
                     try:
+                        values = Box(values)
                         for k, v in values.fbxfiles.items():
                             count_totals.fbxfiles += 1
                             if v[constants.FBX_MAYA_FILE]:
                                 count_totals.mayafiles += 1
-                            if v.materials:
-                                for material_name, material_values in v.materials.items():
+                            if v[constants.FBX_MATERIALS]:
+                                for material_name, material_values in v[constants.FBX_MATERIALS].items():
                                     count_totals.materials += 1
                                     if constants.FBX_TEXTURES in material_values.keys():
                                         for texture_type, texture_path in material_values.textures.items():
@@ -1788,7 +1789,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                 for val in fbx_values:
                     material_list = val[constants.FBX_MATERIALS]
                     for material_key, material_values in material_list.items():
-                        for texture_key, texture_path in material_values[FBX_TEXTURES].items():
+                        for texture_key, texture_path in material_values[constants.FBX_TEXTURES].items():
                             if texture_type:
                                 if os.path.exists(texture_path):
                                     try:
@@ -1830,7 +1831,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                 for val in fbx_values:
                     material_list = val[constants.FBX_MATERIALS]
                     for material_key, material_values in material_list.items():
-                        for texture_key, texture_path in material_values[FBX_TEXTURES].items():
+                        for texture_key, texture_path in material_values[constants.FBX_TEXTURES].items():
                             if texture_key == texture_type:
                                 if os.path.exists(texture_path):
                                     try:

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -1148,7 +1148,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                     _LOGGER.info('Found engine white texture... skipping')
                     continue
 
-            if values.attributes.Shader == 'Illum':
+            if values.attributes.Shader in constants.EXPORT_MATERIAL_TYPES:
                 legacy_textures = values.textures
                 all_textures = self.get_additional_textures(search_path, legacy_textures)
                 fbx_material_dictionary[key][constants.FBX_TEXTURES] = self.get_texture_set(search_path, all_textures) if legacy_textures else ''

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -153,7 +153,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         self.log_file_location = os.path.join(Path.cwd(), 'output.log')
         self.directory_dictionary = {}
         self.materials_dictionary = {}
-        self.materials_db = shelve.open('materialsdb', protocol=2)
+        self.materials_db = {} #shelve.open('materialsdb', protocol=2) # Do not save materialDB on disk as can lead to issue on reopen
         self.file_target_method = 'Directory'
         self.selected_directory_index = -1
         self.separator_layout = QtWidgets.QHBoxLayout()

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -793,8 +793,10 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                                 texture_key = 'Normal'
                             elif material_property == 'opacity':
                                 texture_key = 'Opacity'
-                                if image_conversion.shader_uses_alpha(shader_name):
+                                alpha = 0 if hasattr(material_values.numericalsettings, 'AlphaTest') is False else float(material_values.numericalsettings.AlphaTest)
+                                if image_conversion.shader_uses_alpha(shader_name) and alpha > 0:
                                     temp_dict['mode'] = 'Cutout'
+                                    temp_dict['factor'] = 1. - alpha
                             elif material_property == 'uv':
                                 modifications = material_values['modifications']
                                 if modifications:
@@ -1203,7 +1205,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         :return:
         """
         numerical_settings = {}
-        property_list = ['Diffuse', 'Specular', 'Emittance', 'Opacity']
+        property_list = ['Diffuse', 'Specular', 'Emittance', 'Opacity', 'AlphaTest']
         for material_property in property_list:
             try:
                 numerical_settings[material_property] = mtl_info[material].attributes[material_property]

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -79,7 +79,7 @@ for handler in _logging.root.handlers[:]:
 module_name = 'legacy_asset_converter.main'
 log_file_path = os.path.join(settings.DCCSI_LOG_PATH, f'{module_name}.log')
 if not os.path.exists(settings.DCCSI_LOG_PATH):
-    os.makedirs(settings.DCCSI_LOG_PATH)
+    os.makedirs(settings.DCCSI_LOG_PATH, exist_ok=True)
 
 _log_level = int(20)
 _DCCSI_GDEBUG = True
@@ -581,7 +581,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
 
         # Get Material Definition Template
         mat_abs_path = Path(__file__).with_name(self.default_material_definition)
-        with open(mat_abs_path) as json_file:
+        with mat_abs_path.open() as json_file:
             self.template_lumberyard_material = json.load(json_file)
 
         if os.path.exists(os.path.join(Path.cwd(), 'materialsdb.dat')):

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -55,7 +55,7 @@ print(_config)
 # init lumberyard Qy/PySide2 access
 # now default settings are extended with PySide2
 # this is an alternative to "from dynaconf import settings" with Qt
-settings = _config.get_config_settings(setup_ly_pyside=True)
+settings = _config.get_config_settings(enable_o3de_pyside2=True)
 
 
 # 3rd Party (we may or do provide)
@@ -578,7 +578,8 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         self.initialize_qprocess()
 
         # Get Material Definition Template
-        with open(self.default_material_definition) as json_file:
+        mat_path = Path(__file__).with_name(self.default_material_definition)
+        with open(mat_path) as json_file:
             self.template_lumberyard_material = json.load(json_file)
 
         if os.path.exists(os.path.join(Path.cwd(), 'materialsdb.dat')):
@@ -1261,14 +1262,14 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         Finds the most current version of Maya for use of its standalone python capabilities.
         :return:
         """
-        maya_versions = [int(x.name[-4:]) for x in self.autodesk_directory.iterdir() if x.name.startswith('Maya')]
+        maya_versions = [int(x.name[-4:]) for x in self.autodesk_directory.iterdir() if x.name.startswith('Maya') and x.name[-1].isdigit()]
         if maya_versions:
             target_version = f'Maya{max(maya_versions)}'
             self.create_maya_files_checkbox.setChecked(True)
             return self.autodesk_directory / target_version / 'bin\mayapy.exe'
         else:
             self.create_maya_files_checkbox.setChecked(False)
-            return None
+        return None
 
     def get_section_audit(self, key):
         """

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -580,8 +580,8 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         self.initialize_qprocess()
 
         # Get Material Definition Template
-        mat_path = Path(__file__).with_name(self.default_material_definition)
-        with open(mat_path) as json_file:
+        mat_abs_path = Path(__file__).with_name(self.default_material_definition)
+        with open(mat_abs_path) as json_file:
             self.template_lumberyard_material = json.load(json_file)
 
         if os.path.exists(os.path.join(Path.cwd(), 'materialsdb.dat')):
@@ -927,8 +927,10 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         """
         self.p = QProcess()
         env = [env for env in QtCore.QProcess.systemEnvironment() if not env.startswith('PYTHONPATH=')]
-        env.append(f'MAYA_LOCATION={os.path.dirname(self.mayapy_path)}')
-        env.append(f'PYTHONPATH={os.path.dirname(self.mayapy_path)}')
+        if self.mayapy_path != None: 
+            env.append(f'MAYA_LOCATION={os.path.dirname(self.mayapy_path)}')
+            env.append(f'PYTHONPATH={os.path.dirname(self.mayapy_path)}')
+
         self.p.setEnvironment(env)
         self.p.setProgram(str(self.mayapy_path))
         self.p.setProcessChannelMode(QProcess.SeparateChannels)
@@ -1271,7 +1273,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
             self.create_maya_files_checkbox.setChecked(True)
             return self.autodesk_directory / target_version / 'bin\mayapy.exe'
         else:
-            self.create_maya_files_checkbox.setChecked(False)
+            self.create_maya_files_checkbox.setEnabled(False)
         return None
 
     def get_section_audit(self, key):

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -1217,6 +1217,11 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         return numerical_settings
 
     def get_alpha_test_value(self, numericalsettings):
+        """
+        Return the AlphaTest key value found in dictionnary. Default to 0
+        :param numericalsettings: The shader numerical settings dictionnary
+        :return:
+        """
         if 'AlphaTest' in numericalsettings:
             return float(numericalsettings['AlphaTest'])
         else:

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -809,7 +809,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                                 _LOGGER.info(f'Unknown Material Property found: {material_property}')
 
                             # Add Texture Map
-                            if texture_key and texture_key in material_textures.keys():
+                            if texture_key and texture_key in material_textures.keys() and material_textures[texture_key]:
                                 if material_property not in ['emissive', 'general'] and 'factor' not in temp_dict.keys():
                                     temp_dict['factor'] = 1.0
                                     temp_dict['useTexture'] = True

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -727,7 +727,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         else:
             return value
 
-    def export_material_file(self, file_name, material_name, material_values, destination_directory, shader_name):
+    def export_material_file(self, file_name, material_name, material_values, destination_directory):
         """
         Collects all the information necessary to generate a material definition, and exports the file. Definition
         information is cross-referenced with a StandardPBR material template file, and information that runs counter
@@ -736,7 +736,6 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         :param material_name: The name of the material that the definition represents.
         :param material_values: The values for the material to be included in the definition.
         :param destination_directory: Where the .material file is saved once processed.
-        :param shader_name: The name of the original shader file used by the material
         :return:
         """
         _LOGGER.info(f'\n_\n******** {material_name} -- EXPORT INFO: {material_values}')
@@ -1390,7 +1389,7 @@ class LegacyFilesConverter(QtWidgets.QDialog):
                     if v.attributes.Shader in constants.EXPORT_MATERIAL_TYPES:
                         material_values = Box(values)
                         material_file = self.export_material_file(f'{fbx_file.stem}_{key}.material'.lower(), key,
-                                                                  material_values, destination_directory, v.attributes.Shader)
+                                                                  material_values, destination_directory)
                         values.materialfile = material_file if material_file else ''
         self.set_materials_db(asset_information)
 

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/main.py
@@ -1345,8 +1345,8 @@ class LegacyFilesConverter(QtWidgets.QDialog):
         :param destination_directory: The directory that assets will be saved to in the conversion process
         :return:
         """
-        fbx_files = asset_information.fbxfiles.values()
-        for key, values in fbx_files[0].materials.items():
+        first_key = next(iter(asset_information.fbxfiles))
+        for key, values in asset_information.fbxfiles[first_key].materials.items():
             for k, v in mtl_info.items():
                 if key is v.attributes.Name:
                     if v.attributes.Shader in constants.EXPORT_MATERIAL_TYPES:

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/standardPBR.template.material
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/SDK/Maya/Scripts/Python/legacy_asset_converter/standardPBR.template.material
@@ -64,12 +64,12 @@
             "subsurfaceScatterFactor": 1
         },
         "opacity": {
-            "factor": 1.0,
-            "cutoutAlpha": false,
-            "cutoutThreshold": 0.5,
-            "useBaseColorTextureAlpha": false,
-            "useTexture": false,
-            "textureMap": ""
+            "mode": "Opaque",
+            "alphaSource": "Packed",
+            "textureMap": "",
+            "textureMapUv": "Tiled",
+            "factor": 0.5,
+            "alphaAffectsSpecular": 0.0
         },
         "uv": {
         	"center": [


### PR DESCRIPTION
## What does this PR do?

This PR fixes the "LegacyAssetConverter" python utility which allows to convert textures and materials from lumberyard to o3de. The tool is properly explained via [this legacy documentation](https://github.com/o3de/community/tree/main/Migration%20Guides/Lumberyard%20to%20O3DE/Misc-Documents/Tutorials/Legacy-Asset-Conversion-Utility) (which will be updated in another PR)

<img src="https://github.com/o3de/o3de/assets/19243508/0602d9d3-725c-4675-a77c-d2bfb0bf843e" width="40%">

### Fix details

- Prevent multiple runtime errors when trying to access a wrong key in a dictionnary/box
- Fix material template path to be absolute
- Fix converter texture path to be relative to the material instead of relative to the parent "Object" folder
- Allow to run the tool without maya installed

## How was this PR tested?

Converted all of the assets of the "StarterGame" lumberyard project Gem without issues (3gbs). Only on import in o3De ~5 materials had issues reported in the asset preprocessor. Once in editor, I was able to author and use models and materials without noticeable problems (but I have yet to find how to assign multiple materials to the same fbx)

![image](https://github.com/o3de/o3de/assets/19243508/ea9b7a79-3b07-4a1b-94bb-f04e695b20d9)


## How to run the tool

1. Follow the [steps described](https://github.com/o3de/o3de/tree/development/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface) in the DccScriptingInterface gem (build the gem and run the config.py, you might have to copy and setup the `settings.local.json.example`)
2. Run `.\python SDK\Maya\Scripts\Python\legacy_asset_converter\main.py` from the `DccScriptingInterface` folder
