### PR TITLE
Don't reset the hardware queue class when a scope is deactivated

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -81,7 +81,6 @@ namespace AZ::RHI
         m_index.Reset();
         m_graphNodeIndex.Reset();
         m_estimatedItemCount = 1;
-        m_hardwareQueueClass = HardwareQueueClass::Graphics;
         m_producersByQueueLast.fill(nullptr);
         m_producersByQueue.fill(nullptr);
         m_consumersByQueue.fill(nullptr);


### PR DESCRIPTION
## What does this PR do?

The hardware queue class was reset in the 'Scope::Deactivate' function. This function is called every frame.
All passes in the Engine set the hardware queue class through the 'InitScope' function of the 'ScopeProducer'. This is only called once when initializing the scope. This means that after one frame the hardware queue class was always Graphics, regardless of the value passed to the 'InitScope' function.

This fixes the issue with the queues mentioned in this PR: https://github.com/o3de/o3de/pull/17022

## How was this PR tested?

Tested with Windows + Vulkan/Dx12 and a level with two animated actors
