### PR TITLE
Headless App: LOD Component Crash Fix

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
@@ -169,6 +169,13 @@ namespace EMotionFX
 
         void SimpleLODComponent::Deactivate()
         {
+            AZ::ApplicationTypeQuery appType;
+            AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+            if (appType.IsHeadless())
+            {
+                return;
+            }
+
             AZ::TickBus::Handler::BusDisconnect();
             ActorComponentNotificationBus::Handler::BusDisconnect();
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <AzCore/PlatformDef.h>
 
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -145,6 +146,13 @@ namespace EMotionFX
 
         void SimpleLODComponent::Activate()
         {
+            AZ::ApplicationTypeQuery appType;
+            AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+            if (appType.IsHeadless())
+            {
+                return;
+            }
+
             ActorComponentNotificationBus::Handler::BusConnect(GetEntityId());
             AZ::TickBus::Handler::BusConnect();
 
@@ -224,6 +232,11 @@ namespace EMotionFX
 
                 AZ::RPI::ViewportContextPtr defaultViewportContext =
                     viewportContextManager->GetViewportContextByName(viewportContextManager->GetDefaultViewportContextName());
+                if (!defaultViewportContext)
+                {
+                    return;
+                }
+
                 const float distance = worldPos.GetDistance(defaultViewportContext->GetCameraTransform().GetTranslation());
                 const size_t requestedLod = GetLodByDistance(configuration.m_lodDistances, distance);
                 actorInstance->SetLODLevel(requestedLod);


### PR DESCRIPTION
Stop animation simple LOD component from crashing on headless server applications due to missing camera viewport context
Fixes #17470 
