### PR TITLE
Fix Headless Server Crashing Due to Shadows

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CoreLightsSystemComponent.cpp
@@ -109,6 +109,13 @@ namespace AZ
 
         void CoreLightsSystemComponent::Activate()
         {
+            AZ::ApplicationTypeQuery appType;
+            ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+            if (appType.IsHeadless())
+            {
+                return;
+            }
+
             m_ltcCommonInterface.reset(aznew LtcCommon());
 
             AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<SimplePointLightFeatureProcessor, SimplePointLightFeatureProcessorInterface>();


### PR DESCRIPTION
Disable atom lighting features for headless applications

Tested by running headless server and connecting clients. Shadows appear for clients, but headless server keeps shadows disabled.
Fixes #17452 