### PR TITLE
[Vulkan] Add support for null images with depth support

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
@@ -144,7 +144,8 @@ namespace AZ
                         auto& device = static_cast<Device&>(GetDevice());
                         NullDescriptorManager& nullDescriptorManager = device.GetNullDescriptorManager();
                         bool storageImage = (layout.GetDescriptorType(layoutIndex) == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
-                        imageInfo = nullDescriptorManager.GetDescriptorImageInfo(imageType, storageImage);
+                        imageInfo =
+                            nullDescriptorManager.GetDescriptorImageInfo(imageType, storageImage, layout.UsesDepthFormat(layoutIndex));
                     }
                 }
                 else

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.cpp
@@ -14,6 +14,7 @@
 #include <RHI/DescriptorSetLayout.h>
 #include <RHI/Device.h>
 #include <Atom/RHI.Reflect/VkAllocator.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
 {
@@ -43,27 +44,27 @@ namespace AZ
 
         const AZStd::vector<VkDescriptorSetLayoutBinding>& DescriptorSetLayout::GetNativeLayoutBindings() const
         {
-            return m_descriptorSetLayoutBindings;
+            return m_layoutBindingInfo.GetLayoutBindings();
         }
 
         const AZStd::vector<VkDescriptorBindingFlags>& DescriptorSetLayout::GetNativeBindingFlags() const
         {
-            return m_descriptorBindingFlags;
+            return m_layoutBindingInfo.GetBindingFlags();
         }
 
         size_t DescriptorSetLayout::GetDescriptorSetLayoutBindingsCount() const
         {
-            return m_descriptorSetLayoutBindings.size();
+            return GetNativeBindingFlags().size();
         }
 
         VkDescriptorType DescriptorSetLayout::GetDescriptorType(size_t index) const
         {
-            return m_descriptorSetLayoutBindings[index].descriptorType;
+            return GetNativeLayoutBindings()[index].descriptorType;
         }
 
         uint32_t DescriptorSetLayout::GetDescriptorCount(size_t index) const
         {
-            return m_descriptorSetLayoutBindings[index].descriptorCount;
+            return GetNativeLayoutBindings()[index].descriptorCount;
         }
 
         uint32_t DescriptorSetLayout::GetConstantDataSize() const
@@ -73,7 +74,7 @@ namespace AZ
 
         uint32_t DescriptorSetLayout::GetBindingIndex(uint32_t index) const
         {
-            return m_descriptorSetLayoutBindings[index].binding;
+            return GetNativeLayoutBindings()[index].binding;
         }
 
         uint32_t DescriptorSetLayout::GetLayoutIndexFromGroupIndex(uint32_t groupIndex, ResourceType type) const
@@ -137,8 +138,8 @@ namespace AZ
 
             VkDescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsCreateInfo{};
             bindingFlagsCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
-            bindingFlagsCreateInfo.bindingCount = aznumeric_cast<uint32_t>(m_descriptorBindingFlags.size());
-            bindingFlagsCreateInfo.pBindingFlags = m_descriptorBindingFlags.data();
+            bindingFlagsCreateInfo.bindingCount = aznumeric_cast<uint32_t>(GetNativeBindingFlags().size());
+            bindingFlagsCreateInfo.pBindingFlags = GetNativeBindingFlags().data();
 
             VkDescriptorSetLayoutCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -149,14 +150,22 @@ namespace AZ
                 // This flag is needed as we are using VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT for descriptors within unbounded arrays
                 createInfo.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
             }
-            createInfo.bindingCount = static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
-            createInfo.pBindings = m_descriptorSetLayoutBindings.size() ? m_descriptorSetLayoutBindings.data() : nullptr;
+            createInfo.bindingCount = static_cast<uint32_t>(GetNativeLayoutBindings().size());
+            createInfo.pBindings = GetNativeLayoutBindings().size() ? GetNativeLayoutBindings().data() : nullptr;
 
             auto& device = static_cast<Device&>(GetDevice());
             const VkResult result = device.GetContext().CreateDescriptorSetLayout(
                 device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeDescriptorSetLayout);
 
             return ConvertResult(result);
+        }
+
+        bool IsUsingDepthFormat(const RHI::ShaderInputImageDescriptor& input)
+        {
+            // [GFX_TODO] Use Azslc or reflection to properly check if a texture may use a depth format.
+            // This is needed when using the NullDescriptorManager and the texture to use as "null" needs a depth format (if not it generates a validation error)
+            return AzFramework::StringFunc::Contains(input.m_name.GetStringView(), "Shadow") ||
+                AzFramework::StringFunc::Contains(input.m_name.GetStringView(), "Depth");
         }
 
         RHI::ResultCode DescriptorSetLayout::BuildDescriptorSetLayoutBindings()
@@ -194,7 +203,7 @@ namespace AZ
             static const VkShaderStageFlags DefaultShaderStageVisibility = VK_SHADER_STAGE_ALL;
 
             // The + 1 is for Constant Data.
-            m_descriptorSetLayoutBindings.reserve(
+            m_layoutBindingInfo = LayoutBindingInfo(
                 1 +
                 bufferDescs.size() +
                 imageDescs.size() +
@@ -203,15 +212,12 @@ namespace AZ
                 samplerDescs.size() +
                 staticSamplerDescs.size());
 
-            m_descriptorBindingFlags.reserve(m_descriptorSetLayoutBindings.capacity());
             m_constantDataSize = m_shaderResourceGroupLayout->GetConstantDataSize();
             if (m_constantDataSize)
             {
                 AZStd::span<const RHI::ShaderInputConstantDescriptor> inputListForConstants = m_shaderResourceGroupLayout->GetShaderInputListForConstants();
                 AZ_Assert(!inputListForConstants.empty(), "Empty constant input list");
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
+                auto [vbinding, _1, _2] = m_layoutBindingInfo.Add();
 
                 // All constant data of the SRG have the same binding.
                 vbinding.binding = inputListForConstants[0].m_registerId;
@@ -224,15 +230,12 @@ namespace AZ
 
             // buffers
             m_layoutIndexOffset[static_cast<uint32_t>(ResourceType::BufferView)] =
-                bufferDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
+                bufferDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_layoutBindingInfo.GetSize());
 
             for (uint32_t index = 0; index < bufferDescs.size(); ++index)
             {
                 const RHI::ShaderInputBufferDescriptor& desc = bufferDescs[index];
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                auto [vbinding, _1, _2] = m_layoutBindingInfo.Add();
                 vbinding.binding = desc.m_registerId;
                 switch (desc.m_access)
                 {
@@ -273,15 +276,13 @@ namespace AZ
 
             // images
             m_layoutIndexOffset[static_cast<uint32_t>(ResourceType::ImageView)] =
-                imageDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
+                imageDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_layoutBindingInfo.GetSize());
 
             for (uint32_t index = 0; index < imageDescs.size(); ++index)
             {
                 const RHI::ShaderInputImageDescriptor& desc = imageDescs[index];
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                auto [vbinding, _, usesDepthFormat] = m_layoutBindingInfo.Add();
+                usesDepthFormat = IsUsingDepthFormat(desc);
                 vbinding.binding = desc.m_registerId;
                 if (desc.m_type == RHI::ShaderInputImageType::SubpassInput)
                 {
@@ -311,15 +312,12 @@ namespace AZ
 
             // samplers
             m_layoutIndexOffset[static_cast<uint32_t>(ResourceType::Sampler)] =
-                samplerDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
+                samplerDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_layoutBindingInfo.GetSize());
 
             for (uint32_t index = 0; index < samplerDescs.size(); ++index)
             {
                 const RHI::ShaderInputSamplerDescriptor& desc = samplerDescs[index];
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                auto [vbinding, _1, _2] = m_layoutBindingInfo.Add();
                 vbinding.binding = desc.m_registerId;
                 vbinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
                 vbinding.descriptorCount = desc.m_count;
@@ -339,10 +337,7 @@ namespace AZ
                     samplerDesc.m_samplerState = staticSamplerInput.m_samplerState;
                     m_nativeSamplers[index] = device.AcquireSampler(samplerDesc)->GetNativeSampler();
 
-                    m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                    VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                    m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                    auto [vbinding, _1, _2] = m_layoutBindingInfo.Add();
                     vbinding.binding = staticSamplerInput.m_registerId;
                     vbinding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
                     vbinding.descriptorCount = 1;
@@ -353,14 +348,11 @@ namespace AZ
 
             // buffer unbounded arrays
             m_layoutIndexOffset[static_cast<uint32_t>(ResourceType::BufferViewUnboundedArray)] =
-                bufferUnboundedArrayDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
+                bufferUnboundedArrayDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_layoutBindingInfo.GetSize());
 
             for (const RHI::ShaderInputBufferUnboundedArrayDescriptor& desc : bufferUnboundedArrayDescs)
             {
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                auto [vbinding, bindingFlags, _] = m_layoutBindingInfo.Add();
                 VkDescriptorBindingFlags descriptorBindingFlag = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
                 if (IsBindlessSRGLayout())
                 {
@@ -370,7 +362,7 @@ namespace AZ
                 {
                     descriptorBindingFlag |= VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT;
                 }
-                m_descriptorBindingFlags.back() = descriptorBindingFlag;
+                bindingFlags = descriptorBindingFlag;
 
                 vbinding.binding = desc.m_registerId;
                 switch (desc.m_access)
@@ -406,15 +398,12 @@ namespace AZ
 
             // image unbounded arrays
             m_layoutIndexOffset[static_cast<uint32_t>(ResourceType::ImageViewUnboundedArray)] =
-                imageUnboundedArrayDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_descriptorSetLayoutBindings.size());
+                imageUnboundedArrayDescs.empty() ? InvalidLayoutIndex : static_cast<uint32_t>(m_layoutBindingInfo.GetSize());
 
             for (const RHI::ShaderInputImageUnboundedArrayDescriptor& desc : imageUnboundedArrayDescs)
             {
 
-                m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
-                VkDescriptorSetLayoutBinding& vbinding = m_descriptorSetLayoutBindings.back();
-                m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
-
+                auto [vbinding, bindingFlags, _] = m_layoutBindingInfo.Add();
                 VkDescriptorBindingFlags descriptorBindingFlag = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
                 if (IsBindlessSRGLayout())
                 {
@@ -424,7 +413,7 @@ namespace AZ
                 {
                     descriptorBindingFlag |= VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT;
                 }
-                m_descriptorBindingFlags.back() = descriptorBindingFlag;
+                bindingFlags = descriptorBindingFlag;
 
                 vbinding.binding = desc.m_registerId;
                 switch (desc.m_access)
@@ -469,10 +458,52 @@ namespace AZ
             return m_shaderResourceGroupLayout.get();
         }
 
+        bool DescriptorSetLayout::UsesDepthFormat(uint32_t layoutIndex) const
+        {
+            return m_layoutBindingInfo.GetUseDepthFormat()[layoutIndex];
+        }
+
         bool DescriptorSetLayout::IsBindlessSRGLayout()
         {
             auto& device = static_cast<Device&>(GetDevice());
             return m_shaderResourceGroupLayout->GetBindingSlot() == device.GetBindlessDescriptorPool().GetBindlessSrgBindingSlot();
         }
-    }
+
+        DescriptorSetLayout::LayoutBindingInfo::LayoutBindingInfo(size_t size)
+        {
+            m_descriptorSetLayoutBindings.reserve(size);
+            m_descriptorBindingFlags.reserve(size);
+            m_useDepthFormat.reserve(size);
+        }
+
+        DescriptorSetLayout::LayoutBindingInfo::Element DescriptorSetLayout::LayoutBindingInfo::Add()
+        {
+            m_descriptorSetLayoutBindings.emplace_back(VkDescriptorSetLayoutBinding{});
+            m_descriptorBindingFlags.emplace_back(VkDescriptorBindingFlags{});
+            m_useDepthFormat.emplace_back(false);
+
+            return LayoutBindingInfo::Element(
+                m_descriptorSetLayoutBindings.back(), m_descriptorBindingFlags.back(), m_useDepthFormat.back());
+        }
+
+        AZStd::size_t DescriptorSetLayout::LayoutBindingInfo::GetSize() const
+        {
+            return m_descriptorSetLayoutBindings.size();
+        }
+
+        const AZStd::vector<VkDescriptorSetLayoutBinding>& DescriptorSetLayout::LayoutBindingInfo::GetLayoutBindings() const
+        {
+            return m_descriptorSetLayoutBindings;
+        }
+
+        const AZStd::vector<VkDescriptorBindingFlags>& DescriptorSetLayout::LayoutBindingInfo::GetBindingFlags() const
+        {
+            return m_descriptorBindingFlags;
+        }
+
+        const AZStd::vector<bool>& DescriptorSetLayout::LayoutBindingInfo::GetUseDepthFormat() const
+        {
+            return m_useDepthFormat;
+        }
+    } // namespace Vulkan
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/NullDescriptorManager.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/NullDescriptorManager.h
@@ -28,7 +28,8 @@ namespace AZ
                 // 2d images
                 General2D = 0,
                 ReadOnly2D,
-                Storage2D,  
+                Storage2D,
+                Depth2D,
 
                 // 2d images that are multi-sampled
                 MultiSampleGeneral2D,
@@ -38,10 +39,12 @@ namespace AZ
                 GeneralArray2D,
                 ReadOnlyArray2D,
                 StorageArray2D,
+                DepthArray2D,
 
                 // cube images
                 GeneralCube,
                 ReadOnlyCube,
+                DepthCube,
 
                 // 3d images
                 General3D,
@@ -70,7 +73,7 @@ namespace AZ
 
             //! Returns the null descriptor for image info based on the image type,
             //! access, and if the image is used as storage
-            VkDescriptorImageInfo GetDescriptorImageInfo(RHI::ShaderInputImageType imageType, bool storageImage) const;
+            VkDescriptorImageInfo GetDescriptorImageInfo(RHI::ShaderInputImageType imageType, bool storageImage, bool usesDepthFormat) const;
 
         protected:
             NullDescriptorManager() = default;


### PR DESCRIPTION
## What does this PR do?

When using the NullDescriptorManager, if an image is using a depth comparison operation in the shader, then the image must have a valid depth format. If not it generates a validation error. So when the NullDescriptorManager needs to use an image as "null", it must be a one with a depth format. Because of this, images with depth format were added to the NullDescriptorManger.

## How was this PR tested?

Run Vulkan on PC and Android using the NullDescriptorManger and shaders that use images with depth format (like shadowmaps).