### PR TITLE
DPE - Fix GrowTextEdit sizing

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.cpp
@@ -17,6 +17,8 @@ AZ_POP_DISABLE_WARNING
 namespace AzToolsFramework
 {
     const int GrowTextEdit::s_padding = 10;
+    const int GrowTextEdit::s_minHeight = PropertyQTConstant_DefaultHeight * 3;
+    const int GrowTextEdit::s_maxHeight = PropertyQTConstant_DefaultHeight * 10;
 
     AZ_CLASS_ALLOCATOR_IMPL(GrowTextEdit, AZ::SystemAllocator)
 
@@ -24,8 +26,8 @@ namespace AzToolsFramework
         : QTextEdit(parent)
         , m_textChanged(false)
     {
-        setMinimumHeight(PropertyQTConstant_DefaultHeight * 3);
-        setMaximumHeight(PropertyQTConstant_DefaultHeight * 10);
+        setMinimumHeight(s_minHeight);
+        setMaximumHeight(s_maxHeight);
 
         connect(this, &GrowTextEdit::textChanged, this, [this]()
         {
@@ -66,7 +68,7 @@ namespace AzToolsFramework
     {
         QSize sizeHint = QTextEdit::sizeHint();
         QSize documentSize = document()->size().toSize();
-        sizeHint.setHeight(AZStd::min(PropertyQTConstant_DefaultHeight * 10, documentSize.height() + s_padding));
+        sizeHint.setHeight(AZStd::min(s_maxHeight, documentSize.height() + s_padding));
         return sizeHint;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.cpp
@@ -24,8 +24,8 @@ namespace AzToolsFramework
         : QTextEdit(parent)
         , m_textChanged(false)
     {
-        setSizePolicy(QSizePolicy::Policy::Ignored, QSizePolicy::Policy::Maximum);
         setMinimumHeight(PropertyQTConstant_DefaultHeight * 3);
+        setMaximumHeight(PropertyQTConstant_DefaultHeight * 10);
 
         connect(this, &GrowTextEdit::textChanged, this, [this]()
         {
@@ -66,7 +66,7 @@ namespace AzToolsFramework
     {
         QSize sizeHint = QTextEdit::sizeHint();
         QSize documentSize = document()->size().toSize();
-        sizeHint.setHeight(documentSize.height() + s_padding);
+        sizeHint.setHeight(AZStd::min(PropertyQTConstant_DefaultHeight * 10, documentSize.height() + s_padding));
         return sizeHint;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GrowTextEdit.h
@@ -40,6 +40,8 @@ namespace AzToolsFramework
         void EditCompleted();
     private:
         static const int s_padding;
+        static const int s_minHeight;
+        static const int s_maxHeight;
         bool m_textChanged;
     };
 }


### PR DESCRIPTION
Fixes #16908
Adjusts the GrowTextEdit class so that its size is correctly detected by the DPE resizing code.

![TextResizing](https://github.com/o3de/o3de/assets/82231674/79fa3418-9a20-47c6-9943-631af1208cee)
