### PR TITLE
Fix release installer test missing folder

### DIFF
--- a/cmake/Platform/Windows/Packaging/Tests/conftest.py
+++ b/cmake/Platform/Windows/Packaging/Tests/conftest.py
@@ -47,6 +47,9 @@ class SessionContext:
         self.install_root = Path(request.config.getoption("--install-root")).resolve()
         self.project_path = Path(request.config.getoption("--project-path")).resolve()
 
+        # create the project path or TemporaryDirectory can fail
+        os.makedirs(self.project_path, exist_ok=True)
+
         # use a temp folder inside the project path to avoid issues where we cannot
         # clean up or remove the actual project folder
         with TemporaryDirectory(dir=self.project_path) as tmp_project_dir:


### PR DESCRIPTION
## What does this PR do?

The installer test is failing because `TemporaryDirectory` does not create all elements of a folder path. https://jenkins.build.o3de.org/job/O3DE-development_nightly-installer/145/execution/node/672/log/

This change will ensure the path exists before `TemporaryDirectory` is used.

## How was this PR tested?

- n/a will run test on Jenkins
