### PR TITLE
update SMC batch script to prompt user and generate files to temp folder first

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 import json
 import os
 import re
+import shutil
 import sys
 
 import azlmbr.bus
@@ -17,10 +18,23 @@ import GenerateShaderVariantListUtil
 
 from PySide2 import QtWidgets
 
-PROJECT_SHADER_VARIANTS_FOLDER = "ShaderVariants"
-
 def main():
+    msgBox = QtWidgets.QMessageBox()
+    msgBox.setIcon(QtWidgets.QMessageBox.Information)
+    msgBox.setWindowTitle("Generate shader variant lists for project")
+    msgBox.setText("This process generates shader variant lists for your project and all active gems. Your project's ShaderVariants folder will be deleted and replaced with new shader variant lists. Make sure that the asset processor has finished processing all shader and material assets before proceeding because they will be used as part of this process. Continue?")
+    msgBox.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
+    if msgBox.exec() != QtWidgets.QMessageBox.Ok:
+        return
+
     print("==== Begin generating shader variant lists for all shaders ==========")
+
+    projectShaderVariantListFolder = os.path.join(azlmbr.paths.projectroot, "ShaderVariants")
+    projectShaderVariantListFolderTmp = os.path.join(azlmbr.paths.projectroot, "$tmp_ShaderVariants")
+
+    # Remove the temporary shade of variant list folder in case it wasn't cleared last run.
+    if os.path.exists(projectShaderVariantListFolderTmp):
+        shutil.rmtree(projectShaderVariantListFolderTmp)
 
     paths = azlmbr.atomtools.util.GetPathsInSourceFoldersMatchingExtension('shader')
 
@@ -38,18 +52,22 @@ def main():
         relativePath = azlmbr.shadermanagementconsole.ShaderManagementConsoleRequestBus(azlmbr.bus.Broadcast, 'GenerateRelativeSourcePath', path)
 
         pre, ext = os.path.splitext(relativePath)
-        savePath = os.path.join(azlmbr.paths.projectroot, PROJECT_SHADER_VARIANTS_FOLDER, f'{pre}.shadervariantlist')
-
-        # clean previously generated shader variant list file so they don't clash.
-        if os.path.exists(savePath):
-            os.remove(savePath)
-            
+        savePath = os.path.join(projectShaderVariantListFolderTmp, f'{pre}.shadervariantlist')
+           
         azlmbr.shader.SaveShaderVariantListSourceData(savePath, shaderVariantList)
 
         progressDialog.setValue(i)
         if progressDialog.wasCanceled():
             return
     progressDialog.close()
+
+    # Remove the final shader variant list folder and all of its contents
+    if os.path.exists(projectShaderVariantListFolder):
+        shutil.rmtree(projectShaderVariantListFolder)
+
+    # Rename the temporary shader variant list folder to replace the final one
+    if os.path.exists(projectShaderVariantListFolderTmp):
+        os.rename(projectShaderVariantListFolderTmp, projectShaderVariantListFolder)
 
     print("==== Finish generating shader variant lists for all shaders ==========")
 


### PR DESCRIPTION
## What does this PR do?

Changing shader management console batch generation script to generate all shader variant lists into a temp folder before copying to the project shader variant folder. This keeps materials, shaders, and shader variant lists from reprocessing in the ap as they are being generated.

Prompting the user before running the script so that they are aware existing shader variants in the project folder will be deleted.

## How was this PR tested?

Used script to regenerate shader variant lists for the automated testing project.