### PR TITLE
fix warning as error for vorbis integer conversions

### DIFF
--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
@@ -8,8 +8,12 @@
 
 #include <AzCore/PlatformDef.h>
 
-AZ_PUSH_DISABLE_WARNING(4701 4244, "-Wuninitialized") //  warning C4701: potentially uninitialized local variable 'mid' used in vorbis
-                                                      //  warning 4244: '=': conversion from 'int' to 'int8', possible loss of data
+// warning C4701: potentially uninitialized local variable 'mid' used in vorbis
+// warning C4244: '=': conversion from 'int' to 'int8', possible loss of data
+// warning C4456: declaration of 'z' hides previous local declaration
+// warning C4457: declaration of 'n' hides function parameter
+// warning C4245: '=': conversion from 'int' to 'uint32', signed /unsigned mismatch
+AZ_PUSH_DISABLE_WARNING(4701 4244 4456 4457 4245, "-Wuninitialized") 
 
 extern "C" {
 

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
@@ -8,7 +8,8 @@
 
 #include <AzCore/PlatformDef.h>
 
-AZ_PUSH_DISABLE_WARNING(4701, "-Wuninitialized") //  warning C4701: potentially uninitialized local variable 'mid' used in vorbis
+AZ_PUSH_DISABLE_WARNING(4701 4244, "-Wuninitialized") //  warning C4701: potentially uninitialized local variable 'mid' used in vorbis
+                                                      //  warning 4244: '=': conversion from 'int' to 'int8', possible loss of data
 
 extern "C" {
 


### PR DESCRIPTION
## What does this PR do?

Fixes a compile warning treated as an error.

## How was this PR tested?

configured and built a new project using the MiniAudio gem
