### PR TITLE
Fix editor image gradient allocation crash

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponent.h
@@ -41,6 +41,7 @@ namespace GradientSignal
     public:
         AZ_EDITOR_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(EditorImageGradientComponent);
         AZ_COMPONENT_BASE(EditorImageGradientComponent);
+        AZ_CLASS_ALLOCATOR(EditorImageGradientComponent, AZ::ComponentAllocator);
         AZ_RTTI_NO_TYPE_INFO_DECL();
 
         static void Reflect(AZ::ReflectContext* context);


### PR DESCRIPTION
## What does this PR do?

- Attempting to create an editor gradient image component, or load a prefab with one, was asserting and crashing because of a size mismatch
- Compared editor image gradient RTTI and allocator set up to similar components
- Inserted missing allocator macro

Resolves https://github.com/o3de/o3de/issues/17255

## How was this PR tested?

Attempting to add the component before changes crashed
Attempting to add the component after changes didn't crash