### PR TITLE
MiniAudio: Add a pause method for the Playback component

### DIFF
--- a/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioPlaybackBus.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/MiniAudioPlaybackBus.h
@@ -22,6 +22,7 @@ namespace MiniAudio
 
         virtual void Play() = 0;
         virtual void Stop() = 0;
+        virtual void Pause() = 0;
         virtual void SetLooping(bool loop) = 0;
         virtual bool IsLooping() const = 0;
         virtual void SetSoundAsset(AZ::Data::Asset<SoundAsset> soundAsset) = 0;

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponent.cpp
@@ -85,6 +85,7 @@ namespace MiniAudio
                 ->Attribute(AZ::Script::Attributes::Category, "MiniAudio Playback")
                 ->Event("Play", &MiniAudioPlaybackRequests::Play)
                 ->Event("Stop", &MiniAudioPlaybackRequests::Stop)
+                ->Event("Pause", &MiniAudioPlaybackRequests::Pause)
                 ->Event("SetLooping", &MiniAudioPlaybackRequests::SetLooping)
                 ->Event("IsLooping", &MiniAudioPlaybackRequests::IsLooping)
                 ->Event("GetSoundAsset", &MiniAudioPlaybackRequests::GetSoundAssetRef)

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.cpp
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.cpp
@@ -85,7 +85,6 @@ namespace MiniAudio
     {
         if (m_sound)
         {
-            ma_sound_seek_to_pcm_frame(m_sound.get(), 0);
             ma_sound_start(m_sound.get());
         }
     }
@@ -95,12 +94,21 @@ namespace MiniAudio
         if (m_sound)
         {
             ma_sound_stop(m_sound.get());
+            ma_sound_seek_to_pcm_frame(m_sound.get(), 0);
+        }
+    }
+
+    void MiniAudioPlaybackComponentController::Pause()
+    {
+        if (m_sound)
+        {
+            ma_sound_stop(m_sound.get());
         }
     }
 
     float MiniAudioPlaybackComponentController::GetVolumePercentage() const
     {
-        return ma_sound_get_volume(m_sound.get());
+        return ma_sound_get_volume(m_sound.get()) * 100.f;
     }
 
     void MiniAudioPlaybackComponentController::SetVolumePercentage(float volume)

--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentController.h
@@ -45,6 +45,7 @@ namespace MiniAudio
         // MiniAudioPlaybackRequestBus
         void Play() override;
         void Stop() override;
+        void Pause() override;
         void SetVolumePercentage(float volume) override;
         float GetVolumePercentage() const override;
         void SetVolumeDecibels(float volumeDecibels) override;

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.cpp
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.cpp
@@ -44,7 +44,12 @@ namespace MiniAudio
                     ->UIElement(AZ::Edit::UIHandlers::Button, "Stop Sound", "Stops playing the sound")
                     ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                     ->Attribute(AZ::Edit::Attributes::ButtonText, "Stop Sound")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMiniAudioPlaybackComponent::StopSoundInEditor);
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMiniAudioPlaybackComponent::StopSoundInEditor)
+
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "Pause Sound", "Pause playing the sound")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                    ->Attribute(AZ::Edit::Attributes::ButtonText, "Pause Sound")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorMiniAudioPlaybackComponent::PauseSoundInEditor);
 
                 editContext->Class<MiniAudioPlaybackComponentController>("MiniAudioPlaybackComponentController", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
@@ -186,7 +191,6 @@ namespace MiniAudio
 
     AZ::Crc32 EditorMiniAudioPlaybackComponent::PlaySoundInEditor()
     {
-        m_controller.Stop();
         m_controller.Play();
         return AZ::Edit::PropertyRefreshLevels::None;
     }
@@ -194,6 +198,12 @@ namespace MiniAudio
     AZ::Crc32 EditorMiniAudioPlaybackComponent::StopSoundInEditor()
     {
         m_controller.Stop();
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+
+    AZ::Crc32 EditorMiniAudioPlaybackComponent::PauseSoundInEditor()
+    {
+        m_controller.Pause();
         return AZ::Edit::PropertyRefreshLevels::None;
     }
 

--- a/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.h
+++ b/Gems/MiniAudio/Code/Source/Tools/EditorMiniAudioPlaybackComponent.h
@@ -37,6 +37,7 @@ namespace MiniAudio
 
         AZ::Crc32 PlaySoundInEditor();
         AZ::Crc32 StopSoundInEditor();
+        AZ::Crc32 PauseSoundInEditor();
         AZ::Crc32 OnVolumeChanged();
     };
 


### PR DESCRIPTION
## What does this PR do?

* Add a pause method for the Playback component
* Make it so that the `MiniAudioPlaybackComponentController::Play()` method does not set the PCM frame to 0, so that it may continue playing where it left off
* Make the `MiniAudioPlaybackComponentController::Stop()` set the PCM frame to 0
* Make `MiniAudioPlaybackComponentController::GetVolumePercentage()` return a percentage

Add a pause button in the editor:
![image](https://github.com/o3de/o3de/assets/3263382/6d163deb-2eb8-4624-b32b-3cfb069c0aae)

Add a pause method and expose it to the behavior context:
![image](https://github.com/o3de/o3de/assets/3263382/0e557ae1-cf20-45f3-90d1-478f6ddafe02)

## How was this PR tested?

These changes were tested against the main branch (2310.2 release).

Ping @AMZN-alexpete @AMZN-daimini @nick-l-o3de @SelfishOlex @gadams3 @spham-amzn