### PR TITLE
expose IsSkinnedMesh() for a model of a mesh-handle

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -58,6 +58,7 @@ namespace AZ
             };
 
             using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
+            const bool IsSkinnedMesh() { return m_descriptor.m_isSkinnedMesh; }
 
         private:
             class MeshLoader


### PR DESCRIPTION
## What does this PR do?

Exposes the m_isSkinnedMesh - flag maintained by the MeshFeatureProcessor

## How was this PR tested?

locally tested