### PR TITLE
DPE | Delete widgets later in the Editor

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -206,8 +206,20 @@ namespace AzToolsFramework
         {
             if (m_widget)
             {
-                delete m_widget;
-                m_widget = nullptr;
+                // Detect whether this is being run in the Editor or during a Unit Test.
+                AZ::ApplicationTypeQuery appType;
+                AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+                if (appType.IsValid() && !appType.IsEditor())
+                {
+                    // In Unit Tests, immediately delete the widget to prevent triggering the leak detection mechanism.
+                    delete m_widget;
+                    m_widget = nullptr;
+                }
+                else
+                {
+                    // In the Editor, use deleteLater as it is more stable.
+                    m_widget->deleteLater();
+                }
             }
             IndividualPropertyHandlerEditNotifications::Bus::Handler::BusDisconnect();
         }


### PR DESCRIPTION
Fixes #17506

Replaces regular delete with Qt's `deleteLater` in the Editor.
This was the original code, but we had to change it during the submission process as it triggers the automated leak detection in unit tests. The problem is that direct deletion that was implemented in its place can cause instability (see bug above).

While fixing the leak detection would be more effective, I could not find a way yet so a viable fix for now is to detect whether we're running unit tests or not, and change the type of deletion based on that.

Manual testing, the crash above no longer occurs even on multiple tries (while it consistently reproduced on 1 or 2 tries before).