### PR TITLE
Android asset bundle fixes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/seedList.seed
+++ b/Gems/Atom/Feature/Common/Assets/seedList.seed
@@ -265,6 +265,13 @@
             },
             "platformFlags": 255,
             "pathHint": "passes/splashscreenpassrequest.azasset"
+        },
+        {
+            "assetId": {
+                "guid": "{34C75C3F-68EB-5FA7-A2A5-F942D17C0922}"
+            },
+            "platformFlags": 255,
+            "pathHint": "passes/lowendrenderpipeline.azasset"
         }
     ]
 }

--- a/Gems/Atom/Feature/Common/Registry/material_pipelines.setreg
+++ b/Gems/Atom/Feature/Common/Registry/material_pipelines.setreg
@@ -3,7 +3,8 @@
         "Atom": {
             "RPI": {
                 "MaterialPipelineFiles": [
-                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline"
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline",
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipeline.materialpipeline"
                 ]
             }
         }

--- a/Gems/DiffuseProbeGrid/Assets/seedList.seed
+++ b/Gems/DiffuseProbeGrid/Assets/seedList.seed
@@ -7,70 +7,70 @@
             "assetId": {
                 "guid": "{34E20A18-CB2E-5D93-84CF-C2B9E144DA75}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridblenddistance.azshader"
         },
         {
             "assetId": {
                 "guid": "{F70A2001-CC2C-5DFE-BC87-B98A4E0E57EB}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridblendirradiance.azshader"
         },
         {
             "assetId": {
                 "guid": "{44260D05-99D8-5A86-83E7-B7C5EC48F297}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridborderupdaterow.azshader"
         },
         {
             "assetId": {
                 "guid": "{F60AFD1E-1CED-5E33-930E-17DB4EAA1F81}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridborderupdatecolumn.azshader"
         },
         {
             "assetId": {
                 "guid": "{7547FD2E-1630-58B1-9293-F4C9F33E0D72}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridclassification.azshader"
         },
         {
             "assetId": {
                 "guid": "{5A28BC26-22C8-5DC2-870B-3EE03A6DC723}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridrender.azshader"
         },
         {
             "assetId": {
                 "guid": "{55BDC206-9859-52D8-AE08-457F5664F509}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracing.azshader"
         },
         {
             "assetId": {
                 "guid": "{3E4941A5-56BF-5ECD-95B3-64E6D6803159}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracingclosesthit.azshader"
         },
         {
             "assetId": {
                 "guid": "{EB5538D4-1028-534C-9FC0-1421E0926E31}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridraytracingmiss.azshader"
         },
         {
             "assetId": {
                 "guid": "{582D6038-5953-585B-8840-CA5B993B5B08}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridrelocation.azshader"
         },
         {
@@ -105,21 +105,21 @@
             "assetId": {
                 "guid": "{49D6CA83-7AE4-5BF5-9428-636B9EB6DCC7}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridprepare.azshader"
         },
         {
             "assetId": {
                 "guid": "{D20ADC05-ECF9-5305-93FC-F0A88AB2072D}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridquery.azshader"
         },
         {
             "assetId": {
                 "guid": "{B3B664B6-4340-5A35-9A67-DC00A5361D62}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationprepare.azshader"
         },
         {
@@ -133,7 +133,7 @@
             "assetId": {
                 "guid": "{2AAC574D-E80D-5D41-BE12-32B192306FD1}"
             },
-            "platformFlags": 255,
+            "platformFlags": 3,
             "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridqueryfullscreenwithalbedo.azshader"
         },
         {


### PR DESCRIPTION
## What does this PR do?

Added missing assets for lowend render pipeline which are used for android.
remove other platforms from DiffuseProbeGrid shader seeds since they are only available for pc & linux.

## How was this PR tested?

Build an android release build with a newly create o3de project. Have it running on an android device.
