### PR TITLE
SMC Python script updates and fixes

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Registry/scripts.shadermanagementconsole.setreg
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Registry/scripts.shadermanagementconsole.setreg
@@ -8,7 +8,11 @@
             },
             "AssetBrowser": {
                 "ContextMenuScripts": {
-                    "": [ "@gemroot:ShaderManagementConsole@/Scripts/CreateShaderVariantListDocumentFromShader.py" ]
+                    "": [
+                        "@gemroot:ShaderManagementConsole@/Scripts/CreateShaderVariantListDocumentFromShader.py",
+                        "@gemroot:ShaderManagementConsole@/Scripts/CreateShaderVariantListDocumentFromShaderInProjectFolder.py",
+                        "@gemroot:ShaderManagementConsole@/Scripts/CreateShaderVariantListDocumentFromShaderInSameFolder.py"
+                    ]
                 }
             }
         },

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInProjectFolder.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInProjectFolder.py
@@ -5,7 +5,11 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
+import os
 import sys
+
+import azlmbr.bus
+import azlmbr.paths
 import GenerateShaderVariantListUtil
 
 def main():
@@ -16,11 +20,16 @@ def main():
         return
 
     inputPath = sys.argv[1]
-    suffix, extension = inputPath.split(".", 1)
+    rootPath, extension = inputPath.split(".", 1)
 
     if extension != "shader":
         print("The input argument for the script is not a valid .shader file")
         return
+
+    projectShaderVariantListFolder = os.path.join(azlmbr.paths.projectroot, "ShaderVariants")
+    outputPath = rootPath + ".shadervariantlist"
+    outputPath = azlmbr.shadermanagementconsole.ShaderManagementConsoleRequestBus(azlmbr.bus.Broadcast, 'GenerateRelativeSourcePath', outputPath)
+    outputPath = os.path.join(projectShaderVariantListFolder, outputPath)
 
     # Create shader variant list document
     documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(
@@ -37,8 +46,15 @@ def main():
         GenerateShaderVariantListUtil.create_shadervariantlist_for_shader(inputPath)
     )
 
+    # Save the shader variant list
+    documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(
+        azlmbr.bus.Broadcast,
+        'SaveDocumentAsCopy',
+        documentId,
+        outputPath
+    )
+
     print("==== End shader variant script ============================================================")
 
 if __name__ == "__main__":
     main()
-

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInSameFolder.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInSameFolder.py
@@ -5,7 +5,11 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
+import os
 import sys
+
+import azlmbr.bus
+import azlmbr.paths
 import GenerateShaderVariantListUtil
 
 def main():
@@ -16,11 +20,17 @@ def main():
         return
 
     inputPath = sys.argv[1]
-    suffix, extension = inputPath.split(".", 1)
+    rootPath, extension = inputPath.split(".", 1)
 
     if extension != "shader":
         print("The input argument for the script is not a valid .shader file")
         return
+
+    if not azlmbr.atomtools.util.IsDocumentPathEditable(inputPath):
+        print("Cannot create shader variant list in same folder as input file")
+        return
+
+    outputPath = rootPath + ".shadervariantlist"
 
     # Create shader variant list document
     documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(
@@ -37,8 +47,15 @@ def main():
         GenerateShaderVariantListUtil.create_shadervariantlist_for_shader(inputPath)
     )
 
+    # Save the shader variant list
+    documentId = azlmbr.atomtools.AtomToolsDocumentSystemRequestBus(
+        azlmbr.bus.Broadcast,
+        'SaveDocumentAsCopy',
+        documentId,
+        outputPath
+    )
+
     print("==== End shader variant script ============================================================")
 
 if __name__ == "__main__":
     main()
-

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListForAllShaders.py
@@ -57,6 +57,12 @@ def main():
         azlmbr.shader.SaveShaderVariantListSourceData(savePath, shaderVariantList)
 
         progressDialog.setValue(i)
+
+        # processing events to update UI after progress bar changes
+        QtWidgets.QApplication.processEvents()
+
+        # Allowing the application to process idle events for one frame to update systems and garbage collect graphics resources
+        azlmbr.atomtools.general.idle_wait_frames(1)
         if progressDialog.wasCanceled():
             return
     progressDialog.close()

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/GenerateShaderVariantListUtil.py
@@ -5,17 +5,17 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-import os
+from PySide2 import QtWidgets
 import azlmbr.asset as asset
 import azlmbr.atom
 import azlmbr.bus
 import azlmbr.math as math
 import azlmbr.name
 import azlmbr.paths
-import azlmbr.shadermanagementconsole
 import azlmbr.shader
-from PySide2 import QtWidgets
+import azlmbr.shadermanagementconsole
 import json
+import os
 
 # Make a copy of shaderVariants, update target option value and return copy, accumulate stableId
 def updateOptionValue(shaderVariants, targetOptionName, targetValue, stableId):
@@ -109,9 +109,14 @@ def create_shadervariantlist_for_shader(filename):
                     # clear the group from spuriously defaulted options by reducing it to a lean set:
                     clearOptions(optionGroup, lambda optName_Query: not shaderItem.MaterialOwnsShaderOption(optName_Query))
                     shaderOptionGroups.append(optionGroup)
-                    
 
         progressDialog.setValue(i)
+
+        # processing events to update UI after progress bar changes
+        QtWidgets.QApplication.processEvents()
+
+        # Allowing the application to process idle events for one frame to update systems and garbage collect graphics resources
+        azlmbr.atomtools.general.idle_wait_frames(1)
         if progressDialog.wasCanceled():
             return
 


### PR DESCRIPTION
## What does this PR do?

- Added an idle_wait_frames call to shader variant list generation script loops to give the application time to garbage collect graphics resources from creating material instances and SRGs.
- Disabled texture loading and function that enumerates shader items from material instances.
- Replaced asset browser interactions create new variant list side by side command with python scripts that can create the shader variant list in the shader folder or the project folder.
-- These scripts will automatically name and save the shader variant list document.
- Updated settings to register new scripts with file and asset browser menus.

## How was this PR tested?

- Tested all scripts manually.
- Verified that badge script successfully processes all shader assets, generating shader variant lists in the project folder without causing exceptions or locking up.