### PR TITLE
Fix missing Include folder error in SDK

### DIFF
--- a/Gems/RemoteTools/Code/CMakeLists.txt
+++ b/Gems/RemoteTools/Code/CMakeLists.txt
@@ -33,7 +33,6 @@ ly_add_target(
         O3DE_PRIVATE_TARGET TRUE
     INCLUDE_DIRECTORIES
         PRIVATE
-            Include
             Source
     BUILD_DEPENDENCIES
         PUBLIC
@@ -56,8 +55,6 @@ ly_add_target(
         remotetools_shared_files.cmake
         ${pal_dir}/remotetools_shared_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
     INCLUDE_DIRECTORIES
-        PUBLIC
-            Include
         PRIVATE
             Source
     BUILD_DEPENDENCIES


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/17474

The Include folder is empty/missing and not needed in the RemoteTools gem, and CMake treats this as an error when trying to generate a project from the SDK with this gem active.

## How was this PR tested?

- built the RemoteTools targets after modifying the CMakeLists to ensure it still compiles
