### PR TITLE
Server Asset Platform Generates Bootstrap Setting Registry

### DIFF
--- a/Code/Framework/AzCore/AzCore/PlatformId/PlatformDefaults.cpp
+++ b/Code/Framework/AzCore/AzCore/PlatformId/PlatformDefaults.cpp
@@ -230,7 +230,8 @@ namespace AZ
                 platformCodes.emplace_back(PlatformCodeNameJasper);
                 break;
             case PlatformId::SERVER:
-                // Server is not a hardware platform
+                // For 'server' we default to the host
+                platformCodes.emplace_back(AZ_TRAIT_OS_PLATFORM_CODENAME);
                 break;
             default:
                 AZ_Assert(false, "Unsupported Platform ID: %i", platformId);


### PR DESCRIPTION
Ensure AssetProcessor properly generates setreg files for cache/server

"Server" asset platform will return the host (Windows/Linux/Mac/etc) platform code. 
SettingsRegistryBuilder requires the platform code in order to generate the bootstrap.<client/server/unified>.<config>.setreg

Tested by running asset processor with server=enabled and seeing the bootstrap.setreg files populate.
 - Bootstrap setreg contains all the important settings, such as physX collider groups

Fixes #17476 