### PR TITLE
Resolve @EXEFOLDER@ alias in settings registry watch paths

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1127,6 +1127,7 @@ namespace AssetProcessor
 
         AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
         AZ::IO::FixedMaxPathString projectName = AZ::Utils::GetProjectName();
+        AZ::IO::FixedMaxPathString executableDirectory = AZ::Utils::GetExecutableDirectory();
 
         AZ::IO::FixedMaxPath engineRoot(AZ::IO::PosixPathSeparator);
         settingsRegistry->Get(engineRoot.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
@@ -1202,6 +1203,7 @@ namespace AssetProcessor
                 AZ::StringFunc::Replace(scanFolderEntry.m_watchPath.Native(), "@ROOT@", assetRootPath.c_str());
                 AZ::StringFunc::Replace(scanFolderEntry.m_watchPath.Native(), "@PROJECTROOT@", projectPath.c_str());
                 AZ::StringFunc::Replace(scanFolderEntry.m_watchPath.Native(), "@ENGINEROOT@", engineRoot.c_str());
+                AZ::StringFunc::Replace(scanFolderEntry.m_watchPath.Native(), "@EXEFOLDER@", executableDirectory.c_str());
                 // Normalize path make sure it is using posix slashes
                 scanFolderEntry.m_watchPath = scanFolderEntry.m_watchPath.LexicallyNormal();
 


### PR DESCRIPTION
## What does this PR do?

This MR adds code to resolve the `@EXEFOLDER@` alias for watch paths in settings registry entries.

**Background:**
While we are developing one of our gems, we need to test it with different versions of O3DE. The setup is that the two engine versions are in different folders (with their respective build folders), and both use the same instance of the Gem, but use different projects.
The problem is that we are generating an .azsli file with CMake, with the content depending on the engine version, and we want to include that .azsli file in the shader code of our gem. This is currently done by placing the generated .azsli file in the source directory, but this is not satisfactory since now CMake has to be rerun when changing engine versions. With the suggested change we can add a scanfolder in the cmake build directory to the settings registry, making switching engine versions more seamless. (Another options would be put the generated .azsli file in the project cache folder, but this does also not seem like the best option since this would again lead to cmake generating files outside of the build directory.)

## How was this PR tested?

Manually testing by using the new alias in our gem to include a file from the build folder in shader code.
