### PR TITLE
handle dynamic container elements

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Serialization/DynamicSerializableField.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
@@ -218,7 +219,8 @@ namespace AZ::Reflection
                 {
                     return value;
                 }
-                else if (underlyingTypeId == azrtti_typeid<unsigned long>() && GetEnumOptionNameUnsigned(*static_cast<unsigned long*>(instance)))
+                else if (
+                    underlyingTypeId == azrtti_typeid<unsigned long>() && GetEnumOptionNameUnsigned(*static_cast<unsigned long*>(instance)))
                 {
                     return value;
                 }
@@ -599,7 +601,8 @@ namespace AZ::Reflection
                                     groupName = AZStd::string::format("_GROUP[%d]", ++groupCounter);
                                     nodeData.m_groupEntries.insert(groupName);
 
-                                    // Create a dummy group entry that will be used to correctly display all children properties and UI elements.
+                                    // Create a dummy group entry that will be used to correctly display all children properties and UI
+                                    // elements.
                                     AZ::SerializeContext::ClassElement* UIElement = new AZ::SerializeContext::ClassElement();
                                     UIElement->m_editData = &currElement;
                                     UIElement->m_flags = SerializeContext::ClassElement::Flags::FLG_UI_ELEMENT;
@@ -867,6 +870,7 @@ namespace AZ::Reflection
                 StackEntry& parentData = m_stack.back();
 
                 const AZ::Edit::ElementData* elementEditData = (classElement ? classElement->m_editData : nullptr);
+
                 if (classElement)
                 {
                     // Ensure our instance pointer is resolved and safe to bind to member attributes.
@@ -900,6 +904,7 @@ namespace AZ::Reflection
                     }
 
                     if (!elementEditData && ((classElement->m_flags & AZ::SerializeContext::ClassElement::FLG_BASE_CLASS) == 0) &&
+                        ((classElement->m_flags & AZ::SerializeContext::ClassElement::FLG_DYNAMIC_FIELD) == 0) &&
                         !(parentData.m_classData && parentData.m_classData->m_container))
                     {
                         m_nodeWasSkipped = true;


### PR DESCRIPTION
## What does this PR do?
- correctly parse dynamic container elements by allowing items with SerializeContext::ClassElement::FLG_DYNAMIC_FIELD to be parsed, even if they don't have editData (since their children still might)
- simplify container actions to always use the passed containerIndex; this fixes problems with invisible in-between ancestors, like dynamic containers
- partial fix for #17365 ; dynamic container elements can be displayed, removed, and moved, but not yet added by the DPE

## How was this PR tested?
locally in the Editor project