### PR TITLE
Add clear of stencil to LyShineChildPass

### DIFF
--- a/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
@@ -15,7 +15,13 @@
                 {
                     "Name": "DepthInputOutput",
                     "SlotType": "InputOutput",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "ScopeAttachmentUsage": "DepthStencil",
+                    "LoadStoreAction": {
+                        "ClearValue": {
+                            "Type": "DepthStencil"
+                        },
+                        "LoadActionStencil": "Clear"
+                    }
                 }
             ],
             "Connections": [


### PR DESCRIPTION
## What does this PR do?

Adds a clear to the stencil buffer before beginning the LyShineChildPass. Since the LyShine pass is using the depth/stencil from the forward, sometimes it already has stencil values written during the forward pass.

## How was this PR tested?

Run project with LYShine components.