### PR TITLE
Fix missed splash file changes for AutomatedTesting

### DIFF
--- a/AutomatedTesting/Gem/Resources/LegacyLogoLauncher.bmp
+++ b/AutomatedTesting/Gem/Resources/LegacyLogoLauncher.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3584c695998fd5f2d137148a11f68602523c817af5d18fdd6c56b0b5278a6c
-size 462760

--- a/AutomatedTesting/Gem/Resources/Splash.bmp
+++ b/AutomatedTesting/Gem/Resources/Splash.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd314f41b90bc9cba384d86eed865568343cbd332568f74c8ca39a08bc43836
+size 1200056

--- a/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
+++ b/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
@@ -19,8 +19,16 @@ endif()
 
 set(SPLASH_FILE ${project_real_path}/Resources/Splash.bmp)
 if(NOT EXISTS ${SPLASH_FILE})
+    # Try in project Gem
+    set(SPLASH_FILE ${project_real_path}/Gem/Resources/Splash.bmp)
+endif()
+if(NOT EXISTS ${SPLASH_FILE})
     # Try legacy splash
     set(SPLASH_FILE ${project_real_path}/Resources/LegacyLogoLauncher.bmp)
+endif()
+if(NOT EXISTS ${SPLASH_FILE})
+    # Try in Gem
+    set(SPLASH_FILE ${project_real_path}/Gem/Resources/LegacyLogoLauncher.bmp)
 endif()
 
 if(EXISTS ${ICON_FILE} OR EXISTS ${SPLASH_FILE})

--- a/Templates/ScriptOnlyProject/Template/Resources/LegacyLogoLauncher.bmp
+++ b/Templates/ScriptOnlyProject/Template/Resources/LegacyLogoLauncher.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3584c695998fd5f2d137148a11f68602523c817af5d18fdd6c56b0b5278a6c
-size 462760

--- a/Templates/ScriptOnlyProject/Template/Resources/Splash.bmp
+++ b/Templates/ScriptOnlyProject/Template/Resources/Splash.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd314f41b90bc9cba384d86eed865568343cbd332568f74c8ca39a08bc43836
+size 1200056

--- a/Templates/ScriptOnlyProject/template.json
+++ b/Templates/ScriptOnlyProject/template.json
@@ -99,7 +99,7 @@
             "isTemplated": false
         },
         {
-            "file": "Resources/LegacyLogoLauncher.bmp",
+            "file": "Resources/Splash.bmp",
             "isTemplated": false
         },
         {


### PR DESCRIPTION
Fixes an issuer where AutomatedTesting would not compile after the recent splash changes in https://github.com/o3de/o3de/pull/17317/files#diff-338d55e74418c1ff4818e9e9d8447c713b0ebaf5dd4e5ef7d337385d71db9aad has the splash file inside the Gem/Resources folder, which was not the location used in the templates.

## What does this PR do?

- Looks in the Gem/Resources folder for a splash screen
- Fixes the ScriptOnly project template missing the splash screen changes

## How was this PR tested?

- Built and ran AutomatedTesting editor
