### PR TITLE
Add quality settings to default project template

### DIFF
--- a/Templates/DefaultProject/Template/Registry/Platform/Android/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/Platform/Android/quality.setreg
@@ -1,0 +1,67 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Android platform specific quality setting overrides go in this file 
+            "Groups": {
+                "q_general": {
+                    "Default": 1 // override the default level for this platform to be medium
+                },
+                "q_graphics": {
+                    "Default": 1, // override the default level for this platform to be medium
+                    "Settings": {
+                        // Setting overrides can be specified using an array to assign values to
+                        // quality levels. For example if you have 4 quality levels:
+                        // "<cvar>": [<low setting>, <medium setting>, <high setting>, <veryhigh setting>]
+                        // "r_skinnedMeshInstanceMemoryPoolSize": [64, 96, 128, 256] 
+                        // Or you can use a single value for all levels, for example:
+                        // "r_skinnedMeshInstanceMemoryPoolSize": 96 
+                        "r_renderScale": [0.7, 0.8, 0.9, 1.0]
+                    }
+                },
+                "q_shadows": {
+                    "Settings": {
+                        // Shadows console variable setting overrides go here
+                    }
+                }
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for this platform go here 
+                // Device rule groups can have whatever name makes sense to you
+                "DeviceRulesLow": {
+                    "Rules": {
+                        // Device rules are regular expressions
+                        // Rule matching Pixel 3 - 6 
+                        "DeviceModelLow": { "DeviceModel": "^Pixel [3-6]\D*$" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level to low
+                        "q_general": 0 
+                        // For example, to change a specific setting
+                        // "r_skinnedMeshInstanceMemoryPoolSize":  64
+                    }
+                },
+                "DeviceRulesHigh": {
+                    "Rules": {
+                        // Device rules are regular expressions, only one of these rules needs to match
+                        // Rule matching Pixel 8
+                        "PixelModelsHigh": { "DeviceModel": "^Pixel 8\D*$" },
+                        // Rule matching Galaxy S23 models
+                        "GalaxyS23Models": { "DeviceModel": "^(SC-51D|SCG19|SM-S911.*)$" },
+                        "GalaxyS23FEModels": { "DeviceModel": "^SM-S71.*$" },
+                        "GalaxyS23UltraModels": { "DeviceModel": "^(SC-52D|SCG20|SM-S918.*)$" },
+                        "GalaxyS23PlusModels": { "DeviceModel": "^SM-S916.*$" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level for the device to high
+                        "q_general": 2 
+                        // For example, to change a specific setting
+                        // "r_skinnedMeshInstanceMemoryPoolSize":  64
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/Platform/Linux/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/Platform/Linux/quality.setreg
@@ -1,0 +1,25 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Linux platform specific quality setting overrides go in this file 
+            "Groups": {
+                "q_general": {
+                    "Default": 0 // override the default level for this platform to be low 
+                }
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for this platform go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/Platform/Mac/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/Platform/Mac/quality.setreg
@@ -1,0 +1,26 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Mac platform specific quality setting overrides go in this file 
+            "Groups": {
+                // Example of how to override the default quality level for this platform to be high
+                //"q_general": {
+                //    "Default": 2  
+                //}
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for this platform go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/Platform/Windows/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/Platform/Windows/quality.setreg
@@ -1,0 +1,26 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Windows platform specific quality setting overrides go in this file 
+            "Groups": {
+                // Example of how to override the default quality level for this platform to be high
+                //"q_general": {
+                //    "Default": 2  
+                //}
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for this platform go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/Platform/iOS/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/Platform/iOS/quality.setreg
@@ -1,0 +1,84 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Platform specific quality setting overrides go in this file 
+            "Groups": {
+                "q_general": {
+                    "Default": 1 // override the default level for this platform to be medium
+                },
+                "q_graphics": {
+                    "Default": 1, // override the default level for this platform to be medium
+                    "Settings": {
+                        // Setting overrides can be specified using an array to assign values to
+                        // quality levels. For example if you have 4 quality levels:
+                        // "<cvar>": [<low setting>, <medium setting>, <high setting>, <veryhigh setting>]
+                        // "r_skinnedMeshInstanceMemoryPoolSize": [64, 96, 128, 256] 
+                        // Or you can use a single value for all levels, for example:
+                        // "r_skinnedMeshInstanceMemoryPoolSize": 96 
+                        "r_renderScale": [0.7, 0.8, 0.9, 1.0]
+                    }
+                },
+                "q_shadows": {
+                    "Settings": {
+                        // Shadows console variable setting overrides go here
+                    }
+                }
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for this platform go here 
+                // Device rule groups can have whatever name makes sense to you
+                "iPhoneLow": {
+                    "Rules": {
+                        // Device rules are regular expressions
+                        // Rule matching iPhone10,1 (iPhone 8) - iPhone 11,8 (iPhone XR)
+                        "DeviceModelIphone10_11": { "DeviceModel": "iPhone(1[0-1].*)" },
+                        "DeviceModelIphone6_8": { "DeviceModel": "iPhone([6-8].*)" },
+                        "DeviceModelIPad4_6": { "DeviceModel": "iPad([4-6].*)" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level to low (i.e setting 0)
+                        "q_general": 0
+                        // For example, to change a specific setting
+                        // "r_skinnedMeshInstanceMemoryPoolSize":  64
+                    }
+                },
+                "iPhoneMedium": {
+                    "Rules": {
+                        "DeviceModelIphone12_13": { "DeviceModel": "iPhone(1[2-3].*)" },
+                        "DeviceModelIpad7": { "DeviceModel": "iPad(7.*)" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level to medium (i.e setting 1)
+                        "q_general": 1
+                    }
+                },
+                "iPhoneHigh": {
+                    "Rules": {
+                        // Device rules are regular expressions
+                        "DeviceModelIphone14": { "DeviceModel": "iPhone(14.*)" },
+                        "DeviceModelIpad8_9": { "DeviceModel": "iPad([8-9].*)" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level for the device to high (i.e setting 2)
+                        "q_general": 2
+                    }
+                },
+                "iPhoneVeryHigh": {
+                    "Rules": {
+                        // Device rules are regular expressions
+                        "DeviceModelIphone15_16": { "DeviceModel": "iPhone(15,[4-5]|16,[1-9])" }
+                    },
+                    "Settings": {
+                        // Device cvar quality overrides go here for this rule
+                        // Change the general quality level for the device to very high (i.e setting 3)
+                        "q_general": 3
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/quality.client.setreg
+++ b/Templates/DefaultProject/Template/Registry/quality.client.setreg
@@ -1,0 +1,27 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Client specific quality setting overrides go in this file 
+            // See Registry/quality.setreg for more details
+            "Groups": {
+                // Example of how to override the default quality level for clients to be high
+                //"q_general": {
+                //    "Default": 2  
+                //}
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for clients go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/quality.headless.setreg
+++ b/Templates/DefaultProject/Template/Registry/quality.headless.setreg
@@ -1,0 +1,27 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Headless server specific quality setting overrides go in this file 
+            // See Registry/quality.setreg for more details
+            "Groups": {
+                // Example of how to override the default quality level for headelss to be low
+                //"q_general": {
+                //    "Default": 0  
+                //}
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for headless servers go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/quality.server.setreg
+++ b/Templates/DefaultProject/Template/Registry/quality.server.setreg
@@ -1,0 +1,27 @@
+{
+    "O3DE": {
+        "Quality": {
+            // Server specific quality setting overrides go in this file 
+            // See Registry/quality.setreg for more details
+            "Groups": {
+                // Example of how to override the default quality level for server to be low
+                //"q_general": {
+                //    "Default": 0  
+                //}
+                // Additional custom quality groups overrides go here. 
+            },
+            "Devices": {
+                // Device rules for servers go here 
+                // Device rule groups can have whatever name makes sense to you
+                //"Example": {
+                //    "Rules": {
+                //        "ExampleRegexRule": { "DeviceModel": "^ModelRegex$" }
+                //    },
+                //    "Settings": {
+                //        "q_general": 0 
+                //    }
+                //}
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/Template/Registry/quality.setreg
+++ b/Templates/DefaultProject/Template/Registry/quality.setreg
@@ -1,0 +1,56 @@
+{
+    "O3DE": {
+        "Quality": {
+            // NOTE: All text on a line following // are comments and ignored by the JSON parser.
+            // This makes it possible to include your favorite ASCII art in your .setreg files.
+            //
+            // Base quality settings for every platform go in this file.
+            // Platform specific overrides can be found in Registry/Platform/<platform>/quality.setreg
+            // e.g. iOS overrides go in Registry/Platform/iOS/quality.setreg
+            "Groups": {
+                // Each quality setting key (q_general, q_graphics etc.) is accessible as a CVAR 
+                // at runtime.  You can change a quality group level at runtime in the console 
+                // using the key and new level you want to use.  For example, to change the 
+                // q_general level to 3 at runtime, you can run the following console command:
+                //   q_general 3
+                "q_general": {
+                    "Description" : "Default quality group. 0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [ "Low", "Medium", "High", "VeryHigh" ],
+                    "Default": 3,
+                    "Settings": {
+                        "q_graphics": [ 0, 1, 2, 3 ] // map q_general levels 1 to 1 with graphics levels
+                    }
+                },
+                "q_graphics": {
+                    "Description": "Graphics quality settings.  0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [ "Low", "Medium", "High", "VeryHigh" ],
+                    "Default": 3,
+                    "Settings": {
+                        "q_shadows": [ 0, 1, 2, 3 ],
+                        // Settings can be specified using an array to assign values to
+                        // quality levels. For example if you have 4 quality levels:
+                        // "<cvar>": [<low setting>, <medium setting>, <high setting>, <veryhigh setting>]
+                        // "r_skinnedMeshInstanceMemoryPoolSize": [64, 96, 128, 256] 
+                        // Or you can use a single value for all levels, for example:
+                        // "r_skinnedMeshInstanceMemoryPoolSize": 96 
+                        // Example of how to enable mesh instancing:
+                        // "r_meshInstancingEnabled": true,
+                        // "r_meshInstancingEnabledForTransparentObjects": true
+                    }
+                },
+                "q_shadows": {
+                    "Description": "Shadow quality settings.  0 : Low, 1 : Medium, 2 : High, 3 : VeryHigh",
+                    "Levels": [ "Low", "Medium", "High", "VeryHigh" ],
+                    "Settings": {
+                        // Shadows console variable settings go here for example:
+                        // The amount of meters to extrude the Obb towards light 
+                        // direction when doing camera frustum overlap tests
+                        // "r_shadowCascadeExtrusionAmount": [10, -1, -1, -1]
+                    }
+                }
+                // Additional custom quality groups can be defined as desired,
+                // preferably with a 'q_' prefix.
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/template.json
+++ b/Templates/DefaultProject/template.json
@@ -207,6 +207,18 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/quality.client.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/quality.server.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/quality.headless.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Registry/Platform/Android/quality.setreg",
             "isTemplated": false
         },

--- a/Templates/DefaultProject/template.json
+++ b/Templates/DefaultProject/template.json
@@ -203,6 +203,30 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/quality.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/Platform/Android/quality.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/Platform/iOS/quality.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/Platform/Linux/quality.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/Platform/Mac/quality.setreg",
+            "isTemplated": false
+        },
+        {
+            "file": "Registry/Platform/Windows/quality.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },
@@ -471,6 +495,24 @@
         },
         {
             "dir": "Registry"
+        },
+        {
+            "dir": "Registry/Platform"
+        },
+        {
+            "dir": "Registry/Platform/Android"
+        },
+        {
+            "dir": "Registry/Platform/iOS"
+        },
+        {
+            "dir": "Registry/Platform/Linux"
+        },
+        {
+            "dir": "Registry/Platform/Mac"
+        },
+        {
+            "dir": "Registry/Platform/Windows"
         },
         {
             "dir": "Resources"

--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -1884,6 +1884,8 @@ def create_project(project_path: pathlib.Path,
                     logger.error(f'Failed to register the restricted {project_restricted_path}.')
                     return 1
 
+    print(f'Project created at {project_path}')
+
     # Register the project with the either o3de_manifest.json or engine.json
     # and set the project.json "engine" field to match the
     # engine.json "engine_name" field
@@ -2325,6 +2327,8 @@ def create_gem(gem_path: pathlib.Path,
                     logger.error(f'Failed to register the restricted {gem_restricted_path}.')
                     return 1
 
+    print(f'Gem created at {gem_path}')
+
     # Register the gem with the either o3de_manifest.json, engine.json or project.json based on the gem path
     return register.register(gem_path=gem_path) if not no_register else 0
 
@@ -2392,6 +2396,9 @@ def create_repo(repo_path: pathlib.Path,
 
     # create repo.json file
     _execute_template_json(template_json_data, repo_path, template_path, replacements)
+
+    print(f'Repo created at {repo_path}')
+
     return register.register(repo_uri=repo_path.as_posix(), force_register_with_o3de_manifest=True) if not no_register else 0
 
 def _run_create_template(args: argparse) -> int:


### PR DESCRIPTION
## What does this PR do?

- add quality settings with platform overrides and launcher type overrides (client, server, headless)
- add some print output when a project or gem is successfully created.

## How was this PR tested?

- created a project, verified the new files existed
- verified no new errors or warnings appear when running the editor related to the quality settings
