### PR TITLE
fix: Allow to convert .slice to .prefabs

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -140,6 +140,9 @@ namespace AZ
         /// expected by the ClassData for this element
         void* ResolvePointer(void* ptr, const SerializeContext::ClassElement& classElement, const SerializeContext& context);
 
+        //! Open the given file and load it into an ObjectStream that you can inspect
+        //! @param classCallback Called for each root object loaded via the ObjectStream. Use it to read values from the file.
+        //! @param assetFilterCallback Limit the processing/loading to specific asset type(s)
         bool InspectSerializedFile(
             const char* filePath,
             SerializeContext* sc,

--- a/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -139,6 +139,12 @@ namespace AZ
         /// Resolve the instance pointer for a given ClassElement by casting it to the actual type
         /// expected by the ClassData for this element
         void* ResolvePointer(void* ptr, const SerializeContext::ClassElement& classElement, const SerializeContext& context);
+
+        bool InspectSerializedFile(
+            const char* filePath,
+            SerializeContext* sc,
+            const ObjectStream::ClassReadyCB& classCallback,
+            Data::AssetFilterCB assetFilterCallback = AZ::Data::AssetFilterNoAssetLoading);
     } // namespace Utils
 } // namespace Az
 

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
@@ -1052,7 +1052,10 @@ namespace AZ
     //=========================================================================
     // SliceComponent::SliceReference::Instantiate
     //=========================================================================
-    bool SliceComponent::SliceReference::Instantiate(const AZ::ObjectStream::FilterDescriptor& filterDesc)
+    bool SliceComponent::SliceReference::Instantiate(
+        const AZ::ObjectStream::FilterDescriptor& filterDesc,
+        AZ::SerializeContext* serializeContext,
+        AZStd::unordered_map<AZStd::string, AZStd::string>* relativeToAbsoluteSlicePaths)
     {
         AZ_PROFILE_FUNCTION(AzCore);
 
@@ -1061,41 +1064,64 @@ namespace AZ
             return true;
         }
 
-        AZ::Data::AssetInfo assetInfo;
-        AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, m_asset.GetId());
-        bool isAssetStillOnDisk = assetInfo.m_assetId.IsValid();
-
-        bool isCachedAssetReady = m_asset.IsReady();
-
-        if (!(isCachedAssetReady && isAssetStillOnDisk))
+        SliceComponent* dependentSlice = nullptr;
+        const bool useAssetProcessor = !serializeContext || !relativeToAbsoluteSlicePaths;
+        if (useAssetProcessor)
         {
-            // If the asset has been queued for async loading but hasn't completed, we've reached the point where it is required
-            // to be complete, so block until it finishes loading.
-            if (m_asset.IsLoading())
-            {
-                m_asset.BlockUntilLoadComplete();
-            }
+            AZ::Data::AssetInfo assetInfo;
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, m_asset.GetId());
 
-            // If the asset still isn't ready, an unexpected error has occurred.
-            if (!m_asset.IsReady())
+            const bool isAssetStillOnDisk = assetInfo.m_assetId.IsValid();
+            const bool isCachedAssetReady = m_asset.IsReady();
+            if (!(isCachedAssetReady && isAssetStillOnDisk))
             {
+                // If the asset has been queued for async loading but hasn't completed, we've reached the point where it is required
+                // to be complete, so block until it finishes loading.
+                if (m_asset.IsLoading())
+                {
+                    m_asset.BlockUntilLoadComplete();
+                }
+
+                // If the asset still isn't ready, an unexpected error has occurred.
+                if (!m_asset.IsReady())
+                {
 #if defined(AZ_ENABLE_TRACING)
-                const Data::Asset<SliceAsset> owningAsset = m_component->m_myAsset ?
-                    Data::Asset<SliceAsset>(Data::AssetManager::Instance().FindAsset(m_component->m_myAsset->GetId(), AZ::Data::AssetLoadBehavior::Default)) :
-                    Data::Asset<SliceAsset>();
-                AZ_Error("Slice", false,
-                    "Instantiation of %d slice instance(s) of asset %s failed - asset not ready or not found during instantiation of owning slice %s!"
-                    "Saving owning slice will lose data for these instances.",
-                    m_instances.size(),
-                    m_asset.ToString<AZStd::string>().c_str(),
-                    m_component->m_myAsset ? owningAsset.ToString<AZStd::string>().c_str() : "[Could not find owning slice]");
+                    const Data::Asset<SliceAsset> owningAsset = m_component->m_myAsset ?
+                        Data::Asset<SliceAsset>(Data::AssetManager::Instance().FindAsset(m_component->m_myAsset->GetId(), AZ::Data::AssetLoadBehavior::Default)) :
+                        Data::Asset<SliceAsset>();
+                    AZ_Error("Slice", false,
+                        "Instantiation of %d slice instance(s) of asset %s failed - asset not ready or not found during instantiation of owning slice %s!"
+                        "Saving owning slice will lose data for these instances.",
+                        m_instances.size(),
+                        m_asset.ToString<AZStd::string>().c_str(),
+                        m_component->m_myAsset ? owningAsset.ToString<AZStd::string>().c_str() : "[Could not find owning slice]");
 #endif // AZ_ENABLE_TRACING
+                    return false;
+                }
+            }
+            dependentSlice = m_asset.Get()->GetComponent();
+        }
+        else
+        {
+            const AZStd::string& path = (*relativeToAbsoluteSlicePaths)[m_asset.GetHint()];
+            if (path.empty())
+            {
+                AZ_Error("SliceReference::Instantiate", false, "Failed to find Slice relative path from %s", m_asset.GetHint().c_str());
                 return false;
             }
+
+            AZ::Entity* sliceRootEntity = AZ::EntityUtils::LoadRootEntityFromSlicePath(path.c_str(), serializeContext);
+            dependentSlice = AZ::EntityUtils::FindFirstDerivedComponent<SliceComponent>(sliceRootEntity);
+            m_asset.Get()->SetData(sliceRootEntity, dependentSlice, false);
         }
 
-        SliceComponent* dependentSlice = m_asset.Get()->GetComponent();
-        InstantiateResult instantiationResult = dependentSlice->Instantiate();
+        if (!dependentSlice)
+        {
+            AZ_Error("SliceReference::Instantiate", false, "Failed to get SliceComponent from %s", m_asset.GetHint().c_str());
+            return false;
+        }
+        
+        InstantiateResult instantiationResult = dependentSlice->Instantiate(serializeContext, relativeToAbsoluteSlicePaths);
         if (instantiationResult != InstantiateResult::Success)
         {
             #if defined(AZ_ENABLE_TRACING)
@@ -1653,7 +1679,9 @@ namespace AZ
     //=========================================================================
     // SliceComponent::Instantiate
     //=========================================================================
-    SliceComponent::InstantiateResult SliceComponent::Instantiate()
+    SliceComponent::InstantiateResult SliceComponent::Instantiate(
+        AZ::SerializeContext* serializeContext,
+        AZStd::unordered_map<AZStd::string, AZStd::string>* relativeToAbsoluteSlicePaths)
     {
         AZ_PROFILE_FUNCTION(AzCore);
         AZStd::unique_lock<AZStd::recursive_mutex> lock(m_instantiateMutex);
@@ -1684,7 +1712,8 @@ namespace AZ
             }
             else
             {
-                bool instantiateSuccess = slice.Instantiate(AZ::ObjectStream::FilterDescriptor(m_assetLoadFilterCB, m_filterFlags));
+                bool instantiateSuccess = slice.Instantiate(
+                    AZ::ObjectStream::FilterDescriptor(m_assetLoadFilterCB, m_filterFlags), serializeContext, relativeToAbsoluteSlicePaths);
                 if (instantiateSuccess)
                 {
                     // Prune empty slice instances.
@@ -3956,4 +3985,41 @@ namespace AZ
                 ;
         }
     }
+
+    namespace EntityUtils
+    {
+        AZ::Entity* LoadRootEntityFromSlicePath(const char* filePath, SerializeContext* context)
+        {
+            AZ::Entity* sliceRootEntity = nullptr;
+            auto callback = [&sliceRootEntity](void* classPtr, const Uuid& classId, SerializeContext*)
+            {
+                if (classId != azrtti_typeid<AZ::Entity>())
+                {
+                    AZ_Warning("LoadRootEntityFromSlicePath", false, "  File not opened: Slice root is not an entity.\n");
+                    return false;
+                }
+
+                sliceRootEntity = reinterpret_cast<AZ::Entity*>(classPtr);
+                return true;
+            };
+
+            if (!AZ::Utils::InspectSerializedFile(
+                    filePath,
+                    context,
+                    callback,
+                    [](const AZ::Data::AssetFilterInfo& filterInfo)
+                    {
+                        return (filterInfo.m_assetType == azrtti_typeid<AZ::SliceAsset>());
+                    }))
+            {
+                AZ_Warning("LoadRootEntityFromSlicePath", false, "Failed to load '%s'. File may not contain an object stream.", filePath);
+                return nullptr;
+            }
+
+            return sliceRootEntity;
+        }
+    }
+
 } // namespace AZ
+
+

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
@@ -1065,8 +1065,8 @@ namespace AZ
         }
 
         SliceComponent* dependentSlice = nullptr;
-        const bool useAssetProcessor = !serializeContext || !relativeToAbsoluteSlicePaths;
-        if (useAssetProcessor)
+        const bool useAssetCatalog = !serializeContext || !relativeToAbsoluteSlicePaths;
+        if (useAssetCatalog)
         {
             AZ::Data::AssetInfo assetInfo;
             AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, m_asset.GetId());
@@ -3991,15 +3991,14 @@ namespace AZ
         AZ::Entity* LoadRootEntityFromSlicePath(const char* filePath, SerializeContext* context)
         {
             AZ::Entity* sliceRootEntity = nullptr;
-            auto callback = [&sliceRootEntity](void* classPtr, const Uuid& classId, SerializeContext*)
+            auto callback = [&sliceRootEntity](void* classPtr, const Uuid& classId, SerializeContext* serializeContext)
             {
-                if (classId != azrtti_typeid<AZ::Entity>())
+                sliceRootEntity = serializeContext->Cast<AZ::Entity*>(classPtr, classId);
+                if (!sliceRootEntity)
                 {
                     AZ_Warning("LoadRootEntityFromSlicePath", false, "  File not opened: Slice root is not an entity.\n");
                     return false;
                 }
-
-                sliceRootEntity = reinterpret_cast<AZ::Entity*>(classPtr);
                 return true;
             };
 

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.h
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.h
@@ -940,6 +940,7 @@ namespace AZ
 
         /**
         * Instantiate entities for this slice, otherwise only the data are stored.
+        * \param serializeContext and relativeToAbsoluteSlicePaths are used for a specific case when asset processor is not available
         */
         InstantiateResult Instantiate(
             AZ::SerializeContext* serializeContext = nullptr,
@@ -1129,6 +1130,7 @@ namespace AZ
             return replaced;
         }
 
+        // Deserialize a slice without using asset processor and read root entity from it
         AZ::Entity* LoadRootEntityFromSlicePath(const char* filePath, SerializeContext* context);
     } // namespace EntityUtils
 

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.h
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.h
@@ -524,7 +524,11 @@ namespace AZ
                 const AZ::IdUtils::Remapper<AZ::EntityId>::IdMapper& customMapper = nullptr);
 
             /// Instantiate all instances (by default we just hold the deltas - data patch), the Slice component controls the instantiate state
-            bool Instantiate(const AZ::ObjectStream::FilterDescriptor& filterDesc);
+            /// serializeContext and relativeToAbsoluteSlicePaths arguments are used for a specific case when asset processor is not available
+            bool Instantiate(
+                const AZ::ObjectStream::FilterDescriptor& filterDesc,
+                AZ::SerializeContext* serializeContext = nullptr,
+                AZStd::unordered_map<AZStd::string, AZStd::string>* relativeToAbsoluteSlicePaths = nullptr);
 
             void UnInstantiate();
 
@@ -937,7 +941,9 @@ namespace AZ
         /**
         * Instantiate entities for this slice, otherwise only the data are stored.
         */
-        InstantiateResult Instantiate();
+        InstantiateResult Instantiate(
+            AZ::SerializeContext* serializeContext = nullptr,
+            AZStd::unordered_map<AZStd::string, AZStd::string>* relativeToAbsoluteSlicePaths = nullptr);
         bool IsInstantiated() const;
         /**
          * Generate new entity Ids and remap references
@@ -1122,6 +1128,8 @@ namespace AZ
 
             return replaced;
         }
+
+        AZ::Entity* LoadRootEntityFromSlicePath(const char* filePath, SerializeContext* context);
     } // namespace EntityUtils
 
     namespace IdUtils

--- a/Code/Tools/SerializeContextTools/Converter.cpp
+++ b/Code/Tools/SerializeContextTools/Converter.cpp
@@ -114,7 +114,7 @@ namespace AZ
                     }
                     return true;
                 };
-                if (!Utilities::InspectSerializedFile(filePath.c_str(), convertSettings.m_serializeContext, callback))
+                if (!AZ::Utils::InspectSerializedFile(filePath.c_str(), convertSettings.m_serializeContext, callback))
                 {
                     AZ_Warning("Convert", false, "Failed to load '%s'. File may not contain an object stream.", filePath.c_str());
                     result = false;

--- a/Code/Tools/SerializeContextTools/Dumper.cpp
+++ b/Code/Tools/SerializeContextTools/Dumper.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSerializationSettings.h>
+#include <AzCore/Serialization/Utils.h>
 #include <AzCore/Settings/TextParser.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/algorithm.h>
@@ -207,7 +208,7 @@ namespace AZ::SerializeContextTools
                     result = false;
                 }
             };
-            if (!Utilities::InspectSerializedFile(filePath.c_str(), sc, callback))
+            if (!AZ::Utils::InspectSerializedFile(filePath.c_str(), sc, callback))
             {
                 result = false;
                 continue;

--- a/Code/Tools/SerializeContextTools/Runner.cpp
+++ b/Code/Tools/SerializeContextTools/Runner.cpp
@@ -72,11 +72,12 @@ namespace SerializeContextTools
         AZ_Printf("Help", R"(    example: 'convert-ini --files=AssetProcessorPlatformConfig.ini;bootstrap.cfg --ext=setreg)" "\n");
         AZ_Printf("Help", "  'convert-slice': Converts ObjectStream-based slice files or legacy levels to a JSON-based prefab.\n");
         AZ_Printf("Help", "    [arg] -files=<path>: <comma or semicolon>-separated list of files to convert. Supports wildcards.\n");
+        AZ_Printf("Help", "    [opt] -slices=<path>: <comma or semicolon>-separated list of .slice files that you converted files depends on. Supports wildcards. Use this if you cannot use the asset processor on the target project (like o3de converting lumberyard)\n");
         AZ_Printf("Help", "    [opt] -dryrun: Processes as normal, but doesn't write files.\n");
         AZ_Printf("Help", "    [opt] -keepdefaults: Fields are written if a default value was found.\n");
         AZ_Printf("Help", "    [opt] -verbose: Report additional details during the conversion process.\n");
         AZ_Printf("Help", "    example: 'convert-slice -files=*.slice -specializations=editor\n");
-        AZ_Printf("Help", "    example: 'convert-slice -files=Levels/TestLevel/TestLevel.ly -specializations=editor\n");
+        AZ_Printf("Help", "    example: 'convert-slice -files=Levels/TestLevel/TestLevel.ly -project-path=F:/lmbr-fork/dev/StarterGame -slices=Gems/*.slice -specializations=editor\n");
         AZ_Printf("Help", "\n");
         AZ_Printf("Help", "  'createtype': Create a default constructed object using Json Serialization and output the contents.\n");
         AZ_Printf("Help", "    [arg] --type-name=<string>: Name of type to construct and output.\n");

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -654,7 +654,8 @@ namespace AZ
             }
 
             // Instantiate a new instance of the nested slice
-            AZ::SliceComponent::InstantiateResult instantiationResult = dependentSlice->Instantiate(serializeContext, &m_relativeToAbsoluteSlicePaths);
+            AZ::SliceComponent::InstantiateResult instantiationResult =
+                dependentSlice->Instantiate(serializeContext, NeedAssetProcessor() ? nullptr : &m_relativeToAbsoluteSlicePaths);
             if (instantiationResult != AZ::SliceComponent::InstantiateResult::Success)
             {
                 AZ_Error("Convert-Slice", false, "Failed to instantiate instance of %s", sliceAsset.GetHint().c_str());

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -18,7 +18,9 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/std/algorithm.h>
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/Archive/IArchive.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
@@ -57,6 +59,11 @@ namespace AZ
                 return false;
             }
 
+            if (commandLine->HasSwitch("project-path"))
+            {
+                m_projectPath = commandLine->GetSwitchValue("project-path");
+            }
+
             JsonSerializerSettings convertSettings;
             convertSettings.m_keepDefaults = commandLine->HasSwitch("keepdefaults");
             convertSettings.m_registrationContext = application.GetJsonRegistrationContext();
@@ -66,14 +73,34 @@ namespace AZ
                 AZ_Error("Convert-Slice", false, "No serialize context found.");
                 return false;
             }
+
             if (!convertSettings.m_registrationContext)
             {
                 AZ_Error("Convert-Slice", false, "No json registration context found.");
                 return false;
             }
 
+            if (commandLine->HasSwitch("slices"))
+            {
+                AZStd::vector<AZStd::string> sliceAbsPaths = Utilities::ReadFileListFromCommandLine(application, "slices");
+                AZStd::remove_if(
+                    sliceAbsPaths.begin(),
+                    sliceAbsPaths.end(),
+                    [](const AZStd::string& item)
+                    {
+                        return !item.ends_with(".slice");
+                    });
+
+                for (const AZStd::string& absolutePath : sliceAbsPaths)
+                {
+                    const AZStd::string relativePath = Utilities::GenerateRelativePosixPath(m_projectPath, absolutePath);
+                    m_relativeToAbsoluteSlicePaths[relativePath] = absolutePath;
+                }
+            }
+
+            const bool useAssetProcessor = NeedAssetProcessor();
             // Connect to the Asset Processor so that we can get the correct source path to any nested slice references.
-            if (!ConnectToAssetProcessor())
+            if (useAssetProcessor && !ConnectToAssetProcessor())
             {
                 AZ_Error("Convert-Slice", false, "  Failed to connect to the Asset Processor.\n");
                 return false;
@@ -82,7 +109,7 @@ namespace AZ
             AZStd::string logggingScratchBuffer;
             SetupLogging(logggingScratchBuffer, convertSettings.m_reporting, *commandLine);
 
-            bool isDryRun = commandLine->HasSwitch("dryrun");
+            const bool isDryRun = commandLine->HasSwitch("dryrun");
 
             JsonDeserializerSettings verifySettings;
             verifySettings.m_registrationContext = application.GetJsonRegistrationContext();
@@ -100,6 +127,11 @@ namespace AZ
             AZStd::vector<AZStd::string> fileList = Utilities::ReadFileListFromCommandLine(application, "files");
             for (AZStd::string& filePath : fileList)
             {
+                if (filePath.contains("_savebackup"))
+                {
+                    continue;
+                }
+
                 bool convertResult = ConvertSliceFile(convertSettings.m_serializeContext, filePath, isDryRun);
                 result = result && convertResult;
 
@@ -114,7 +146,12 @@ namespace AZ
                 m_createdTemplateIds.clear();
             }
 
-            DisconnectFromAssetProcessor();
+            m_relativeToAbsoluteSlicePaths.clear();
+            if (useAssetProcessor)
+            {
+                DisconnectFromAssetProcessor();
+            }
+
             return result;
         }
 
@@ -177,7 +214,7 @@ namespace AZ
             // Read in the slice file and call the callback on completion to convert the read-in slice to a prefab.
             // This will also load dependent slice assets, but no other dependent asset types.
             // Since we're not actually initializing any of the entities, we don't need any of the non-slice assets to be loaded.
-            if (!Utilities::InspectSerializedFile(
+            if (!AZ::Utils::InspectSerializedFile(
                     inputPath.c_str(), serializeContext, callback,
                     [](const AZ::Data::AssetFilterInfo& filterInfo)
                     {
@@ -302,7 +339,7 @@ namespace AZ
             AZ_Printf("Convert-Slice", "  Slice contains %zu nested slices.\n", sliceList.size());
             if (!sliceList.empty())
             {
-                bool nestedSliceResult = ConvertNestedSlices(sliceComponent, sourceInstance.get(), serializeContext, isDryRun);
+                const bool nestedSliceResult = ConvertNestedSlices(sliceComponent, sourceInstance.get(), serializeContext, isDryRun);
                 if (!nestedSliceResult)
                 {
                     return false;
@@ -410,23 +447,33 @@ namespace AZ
             {
                 // Get the nested slice asset.  These should already be preloaded due to loading the root asset.
                 auto sliceAsset = slice.GetSliceAsset();
-                AZ_Assert(sliceAsset.IsReady(), "slice asset hasn't been loaded yet!");
 
-                // The slice list gives us asset IDs, and we need to get to the source path.  So first we get the asset path from the ID,
-                // then we get the source path from the asset path.
+                AZStd::string assetAbsPath;
+                if (!NeedAssetProcessor())
+                {
+                    assetAbsPath = m_relativeToAbsoluteSlicePaths[sliceAsset.GetHint()];
+                }
+                else
+                {
+                    AZ_Assert(sliceAsset.IsReady(), "slice asset hasn't been loaded yet!");
 
-                AZStd::string processedAssetPath;
-                AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                    processedAssetPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, sliceAsset.GetId());
+                    // The slice list gives us asset IDs, and we need to get to the source path. So first we get the asset path from the
+                    // ID, then we get the source path from the asset path.
+                    AZStd::string processedAssetPath;
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        processedAssetPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, sliceAsset.GetId());
 
-                AZStd::string assetPath;
-                AzToolsFramework::AssetSystemRequestBus::Broadcast(
-                    &AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath,
-                    processedAssetPath, assetPath);
-                if (assetPath.empty())
+                    AzToolsFramework::AssetSystemRequestBus::Broadcast(
+                        &AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath,
+                        processedAssetPath,
+                        assetAbsPath);
+                }
+
+                if (assetAbsPath.empty())
                 {
                     AZ_Warning("Convert-Slice", false,
-                        "  Source path for nested slice '%s' could not be found, slice not converted.", processedAssetPath.c_str());
+                        "  Source path for nested slice '%s' could not be found, slice not converted.",
+                        sliceAsset.GetHint().c_str());
                     return false;
                 }
 
@@ -434,11 +481,16 @@ namespace AZ
                 // occurrence and we need to convert it now.
 
                 // First, take our absolute slice path and turn it into a project-relative prefab path.
-                AZ::IO::Path nestedPrefabPath = assetPath;
+                AZ::IO::Path nestedPrefabPath = assetAbsPath;
                 nestedPrefabPath.ReplaceExtension("prefab");
 
                 auto prefabLoaderInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabLoaderInterface>::Get();
-                nestedPrefabPath = prefabLoaderInterface->GenerateRelativePath(nestedPrefabPath);
+                const auto nestedPrefabCreationPath = prefabLoaderInterface->GenerateRelativePath(nestedPrefabPath);
+
+                // Get relative path from highest priority folder (Assets for Gems and project folders for project assets).
+                // Without asset processor, it is incorrect so we create it ourself and update it on the database later
+                nestedPrefabPath = NeedAssetProcessor() ? nestedPrefabCreationPath
+                                                        : Utilities::GenerateRelativePosixPath(m_projectPath, nestedPrefabPath.String());
 
                 // Now, see if we already have a template ID in memory for it.
                 AzToolsFramework::Prefab::TemplateId nestedTemplateId =
@@ -447,16 +499,22 @@ namespace AZ
                 // If we don't have a template ID yet, convert the nested slice to a prefab and get the template ID.
                 if (nestedTemplateId == AzToolsFramework::Prefab::InvalidTemplateId)
                 {
-                    bool nestedSliceResult = ConvertSliceFile(serializeContext, assetPath, isDryRun);
+                    const bool nestedSliceResult = ConvertSliceFile(serializeContext, assetAbsPath, isDryRun);
                     if (!nestedSliceResult)
                     {
-                        AZ_Warning("Convert-Slice", nestedSliceResult, "  Nested slice '%s' could not be converted.", assetPath.c_str());
+                        AZ_Warning("Convert-Slice", nestedSliceResult, "  Nested slice '%s' could not be converted.", assetAbsPath.c_str());
                         return false;
                     }
 
-                    nestedTemplateId = prefabSystemComponentInterface->GetTemplateIdFromFilePath(nestedPrefabPath);
+                    nestedTemplateId = prefabSystemComponentInterface->GetTemplateIdFromFilePath(nestedPrefabCreationPath);
                     AZ_Assert(nestedTemplateId != AzToolsFramework::Prefab::InvalidTemplateId,
                         "Template ID for %s is invalid", nestedPrefabPath.c_str());
+
+                    if (!NeedAssetProcessor())
+                    {
+                        // Patch the prefab path in the database to have a valid relative value
+                        prefabSystemComponentInterface->UpdateTemplateFilePath(nestedTemplateId, nestedPrefabPath);
+                    }
                 }
 
                 // Get the nested prefab template.
@@ -489,7 +547,7 @@ namespace AZ
                 for (auto& instance : instances)
                 {
                     AZ_Printf("Convert-Slice", "  Converting instance %zu.\n", curInstance++);
-                    bool instanceConvertResult = ConvertSliceInstance(instance, sliceAsset, nestedTemplate, sourceInstance);
+                    const bool instanceConvertResult = ConvertSliceInstance(instance, sliceAsset, nestedTemplate, sourceInstance, serializeContext);
                     if (!instanceConvertResult)
                     {
                         return false;
@@ -530,7 +588,8 @@ namespace AZ
             AZ::SliceComponent::SliceInstance& instance,
             AZ::Data::Asset<AZ::SliceAsset>& sliceAsset,
             AzToolsFramework::Prefab::TemplateReference nestedTemplate,
-            AzToolsFramework::Prefab::Instance* topLevelInstance)
+            AzToolsFramework::Prefab::Instance* topLevelInstance,
+            AZ::SerializeContext* serializeContext)
         {
             /* To convert a slice instance, it's important to understand the similarities and differences between slices and prefabs.
             * Both slices and prefabs have the concept of instances of a nested slice/prefab, where each instance can have its own
@@ -572,10 +631,35 @@ namespace AZ
             AzToolsFramework::Prefab::PrefabDom unmodifiedNestedInstanceDom;
             instanceToTemplateInterface->GenerateInstanceDomBySerializing(unmodifiedNestedInstanceDom, *(nestedInstance.get()));
 
-            // Instantiate a new instance of the nested slice
             SliceComponent* dependentSlice = sliceAsset.Get()->GetComponent();
-            [[maybe_unused]] AZ::SliceComponent::InstantiateResult instantiationResult = dependentSlice->Instantiate();
-            AZ_Assert(instantiationResult == AZ::SliceComponent::InstantiateResult::Success, "Failed to instantiate instance");
+
+            // Fallback if component is not loaded, open the file directly and read the slice from it
+            if (!dependentSlice)
+            {
+                const AZStd::string& path = m_relativeToAbsoluteSlicePaths[sliceAsset.GetHint()];
+                if (path.empty())
+                {
+                    AZ_Error("Convert-Slice", false, "Failed to find Slice relative path from %s", sliceAsset.GetHint().c_str());
+                    return false;
+                }
+
+                AZ::Entity* sliceRootEntity = AZ::EntityUtils::LoadRootEntityFromSlicePath(path.c_str(), serializeContext);
+                dependentSlice = AZ::EntityUtils::FindFirstDerivedComponent<SliceComponent>(sliceRootEntity);
+            }
+
+            if (!dependentSlice)
+            {
+                AZ_Error("Convert-Slice", false, "Failed to get SliceComponent from %s", sliceAsset.GetHint().c_str());
+                return false;
+            }
+
+            // Instantiate a new instance of the nested slice
+            AZ::SliceComponent::InstantiateResult instantiationResult = dependentSlice->Instantiate(serializeContext, &m_relativeToAbsoluteSlicePaths);
+            if (instantiationResult != AZ::SliceComponent::InstantiateResult::Success)
+            {
+                AZ_Error("Convert-Slice", false, "Failed to instantiate instance of %s", sliceAsset.GetHint().c_str());
+                return false;
+            }
 
             // Apply the data patch for this instance of the nested slice.  This will provide us with a version of the slice's entities
             // with all data overrides applied to them.
@@ -868,6 +952,11 @@ namespace AZ
                 &AzFramework::AssetSystem::AssetSystemRequests::WaitUntilAssetProcessorDisconnected, AZStd::chrono::seconds(30));
 
             AZ_Error("Convert-Slice", disconnected, "Asset Processor failed to disconnect successfully.");
+        }
+
+        bool SliceConverter::NeedAssetProcessor() const
+        {
+            return m_relativeToAbsoluteSlicePaths.empty();
         }
 
         void SliceConverter::UpdateSliceEntityInstanceMappings(

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -654,7 +654,7 @@ namespace AZ
             }
 
             // Instantiate a new instance of the nested slice
-            AZ::SliceComponent::InstantiateResult instantiationResult =
+            const AZ::SliceComponent::InstantiateResult instantiationResult =
                 dependentSlice->Instantiate(serializeContext, NeedAssetProcessor() ? nullptr : &m_relativeToAbsoluteSlicePaths);
             if (instantiationResult != AZ::SliceComponent::InstantiateResult::Success)
             {

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -93,7 +93,7 @@ namespace AZ
 
                 for (const AZStd::string& absolutePath : sliceAbsPaths)
                 {
-                    const AZStd::string relativePath = Utilities::GenerateRelativePosixPath(m_projectPath, absolutePath);
+                    const AZStd::string relativePath = Utilities::GenerateRelativePosixPath(m_projectPath, AZ::IO::PathView(absolutePath));
                     m_relativeToAbsoluteSlicePaths[relativePath] = absolutePath;
                 }
             }
@@ -490,7 +490,7 @@ namespace AZ
                 // Get relative path from highest priority folder (Assets for Gems and project folders for project assets).
                 // Without asset processor, it is incorrect so we create it ourself and update it on the database later
                 nestedPrefabPath = NeedAssetProcessor() ? nestedPrefabCreationPath
-                                                        : Utilities::GenerateRelativePosixPath(m_projectPath, nestedPrefabPath.String());
+                                                        : Utilities::GenerateRelativePosixPath(m_projectPath, nestedPrefabPath);
 
                 // Now, see if we already have a template ID in memory for it.
                 AzToolsFramework::Prefab::TemplateId nestedTemplateId =

--- a/Code/Tools/SerializeContextTools/SliceConverter.h
+++ b/Code/Tools/SerializeContextTools/SliceConverter.h
@@ -92,7 +92,7 @@ namespace AZ
                 SliceComponent::InstantiatedContainer* instantiatedEntities,
                 SerializeContext* context);
 
-            AZStd::string m_projectPath;
+            AZ::IO::Path m_projectPath;
 
             // Track all of the entity IDs created and associate them with enough conversion information to know how to place the
             // entities in the correct place in the prefab hierarchy and fix up parent entity ID mappings to work with the nested

--- a/Code/Tools/SerializeContextTools/SliceConverter.h
+++ b/Code/Tools/SerializeContextTools/SliceConverter.h
@@ -62,6 +62,7 @@ namespace AZ
 
             bool ConnectToAssetProcessor();
             void DisconnectFromAssetProcessor();
+            bool NeedAssetProcessor() const;
 
             bool ConvertSliceFile(AZ::SerializeContext* serializeContext, const AZStd::string& slicePath, bool isDryRun);
             bool ConvertSliceToPrefab(
@@ -72,7 +73,9 @@ namespace AZ
                 AZ::SerializeContext* serializeContext, bool isDryRun);
             bool ConvertSliceInstance(
                 AZ::SliceComponent::SliceInstance& instance, AZ::Data::Asset<AZ::SliceAsset>& sliceAsset,
-                AzToolsFramework::Prefab::TemplateReference nestedTemplate, AzToolsFramework::Prefab::Instance* topLevelInstance);
+                AzToolsFramework::Prefab::TemplateReference nestedTemplate,
+                AzToolsFramework::Prefab::Instance* topLevelInstance,
+                AZ::SerializeContext* serializeContext);
             void UpdateCachedTransform(const AZ::Entity& entity);
             void SetParentEntity(const AZ::Entity& entity, const AZ::EntityId& parentId, bool onlySetIfInvalid);
             void PrintPrefab(AzToolsFramework::Prefab::TemplateId templateId);
@@ -89,10 +92,16 @@ namespace AZ
                 SliceComponent::InstantiatedContainer* instantiatedEntities,
                 SerializeContext* context);
 
+            AZStd::string m_projectPath;
+
             // Track all of the entity IDs created and associate them with enough conversion information to know how to place the
             // entities in the correct place in the prefab hierarchy and fix up parent entity ID mappings to work with the nested
             // prefab schema.
             AZStd::unordered_map<AZ::EntityId, SliceEntityMappingInfo> m_aliasIdMapper;
+
+            // When we don't use the asset processor, will store all of the discovered slices path
+            // with their absolute path and the relative posix path used by asset hint
+            AZStd::unordered_map<AZStd::string, AZStd::string> m_relativeToAbsoluteSlicePaths;
 
             // Track all of the created prefab template IDs on a slice conversion so that they can get removed at the end of the
             // conversion for that file.

--- a/Code/Tools/SerializeContextTools/Utilities.cpp
+++ b/Code/Tools/SerializeContextTools/Utilities.cpp
@@ -18,8 +18,10 @@
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Settings/CommandLine.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/std/algorithm.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/functional.h>
+#include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/wildcard.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <Application.h>
@@ -189,57 +191,19 @@ namespace AZ::SerializeContextTools
         return result;
     }
 
-    bool Utilities::InspectSerializedFile(
-        const char* filePath,
-        SerializeContext* sc,
-        const ObjectStream::ClassReadyCB& classCallback,
-        Data::AssetFilterCB assetFilterCallback)
+    AZStd::string Utilities::GenerateRelativePosixPath(const AZStd::string& projectPath, const AZStd::string& absolutePath)
     {
-        if (!AZ::IO::FileIOBase::GetInstance()->Exists(filePath))
-        {
-            AZ_Error("Verify", false, "Unable to open file '%s' as it doesn't exist.", filePath);
-            return false;
-        }
-
-        AZ::IO::HandleType fileHandle;
-        auto openResult = AZ::IO::FileIOBase::GetInstance()->Open(filePath, AZ::IO::OpenMode::ModeRead, fileHandle);
-        if (!openResult)
-        {
-            AZ_Error("Verify", false, "File '%s' could not be opened.", filePath);
-            return false;
-        }
-
-        u64 fileLength = 0;
-        auto sizeResult = AZ::IO::FileIOBase::GetInstance()->Size(fileHandle, fileLength);
-        if (!sizeResult || (fileLength == 0))
-        {
-            AZ_Error("Verify", false, "File '%s' doesn't have content.", filePath);
-            return false;
-        }
-
-        AZStd::vector<u8> data;
-        data.resize_no_construct(fileLength);
-        u64 bytesRead = 0;
-        auto readResult = AZ::IO::FileIOBase::GetInstance()->Read(fileHandle, data.data(), fileLength, true, &bytesRead);
-        if (!readResult || (bytesRead != fileLength))
-        {
-            AZ_Error("Verify", false, "Unable to read file '%s'.", filePath);
-            return false;
-        }
-
-        AZ::IO::FileIOBase::GetInstance()->Close(fileHandle);
-
-        AZ::IO::MemoryStream stream(data.data(), fileLength);
-
-        ObjectStream::FilterDescriptor filter;
-        // By default, never load dependencies. That's another file that would need to be processed
-        // separately from this one.
-        filter.m_assetCB = assetFilterCallback;
-        if (!ObjectStream::LoadBlocking(&stream, *sc, classCallback, filter))
-        {
-            AZ_Printf("Verify", "Failed to deserialize '%s'\n", filePath);
-            return false;
-        }
-        return true;
+        AZStd::string absolutePathCpy = absolutePath;
+        AZStd::replace(absolutePathCpy.begin(), absolutePathCpy.end(), AZ::IO::WindowsPathSeparator, AZ::IO::PosixPathSeparator);
+        AZStd::to_lower(absolutePathCpy.begin(), absolutePathCpy.end());
+        return absolutePath.starts_with(projectPath) ? absolutePathCpy.substr(projectPath.length() + 1)
+                                                     : GetStringAfterFirstOccurenceOf("assets/", absolutePathCpy);
     }
+
+    AZStd::string Utilities::GetStringAfterFirstOccurenceOf(const AZStd::string& toFind, const AZStd::string& string)
+    {
+        const auto startIndex = string.find(toFind);
+        return startIndex == AZStd::string::npos ? string : string.substr(startIndex + toFind.length());
+    }
+
 } // namespace AZ::SerializeContextTools

--- a/Code/Tools/SerializeContextTools/Utilities.cpp
+++ b/Code/Tools/SerializeContextTools/Utilities.cpp
@@ -191,16 +191,21 @@ namespace AZ::SerializeContextTools
         return result;
     }
 
-    AZStd::string Utilities::GenerateRelativePosixPath(const AZStd::string& projectPath, const AZStd::string& absolutePath)
+    AZStd::string Utilities::GenerateRelativePosixPath(const AZ::IO::PathView& projectPath, const AZ::IO::PathView& absolutePath)
     {
-        AZStd::string absolutePathCpy = absolutePath;
-        AZStd::replace(absolutePathCpy.begin(), absolutePathCpy.end(), AZ::IO::WindowsPathSeparator, AZ::IO::PosixPathSeparator);
-        AZStd::to_lower(absolutePathCpy.begin(), absolutePathCpy.end());
-        return absolutePath.starts_with(projectPath) ? absolutePathCpy.substr(projectPath.length() + 1)
-                                                     : GetStringAfterFirstOccurenceOf("assets/", absolutePathCpy);
+        AZ::IO::FixedMaxPath projectRelativeFilePath = absolutePath.LexicallyProximate(projectPath);
+        AZStd::to_lower(projectRelativeFilePath.Native().begin(), projectRelativeFilePath.Native().end());
+
+        AZStd::string result = projectRelativeFilePath.StringAsPosix();
+        const bool isOutsideProjectFolder = result.starts_with("..");
+        if (isOutsideProjectFolder)
+        {
+            result = GetStringAfterFirstOccurenceOf("assets/", result);
+        }
+        return result;
     }
 
-    AZStd::string Utilities::GetStringAfterFirstOccurenceOf(const AZStd::string& toFind, const AZStd::string& string)
+    AZStd::string_view Utilities::GetStringAfterFirstOccurenceOf(const AZStd::string_view& toFind, const AZStd::string_view& string)
     {
         const auto startIndex = string.find(toFind);
         return startIndex == AZStd::string::npos ? string : string.substr(startIndex + toFind.length());

--- a/Code/Tools/SerializeContextTools/Utilities.h
+++ b/Code/Tools/SerializeContextTools/Utilities.h
@@ -13,6 +13,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
+#include <AzCore/IO/Path/Path_fwd.h>
 
 namespace AZ
 {
@@ -37,8 +38,8 @@ namespace AZ
 
             //! Converts path into a path that's relative to the highest-priority containing folder
             //! (the Assets folder for a Gem or the Projects folder for project's assets)
-            static AZStd::string GenerateRelativePosixPath(const AZStd::string& projectPath, const AZStd::string& path);
-            static AZStd::string GetStringAfterFirstOccurenceOf(const AZStd::string& toFind, const AZStd::string& string);
+            static AZStd::string GenerateRelativePosixPath(const AZ::IO::PathView& projectPath, const AZ::IO::PathView& absolutePath);
+            static AZStd::string_view GetStringAfterFirstOccurenceOf(const AZStd::string_view& toFind, const AZStd::string_view& string);
 
         private:
             Utilities() = delete;

--- a/Code/Tools/SerializeContextTools/Utilities.h
+++ b/Code/Tools/SerializeContextTools/Utilities.h
@@ -35,11 +35,10 @@ namespace AZ
 
             static AZStd::vector<AZ::Uuid> GetSystemComponents(const Application& application);
 
-            static bool InspectSerializedFile(
-                const char* filePath,
-                SerializeContext* sc,
-                const ObjectStream::ClassReadyCB& classCallback,
-                Data::AssetFilterCB assetFilterCallback = AZ::Data::AssetFilterNoAssetLoading);
+            //! Converts path into a path that's relative to the highest-priority containing folder
+            //! (the Assets folder for a Gem or the Projects folder for project's assets)
+            static AZStd::string GenerateRelativePosixPath(const AZStd::string& projectPath, const AZStd::string& path);
+            static AZStd::string GetStringAfterFirstOccurenceOf(const AZStd::string& toFind, const AZStd::string& string);
 
         private:
             Utilities() = delete;


### PR DESCRIPTION
## What does this PR do?

Repair the pipeline to convert .slice and .ly to .prefab, via an optionnal path to skip the asset processor (we deserialize the files ourselves to get needed values).
(Follow-up to https://github.com/o3de/o3de/pull/17397 and https://github.com/o3de/o3de/pull/17377).

- Add the optional argument "slices" used to list the wanted dependencies to convert
- Rely on the optional argument "project-path" already in usage for other commands
- Auto skip save backups folders
- Move InspectSerializedFile method to AzCore serialization utils
- Add method in SliceComponent to load slice file and get the root entity

*StarterGame level on Lumberyard*

![lmbr singleplayer](https://github.com/o3de/o3de/assets/19243508/c1cde504-41d1-4be0-9e62-fdaea7218e74)

*StarterGame level on O3de*

![image](https://github.com/o3de/o3de/assets/19243508/97a9608e-5b55-4f61-b595-9773c6e2ce63)

## Limitations

- The slice converter cannot handle layers (yet). When converting a level with layers, need to move its entities out of the layer (and parent them to a parent entity which will act as the layer).

- Once the level and slices where converted, need to copy the .prefab files by hand onto the o3de project and make sure we keep the same relative path to the project/gem Asset folder.

## How was this PR tested?

Converted the whole StarterGame level from lumberyard to O3de. Precise instruction are on this doc PR (https://github.com/o3de/o3de.org/pull/2545)
