### PR TITLE
Potential fix for ScriptCanvasDeveloper crash

### DIFF
--- a/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
@@ -49,6 +49,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             Gem::${gem_name}.Static
+            Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
     RUNTIME_DEPENDENCIES
         Gem::ScriptCanvas
 )
@@ -94,6 +95,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Static
                 Gem::ScriptCanvas.Editor.Static
                 Gem::GraphCanvasWidgets
+                Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
         RUNTIME_DEPENDENCIES
             Gem::ScriptCanvas.Editor
             Gem::GraphCanvasWidgets

--- a/Gems/ScriptCanvasDeveloper/Code/Include/ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h
+++ b/Gems/ScriptCanvasDeveloper/Code/Include/ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h
@@ -11,19 +11,14 @@
 #include <AzCore/Component/Component.h>
 
 #include <ScriptCanvas/PerformanceStatistician.h>
-
-#ifdef IMGUI_ENABLED
-#include <imgui/imgui.h>
 #include <ImGuiBus.h>
-#endif // IMGUI_ENABLED
+
 
 namespace ScriptCanvas::Developer
 {
     class SystemComponent
         : public AZ::Component
-#ifdef IMGUI_ENABLED
         , public ImGui::ImGuiUpdateListenerBus::Handler
-#endif // IMGUI_ENABLED
     {
     public:
         AZ_COMPONENT(SystemComponent, "{46BDD372-8E86-4C0F-B12C-DC271C5DCED1}");
@@ -39,17 +34,17 @@ namespace ScriptCanvas::Developer
         void Init() override;
         void Activate() override;
         void Deactivate() override;
-        ////
 
-#ifdef IMGUI_ENABLED
-
+        // Avoid using IMGUI_ENABLED in any situation that could alter the final vtable or size of this
+        // object, as this header may be compiled in different compile units with different defines
         void OnImGuiMainMenuUpdate() override;
 
+#if defined(IMGUI_ENABLED)  
+        // Non-overrides / non-virtuals are ok
         void GraphHistoryListBox();
-
         void FullPerformanceWindow();
-
 #endif // IMGUI_ENABLED
+
     private:
         ScriptCanvas::Execution::PerformanceStatistician  m_perfStatistician;
     };

--- a/Gems/ScriptCanvasDeveloper/Code/Source/ScriptCanvasDeveloperComponent.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Source/ScriptCanvasDeveloperComponent.cpp
@@ -11,6 +11,10 @@
 #include <ScriptCanvas/Core/Node.h>
 #include <ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h>
 
+#if defined(IMGUI_ENABLED)
+#include <imgui/imgui.h>
+#endif
+
 namespace ScriptCanvasDeveloperComponentCpp
 {
     bool GetListEntryFromAZStdStringVector(void* data, int idx, const char** out_text)
@@ -58,18 +62,16 @@ namespace ScriptCanvas::Developer
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
 #endif // IMGUI_ENABLED
-
     }
 
     void SystemComponent::Deactivate()
     {
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusDisconnect();
-#endif // IMGUI_ENABLED
+#endif 
     }
 
 #ifdef IMGUI_ENABLED
-
     void SystemComponent::FullPerformanceWindow()
     {
         GraphHistoryListBox();
@@ -82,16 +84,17 @@ namespace ScriptCanvas::Developer
         const int k_HeightInItemCount = 30;
         ImGui::ListBox(":Graph", &index, &ScriptCanvasDeveloperComponentCpp::GetListEntryFromAZStdStringVector, &scriptHistory, aznumeric_cast<int>(scriptHistory.size()), k_HeightInItemCount);
     }
+#endif // IMGUI_ENABLED
 
     void SystemComponent::OnImGuiMainMenuUpdate()
     {
+#ifdef IMGUI_ENABLED
+
         if (ImGui::BeginMenu("Script Canvas"))
         {
             FullPerformanceWindow();
             ImGui::EndMenu();
         }
+#endif
     }
-
-#endif // IMGUI_ENABLED
-
 }


### PR DESCRIPTION
## What does this PR do?
possibly fixes issue #15959 - a crash on startup if you enable the Script Canvas Developer gem on Linux.
Its probably a memory stomp on other platforms but Linux might reveal it more readily than other ones and show symptoms.

It turns out that the script canvas developer gem enables imgui for its static library, but not for its gem modules.  this causes a mismatch in the size of the object - specifically, the component object factory (as created in the gem module) is NOT derived from the IMGUI Bus listener, as that is `ifdef IMGUI_ENABLED`, but in the actual code (as coming from the static library), it is derived from it, and calls into those functions.   This causes it to call into and modify code outside its actual class size.

This PR changes it so that the object's size and vtable layout is the same regardless of whats going on with the IMGUI Define.  It doesn't change anything else though.  Other malfunctions that were already present, if any, will remain present, it just shouldn't crash anymore (or assert - it depends on what random memory is there).

## How was this PR tested?
Compile in debug, profile, and also release.
Run in debug and profile (I can't run release here at the moment).
All on Linux Ubuntu.

Before it asserts, and suffers random crashes in IMGUI stuff, with this PR it passes cleanly.

It doesn't necessarily achieve the goals that this code set out to achieve though - someone needs to take a look at the actual script canvas developer gem and see why its messing with IMGUI_ENABLED, because it looks like the imgui gem itself pushes that on anything that uses it and does so appropriately (ie, not enabled in release, enabled in debug and profile).

the code I have here is basically 'defensive' programming - by not messing with the size of the object or its vtable, it will function regardless of whether imgui is active or not, regardless of whether there's a mismatch or not.  The worst outcome is that the panel is just not visible when you think it should be (potentially) as opposed to a crash.

I also tested actually going into the editor and showing this IMGUI graph panel, and it does show up, indicating that the code is running.
