### PR TITLE
Multi device attachment readback

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceCopyItem.h>
-#include <Atom/RHI/SingleDeviceDispatchItem.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
@@ -146,7 +146,7 @@ namespace AZ
             struct ReadbackItem
             {
                 // The copy item used to read back a buffer, or a particular mip level of an image
-                RHI::SingleDeviceCopyItem m_copyItem;
+                RHI::MultiDeviceCopyItem m_copyItem;
 
                 // Host accessible buffer to save read back result
                 // Using triple buffer pointers, as it allows use to clear the buffer outside the async callback.
@@ -172,7 +172,7 @@ namespace AZ
 
             ReadbackState m_state = ReadbackState::Uninitialized;
 
-            Ptr<RHI::SingleDeviceFence> m_fence;
+            Ptr<RHI::MultiDeviceFence> m_fence;
 
             // Callback function when read back finished
             CallbackFunction m_callback = nullptr;
@@ -182,7 +182,7 @@ namespace AZ
             Data::Instance<ShaderResourceGroup> m_decomposeSrg;
             RHI::ShaderInputImageIndex m_decomposeInputImageIndex;
             RHI::ShaderInputImageIndex m_decomposeOutputImageIndex;
-            RHI::SingleDeviceDispatchItem m_dispatchItem;
+            RHI::MultiDeviceDispatchItem m_dispatchItem;
 
             // Scope producer for decomposing multi-sample image
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_decomposeScopeProducer;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -17,7 +17,7 @@
 
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceFence.h>
+#include <Atom/RHI/MultiDeviceFence.h>
 #include <Atom/RHI/FrameGraphExecuteContext.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/RHISystemInterface.h>
@@ -111,7 +111,7 @@ namespace AZ
             return format;
         }
 
-        AttachmentReadback::AttachmentReadback(const RHI::ScopeId& scopeId)
+        AttachmentReadback::AttachmentReadback(const RHI::ScopeId& scopeId) : m_dispatchItem(RHI::MultiDevice::AllDevices)
         {
             for(uint32_t i = 0; i < RHI::Limits::Device::FrameCountMax; i++)
             {
@@ -120,9 +120,9 @@ namespace AZ
             
             // Create fence
             RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            m_fence = RHI::Factory::Get().CreateFence();
+            m_fence = aznew RHI::MultiDeviceFence;
             AZ_Assert(m_fence != nullptr, "AttachmentReadback failed to create a fence");
-            [[maybe_unused]] RHI::ResultCode result = m_fence->Init(*device, RHI::FenceState::Reset);
+            [[maybe_unused]] RHI::ResultCode result = m_fence->Init(RHI::MultiDevice::AllDevices, RHI::FenceState::Reset);
             AZ_Assert(result == RHI::ResultCode::Success, "AttachmentReadback failed to init fence");
 
             // Load shader and srg
@@ -152,10 +152,11 @@ namespace AZ
             const auto& shaderVariant = m_decomposeShader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId);
             shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
 
-            m_dispatchItem.m_pipelineState = m_decomposeShader->AcquirePipelineState(pipelineStateDescriptor)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_dispatchItem.SetPipelineState(m_decomposeShader->AcquirePipelineState(pipelineStateDescriptor));
 
-            m_dispatchItem.m_shaderResourceGroupCount = 1;
-            m_dispatchItem.m_shaderResourceGroups[0] = m_decomposeSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+            AZStd::array<const RHI::MultiDeviceShaderResourceGroup*, 1> srgs{m_decomposeSrg->GetRHIShaderResourceGroup()};
+
+            m_dispatchItem.SetShaderResourceGroups(srgs, 1);
 
             // find srg input indexes
             m_decomposeInputImageIndex = m_decomposeSrg->FindShaderInputImageIndex(Name("m_msImage"));
@@ -287,7 +288,7 @@ namespace AZ
             dispatchArgs.m_threadsPerGroupY = 16;
             dispatchArgs.m_threadsPerGroupZ = 1;
 
-            m_dispatchItem.m_arguments = dispatchArgs;
+            m_dispatchItem.SetArguments(dispatchArgs);
 
             const RHI::MultiDeviceImageView* imageView = context.GetImageView(m_attachmentId);
             m_decomposeSrg->SetImageView(m_decomposeInputImageIndex, imageView);
@@ -299,7 +300,7 @@ namespace AZ
 
         void AttachmentReadback::DecomposeExecute(const RHI::FrameGraphExecuteContext& context)
         {
-            context.GetCommandList()->Submit(m_dispatchItem);
+            context.GetCommandList()->Submit(m_dispatchItem.GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex));
         }
         
         void AttachmentReadback::CopyPrepare(RHI::FrameGraphInterface frameGraph)
@@ -317,7 +318,7 @@ namespace AZ
             }
 
             frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_readbackItems.size()));
-            frameGraph.SignalFence(*m_fence);
+            frameGraph.SignalFence(*m_fence->GetDeviceFence(RHI::MultiDevice::DefaultDeviceIndex));
 
             // CPU has already consumed the GPU buffer. We can clear it now.
             // We don't do this in the Async callback as the callback can get signaled by the GPU at anytime.
@@ -376,9 +377,9 @@ namespace AZ
                 m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex] = BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
 
                 // copy buffer
-                RHI::SingleDeviceCopyBufferDescriptor copyBuffer;
-                copyBuffer.m_sourceBuffer = buffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
-                copyBuffer.m_destinationBuffer = m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
+                RHI::MultiDeviceCopyBufferDescriptor copyBuffer;
+                copyBuffer.m_mdSourceBuffer = buffer;
+                copyBuffer.m_mdDestinationBuffer = m_readbackItems[0].m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
                 copyBuffer.m_size = aznumeric_cast<uint32_t>(desc.m_byteCount);
 
                 m_readbackItems[0].m_copyItem = copyBuffer;
@@ -430,14 +431,14 @@ namespace AZ
                     m_imageDescriptor.m_format = FindFormatForAspect(m_imageDescriptor.m_format, imageAspect);
 
                     // copy descriptor for copying image to buffer
-                    RHI::SingleDeviceCopyImageToBufferDescriptor copyImageToBuffer;
-                    copyImageToBuffer.m_sourceImage = image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    RHI::MultiDeviceCopyImageToBufferDescriptor copyImageToBuffer;
+                    copyImageToBuffer.m_mdSourceImage = image;
                     copyImageToBuffer.m_sourceSize = imageSubresourceLayouts[mipSlice].m_size;
                     copyImageToBuffer.m_sourceSubresource = RHI::ImageSubresource(mipSlice, 0 /*arraySlice*/, imageAspect);
                     copyImageToBuffer.m_destinationOffset = 0;
                     copyImageToBuffer.m_destinationBytesPerRow = imageSubresourceLayouts[mipSlice].m_bytesPerRow;
                     copyImageToBuffer.m_destinationBytesPerImage = imageSubresourceLayouts[mipSlice].m_bytesPerImage;
-                    copyImageToBuffer.m_destinationBuffer = readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    copyImageToBuffer.m_mdDestinationBuffer = readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
                     copyImageToBuffer.m_destinationFormat = m_imageDescriptor.m_format;
 
                     readbackItem.m_mipInfo.m_slice = mipSlice;
@@ -454,7 +455,7 @@ namespace AZ
             {
                 if (readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex])
                 {
-                    context.GetCommandList()->Submit(readbackItem.m_copyItem);
+                    context.GetCommandList()->Submit(readbackItem.m_copyItem.GetDeviceCopyItem(RHI::MultiDevice::DefaultDeviceIndex));
                 }
             }
         }
@@ -608,7 +609,7 @@ namespace AZ
                         uint8_t* const destBegin = readbackItem.m_dataBuffer->data();
                         // The source image WAS the destination when the copy item transferred data from GPU to CPU
                         // this explains why the name srcBytesPerRow for these memcpy operations.
-                        const auto srcBytesPerRow = readbackItem.m_copyItem.m_imageToBuffer.m_destinationBytesPerRow;
+                        const auto srcBytesPerRow = readbackItem.m_copyItem.m_mdImageToBuffer.m_destinationBytesPerRow;
                         for (uint32_t row = 0; row < rowCount; ++row)
                         {
                             void* dest = destBegin + row * imageLayout.m_bytesPerRow;


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

This specific PR transitions the remaining uses of `RHI::SingleDevice*` in the `AttachmentReadback` class to `RHI::MultiDevice*`.

## How was this PR tested?

`Gem::Atom_RPI.Tests.main`
