### PR TITLE
DPE | Layout classes rewrite to fix refresh issues with containers.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -228,6 +228,7 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
     enum class ContainerAction
     {
+        None = 0,
         AddElement,
         RemoveElement,
         Clear,

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -1801,7 +1801,7 @@ namespace AZ::Reflection
         if (serializeContext == nullptr)
         {
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-            AZ_Assert(serializeContext != nullptr, "Unable to retreive a SerializeContext");
+            AZ_Assert(serializeContext != nullptr, "Unable to retrieve a SerializeContext");
         }
 
         LegacyReflectionInternal::InstanceVisitor helper(visitor, instance, typeId, serializeContext);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.h
@@ -90,7 +90,7 @@ namespace AZ::Reflection::LegacyReflectionInternal
     {
         AZ_TYPE_INFO(KeyEntry, "{718537E1-DFF5-4662-AB86-1D5C0C8A0768}");
 
-        //! Stores the address and type ID of an associative contaienr key
+        //! Stores the address and type ID of an associative container key
         AZ::PointerObject m_keyInstance;
         //! Stores the attributes of a single associative container element key
         AZStd::vector<AttributeData> m_keyAttributes;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -43,7 +43,7 @@ namespace AzToolsFramework
         case ContainerAction::AddElement:
             {
                 setIcon(s_iconAdd);
-                setToolTip("Add new child element");
+                setToolTip(tr("Add new child element"));
                 break;
             }
         case ContainerAction::RemoveElement:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -18,46 +18,62 @@ namespace AzToolsFramework
 
     void ContainerActionButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)
     {
-        GenericButtonHandler::SetValueFromDom(node);
 
-        static QIcon s_iconAdd(QStringLiteral(":/stylesheet/img/UI20/add-16.svg"));
-        static QIcon s_iconRemove(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
-        static QIcon s_iconClear(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
-        static QIcon s_iconUp(QStringLiteral(":/stylesheet/img/indicator-arrow-up.svg"));
-        static QIcon s_iconDown(QStringLiteral(":/stylesheet/img/indicator-arrow-down.svg"));
+        static const QIcon s_iconAdd(QStringLiteral(":/stylesheet/img/UI20/add-16.svg"));
+        static const QIcon s_iconRemove(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
+        static const QIcon s_iconClear(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
+        static const QIcon s_iconUp(QStringLiteral(":/stylesheet/img/indicator-arrow-up.svg"));
+        static const QIcon s_iconDown(QStringLiteral(":/stylesheet/img/indicator-arrow-down.svg"));
 
         using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
         using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
 
+        GenericButtonHandler::SetValueFromDom(node);
+
         auto oldAction = m_action;
         m_action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
 
-        if (m_action != oldAction)
+        if (m_action == oldAction)
         {
-            switch (m_action)
+            return;
+        }
+
+        switch (m_action)
+        {
+        case ContainerAction::AddElement:
             {
-            case ContainerAction::None:
-                AZ_Error("DPE", false, "ContainerActionButtonHandler::SetValueFromDom passed invalid action!");
-                break;
-            case ContainerAction::AddElement:
                 setIcon(s_iconAdd);
                 setToolTip("Add new child element");
                 break;
-            case ContainerAction::RemoveElement:
+            }
+        case ContainerAction::RemoveElement:
+            {
                 setIcon(s_iconRemove);
                 setToolTip(tr("Remove this element"));
                 break;
-            case ContainerAction::Clear:
+            }
+        case ContainerAction::Clear:
+            {
                 setIcon(s_iconClear);
                 setToolTip(tr("Remove all elements"));
                 break;
-            case ContainerAction::MoveUp:
+            }
+        case ContainerAction::MoveUp:
+            {
                 setIcon(s_iconUp);
                 setToolTip(tr("move this element up"));
                 break;
-            case ContainerAction::MoveDown:
+            }
+        case ContainerAction::MoveDown:
+            {
                 setIcon(s_iconDown);
                 setToolTip(tr("move this element down"));
+                break;
+            }
+        case ContainerAction::None:
+        default:
+            {
+                AZ_Error("DPE", false, "ContainerActionButtonHandler::SetValueFromDom passed invalid action!");
                 break;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -29,30 +29,43 @@ namespace AzToolsFramework
         using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
         using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
 
+        auto oldAction = m_action;
         m_action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
-        switch (m_action)
+
+        if (m_action != oldAction)
         {
-        case ContainerAction::AddElement:
-            setIcon(s_iconAdd);
-            setToolTip("Add new child element");
-            break;
-        case ContainerAction::RemoveElement:
-            setIcon(s_iconRemove);
-            setToolTip(tr("Remove this element"));
-            break;
-        case ContainerAction::Clear:
-            setIcon(s_iconClear);
-            setToolTip(tr("Remove all elements"));
-            break;
-        case ContainerAction::MoveUp:
-            setIcon(s_iconUp);
-            setToolTip(tr("move this element up"));
-            break;
-        case ContainerAction::MoveDown:
-            setIcon(s_iconDown);
-            setToolTip(tr("move this element down"));
-            break;
+            switch (m_action)
+            {
+            case ContainerAction::None:
+                AZ_Error("DPE", false, "ContainerActionButtonHandler::SetValueFromDom passed invalid action!");
+                break;
+            case ContainerAction::AddElement:
+                setIcon(s_iconAdd);
+                setToolTip("Add new child element");
+                break;
+            case ContainerAction::RemoveElement:
+                setIcon(s_iconRemove);
+                setToolTip(tr("Remove this element"));
+                break;
+            case ContainerAction::Clear:
+                setIcon(s_iconClear);
+                setToolTip(tr("Remove all elements"));
+                break;
+            case ContainerAction::MoveUp:
+                setIcon(s_iconUp);
+                setToolTip(tr("move this element up"));
+                break;
+            case ContainerAction::MoveDown:
+                setIcon(s_iconDown);
+                setToolTip(tr("move this element down"));
+                break;
+            }
         }
+    }
+
+    bool ContainerActionButtonHandler::ResetToDefaults()
+    {
+        return GenericButtonHandler::ResetToDefaults();
     }
 
     void ContainerActionButtonHandler::OnClicked()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
@@ -18,6 +18,7 @@ namespace AzToolsFramework
         ContainerActionButtonHandler();
 
         void SetValueFromDom(const AZ::Dom::Value& node) override;
+        virtual bool ResetToDefaults() override;
 
         static constexpr const AZStd::string_view GetHandlerName()
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -70,7 +70,7 @@ namespace AzToolsFramework
         m_expanded = true;
         delete m_expanderWidget;
         m_expanderWidget = nullptr;
-        m_sharePriorColumn.clear();
+        m_columnStarts.clear();
         m_cachedLayoutSize = QSize();
         m_cachedMinLayoutSize = QSize();
         for (int index = count(); index > 0; --index)
@@ -201,171 +201,206 @@ namespace AzToolsFramework
         QLayout::setGeometry(rect);
 
         // todo: implement QSplitter-like functionality to allow the user to resize columns within a DPE
+        
+        // Determine the number of columns.
+        const int columnCount = m_columnStarts.size();
 
-        //! Treat all widgets in a shared column as one item.
-        //! Sum all the widgets, but remove all shared widgets other than the first widget of each shared column.
-        const int itemCount = count();
-        const int effectiveCount = itemCount - SharedWidgetCount() + static_cast<int>(m_sharePriorColumn.size());
-
-        if (effectiveCount > 0)
+        // Early out if no columns are detected.
+        if (columnCount == 0)
         {
-            // divide evenly, unless there are 2 columns, in which case follow the 2/5ths rule here:
-            // https://www.o3de.org/docs/tools-ui/ux-patterns/component-card/overview/
-            const int perItemWidth = (effectiveCount == 2 ? (rect.width() * 3) / 5 : rect.width() / effectiveCount);
+            return;
+        }
 
-            // special case the first item to handle indent and the 2/5ths rule
-            constexpr int indentSize = 15; // child indent of first item, in pixels
-            QRect itemGeometry(rect);
-            itemGeometry.setRight(effectiveCount == 2 ? itemGeometry.width() - perItemWidth : perItemWidth);
-            itemGeometry.setLeft(itemGeometry.left() + (m_depth * indentSize));
+        // Divide horizontal space evenly, unless there are 2 columns, in which case follow the 2/5ths rule here:
+        // https://www.o3de.org/docs/tools-ui/ux-patterns/component-card/overview/
+        const int columnWidth = (columnCount == 2 ? (rect.width() * 3) / 5 : rect.width() / columnCount);
 
-            if (m_showExpander)
+        // special case the first item to handle indent and the 2/5ths rule
+        constexpr int indentSize = 15; // child indent of first item, in pixels
+        QRect itemGeometry(rect);
+        itemGeometry.setRight(columnCount == 2 ? itemGeometry.width() - columnWidth : columnWidth);
+        itemGeometry.setLeft(itemGeometry.left() + (m_depth * indentSize));
+
+        // Show Expander if needed.
+        if (m_showExpander)
+        {
+            if (!m_expanderWidget)
             {
-                if (!m_expanderWidget)
+                CreateExpanderWidget();
+            }
+
+            m_expanderWidget->move(itemGeometry.topLeft());
+
+            if (auto* widgetParent = parentWidget(); widgetParent && widgetParent->isVisible())
+            {
+                m_expanderWidget->show();
+            }
+        }
+
+        // Leave space for Expander even if it's not there.
+        constexpr int expanderSpace = 16;
+        itemGeometry.setLeft(itemGeometry.left() + expanderSpace);
+
+        // Helper variables for column handling
+        QHBoxLayout* currentColumnLayout = nullptr;
+        int currentColumnCount = 0;
+        int currentColumnWidgetsCount = 0;
+        int currentColumnNonStretchedWidgetsCount = 0;
+        bool isFirstColumn = true;
+
+        // Store spacing info from last element of each column.
+        bool startSpacer = false;
+        bool endSpacer = false;
+
+        // Loop through all items one by one.
+        auto* myRow = GetRow();
+        const int itemCount = count();
+        for (int itemIndex = 0; itemIndex < itemCount; ++itemIndex)
+        {
+            auto* currentItem = itemAt(itemIndex);
+            auto* currentWidget = currentItem->widget();
+
+            // Only handle widgets here.
+            if (currentWidget == nullptr)
+            {
+                if (currentColumnLayout)
                 {
-                    CreateExpanderWidget();
+                    currentColumnLayout->addItem(currentItem);
                 }
-                m_expanderWidget->move(itemGeometry.topLeft());
-                if (auto* widgetParent = parentWidget(); widgetParent && widgetParent->isVisible())
+                continue;
+            }
+
+            // Retrieve the dom index for this widget, which is what is used in m_columnStarts.
+            auto domIndex = myRow->GetDomIndexOfChild(currentWidget);
+            AZ_Assert(domIndex != -1, "widget in layout was not found in row's dom list!");
+
+            // Retrieve attributes.
+            AzToolsFramework::DPERowWidget::AttributeInfo* domAttributes = myRow->GetCachedAttributes(domIndex);
+
+            // Save the alignment of the last widget in the shared column with an alignment attribute
+            if (domAttributes)
+            {
+                switch (domAttributes->m_alignment)
                 {
-                    m_expanderWidget->show();
+                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignLeft:
+                    {
+                        endSpacer = true;
+                        break;
+                    }
+                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignCenter:
+                    {
+                        startSpacer = true;
+                        endSpacer = true;
+                        break;
+                    }
+                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight:
+                    {
+                        startSpacer = true;
+                        break;
+                    }
+                default:
+                    break;
                 }
             }
 
-            // space to leave for expander, whether it's there or not
-            constexpr int expanderSpace = 16;
-            itemGeometry.setLeft(itemGeometry.left() + expanderSpace);
-
-            // used to iterate through the vector containing a shared column's first widget and size
-            auto* myRow = GetRow();
-            int sharedVectorIndex = 0;
-            // iterate over each item, laying them left to right
-            int layoutIndex = 0;
-            while (layoutIndex < itemCount)
+            // If the current widget is the first widget of a column, create the shared column layour and add widgets to it.
+            // First widget always creates a column.
+            if (m_columnStarts.contains(domIndex) || isFirstColumn)
             {
-                auto* currentItem = itemAt(layoutIndex);
-                auto* currentWidget = currentItem->widget();
-                if (currentWidget)
+                // Close previous column.
+                if (!isFirstColumn)
                 {
-                    auto domIndex = myRow->GetDomIndexOfChild(currentWidget);
-                    AZ_Assert(domIndex != -1, "widget in layout was not found in row's dom list!");
-
-                    AzToolsFramework::DPERowWidget::AttributeInfo* attributes = myRow->GetCachedAttributes(domIndex);
-
-                    //! If the current widget is the first widget of a shared column, create the shared column layout and add widgets to it
-                    if (sharedVectorIndex < m_sharePriorColumn.size() &&
-                        domIndex == static_cast<int>(m_sharePriorColumn[sharedVectorIndex][0]))
+                    // if all widgets in this shared column take up only their minimum width, set the appropriate alignment with spacers
+                    if (currentColumnNonStretchedWidgetsCount == currentColumnWidgetsCount)
                     {
-                        QHBoxLayout* sharedColumnLayout = new QHBoxLayout;
-                        const int numItems = static_cast<int>(m_sharePriorColumn[sharedVectorIndex].size());
-                        int sharedWidgetIndex = 0;
-                        // values used to remember the alignment of each widget
-                        bool startSpacer = false, endSpacer = false;
-                        // number of widgets that should be set to their minimum size
-                        int minWidthCount = 0;
-
-                        // Iterate over each item in the current shared column, adding them to a single layout
-                        while (sharedWidgetIndex < numItems)
+                        QSpacerItem* spacer = new QSpacerItem(columnWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
+                        if (startSpacer)
                         {
-                            domIndex = aznumeric_cast<int>(m_sharePriorColumn[sharedVectorIndex][sharedWidgetIndex]);
-                            attributes = myRow->GetCachedAttributes(domIndex);
-                            // Save the alignment of the last widget in the shared column with an alignment attribute
-                            if (attributes)
-                            {
-                                switch (attributes->m_alignment)
-                                {
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignLeft:
-                                    startSpacer = false;
-                                    endSpacer = true;
-                                    break;
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignCenter:
-                                    startSpacer = true;
-                                    endSpacer = true;
-                                    break;
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight:
-                                    startSpacer = true;
-                                    endSpacer = false;
-                                    break;
-                                }
-                            }
-                            auto* itemToAdd = itemAt(layoutIndex + sharedWidgetIndex);
-                            AZ_Assert(itemToAdd, "layout item not found!");
-                            sharedColumnLayout->addItem(itemToAdd);
-
-                            // If a widget should only take up its minimum width, do not stretch it
-                            if (attributes && attributes->m_minimumWidth)
-                            {
-                                minWidthCount++;
-                            }
-                            else
-                            {
-                                sharedColumnLayout->setStretch(sharedColumnLayout->count() - 1, 1);
-                            }
-                            sharedWidgetIndex++;
+                            currentColumnLayout->insertSpacerItem(0, spacer);
                         }
-
-                        // if all widgets in this shared column take up only their minimum width, set the appropriate alignment with spacers
-                        if (minWidthCount == numItems)
+                        if (endSpacer)
                         {
-                            QSpacerItem* spacer = new QSpacerItem(perItemWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
-                            if (startSpacer)
-                            {
-                                sharedColumnLayout->insertSpacerItem(0, spacer);
-                            }
-                            if (endSpacer)
-                            {
-                                sharedColumnLayout->addSpacerItem(spacer);
-                            }
+                            currentColumnLayout->addSpacerItem(spacer);
                         }
-
-                        // Special case if this is the first column in a row
-                        if (layoutIndex == 0)
-                        {
-                            sharedColumnLayout->setGeometry(itemGeometry);
-                        }
-                        else
-                        {
-                            itemGeometry.setLeft(itemGeometry.right() + 1);
-                            itemGeometry.setRight(itemGeometry.left() + perItemWidth);
-                            sharedColumnLayout->setGeometry(itemGeometry);
-                        }
-                        ++sharedVectorIndex;
-                        // Increase the layout index by the amount of widgets in the shared column we have iterated over
-                        layoutIndex += sharedWidgetIndex;
                     }
-                    // Widget is not in a shared column, lay it individually with its appropriate alignment
+
+                    // Correctly set the geometry based on the column.
+                    if (currentColumnCount == 0)
+                    {
+                        currentColumnLayout->setGeometry(itemGeometry);
+                    }
                     else
                     {
-                        if (layoutIndex == 0)
-                        {
-                            itemAt(layoutIndex)->setGeometry(itemGeometry);
-                        }
-                        else
-                        {
-                            auto* currItem = itemAt(layoutIndex);
-                            itemGeometry.setLeft(itemGeometry.right() + 1);
-                            itemGeometry.setRight(itemGeometry.left() + perItemWidth);
-                            if (attributes)
-                            {
-                                switch (attributes->m_alignment)
-                                {
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignLeft:
-                                    currItem->setAlignment(Qt::AlignLeft);
-                                    break;
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignCenter:
-                                    currItem->setAlignment(Qt::AlignCenter);
-                                    break;
-                                case AZ::Dpe::Nodes::PropertyEditor::Align::AlignRight:
-                                    currItem->setAlignment(Qt::AlignRight);
-                                    break;
-                                }
-                            }
-                            currItem->setGeometry(itemGeometry);
-                        }
-                        layoutIndex++;
+                        itemGeometry.setLeft(itemGeometry.right() + 1);
+                        itemGeometry.setRight(itemGeometry.left() + columnWidth);
+                        currentColumnLayout->setGeometry(itemGeometry);
                     }
+
+                    // Count completed columns.
+                    ++currentColumnCount;
+                }
+
+                // Create new column.
+                currentColumnLayout = new QHBoxLayout;
+                currentColumnWidgetsCount = 0;
+                currentColumnNonStretchedWidgetsCount = 0;
+                startSpacer = false;
+                endSpacer = false;
+
+                if (isFirstColumn)
+                {
+                    isFirstColumn = false;
                 }
             }
+
+            // Add widget to column
+            currentColumnLayout->addItem(currentItem);
+
+            // If a widget should only take up its minimum width, do not stretch it
+            if (domAttributes && domAttributes->m_minimumWidth)
+            {
+                ++currentColumnNonStretchedWidgetsCount;
+            }
+            else
+            {
+                currentColumnLayout->setStretch(currentColumnLayout->count() - 1, 1);
+            }
+
+            ++currentColumnWidgetsCount;
+        }
+
+        // Close the last column
+        // TODO - Avoid repeated code...
+        // TODO - Check for edge cases of already closed column just in case...
+        {
+            // if all widgets in this shared column take up only their minimum width, set the appropriate alignment with spacers
+            if (currentColumnNonStretchedWidgetsCount == currentColumnWidgetsCount)
+            {
+                QSpacerItem* spacer = new QSpacerItem(columnWidth, 1, QSizePolicy::Expanding, QSizePolicy::Fixed);
+                if (startSpacer)
+                {
+                    currentColumnLayout->insertSpacerItem(0, spacer);
+                }
+                if (endSpacer)
+                {
+                    currentColumnLayout->addSpacerItem(spacer);
+                }
+            }
+
+            // Correctly set the geometry based on the column.
+            if (currentColumnCount == 0)
+            {
+                currentColumnLayout->setGeometry(itemGeometry);
+            }
+            else
+            {
+                itemGeometry.setLeft(itemGeometry.right() + 1);
+                itemGeometry.setRight(itemGeometry.left() + columnWidth);
+                currentColumnLayout->setGeometry(itemGeometry);
+            }
+
+            // Count completed columns.
+            ++currentColumnCount;
         }
     }
 
@@ -392,97 +427,9 @@ namespace AzToolsFramework
         connect(m_expanderWidget, &QCheckBox::stateChanged, this, &DPELayout::onCheckstateChanged);
     }
 
-    void DPELayout::AddSharePriorColumn(size_t previousIndex, size_t widgetIndex)
+    void DPELayout::SetAsStartOfNewColumn(size_t widgetIndex)
     {
-        // Add to an existing sharePrior group if the previous widget's index is already there, otherwise create a new group
-        if (!m_sharePriorColumn.empty() && m_sharePriorColumn.back().back() == previousIndex)
-        {
-            m_sharePriorColumn.back().push_back(widgetIndex);
-        }
-        else
-        {
-            AZStd::vector<size_t> newEntry;
-            newEntry.push_back(previousIndex);
-            newEntry.push_back(widgetIndex);
-            m_sharePriorColumn.push_back(newEntry);
-        }
-    }
-
-    void DPELayout::RemoveSharePriorColumn(size_t widgetIndex)
-    {
-        for (auto groupIt = m_sharePriorColumn.begin(); groupIt != m_sharePriorColumn.end(); ++groupIt)
-        {
-            AZStd::vector<size_t> currentGroup = *groupIt;
-            for (int currentGroupIndex = 0; currentGroupIndex < currentGroup.size(); currentGroupIndex++)
-            {
-                if (widgetIndex != currentGroup[currentGroupIndex])
-                {
-                    continue;
-                }
-                else
-                {
-                    if (currentGroupIndex == currentGroup.size() - 1)
-                    {
-                        // If we are removing from shared group of 2 or less, erase the group
-                        if (currentGroup.size() <= 2)
-                        {
-                            m_sharePriorColumn.erase(groupIt);
-                            return;
-                        }
-                        // Group size is bigger than 2 and widget is at the end of the group, so just remove it
-                        else
-                        {
-                            currentGroup.erase(currentGroup.begin() + currentGroupIndex);
-                            return;
-                        }
-                    }
-                    // If the widget is the second member of the group, remove the first widget in the group
-                    else if (currentGroupIndex == 1)
-                    {
-                        currentGroup.erase(currentGroup.begin());
-                        return;
-                    }
-                    //! The widget being removed is in the middle of a sharedGroup,
-                    //! Create a vector of all the widgets in the group until you reach the element to be removed from the group
-                    //! Create a new group of all the elements in the group after the element to be removed
-                    else if (currentGroupIndex != 0)
-                    {
-                        AZStd::vector<size_t> oldGroup;
-                        AZStd::vector<size_t> newGroup;
-                        bool switchGroups = false;
-                        for (int elementIt = 0; elementIt < currentGroup.size(); elementIt++)
-                        {
-                            if (elementIt == currentGroupIndex)
-                            {
-                                switchGroups = true;
-                            }
-                            if (!switchGroups)
-                            {
-                                oldGroup.emplace_back(currentGroup[elementIt]);
-                            }
-                            else
-                            {
-                                newGroup.emplace_back(currentGroup[elementIt]);
-                            }
-                        }
-                        m_sharePriorColumn.insert(groupIt + 1, newGroup);
-                        currentGroup.swap(oldGroup);
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    // Returns the total number of widgets in all shared columns.
-    int DPELayout::SharedWidgetCount()
-    {
-        int numWidgets = 0;
-        for (int currentGroup = 0; currentGroup < m_sharePriorColumn.size(); currentGroup++)
-        {
-            numWidgets = numWidgets + static_cast<int>(m_sharePriorColumn[currentGroup].size());
-        }
-        return numWidgets;
+        m_columnStarts.insert(widgetIndex);
     }
 
     DPERowWidget::DPERowWidget()
@@ -730,26 +677,9 @@ namespace AzToolsFramework
         updatedLayoutAttributes.m_minimumWidth =
             AZ::Dpe::Nodes::PropertyEditor::UseMinimumWidth.ExtractFromDomNode(domArray).value_or(false);
 
-        if (updatedLayoutAttributes.m_sharePriorColumn)
+        if (!updatedLayoutAttributes.m_sharePriorColumn)
         {
-            // Check for a widget in the previous column
-            int priorColumnDomIndex = -1;
-            for (int searchIndex = static_cast<int>(domIndex) - 1; (priorColumnDomIndex == -1 && searchIndex >= 0); --searchIndex)
-            {
-                if (m_columnLayout->indexOf(m_domOrderedChildren[searchIndex]) != -1)
-                {
-                    priorColumnDomIndex = searchIndex;
-                }
-            }
-            AZ_Error("DocumentPropertyEditor", priorColumnDomIndex != -1, "Tried to share column with an out of bounds index!");
-            if (priorColumnDomIndex != -1)
-            {
-                m_columnLayout->AddSharePriorColumn(priorColumnDomIndex, domIndex);
-            }
-        }
-        else
-        {
-            m_columnLayout->RemoveSharePriorColumn(domIndex);
+            m_columnLayout->SetAsStartOfNewColumn(domIndex);
         }
 
         // Remove any cached attribute info that is default, else cache it for the layout to use.
@@ -796,24 +726,22 @@ namespace AzToolsFramework
         if (foundEntry != m_childIndexToCachedAttributeInfo.end())
         {
             m_childIndexToCachedAttributeInfo.erase(foundEntry);
-            m_columnLayout->RemoveSharePriorColumn(domIndex);
+            m_columnLayout->m_columnStarts.erase(domIndex);
         }
     }
 
     void DPERowWidget::ClearCachedAttributes()
     {
         m_childIndexToCachedAttributeInfo.clear();
-        for (AZStd::vector<size_t> sharedGroup : m_columnLayout->m_sharePriorColumn)
-        {
-            sharedGroup.clear();
-        }
-        m_columnLayout->m_sharePriorColumn.clear();
+        m_columnLayout->m_columnStarts.clear();
     }
 
     void DPERowWidget::HandleOperationAtPath(const AZ::Dom::PatchOperation& domOperation, size_t pathIndex)
     {
         if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Move)
         {
+            AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Move");
+
             /* For a move operation, note that source and/or destination widgets might not exist due to collapsed nodes.
              * if both source and destination location exist, move the existing widget
              * if source exists but not destination, it's a remove
@@ -930,12 +858,14 @@ namespace AzToolsFramework
                 if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Remove ||
                     domOperation.GetType() == AZ::Dom::PatchOperation::Type::Replace)
                 {
+                    AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Remove");
                     RemoveChildAt(childIndex);
                 }
 
                 if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Replace ||
                     domOperation.GetType() == AZ::Dom::PatchOperation::Type::Add)
                 {
+                    AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Add");
                     AddChildFromDomValue(domOperation.GetValue(), childIndex);
                 }
             }
@@ -1012,7 +942,8 @@ namespace AzToolsFramework
                             childWidget->hide();
                             m_columnLayout->removeWidget(childWidget);
                             DocumentPropertyEditor::ReleaseHandler(handlerInfo);
-                            m_columnLayout->RemoveSharePriorColumn(childIndex);
+                            // TODO - Check if we still need something here!
+                            //m_columnLayout->RemoveSharePriorColumn(childIndex);
 
                             // Replace the existing handler widget with one appropriate for the new type
                             auto replacementWidget = theDPE->CreateWidgetForHandler(handlerId, valueAtSubPath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -733,8 +733,6 @@ namespace AzToolsFramework
     {
         if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Move)
         {
-            AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Move");
-
             /* For a move operation, note that source and/or destination widgets might not exist due to collapsed nodes.
              * if both source and destination location exist, move the existing widget
              * if source exists but not destination, it's a remove
@@ -851,14 +849,12 @@ namespace AzToolsFramework
                 if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Remove ||
                     domOperation.GetType() == AZ::Dom::PatchOperation::Type::Replace)
                 {
-                    AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Remove");
                     RemoveChildAt(childIndex);
                 }
 
                 if (domOperation.GetType() == AZ::Dom::PatchOperation::Type::Replace ||
                     domOperation.GetType() == AZ::Dom::PatchOperation::Type::Add)
                 {
-                    AZ_TracePrintf("HandleOperationAtPath", "PatchOperation::Type::Add");
                     AddChildFromDomValue(domOperation.GetValue(), childIndex);
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -338,7 +338,7 @@ namespace AzToolsFramework
                 }
             }
 
-            // If the current widget is the first widget of a column, create the shared column layour and add widgets to it.
+            // If the current widget is the first widget of a column, create the shared column layout and add widgets to it.
             // First widget always creates a column.
             if (m_columnStarts.contains(domIndex) || isFirstColumn)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -80,6 +80,16 @@ namespace AzToolsFramework
         AZStd::unordered_set<size_t> m_columnStarts;
 
     private:
+        void CloseColumn(
+            QHBoxLayout* currentColumnLayout,
+            QRect& itemGeometry,
+            int& currentColumnCount,
+            const int columnWidth,
+            bool allWidgetsUnstretched,
+            bool startSpacer,
+            bool endSpacer
+        );
+
         // These cached sizes must be mutable since they are set inside of an overidden const function
         mutable QSize m_cachedLayoutSize;
         mutable QSize m_cachedMinLayoutSize;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Instance/InstancePool.h>
+#include <AzCore/std/containers/unordered_set.h>
 #include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
 #include <AzFramework/DocumentPropertyEditor/ExpanderSettings.h>
 #include <AzQtComponents/Components/Widgets/ElidingLabel.h>
@@ -53,9 +54,7 @@ namespace AzToolsFramework
         void SetExpanded(bool expanded);
         bool IsExpanded() const;
 
-        void AddSharePriorColumn(size_t previousIndex, size_t widgetIndex);
-        void RemoveSharePriorColumn(size_t widgetIndex);
-        int SharedWidgetCount();
+        void SetAsStartOfNewColumn(size_t widgetIndex);
 
         // QLayout overrides
         void invalidate() override;
@@ -77,9 +76,8 @@ namespace AzToolsFramework
         bool m_expanded = true;
         QCheckBox* m_expanderWidget = nullptr;
 
-        //! Vector containing vectors of widgets, where each vector represents a unique shared column group.
-        //! Each widget in a vector will be a widget that belongs to that shared column group.
-        AZStd::vector<AZStd::vector<size_t>> m_sharePriorColumn;
+        // Contains the indices of all widgets that start a new column.
+        AZStd::unordered_set<size_t> m_columnStarts;
 
     private:
         // These cached sizes must be mutable since they are set inside of an overidden const function

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
@@ -19,7 +19,12 @@ namespace AzToolsFramework
     public:
         GenericButtonHandler();
 
-        virtual void SetValueFromDom(const AZ::Dom::Value& node);
+        virtual void SetValueFromDom(const AZ::Dom::Value& node) override;
+        virtual bool ResetToDefaults() override
+        {
+            m_node.SetNull();
+            return true;
+        }
 
         static constexpr const AZStd::string_view GetHandlerName()
         {


### PR DESCRIPTION
Fixes #17275

Rewrites the DPE Layout class to be more straightforward, since the missing refreshes were due to edge cases tied to overly complex logic.
Verified that the new code fixes issues like buttons and labels disappearing when clearing containers.
Some container bugs are still present, but they were verified to be unrelated to this change and will be addressed separately.

![dpeClearAllFix](https://github.com/o3de/o3de/assets/82231674/8e08ea5f-21a2-4840-8ba6-3c631e46851d)