### PR TITLE
Fix missing include guard in `QtEditorApplication_*.h`

### DIFF
--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
@@ -6,6 +6,8 @@
  *
  */
 
+#pragma once
+
 #if !defined(Q_MOC_RUN)
 #include <Editor/Core/QtEditorApplication.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>

--- a/Code/Editor/Platform/Mac/Editor/Core/QtEditorApplication_mac.h
+++ b/Code/Editor/Platform/Mac/Editor/Core/QtEditorApplication_mac.h
@@ -6,6 +6,8 @@
  *
  */
 
+#pragma once
+
 #include <Editor/Core/QtEditorApplication.h>
 
 namespace Editor

--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.h
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.h
@@ -6,6 +6,8 @@
  *
  */
 
+#pragma once
+
 #include <Editor/Core/QtEditorApplication.h>
 
 namespace Editor


### PR DESCRIPTION
## What does this PR do?

This PR fixes missing include guards in `QtEditorApplication_*.h`.