### PR TITLE
DrawItem-related resources

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI/DrawList.h>
 
@@ -26,7 +26,7 @@ namespace AZ
 {
     namespace RHI
     {
-        class SingleDeviceDrawPacketBuilder;
+        class MultiDeviceDrawPacketBuilder;
     }
 
     namespace RPI
@@ -75,18 +75,18 @@ namespace AZ
 
         private: // types
 
-            using StreamBufferViewsForAllStreams = AZStd::fixed_vector<AZ::RHI::SingleDeviceStreamBufferView, AZ::RHI::Limits::Pipeline::StreamCountMax>;
+            using StreamBufferViewsForAllStreams = AZStd::fixed_vector<AZ::RHI::MultiDeviceStreamBufferView, AZ::RHI::Limits::Pipeline::StreamCountMax>;
 
             struct DynamicBufferGroup
             {
                 //! The view into the index buffer
-                AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+                AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
 
                 //! The stream views into the vertex buffer (we only have one in our case)
                 StreamBufferViewsForAllStreams m_streamBufferViews;
             };
 
-            using DrawPackets = AZStd::vector<AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket>>;
+            using DrawPackets = AZStd::vector<AZ::RHI::ConstPtr<RHI::MultiDeviceDrawPacket>>;
 
             struct ShaderData
             {
@@ -111,13 +111,13 @@ namespace AZ
         private: // functions
 
             //!Uses the given drawPacketBuilder to build a draw packet with given data and returns it
-            const RHI::SingleDeviceDrawPacket* BuildDrawPacketForDynamicPrimitive(
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacketForDynamicPrimitive(
                 DynamicBufferGroup& group,
                 const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
                 Data::Instance<RPI::ShaderResourceGroup> srg,
                 uint32_t indexCount,
                 uint32_t indexOffset,
-                RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+                RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
                 RHI::DrawItemSortKey sortKey = 0);
 
             // Update a dynamic index buffer, given the data from draw requests

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -13,7 +13,7 @@
 #include <AzCore/std/containers/array.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
@@ -132,7 +132,7 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(AzRender, "FixedShapeProcessor: ProcessObjects");
 
-            RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+            RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
 
             // Draw opaque shapes with LODs. This requires a separate draw packet per shape per view that it is in (usually only one)
 
@@ -173,12 +173,12 @@ namespace AZ
                             continue;
                         }
                         LodIndex lodIndex = GetLodIndexForShape(shape.m_shapeType, view.get(), position, scale);
-                        const RHI::SingleDeviceDrawPacket* drawPacket = BuildDrawPacketForShape(
+                        auto drawPacket = BuildDrawPacketForShape(
                             drawPacketBuilder, shape, drawStyle, bufferData->m_viewProjOverrides, pipelineState, lodIndex);
                         if (drawPacket)
                         {
                             m_drawPackets.emplace_back(drawPacket);
-                            view->AddDrawPacket(drawPacket);
+                            view->AddDrawPacket(drawPacket.get());
                         }
                     }
                 }
@@ -195,7 +195,7 @@ namespace AZ
 
                     RPI::Ptr<RPI::PipelineStateForDraw> pipelineState = GetPipelineState(pipelineStateOptions);
 
-                    const RHI::SingleDeviceDrawPacket* drawPacket =
+                    auto drawPacket =
                         BuildDrawPacketForBox(drawPacketBuilder, box, drawStyle, bufferData->m_viewProjOverrides, pipelineState);
                     if (drawPacket)
                     {
@@ -208,7 +208,7 @@ namespace AZ
                             {
                                 continue;
                             }
-                            view->AddDrawPacket(drawPacket);
+                            view->AddDrawPacket(drawPacket.get());
                         }
                     }
                 }
@@ -253,12 +253,12 @@ namespace AZ
                         RHI::DrawItemSortKey sortKey = view->GetSortKeyForPosition(position);
                         LodIndex lodIndex = GetLodIndexForShape(shape.m_shapeType, view.get(), position, scale);
 
-                        const RHI::SingleDeviceDrawPacket* drawPacket = BuildDrawPacketForShape(
+                        auto drawPacket = BuildDrawPacketForShape(
                             drawPacketBuilder, shape, drawStyle, bufferData->m_viewProjOverrides, pipelineState, lodIndex, sortKey);
                         if (drawPacket)
                         {
                             m_drawPackets.emplace_back(drawPacket);
-                            view->AddDrawPacket(drawPacket);
+                            view->AddDrawPacket(drawPacket.get());
                         }
                     }
                 }
@@ -285,12 +285,12 @@ namespace AZ
                             continue;
                         }
                         RHI::DrawItemSortKey sortKey = view->GetSortKeyForPosition(position);
-                        const RHI::SingleDeviceDrawPacket* drawPacket = BuildDrawPacketForBox(
+                        auto drawPacket = BuildDrawPacketForBox(
                             drawPacketBuilder, box, drawStyle, bufferData->m_viewProjOverrides, pipelineState, sortKey);
                         if (drawPacket)
                         {
                             m_drawPackets.emplace_back(drawPacket);
-                            view->AddDrawPacket(drawPacket);
+                            view->AddDrawPacket(drawPacket.get());
                         }
                     }
                 }
@@ -1301,9 +1301,9 @@ namespace AZ
 
             // Setup point index buffer view
             objectBuffers.m_pointIndexCount = static_cast<uint32_t>(meshData.m_pointIndices.size());
-            AZ::RHI::SingleDeviceIndexBufferView pointIndexBufferView =
+            AZ::RHI::MultiDeviceIndexBufferView pointIndexBufferView =
             {
-                *objectBuffers.m_pointIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *objectBuffers.m_pointIndexBuffer,
                 0,
                 static_cast<uint32_t>(objectBuffers.m_pointIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1312,9 +1312,9 @@ namespace AZ
 
             // Setup line index buffer view
             objectBuffers.m_lineIndexCount = static_cast<uint32_t>(meshData.m_lineIndices.size());
-            AZ::RHI::SingleDeviceIndexBufferView lineIndexBufferView =
+            AZ::RHI::MultiDeviceIndexBufferView lineIndexBufferView =
             {
-                *objectBuffers.m_lineIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *objectBuffers.m_lineIndexBuffer,
                 0,
                 static_cast<uint32_t>(objectBuffers.m_lineIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1323,9 +1323,9 @@ namespace AZ
 
             // Setup triangle index buffer view
             objectBuffers.m_triangleIndexCount = static_cast<uint32_t>(meshData.m_triangleIndices.size());
-            AZ::RHI::SingleDeviceIndexBufferView triangleIndexBufferView =
+            AZ::RHI::MultiDeviceIndexBufferView triangleIndexBufferView =
             {
-                *objectBuffers.m_triangleIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *objectBuffers.m_triangleIndexBuffer,
                 0,
                 static_cast<uint32_t>(objectBuffers.m_triangleIndexCount * sizeof(uint16_t)),
                 AZ::RHI::IndexFormat::Uint16,
@@ -1336,9 +1336,9 @@ namespace AZ
             const auto positionCount = static_cast<uint32_t>(meshData.m_positions.size());
             const uint32_t positionSize = sizeof(float) * 3;
 
-            AZ::RHI::SingleDeviceStreamBufferView positionBufferView =
+            AZ::RHI::MultiDeviceStreamBufferView positionBufferView =
             {
-                *objectBuffers.m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *objectBuffers.m_positionBuffer,
                 0,
                 positionCount * positionSize,
                 positionSize,
@@ -1348,9 +1348,9 @@ namespace AZ
             const auto normalCount = static_cast<uint32_t>(meshData.m_normals.size());
             const uint32_t normalSize = sizeof(float) * 3;
 
-            AZ::RHI::SingleDeviceStreamBufferView normalBufferView =
+            AZ::RHI::MultiDeviceStreamBufferView normalBufferView =
             {
-                *objectBuffers.m_normalBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *objectBuffers.m_normalBuffer,
                 0,
                 normalCount * normalSize,
                 normalSize,
@@ -1559,7 +1559,7 @@ namespace AZ
             destPipelineState->Finalize();
         }
 
-        const AZ::RHI::SingleDeviceIndexBufferView& FixedShapeProcessor::GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const
+        const AZ::RHI::MultiDeviceIndexBufferView& FixedShapeProcessor::GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const
         {
             switch(drawStyle)
             {
@@ -1600,8 +1600,8 @@ namespace AZ
             }
         }
 
-        const RHI::SingleDeviceDrawPacket* FixedShapeProcessor::BuildDrawPacketForShape(
-            RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> FixedShapeProcessor::BuildDrawPacketForShape(
+            RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
             const ShapeBufferEntry& shape,
             int drawStyle,
             const AZStd::vector<AZ::Matrix4x4>& viewProjOverrides,
@@ -1661,7 +1661,7 @@ namespace AZ
             return nullptr;
         }
 
-        const AZ::RHI::SingleDeviceIndexBufferView& FixedShapeProcessor::GetBoxIndexBufferView(int drawStyle) const
+        const AZ::RHI::MultiDeviceIndexBufferView& FixedShapeProcessor::GetBoxIndexBufferView(int drawStyle) const
         {
             switch(drawStyle)
             {
@@ -1702,8 +1702,8 @@ namespace AZ
             }
         }
 
-        const RHI::SingleDeviceDrawPacket* FixedShapeProcessor::BuildDrawPacketForBox(
-            RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> FixedShapeProcessor::BuildDrawPacketForBox(
+            RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
             const BoxBufferEntry& box,
             int drawStyle,
             const AZStd::vector<AZ::Matrix4x4>& viewProjOverrides,
@@ -1754,11 +1754,11 @@ namespace AZ
                 sortKey);
         }
 
-        const RHI::SingleDeviceDrawPacket* FixedShapeProcessor::BuildDrawPacket(
-            RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> FixedShapeProcessor::BuildDrawPacket(
+            RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
             AZ::Data::Instance<RPI::ShaderResourceGroup>& srg,
             uint32_t indexCount,
-            const RHI::SingleDeviceIndexBufferView& indexBufferView,
+            const RHI::MultiDeviceIndexBufferView& indexBufferView,
             const StreamBufferViewsForAllStreams& streamBufferViews,
             RHI::DrawListTag drawListTag,
             const RHI::MultiDevicePipelineState* pipelineState,
@@ -1772,11 +1772,11 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
             drawPacketBuilder.SetDrawArguments(drawIndexed);
             drawPacketBuilder.SetIndexBufferView(indexBufferView);
-            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
 
-            RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+            RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
             drawRequest.m_listTag = drawListTag;
-            drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = pipelineState;
             drawRequest.m_streamBufferViews = streamBufferViews;
             drawRequest.m_sortKey = sortKey;
             drawPacketBuilder.AddDrawItem(drawRequest);

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
@@ -10,8 +10,8 @@
 
 #include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 
 #include <Atom/RPI.Public/FeatureProcessor.h>
@@ -29,7 +29,7 @@ namespace AZ
 {
     namespace RHI
     {
-        class SingleDeviceDrawPacketBuilder;
+        class MultiDeviceDrawPacketBuilder;
     }
 
     namespace RPI
@@ -51,7 +51,7 @@ namespace AZ
         class FixedShapeProcessor final
         {
         public:
-            using StreamBufferViewsForAllStreams = AZStd::fixed_vector<AZ::RHI::SingleDeviceStreamBufferView, AZ::RHI::Limits::Pipeline::StreamCountMax>;
+            using StreamBufferViewsForAllStreams = AZStd::fixed_vector<AZ::RHI::MultiDeviceStreamBufferView, AZ::RHI::Limits::Pipeline::StreamCountMax>;
 
             using AuxGeomNormal = AuxGeomPosition;
 
@@ -89,15 +89,15 @@ namespace AZ
             {
                 uint32_t m_pointIndexCount;
                 AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_pointIndexBuffer;
-                AZ::RHI::SingleDeviceIndexBufferView m_pointIndexBufferView;
+                AZ::RHI::MultiDeviceIndexBufferView m_pointIndexBufferView;
 
                 uint32_t m_lineIndexCount;
                 AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_lineIndexBuffer;
-                AZ::RHI::SingleDeviceIndexBufferView m_lineIndexBufferView;
+                AZ::RHI::MultiDeviceIndexBufferView m_lineIndexBufferView;
 
                 uint32_t m_triangleIndexCount;
                 AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_triangleIndexBuffer;
-                AZ::RHI::SingleDeviceIndexBufferView m_triangleIndexBufferView;
+                AZ::RHI::MultiDeviceIndexBufferView m_triangleIndexBufferView;
 
                 AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
                 AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_normalBuffer;
@@ -173,13 +173,13 @@ namespace AZ
             void InitPipelineState(const PipelineStateOptions& options);
             RPI::Ptr<RPI::PipelineStateForDraw>& GetPipelineState(const PipelineStateOptions& pipelineStateOptions);
 
-            const AZ::RHI::SingleDeviceIndexBufferView& GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
+            const AZ::RHI::MultiDeviceIndexBufferView& GetShapeIndexBufferView(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex) const;
             const StreamBufferViewsForAllStreams& GetShapeStreamBufferViews(AuxGeomShapeType shapeType, LodIndex lodIndex, int drawStyle) const;
             uint32_t GetShapeIndexCount(AuxGeomShapeType shapeType, int drawStyle, LodIndex lodIndex);
 
             //! Uses the given drawPacketBuilder to build a draw packet for given shape and state and returns it
-            const RHI::SingleDeviceDrawPacket* BuildDrawPacketForShape(
-                RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacketForShape(
+                RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
                 const ShapeBufferEntry& shape,
                 int drawStyle,
                 const AZStd::vector<AZ::Matrix4x4>& viewProjOverrides,
@@ -187,13 +187,13 @@ namespace AZ
                 LodIndex lodIndex,
                 RHI::DrawItemSortKey sortKey = 0);
 
-            const AZ::RHI::SingleDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
+            const AZ::RHI::MultiDeviceIndexBufferView& GetBoxIndexBufferView(int drawStyle) const;
             const StreamBufferViewsForAllStreams& GetBoxStreamBufferViews(int drawStyle) const;
             uint32_t GetBoxIndexCount(int drawStyle);
 
             //! Uses the given drawPacketBuilder to build a draw packet for given box and state and returns it
-            const RHI::SingleDeviceDrawPacket* BuildDrawPacketForBox(
-                RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacketForBox(
+                RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
                 const BoxBufferEntry& box,
                 int drawStyle,
                 const AZStd::vector<AZ::Matrix4x4>& overrideViewProjMatrices,
@@ -201,11 +201,11 @@ namespace AZ
                 RHI::DrawItemSortKey sortKey = 0);
 
             //! Uses the given drawPacketBuilder to build a draw packet with the given data
-            const RHI::SingleDeviceDrawPacket* BuildDrawPacket(
-                RHI::SingleDeviceDrawPacketBuilder& drawPacketBuilder,
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacket(
+                RHI::MultiDeviceDrawPacketBuilder& drawPacketBuilder,
                 AZ::Data::Instance<RPI::ShaderResourceGroup>& srg,
                 uint32_t indexCount,
-                const RHI::SingleDeviceIndexBufferView& indexBufferView,
+                const RHI::MultiDeviceIndexBufferView& indexBufferView,
                 const StreamBufferViewsForAllStreams& streamBufferViews,
                 RHI::DrawListTag drawListTag,
                 const AZ::RHI::MultiDevicePipelineState* pipelineState,
@@ -256,7 +256,7 @@ namespace AZ
             ShaderData m_perObjectShaderData[ShapeLightingStyle_Count];
             ShaderData& GetShaderDataForDrawStyle(int drawStyle) {return m_perObjectShaderData[drawStyle == DrawStyle_Shaded];}
 
-            AZStd::vector<AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket>> m_drawPackets;
+            AZStd::vector<AZ::RHI::ConstPtr<RHI::MultiDeviceDrawPacket>> m_drawPackets;
 
             const AZ::RPI::Scene* m_scene = nullptr;
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -156,7 +156,7 @@ namespace AZ
             m_scissorState = scissor;
         }
 
-        void ShadowmapPass::SetClearShadowDrawPacket(AZ::RHI::ConstPtr<RHI::SingleDeviceDrawPacket> clearShadowDrawPacket)
+        void ShadowmapPass::SetClearShadowDrawPacket(AZ::RHI::ConstPtr<RHI::MultiDeviceDrawPacket> clearShadowDrawPacket)
         {
             m_clearShadowDrawPacket = clearShadowDrawPacket;
             m_clearShadowDrawItemProperties = clearShadowDrawPacket->GetDrawItemProperties(0);
@@ -201,7 +201,7 @@ namespace AZ
                 if (startIndex == 0)
                 {
                     RHI::CommandList* commandList = context.GetCommandList();
-                    commandList->Submit(*m_clearShadowDrawPacket->GetDrawItemProperties(0).m_item, 0);
+                    commandList->Submit(m_clearShadowDrawPacket->GetDrawItemProperties(0).m_mdItem->GetDeviceDrawItem(RHI::MultiDevice::DefaultDeviceIndex), 0);
                 }
                 else
                 {

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Size.h>
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
 #include <Atom/RPI.Public/Pass/RasterPass.h>
 #include <Atom/RPI.Reflect/Pass/RasterPassData.h>
 
@@ -63,7 +63,7 @@ namespace AZ
             void SetViewportScissor(const RHI::Viewport& viewport, const RHI::Scissor& scissor);
 
             //! Sets the draw packet used for clearing a shadow viewport.
-            void SetClearShadowDrawPacket(RHI::ConstPtr<RHI::SingleDeviceDrawPacket> clearShadowDrawPacket);
+            void SetClearShadowDrawPacket(AZ::RHI::ConstPtr<AZ::RHI::MultiDeviceDrawPacket> clearShadowDrawPacket);
 
         private:
             ShadowmapPass() = delete;
@@ -83,8 +83,8 @@ namespace AZ
             // Gets the number of expected draws, taking into account if this shadow is static.
             uint32_t GetNumDraws() const;
 
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_clearShadowDrawPacket;
-            RHI::SingleDeviceDrawItemProperties m_clearShadowDrawItemProperties;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_clearShadowDrawPacket;
+            RHI::MultiDeviceDrawItemProperties m_clearShadowDrawItemProperties;
             RHI::Handle<uint32_t> m_casterMovedBit;
             uint16_t m_arraySlice = 0;
             bool m_clearEnabled = true;

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -535,8 +535,8 @@ namespace AZ
             desc.m_byteCount = 64;
             desc.m_bufferData = instanceData;
             m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
-            m_instanceBufferView = RHI::SingleDeviceStreamBufferView(
-                *m_instanceBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            m_instanceBufferView = RHI::MultiDeviceStreamBufferView(
+                *m_instanceBuffer->GetRHIBuffer(),
                 0,
                 aznumeric_cast<uint32_t>(desc.m_byteCount),
                 aznumeric_cast<uint32_t>(desc.m_elementSize));
@@ -752,9 +752,9 @@ namespace AZ
             }
 
             static_assert(indexSize == 2, "Expected index size from ImGui to be 2 to match RHI::IndexFormat::Uint16");
-            m_indexBufferView = indexBuffer->GetIndexBufferView(RHI::IndexFormat::Uint16);
-            m_vertexBufferView[0] = vertexBuffer->GetStreamBufferView(vertexSize);
-            m_vertexBufferView[1] = m_instanceBufferView;
+            m_indexBufferView = indexBuffer->GetIndexBufferView(RHI::IndexFormat::Uint16).GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+            m_vertexBufferView[0] = vertexBuffer->GetStreamBufferView(vertexSize).GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+            m_vertexBufferView[1] = m_instanceBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
 
             RHI::ValidateStreamBufferViews(m_pipelineState->ConstDescriptor().m_inputStreamLayout, m_vertexBufferView);
 

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -13,7 +13,7 @@
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
 
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
@@ -171,7 +171,7 @@ namespace AZ
 
             AZStd::unordered_map<Data::Instance<RPI::StreamingImage>, uint32_t> m_userTextures;
             Data::Instance<RPI::Buffer> m_instanceBuffer;
-            RHI::SingleDeviceStreamBufferView m_instanceBufferView;
+            RHI::MultiDeviceStreamBufferView m_instanceBufferView;
 
             // cache the font text id
             void* m_imguiFontTexId = nullptr;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -748,12 +748,12 @@ namespace AZ
             {
                 // Since there is only one task that will operate both on this view index and on the bucket with this instance group,
                 // there is no need to lock here.
-                RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+                RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
                 instanceGroup.m_perViewDrawPackets[viewIndex] = drawPacketBuilder.Clone(instanceGroup.m_drawPacket.GetRHIDrawPacket());
             }
 
             // Now that we have a valid cloned draw packet, update it with the latest offset + count
-            RHI::Ptr<RHI::SingleDeviceDrawPacket> clonedDrawPacket = instanceGroup.m_perViewDrawPackets[viewIndex];
+            RHI::Ptr<RHI::MultiDeviceDrawPacket> clonedDrawPacket = instanceGroup.m_perViewDrawPackets[viewIndex];
 
             // Set the instance data offset
             AZStd::span<uint8_t> data{ reinterpret_cast<uint8_t*>(&instanceGroupBeginIndex), sizeof(uint32_t) };
@@ -1006,7 +1006,7 @@ namespace AZ
             {
                 for (AZ::RPI::MeshDrawPacket& meshDrawPacket : drawPacketList)
                 {
-                    RHI::SingleDeviceDrawPacket* drawPacket = meshDrawPacket.GetRHIDrawPacket();
+                    RHI::MultiDeviceDrawPacket* drawPacket = meshDrawPacket.GetRHIDrawPacket();
 
                     if (drawPacket != nullptr)
                     {
@@ -1017,7 +1017,7 @@ namespace AZ
                             // Ensure that the draw item belongs to the specified tag
                             if (drawPacket->GetDrawListTag(idx) == drawListTag)
                             {
-                                drawPacket->GetDrawItem(idx)->m_enabled = enabled;
+                                drawPacket->GetDrawItem(idx)->SetEnabled(enabled);
                             }
                         }
                     }
@@ -1038,7 +1038,7 @@ namespace AZ
                 u32 drawPacketCounter = 0;
                 for (AZ::RPI::MeshDrawPacket& meshDrawPacket : drawPacketList)
                 {
-                    RHI::SingleDeviceDrawPacket* drawPacket = meshDrawPacket.GetRHIDrawPacket();
+                    RHI::MultiDeviceDrawPacket* drawPacket = meshDrawPacket.GetRHIDrawPacket();
                     if (drawPacket)
                     {
                         size_t numDrawItems = drawPacket->GetDrawItemCount();
@@ -1046,10 +1046,10 @@ namespace AZ
 
                         for (size_t drawItemIdx = 0; drawItemIdx < numDrawItems; ++drawItemIdx)
                         {
-                            RHI::SingleDeviceDrawItem* drawItem = drawPacket->GetDrawItem(drawItemIdx);
+                            RHI::MultiDeviceDrawItem* drawItem = drawPacket->GetDrawItem(drawItemIdx);
                             RHI::DrawListTag tag = drawPacket->GetDrawListTag(drawItemIdx);
                             stringOutput += AZStd::string::format("Item %zu | ", drawItemIdx);
-                            stringOutput += drawItem->m_enabled ? "Enabled  | " : "Disabled | ";
+                            stringOutput += drawItem->GetEnabled() ? "Enabled  | " : "Disabled | ";
                             stringOutput += AZStd::string::format("%s Tag\n", RHI::GetDrawListName(tag).GetCStr());
                         }
 
@@ -2754,7 +2754,7 @@ namespace AZ
                     for (const RPI::MeshDrawPacket& drawPacket : drawPacketList)
                     {
                         // If mesh instancing is disabled, get the draw packets directly from this ModelDataInstance
-                        const RHI::SingleDeviceDrawPacket* rhiDrawPacket = drawPacket.GetRHIDrawPacket();
+                        const RHI::MultiDeviceDrawPacket* rhiDrawPacket = drawPacket.GetRHIDrawPacket();
 
                         if (rhiDrawPacket)
                         {
@@ -2771,7 +2771,7 @@ namespace AZ
                     for (const ModelDataInstance::PostCullingInstanceData& postCullingData : postCullingInstanceDataList)
                     {
                         // If mesh instancing is enabled, get the draw packet from the MeshInstanceManager
-                        const RHI::SingleDeviceDrawPacket* rhiDrawPacket = postCullingData.m_instanceGroupHandle->m_drawPacket.GetRHIDrawPacket();
+                        const RHI::MultiDeviceDrawPacket* rhiDrawPacket = postCullingData.m_instanceGroupHandle->m_drawPacket.GetRHIDrawPacket();
 
                         if (rhiDrawPacket)
                         {

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
@@ -27,7 +27,7 @@ namespace AZ::Render
 
         // We modify the original draw packet each frame with a new instance count and a new root constant offset
         // The instance count and offset varies per view, so we keep one modifiable copy of the draw packet for each view
-        AZStd::vector<RHI::Ptr<RHI::SingleDeviceDrawPacket>> m_perViewDrawPackets;
+        AZStd::vector<RHI::Ptr<RHI::MultiDeviceDrawPacket>> m_perViewDrawPackets;
 
         // All draw items in a draw packet share the same root constant layout
         uint32_t m_drawRootConstantOffset = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -278,7 +278,7 @@ namespace AZ
             m_bakeExposure = bakeExposure;
         }
 
-        const RHI::SingleDeviceDrawPacket* ReflectionProbe::BuildDrawPacket(
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> ReflectionProbe::BuildDrawPacket(
             const Data::Instance<RPI::ShaderResourceGroup>& srg,
             const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
             const RHI::DrawListTag& drawListTag,
@@ -291,7 +291,7 @@ namespace AZ
                 return nullptr;
             }
 
-            RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+            RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
 
             RHI::DrawIndexed drawIndexed;
             drawIndexed.m_indexCount = (uint32_t)m_reflectionRenderData->m_boxIndexCount;
@@ -301,11 +301,11 @@ namespace AZ
             drawPacketBuilder.Begin(nullptr);
             drawPacketBuilder.SetDrawArguments(drawIndexed);
             drawPacketBuilder.SetIndexBufferView(m_reflectionRenderData->m_boxIndexBufferView);
-            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+            drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
 
-            RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+            RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
             drawRequest.m_listTag = drawListTag;
-            drawRequest.m_pipelineState = pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = pipelineState->GetRHIPipelineState();
             drawRequest.m_streamBufferViews = m_reflectionRenderData->m_boxPositionBufferView;
             drawRequest.m_stencilRef = static_cast<uint8_t>(stencilRef);
             drawRequest.m_sortKey = m_sortKey;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.h
@@ -27,8 +27,8 @@ namespace AZ
         // shared data for rendering reflections, loaded and stored by the ReflectionProbeFeatureProcessor and passed to all probes
         struct ReflectionRenderData
         {
-            AZStd::array<RHI::SingleDeviceStreamBufferView, 1> m_boxPositionBufferView;
-            RHI::SingleDeviceIndexBufferView m_boxIndexBufferView;
+            AZStd::array<RHI::MultiDeviceStreamBufferView, 1> m_boxPositionBufferView;
+            RHI::MultiDeviceIndexBufferView m_boxIndexBufferView;
             uint32_t m_boxIndexCount = 0;
 
             RPI::Ptr<RPI::PipelineStateForDraw> m_stencilPipelineState;
@@ -120,7 +120,7 @@ namespace AZ
 
             AZ_DISABLE_COPY_MOVE(ReflectionProbe);
 
-            const RHI::SingleDeviceDrawPacket* BuildDrawPacket(
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacket(
                 const Data::Instance<RPI::ShaderResourceGroup>& srg,
                 const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
                 const RHI::DrawListTag& drawListTag,
@@ -163,10 +163,10 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> m_blendWeightSrg;
             Data::Instance<RPI::ShaderResourceGroup> m_renderOuterSrg;
             Data::Instance<RPI::ShaderResourceGroup> m_renderInnerSrg;
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_stencilDrawPacket;
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_blendWeightDrawPacket;
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_renderOuterDrawPacket;
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_renderInnerDrawPacket;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_stencilDrawPacket;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_blendWeightDrawPacket;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_renderOuterDrawPacket;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_renderInnerDrawPacket;
             float m_renderExposure = 0.0f;
             float m_bakeExposure = 0.0f;
             bool m_updateSrg = false;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -623,9 +623,9 @@ namespace AZ
             AZ_Error("ReflectionProbeFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create index buffer view
-            AZ::RHI::SingleDeviceIndexBufferView indexBufferView =
+            AZ::RHI::MultiDeviceIndexBufferView indexBufferView =
             {
-                *m_boxIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_boxIndexBuffer,
                 0,
                 sizeof(indices),
                 AZ::RHI::IndexFormat::Uint16,
@@ -642,9 +642,9 @@ namespace AZ
             AZ_Error("ReflectionProbeFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create position buffer view
-            RHI::SingleDeviceStreamBufferView positionBufferView =
+            RHI::MultiDeviceStreamBufferView positionBufferView =
             {
-                *m_boxPositionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_boxPositionBuffer,
                 0,
                 (uint32_t)(m_boxPositions.size() * sizeof(Position)),
                 sizeof(Position),

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -11,7 +11,7 @@
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Name/NameDictionary.h>
 #include <Math/GaussianMathFilter.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -728,13 +728,13 @@ namespace AZ::Render
             return;
         }
 
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
         drawPacketBuilder.Begin(nullptr);
         drawPacketBuilder.SetDrawArguments(RHI::DrawLinear(1, 0, 3, 0));
 
-        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
         drawRequest.m_listTag = m_clearShadowShader->GetDrawListTag();
-        drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_pipelineState = pipelineState;
         drawRequest.m_sortKey = AZStd::numeric_limits<RHI::DrawItemSortKey>::min();
 
         drawPacketBuilder.AddDrawItem(drawRequest);

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
@@ -148,7 +148,7 @@ namespace AZ::Render
         RPI::RenderPipeline* m_primaryShadowPipeline = nullptr;
 
         Data::Instance<RPI::Shader> m_clearShadowShader;
-        RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_clearShadowDrawPacket;
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_clearShadowDrawPacket;
 
         RHI::ShaderInputNameIndex m_shadowmapAtlasSizeIndex{ "m_shadowmapAtlasSize" };
         RHI::ShaderInputNameIndex m_invShadowmapAtlasSizeIndex{ "m_invShadowmapAtlasSize" };

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
@@ -11,7 +11,6 @@
 #include <AzFramework/Asset/AssetSystemBus.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawList.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI.Reflect/Handle.h>
 
@@ -31,8 +31,8 @@ namespace AZ::RHI
     using DrawListTag = Handle<uint8_t>;
     using DrawListMask = AZStd::bitset<RHI::Limits::Pipeline::DrawListTagCountMax>;
 
-    using DrawList = AZStd::vector<RHI::SingleDeviceDrawItemProperties>;
-    using DrawListView = AZStd::span<const RHI::SingleDeviceDrawItemProperties>;
+    using DrawList = AZStd::vector<RHI::MultiDeviceDrawItemProperties>;
+    using DrawListView = AZStd::span<const RHI::MultiDeviceDrawItemProperties>;
 
     /// Contains a table of draw lists, indexed by the tag.
     using DrawListsByTag = AZStd::array<DrawList, RHI::Limits::Pipeline::DrawListTagCountMax>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListContext.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
 #include <Atom/RHI/DrawList.h>
 #include <Atom/RHI/ThreadLocalContext.h>
 
@@ -41,11 +41,11 @@ namespace AZ::RHI
 
         /// Filters the draw items in the draw packet into draw lists. Only draw lists specified at init time are appended.
         /// The depth value here is the depth of the object from the perspective of the view.
-        void AddDrawPacket(const SingleDeviceDrawPacket* drawPacket, float depth = 0.0f);
+        void AddDrawPacket(const MultiDeviceDrawPacket* drawPacket, float depth = 0.0f);
 
         /// Adds an individual draw item to the draw list associated with the provided tag. This will
         /// no-op if the tag is not present in the internal draw list mask.
-        void AddDrawItem(DrawListTag drawListTag, SingleDeviceDrawItemProperties drawItemProperties);
+        void AddDrawItem(DrawListTag drawListTag, MultiDeviceDrawItemProperties drawItemProperties);
 
         /// Coalesces the draw lists in preparation for access via GetList. This should
         /// be called from a single thread as a sync point between the append / consume phases.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -254,7 +254,7 @@ namespace AZ::RHI
         AZStd::unordered_map<int, SingleDeviceDrawItem> m_deviceDrawItems;
         //! A map of pointers to device-specific DrawItems, indexed by the device index
         //! These pointers may point to m_deviceDrawItems (in case of direct usage of a SingleDeviceDrawItem)
-        //! or may point to DrawItems in linear memory (when allocated via a SingleDeviceDrawPacket)
+        //! or may point to DrawItems in linear memory (when allocated via a MultiDeviceDrawPacket)
         AZStd::unordered_map<int, SingleDeviceDrawItem*> m_deviceDrawItemPtrs;
         //! A map of all device-specific IndexBufferViews, indexed by the device index
         //! This additional cache is needed since device-specific IndexBufferViews are returned as objects

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawItem.h
@@ -90,6 +90,9 @@ namespace AZ::RHI
 
         MultiDeviceDrawItem(MultiDevice::DeviceMask deviceMask, AZStd::unordered_map<int, SingleDeviceDrawItem*>&& deviceDrawItemPtrs);
 
+        MultiDeviceDrawItem(const MultiDeviceDrawItem& other) = delete;
+        MultiDeviceDrawItem(MultiDeviceDrawItem&& other) = default;
+
         //! Returns the device-specific SingleDeviceDrawItem for the given index
         const SingleDeviceDrawItem& GetDeviceDrawItem(int deviceIndex) const
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -61,6 +61,9 @@ namespace AZ::RHI
             AZStd::unordered_map<int, AZStd::vector<SingleDeviceStreamBufferView>> m_deviceStreamBufferViews;
 
             AZStd::unordered_map<int, SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest> m_deviceDrawRequests;
+
+            MultiDeviceDrawRequest(const MultiDeviceDrawRequest& other);
+            MultiDeviceDrawRequest& operator=(const MultiDeviceDrawRequest& other);
         };
 
         explicit MultiDeviceDrawPacketBuilder(RHI::MultiDevice::DeviceMask deviceMask)
@@ -77,6 +80,9 @@ namespace AZ::RHI
                 }
             }
         }
+
+        MultiDeviceDrawPacketBuilder(const MultiDeviceDrawPacketBuilder& other);
+        MultiDeviceDrawPacketBuilder& operator=(const MultiDeviceDrawPacketBuilder& other);
 
         // NOTE: This is configurable; just used to control the amount of memory held by the builder.
         static const size_t DrawItemCountMax = 16;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDrawPacketBuilder.h
@@ -30,7 +30,7 @@ namespace AZ::RHI
             MultiDeviceDrawRequest() = default;
 
             //! Returns the device-specific SingleDeviceDrawRequest for the given index
-            SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest BuildDeviceDrawRequest(int deviceIndex);
+            const SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest& GetDeviceDrawRequest(int deviceIndex);
 
             //! The filter tag used to direct the draw item.
             DrawListTag m_listTag;
@@ -59,6 +59,8 @@ namespace AZ::RHI
             //! This additional cache is needed since device-specific StreamBufferViews are returned as objects
             //! and the device-specific SingleDeviceDrawItem holds a pointer to it.
             AZStd::unordered_map<int, AZStd::vector<SingleDeviceStreamBufferView>> m_deviceStreamBufferViews;
+
+            AZStd::unordered_map<int, SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest> m_deviceDrawRequests;
         };
 
         explicit MultiDeviceDrawPacketBuilder(RHI::MultiDevice::DeviceMask deviceMask)

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
@@ -29,7 +29,7 @@ namespace AZ::RHI
         switch (sortType)
         {
         case DrawListSortType::KeyThenDepth:
-            AZStd::sort(drawList.begin(), drawList.end(), [](const SingleDeviceDrawItemProperties& a, const SingleDeviceDrawItemProperties& b)
+            AZStd::sort(drawList.begin(), drawList.end(), [](const MultiDeviceDrawItemProperties& a, const MultiDeviceDrawItemProperties& b)
                 {
                     if (a.m_sortKey != b.m_sortKey)
                     {
@@ -39,13 +39,13 @@ namespace AZ::RHI
                     {
                         return a.m_depth < b.m_depth;
                     }
-                    return a.m_item < b.m_item;
+                    return a.m_mdItem < b.m_mdItem;
                 }
             );
             break;
 
         case DrawListSortType::KeyThenReverseDepth:
-            AZStd::sort(drawList.begin(), drawList.end(), [](const SingleDeviceDrawItemProperties& a, const SingleDeviceDrawItemProperties& b)
+            AZStd::sort(drawList.begin(), drawList.end(), [](const MultiDeviceDrawItemProperties& a, const MultiDeviceDrawItemProperties& b)
                 {
                     if (a.m_sortKey != b.m_sortKey)
                     {
@@ -55,13 +55,13 @@ namespace AZ::RHI
                     {
                         return a.m_depth > b.m_depth;
                     }
-                    return a.m_item < b.m_item;
+                    return a.m_mdItem < b.m_mdItem;
                 }
             );
             break;
 
         case DrawListSortType::DepthThenKey:
-            AZStd::sort(drawList.begin(), drawList.end(), [](const SingleDeviceDrawItemProperties& a, const SingleDeviceDrawItemProperties& b)
+            AZStd::sort(drawList.begin(), drawList.end(), [](const MultiDeviceDrawItemProperties& a, const MultiDeviceDrawItemProperties& b)
                 {
                     if (a.m_depth != b.m_depth)
                     {
@@ -71,13 +71,13 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_item < b.m_item;
+                    return a.m_mdItem < b.m_mdItem;
                 }
             );
             break;
 
         case DrawListSortType::ReverseDepthThenKey:
-            AZStd::sort(drawList.begin(), drawList.end(), [](const SingleDeviceDrawItemProperties& a, const SingleDeviceDrawItemProperties& b)
+            AZStd::sort(drawList.begin(), drawList.end(), [](const MultiDeviceDrawItemProperties& a, const MultiDeviceDrawItemProperties& b)
                 {
                     if (a.m_depth != b.m_depth)
                     {
@@ -87,7 +87,7 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_item < b.m_item;
+                    return a.m_mdItem < b.m_mdItem;
                 }
             );
             break;

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawListContext.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawListContext.cpp
@@ -39,7 +39,7 @@ namespace AZ::RHI
         m_drawListMask.reset();
     }
 
-    void DrawListContext::AddDrawPacket(const SingleDeviceDrawPacket* drawPacket, float depth)
+    void DrawListContext::AddDrawPacket(const MultiDeviceDrawPacket* drawPacket, float depth)
     {
         if (drawPacket)
         {
@@ -51,8 +51,8 @@ namespace AZ::RHI
 
                 if (m_drawListMask[drawListTag.GetIndex()])
                 {
-                    SingleDeviceDrawItemProperties drawItem = drawPacket->GetDrawItemProperties(i);
-                    if (drawItem.m_item->m_enabled)
+                    MultiDeviceDrawItemProperties drawItem = drawPacket->GetDrawItemProperties(i);
+                    if (drawItem.m_mdItem->GetEnabled())
                     {
                         drawItem.m_depth = depth;
                         threadListsByTag[drawListTag.GetIndex()].push_back(drawItem);
@@ -69,9 +69,9 @@ namespace AZ::RHI
         }
     }
 
-    void DrawListContext::AddDrawItem(DrawListTag drawListTag, SingleDeviceDrawItemProperties drawItemProperties)
+    void DrawListContext::AddDrawItem(DrawListTag drawListTag, MultiDeviceDrawItemProperties drawItemProperties)
     {
-        if (!drawItemProperties.m_item->m_enabled)
+        if (!drawItemProperties.m_mdItem->GetEnabled())
         {
             return;
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -212,7 +212,7 @@ namespace AZ::RHI
             AZStd::unordered_map<int, SingleDeviceDrawItem*> deviceDrawItemPtrs;
             for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
             {
-                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(0));
+                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(i));
             }
             m_drawPacketInFlight->m_drawItems.emplace_back(MultiDeviceDrawItem{ m_deviceMask, AZStd::move(deviceDrawItemPtrs) });
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -16,26 +16,37 @@
 
 namespace AZ::RHI
 {
-    SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::BuildDeviceDrawRequest(int deviceIndex)
+    const SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest& MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::
+        GetDeviceDrawRequest(int deviceIndex)
     {
-        if (!m_deviceStreamBufferViews.contains(deviceIndex))
+        if (auto it{ m_deviceDrawRequests.find(deviceIndex) }; it != m_deviceDrawRequests.end())
         {
-            // We need to hold the memory for the single-device StreamBufferViews
-            AZStd::vector<SingleDeviceStreamBufferView> deviceStreamBufferView;
-            for (auto& mdStreamBufferView : m_streamBufferViews)
-            {
-                deviceStreamBufferView.emplace_back(mdStreamBufferView.GetDeviceStreamBufferView(deviceIndex));
-            }
-            m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::move(deviceStreamBufferView));
+            return it->second;
         }
-
-        return { m_listTag,
-                 m_stencilRef,
-                 m_deviceStreamBufferViews.at(deviceIndex),
-                 m_uniqueShaderResourceGroup ? m_uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get() : nullptr,
-                 m_pipelineState ? m_pipelineState->GetDevicePipelineState(deviceIndex).get() : nullptr,
-                 m_sortKey,
-                 m_drawFilterMask };
+        else
+        {
+            if (!m_deviceStreamBufferViews.contains(deviceIndex))
+            {
+                // We need to hold the memory for the single-device StreamBufferViews
+                AZStd::vector<SingleDeviceStreamBufferView> deviceStreamBufferView;
+                for (auto& mdStreamBufferView : m_streamBufferViews)
+                {
+                    deviceStreamBufferView.emplace_back(mdStreamBufferView.GetDeviceStreamBufferView(deviceIndex));
+                }
+                m_deviceStreamBufferViews.emplace(deviceIndex, AZStd::move(deviceStreamBufferView));
+            }
+            auto [iter, ok]{ m_deviceDrawRequests.insert(AZStd::make_pair(
+                deviceIndex,
+                SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest{
+                    m_listTag,
+                    m_stencilRef,
+                    m_deviceStreamBufferViews.at(deviceIndex),
+                    m_uniqueShaderResourceGroup ? m_uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get() : nullptr,
+                    m_pipelineState ? m_pipelineState->GetDevicePipelineState(deviceIndex).get() : nullptr,
+                    m_sortKey,
+                    m_drawFilterMask })) };
+            return iter->second;
+        }
     }
 
     void MultiDeviceDrawPacketBuilder::Begin(IAllocator* allocator)
@@ -122,7 +133,7 @@ namespace AZ::RHI
             m_drawPacketInFlight->m_drawListMask.set(request.m_listTag.GetIndex());
             for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
             {
-                deviceDrawPacketBuilder.AddDrawItem(request.BuildDeviceDrawRequest(deviceIndex));
+                deviceDrawPacketBuilder.AddDrawItem(m_drawRequests.back().GetDeviceDrawRequest(deviceIndex));
             }
         }
         else
@@ -149,12 +160,12 @@ namespace AZ::RHI
         m_drawPacketInFlight->m_drawItems.reserve(m_drawRequests.size());
 
         // Setup single-device DrawItems
-        for (auto i{ 0 }; i < m_drawRequests.size(); ++i)
+        for (auto drawItemIndex{ 0 }; drawItemIndex < m_drawRequests.size(); ++drawItemIndex)
         {
             AZStd::unordered_map<int, SingleDeviceDrawItem*> deviceDrawItemPtrs;
             for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
             {
-                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(0));
+                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(drawItemIndex));
             }
             m_drawPacketInFlight->m_drawItems.emplace_back(MultiDeviceDrawItem{ m_deviceMask, AZStd::move(deviceDrawItemPtrs) });
         }
@@ -207,12 +218,12 @@ namespace AZ::RHI
         }
 
         // Setup single-device DrawItems
-        for (auto i{ 0 }; i < drawRequestCount; ++i)
+        for (auto drawItemIndex{ 0 }; drawItemIndex < drawRequestCount; ++drawItemIndex)
         {
             AZStd::unordered_map<int, SingleDeviceDrawItem*> deviceDrawItemPtrs;
             for (auto& [deviceIndex, deviceDrawPacketBuilder] : m_deviceDrawPacketBuilders)
             {
-                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(i));
+                deviceDrawItemPtrs.emplace(deviceIndex, m_drawPacketInFlight->m_deviceDrawPackets[deviceIndex]->GetDrawItem(drawItemIndex));
             }
             m_drawPacketInFlight->m_drawItems.emplace_back(MultiDeviceDrawItem{ m_deviceMask, AZStd::move(deviceDrawItemPtrs) });
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceDrawPacketBuilder.cpp
@@ -49,6 +49,71 @@ namespace AZ::RHI
         }
     }
 
+    MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::MultiDeviceDrawRequest(const MultiDeviceDrawRequest& other)
+    {
+        m_listTag = other.m_listTag;
+        m_stencilRef = other.m_stencilRef;
+        m_streamBufferViews = other.m_streamBufferViews;
+        m_uniqueShaderResourceGroup = other.m_uniqueShaderResourceGroup;
+        m_pipelineState = other.m_pipelineState;
+        m_sortKey = other.m_sortKey;
+        m_drawFilterMask = other.m_drawFilterMask;
+        m_deviceStreamBufferViews = other.m_deviceStreamBufferViews;
+        m_deviceDrawRequests = other.m_deviceDrawRequests;
+
+        for(auto& [deviceIndex, deviceDrawRequest] : m_deviceDrawRequests)
+        {
+            deviceDrawRequest.m_streamBufferViews = m_deviceStreamBufferViews[deviceIndex];
+        }
+    }
+
+    MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest& MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest::operator=(
+        const MultiDeviceDrawRequest& other)
+    {
+        m_listTag = other.m_listTag;
+        m_stencilRef = other.m_stencilRef;
+        m_streamBufferViews = other.m_streamBufferViews;
+        m_uniqueShaderResourceGroup = other.m_uniqueShaderResourceGroup;
+        m_pipelineState = other.m_pipelineState;
+        m_sortKey = other.m_sortKey;
+        m_drawFilterMask = other.m_drawFilterMask;
+        m_deviceStreamBufferViews = other.m_deviceStreamBufferViews;
+        m_deviceDrawRequests = other.m_deviceDrawRequests;
+
+        for(auto& [deviceIndex, deviceDrawRequest] : m_deviceDrawRequests)
+        {
+            deviceDrawRequest.m_streamBufferViews = m_deviceStreamBufferViews[deviceIndex];
+        }
+
+        return *this;
+    }
+
+    MultiDeviceDrawPacketBuilder::MultiDeviceDrawPacketBuilder(const MultiDeviceDrawPacketBuilder& other)
+    {
+        m_deviceMask = other.m_deviceMask;
+
+        m_drawRequests = other.m_drawRequests;
+
+        m_drawPacketInFlight = aznew MultiDeviceDrawPacket;
+        m_drawPacketInFlight->m_drawListMask = other.m_drawPacketInFlight->m_drawListMask;
+
+        m_deviceDrawPacketBuilders = other.m_deviceDrawPacketBuilders;
+    }
+
+    MultiDeviceDrawPacketBuilder& MultiDeviceDrawPacketBuilder::operator=(const MultiDeviceDrawPacketBuilder& other)
+    {
+        m_deviceMask = other.m_deviceMask;
+
+        m_drawRequests = other.m_drawRequests;
+
+        m_drawPacketInFlight = aznew MultiDeviceDrawPacket;
+        m_drawPacketInFlight->m_drawListMask = other.m_drawPacketInFlight->m_drawListMask;
+
+        m_deviceDrawPacketBuilders = other.m_deviceDrawPacketBuilders;
+
+        return *this;
+    }
+
     void MultiDeviceDrawPacketBuilder::Begin(IAllocator* allocator)
     {
         AZ_Error(

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceStreamBufferView.cpp
@@ -52,7 +52,7 @@ namespace AZ::RHI
         return m_byteStride;
     }
 
-    bool ValidateStreamBufferViews(
+    bool  ValidateStreamBufferViews(
         const RHI::InputStreamLayout& inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView> streamBufferViews)
     {
         bool ok = true;

--- a/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
@@ -348,84 +348,6 @@ namespace UnitTest
             EXPECT_EQ(drawPacket, nullptr);
         }
 
-        void DrawListContextFilter()
-        {
-            AZ::SimpleLcgRandom random(s_randomSeed);
-            DrawPacketData drawPacketData(random);
-
-            RHI::SingleDeviceDrawPacketBuilder builder;
-            const RHI::SingleDeviceDrawPacket* drawPacket = drawPacketData.Build(builder);
-
-            RHI::DrawListContext drawListContext;
-            drawListContext.Init(RHI::DrawListMask{}.set());
-            drawListContext.AddDrawPacket(drawPacket);
-
-            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
-            {
-                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
-
-                RHI::DrawListView drawList = drawListContext.GetList(tag);
-                EXPECT_TRUE(drawList.empty());
-            }
-
-            drawListContext.FinalizeLists();
-
-            RHI::DrawListsByTag listsByTag;
-            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
-            {
-                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
-
-                listsByTag[tag.GetIndex()].push_back(drawPacket->GetDrawItemProperties(i));
-            }
-
-            size_t tagIndex = 0;
-            for (auto& drawList : listsByTag)
-            {
-                SortDrawList(drawList, RHI::DrawListSortType::KeyThenDepth);
-
-                RHI::DrawListTag tag(tagIndex);
-
-                RHI::DrawListView drawListView = drawListContext.GetList(tag);
-                EXPECT_EQ(drawListView.size(), drawList.size());
-
-                for (size_t i = 0; i < drawList.size(); ++i)
-                {
-                    EXPECT_EQ(drawList[i], drawListView[i]);
-                }
-
-                tagIndex++;
-            }
-
-            drawListContext.Shutdown();
-
-            delete drawPacket;
-        }
-
-        void DrawListContextNullFilter()
-        {
-            AZ::SimpleLcgRandom random(s_randomSeed);
-            DrawPacketData drawPacketData(random);
-
-            RHI::SingleDeviceDrawPacketBuilder builder;
-            const RHI::SingleDeviceDrawPacket* drawPacket = drawPacketData.Build(builder);
-
-            RHI::DrawListContext drawListContext;
-            drawListContext.Init(RHI::DrawListMask{}); // Mask set to not contain any draw lists.
-            drawListContext.AddDrawPacket(drawPacket);
-            drawListContext.FinalizeLists();
-
-            for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
-            {
-                RHI::DrawListTag tag = drawPacket->GetDrawListTag(i);
-                RHI::DrawListView drawList = drawListContext.GetList(tag);
-                EXPECT_TRUE(drawList.empty());
-            }
-
-            drawListContext.Shutdown();
-
-            delete drawPacket;
-        }
-
         void DrawPacketClone()
         {
             AZ::SimpleLcgRandom random(s_randomSeed);
@@ -686,16 +608,6 @@ namespace UnitTest
     TEST_F(DrawPacketTest, DrawPacketBuildClearBuildNull)
     {
         DrawPacketBuildClearBuildNull();
-    }
-
-    TEST_F(DrawPacketTest, DrawListContextFilter)
-    {
-        DrawListContextFilter();
-    }
-
-    TEST_F(DrawPacketTest, DrawListContextNullFilter)
-    {
-        DrawListContextNullFilter();
     }
 
     TEST_F(DrawPacketTest, DrawPacketClone)

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
@@ -222,19 +222,17 @@ namespace UnitTest
             EXPECT_EQ(drawPacket.get(), nullptr);
         }
 
-        //! Add these tests once DrawListContext takes MultiDeviceDrawPackets
-        /*
         void DrawListContextFilter()
         {
             AZ::SimpleLcgRandom random(s_randomSeed);
             MultiDeviceDrawPacketData drawPacketData(random);
 
             RHI::MultiDeviceDrawPacketBuilder builder(LocalDeviceMask);
-            const auto drawPacket = drawPacketData.Build(builder);
+            auto drawPacket = drawPacketData.Build(builder);
 
             RHI::DrawListContext drawListContext;
             drawListContext.Init(RHI::DrawListMask{}.set());
-            drawListContext.AddDrawPacket(drawPacket);
+            drawListContext.AddDrawPacket(drawPacket.get());
 
             for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
             {
@@ -278,14 +276,14 @@ namespace UnitTest
         void DrawListContextNullFilter()
         {
             AZ::SimpleLcgRandom random(s_randomSeed);
-            DrawPacketData drawPacketData(random);
+            MultiDeviceDrawPacketData drawPacketData(random);
 
-            RHI::SingleDeviceDrawPacketBuilder builder;
-            const RHI::SingleDeviceDrawPacket* drawPacket = drawPacketData.Build(builder);
+            RHI::MultiDeviceDrawPacketBuilder builder{RHI::MultiDevice::DefaultDevice};
+            auto drawPacket = drawPacketData.Build(builder);
 
             RHI::DrawListContext drawListContext;
             drawListContext.Init(RHI::DrawListMask{}); // Mask set to not contain any draw lists.
-            drawListContext.AddDrawPacket(drawPacket);
+            drawListContext.AddDrawPacket(drawPacket.get());
             drawListContext.FinalizeLists();
 
             for (size_t i = 0; i < drawPacket->GetDrawItemCount(); ++i)
@@ -296,10 +294,7 @@ namespace UnitTest
             }
 
             drawListContext.Shutdown();
-
-            delete drawPacket;
         }
-        */
 
         void DrawPacketClone()
         {
@@ -580,8 +575,6 @@ namespace UnitTest
         DrawPacketBuildClearBuildNull();
     }
 
-    //! Add these tests once DrawListContext takes MultiDeviceDrawPackets
-    /*
     TEST_F(MultiDeviceDrawPacketTest, DrawListContextFilter)
     {
         DrawListContextFilter();
@@ -591,7 +584,6 @@ namespace UnitTest
     {
         DrawListContextNullFilter();
     }
-    */
 
     TEST_F(MultiDeviceDrawPacketTest, DrawPacketClone)
     {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -273,7 +273,6 @@ namespace AZ
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
                 vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
                 vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
-                shaderImageAtomicInt64.pNext = &vulkan12Features;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -98,7 +98,7 @@ namespace AZ
                 {
                     float m_screenCoverageMin = 0.0f;
                     float m_screenCoverageMax = 1.0f;
-                    AZStd::vector<const RHI::SingleDeviceDrawPacket*> m_drawPackets;
+                    AZStd::vector<const RHI::MultiDeviceDrawPacket*> m_drawPackets;
                     void* m_visibleObjectUserData = nullptr;
                 };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
@@ -13,8 +13,8 @@
 
 #include <AzCore/std/smart_ptr/intrusive_base.h>
 
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 namespace AZ
 {
@@ -51,11 +51,11 @@ namespace AZ
             void* GetBufferAddress();
 
             //! Get IndexBufferView if this buffer is used as index buffer
-            RHI::SingleDeviceIndexBufferView GetIndexBufferView(RHI::IndexFormat format);
+            RHI::MultiDeviceIndexBufferView GetIndexBufferView(RHI::IndexFormat format);
 
             //! Get StreamBufferView if this buffer is used as vertex buffer
             //! @param strideByteCount the byte count of the element
-            RHI::SingleDeviceStreamBufferView GetStreamBufferView(uint32_t strideByteCount);
+            RHI::MultiDeviceStreamBufferView GetStreamBufferView(uint32_t strideByteCount);
 
         private:
             // Only DynamicBufferAllocator can allocate a DynamicBuffer

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
@@ -10,8 +10,8 @@
 
 #include <AtomCore/Instance/Instance.h>
 
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
@@ -48,10 +48,10 @@ namespace AZ
             RHI::Ptr<DynamicBuffer> Allocate(uint32_t size, uint32_t alignment);
 
             //! Get an IndexBufferView for a DynamicBuffer used as an index buffer
-            RHI::SingleDeviceIndexBufferView GetIndexBufferView(RHI::Ptr<DynamicBuffer> subBuffer, RHI::IndexFormat format);
+            RHI::MultiDeviceIndexBufferView GetIndexBufferView(RHI::Ptr<DynamicBuffer> subBuffer, RHI::IndexFormat format);
 
             //! Get an StreamBufferView for a DynamicBuffer used as a vertex buffer
-            RHI::SingleDeviceStreamBufferView GetStreamBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, uint32_t strideByteCount);
+            RHI::MultiDeviceStreamBufferView GetStreamBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, uint32_t strideByteCount);
 
             //! Submit allocated dynamic buffer to gpu for current frame
             void FrameEnd();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
@@ -237,7 +237,7 @@ namespace AZ
             // Data for draw item
             Ptr<PipelineStateForDraw> m_pipelineState;
             Data::Instance<ShaderResourceGroup> m_srgPerContext;
-            RHI::SingleDeviceShaderResourceGroup* m_srgGroups[1]; // array for draw item's srg groups
+            RHI::MultiDeviceShaderResourceGroup* m_srgGroups[1]; // array for draw item's srg groups
             uint32_t m_perVertexDataSize = 0;
             RHI::Ptr<RHI::ShaderResourceGroupLayout> m_drawSrgLayout;
             bool m_hasShaderVariantKeyFallbackEntry = false;
@@ -266,8 +266,8 @@ namespace AZ
             RHI::DrawFilterMask m_drawFilter = RHI::DrawFilterMaskDefaultValue;
 
             // Cached draw data
-            AZStd::vector<RHI::SingleDeviceStreamBufferView> m_cachedStreamBufferViews;
-            AZStd::vector<RHI::SingleDeviceIndexBufferView> m_cachedIndexBufferViews;
+            AZStd::vector<RHI::MultiDeviceStreamBufferView> m_cachedStreamBufferViews;
+            AZStd::vector<RHI::MultiDeviceIndexBufferView> m_cachedIndexBufferViews;
             AZStd::vector<Data::Instance<ShaderResourceGroup>> m_cachedDrawSrg;
 
             uint32_t m_nextDrawSrgIdx = 0;
@@ -277,7 +277,7 @@ namespace AZ
             static const BufferViewIndexType InvalidIndex = static_cast<BufferViewIndexType>(-1);
             struct DrawItemInfo
             {
-                RHI::SingleDeviceDrawItem m_drawItem;
+                RHI::MultiDeviceDrawItem m_drawItem;
                 RHI::DrawItemSortKey m_sortKey = 0;
                 BufferViewIndexType m_vertexBufferViewIndex = InvalidIndex;
                 BufferViewIndexType m_indexBufferViewIndex = InvalidIndex;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
 
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/DynamicDraw/DynamicBuffer.h>
@@ -59,15 +59,15 @@ namespace AZ
             //! Draw a geometry to a scene with a given material
             virtual void DrawGeometry(Data::Instance<Material> material, const GeometryData& geometry, ScenePtr scene) = 0;
 
-            //! Deprecated. Please use AddDrawPacket(Scene* scene, ConstPtr<RHI::SingleDeviceDrawPacket> drawPacket) instead
+            //! Deprecated. Please use AddDrawPacket(Scene* scene, ConstPtr<RHI::MultiDeviceDrawPacket> drawPacket) instead
             //! Submits a DrawPacket to the renderer.
             //! Note that ownership of the DrawPacket pointer is passed to the dynamic draw system.
             //! (it will be cleaned up correctly since the DrawPacket keeps track of the allocator that was used when it was built)
-            virtual void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket) = 0;
+            virtual void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::MultiDeviceDrawPacket> drawPacket) = 0;
             
             //! Submits a DrawPacket to the scene.
             //! The dynamic draw system will keep a reference for the DrawPacket until it's rendered.
-            virtual void AddDrawPacket(Scene* scene, ConstPtr<RHI::SingleDeviceDrawPacket> drawPacket) = 0;
+            virtual void AddDrawPacket(Scene* scene, ConstPtr<RHI::MultiDeviceDrawPacket> drawPacket) = 0;
 
             //! Get DrawLists from any DynamicDrawContext which output to the specified RasterPass.
             virtual AZStd::vector<RHI::DrawListView> GetDrawListsForPass(const RasterPass* pass) = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawSystem.h
@@ -34,8 +34,8 @@ namespace AZ
             RHI::Ptr<DynamicDrawContext> CreateDynamicDrawContext() override;
             RHI::Ptr<DynamicBuffer> GetDynamicBuffer(uint32_t size, uint32_t alignment) override;
             void DrawGeometry(Data::Instance<Material> material, const GeometryData& geometry, ScenePtr scene) override;
-            void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket) override;
-            void AddDrawPacket(Scene* scene, ConstPtr<RHI::SingleDeviceDrawPacket> drawPacket) override;
+            void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::MultiDeviceDrawPacket> drawPacket) override;
+            void AddDrawPacket(Scene* scene, ConstPtr<RHI::MultiDeviceDrawPacket> drawPacket) override;
             AZStd::vector<RHI::DrawListView> GetDrawListsForPass(const RasterPass* pass) override;
 
             // Submit draw data for selected scene and pipeline
@@ -53,7 +53,7 @@ namespace AZ
             AZStd::list<RHI::Ptr<DynamicDrawContext>> m_dynamicDrawContexts;
 
             AZStd::mutex m_mutexDrawPackets;
-            AZStd::map<Scene*, AZStd::vector<ConstPtr<const RHI::SingleDeviceDrawPacket>>> m_drawPackets;
+            AZStd::map<Scene*, AZStd::vector<ConstPtr<const RHI::MultiDeviceDrawPacket>>> m_drawPackets;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -11,8 +11,8 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Model/ModelLod.h>
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 #include <AzCore/Math/Obb.h>
 #include <AzCore/std/containers/fixed_vector.h>
@@ -58,8 +58,8 @@ namespace AZ
 
             bool Update(const Scene& parentScene, bool forceUpdate = false);
 
-            RHI::SingleDeviceDrawPacket* GetRHIDrawPacket() { return m_drawPacket.get(); }
-            const RHI::SingleDeviceDrawPacket* GetRHIDrawPacket() const { return m_drawPacket.get(); }
+            RHI::MultiDeviceDrawPacket* GetRHIDrawPacket() { return m_drawPacket.get(); }
+            const RHI::MultiDeviceDrawPacket* GetRHIDrawPacket() const { return m_drawPacket.get(); }
             const RHI::ConstPtr<RHI::ConstantsLayout> GetRootConstantsLayout() const;
 
             void SetStencilRef(uint8_t stencilRef);
@@ -83,10 +83,10 @@ namespace AZ
             bool DoUpdate(const Scene& parentScene);
             void ForValidShaderOptionName(const Name& shaderOptionName, const AZStd::function<bool(const ShaderCollection::Item&, ShaderOptionIndex)>& callback);
 
-            Ptr<RHI::SingleDeviceDrawPacket> m_drawPacket;
+            Ptr<RHI::MultiDeviceDrawPacket> m_drawPacket;
 
             // Note, many of the following items are held locally in the MeshDrawPacket solely to keep them resident in memory as long as they are needed
-            // for the m_drawPacket. RHI::SingleDeviceDrawPacket uses raw pointers only, but we use smart pointers here to hold on to the data.
+            // for the m_drawPacket. RHI::MultiDeviceDrawPacket uses raw pointers only, but we use smart pointers here to hold on to the data.
 
             // Maintains references to the shader instances to keep their PSO caches resident (see Shader::Shutdown())
             ShaderList m_activeShaders;
@@ -106,7 +106,7 @@ namespace AZ
             // does not allow public access to its Instance<RPI::ShaderResourceGroup>.
             ConstPtr<RHI::SingleDeviceShaderResourceGroup> m_materialSrg;
 
-            AZStd::fixed_vector<Data::Instance<ShaderResourceGroup>, RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
+            AZStd::fixed_vector<Data::Instance<ShaderResourceGroup>, RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
 
             // A reference to the material, used to rebuild the DrawPacket if needed
             Data::Instance<Material> m_material;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
@@ -12,7 +12,6 @@
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Model/UvStreamTangentBitmask.h>
 
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/MultiDeviceIndexBufferView.h>
 #include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
@@ -71,9 +70,9 @@ namespace AZ
             //! Mesh data associated with a specific material.
             struct Mesh final
             {
-                RHI::SingleDeviceDrawArguments m_drawArguments;
+                RHI::MultiDeviceDrawArguments m_drawArguments;
                 RHI::MultiDeviceIndexBufferView m_indexBufferView;
-                RHI::SingleDeviceIndexBufferView m_sdIndexBufferView; // TODO: Remove once IndexBufferViews have been converted to multi device
+                RHI::MultiDeviceIndexBufferView m_sdIndexBufferView; // TODO: Remove once IndexBufferViews have been converted to multi device
 
                 StreamInfoList m_streamInfo;
 
@@ -85,7 +84,6 @@ namespace AZ
             };
 
             using StreamBufferViewList = AZStd::fixed_vector<RHI::MultiDeviceStreamBufferView, RHI::Limits::Pipeline::StreamCountMax>;
-            using TempStreamBufferViewList = AZStd::fixed_vector<RHI::SingleDeviceStreamBufferView, RHI::Limits::Pipeline::StreamCountMax>;
 
             AZ_INSTANCE_DATA(ModelLod, "{3C796FC9-2067-4E0F-A660-269F8254D1D5}");
             AZ_CLASS_ALLOCATOR(ModelLod, AZ::SystemAllocator);
@@ -121,21 +119,6 @@ namespace AZ
             bool GetStreamsForMesh(
                 RHI::InputStreamLayout& layoutOut,
                 ModelLod::StreamBufferViewList& streamBufferViewsOut,
-                UvStreamTangentBitmask* uvStreamTangentBitmaskOut,
-                const ShaderInputContract& contract,
-                size_t meshIndex,
-                const MaterialModelUvOverrideMap& materialModelUvMap = {},
-                const MaterialUvNameMap& materialUvNameMap = {}) const;
-
-            //! Fills a InputStreamLayout and StreamBufferViewList for the set of streams that satisfy a ShaderInputContract.
-            // @param uvStreamTangentBitmaskOut a mask processed during UV stream matching, and later to determine which tangent/bitangent stream to use.
-            // @param contract the contract that defines the expected inputs for a shader, used to determine which streams are optional.
-            // @param meshIndex the index of the mesh to search in.
-            // @param materialModelUvMap a map of UV name overrides, which can be supplied to bind a specific mesh stream name to a different material shader stream name.
-            // @param materialUvNameMap the UV name map that came from a MaterialTypeAsset, which defines the default set of material shader stream names.
-            bool GetStreamsForMesh(
-                RHI::InputStreamLayout& layoutOut,
-                ModelLod::TempStreamBufferViewList& streamBufferViewsOut,
                 UvStreamTangentBitmask* uvStreamTangentBitmaskOut,
                 const ShaderInputContract& contract,
                 size_t meshIndex,

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
@@ -72,7 +72,6 @@ namespace AZ
             {
                 RHI::MultiDeviceDrawArguments m_drawArguments;
                 RHI::MultiDeviceIndexBufferView m_indexBufferView;
-                RHI::MultiDeviceIndexBufferView m_sdIndexBufferView; // TODO: Remove once IndexBufferViews have been converted to multi device
 
                 StreamInfoList m_streamInfo;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -72,10 +72,10 @@ namespace AZ
             
             //! Add a draw packet to this view. DrawPackets need to be added every frame. This function is thread safe.
             //! The depth value here is the depth of the object from the perspective of the view.
-            void AddDrawPacket(const RHI::SingleDeviceDrawPacket* drawPacket, float depth = 0.0f);
+            void AddDrawPacket(const RHI::MultiDeviceDrawPacket* drawPacket, float depth = 0.0f);
 
             //! Similar to previous AddDrawPacket() but calculates depth from packet position
-            void AddDrawPacket(const RHI::SingleDeviceDrawPacket* drawPacket, const Vector3& worldPosition);
+            void AddDrawPacket(const RHI::MultiDeviceDrawPacket* drawPacket, const Vector3& worldPosition);
             
             //! Similar to AddDrawPacket, but the view will not submit any draw items for rendering. It will just
             //! maintain a list of visible objects for the current frame, and the caller must get that list, reinterpret the
@@ -86,7 +86,7 @@ namespace AZ
             void AddVisibleObject(const void* userData, const Vector3& worldPosition);
 
             //! Add a draw item to this view with its associated draw list tag
-            void AddDrawItem(RHI::DrawListTag drawListTag, const RHI::SingleDeviceDrawItemProperties& drawItemProperties);
+            void AddDrawItem(RHI::DrawListTag drawListTag, const RHI::MultiDeviceDrawItemProperties& drawItemProperties);
 
             //! Applies some flags to the view that are reset each frame. The provided flags are combined with m_andFlags
             //! using &, and are combined with m_orFlags using |.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/VisibleObjectContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/VisibleObjectContext.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ThreadLocalContext.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -922,7 +922,7 @@ namespace AZ
                 }
                 else if (typeFlags & AzFramework::VisibilityEntry::TYPE_RPI_Cullable)
                 {
-                    for (const RHI::SingleDeviceDrawPacket* drawPacket : lod.m_drawPackets)
+                    for (const RHI::MultiDeviceDrawPacket* drawPacket : lod.m_drawPackets)
                     {
                         view.AddDrawPacket(drawPacket, pos);
                     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
@@ -34,12 +34,12 @@ namespace AZ
             return m_address;
         }
 
-        RHI::SingleDeviceIndexBufferView DynamicBuffer::GetIndexBufferView(RHI::IndexFormat format)
+        RHI::MultiDeviceIndexBufferView DynamicBuffer::GetIndexBufferView(RHI::IndexFormat format)
         {
             return m_allocator->GetIndexBufferView(this, format);
         }
 
-        RHI::SingleDeviceStreamBufferView DynamicBuffer::GetStreamBufferView(uint32_t strideByteCount)
+        RHI::MultiDeviceStreamBufferView DynamicBuffer::GetStreamBufferView(uint32_t strideByteCount)
         {
             return m_allocator->GetStreamBufferView(this, strideByteCount);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
@@ -131,20 +131,20 @@ namespace AZ
             return allocatedBuffer;
         }
 
-        RHI::SingleDeviceIndexBufferView DynamicBufferAllocator::GetIndexBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, RHI::IndexFormat format)
+        RHI::MultiDeviceIndexBufferView DynamicBufferAllocator::GetIndexBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, RHI::IndexFormat format)
         {
-            return RHI::SingleDeviceIndexBufferView(
-                *m_ringBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            return RHI::MultiDeviceIndexBufferView(
+                *m_ringBuffer->GetRHIBuffer(),
                 GetBufferAddressOffset(dynamicBuffer),
                 dynamicBuffer->m_size,
                 format
             );
         }
 
-        RHI::SingleDeviceStreamBufferView DynamicBufferAllocator::GetStreamBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, uint32_t strideByteCount)
+        RHI::MultiDeviceStreamBufferView DynamicBufferAllocator::GetStreamBufferView(RHI::Ptr<DynamicBuffer> dynamicBuffer, uint32_t strideByteCount)
         {
-            return RHI::SingleDeviceStreamBufferView(
-                *m_ringBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            return RHI::MultiDeviceStreamBufferView(
+                *m_ringBuffer->GetRHIBuffer(),
                 GetBufferAddressOffset(dynamicBuffer),
                 dynamicBuffer->m_size,
                 strideByteCount

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -542,7 +542,7 @@ namespace AZ
             drawItem.SetStencilRef(m_stencilRef);
 
             drawItemInfo.m_sortKey = m_sortKey++;
-            m_cachedDrawItems.emplace_back(drawItemInfo);
+            m_cachedDrawItems.emplace_back(AZStd::move(drawItemInfo));
         }
 
         void DynamicDrawContext::DrawLinear(const void* vertexData, uint32_t vertexCount, Data::Instance<ShaderResourceGroup> drawSrg)
@@ -624,7 +624,7 @@ namespace AZ
             }
 
             drawItemInfo.m_sortKey = m_sortKey++;
-            m_cachedDrawItems.emplace_back(drawItemInfo);
+            m_cachedDrawItems.emplace_back(AZStd::move(drawItemInfo));
         }
 
         Data::Instance<ShaderResourceGroup> DynamicDrawContext::NewDrawSrg()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -130,7 +130,7 @@ namespace AZ
             {
                 m_srgPerContext = AZ::RPI::ShaderResourceGroup::Create(
                     m_shader->GetAsset(), m_shader->GetSupervariantIndex(), Name { PerContextSrgName });
-                m_srgGroups[0] = m_srgPerContext->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                m_srgGroups[0] = m_srgPerContext->GetRHIShaderResourceGroup();
             }
 
             // Save per draw srg asset which can be used to create draw srg later
@@ -491,23 +491,22 @@ namespace AZ
                 return;
             }
 
-            DrawItemInfo drawItemInfo;
-            RHI::SingleDeviceDrawItem& drawItem = drawItemInfo.m_drawItem;
+            DrawItemInfo drawItemInfo{{RHI::MultiDevice::AllDevices}};
+            RHI::MultiDeviceDrawItem& drawItem = drawItemInfo.m_drawItem;
 
             // Draw argument
             RHI::DrawIndexed drawIndexed;
             drawIndexed.m_indexCount = indexCount;
             drawIndexed.m_instanceCount = 1;
-            drawItem.m_arguments = drawIndexed;
+            drawItem.SetArguments(drawIndexed);
 
             // Get RHI pipeline state from cached RHI pipeline states based on current draw state options
-            drawItem.m_pipelineState = GetCurrentPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawItem.SetPipelineState(GetCurrentPipelineState());
 
             // Write data to vertex buffer and set up stream buffer views for DrawItem
             // The stream buffer view need to be cached before the frame is end
             vertexBuffer->Write(vertexData, vertexDataSize);
             m_cachedStreamBufferViews.push_back(vertexBuffer->GetStreamBufferView(m_perVertexDataSize));
-            drawItem.m_streamBufferViewCount = 1;
             drawItemInfo.m_vertexBufferViewIndex = static_cast<BufferViewIndexType>(m_cachedStreamBufferViews.size() - 1);
 
             // Write data to index buffer and set up index buffer view for DrawItem
@@ -518,32 +517,29 @@ namespace AZ
             // Setup per context srg if it exists
             if (m_srgPerContext)
             {
-                drawItem.m_shaderResourceGroupCount = 1;
-                drawItem.m_shaderResourceGroups = m_srgGroups;
+                drawItem.SetShaderResourceGroups(m_srgGroups, 1);
             }
 
             // Setup per draw srg
             if (drawSrg)
             {
-                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawItem.SetUniqueShaderResourceGroup(drawSrg->GetRHIShaderResourceGroup());
             }
 
             // Set scissor per draw if scissor is enabled.
             if (m_useScissor)
             {
-                drawItem.m_scissorsCount = 1;
-                drawItem.m_scissors = &m_scissor;
+                drawItem.SetScissors(&m_scissor, 1);
             }
 
             // Set viewport per draw if viewport is enabled.
             if (m_useViewport)
             {
-                drawItem.m_viewportsCount = 1;
-                drawItem.m_viewports = &m_viewport;
+                drawItem.SetViewports(&m_viewport, 1);
             }
 
             // Set stencil reference. Used when stencil is enabled.
-            drawItem.m_stencilRef = m_stencilRef;
+            drawItem.SetStencilRef(m_stencilRef);
 
             drawItemInfo.m_sortKey = m_sortKey++;
             m_cachedDrawItems.emplace_back(drawItemInfo);
@@ -585,50 +581,46 @@ namespace AZ
                 return;
             }
 
-            DrawItemInfo drawItemInfo;
-            RHI::SingleDeviceDrawItem& drawItem = drawItemInfo.m_drawItem;
+            DrawItemInfo drawItemInfo{{RHI::MultiDevice::AllDevices}};
+            RHI::MultiDeviceDrawItem& drawItem = drawItemInfo.m_drawItem;
 
             // Draw argument
             RHI::DrawLinear drawLinear;
             drawLinear.m_instanceCount = 1;
             drawLinear.m_vertexCount = vertexCount;
-            drawItem.m_arguments = drawLinear;
+            drawItem.SetArguments(drawLinear);
 
             // Get RHI pipeline state from cached RHI pipeline states based on current draw state options
-            drawItem.m_pipelineState = GetCurrentPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawItem.SetPipelineState(GetCurrentPipelineState());
 
             // Write data to vertex buffer and set up stream buffer views for DrawItem
             // The stream buffer view need to be cached before the frame is end
             vertexBuffer->Write(vertexData, vertexDataSize);
             m_cachedStreamBufferViews.push_back(vertexBuffer->GetStreamBufferView(m_perVertexDataSize));
-            drawItem.m_streamBufferViewCount = 1;
             drawItemInfo.m_vertexBufferViewIndex = uint32_t(m_cachedStreamBufferViews.size() - 1);
 
             // Setup per context srg if it exists
             if (m_srgPerContext)
             {
-                drawItem.m_shaderResourceGroupCount = 1;
-                drawItem.m_shaderResourceGroups = m_srgGroups;
+                drawItem.SetShaderResourceGroups(m_srgGroups, 1);
             }
 
             // Setup per draw srg
             if (drawSrg)
             {
-                drawItem.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawItem.SetUniqueShaderResourceGroup(drawSrg->GetRHIShaderResourceGroup());
             }
 
             // Set scissor per draw if scissor is enabled.
             if (m_useScissor)
             {
-                drawItem.m_scissorsCount = 1;
-                drawItem.m_scissors = &m_scissor;
+                drawItem.SetScissors(&m_scissor, 1);
             }
 
             // Set viewport per draw if viewport is enabled.
             if (m_useViewport)
             {
-                drawItem.m_viewportsCount = 1;
-                drawItem.m_viewports = &m_viewport;
+                drawItem.SetViewports(&m_viewport, 1);
             }
 
             drawItemInfo.m_sortKey = m_sortKey++;
@@ -718,17 +710,17 @@ namespace AZ
             {
                 if (drawItemInfo.m_indexBufferViewIndex != InvalidIndex)
                 {
-                    drawItemInfo.m_drawItem.m_indexBufferView = &m_cachedIndexBufferViews[drawItemInfo.m_indexBufferViewIndex];
+                    drawItemInfo.m_drawItem.SetIndexBufferView(&m_cachedIndexBufferViews[drawItemInfo.m_indexBufferViewIndex]);
                 }
 
                 if (drawItemInfo.m_vertexBufferViewIndex != InvalidIndex)
                 {
-                    drawItemInfo.m_drawItem.m_streamBufferViews = &m_cachedStreamBufferViews[drawItemInfo.m_vertexBufferViewIndex];
+                    drawItemInfo.m_drawItem.SetStreamBufferViews(&m_cachedStreamBufferViews[drawItemInfo.m_vertexBufferViewIndex], 1);
                 }
 
-                RHI::SingleDeviceDrawItemProperties drawItemProperties;
+                RHI::MultiDeviceDrawItemProperties drawItemProperties;
                 drawItemProperties.m_sortKey = drawItemInfo.m_sortKey;
-                drawItemProperties.m_item = &drawItemInfo.m_drawItem;
+                drawItemProperties.m_mdItem = &drawItemInfo.m_drawItem;
                 drawItemProperties.m_drawFilterMask = m_drawFilter;
                 m_cachedDrawList.emplace_back(drawItemProperties);
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
@@ -67,13 +67,13 @@ namespace AZ
             AZ_Error("RPI", false, "Unimplemented function");
         }
 
-        void DynamicDrawSystem::AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket)
+        void DynamicDrawSystem::AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::MultiDeviceDrawPacket> drawPacket)
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_mutexDrawPackets);
-            m_drawPackets[scene].emplace_back(ConstPtr<RHI::SingleDeviceDrawPacket>(drawPacket.release()));
+            m_drawPackets[scene].emplace_back(ConstPtr<RHI::MultiDeviceDrawPacket>(drawPacket.release()));
         }
 
-        void DynamicDrawSystem::AddDrawPacket(Scene* scene, ConstPtr<RHI::SingleDeviceDrawPacket> drawPacket)
+        void DynamicDrawSystem::AddDrawPacket(Scene* scene, ConstPtr<RHI::MultiDeviceDrawPacket> drawPacket)
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_mutexDrawPackets);
             m_drawPackets[scene].emplace_back(drawPacket);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -12,7 +12,7 @@
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <AzCore/Console/Console.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
@@ -226,29 +226,23 @@ namespace AZ
 
             ShaderReloadDebugTracker::ScopedSection reloadSection("MeshDrawPacket::DoUpdate");
 
-            RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+            RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
             drawPacketBuilder.Begin(nullptr);
 
             drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-            drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
-            drawPacketBuilder.AddShaderResourceGroup(
-                m_objectSrg->GetRHIShaderResourceGroup()
-                    ? m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
-                    : nullptr);
-            drawPacketBuilder.AddShaderResourceGroup(
-                m_material->GetRHIShaderResourceGroup()
-                    ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
-                    : nullptr);
+            drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView  );
+            drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
 
             // We build the list of used shaders in a local list rather than m_activeShaders so that
             // if DoUpdate() fails it won't modify any member data.
             MeshDrawPacket::ShaderList shaderList;
             shaderList.reserve(m_activeShaders.size());
 
-            // We have to keep a list of these outside the loops that collect all the shaders because the SingleDeviceDrawPacketBuilder
-            // keeps pointers to StreamBufferViews until SingleDeviceDrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
+            // We have to keep a list of these outside the loops that collect all the shaders because the MultiDeviceDrawPacketBuilder
+            // keeps pointers to StreamBufferViews until MultiDeviceDrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
             // that the memory won't be relocated when new entries are added.
-            AZStd::fixed_vector<ModelLod::TempStreamBufferViewList, RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
+            AZStd::fixed_vector<ModelLod::StreamBufferViewList, RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
 
             // The root constants are shared by all draw items in the draw packet. We must populate them with default values.
             // The draw packet builder needs to know where the data is coming from during appendShader, but it's not actually read
@@ -416,15 +410,15 @@ namespace AZ
                         m_material->GetAsset().ToString<AZStd::string>().c_str());
                 }
 
-                RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
                 drawRequest.m_listTag = drawListTag;
-                drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawRequest.m_pipelineState = pipelineState;
                 drawRequest.m_streamBufferViews = streamBufferViews;
                 drawRequest.m_stencilRef = m_stencilRef;
                 drawRequest.m_sortKey = m_sortKey;
                 if (drawSrg)
                 {
-                    drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
                     // Hold on to a reference to the drawSrg so the refcount doesn't drop to zero
                     m_perDrawSrgs.push_back(drawSrg);
                 }
@@ -458,9 +452,9 @@ namespace AZ
                 {
                     if (shaderItem.IsEnabled())
                     {
-                        if (shaderList.size() == RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax)
+                        if (shaderList.size() == RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax)
                         {
-                            AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax);
+                            AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax);
                             return false;
                         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -87,7 +87,7 @@ namespace AZ
                         bufferViewDescriptor.m_elementOffset * bufferViewDescriptor.m_elementSize,
                         bufferViewDescriptor.m_elementCount * bufferViewDescriptor.m_elementSize,
                         indexFormat);
-                    meshInstance.m_sdIndexBufferView = meshInstance.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+                    meshInstance.m_sdIndexBufferView = meshInstance.m_indexBufferView;
 
                     RHI::DrawIndexed drawIndexed;
                     drawIndexed.m_indexCount = bufferViewDescriptor.m_elementCount;
@@ -331,95 +331,6 @@ namespace AZ
 
                         RHI::MultiDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
                         streamBufferViewsOut.push_back(bufferView);
-                    }
-                }
-            }
-
-            if (success)
-            {
-                layoutOut = layoutBuilder.End();
-
-                success &= RHI::ValidateStreamBufferViews(layoutOut, streamBufferViewsOut);
-            }
-
-            return success;
-        }
-
-        bool ModelLod::GetStreamsForMesh(
-            RHI::InputStreamLayout& layoutOut,
-            TempStreamBufferViewList& streamBufferViewsOut,
-            UvStreamTangentBitmask* uvStreamTangentBitmaskOut,
-            const ShaderInputContract& contract,
-            size_t meshIndex,
-            const MaterialModelUvOverrideMap& materialModelUvMap,
-            const MaterialUvNameMap& materialUvNameMap) const
-        {
-            streamBufferViewsOut.clear();
-
-            RHI::InputStreamLayoutBuilder layoutBuilder;
-
-            const Mesh& mesh = m_meshes[meshIndex];
-
-            bool success = true;
-
-            // Searching for the first UV in the mesh, so it can be used to paired with tangent/bitangent stream
-            auto firstUv = FindFirstUvStreamFromMesh(meshIndex);
-            auto defaultUv = FindDefaultUvStream(meshIndex, materialUvNameMap);
-            if (uvStreamTangentBitmaskOut)
-            {
-                uvStreamTangentBitmaskOut->Reset();
-            }
-
-            for (auto& contractStreamChannel : contract.m_streamChannels)
-            {
-                auto iter = FindMatchingStream(meshIndex, materialModelUvMap, materialUvNameMap, contractStreamChannel, defaultUv, firstUv, uvStreamTangentBitmaskOut);
-
-                if (iter == mesh.m_streamInfo.end())
-                {
-                    if (contractStreamChannel.m_isOptional)
-                    {
-                        // The configuration of the dummy input stream is a bit touchy, and could result in crashes or validation failures that are platform-specific.
-                        // If you modify this code, be sure to test with "-rhi-device-validation=enable" on every platform.
-                        // Here are some criteria that we've noticed before, even for empty buffers:
-                        // Metal: Mesh stream formats need to be at least 4 byte aligned.
-                        // Vulkan: Mesh stream data type (float vs uint) must match the shader, or validation errors are reported
-                        //        ("does not match vertex shader input type")
-                        // Vulkan: We can't just use a null buffer pointer because vulkan will occasionally crash. So we bind some valid non-null buffer and view it with length 0.
-                        // Dx12: Mesh stream data type (float vs uint) must match the shader, or validation warnings are reported
-                        //       ("the matching entry in the Input Layout declaration ... specifies mismatched format").
-                        //
-                        // The stride value does not seem to matter, just the Format type. Still, we use GetFormatSize to set an accurate stride.
-
-                        RHI::Format dummyStreamFormat = RHI::Format::R32G32B32A32_FLOAT;
-                        layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, dummyStreamFormat);
-                        RHI::MultiDeviceStreamBufferView dummyBuffer{*mesh.m_indexBufferView.GetBuffer(), 0, 0, RHI::GetFormatSize(dummyStreamFormat)};
-                        streamBufferViewsOut.push_back(dummyBuffer.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
-                    }
-                    else
-                    {
-                        AZ_Warning("Mesh", false, "Mesh does not have all the required input streams. Missing '%s'.", contractStreamChannel.m_semantic.ToString().c_str());
-                        success = false;
-                    }
-                }
-                else
-                {
-                    // Note, we may need to iterate on the details of this validation. It might not be correct for all use cases.
-                    if (RHI::GetFormatComponentCount(iter->m_format) < contractStreamChannel.m_componentCount)
-                    {
-                        AZ_Error("Mesh", false, "Mesh format (%s) for stream '%s' provides %d components but the shader requires %d.",
-                                 RHI::ToString(iter->m_format),
-                                 contractStreamChannel.m_semantic.ToString().c_str(),
-                                 RHI::GetFormatComponentCount(iter->m_format),
-                                 contractStreamChannel.m_componentCount);
-                        success = false;
-                    }
-                    else
-                    {
-                        // Note, don't use iter->m_semantic as it can be a UV name matching.
-                        layoutBuilder.AddBuffer()->Channel(contractStreamChannel.m_semantic, iter->m_format);
-
-                        RHI::MultiDeviceStreamBufferView bufferView(*m_buffers[iter->m_bufferIndex]->GetRHIBuffer(), iter->m_byteOffset, iter->m_byteCount, iter->m_stride);
-                        streamBufferViewsOut.push_back(bufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
                     }
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -87,7 +87,6 @@ namespace AZ
                         bufferViewDescriptor.m_elementOffset * bufferViewDescriptor.m_elementSize,
                         bufferViewDescriptor.m_elementCount * bufferViewDescriptor.m_elementSize,
                         indexFormat);
-                    meshInstance.m_sdIndexBufferView = meshInstance.m_indexBufferView;
 
                     RHI::DrawIndexed drawIndexed;
                     drawIndexed.m_indexCount = bufferViewDescriptor.m_elementCount;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -218,10 +218,10 @@ namespace AZ
             }
             PassSystemInterface::Get()->IncrementFrameDrawItemCount(m_drawItemCount);
             m_combinedDrawList.resize(m_drawItemCount);
-            RHI::SingleDeviceDrawItemProperties* currentBuffer = m_combinedDrawList.data();
+            RHI::MultiDeviceDrawItemProperties* currentBuffer = m_combinedDrawList.data();
             for (auto drawList : drawLists)
             {
-                memcpy(currentBuffer, drawList.data(), drawList.size()*sizeof(RHI::SingleDeviceDrawItemProperties));
+                memcpy(currentBuffer, drawList.data(), drawList.size()*sizeof(RHI::MultiDeviceDrawItemProperties));
                 currentBuffer += drawList.size();
             }
             SortDrawList(m_combinedDrawList);
@@ -264,10 +264,10 @@ namespace AZ
             uint32_t clampedEndIndex = AZStd::GetMin<uint32_t>(endIndex, static_cast<uint32_t>(m_drawListView.size()));
             for (uint32_t index = startIndex; index < clampedEndIndex; ++index)
             {
-                const RHI::SingleDeviceDrawItemProperties& drawItemProperties = m_drawListView[index];
+                const RHI::MultiDeviceDrawItemProperties& drawItemProperties = m_drawListView[index];
                 if (drawItemProperties.m_drawFilterMask & m_pipeline->GetDrawFilterMask())
                 {
-                    commandList->Submit(*drawItemProperties.m_item, index + indexOffset);
+                    commandList->Submit(drawItemProperties.m_mdItem->GetDeviceDrawItem(RHI::MultiDevice::DefaultDeviceIndex), index + indexOffset);
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -108,13 +108,13 @@ namespace AZ
             return m_shaderResourceGroup;
         }
 
-        void View::AddDrawPacket(const RHI::SingleDeviceDrawPacket* drawPacket, float depth)
+        void View::AddDrawPacket(const RHI::MultiDeviceDrawPacket* drawPacket, float depth)
         {
             // This function is thread safe since DrawListContent has storage per thread for draw item data.
             m_drawListContext.AddDrawPacket(drawPacket, depth);
         }        
 
-        void View::AddDrawPacket(const RHI::SingleDeviceDrawPacket* drawPacket, const Vector3& worldPosition)
+        void View::AddDrawPacket(const RHI::MultiDeviceDrawPacket* drawPacket, const Vector3& worldPosition)
         {
             Vector3 cameraToObject = worldPosition - m_position;
             float depth = cameraToObject.Dot(-m_viewToWorldMatrix.GetBasisZAsVector3());
@@ -134,7 +134,7 @@ namespace AZ
             AddVisibleObject(userData, depth);
         }
 
-        void View::AddDrawItem(RHI::DrawListTag drawListTag, const RHI::SingleDeviceDrawItemProperties& drawItemProperties)
+        void View::AddDrawItem(RHI::DrawListTag drawListTag, const RHI::MultiDeviceDrawItemProperties& drawItemProperties)
         {
             m_drawListContext.AddDrawItem(drawListTag, drawItemProperties);
         }

--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
@@ -27,9 +27,7 @@
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI/DrawList.h>
 #include <Atom/RHI/MultiDeviceImage.h>
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -43,7 +43,6 @@
 #include <AzCore/Interface/Interface.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
 #include <Atom/RHI/MultiDeviceImagePool.h>
 
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -226,27 +226,26 @@ namespace AZ::Render
             defaultAA = AZ::RPI::RenderPipeline::GetAAMethodNameByIndex(defaultAAMethod);
             hasAAMethod = (defaultAAMethod != AZ::RPI::AntiAliasingMode::MSAA && defaultAAMethod != AZ::RPI::AntiAliasingMode::Default);
         }
-        const char* resolutionStr =
+        auto resolutionStr =
             AZStd::string::format(
-                "Resolution: %dx%d", viewportContext->GetViewportSize().m_width, viewportContext->GetViewportSize().m_height)
-                .c_str();
-        const char* msaaStr =
-            multisampleState.m_samples > 1 ? AZStd::string::format("MSAA %dx", multisampleState.m_samples).c_str() : "NoMSAA";
+                "Resolution: %dx%d", viewportContext->GetViewportSize().m_width, viewportContext->GetViewportSize().m_height);
+        auto msaaStr =
+            multisampleState.m_samples > 1 ? AZStd::string::format("MSAA %dx", multisampleState.m_samples) : AZStd::string("NoMSAA");
  
         if (hasAAMethod)
         {
             if (multisampleState.m_samples > 1)
             {
-                DrawLine(AZStd::string::format("%s (%s + %s)", resolutionStr, defaultAA.c_str(), msaaStr));
+                DrawLine(AZStd::string::format("%s (%s + %s)", resolutionStr.c_str(), defaultAA.c_str(), msaaStr.c_str()));
             }
             else
             {
-                DrawLine(AZStd::string::format("%s (%s)", resolutionStr, defaultAA.c_str()));
+                DrawLine(AZStd::string::format("%s (%s)", resolutionStr.c_str(), defaultAA.c_str()));
             }
         }
         else
         {
-            DrawLine(AZStd::string::format("%s (%s)", resolutionStr, msaaStr));
+            DrawLine(AZStd::string::format("%s (%s)", resolutionStr.c_str(), msaaStr.c_str()));
         }
 
         if(viewportContext->GetCurrentPipeline())   // avoid VR crash on nullptr

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -13,7 +13,7 @@
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <AzCore/Console/Console.h>
 
@@ -124,29 +124,23 @@ namespace AZ::Render
             return false;
         }
 
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
         drawPacketBuilder.Begin(nullptr);
 
         drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
         drawPacketBuilder.SetIndexBufferView(mesh.m_sdIndexBufferView);
-        drawPacketBuilder.AddShaderResourceGroup(
-            m_objectSrg->GetRHIShaderResourceGroup()
-                ? m_objectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
-                : nullptr);
-        drawPacketBuilder.AddShaderResourceGroup(
-            m_material->GetRHIShaderResourceGroup()
-                ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
-                : nullptr);
+        drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
+        drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
 
         // We build the list of used shaders in a local list rather than m_activeShaders so that
         // if DoUpdate() fails it won't modify any member data.
         EditorStateMeshDrawPacket::ShaderList shaderList;
         shaderList.reserve(m_activeShaders.size());
 
-        // We have to keep a list of these outside the loops that collect all the shaders because the SingleDeviceDrawPacketBuilder
-        // keeps pointers to StreamBufferViews until SingleDeviceDrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
+        // We have to keep a list of these outside the loops that collect all the shaders because the MultiDeviceDrawPacketBuilder
+        // keeps pointers to StreamBufferViews until MultiDeviceDrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
         // that the memory won't be relocated when new entries are added.
-        AZStd::fixed_vector<RPI::ModelLod::TempStreamBufferViewList, RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
+        AZStd::fixed_vector<RPI::ModelLod::StreamBufferViewList, RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
 
         m_perDrawSrgs.clear();
 
@@ -255,15 +249,15 @@ namespace AZ::Render
                 return false;
             }
 
-            RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+            RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
             drawRequest.m_listTag = m_drawListTag;
-            drawRequest.m_pipelineState = pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = pipelineState;
             drawRequest.m_streamBufferViews = streamBufferViews;
             drawRequest.m_stencilRef = m_stencilRef;
             drawRequest.m_sortKey = m_sortKey;
             if (drawSrg)
             {
-                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
                 m_perDrawSrgs.push_back(drawSrg);
             }
 
@@ -300,9 +294,9 @@ namespace AZ::Render
             {
                 if (shaderItem.IsEnabled())
                 {
-                    if (shaderList.size() == RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax)
+                    if (shaderList.size() == RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax)
                     {
-                        AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax);
+                        AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax);
                         return false;
                     }
 
@@ -327,7 +321,7 @@ namespace AZ::Render
         }
     }
 
-    const RHI::SingleDeviceDrawPacket* EditorStateMeshDrawPacket::GetRHIDrawPacket() const
+    const RHI::MultiDeviceDrawPacket* EditorStateMeshDrawPacket::GetRHIDrawPacket() const
     {
         return m_drawPacket.get();
     }

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -128,7 +128,7 @@ namespace AZ::Render
         drawPacketBuilder.Begin(nullptr);
 
         drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-        drawPacketBuilder.SetIndexBufferView(mesh.m_sdIndexBufferView);
+        drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
         drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
         drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
 

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
@@ -11,8 +11,8 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Model/ModelLod.h>
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 #include <AzCore/Math/Obb.h>
 
@@ -45,7 +45,7 @@ namespace AZ::Render
 
         bool Update(const RPI::Scene& parentScene, bool forceUpdate = false);
 
-        const RHI::SingleDeviceDrawPacket* GetRHIDrawPacket() const;
+        const RHI::MultiDeviceDrawPacket* GetRHIDrawPacket() const;
 
         void SetStencilRef(uint8_t stencilRef) { m_stencilRef = stencilRef; }
         void SetSortKey(RHI::DrawItemSortKey sortKey) { m_sortKey = sortKey; };
@@ -56,10 +56,10 @@ namespace AZ::Render
     private:
         bool DoUpdate(const RPI::Scene& parentScene);
 
-        RPI::ConstPtr<RHI::SingleDeviceDrawPacket> m_drawPacket;
+        RPI::ConstPtr<RHI::MultiDeviceDrawPacket> m_drawPacket;
 
         // Note, many of the following items are held locally in the EditorStateMeshDrawPacket solely to keep them resident in memory as long as they are needed
-        // for the m_drawPacket. RHI::SingleDeviceDrawPacket uses raw pointers only, but we use smart pointers here to hold on to the data.
+        // for the m_drawPacket. RHI::MultiDeviceDrawPacket uses raw pointers only, but we use smart pointers here to hold on to the data.
 
         // Maintains references to the shader instances to keep their PSO caches resident (see Shader::Shutdown())
         ShaderList m_activeShaders;
@@ -77,7 +77,7 @@ namespace AZ::Render
         // does not allow public access to its Instance<RPI::ShaderResourceGroup>.
         RPI::ConstPtr<RHI::MultiDeviceShaderResourceGroup> m_materialSrg;
 
-        AZStd::fixed_vector<Data::Instance<RPI::ShaderResourceGroup>, RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
+        AZStd::fixed_vector<Data::Instance<RPI::ShaderResourceGroup>, RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
 
         // A reference to the material, used to rebuild the DrawPacket if needed
         Data::Instance<RPI::Material> m_material;

--- a/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.cpp
@@ -186,9 +186,9 @@ namespace AZ
                     return false;
                 }
 
-                RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
                 drawRequest.m_listTag = m_drawListTag;
-                drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawRequest.m_pipelineState = m_pipelineState;
 //                drawRequest.m_streamBufferViews =  // no explicit vertex buffer.  shader is using the srg buffers
                 drawRequest.m_stencilRef = 0;
                 drawRequest.m_sortKey = 0;
@@ -214,7 +214,7 @@ namespace AZ
 
                 for (auto& renderObject : hairRenderObjects)
                 {
-                    const RHI::SingleDeviceDrawPacket* drawPacket = renderObject->GetGeometrylDrawPacket(m_shader.get());
+                    const RHI::MultiDeviceDrawPacket* drawPacket = renderObject->GetGeometrylDrawPacket(m_shader.get());
                     if (!drawPacket)
                     {   // might not be an error - the object might have just been added and the DrawPacket is
                         // scheduled to be built when the render frame begins

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
@@ -8,7 +8,6 @@
 
 //#include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/RHISystemInterface.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 
 #include <Atom/RPI.Public/View.h>

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
@@ -12,7 +12,7 @@
 #include <AzCore/Math/Vector3.h>
 
 #include <Atom/RHI/SingleDeviceBufferView.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 // Hair specific
 #include <TressFX/AMD_TressFX.h>
@@ -185,9 +185,9 @@ namespace AZ
                     AMD::TressFXSimulationSettings* simSettings, AMD::TressFXRenderingSettings* renderSettings
                 );
 
-                bool BuildDrawPacket(RPI::Shader* geometryShader, RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest& drawRequest);
+                bool BuildDrawPacket(RPI::Shader* geometryShader, RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest& drawRequest);
 
-                const RHI::SingleDeviceDrawPacket* GetGeometrylDrawPacket(RPI::Shader* geometryShader);
+                const RHI::MultiDeviceDrawPacket* GetGeometrylDrawPacket(RPI::Shader* geometryShader);
 
                 //! Creates and fill the dispatch item associated with the compute shader
                 bool BuildDispatchItem(RPI::Shader* computeShader, DispatchLevel dispatchLevel);
@@ -316,7 +316,7 @@ namespace AZ
                 Data::Instance<RPI::Shader> m_geometryRasterShader = nullptr;
 
                 //! DrawPacket for the multi object geometry raster pass.
-                AZStd::unordered_map<RPI::Shader*, const RHI::SingleDeviceDrawPacket*>  m_geometryDrawPackets;
+                AZStd::unordered_map<RPI::Shader*, RHI::ConstPtr<RHI::MultiDeviceDrawPacket>>  m_geometryDrawPackets;
 
                 float m_frameDeltaTime = 0.02;
 
@@ -381,7 +381,7 @@ namespace AZ
  
                 //! Index buffer for the render pass via draw calls - naming was kept
                 Data::Instance<RHI::MultiDeviceBuffer> m_indexBuffer;
-                RHI::SingleDeviceIndexBufferView m_indexBufferView;
+                RHI::MultiDeviceIndexBufferView m_indexBufferView;
                 //-------------------------------------------------------------------
 
                 AZStd::mutex m_mutex;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -83,7 +83,7 @@ namespace AZ
                         // the sort key changed, rebuild draw packets
                         m_sortKey = sortKey;
 
-                        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+                        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
 
                         RHI::DrawIndexed drawIndexed;
                         drawIndexed.m_indexCount = aznumeric_cast<uint32_t>(m_renderData->m_boxIndexCount);
@@ -93,11 +93,11 @@ namespace AZ
                         drawPacketBuilder.Begin(nullptr);
                         drawPacketBuilder.SetDrawArguments(drawIndexed);
                         drawPacketBuilder.SetIndexBufferView(m_renderData->m_boxIndexBufferView);
-                        drawPacketBuilder.AddShaderResourceGroup(m_renderObjectSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                        drawPacketBuilder.AddShaderResourceGroup(m_renderObjectSrg->GetRHIShaderResourceGroup());
 
-                        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+                        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
                         drawRequest.m_listTag = m_renderData->m_drawListTag;
-                        drawRequest.m_pipelineState = m_renderData->m_pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                        drawRequest.m_pipelineState = m_renderData->m_pipelineState->GetRHIPipelineState();
                         drawRequest.m_streamBufferViews = m_renderData->m_boxPositionBufferView;
                         drawRequest.m_sortKey = m_sortKey;
                         drawPacketBuilder.AddDrawItem(drawRequest);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/PipelineState.h>
@@ -33,8 +33,8 @@ namespace AZ
             RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
             RHI::Ptr<RHI::MultiDeviceBufferPool> m_bufferPool;
 
-            AZStd::array<RHI::SingleDeviceStreamBufferView, 1> m_boxPositionBufferView;
-            RHI::SingleDeviceIndexBufferView m_boxIndexBufferView;
+            AZStd::array<RHI::MultiDeviceStreamBufferView, 1> m_boxPositionBufferView;
+            RHI::MultiDeviceIndexBufferView m_boxIndexBufferView;
             uint32_t m_boxIndexCount = 0;
 
             // image views
@@ -391,7 +391,7 @@ namespace AZ
             DiffuseProbeGridRenderData* m_renderData = nullptr;
 
             // render draw packet
-            RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_drawPacket;
+            RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_drawPacket;
 
             // sort key for the draw item
             const RHI::DrawItemSortKey InvalidSortKey = static_cast<RHI::DrawItemSortKey>(-1);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -745,9 +745,9 @@ namespace AZ
             AZ_Error("DiffuseProbeGridFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create index buffer view
-            AZ::RHI::SingleDeviceIndexBufferView indexBufferView =
+            AZ::RHI::MultiDeviceIndexBufferView indexBufferView =
             {
-                *m_boxIndexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_boxIndexBuffer,
                 0,
                 sizeof(indices),
                 AZ::RHI::IndexFormat::Uint16,
@@ -764,9 +764,9 @@ namespace AZ
             AZ_Error("DiffuseProbeGridFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create position buffer view
-            RHI::SingleDeviceStreamBufferView positionBufferView =
+            RHI::MultiDeviceStreamBufferView positionBufferView =
             {
-                *m_boxPositionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_boxPositionBuffer,
                 0,
                 (uint32_t)(m_boxPositions.size() * sizeof(Position)),
                 sizeof(Position),

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
@@ -256,14 +256,14 @@ namespace AZ
                 // ObjectId belongs to the instance and not the object - to be moved
                 lodRenderData->ObjectId = objectId;
 
-                RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
                 m_renderPass->FillDrawRequestData(drawRequest);
                 drawRequest.m_stencilRef = 0;
                 drawRequest.m_sortKey = 0;
 // Leave the following empty if using buffers rather than vertex streams.
 //                drawRequest.m_streamBufferViews = lodRenderData->m_renderStreamBuffersViews; 
 
-                RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+                RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder;
                 RHI::DrawIndexed drawIndexed;
 
                 drawIndexed.m_indexCount = lodRenderData->IndexCount;
@@ -379,7 +379,7 @@ namespace AZ
             DeletePendingMeshletsRenderObjects();
 
             AZStd::list<RHI::SingleDeviceDispatchItem*> dispatchItems;
-            AZStd::list<const RHI::SingleDeviceDrawPacket*> drawPackets;
+            AZStd::list<const RHI::MultiDeviceDrawPacket*> drawPackets;
             for (auto renderObject : m_meshletsRenderObjects)
             {
                 // For demo purposed the model lod index is set for 0.

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
@@ -408,7 +408,7 @@ namespace AZ
                         uint8_t mappedIdx = uint8_t(ComputeStreamsSemantics::Indices);
                         bufferDesc.m_viewOffsetInBytes = meshRenderData.ComputeBuffersDescriptors[mappedIdx].m_viewOffsetInBytes;
 
-                        meshRenderData.IndexBufferView = RHI::SingleDeviceIndexBufferView(
+                        meshRenderData.IndexBufferView = RHI::MultiDeviceIndexBufferView(
                             *meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                             bufferDesc.m_viewOffsetInBytes,
                             (uint64_t)bufferDesc.m_elementCount * bufferDesc.m_elementSize,

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.h
@@ -17,10 +17,7 @@
 #include <AtomCore/Instance/Instance.h>
 #include <AtomCore/Instance/InstanceData.h>
 
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
-
-#include <Atom/RPI.Public/MeshDrawPacket.h>
-#include <Atom/RPI.Public/Model/Model.h>
+#include <Atom/RPI.MultiDeviceStreamBufferViewclude <Atom/RPI.Public/Model/Model.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
@@ -72,11 +69,11 @@ namespace AZ
             //! Render pass data
             Data::Instance<RPI::ShaderResourceGroup> RenderObjectSrg;     // Per object render data - includes instanceId and vertex buffers
             AZStd::vector<SrgBufferDescriptor> RenderBuffersDescriptors;
-            RHI::SingleDeviceIndexBufferView IndexBufferView;
+            RHI::MultiDeviceIndexBufferView IndexBufferView;
             AZStd::vector<Data::Instance<RHI::MultiDeviceBufferView>> RenderBuffersViews;
             AZStd::vector <Data::Instance<RPI::Buffer>> RenderBuffers;    // stand alone non shared buffers
 
-            const RHI::SingleDeviceDrawPacket* MeshDrawPacket = nullptr;    // Should be moved to the instance data structure
+            const RHI::MultiDeviceDrawPacket* MeshDrawPacket = nullptr;    // Should be moved to the instance data structure
         };
         using ModelLodDataArray = AZStd::vector<MeshRenderData*>;    // MeshRenderData per mesh in the Lod
 
@@ -151,7 +148,7 @@ namespace AZ
             uint32_t CreateMeshletsRenderObject(const RPI::ModelLodAsset::Mesh& meshAsset, MeshRenderData &meshRenderData);
 
 
-            bool BuildDrawPacket( RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest& drawRequest, MeshRenderData& meshRenderData);
+            bool BuildDrawPacket( RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest& drawRequest, MeshRenderData& meshRenderData);
 
             bool CreateAndBindRenderBuffers(MeshRenderData &meshRenderData);
 

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.cpp
@@ -8,7 +8,7 @@
 
 #include <StarsFeatureProcessor.h>
 
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -166,7 +166,7 @@ namespace AZ::Render
             m_starsVertexBuffer->UpdateData(m_starsMeshData.data(), bufferSize);
         }
 
-        m_meshStreamBufferViews[0] = RHI::SingleDeviceStreamBufferView(*m_starsVertexBuffer->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, bufferSize, elementSize);
+        m_meshStreamBufferViews[0] = RHI::MultiDeviceStreamBufferView(*m_starsVertexBuffer->GetRHIBuffer(), 0, bufferSize, elementSize);
 
         UpdateDrawPacket();
     }
@@ -276,11 +276,11 @@ namespace AZ::Render
         RPI::PassSystemInterface::Get()->ForEachPass(passFilter, setClearValue);
     }
 
-    RHI::ConstPtr<RHI::SingleDeviceDrawPacket> StarsFeatureProcessor::BuildDrawPacket(
+    RHI::ConstPtr<RHI::MultiDeviceDrawPacket> StarsFeatureProcessor::BuildDrawPacket(
                 const Data::Instance<RPI::ShaderResourceGroup>& srg,
                 const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
                 const RHI::DrawListTag& drawListTag,
-                const AZStd::span<const AZ::RHI::SingleDeviceStreamBufferView>& streamBufferViews,
+                const AZStd::span<const AZ::RHI::MultiDeviceStreamBufferView>& streamBufferViews,
                 uint32_t vertexCount)
     {
         RHI::DrawLinear drawLinear;
@@ -289,14 +289,14 @@ namespace AZ::Render
         drawLinear.m_instanceCount = 1;
         drawLinear.m_instanceOffset = 0;
 
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::AllDevices};
         drawPacketBuilder.Begin(nullptr);
         drawPacketBuilder.SetDrawArguments(drawLinear);
-        drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+        drawPacketBuilder.AddShaderResourceGroup(srg->GetRHIShaderResourceGroup());
 
-        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
         drawRequest.m_listTag = drawListTag;
-        drawRequest.m_pipelineState = pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_pipelineState = pipelineState->GetRHIPipelineState();
         drawRequest.m_streamBufferViews = streamBufferViews;
         drawPacketBuilder.AddDrawItem(drawRequest);
         return drawPacketBuilder.End();

--- a/Gems/Stars/Code/Source/StarsFeatureProcessor.h
+++ b/Gems/Stars/Code/Source/StarsFeatureProcessor.h
@@ -67,15 +67,15 @@ namespace AZ::Render
         void UpdateBackgroundClearColor();
 
         //! build a draw packet to draw the star mesh
-        RHI::ConstPtr<RHI::SingleDeviceDrawPacket> BuildDrawPacket(
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> BuildDrawPacket(
             const Data::Instance<RPI::ShaderResourceGroup>& srg,
             const RPI::Ptr<RPI::PipelineStateForDraw>& pipelineState,
             const RHI::DrawListTag& drawListTag,
-            const AZStd::span<const RHI::SingleDeviceStreamBufferView>& streamBufferViews,
+            const AZStd::span<const RHI::MultiDeviceStreamBufferView>& streamBufferViews,
             uint32_t vertexCount);
 
         RPI::Ptr<RPI::PipelineStateForDraw> m_meshPipelineState;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 1> m_meshStreamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 1> m_meshStreamBufferViews;
 
         Data::Instance<RPI::ShaderResourceGroup> m_drawSrg = nullptr;
         Data::Instance<RPI::Shader> m_shader = nullptr;
@@ -85,7 +85,7 @@ namespace AZ::Render
 
         Data::Instance<RPI::Buffer> m_starsVertexBuffer = nullptr;
         RHI::DrawListTag m_drawListTag;
-        RHI::ConstPtr<RHI::SingleDeviceDrawPacket> m_drawPacket;
+        RHI::ConstPtr<RHI::MultiDeviceDrawPacket> m_drawPacket;
 
         bool m_updateShaderConstants = false;
         AZ::Matrix3x3 m_orientation = AZ::Matrix3x3::CreateIdentity();

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.h
@@ -159,15 +159,15 @@ namespace Terrain
             Vector2i m_worldCoord = AZStd::numeric_limits<int32_t>::max();
 
             // When drawing, either the m_rhiDrawPacket will be used, or some number of the m_rhiDrawPacketQuadrants
-            AZ::RHI::ConstPtr<AZ::RHI::SingleDeviceDrawPacket> m_rhiDrawPacket;
-            AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::SingleDeviceDrawPacket>, 4> m_rhiDrawPacketQuadrant;
+            AZ::RHI::ConstPtr<AZ::RHI::MultiDeviceDrawPacket> m_rhiDrawPacket;
+            AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDeviceDrawPacket>, 4> m_rhiDrawPacketQuadrant;
 
             AZ::Data::Instance<AZ::RPI::Buffer> m_heightsNormalsBuffer;
             AZ::Data::Instance<AZ::RPI::Buffer> m_lodHeightsNormalsBuffer;
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, StreamIndex::Count> m_streamBufferViews;
+            AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, StreamIndex::Count> m_streamBufferViews;
 
             // Hold reference to the draw srgs so they don't get released.
-            AZStd::fixed_vector<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, AZ::RHI::SingleDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
+            AZStd::fixed_vector<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, AZ::RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
 
             AZStd::unique_ptr<RtSector> m_rtData;
 
@@ -231,7 +231,7 @@ namespace Terrain
         struct CandidateSector
         {
             AZ::Aabb m_aabb;
-            const AZ::RHI::SingleDeviceDrawPacket* m_rhiDrawPacket;
+            const AZ::RHI::MultiDeviceDrawPacket* m_rhiDrawPacket;
         };
 
         struct XYPosition
@@ -259,7 +259,7 @@ namespace Terrain
         void RebuildSectors();
         void RebuildDrawPackets();
         void RemoveRayTracedMeshes();
-        AZ::RHI::SingleDeviceStreamBufferView CreateStreamBufferView(AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset = 0);
+        AZ::RHI::MultiDeviceStreamBufferView CreateStreamBufferView(AZ::Data::Instance<AZ::RPI::Buffer>& buffer, uint32_t offset = 0);
 
         void CreateCommonBuffers();
         void UpdateSectorBuffers(Sector& sector, const AZStd::span<const HeightNormalVertex> heightsNormals);
@@ -305,7 +305,7 @@ namespace Terrain
         AZ::Data::Instance<AZ::RPI::Buffer> m_indexBuffer;
         AZ::Data::Instance<AZ::RPI::Buffer> m_rtIndexBuffer;
         AZ::Data::Instance<AZ::RPI::Buffer> m_dummyLodHeightsNormalsBuffer;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
 
         AZStd::vector<SectorLodGrid> m_sectorLods;
         AZStd::vector<CandidateSector> m_candidateSectors;


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

This specific PR transitions the usage of `RHI::SingleDeviceDrawItem` and all related-resources (`RHI::SingleDeviceDrawPacket`, `RHI::SingleDeviceDrawRequest` and `RHI::SingleDeviceDrawPacketBuilder`) throughout the upper layers of the codebase, including the usage of `RHI::SingleDeviceIndexBufferView` and `RHI::SingleDeviceStreamBufferView` as needed by the draw items.

This PR currently also holds a number of fixes, which either already are or shortly will be part of `development` and will be rebased then during the final integration.

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`

