### PR TITLE
Misc Asset Bundler / Asset Bundler Batch fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/PlatformId/PlatformDefaults.h
+++ b/Code/Framework/AzCore/AzCore/PlatformId/PlatformDefaults.h
@@ -87,6 +87,8 @@ namespace AZ
             Platform_ALL_CLIENT = 1ULL << 31,
 
             AllNamedPlatforms = Platform_PC | Platform_LINUX | Platform_ANDROID | Platform_IOS | Platform_MAC | Platform_PROVO | Platform_SALEM | Platform_JASPER | Platform_SERVER,
+
+            UnrestrictedPlatforms = Platform_PC | Platform_LINUX | Platform_ANDROID | Platform_IOS | Platform_MAC | Platform_SERVER,
         };
 
         AZ_DEFINE_ENUM_BITWISE_OPERATORS(PlatformFlags);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
@@ -699,14 +699,20 @@ namespace AzToolsFramework
     const AZStd::string& AssetSeedManager::GetReadablePlatformList(const AzFramework::SeedInfo& seed)
     {
         using namespace AzFramework;
-        auto readablePlatformListIter = m_platformFlagsToReadablePlatformList.find(seed.m_platformFlags);
+
+        PlatformFlags visiblePlatforms = seed.m_platformFlags;
+#ifndef AZ_TOOLS_EXPAND_FOR_RESTRICTED_PLATFORMS
+        // don't include restricted platforms when they are not enabled
+        visiblePlatforms &= PlatformFlags::UnrestrictedPlatforms;
+#endif
+        auto readablePlatformListIter = m_platformFlagsToReadablePlatformList.find(visiblePlatforms);
         if (readablePlatformListIter != m_platformFlagsToReadablePlatformList.end())
         {
             return readablePlatformListIter->second;
         }
 
-        m_platformFlagsToReadablePlatformList[seed.m_platformFlags] = PlatformHelper::GetCommaSeparatedPlatformList(seed.m_platformFlags);
-        return m_platformFlagsToReadablePlatformList.at(seed.m_platformFlags);
+        m_platformFlagsToReadablePlatformList[visiblePlatforms] = PlatformHelper::GetCommaSeparatedPlatformList(visiblePlatforms);
+        return m_platformFlagsToReadablePlatformList.at(visiblePlatforms);
     }
 
     void AssetSeedManager::Reflect(AZ::ReflectContext* context)

--- a/Code/Tools/AssetBundler/CMakeLists.txt
+++ b/Code/Tools/AssetBundler/CMakeLists.txt
@@ -47,9 +47,22 @@ ly_add_target(
             AZ::AssetBundlerBatch.Static
 )
 
-# Adds a specialized .setreg to identify gems enabled in the active project.
-# This associates the AssetBundlerBatch target with the .Builders gem variants.
-ly_set_gem_variant_to_load(TARGETS AssetBundlerBatch VARIANTS Builders)
+if(TARGET AssetBundlerBatch)
+    # Adds a specialized .setreg to identify gems enabled in the active project.
+    # This associates the AssetBundlerBatch target with the .Builders gem variants.
+    ly_set_gem_variant_to_load(TARGETS AssetBundlerBatch VARIANTS Builders)
+
+    set_source_files_properties(
+        source/utils/AssetBundlerBatchBuildTarget.cpp
+        PROPERTIES
+            COMPILE_DEFINITIONS
+                O3DE_CMAKE_TARGET="AssetBundlerBatch"
+    )
+else()
+    message(FATAL_ERROR "Cannot set O3DE_CMAKE_TARGET define to AssetBundlerBatch as the target doesn't exist anymore."
+        " Perhaps it has been renamed")
+endif()
+
 
 # AssetBundler - Qt GUI Application
 ly_add_target(
@@ -81,9 +94,22 @@ if(LY_DEFAULT_PROJECT_PATH)
     set_property(TARGET AssetBundler AssetBundlerBatch APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\"")
 endif()
 
-# Adds a specialized .setreg to identify gems enabled in the active project.
-# This associates the AssetBundler target with the .Builders gem variants.
-ly_set_gem_variant_to_load(TARGETS AssetBundler VARIANTS Builders)
+if(TARGET AssetBundler)
+    # Adds a specialized .setreg to identify gems enabled in the active project.
+    # This associates the AssetBundler target with the .Builders gem variants.
+    ly_set_gem_variant_to_load(TARGETS AssetBundler VARIANTS Builders)
+
+    set_source_files_properties(
+        source/utils/AssetBundlerBuildTarget.cpp
+        PROPERTIES
+            COMPILE_DEFINITIONS
+                O3DE_CMAKE_TARGET="AssetBundler"
+    )
+else()
+    message(FATAL_ERROR "Cannot set O3DE_CMAKE_TARGET define to AssetBundler as the target doesn't exist anymore."
+        " Perhaps it has been renamed")
+endif()
+
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
 

--- a/Code/Tools/AssetBundler/assetbundlerbatch_files.cmake
+++ b/Code/Tools/AssetBundler/assetbundlerbatch_files.cmake
@@ -11,4 +11,5 @@ set(FILES
     source/utils/utils.cpp
     source/utils/applicationManager.h
     source/utils/applicationManager.cpp
+    source/utils/AssetBundlerBatchBuildTarget.cpp
 )

--- a/Code/Tools/AssetBundler/assetbundlergui_files.cmake
+++ b/Code/Tools/AssetBundler/assetbundlergui_files.cmake
@@ -64,4 +64,5 @@ set(FILES
     source/ui/SeedTabWidget.ui
     source/utils/GUIApplicationManager.h
     source/utils/GUIApplicationManager.cpp
+    source/utils/AssetBundlerBuildTarget.cpp
 )

--- a/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
+++ b/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
@@ -65,13 +65,29 @@ namespace AssetBundler
 
         AZ::Data::AssetInfo assetInfo;
         QString platformList;
+        const auto& enabledPlatforms = AzToolsFramework::PlatformAddressedAssetCatalogManager::GetEnabledPlatforms();
+        AZ_Error(AssetBundler::AppWindowName, !enabledPlatforms.empty(), "Unable to find any enabled asset platforms. Please verify the Asset Processor has run and generated assets successfully.");
+
+        [[maybe_unused]] bool missingAssets = false;
+
         for (const auto& seed : m_seedListManager->GetAssetSeedList())
         {
-            assetInfo = AzToolsFramework::AssetSeedManager::GetAssetInfoById(
-                seed.m_assetId,
-                AzFramework::PlatformHelper::GetPlatformIndicesInterpreted(seed.m_platformFlags)[0],
-                absolutePath,
-                seed.m_assetRelativePath);
+            for (AZ::PlatformId platformId : enabledPlatforms)
+            {
+                if (AZ::PlatformHelper::HasPlatformFlag(seed.m_platformFlags, platformId))
+                {
+                    assetInfo = AzToolsFramework::AssetSeedManager::GetAssetInfoById(
+                        seed.m_assetId,
+                        platformId,
+                        absolutePath,
+                        seed.m_assetRelativePath);
+                    if (assetInfo.m_assetId.IsValid())
+                    {
+                        break;
+                    }
+                }
+            }
+
             platformList = QString(m_seedListManager->GetReadablePlatformList(seed).c_str());
 
             m_additionalSeedInfoMap[seed.m_assetId].reset(new AdditionalSeedInfo(assetInfo.m_relativePath.c_str(), platformList));
@@ -80,9 +96,12 @@ namespace AssetBundler
             if (!assetInfo.m_assetId.IsValid())
             {
                 const AZStd::string assetIdStr(seed.m_assetId.ToString<AZStd::string>());
-                m_additionalSeedInfoMap[seed.m_assetId]->m_errorMessage = tr("Missing asset: path hint '%1', asset ID '%2'").arg(seed.m_assetRelativePath.c_str()).arg(assetIdStr.c_str());
+                m_additionalSeedInfoMap[seed.m_assetId]->m_errorMessage = tr("Asset not found for enabled platforms: path hint '%1', asset ID '%2'").arg(seed.m_assetRelativePath.c_str()).arg(assetIdStr.c_str());
+                missingAssets = true;
             }
         }
+
+        AZ_Warning(AssetBundler::AppWindowName, !missingAssets, "Not all assets were found. Please verify the Asset Processor has run for the enabled platforms and generated assets successfully.");
     }
 
     AZ::Outcome<AzFramework::PlatformFlags, void> SeedListTableModel::GetSeedPlatforms(const QModelIndex& index) const

--- a/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
+++ b/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
@@ -14,7 +14,7 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/StringFunc/StringFunc.h>
-#include <AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalog.h>
+#include <AzToolsFramework/AssetCatalog/PlatformAddressedAssetCatalogManager.h>
 
 #include <QFont>
 
@@ -66,7 +66,8 @@ namespace AssetBundler
         AZ::Data::AssetInfo assetInfo;
         QString platformList;
         const auto& enabledPlatforms = AzToolsFramework::PlatformAddressedAssetCatalogManager::GetEnabledPlatforms();
-        AZ_Error(AssetBundler::AppWindowName, !enabledPlatforms.empty(), "Unable to find any enabled asset platforms. Please verify the Asset Processor has run and generated assets successfully.");
+        [[maybe_unused]] const bool hasEnabledPlatforms = !enabledPlatforms.empty();
+        AZ_Error(AssetBundler::AppWindowName, hasEnabledPlatforms, "Unable to find any enabled asset platforms. Please verify the Asset Processor has run and generated assets successfully.");
 
         [[maybe_unused]] bool missingAssets = false;
 

--- a/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
+++ b/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
@@ -158,8 +158,14 @@ namespace AssetBundler
             AZ_Error(AssetBundler::AppWindowName, false, "Unable to find additional Seed info");
             return false;
         }
+
+        auto visiblePlatforms = platforms;
+#ifndef AZ_TOOLS_EXPAND_FOR_RESTRICTED_PLATFORMS
+        // don't include restricted platforms when they are not enabled
+        visiblePlatforms &= AzFramework::PlatformFlags::UnrestrictedPlatforms;
+#endif
         additionalSeedInfo->second->m_platformList =
-            QString(AzFramework::PlatformHelper::GetCommaSeparatedPlatformList(platforms).c_str());
+            QString(AzFramework::PlatformHelper::GetCommaSeparatedPlatformList(visiblePlatforms).c_str());
 
         SetHasUnsavedChanges(true);
 
@@ -176,13 +182,18 @@ namespace AssetBundler
         AZStd::pair<AZ::Data::AssetId, AzFramework::PlatformFlags> addSeedsResult =
             m_seedListManager->AddSeedAssetForValidPlatforms(seedRelativePath, platforms);
 
-        if (!addSeedsResult.first.IsValid() || addSeedsResult.second == AzFramework::PlatformFlags::Platform_NONE)
+        AzFramework::PlatformFlags validPlatforms = addSeedsResult.second;
+        if (!addSeedsResult.first.IsValid() || validPlatforms == AzFramework::PlatformFlags::Platform_NONE)
         {
             // Error has already been thrown
             return false;
         }
 
-        QString platformList = QString(AzFramework::PlatformHelper::GetCommaSeparatedPlatformList(addSeedsResult.second).c_str());
+#ifndef AZ_TOOLS_EXPAND_FOR_RESTRICTED_PLATFORMS
+        // don't include restricted platforms when they are not enabled
+        validPlatforms &= AzFramework::PlatformFlags::UnrestrictedPlatforms;
+#endif
+        QString platformList = QString(AzFramework::PlatformHelper::GetCommaSeparatedPlatformList(validPlatforms).c_str());
 
         int lastRowIndex = AZStd::max(rowCount() - 1, 0);
         beginInsertRows(QModelIndex(), lastRowIndex, lastRowIndex);

--- a/Code/Tools/AssetBundler/source/utils/AssetBundlerBatchBuildTarget.cpp
+++ b/Code/Tools/AssetBundler/source/utils/AssetBundlerBatchBuildTarget.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/std/string/string_view.h>
+
+namespace AssetBundler
+{
+    //! This file is to be added only to the AssetProcessorBatch build target
+    //! This function returns the build system target name
+    AZStd::string_view GetBuildTargetName()
+    {
+#if !defined (O3DE_CMAKE_TARGET)
+#error "O3DE_CMAKE_TARGET must be defined in order to add this source file to a CMake executable target"
+#endif
+        return AZStd::string_view{ O3DE_CMAKE_TARGET };
+    }
+}

--- a/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
+++ b/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/std/string/string_view.h>
+
+namespace AssetBundler
+{
+    //! This file is to be added only to the AssetProcessor build target
+    //! This function returns the build system target name
+    AZStd::string_view GetBuildTargetName()
+    {
+#if !defined (O3DE_CMAKE_TARGET)
+#error "O3DE_CMAKE_TARGET must be defined in order to add this source file to a CMake executable target"
+#endif
+        return AZStd::string_view{ O3DE_CMAKE_TARGET };
+    }
+}

--- a/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
+++ b/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
@@ -9,7 +9,7 @@
 
 namespace AssetBundler
 {
-    //! This file is to be added only to the AssetProcessor build target
+    //! This file is to be added only to the AssetBundler build target
     //! This function returns the build system target name
     AZStd::string_view GetBuildTargetName()
     {

--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -37,6 +37,11 @@
 
 namespace AssetBundler
 {
+    // Added a declaration of GetBuildTargetName which retrieves the name of the build target
+    // The build target changes depending on which shared library/executable applicationManager.cpp
+    // is linked to 
+    AZStd::string_view GetBuildTargetName();
+
     const char compareVariablePrefix = '$';
 
     ApplicationManager::ApplicationManager(int* argc, char*** argv, QObject* parent)
@@ -198,7 +203,7 @@ namespace AssetBundler
     void ApplicationManager::SetSettingsRegistrySpecializations(AZ::SettingsRegistryInterface::Specializations& specializations)
     {
         AzToolsFramework::ToolsApplication::SetSettingsRegistrySpecializations(specializations);
-        specializations.Append("assetbundler");
+        specializations.Append(GetBuildTargetName());
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

- fixes an issue where AssetBundler would show errors for platforms that were not enabled. 
- fixes an issue where AssetBundlerBatch was looking for the cmake_dependencies setreg using the AssetBundler specialization and if not found wouldn't know where all the gems were and a bunch of engine assets would be missed. This change mirrors how the AssetProcessor and AssetProcessorBatch handle that issue. Fixes https://github.com/o3de/o3de/issues/17442
- fixes https://github.com/o3de/o3de/issues/17298

## How was this PR tested?

- Ran AssetBundler and AssetBundlerBatch with engine dependencies on Mac and Windows and compared the before/after generated asset lists.
