### PR TITLE
XR Initializes after Asset System

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
@@ -100,7 +100,7 @@ namespace AZ::RHI
         if (BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context))
         {
             behaviorContext->Class<Handle<T, NamespaceType>>()
-                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "RHI")
                 ->Attribute(AZ::Script::Attributes::Module, "rhi")
                 ->Method("IsValid", &Handle<T, NamespaceType>::IsValid)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -99,7 +99,6 @@ namespace AZ
             m_passSystem.Init();
             m_featureProcessorFactory.Init();
             m_querySystem.Init(m_descriptor.m_gpuQuerySystemDescriptor);
-            InitXRSystem();
 
             Interface<RPISystemInterface>::Register(this);
 
@@ -285,6 +284,11 @@ namespace AZ
 
         void RPISystem::InitXRSystem()
         {
+            // The creation of an XR Session requires an asset that defines
+            // the action bindings for the application. This means the asset catalog
+            // must be available before creating the XR Session.
+            AZ_Assert(m_systemAssetsInitialized, "IntXRSystem should not be called before the asset system is ready.");
+
             if (!m_xrSystem)
             {
                 return;
@@ -441,6 +445,10 @@ namespace AZ
 
             m_systemAssetsInitialized = true;
             AZ_TracePrintf("RPI system", "System assets initialized\n");
+
+            // Now that the asset system is up and running, we can safely initialize
+            // the XR System and the XR Session.
+            InitXRSystem();
         }
 
         bool RPISystem::IsInitialized() const


### PR DESCRIPTION
## What does this PR do?

This PR makes sure the XR System is initialized
only after the Asset System is initialized.

This change was required because the new version
of the OpenXRVk Gem requires an asset that defines all actions supported by the application, this asset is required during XR Session initialization.

The AZ::RHI::Handle template class is now available in all script contexts. This is necessary because in an upcoming PR for o3de-extras some OpenXR APIs are exposed to the behavior context.

## How was this PR tested?

Validated with OpenXRTest running on Link mode, and on device with a Meta Quest Pro.
