### PR TITLE
Added RemoteTools Gem to the default project template

### DIFF
--- a/Templates/DefaultProject/Template/project.json
+++ b/Templates/DefaultProject/Template/project.json
@@ -41,6 +41,7 @@
         "ScriptEvents",
         "StartingPointInput",
         "TextureAtlas",
-        "WhiteBox"
+        "WhiteBox",
+        "RemoteTools"
     ]
 }

--- a/Templates/ScriptOnlyProject/Template/project.json
+++ b/Templates/ScriptOnlyProject/Template/project.json
@@ -38,6 +38,7 @@
         "ScriptEvents",
         "StartingPointInput",
         "TextureAtlas",
-        "WhiteBox"
+        "WhiteBox",
+        "RemoteTools"
     ]
 }


### PR DESCRIPTION
## What does this PR do?
Added RemoteTools Gem to the default project template
to enable Lua Debugging by default.

It's been an old complaint, in particular for new
O3DE developers, being baffled for a while trying
to figure out why they can't debug a Lua Script.

## How was this PR tested?

Created a new project from the Default template and made sure
I was able to debug Lua code.
