### PR TITLE
Smc compaction stableidfix

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -623,7 +623,7 @@ namespace AZ::RHI
         {
             auto& rhiMetrics = statsProfiler->GetProfiler(rhiMetricsId);
             const auto* frameTimeStat = rhiMetrics.GetStatistic(frameTimeMetricId);
-            return (frameTimeStat->GetMostRecentSample() * 1000) / aznumeric_cast<double>(AZStd::GetTimeTicksPerSecond());
+            return !frameTimeStat ? 0 : (frameTimeStat->GetMostRecentSample() * 1000) / aznumeric_cast<double>(AZStd::GetTimeTicksPerSecond());
         }
         return 0;
     }

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Document/ShaderManagementConsoleDocument.cpp
@@ -269,7 +269,7 @@ namespace ShaderManagementConsole
         AZ::u32 idCounter = 1;  // start at 1 (0 is reserved as explained in ShaderVariantTreeAssetCreator)
         for (auto& variantInfo : newSourceData.m_shaderVariants)
         {
-            variantInfo.m_stableId = ++idCounter;
+            variantInfo.m_stableId = idCounter++;
         }
         SetShaderVariantListSourceData(newSourceData);
     }


### PR DESCRIPTION
Fixes this dead end bug in the shader management console:

![image](https://github.com/o3de/o3de/assets/25970839/7aff6a81-053e-45e1-8b1f-5dc52c9a399e)

recompact wouldn't fix the problem, in fact, using it in the first place would put the user in a predicament and render the document unsavable.

The bug was caused by a too quick sweep and "fix" pass on the code using string search, to change all stableid count starts at 1. But the subsequent code was working with 0 start. Changed the increment to postcrement for fix.