### PR TITLE
Set "Add Component" filter correctly for container entity

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1304,7 +1304,8 @@ namespace AzToolsFramework
             entityDetailsVisible = true;
             entityDetailsLabelText = GetEntityDetailsLabelText();
         }
-        else if (selectionEntityTypeInfo == SelectionEntityTypeInfo::OnlyLayerEntities || selectionEntityTypeInfo == SelectionEntityTypeInfo::OnlyPrefabEntities)
+        else if (selectionEntityTypeInfo == SelectionEntityTypeInfo::OnlyLayerEntities || selectionEntityTypeInfo == SelectionEntityTypeInfo::OnlyPrefabEntities ||
+            selectionEntityTypeInfo == SelectionEntityTypeInfo::ContainerEntityOfFocusedPrefab)
         {
             // If a customer filter is not already in use, only show layer components.
             if (!m_customFilterSet)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/17390

This PR fixes the issue with the "Add Component" filter for prefabs' container entities. The filter sometime doesn't work as expected, which then allows users to add unsupported components to container entities. This is not what we want.

See details in GHI.

## How was this PR tested?

Tested in editor.

https://github.com/o3de/o3de/assets/11157226/407ce25e-37ea-494d-ad85-1552df0102d9