### PR TITLE
fixed trace print log panel crash when pressing reset

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -17,7 +17,7 @@
 #include <AzQtComponents/Components/FancyDocking.h>
 #include <AzQtComponents/Components/StyledDockWidget.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
-#include <AzToolsFramework/UI/Logging/TracePrintFLogPanel.h>
+#include <AzToolsFramework/UI/Logging/StyledTracePrintFLogPanel.h>
 
 #include <QLabel>
 #include <QTimer>
@@ -104,7 +104,7 @@ namespace AtomToolsFramework
         QMenu* m_menuHelp = {};
 
         AtomToolsFramework::AtomToolsAssetBrowser* m_assetBrowser = {};
-        AzToolsFramework::LogPanel::TracePrintFLogPanel* m_logPanel = {};
+        AzToolsFramework::LogPanel::StyledTracePrintFLogPanel* m_logPanel = {};
 
         mutable AZStd::shared_ptr<DynamicPropertyGroup> m_applicationSettingsGroup;
         mutable AZStd::shared_ptr<DynamicPropertyGroup> m_assetBrowserSettingsGroup;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -60,7 +60,7 @@ namespace AtomToolsFramework
         AddDockWidget("Python Terminal", new AzToolsFramework::CScriptTermDialog, Qt::BottomDockWidgetArea);
         SetDockWidgetVisible("Python Terminal", false);
 
-        m_logPanel = new AzToolsFramework::LogPanel::TracePrintFLogPanel(this);
+        m_logPanel = new AzToolsFramework::LogPanel::StyledTracePrintFLogPanel(this);
         m_logPanel->AddLogTab(AzToolsFramework::LogPanel::TabSettings("Log", "", ""));
         AddDockWidget("Logging", m_logPanel, Qt::BottomDockWidgetArea);
         SetDockWidgetVisible("Logging", false);


### PR DESCRIPTION
## What does this PR do?

The log panel was using the system tick bus queue to add a function that captured 'this' pointer. Clicking reset deleted the log panel tab, which was still being referenced by the queued function, causing it to crash when the function was invoked. Fixed this by removing the connect to the bus as needed logic and keeping it connected at all times, disconnecting on destruction.

After fixing the issue, switched to using the newer styled version of the log panel.

Resolves https://github.com/o3de/o3de/issues/17410

## How was this PR tested?

Verified that the crash no longer occurred after changing the system tick bus handler registration.