### PR TITLE
Porting bugfixes from the multi-device-resources branch.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBuffer.h
@@ -50,8 +50,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        void InvalidateViews() override final;
-
         //! Returns true if the ResourceView is in the cache of all single device buffers
         bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
 
@@ -86,7 +84,7 @@ namespace AZ::RHI
         //! Return the contained multi-device buffer
         const RHI::MultiDeviceBuffer* GetBuffer() const
         {
-            return m_buffer;
+            return m_buffer.get();
         }
 
         //! Return the contained BufferViewDescriptor
@@ -97,7 +95,7 @@ namespace AZ::RHI
 
         const MultiDeviceResource* GetResource() const override
         {
-            return m_buffer;
+            return m_buffer.get();
         }
 
         const ResourceView* GetDeviceResourceView(int deviceIndex) const override
@@ -107,7 +105,7 @@ namespace AZ::RHI
 
     private:
         //! A raw pointer to a multi-device buffer
-        const RHI::MultiDeviceBuffer* m_buffer;
+        ConstPtr<RHI::MultiDeviceBuffer> m_buffer;
         //! The corresponding BufferViewDescriptor for this view.
         BufferViewDescriptor m_descriptor;
         //! BufferView cache

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -121,8 +121,6 @@ namespace AZ::RHI
         //! the map reference counts for the buffer and the pool.
         void ValidateBufferMap(MultiDeviceBuffer& buffer, bool isDataValid);
 
-        bool ValidateNotDeviceLevel() const;
-
         bool ValidatePoolDescriptor(const BufferPoolDescriptor& descriptor) const;
         bool ValidateInitRequest(const MultiDeviceBufferInitRequest& initRequest) const;
         bool ValidateIsHostHeap() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceImage.h
@@ -92,9 +92,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Invalidate all device-specific views by setting off events on all corresponding ResourceInvalidateBusses
-        void InvalidateViews() override final;
-
         //! Returns true if the ResourceView is in the cache of all single device images
         bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
 
@@ -133,7 +130,7 @@ namespace AZ::RHI
         //! Return the contained multi-device image
         const RHI::MultiDeviceImage* GetImage() const
         {
-            return m_image;
+            return m_image.get();
         }
 
         //! Return the contained ImageViewDescriptor
@@ -144,7 +141,7 @@ namespace AZ::RHI
 
         const MultiDeviceResource* GetResource() const override
         {
-            return m_image;
+            return m_image.get();
         }
 
         const ResourceView* GetDeviceResourceView(int deviceIndex) const override
@@ -154,7 +151,7 @@ namespace AZ::RHI
 
     private:
         //! A raw pointer to a multi-device image
-        const RHI::MultiDeviceImage* m_image;
+        ConstPtr<RHI::MultiDeviceImage> m_image;
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
         //! ImageView cache

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceQuery.h
@@ -41,8 +41,5 @@ namespace AZ::RHI
 
         //! Shuts down the device-specific resources by detaching them from their parent pool.
         void Shutdown() override final;
-
-        //! Invalidates all views by setting off events on all device-specific ResourceInvalidateBusses
-        void InvalidateViews() override final;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceResource.h
@@ -60,7 +60,7 @@ namespace AZ::RHI
         //!
         //! Platform back-ends which invalidate GPU-specific data on the resource without an explicit
         //! shutdown / re-initialization will need to call this method explicitly.
-        virtual void InvalidateViews() = 0;
+        void InvalidateViews();
 
     protected:
         MultiDeviceResource() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroup.h
@@ -49,9 +49,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Invalidate all views by setting off events on all device-specific ResourceInvalidateBusses
-        void InvalidateViews() override final;
-
     private:
         MultiDeviceShaderResourceGroupData m_mdData;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
@@ -73,6 +73,8 @@ namespace AZ::RHI
     //!
     class RayTracingPipelineStateDescriptor final
     {
+        friend class MultiDeviceRayTracingPipelineStateDescriptor;
+
     public:
         RayTracingPipelineStateDescriptor() = default;
         ~RayTracingPipelineStateDescriptor() = default;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBuffer.cpp
@@ -53,14 +53,6 @@ namespace AZ::RHI
         MultiDeviceResource::Shutdown();
     }
 
-    void MultiDeviceBuffer::InvalidateViews()
-    {
-        IterateObjects<Buffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
-        {
-            deviceBuffer->InvalidateViews();
-                                           });
-    }
-
     bool MultiDeviceBuffer::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor)
     {
         bool isInResourceCache{true};

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -172,7 +172,7 @@ namespace AZ::RHI
 
     ResultCode MultiDeviceBufferPool::OrphanBuffer(MultiDeviceBuffer& buffer)
     {
-        if (!ValidateIsInitialized() || !ValidateIsHostHeap() || !ValidateNotDeviceLevel())
+        if (!ValidateIsInitialized() || !ValidateIsHostHeap())
         {
             return ResultCode::InvalidOperation;
         }
@@ -242,7 +242,7 @@ namespace AZ::RHI
 
     void MultiDeviceBufferPool::UnmapBuffer(MultiDeviceBuffer& buffer)
     {
-        if (ValidateIsInitialized() && ValidateNotDeviceLevel() && ValidateIsRegistered(&buffer))
+        if (ValidateIsInitialized() && ValidateIsRegistered(&buffer))
         {
             IterateObjects<BufferPool>([&buffer](auto deviceIndex, auto deviceBufferPool)
             {
@@ -293,11 +293,6 @@ namespace AZ::RHI
                 AZ_Error("MultiDeviceBufferPool", false, "Failed to map buffer '%s'.", buffer.GetName().GetCStr());
             }
         }
-    }
-
-    bool MultiDeviceBufferPool::ValidateNotDeviceLevel() const
-    {
-        return GetDescriptor().m_heapMemoryLevel != HeapMemoryLevel::Device;
     }
 
     void MultiDeviceBufferPool::Shutdown()

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceImage.cpp
@@ -92,14 +92,6 @@ namespace AZ::RHI
         MultiDeviceResource::Shutdown();
     }
 
-    void MultiDeviceImage::InvalidateViews()
-    {
-        IterateObjects<Image>([]([[maybe_unused]] auto deviceIndex, auto deviceImage)
-        {
-            deviceImage->InvalidateViews();
-        });
-    }
-
     bool MultiDeviceImage::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor)
     {
         bool isInResourceCache{true};

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceQuery.cpp
@@ -29,12 +29,4 @@ namespace AZ::RHI
 
         MultiDeviceResource::Shutdown();
     }
-
-    void MultiDeviceQuery::InvalidateViews()
-    {
-        IterateObjects<Query>([]([[maybe_unused]] auto deviceIndex, auto deviceQuery)
-        {
-            deviceQuery->InvalidateViews();
-        });
-    }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -234,22 +234,19 @@ namespace AZ::RHI
         const MultiDeviceRayTracingBufferPools& rayTracingBufferPools)
     {
         m_mdDescriptor = *descriptor;
-        ResultCode resultCode{ ResultCode::Success };
 
         MultiDeviceObject::Init(deviceMask);
 
-        IterateObjects<RayTracingTlas>(
-            [this, &resultCode, &descriptor, &rayTracingBufferPools](int deviceIndex, auto deviceRayTracingTlas)
+        ResultCode resultCode = IterateObjects<RayTracingTlas>(
+            [this, &descriptor, &rayTracingBufferPools](int deviceIndex, auto deviceRayTracingTlas)
             {
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingTlas();
 
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
 
-                resultCode = deviceRayTracingTlas->CreateBuffers(
+                return deviceRayTracingTlas->CreateBuffers(
                     *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
-
-                return resultCode == ResultCode::Success;
             });
 
         if (resultCode != ResultCode::Success)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingPipelineState.cpp
@@ -21,7 +21,7 @@ namespace AZ::RHI
 
         if (m_mdPipelineState)
         {
-            descriptor.PipelineState(m_mdPipelineState->GetDevicePipelineState(deviceIndex).get());
+            descriptor.m_pipelineState = m_mdPipelineState->GetDevicePipelineState(deviceIndex).get();
         }
 
         return descriptor;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceResource.cpp
@@ -42,6 +42,15 @@ namespace AZ::RHI
         return m_version == 0;
     }
 
+    void MultiDeviceResource::InvalidateViews()
+    {
+        IterateObjects<Resource>(
+            []([[maybe_unused]] auto deviceIndex, auto deviceResource)
+            {
+                deviceResource->InvalidateViews();
+            });
+    }
+
     void MultiDeviceResource::SetPool(MultiDeviceResourcePool* bufferPool)
     {
         m_mdPool = bufferPool;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroup.cpp
@@ -63,12 +63,4 @@ namespace AZ::RHI
 
         MultiDeviceResource::Shutdown();
     }
-
-    void MultiDeviceShaderResourceGroup::InvalidateViews()
-    {
-        IterateObjects<ShaderResourceGroup>([]([[maybe_unused]] auto deviceIndex, auto deviceShaderResourceGroup)
-        {
-            deviceShaderResourceGroup->InvalidateViews();
-        });
-    }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceTransientAttachmentPool.cpp
@@ -160,6 +160,14 @@ namespace AZ::RHI
                     image->m_deviceObjects[deviceIndex] = deviceImage;
                     image->SetDescriptor(deviceImage->GetDescriptor());
                 }
+                else
+                {
+                    if (auto potentialDeviceImage{ image->m_deviceObjects.find(deviceIndex) };
+                        potentialDeviceImage != image->m_deviceObjects.end())
+                    {
+                        image->m_deviceObjects.erase(potentialDeviceImage);
+                    }
+                }
             });
 
         if (image->m_deviceObjects.empty())
@@ -211,6 +219,14 @@ namespace AZ::RHI
                 {
                     buffer->m_deviceObjects[deviceIndex] = deviceBuffer;
                     buffer->SetDescriptor(deviceBuffer->GetDescriptor());
+                }
+                else
+                {
+                    if (auto potentialDeviceBuffer{ buffer->m_deviceObjects.find(deviceIndex) };
+                        potentialDeviceBuffer != buffer->m_deviceObjects.end())
+                    {
+                        buffer->m_deviceObjects.erase(potentialDeviceBuffer);
+                    }
                 }
             });
 


### PR DESCRIPTION
## What does this PR do?

Porting some already reviewed and merged changes from https://github.com/o3de/o3de/tree/multi-device-resources

- Bugfix for buffer mapping.
- Consolidate Views.
- Fix handling of nullptr during Activate* in MDTransientAttachmentPool.
- Fixes for some minor issues/warnings.

## How was this PR tested?

Gem::Atom_RHI.Tests.main
Gem::Atom_RPI.Tests.main
