### PR TITLE
Apply inverse rotation to PhysX capsule when quering local pose

### DIFF
--- a/Gems/PhysX/Code/Source/Shape.cpp
+++ b/Gems/PhysX/Code/Source/Shape.cpp
@@ -269,6 +269,11 @@ namespace PhysX
         PHYSX_SCENE_READ_LOCK(GetScene());
 
         physx::PxTransform pose = m_pxShape->getLocalPose();
+        if (m_pxShape->getGeometryType() == physx::PxGeometryType::eCAPSULE)
+        {
+            physx::PxQuat PxTolyRotation(-AZ::Constants::HalfPi, physx::PxVec3(0.0f, 1.0f, 0.0f));
+            pose.q *= PxTolyRotation;
+        }
         return { PxMathConvert(pose.p), PxMathConvert(pose.q) };
     }
 


### PR DESCRIPTION
## What does this PR do?

While setting local pose, for eCapsule a rotation is applied, this happens in:
- [SetLocalPose](https://github.com/o3de/o3de/blame/6555c1eacc9e057831fdabedbab39d70c8510b25/Gems/PhysX/Code/Source/Shape.cpp#L253)
- [CreatePxShapeFromConfig](https://github.com/o3de/o3de/blob/6555c1eacc9e057831fdabedbab39d70c8510b25/Gems/PhysX/Code/Source/Utils.cpp#L486)

This PR applies inverse rotation while reading local pose

## How was this PR tested?

PhysX tests do not test if local pose is set correctly.
This does not impact Editor directly. 
External code that uses `GetLocalPose` will be able get accurate shape rotation for CapsuleShape  
