### PR TITLE
DPE | Fix Spline type handling

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.cpp
@@ -398,7 +398,7 @@ namespace LmbrCentral
         return m_splineCommon.m_spline;
     }
 
-    void EditorSplineComponent::ChangeSplineType(const AZ::u64 splineType)
+    void EditorSplineComponent::ChangeSplineType(const SplineType splineType)
     {
         m_splineCommon.ChangeSplineType(splineType);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSplineComponent.h
@@ -73,7 +73,7 @@ namespace LmbrCentral
 
         // SplineComponentRequestBus overrides ...
         AZ::SplinePtr GetSpline() override;
-        void ChangeSplineType(AZ::u64 splineType) override;
+        void ChangeSplineType(SplineType splineType) override;
         void SetClosed(bool closed) override;
 
         // SplineComponentRequestBus/VertexContainerInterface overrides ...

--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.cpp
@@ -15,57 +15,97 @@
 
 namespace LmbrCentral
 {
-    using SplineComboBoxVec = AZStd::vector<AZ::Edit::EnumConstant<size_t>>;
+    using SplineComboBoxVec = AZStd::vector<AZ::Edit::EnumConstant<SplineType>>;
     static SplineComboBoxVec PopulateSplineTypeList()
     {
         return SplineComboBoxVec
         {
-            { AZ::LinearSpline::RTTI_Type().GetHash(), "Linear" },
-            { AZ::BezierSpline::RTTI_Type().GetHash(), "Bezier" },
-            { AZ::CatmullRomSpline::RTTI_Type().GetHash(), "Catmull-Rom" }
+            { SplineType::LINEAR, "Linear" },
+            { SplineType::BEZIER, "Bezier" },
+            { SplineType::CATMULL_ROM, "Catmull-Rom" }
         };
     }
-
-    static AZ::SplinePtr MakeSplinePtr(AZ::u64 splineType)
+    static bool IsMatchingType(AZ::SplinePtr spline, SplineType splineType)
     {
-        if (splineType == AZ::LinearSpline::RTTI_Type().GetHash())
+        auto splineTypeHash = spline->RTTI_GetType().GetHash();
+        switch (splineType)
         {
-            return AZStd::make_shared<AZ::LinearSpline>();
+        case SplineType::LINEAR:
+            {
+                return (splineTypeHash == AZ::LinearSpline::RTTI_Type().GetHash());
+            }
+            break;
+        case SplineType::BEZIER:
+            {
+                return (splineTypeHash == AZ::BezierSpline::RTTI_Type().GetHash());
+            }
+            break;
+        case SplineType::CATMULL_ROM:
+            {
+                return (splineTypeHash == AZ::CatmullRomSpline::RTTI_Type().GetHash());
+            }
+            break;
+        default:
+            break;
         }
 
-        if (splineType == AZ::BezierSpline::RTTI_Type().GetHash())
-        {
-            return AZStd::make_shared<AZ::BezierSpline>();
-        }
+        return false;
+    }
 
-        if (splineType == AZ::CatmullRomSpline::RTTI_Type().GetHash())
+    static AZ::SplinePtr MakeSplinePtr(SplineType splineType)
+    {
+        switch (splineType)
         {
-            return AZStd::make_shared<AZ::CatmullRomSpline>();
+        case SplineType::LINEAR:
+            {
+                return AZStd::make_shared<AZ::LinearSpline>();
+            }
+            break;
+        case SplineType::BEZIER:
+            {
+                return AZStd::make_shared<AZ::BezierSpline>();
+            }
+            break;
+        case SplineType::CATMULL_ROM:
+            {
+                return AZStd::make_shared<AZ::CatmullRomSpline>();
+            }
+            break;
+        default:
+            {
+                AZ_Assert(false, "Unhandled spline type %d in %s", splineType, __FUNCTION__);
+            }
+            break;
         }
-
-        AZ_Assert(false, "Unhandled spline type %d in %s", splineType, __FUNCTION__);
 
         return nullptr;
     }
 
-    static AZ::SplinePtr CopySplinePtr(AZ::u64 splineType, const AZ::SplinePtr& spline)
+    static AZ::SplinePtr CopySplinePtr(SplineType splineType, const AZ::SplinePtr& spline)
     {
-        if (splineType == AZ::LinearSpline::RTTI_Type().GetHash())
+        switch (splineType)
         {
-            return AZStd::make_shared<AZ::LinearSpline>(*spline);
+        case SplineType::LINEAR:
+            {
+                return AZStd::make_shared<AZ::LinearSpline>(*spline);
+            }
+            break;
+        case SplineType::BEZIER:
+            {
+                return AZStd::make_shared<AZ::BezierSpline>(*spline);
+            }
+            break;
+        case SplineType::CATMULL_ROM:
+            {
+                return AZStd::make_shared<AZ::CatmullRomSpline>(*spline);
+            }
+            break;
+        default:
+            {
+                AZ_Assert(false, "Unhandled spline type %d in %s", splineType, __FUNCTION__);
+            }
+            break;
         }
-
-        if (splineType == AZ::BezierSpline::RTTI_Type().GetHash())
-        {
-            return AZStd::make_shared<AZ::BezierSpline>(*spline);
-        }
-
-        if (splineType == AZ::CatmullRomSpline::RTTI_Type().GetHash())
-        {
-            return AZStd::make_shared<AZ::CatmullRomSpline>(*spline);
-        }
-
-        AZ_Assert(false, "Unhandled spline type %d in %s", splineType, __FUNCTION__);
 
         return nullptr;
     }
@@ -101,7 +141,7 @@ namespace LmbrCentral
         }
     }
 
-    void SplineCommon::ChangeSplineType(AZ::u64 splineType)
+    void SplineCommon::ChangeSplineType(SplineType splineType)
     {
         m_splineType = splineType;
         OnChangeSplineType();
@@ -132,7 +172,7 @@ namespace LmbrCentral
     {
         AZ::u32 ret = AZ::Edit::PropertyRefreshLevels::None;
 
-        if (m_spline->RTTI_GetType().GetHash() != m_splineType)
+        if (!IsMatchingType(m_spline, m_splineType))
         {
             m_spline = CopySplinePtr(m_splineType, m_spline);
             m_spline->SetCallbacks(
@@ -298,7 +338,7 @@ namespace LmbrCentral
         return m_splineCommon.m_spline;
     }
 
-    void SplineComponent::ChangeSplineType(AZ::u64 splineType)
+    void SplineComponent::ChangeSplineType(SplineType splineType)
     {
         m_splineCommon.ChangeSplineType(splineType);
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Shape/SplineComponent.h
@@ -27,7 +27,7 @@ namespace LmbrCentral
 
         static void Reflect(AZ::ReflectContext* context);
 
-        void ChangeSplineType(AZ::u64 splineType);
+        void ChangeSplineType(SplineType splineType);
 
         /// Override callbacks to be used when spline changes/is modified.
         void SetCallbacks(
@@ -41,7 +41,7 @@ namespace LmbrCentral
     private:
         AZ::u32 OnChangeSplineType();
 
-        AZ::u64 m_splineType = AZ::LinearSpline::RTTI_Type().GetHash(); ///< The currently set spline type (default to Linear).
+        SplineType m_splineType = SplineType::LINEAR; ///< The currently set spline type (default to Linear).
 
         AZ::IndexFunction m_onAddVertex = nullptr;
         AZ::IndexFunction m_onRemoveVertex = nullptr;
@@ -69,7 +69,7 @@ namespace LmbrCentral
 
         // SplineComponentRequestBus
         AZ::SplinePtr GetSpline() override;
-        void ChangeSplineType(AZ::u64 splineType) override;
+        void ChangeSplineType(SplineType splineType) override;
         void SetClosed(bool closed) override;
 
         // SplineComponentRequestBus/VertexContainerInterface

--- a/Gems/LmbrCentral/Code/Tests/SplineComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/SplineComponentTests.cpp
@@ -106,7 +106,7 @@ namespace UnitTest
             AZ_TEST_ASSERT(linearSplinePtr->GetVertexCount() == 4);
 
             // change spline type to Bezier
-            LmbrCentral::SplineComponentRequestBus::Event(entity.GetId(), &LmbrCentral::SplineComponentRequests::ChangeSplineType, AZ::BezierSpline::RTTI_Type().GetHash());
+            LmbrCentral::SplineComponentRequestBus::Event(entity.GetId(), &LmbrCentral::SplineComponentRequests::ChangeSplineType, LmbrCentral::SplineType::BEZIER);
 
             // check data was created after change correctly
             AZ::ConstSplinePtr bezierSplinePtr;
@@ -164,7 +164,7 @@ namespace UnitTest
             }
 
             // change spline type to CatmullRom
-            LmbrCentral::SplineComponentRequestBus::Event(entity.GetId(), &LmbrCentral::SplineComponentRequests::ChangeSplineType, AZ::CatmullRomSpline::RTTI_Type().GetHash());
+            LmbrCentral::SplineComponentRequestBus::Event(entity.GetId(), &LmbrCentral::SplineComponentRequests::ChangeSplineType, LmbrCentral::SplineType::CATMULL_ROM);
             
             AZ::ConstSplinePtr catmullRomSplinePtr;
             LmbrCentral::SplineComponentRequestBus::EventResult(catmullRomSplinePtr, entity.GetId(), &LmbrCentral::SplineComponentRequests::GetSpline);

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/SplineComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Shape/SplineComponentBus.h
@@ -14,6 +14,13 @@
 
 namespace LmbrCentral
 {
+    enum class SplineType
+    {
+        LINEAR = 0,
+        BEZIER,
+        CATMULL_ROM
+    };
+
     /// Services provided by the Spline Component.
     class SplineComponentRequests
         : public AZ::VariableVertices<AZ::Vector3>
@@ -24,7 +31,7 @@ namespace LmbrCentral
         /// Change the type of interpolation used by the spline.
         /// @param splineType Refers to the RTTI Hash of the underlying Spline type
         /// (example: AZ::LinearSpline::RTTI_Type().GetHash()).
-        virtual void ChangeSplineType(AZ::u64 splineType) = 0;
+        virtual void ChangeSplineType(SplineType splineType) = 0;
         /// Set whether the spline should form a closed loop or not.
         virtual void SetClosed(bool closed) = 0;
 


### PR DESCRIPTION
## What does this PR do?

Fixes splines in the DPE inspector.
The spline component would crash when trying to select a spline type, while it now works as expected again.

My guess as to what the issue was is that using an AZ::u64 as a ComboBox value, the RPE would pass it correctly while the DPE tries to convert it somewhere down the line. I honestly think using an enum works much better in the component either way as it helps readability and debugging. Will keep an eye on other components that may have similar setups to see if this broke anything else tho.

## How was this PR tested?

Manual testing.
