### PR TITLE
iOS MiniAudio Gem Compilation fixes

### DIFF
--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -42,6 +42,8 @@ ly_add_target(
     FILES_CMAKE
         miniaudio_private_files.cmake
         ${pal_dir}/miniaudio_private_files.cmake
+        PLATFORM_INCLUDE_FILES
+        ${pal_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
     TARGET_PROPERTIES
         O3DE_PRIVATE_TARGET TRUE
     INCLUDE_DIRECTORIES

--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -42,7 +42,7 @@ ly_add_target(
     FILES_CMAKE
         miniaudio_private_files.cmake
         ${pal_dir}/miniaudio_private_files.cmake
-        PLATFORM_INCLUDE_FILES
+    PLATFORM_INCLUDE_FILES
         ${pal_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
     TARGET_PROPERTIES
         O3DE_PRIVATE_TARGET TRUE

--- a/Gems/MiniAudio/Code/Platform/Android/platform_android.cmake
+++ b/Gems/MiniAudio/Code/Platform/Android/platform_android.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Gems/MiniAudio/Code/Platform/Linux/platform_linux.cmake
+++ b/Gems/MiniAudio/Code/Platform/Linux/platform_linux.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Gems/MiniAudio/Code/Platform/Mac/platform_mac.cmake
+++ b/Gems/MiniAudio/Code/Platform/Mac/platform_mac.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Gems/MiniAudio/Code/Platform/Windows/platform_windows.cmake
+++ b/Gems/MiniAudio/Code/Platform/Windows/platform_windows.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Gems/MiniAudio/Code/Platform/iOS/platform_ios.cmake
+++ b/Gems/MiniAudio/Code/Platform/iOS/platform_ios.cmake
@@ -1,0 +1,28 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+find_library(AV_FOUNDATION_LIBRARY AVFoundation)
+find_library(AUDIO_TOOLBOX_GRAPHICS_LIBRARY AudioToolbox)
+find_library(CORE_AUDIO_SERVICES_LIBRARY CoreAudio)
+find_library(FOUNDATION_LIBRARY Foundation)
+
+set(LY_BUILD_DEPENDENCIES
+    PRIVATE
+        ${AV_FOUNDATION_LIBRARY}
+        ${AUDIO_TOOLBOX_GRAPHICS_LIBRARY}
+        ${CORE_AUDIO_SERVICES_LIBRARY}
+        ${FOUNDATION_LIBRARY}
+)
+
+add_compile_definitions(MA_NO_RUNTIME_LINKING=1)
+
+ly_add_source_properties(
+    SOURCES Source/Clients/MiniAudioImplementation.cpp
+    PROPERTY COMPILE_OPTIONS
+    VALUES -xobjective-c++
+)

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioImplementation.cpp
@@ -19,10 +19,12 @@ extern "C" {
 
 #define STB_VORBIS_HEADER_ONLY
 #include <stb_vorbis.c>    // Enables Vorbis decoding.
+}
 
 #define MINIAUDIO_IMPLEMENTATION
 #include <miniaudio.h>
 
+extern "C" {
 // The stb_vorbis implementation must come after the implementation of miniaudio.
 #undef STB_VORBIS_HEADER_ONLY
 #include <stb_vorbis.c>

--- a/Templates/DefaultProject/Template/project.json
+++ b/Templates/DefaultProject/Template/project.json
@@ -22,7 +22,6 @@
         "${Name}",
         "Atom",
         "AudioSystem",
-        "AWSCore",
         "CameraFramework",
         "DebugDraw",
         "DiffuseProbeGrid",


### PR DESCRIPTION
## What does this PR do?

During testing of project export for iOS using the Default Project template, it was discovered that the main source of issues was compilation errors for the MiniAudio Gem. The main source of the issue was that iOS was expecting objective c code, but Xcode treats the code files as CPP only, thus preventing the expected ObjC runtime from getting linked.

This PR fixes all compilation and linking errors that block export from projects using the Default Project template. The template has also been updated to remove AWSCore as well.

## How was this PR tested?

The changes were tested on a macbook pro with xcode and a physical iPhone device. The app successfully exported and ran on the iOS device, and expected PAK files were verified for release mode.

