### PR TITLE
Fixed an issue that the UI render target texture became black when resize the viewport.

### DIFF
--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -126,6 +126,9 @@ namespace LyShine
         rttChildPass->m_attachmentImage = attachmentImage;
         rttChildPass->m_attachmentImageDependencies = attachmentImageDependencies;
 
+        // Disable by default, the RenderGraph will enable it when render to render target
+        rttChildPass->SetEnabled(false);
+
         AddChild(rttChildPass);
     }
 

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -949,18 +949,12 @@ namespace LyShine
         defaultBlendModeState.m_writeMask = uiRenderer->GetBaseState().m_blendStateWriteMask;
         dynamicDraw->SetTarget0BlendState(defaultBlendModeState);
 
-        // First render the render targets, they are sorted so that more deeply nested ones are rendered first.
-        // They only need to be rendered the first time that a render graph is rendered after it has been built.
-        if (m_renderToRenderTargetCount == 0)
-        {
-            // Enable the Rtt passes to draw onto the render targets
-            SetRttPassesEnabled(uiRenderer, true);
-        }
-
         // LYSHINE_ATOM_TODO - It is currently necessary to render to the targets twice. Needs investigation
+        // Note, the rtt pass might not be created when the first time the render is called. So we enable rtt pass in both frames when render the node.
         constexpr int timesToRenderToRenderTargets = 2;
         if (m_renderToRenderTargetCount < timesToRenderToRenderTargets)
         {
+            SetRttPassesEnabled(uiRenderer, true);
             for (RenderNode* renderNode : m_renderTargetRenderNodes)
             {
                 renderNode->Render(uiRenderer, uiRenderer->GetModelViewProjectionMatrix(), dynamicDraw);


### PR DESCRIPTION
## What does this PR do?

Fix for the GHI: https://github.com/o3de/o3de/issues/17415
The issue was because the RttChildPass was re-created when viewport was resized. So the render target of the RttChildPass was cleared in the pass. Although the UICanvas' render graph node wasn't redrawn when that happened. 

Basically the RttChildPass' enable/disable was not synced with the condition check around m_renderToRenderTargetCount which to trigger the uicanvas re-draw to the render target. 
The fix is to disable the RttChildPass by default unless the uicanvas render is called. 

## How was this PR tested?

Follow the steps mentioned in the GHI. 
