### PR TITLE
Fix required components notification UI

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -433,8 +433,8 @@ namespace AzToolsFramework
 
     AzQtComponents::CardNotification* ComponentEditor::CreateNotificationForMissingComponents(
         const QString& message, 
-        AZStd::span<const AZ::ComponentServiceType> services,
-        AZStd::span<const AZ::ComponentServiceType> incompatibleServices)
+        const AZ::ComponentDescriptor::DependencyArrayType& services,
+        const AZ::ComponentDescriptor::DependencyArrayType& incompatibleServices)
     {
         auto notification = CreateNotification(message);
         auto featureButton = notification->addButtonFeature(tr("Add Required Component \342\226\276"));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -155,8 +155,8 @@ namespace AzToolsFramework
         AzQtComponents::CardNotification* CreateNotificationForConflictingComponents(const QString& message, const AZ::Entity::ComponentArrayType& conflictingComponents);
         AzQtComponents::CardNotification* CreateNotificationForMissingComponents(
             const QString& message,
-            AZStd::span<const AZ::ComponentServiceType> services,
-            AZStd::span<const AZ::ComponentServiceType> incompatibleServices);
+            const AZ::ComponentDescriptor::DependencyArrayType& services,
+            const AZ::ComponentDescriptor::DependencyArrayType& incompatibleServices);
 
         AzQtComponents::CardNotification* CreateNotificationForWarningComponents(const QString& message);
 


### PR DESCRIPTION
## What does this PR do?

Fixes #17329  Required component notification UI empty issue

## How was this PR tested?
Added a navigation mesh component and verified the required component notification UI showed the components to add in a list and I could select them to add those components.
