### PR TITLE
Update iOS Export scripts

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -377,7 +377,7 @@ namespace AZ::DocumentPropertyEditor
                 const AZ::SerializeContext::ClassElement* containerClassElement =
                     m_container->GetElement(m_container->GetDefaultElementNameCrc());
                 auto elementInstance = m_container->GetElementByIndex(m_containerInstance, containerClassElement, m_elementIndex);
-                const bool elementRemoved = m_container->RemoveElement(m_containerInstance, elementInstance, impl->m_serializeContext);
+                [[maybe_unused]] const bool elementRemoved = m_container->RemoveElement(m_containerInstance, elementInstance, impl->m_serializeContext);
                 AZ_Assert(elementRemoved, "could not remove element!");
                 auto containerNode = GetContainerNode(impl, path);
                 Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);

--- a/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
+++ b/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
@@ -50,6 +50,7 @@ add_custom_command(TARGET ${project_name}.GameLauncher POST_BUILD
         --warn-on-missing-assets
         --verify
         --copy
+        --override-pak-folder ${project_real_path}/AssetBundling/Bundles
         ${LY_OVERRIDE_PAK_ARGUMENT}
     WORKING_DIRECTORY ${layout_tool_dir}
     COMMENT "Synchronizing Layout Assets ..."

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -135,14 +135,12 @@ def verify_layout(layout_dir, platform_name, project_path, asset_mode, asset_typ
         else:
             # Validation steps based on the asset mode
             if asset_mode == ASSET_MODE_PAK:
-
-                # iOS layout verification must point to the bundles folder 
                 if platform_name_lower == 'ios':
-                    project_asset_path /= 'AssetBundling/Bundles'
+                    project_asset_path = pathlib.Path(project_path) / 'AssetBundling/Bundles'
 
                 # Validate that we have pak files
                 project_paks = project_asset_path.glob("*.pak")
-                pak_count = len(project_paks)
+                pak_count = len(list(project_paks))
 
                 if pak_count == 0:
                     warning_count += _warn("No pak files found for PAK mode deployment")

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -135,6 +135,11 @@ def verify_layout(layout_dir, platform_name, project_path, asset_mode, asset_typ
         else:
             # Validation steps based on the asset mode
             if asset_mode == ASSET_MODE_PAK:
+
+                # iOS layout verification must point to the bundles folder 
+                if platform_name_lower == 'ios':
+                    project_asset_path /= 'AssetBundling/Bundles'
+
                 # Validate that we have pak files
                 project_paks = project_asset_path.glob("*.pak")
                 pak_count = len(project_paks)

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -129,15 +129,12 @@ def verify_layout(layout_dir, platform_name, project_path, asset_mode, asset_typ
         # Validate that if '<platform>_connect_to_remote is enabled, that the 'remote_ip' is not set to local host
         warning_count += _validate_remote_ap(remote_ip, remote_connect, None)
 
-        project_asset_path = layout_path / project_name_lower
+        project_asset_path = layout_path
         if not project_asset_path.is_dir():
             warning_count += _warn(f"Asset folder for project {project_name} is missing from the deployment layout.")
         else:
             # Validation steps based on the asset mode
             if asset_mode == ASSET_MODE_PAK:
-                if platform_name_lower == 'ios':
-                    project_asset_path = pathlib.Path(project_path) / 'AssetBundling/Bundles'
-
                 # Validate that we have pak files
                 project_paks = project_asset_path.glob("*.pak")
                 pak_count = len(list(project_paks))
@@ -414,7 +411,10 @@ def sync_layout_non_vfs(mode, target_platform, project_path, asset_type, warning
 
     if mode == ASSET_MODE_PAK:
         target_pak_folder_name = '{}_{}_paks'.format(project_name_lower, asset_type)
-        project_asset_folder = os.path.join(project_path, override_pak_folder or PAK_FOLDER_NAME, target_pak_folder_name)
+        if override_pak_folder:
+            project_asset_folder = override_pak_folder
+        else:    
+            project_asset_folder = os.path.join(project_path, override_pak_folder or PAK_FOLDER_NAME, target_pak_folder_name)
         if not os.path.isdir(project_asset_folder):
             if warning_on_missing_assets:
                 logging.warning(f'Pak folder for the project at path "{project_path}" is missing'

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -64,10 +64,15 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
         logger = logging.getLogger()
         logger.setLevel(logging.ERROR)
 
+    default_base_path =  ctx.project_path
+
+    if not tools_build_path:
+        tools_build_path = default_base_path / 'build/tools'
+    elif not tools_build_path.is_absolute():
+        tools_build_path = default_base_path / tools_build_path
+
     tools_build_path_str = str(tools_build_path)
     ios_build_folder_str = str(target_ios_project_path)
-
-    default_base_path =  ctx.project_path
 
     # Resolve (if possible) and validate any provided seedlist files
     validated_seedslist_paths = exp.validate_project_artifact_paths(project_path=ctx.project_path,

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -99,12 +99,19 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
                                   ctx.project_path/'AssetBundling', max_bundle_size,
                                   logger)
 
+    if should_build_all_assets:
+        if (ctx.project_path / 'AssetBundling/Bundles').is_dir():
+            (ctx.project_path / 'Pak' / f'{ctx.project_name}_ios_paks').mkdir(parents=True)
+            exp.process_command(['cp', '-r', str(ctx.project_path / 'AssetBundling/Bundles/engine_ios.pak'), 
+                            str( ctx.project_path / 'Pak' / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
+            exp.process_command(['cp', '-r', str(ctx.project_path / 'AssetBundling/Bundles/game_ios.pak'), 
+                            str( ctx.project_path / 'Pak' / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
+
     # Generate the Xcode project file for the O3DE project
     cmake_toolchain_path = ctx.engine_path / 'cmake/Platform/iOS/Toolchain_ios.cmake'
 
     exp.process_command(['cmake', '-B', ios_build_folder_str, '-G', "Xcode", f'-DCMAKE_TOOLCHAIN_FILE={str(cmake_toolchain_path)}', '-DLY_MONOLITHIC_GAME=1'],
                     cwd= ctx.project_path)
-
 
     logger.info(f"Xcode project file should be generated now. Please check {ios_build_folder_str}")
 

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -42,13 +42,20 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
     Note: In order to use this functionality, you must be running this script from a MacOS machine with a valid copy of Xcode. 
     This will also require setting up an AppleID and provisioning profile in Xcode when the resulting xcode-project file is generated before deploying to device.
 
-    Instructions to handle iOS projects in Xcode will be provided soon. This export function is currently experimental.
+    This export script produces an IPA file, but using a workaround to the traditional archive approach.
 
     :param ctx:                                     The O3DE Script context provided by the export-command
-    :param tools_build_path:                        Optional build path to build the tools. (see default_tools_path below)
-    :param ios_build_folder:                        The base output path of the generated Xcode Project file for iOS
+    :param target_ios_project_path:                 The base output path of the generated Xcode Project file for iOS
+    :param seedlist_paths:                          List of seed list files to optionally include in the asset bundling process
+    :param seedfile_paths:                          List of seed files to optionally include in the asset bundling process. These can be individual O3DE assets, such as levels or prefabs.
+    :param level_names:                             List of individual level names. These are assumed to follow standard O3DE level convention, and will be used in the asset bundler.
     :param should_build_tools:                      Option to build the export process dependent tools (AssetProcessor, AssetBundlerBatch, and dependencies)
     :param should_build_all_assets:                 Option to process all the assets for the game
+    :param build_config:                            The build configuration to use for the export package launchers
+    :param tool_config:                             The build configuration to refer to for tool binaries
+    :param tools_build_path:                        Optional build path to build the tools. (see default_tools_path below)
+    :param max_bundle_size:                         Maximum size to set for the archived bundle files
+    :param fail_on_asset_errors:                    Option to fail the process on any asset processing error
     :param logger:                                  Optional logger to use to log the process and errors
     """
     
@@ -105,6 +112,7 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
     exp.process_command(xcode_build_common_args + ['build'], cwd=ctx.project_path)
     
     # Note: This workaround enables the creation of an IPA file, even if xcode archive doesn't work, but will require manual upload
+    logger.info(f"Creating IPA file for {ctx.project_name}")
     payload_path = target_ios_project_path / 'bin'/ build_config /'Payload'
     payload_path_str = str(payload_path)
     exp.process_command(['mkdir', payload_path_str], cwd=ctx.project_path)
@@ -118,24 +126,7 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
     logger.info(f"iOS IPA file should be generated now. Please check {ipa_path_str}")
 
 
-# This code is only run by the 'export-project' O3DE CLI command
-if "o3de_context" in globals():
-    global o3de_context
-    global o3de_logger
-
-    # Resolve the export config
-    try:
-        if o3de_context is None:
-            project_name, project_path = command_utils.resolve_project_name_and_path()
-            export_config = exp.get_export_project_config(project_path=project_name)
-        else:
-            export_config = exp.get_export_project_config(project_path=o3de_context.project_path)
-    except command_utils.O3DEConfigError:
-        o3de_logger.debug(f"No project detected at {os.getcwd()}, default settings from global config.")
-        project_name = None
-        export_config = exp.get_export_project_config(project_path=None)
-
-    def parse_args(o3de_context: exp.O3DEScriptExportContext):
+def export_source_ios_parse_args(o3de_context: exp.O3DEScriptExportContext, export_config: command_utils.O3DEConfig):
         parser = argparse.ArgumentParser(
                     prog=f'o3de.py export-project -es {__file__}',
                     description="Exports a project as a generated iOS Xcode project in the project directory. "
@@ -162,8 +153,7 @@ if "o3de_context" in globals():
 
         return parsed_args
 
-    args = parse_args(o3de_context)
-
+def export_source_ios_run_command(o3de_context: exp.O3DEScriptExportContext, args, export_config: command_utils.O3DEConfig, o3de_logger):
     option_build_tools = export_config.get_parsed_boolean_option(parsed_args=args,
                                                                  key=exp.SETTINGS_OPTION_BUILD_TOOLS.key,
                                                                  enable_attribute='build_tools',
@@ -173,6 +163,12 @@ if "o3de_context" in globals():
                                                                   key=exp.SETTINGS_OPTION_BUILD_ASSETS.key,
                                                                   enable_attribute='build_assets',
                                                                   disable_attribute='skip_build_assets')
+    
+    fail_on_asset_errors = export_config.get_parsed_boolean_option(parsed_args=args,
+                                                                   key=exp.SETTINGS_OPTION_FAIL_ON_ASSET_ERR.key,
+                                                                   enable_attribute='fail_on_asset_errors',
+                                                                   disable_attribute='continue_on_asset_errors')
+
 
     if args.quiet:
         o3de_logger.setLevel(logging.ERROR)
@@ -188,8 +184,33 @@ if "o3de_context" in globals():
                                  tool_config=args.tool_config,
                                  tools_build_path=args.tools_build_path,
                                  max_bundle_size=args.max_bundle_size,
-                                 fail_on_asset_errors=args.fail_on_asset_errors,
+                                 fail_on_asset_errors=fail_on_asset_errors,
                                  logger=o3de_logger)
     except exp.ExportProjectError as err:
         print(err)
         sys.exit(1)
+
+# This code is only run by the 'export-project' O3DE CLI command
+if "o3de_context" in globals():
+    global o3de_context
+    global o3de_logger
+
+    # Resolve the export config
+    try:
+        if o3de_context is None:
+            project_name, project_path = command_utils.resolve_project_name_and_path()
+            export_config = exp.get_export_project_config(project_path=project_name)
+        else:
+            export_config = exp.get_export_project_config(project_path=o3de_context.project_path)
+    except command_utils.O3DEConfigError:
+        o3de_logger.debug(f"No project detected at {os.getcwd()}, default settings from global config.")
+        project_name = None
+        export_config = exp.get_export_project_config(project_path=None)
+
+    
+
+    args = export_source_ios_parse_args(o3de_context, export_config)
+
+    export_source_ios_run_command(o3de_context, args, export_config, o3de_logger)
+    o3de_logger.info("Finished exporting ios project")
+    sys.exit(0)

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -94,20 +94,22 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
                                   ctx.project_path/'AssetBundling', max_bundle_size,
                                   logger)
 
-    if should_build_all_assets:
-        bundling_path = ctx.project_path / 'AssetBundling/Bundles'
-        pak_path = ctx.project_path / 'Pak'
-        if bundling_path.is_dir():
-            (pak_path / f'{ctx.project_name}_ios_paks').mkdir(parents=True)
-            exp.process_command(['cp', '-r', str(bundling_path / 'engine_ios.pak'), 
-                            str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
-            exp.process_command(['cp', '-r', str(bundling_path / 'game_ios.pak'), 
-                            str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
+    bundling_path = ctx.project_path / 'AssetBundling/Bundles'
+
+    # if should_build_all_assets:  
+        # pak_path = ctx.project_path / 'Pak'
+        # if bundling_path.is_dir():
+        #     (pak_path / f'{ctx.project_name}_ios_paks').mkdir(parents=True)
+        #     exp.process_command(['cp', '-r', str(bundling_path / 'engine_ios.pak'), 
+        #                     str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
+        #     exp.process_command(['cp', '-r', str(bundling_path / 'game_ios.pak'), 
+        #                     str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
 
     # Generate the Xcode project file for the O3DE project
     cmake_toolchain_path = ctx.engine_path / 'cmake/Platform/iOS/Toolchain_ios.cmake'
 
-    exp.process_command(['cmake', '-B', ios_build_folder_str, '-G', "Xcode", f'-DCMAKE_TOOLCHAIN_FILE={str(cmake_toolchain_path)}', '-DLY_MONOLITHIC_GAME=1'],
+    exp.process_command(['cmake', '-B', ios_build_folder_str, '-G', "Xcode",
+                        f'-DCMAKE_TOOLCHAIN_FILE={str(cmake_toolchain_path)}', '-DLY_MONOLITHIC_GAME=1'],
                     cwd= ctx.project_path)
 
     logger.info(f"Xcode project file should be generated now. Please check {ios_build_folder_str}")

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -96,15 +96,6 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
 
     bundling_path = ctx.project_path / 'AssetBundling/Bundles'
 
-    # if should_build_all_assets:  
-        # pak_path = ctx.project_path / 'Pak'
-        # if bundling_path.is_dir():
-        #     (pak_path / f'{ctx.project_name}_ios_paks').mkdir(parents=True)
-        #     exp.process_command(['cp', '-r', str(bundling_path / 'engine_ios.pak'), 
-        #                     str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
-        #     exp.process_command(['cp', '-r', str(bundling_path / 'game_ios.pak'), 
-        #                     str( pak_path / f'{ctx.project_name}_ios_paks')], cwd=ctx.project_path)
-
     # Generate the Xcode project file for the O3DE project
     cmake_toolchain_path = ctx.engine_path / 'cmake/Platform/iOS/Toolchain_ios.cmake'
 
@@ -137,7 +128,7 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
     exp.process_command(['mv', str(payload_path)+".zip", ipa_path_str])
 
     if ipa_path.is_file():
-        logger.info(f"iOS IPA file should be generated now. Please check {ipa_path_str}")
+        logger.info(f"iOS IPA file generated at {ipa_path_str}")
     else:
         raise exp.ExportProjectError("iOS IPA generation has failed")
 

--- a/scripts/o3de/ExportScripts/export_source_ios_xcode.py
+++ b/scripts/o3de/ExportScripts/export_source_ios_xcode.py
@@ -10,16 +10,29 @@ import argparse
 import logging
 import os
 import sys
+import shutil
 
 import o3de.export_project as exp
+import export_utility as eutil
 import o3de.command_utils as command_utils
 import pathlib
 
+ASSET_PLATFORM = 'ios'
+
+from typing import List
+
 def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
-                             tools_build_folder: pathlib.Path,
-                             ios_build_folder: pathlib.Path,
-                             should_build_tools:bool = True,
-                             skip_asset_processing: bool = False,
+                             target_ios_project_path: pathlib.Path,
+                             seedlist_paths: List[pathlib.Path],
+                             seedfile_paths: List[pathlib.Path],
+                             level_names: List[str],
+                             should_build_tools:bool,
+                             should_build_all_assets: bool,
+                             build_config,
+                             tool_config,
+                             tools_build_path: pathlib.Path,
+                             max_bundle_size: int,
+                             fail_on_asset_errors: bool,
                              logger: logging.Logger|None = None):
     """
     This function serves as an initial exporter for project to the iOS platform. The steps in this code will generate
@@ -32,7 +45,7 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
     Instructions to handle iOS projects in Xcode will be provided soon. This export function is currently experimental.
 
     :param ctx:                                     The O3DE Script context provided by the export-command
-    :param tools_build_folder:                      Optional build path to build the tools. (see default_tools_path below)
+    :param tools_build_path:                        Optional build path to build the tools. (see default_tools_path below)
     :param ios_build_folder:                        The base output path of the generated Xcode Project file for iOS
     :param should_build_tools:                      Option to build the export process dependent tools (AssetProcessor, AssetBundlerBatch, and dependencies)
     :param should_build_all_assets:                 Option to process all the assets for the game
@@ -44,21 +57,35 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
         logger = logging.getLogger()
         logger.setLevel(logging.ERROR)
 
-    tools_build_folder_str = str(tools_build_folder)
-    ios_build_folder_str = str(ios_build_folder)
+    tools_build_path_str = str(tools_build_path)
+    ios_build_folder_str = str(target_ios_project_path)
+
+    default_base_path =  ctx.project_path
+
+    # Resolve (if possible) and validate any provided seedlist files
+    validated_seedslist_paths = exp.validate_project_artifact_paths(project_path=ctx.project_path,
+                                                                    artifact_paths=seedlist_paths)
+    
+    # Preprocess the seed file paths in case there are any wildcard patterns to use
+    preprocessed_seedfile_paths = exp.preprocess_seed_path_list(project_path=ctx.project_path,
+                                                                paths=seedfile_paths)
+    
+    eutil.process_level_names(ctx, preprocessed_seedfile_paths, level_names, ASSET_PLATFORM)
 
     # Optionally build the toolchain needed to process the assets
+    # note: For now, I am keeping the tool building logic restricted on iOS, b/c atm it's unreliable for most configurations besides this one
     if should_build_tools:
-        exp.process_command(["cmake", "-B", tools_build_folder_str, '-G', "Xcode"], cwd=ctx.project_path)
+        exp.process_command(["cmake", "-B", tools_build_path_str, '-G', "Xcode"], cwd=ctx.project_path)
 
-        exp.process_command(["cmake", "--build", tools_build_folder_str, "--target", "AssetProcessorBatch", "AssetBundlerBatch", "--config", "profile"],
+        exp.process_command(["cmake", "--build", tools_build_path_str, "--target", "Editor", "AssetProcessor", "AssetBundler","AssetProcessorBatch", "AssetBundlerBatch", "--config", "profile"],
                     cwd=ctx.project_path)
         
     # Optionally process the assets
-    if not skip_asset_processing:
-        asset_processor_batch_path = exp.get_asset_processor_batch_path(tools_build_folder, required=True)
-        exp.process_command([ str(asset_processor_batch_path), '--platforms=ios',
-                        '--project-path', ctx.project_path ], cwd=ctx.project_path)
+    eutil.build_and_bundle_assets(ctx, should_build_all_assets, tools_build_path, False, 
+                                  tool_config, False, fail_on_asset_errors,
+                                  [ASSET_PLATFORM], validated_seedslist_paths, preprocessed_seedfile_paths, 
+                                  ctx.project_path/'AssetBundling', max_bundle_size,
+                                  logger)
 
     # Generate the Xcode project file for the O3DE project
     cmake_toolchain_path = ctx.engine_path / 'cmake/Platform/iOS/Toolchain_ios.cmake'
@@ -69,6 +96,26 @@ def export_ios_xcode_project(ctx: exp.O3DEScriptExportContext,
 
     logger.info(f"Xcode project file should be generated now. Please check {ios_build_folder_str}")
 
+    xcode_build_common_args = ['xcodebuild', '-project', str(target_ios_project_path / f'{ctx.project_name}.xcodeproj'),
+                        '-scheme', f'{ctx.project_name}.GameLauncher', '-configuration', build_config, '-sdk',
+                        'iphoneos', '-allowProvisioningUpdates']
+
+    exp.process_command(xcode_build_common_args + ['clean'], cwd=ctx.project_path)
+    
+    exp.process_command(xcode_build_common_args + ['build'], cwd=ctx.project_path)
+    
+    # Note: This workaround enables the creation of an IPA file, even if xcode archive doesn't work, but will require manual upload
+    payload_path = target_ios_project_path / 'bin'/ build_config /'Payload'
+    payload_path_str = str(payload_path)
+    exp.process_command(['mkdir', payload_path_str], cwd=ctx.project_path)
+    exp.process_command(['cp', '-r', str(target_ios_project_path / 'bin'/ build_config / f'{ctx.project_name}.GameLauncher.app'), 
+                        str( payload_path / f'{ctx.project_name}.GameLauncher.app')], cwd=ctx.project_path)
+    
+    shutil.make_archive(payload_path, 'zip', root_dir=(payload_path.parent.resolve()))
+    ipa_path_str = str(target_ios_project_path / 'bin'/ build_config /f'{ctx.project_name}.GameLauncher.ipa')
+    exp.process_command(['mv', str(payload_path)+".zip", ipa_path_str])
+
+    logger.info(f"iOS IPA file should be generated now. Please check {ipa_path_str}")
 
 
 # This code is only run by the 'export-project' O3DE CLI command
@@ -98,33 +145,12 @@ if "o3de_context" in globals():
                     add_help=False
         )
 
-        parser.add_argument(exp.CUSTOM_SCRIPT_HELP_ARGUMENT, default=False, action='store_true', help='Show this help message and exit.')
-
-        export_config.add_boolean_argument(parser=parser,
-                                           key=exp.SETTINGS_OPTION_BUILD_TOOLS.key,
-                                           enable_override_arg=['-bt', '--build-tools'],
-                                           enable_override_desc="Enable the building of the O3DE toolchain executables (AssetBundlerBatch, AssetProcessorBatch) as part of the export process. "
-                                                                "The tools will be built into the location specified by the '--tools-build-path' argument",
-                                           disable_override_arg=['-sbt', '--skip-build-tools'],
-                                           disable_override_desc="Skip the building of the O3DE toolchain executables (AssetBundlerBatch, AssetProcessorBatch) as part of the export process. "
-                                                                 "The tools must be already available at the location specified by the '--tools-build-path' argument.")
-
-        default_build_tools_path = export_config.get_value(exp.SETTINGS_DEFAULT_BUILD_TOOLS_PATH.key, exp.SETTINGS_DEFAULT_BUILD_TOOLS_PATH.default)
-        parser.add_argument('-tbp', '--tools-build-path', type=pathlib.Path, default=pathlib.Path(default_build_tools_path),
-                            help=f'Designates where the build files for the O3DE toolchain are generated. If not specified, default is {default_build_tools_path}')
+        eutil.create_common_export_params_and_config(parser, export_config)
 
         default_ios_path = export_config.get_value(exp.SETTINGS_DEFAULT_IOS_BUILD_PATH.key, exp.SETTINGS_DEFAULT_IOS_BUILD_PATH.default)
         parser.add_argument('-ibp', '--ios-build-path', type=pathlib.Path, default=pathlib.Path(default_ios_path),
                             help=f'Designates where the build files for the O3DE toolchain are generated. If not specified, default is {default_ios_path}')
 
-        export_config.add_boolean_argument(parser=parser,
-                                           key=exp.SETTINGS_OPTION_BUILD_ASSETS.key,
-                                           enable_override_arg=['-assets', '--should-build-assets'],
-                                           enable_override_desc='Build and update all iOS assets before bundling.',
-                                           disable_override_arg=['-noassets', '--skip-build-assets'],
-                                           disable_override_desc='Skip building of iOS assets and use assets that were already built.')
-
-        parser.add_argument('-q', '--quiet', action='store_true', help='Suppresses logging information unless an error occurs.')
         if o3de_context is None:
             parser.print_help()
             exit(0)
@@ -152,10 +178,17 @@ if "o3de_context" in globals():
         o3de_logger.setLevel(logging.ERROR)
     try:
         export_ios_xcode_project(ctx=o3de_context,
-                                 tools_build_folder=args.tools_build_path,
-                                 ios_build_folder=args.ios_build_path,
+                                 target_ios_project_path=args.ios_build_path,
+                                 seedlist_paths=args.seedlist_paths,
+                                 seedfile_paths=args.seedfile_paths,
+                                 level_names=args.level_names,
                                  should_build_tools=option_build_tools,
-                                 skip_asset_processing=not option_build_assets,
+                                 should_build_all_assets=option_build_assets,
+                                 build_config=args.config,
+                                 tool_config=args.tool_config,
+                                 tools_build_path=args.tools_build_path,
+                                 max_bundle_size=args.max_bundle_size,
+                                 fail_on_asset_errors=args.fail_on_asset_errors,
                                  logger=o3de_logger)
     except exp.ExportProjectError as err:
         print(err)

--- a/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
+++ b/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
@@ -302,6 +302,7 @@ def test_build_tool_combinations(tmp_path, should_build_tools_flag):
          patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory,\
          patch('o3de.export_project.process_command', return_value=0) as mock_process_command,\
          patch('pathlib.Path.is_dir', return_value=True),\
+         patch('pathlib.Path.mkdir'),\
          patch('shutil.make_archive'),\
          patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
@@ -384,6 +385,7 @@ def test_asset_bundler_combinations(tmp_path, should_build_tools_flag):
          patch('o3de.export_project.process_command', return_value=0) as mock_process_command,\
          patch('pathlib.Path.is_dir', return_value=True),\
          patch('shutil.make_archive'),\
+         patch('pathlib.Path.mkdir'),\
          patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
@@ -478,6 +480,7 @@ def test_asset_bundler_seed_combinations(tmp_path, test_seedlists, test_seedfile
          patch('o3de.export_project.process_command', return_value=0) as mock_process_command,\
          patch('shutil.make_archive'),\
          patch('argparse.ArgumentParser.parse_args'),\
+         patch('pathlib.Path.mkdir'),\
          patch('pathlib.Path.is_file'),\
          patch('o3de.export_project.setup_launcher_layout_directory') as mock_setup_launcher_layout_directory:
         
@@ -552,6 +555,7 @@ def test_asset_processor_combinations(tmp_path, should_build_tools_flag):
          patch('o3de.export_project.process_command', return_value=0) as mock_process_command,\
          patch('shutil.make_archive'),\
          patch('pathlib.Path.is_dir', return_value=True),\
+         patch('pathlib.Path.mkdir'),\
          patch('logging.getLogger', return_value=mock_logger) as mock_get_logger:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)

--- a/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
+++ b/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
@@ -10,30 +10,43 @@ import pytest
 import pathlib
 from unittest.mock import patch, create_autospec, MagicMock, Mock, PropertyMock
 from o3de.export_project import O3DEScriptExportContext
+import shutil
 
 # Because the export scripts are standalone, we have to manually import them to test
 import o3de.utils as utils
 utils.prepend_to_system_path(pathlib.Path(__file__).parent.parent.parent / 'ExportScripts')
+import export_source_ios_xcode as exp_ios
 from export_source_ios_xcode import export_ios_xcode_project
+import export_utility as eutil
+
+from export_test_utility import setup_local_export_config_test
+
+
+
 
 @pytest.mark.parametrize("skip_assets_flag, should_build_tools_flag, expect_get_asset_path, expect_process_command_count", [
-    pytest.param(True, True, False, 3),
-    pytest.param(True, False, False, 1),
-    pytest.param(False, True, True, 4),
-    pytest.param(False, False, True, 2)
+    pytest.param(True, True, False, 8),
+    pytest.param(True, False, False, 6),
+    pytest.param(False, True, True, 8),
+    pytest.param(False, False, True, 6)
 ])
 def test_asset_and_build_combinations(tmp_path, skip_assets_flag, should_build_tools_flag, expect_get_asset_path, expect_process_command_count):
     test_project_name = "TestProject"
     test_project_path = tmp_path / "project"
     test_engine_path = tmp_path / "engine"
     test_tools_build_path = (test_project_path / "build" / "test") 
+    test_ios_build_path = (test_project_path / "build" / "game-ios") 
     test_tools_build_path.mkdir(parents=True)
+    test_ios_build_path.mkdir(parents=True)
     test_asset_processor_batch_path = test_tools_build_path / "AssetProcessorBatch"
     test_asset_processor_batch_path.write_bytes(b'fake processor')
 
-    test_output_path = tmp_path / "output"
-
     with patch('o3de.export_project.process_command') as mock_process_command,\
+         patch('export_utility.process_level_names'),\
+         patch('export_utility.build_and_bundle_assets'),\
+         patch('o3de.export_project.validate_project_artifact_paths'),\
+         patch('o3de.export_project.preprocess_seed_path_list'),\
+         patch('shutil.make_archive'),\
          patch('o3de.export_project.get_asset_processor_batch_path')  as mock_asset_processor_path:
         
         mock_ctx = create_autospec(O3DEScriptExportContext)
@@ -42,14 +55,19 @@ def test_asset_and_build_combinations(tmp_path, skip_assets_flag, should_build_t
         mock_ctx.project_name = test_project_name
 
         ret = export_ios_xcode_project(mock_ctx,
-                                        test_tools_build_path,
-                                        test_output_path,
+                                       test_ios_build_path,
+                                        [],
+                                        [],
+                                        [],
                                         should_build_tools_flag,
-                                        skip_assets_flag)
+                                        skip_assets_flag,
+                                        'release',
+                                        'profile',
+                                        test_tools_build_path,
+                                        2048,
+                                        False,
+                                        None)
         
-        if expect_get_asset_path:
-            mock_asset_processor_path.assert_called_once_with(test_tools_build_path, required=True)
-        else:
-            mock_asset_processor_path.assert_not_called()
+        mock_asset_processor_path.assert_not_called()
         
         assert mock_process_command.call_count == expect_process_command_count

--- a/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
+++ b/scripts/o3de/tests/ExportScripts/test_export_source_ios_xcode.py
@@ -10,7 +10,9 @@ import pytest
 import pathlib
 from unittest.mock import patch, create_autospec, MagicMock, Mock, PropertyMock
 from o3de.export_project import O3DEScriptExportContext
+import o3de.export_project as exp
 import shutil
+import logging
 
 # Because the export scripts are standalone, we have to manually import them to test
 import o3de.utils as utils
@@ -21,7 +23,7 @@ import export_utility as eutil
 
 from export_test_utility import setup_local_export_config_test
 
-
+from itertools import product
 
 
 @pytest.mark.parametrize("skip_assets_flag, should_build_tools_flag, expect_get_asset_path, expect_process_command_count", [
@@ -71,3 +73,199 @@ def test_asset_and_build_combinations(tmp_path, skip_assets_flag, should_build_t
         mock_asset_processor_path.assert_not_called()
         
         assert mock_process_command.call_count == expect_process_command_count
+
+
+@pytest.mark.parametrize("seedlists, seedfiles, levelnames, gamefile_patterns, serverfile_patterns, project_patterns",[
+    pytest.param([],[],[], [], [], []),
+    pytest.param(["/test/test.seedlist"],["/test2/seed.seed"],['main'], ['game.cfg'], ['server.cfg'], ['licensing/test*.txt']),
+    pytest.param(["/test/test.seedlist", "/test/test2.seedlist"],["/test2/seed.seed","/test2/seed2.seed"],['main', 'second', 'THIRD'], ['game.cfg', 'music/test*.mp3'], ['access_ctrls.xml','server.cfg'], ['licensing/test*.txt', 'dependency.graph']),
+])
+def test_export_standalone_multipart_args(tmpdir, seedlists, seedfiles, levelnames, gamefile_patterns, serverfile_patterns, project_patterns):
+
+    test_project_name, test_project_path, test_engine_path = setup_local_export_config_test(tmpdir)
+    
+    with patch('o3de.manifest.get_o3de_folder') as mock_get_o3de_folder,\
+         patch('o3de.export_project.get_default_asset_platform', return_value='mac') as mock_get_asset_platform,\
+         patch('export_source_ios_xcode.export_ios_xcode_project') as mock_export_func:
+        
+        mock_get_o3de_folder.return_value = pathlib.Path(tmpdir.join('.o3de').realpath())
+
+        mock_ctx = create_autospec(O3DEScriptExportContext)
+        mock_ctx.project_path = test_project_path
+        mock_ctx.engine_path = test_engine_path
+        mock_ctx.project_name = test_project_name
+        
+        mock_logger = create_autospec(logging.Logger)
+        test_export_config = exp.get_export_project_config(project_path=None)
+
+        mock_bundle_size = 777
+
+        mock_ctx.args = [ "--max-bundle-size", str(mock_bundle_size),
+                         '-bt', '-assets', '-cfg','release', '-tcfg','profile',
+                         '-tbp', str(tmpdir / 'tool_builds'),]
+        
+        for ln in levelnames:
+            mock_ctx.args += ['-lvl', ln]
+        
+        verify_seedlists = []
+        for sl in seedlists:
+            mock_ctx.args += ['-sl',  sl]
+            verify_seedlists += [pathlib.Path(sl)]
+        
+        verify_seedfiles = []
+        for sf in seedfiles:
+            mock_ctx.args += ['-sf', sf]
+            verify_seedfiles += [pathlib.Path(sf)]
+
+        args = exp_ios.export_source_ios_parse_args(mock_ctx, test_export_config)
+
+        assert 'level_names' in args and getattr(args, 'level_names')  == levelnames
+
+        assert 'seedlist_paths' in args and getattr(args, 'seedlist_paths') == verify_seedlists
+        assert 'seedfile_paths' in args and getattr(args, 'seedfile_paths') == verify_seedfiles
+
+        exp_ios.export_source_ios_run_command(mock_ctx, args, test_export_config, mock_logger)
+
+        mock_export_func.assert_called_once_with(ctx=mock_ctx,
+                                    target_ios_project_path=args.ios_build_path,
+                                    seedlist_paths=args.seedlist_paths,
+                                    seedfile_paths=args.seedfile_paths,
+                                    level_names=args.level_names,
+                                    should_build_tools=True,
+                                    should_build_all_assets=True,
+                                    build_config='release',
+                                    tool_config='profile',
+                                    tools_build_path=args.tools_build_path,
+                                    max_bundle_size=777,
+                                    fail_on_asset_errors=False,
+                                    logger=mock_logger)
+
+@pytest.mark.parametrize('dum_fail_asset_err', [True, False])
+@pytest.mark.parametrize('dum_build_tools', [True, False])
+@pytest.mark.parametrize('dum_build_assets', [True, False])
+def test_export_standalone_exhaustive(tmpdir, dum_fail_asset_err, dum_build_tools, dum_build_assets):
+    test_export_standalone_single(tmpdir, dum_fail_asset_err, dum_build_tools, dum_build_assets)
+
+
+@pytest.mark.parametrize("dum_fail_asset_err, dum_build_tools, dum_build_assets",[])
+def test_export_standalone_single(tmpdir, dum_fail_asset_err, dum_build_tools, dum_build_assets):
+    dummy_build_config = 'release'
+    dummy_tool_config = 'profile'
+    dummy_archive_format = 'none'
+
+    test_project_name, test_project_path, test_engine_path = \
+        setup_local_export_config_test(tmpdir, build_config=dummy_build_config, tool_config=dummy_tool_config, archive_format=dummy_archive_format,
+            fail_asset_errors=dum_fail_asset_err, build_assets=dum_build_assets, build_tools=dum_build_tools)
+    
+    with patch('o3de.manifest.get_o3de_folder') as mock_get_o3de_folder,\
+         patch('o3de.export_project.get_default_asset_platform', return_value='pc') as mock_get_asset_platform,\
+         patch('o3de.export_project.get_asset_processor_batch_path', return_value=tmpdir/'assetproc'),\
+         patch('o3de.export_project.get_asset_bundler_batch_path', return_value=tmpdir/'assetbundles'),\
+         patch('o3de.export_project.process_command', return_value=0) as mock_process_command,\
+         patch('export_utility.process_level_names'),\
+         patch('export_utility.build_and_bundle_assets'),\
+         patch('o3de.export_project.validate_project_artifact_paths'),\
+         patch('o3de.export_project.preprocess_seed_path_list'),\
+         patch('shutil.make_archive'),\
+         patch('export_source_ios_xcode.export_ios_xcode_project') as mock_export_func:
+        
+        mock_get_o3de_folder.return_value = pathlib.Path(tmpdir.join('.o3de').realpath())
+
+        mock_ctx = create_autospec(O3DEScriptExportContext)
+        mock_ctx.project_path = test_project_path
+        mock_ctx.engine_path = test_engine_path
+        mock_ctx.project_name = test_project_name
+        
+        mock_logger = create_autospec(logging.Logger)
+        test_export_config = exp.get_export_project_config(project_path=None)
+        
+        for use_asset_arg, use_build_tool_arg, use_asset_fail_arg, build_config in product(
+                    [True, False],
+                    [True, False],
+                    [True, False],
+                    ['release', 'profile']):
+                
+                tool_config = 'profile'
+
+                mock_ctx.args = ['-ibp', str(tmpdir/'output')]
+
+                #add all necessary arguments
+
+                check_build_config = build_config
+                if build_config:
+                    mock_ctx.args += ['-cfg', build_config]
+                if not check_build_config:
+                    check_build_config = test_export_config.get_value("project.build.config")
+                
+                check_tool_config = tool_config
+                if tool_config:
+                    mock_ctx.args += ['-tcfg', tool_config]
+                if not check_tool_config:
+                    check_tool_config = test_export_config.get_value("tool.build.config")
+
+                #now check for the boolean arguments
+
+                check_asset_build = dum_build_assets
+                if use_asset_arg:
+                    check_asset_build = not check_asset_build
+                    if dum_build_assets:
+                        mock_ctx.args += ['--skip-build-assets']
+                    else:
+                        mock_ctx.args += ['--build-assets']
+                
+                check_fail_asset_err = dum_fail_asset_err
+                if use_asset_fail_arg:
+                    check_fail_asset_err = not check_fail_asset_err
+                    if dum_fail_asset_err:
+                        mock_ctx.args += ['-coa']
+                    else:
+                        mock_ctx.args += ['-foa']
+
+                check_tool_build  = dum_build_tools
+                if use_build_tool_arg:
+                    check_tool_build = not check_tool_build
+                    if dum_build_tools:
+                        mock_ctx.args += ['--skip-build-tools']
+                    else:
+                        mock_ctx.args += ['--build-tools']
+
+                args = exp_ios.export_source_ios_parse_args(mock_ctx, test_export_config)
+
+                assert getattr(args, 'config') == check_build_config
+                assert getattr(args, 'tool_config') == check_tool_config
+
+                if use_asset_arg:
+                    if dum_build_assets:
+                        assert getattr(args, 'skip_build_assets')
+                    else:
+                        assert getattr(args, 'build_assets')
+                
+                if use_asset_fail_arg:
+                    if dum_fail_asset_err:
+                        assert getattr(args, 'continue_on_asset_errors')
+                    else:
+                        assert getattr(args, 'fail_on_asset_errors')
+                
+                if use_build_tool_arg:
+                    if dum_build_tools:
+                        assert getattr(args, 'skip_build_tools')
+                    else:
+                        assert getattr(args, 'build_tools')
+                
+                exp_ios.export_source_ios_run_command(mock_ctx, args, test_export_config, mock_logger)
+
+                mock_export_func.assert_called_once_with(ctx=mock_ctx,
+                                  target_ios_project_path=tmpdir/'output',
+                                  seedlist_paths=[],
+                                  seedfile_paths=[],
+                                  level_names=[],
+                                  should_build_all_assets=check_asset_build,
+                                  should_build_tools=check_tool_build,
+                                  build_config=check_build_config,
+                                  tool_config=check_tool_config,
+                                  tools_build_path=args.tools_build_path,
+                                  max_bundle_size=2048,
+                                  fail_on_asset_errors=check_fail_asset_err,
+                                  logger=mock_logger)
+                mock_export_func.reset_mock()
+


### PR DESCRIPTION
## What does this PR do?

This PR updates the existing iOS export script to bring functionality closer in line with updates for the PC and Android export scripts. The logic is upgraded such that the entire export process can now fully automate building the IPA package for the game launcher. 

This means the only manual steps required from the user are setting up Xcode for the first time with a valid Apple ID and provisioning profile, and uploading the IPA to their iOS device. A follow up PR will include necessary documentation changes.

## How was this PR tested?

Unit tests were added to verify script behavior with arguments.

Export testing was performed on a macbook pro with mac os 13.6.3, using Xcode 14.3.2. IPAs were confirmed to be created with the intended pak files in the asset folder and installed on a physical ios 16 device.

There is further work to be done in making the release build of iOS IPAs with pak files to run without crashing, but that is out of scope for the current PR, and will be followed up soon.
