### PR TITLE
Fix validation issues in Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -273,7 +273,6 @@ namespace AZ
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
                 vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
                 vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
-                shaderImageAtomicInt64.pNext = &vulkan12Features;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;


### PR DESCRIPTION
## What does this PR do?

This pr removes double initialization of shaderImageAtomicInt64.pNext introduced by https://github.com/o3de/o3de/pull/17266. pNext is already initalized by AppendVkStruct and reinitializing it breaks the chain and causes validation issues.

## How was this PR tested?

Run a test project in Vulkan with Validation enabled