### PR TITLE
Allow gems to add material pipelines

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
@@ -61,7 +61,7 @@ namespace AZ
                     MaterialTypeSourceData& materialTypeSourceData) const;
 
             private:
-                AZStd::vector<AZStd::string> GetMaterialPipelinePaths() const;
+                AZStd::set<AZStd::string> GetMaterialPipelinePaths() const;
                 AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> LoadMaterialPipelines() const;
                 Name GetMaterialPipelineName(const AZ::IO::Path& materialPipelineFilePath) const;
 


### PR DESCRIPTION
## What does this PR do?

This PR adds the option for Gems to add their own materialpipelines via settings files by using the `MaterialPipelineFilesByGem` json key. This was previously only possible by adding all required materialpipelene paths to a settings file of a project, because json arrays are not merged and project settings take precedence over gem settings.
With the new method a list of materialpipelines can be specified per gem in the settings json, and since json dictionaries are merged without problem, all pipelines can later be queried in `MaterialTypeBuilder.cpp`.

For backwards compatibility the old version of specifying a single array is still supported. With this change, all pipelines from `MaterialPipelineFiles` and the entries of `MaterialPipelineFilesByGem` are merged.
This implements the second proposal by @gadams3 on [Discord](https://discord.com/channels/805939474655346758/816043793576886273/1195301149742477343).

## How was this PR tested?

Adding the new materialpipelines json entry to one of our internal Gems leads to both Atoms MainPipeline and the specified custom materialpipeline showing up in the "materialPipelines" of eg. standardpbr_generated.materialtype in the intermediate-cache folder.
