### PR TITLE
Fix issue #14877 - mouse wheel being intepreted as x-axis movement on linux

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -500,6 +500,35 @@ namespace AzFramework
             {
                 const xcb_input_raw_motion_event_t* mouseMotionEvent = reinterpret_cast<const xcb_input_raw_motion_event_t*>(event);
 
+                // Valuators in XCB are things that don't have a binary set of states but rather a range of values.
+                // In this case, they represent an axis of motion.
+
+                // The valuator mask is a bitset of which axes have changed and have values in this motion event.
+                //  For every bit set in the valuator mask, there will be a corresponding entry in the axis values, 
+                // and the length of the axis values array will be the number of bits that are set in this valuator mask.
+
+                // For example, x and y movement mouse axis movement will have bits 0x1 (x) or 0x2 (y), or 0x3 if both.
+                // In testing, I always saw 'both' (so 0x3) for all mouse movements.  There are no constants for these
+                // that I can find since each bit just represents a possible axis with the convention being the first two
+                // being the first two axes of the device, which for mice, is going to be the normal x and y axes.
+
+                // Anything beyond that is a completely different axis, such as the mouse wheel, z axis, other things
+                // special mice can do.  The
+                uint32_t *mask = xcb_input_raw_button_press_valuator_mask(mouseMotionEvent);
+                if (!mask)
+                {
+                    // something is broken with this event - at the very least, it cannot contain mouse movement.
+                    break;
+                }
+
+                if ((mask[0] & 0x3) == 0)
+                {
+                    // x and y movement are not present in the mask.  This is not necessarily a wheel roll,
+                    // but its also not x and y movement.  What it is depends on how many axes the device actually has.
+                    // Since we capture wheel roll as button presses (above), ignore this.
+                    break;
+                }
+
                 int axisLen = xcb_input_raw_button_press_axisvalues_length(mouseMotionEvent);
                 const xcb_input_fp3232_t* axisvalues = xcb_input_raw_button_press_axisvalues_raw(mouseMotionEvent);
                 for (int i = 0; i < axisLen; ++i)

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -513,7 +513,7 @@ namespace AzFramework
                 // being the first two axes of the device, which for mice, is going to be the normal x and y axes.
 
                 // Anything beyond that is a completely different axis, such as the mouse wheel, z axis, other things
-                // special mice can do.  The
+                // special mice can do.
                 uint32_t *mask = xcb_input_raw_button_press_valuator_mask(mouseMotionEvent);
                 if (!mask)
                 {

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
@@ -263,5 +263,8 @@ xcb_input_fp3232_t* xcb_input_raw_button_press_axisvalues_raw(const xcb_input_ra
 {
     return MockXcbInterface::Instance()->xcb_input_raw_button_press_axisvalues_raw(R);
 }
-
+uint32_t* xcb_input_raw_button_press_valuator_mask (const xcb_input_raw_button_press_event_t *R)
+{
+    return MockXcbInterface::Instance()->xcb_input_raw_button_press_valuator_mask(R);
+}
 }

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
@@ -142,6 +142,7 @@ public:
     MOCK_CONST_METHOD4(xcb_input_xi_select_events, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window, uint16_t num_mask, const xcb_input_event_mask_t* masks));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_length, int(const xcb_input_raw_button_press_event_t* R));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_raw, xcb_input_fp3232_t*(const xcb_input_raw_button_press_event_t* R));
+    MOCK_CONST_METHOD1(xcb_input_raw_button_press_valuator_mask, uint32_t*(const xcb_input_raw_button_press_event_t* R));
 
 private:
     static inline MockXcbInterface* self = nullptr;


### PR DESCRIPTION
## What does this PR do?

Fixes the code in the XCB mouse input handler.
The code was previously assuming every raw motion event coming in was either for the x or y axis of the mouse.  However, raw motion events have a mask to describe which axis the event packet contains.  When you roll the wheel, or presumably, move the Z axis or other axes of a multi-axis device, it sets those bits to indicate which axes the data represents.

This change makes it so that the mouse movement code only considers the axes data if bit 0x1 or 0x2 are set (x and y mouse motion).
Wheel motion is captured by the button press code elsewhere.

## How was this PR tested?
Compile and building in linux debug and profile.  In debug, clear box testing and profile opaque box testing.  
The event now only triggers X and Y when I actuallymove the mouse X and y, and does not trigger if I roll the wheel anymore.
