### PR TITLE
Fix clang-16 compile errors

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -23,6 +23,7 @@
 #include <AzCore/Memory/SystemAllocator.h> // Used as the allocator for most components.
 #include <AzCore/Memory/ChildAllocatorSchema.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/PlatformDef.h> // Needed for Component_Platform.inl include
 #include <AzCore/std/containers/unordered_set.h>
 
 namespace AZ
@@ -467,12 +468,11 @@ namespace AZ
     //! The `AZ_CLASS` is a placeholder macro that is used to substitute `class` template parameters
     //! For non-type template parameters such as `size_t` or `int` the `AZ_AUTO` placeholder can be used
 
-    // Clang on Windows uses the preprocessor in MSVC compatibility mode, which cannot parse the AZ_VA_OPT macro in some instances, but
-    // since the comma after __VA_ARGS__ is removed automatically if __VA_ARGS__ is empty, it does not have to be used.
-    #if defined(AZ_COMPILER_CLANG) && defined(AZ_PLATFORM_WINDOWS)
-    #define AZ_RTTI_NO_TYPE_INFO_IMPL_VA_OPT_HELPER(_ComponentClassOrTemplate, _BaseClass, ...) \
-        AZ_RTTI_NO_TYPE_INFO_IMPL(_ComponentClassOrTemplate, __VA_ARGS__, _BaseClass)
-    #else
+    // Include the platform specific implementation of AZ_RTTI_NO_TYPE_INFO_IMPL_VA_OPT_HELPER
+    #include <AzCore/Component/Component_Platform.inl>
+
+    // If there was no platform specific implementation defined, use a default one:
+    #if !defined(AZ_RTTI_NO_TYPE_INFO_IMPL_VA_OPT_HELPER)
     #define AZ_RTTI_NO_TYPE_INFO_IMPL_VA_OPT_HELPER(_ComponentClassOrTemplate, _BaseClass, ...) \
         AZ_RTTI_NO_TYPE_INFO_IMPL(_ComponentClassOrTemplate, __VA_ARGS__ AZ_VA_OPT(AZ_COMMA_SEPARATOR, __VA_ARGS__) _BaseClass)
     #endif

--- a/Code/Framework/AzCore/Platform/Android/AzCore/Component/Component_Platform.inl
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Component/Component_Platform.inl
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/Component/Component_Platform.inl
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/Component/Component_Platform.inl
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/Component/Component_Platform.inl
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/Component/Component_Platform.inl
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/Component/Component_Platform.inl
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/Component/Component_Platform.inl
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Clang on Windows uses the preprocessor in MSVC compatibility mode, which cannot parse the AZ_VA_OPT macro in some instances, but
+// since the comma after __VA_ARGS__ is removed automatically if __VA_ARGS__ is empty, it does not have to be used.
+#if defined(AZ_COMPILER_CLANG)
+#define AZ_RTTI_NO_TYPE_INFO_IMPL_VA_OPT_HELPER(_ComponentClassOrTemplate, _BaseClass, ...) \
+    AZ_RTTI_NO_TYPE_INFO_IMPL(_ComponentClassOrTemplate, __VA_ARGS__, _BaseClass)
+#endif

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/Component/Component_Platform.inl
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/Component/Component_Platform.inl
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */


### PR DESCRIPTION
## What does this PR do?

This PR fixes 3 instances of the following compile error with Clang-16 on Windows:

```
.../o3de-2/Gems/Compression/Code/Source/Clients/CompressionSystemComponent.cpp:56:5: error: expected ';' after top level declarator
    AZ_COMPONENT_IMPL(CompressionSystemComponent, "CompressionSystemComponent",
    ^
../Code/Framework/AzCore\AzCore/Component/Component.h:487:9: note: expanded from macro 'AZ_COMPONENT_IMPL'
        AZ_COMPONENT_IMPL_WITH_ALLOCATOR(_ComponentClassOrTemplate, _DisplayName, _Uuid, AZ::ComponentAllocator, __VA_ARGS__)
        ^
../Code/Framework/AzCore\AzCore/Component/Component.h:478:113: note: expanded from macro 'AZ_COMPONENT_IMPL_WITH_ALLOCATOR'
    AZ_RTTI_NO_TYPE_INFO_IMPL(_ComponentClassOrTemplate, __VA_ARGS__ AZ_VA_OPT(AZ_COMMA_SEPARATOR, __VA_ARGS__) AZ::Component) \
                                                                                                                ^
```

## How was this PR tested?

No manual tests were run, the engine and tests compiled successfully with Clang-16 after these changes.
