### PR TITLE
Skip propagating template changes when removing all prefabs

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -1263,7 +1263,7 @@ namespace AzToolsFramework
             {
                 removed = templateIterator->second.RemoveLink(linkId);
 
-                //remove link
+                // Remove link
                 PrefabDomValueReference templateInstancesRef = templateIterator->second.GetInstancesValue();
                 if (templateInstancesRef == AZStd::nullopt)
                 {
@@ -1274,7 +1274,9 @@ namespace AzToolsFramework
                 removed = templateInstancesRef->get().RemoveMember(link.GetInstanceName().c_str())
                     ? removed : false;
 
-                if (removed)
+                // If removing all templates, we should not make any unnecessary updates for the linked instance DOMs.
+                // It is because doing such updates might cause some unexpected prefab patch warnings.
+                if (removed && !m_removingAllTemplates)
                 {
                     templateIterator->second.MarkAsDirty(true);
                     PropagateTemplateChanges(targetTemplateId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -449,7 +449,8 @@ namespace AzToolsFramework
 
             PrefabSystemScriptingHandler m_prefabSystemScriptingHandler;
 
-            // If true, individual template-remove messages will be suppressed
+            // If true, individual template-remove messages will be suppressed.
+            // It also prevents unnecessary link instance updates during template removal.
             bool m_removingAllTemplates = false;
 
             AZStd::unordered_set<TemplateId> m_templatesWhichNeedGarbageCollection;


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/17468

This PR stops propagating prefab template changes when the PSC (PrefabSystemComponent) is in the progress of removing all templates from the system. During the template and link removals, there is no need to update linked instance DOM within the target template anymore (since it will be removed eventually).

## How was this PR tested?

Tested in Editor and AP. No issues.
