### PR TITLE
Fixes GraphicsGem Template Compilation

### DIFF
--- a/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.cpp
+++ b/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.cpp
@@ -86,15 +86,4 @@ namespace ${Name}
         }
     }
 
-    void Editor${Name}Component::OnEntityVisibilityChanged(bool visibility)
-    {
-        if (visibility)
-        {
-            m_controller.EnableFeatureProcessor(GetEntityId());
-        }
-        else
-        {
-            m_controller.DisableFeatureProcessor();
-        }
-    }
 }

--- a/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.h
+++ b/Templates/GraphicsGem/Template/Code/Source/Tools/Components/Editor${Name}Component.h
@@ -43,10 +43,6 @@ namespace ${Name}
         void Activate() override;
         void Deactivate() override;
 
-    protected:
-
-        void OnEntityVisibilityChanged(bool visibility) override;
-
     private:
 
         // AZ::TickBus overrides


### PR DESCRIPTION
## What does this PR do?

The existing GraphicsGem Template was calling a pair of obsolete function in the controller class:
`m_controller.EnableFeatureProcessor(GetEntityId());` and
`m_controller.DisableFeatureProcessor();`

The fix was to simply remove the declaration
and implementation of the override:
`void OnEntityVisibilityChanged(bool visibility) override;`

## How was this PR tested?

Generated a new project after the fix and it compiles.
