### PR TITLE
Fixed the crash which was caused by BloomComposite4 pass's compute shader trying to write to an attachment which was created with shaderRead and Color flags

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
@@ -113,7 +113,7 @@ namespace AZ
             virtual void CreateChildPassesInternal() { }
 
             // --- Pass Behaviour Overrides ---
-
+            void UpdateConnectedBindings() override;
             void ResetInternal() override;
             void BuildInternal() override;
             void OnInitializationFinishedInternal() override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -307,13 +307,7 @@ namespace AZ
             PassState GetPassState() const { return m_state; }
 
             // Update all bindings on this pass that are connected to bindings on other passes
-            void UpdateConnectedBindings();
-
-            // Update input and input/output bindings on this pass that are connected to bindings on other passes
-            void UpdateConnectedInputBindings();
-
-            // Update output bindings on this pass that are connected to bindings on other passes
-            void UpdateConnectedOutputBindings();
+            virtual void UpdateConnectedBindings();
 
         protected:
             explicit Pass(const PassDescriptor& descriptor);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -396,6 +396,18 @@ namespace AZ
             }
         }
 
+        void ParentPass::UpdateConnectedBindings()
+        {
+            Pass::UpdateConnectedBindings();
+            if (IsEnabled())
+            {
+                for (const Ptr<Pass>& child : m_children)
+                {
+                    child->UpdateConnectedBindings();
+                }
+            }
+        }
+
         void ParentPass::FrameBeginInternal(FramePrepareParams params)
         {
             for (const Ptr<Pass>& child : m_children)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1033,26 +1033,6 @@ namespace AZ
             }
         }
 
-        void Pass::UpdateConnectedInputBindings()
-        {
-            for (uint8_t idx : m_inputBindingIndices)
-            {
-                UpdateConnectedBinding(m_attachmentBindings[idx]);
-            }
-            for (uint8_t idx : m_inputOutputBindingIndices)
-            {
-                UpdateConnectedBinding(m_attachmentBindings[idx]);
-            }
-        }
-
-        void Pass::UpdateConnectedOutputBindings()
-        {
-            for (uint8_t idx : m_outputBindingIndices)
-            {
-                UpdateConnectedBinding(m_attachmentBindings[idx]);
-            }
-        }
-
         void Pass::RegisterPipelineGlobalConnections()
         {
             if (!m_pipeline)
@@ -1312,18 +1292,17 @@ namespace AZ
         {
             AZ_RPI_BREAK_ON_TARGET_PASS;
 
-            bool earlyOut = !IsEnabled();
+             bool earlyOut = !IsEnabled();
 
             // Skip if this pass is the root of the pipeline and the pipeline is set to not render
-            if (m_flags.m_isPipelineRoot)
+             if (m_flags.m_isPipelineRoot)
             {
-                AZ_RPI_PASS_ASSERT(m_pipeline != nullptr, "Pass is flagged as a pipeline root but it's pipeline pointer is invalid while trying to render");
-                earlyOut = earlyOut || m_pipeline == nullptr || m_pipeline->GetRenderMode() == RenderPipeline::RenderMode::NoRender;
-            }
+                 AZ_RPI_PASS_ASSERT(m_pipeline != nullptr, "Pass is flagged as a pipeline root but it's pipeline pointer is invalid while trying to render");
+                 earlyOut = earlyOut || m_pipeline == nullptr || m_pipeline->GetRenderMode() == RenderPipeline::RenderMode::NoRender;
+             }
 
             if (earlyOut)
             {
-                UpdateConnectedBindings();
                 return;
             }
 
@@ -1333,7 +1312,6 @@ namespace AZ
 
             m_state = PassState::Rendering;
 
-            UpdateConnectedInputBindings();
             UpdateOwnedAttachments();
 
             CreateTransientAttachments(params.m_frameGraphBuilder->GetAttachmentDatabase());
@@ -1351,8 +1329,6 @@ namespace AZ
 
             // update attachment copy for preview
             UpdateAttachmentCopy(params);
-
-            UpdateConnectedOutputBindings();
         }
 
         void Pass::FrameEnd()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1292,14 +1292,14 @@ namespace AZ
         {
             AZ_RPI_BREAK_ON_TARGET_PASS;
 
-             bool earlyOut = !IsEnabled();
+            bool earlyOut = !IsEnabled();
 
             // Skip if this pass is the root of the pipeline and the pipeline is set to not render
-             if (m_flags.m_isPipelineRoot)
+            if (m_flags.m_isPipelineRoot)
             {
-                 AZ_RPI_PASS_ASSERT(m_pipeline != nullptr, "Pass is flagged as a pipeline root but it's pipeline pointer is invalid while trying to render");
-                 earlyOut = earlyOut || m_pipeline == nullptr || m_pipeline->GetRenderMode() == RenderPipeline::RenderMode::NoRender;
-             }
+                AZ_RPI_PASS_ASSERT(m_pipeline != nullptr, "Pass is flagged as a pipeline root but it's pipeline pointer is invalid while trying to render");
+                earlyOut = earlyOut || m_pipeline == nullptr || m_pipeline->GetRenderMode() == RenderPipeline::RenderMode::NoRender;
+            }
 
             if (earlyOut)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -224,6 +224,7 @@ namespace AZ
             {
                 pipeline->PassSystemFrameBegin(params);
             }
+            m_passesWithoutPipeline.m_rootPass->UpdateConnectedBindings();
             m_passesWithoutPipeline.m_rootPass->FrameBegin(params);
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -722,6 +722,7 @@ namespace AZ
             {
                 params.m_viewportState = m_viewport;
                 params.m_scissorState = m_scissor;
+                m_passTree.m_rootPass->UpdateConnectedBindings();
                 m_passTree.m_rootPass->FrameBegin(params);
             }
         }


### PR DESCRIPTION
## What does this PR do?
Move updating pass connections out of Pass::FrameBegin() so all the pass attachments would have bind flags from the full pass tree.
This fixed a use case that a transient image was created with only color/shaderRead flags then used for shader write.

## How was this PR tested?

AutomatedTesting levels under graphics folder.
Bake reflection probes in stanza level.
ASV screenshots tests.

Performance: the RenderPipeline::PassSystemFrameBegin function takes 0.18~0.22ms for a frame with around 45 activated passes. The cpu time still lands in this range after the change.
