### PR TITLE
Fix compile issue on Linux.

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad_Linux.cpp
@@ -8,9 +8,6 @@
 
 #include <AzCore/PlatformIncl.h>
 
-#include <linux/input.h>
-#include <linux/input-event-codes.h>
-
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Time/ITime.h>
 #include <AzFramework/Input/LibEVDevWrapper.h>

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/LibEVDevWrapper.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/LibEVDevWrapper.h
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+#include <linux/input.h>
+#include <linux/input-event-codes.h>
+
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/Module/DynamicModuleHandle.h>
 


### PR DESCRIPTION
## What does this PR do?

Fixes current compile issue on cec608023e26525413e1cd8b8b4e125f78991484

## How was this PR tested?

Compile O3DE on Kubuntu 22.04 LTS
