### PR TITLE
Try to de-register the view for a viewport before registering it as a default view

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -369,6 +369,7 @@ namespace AZ
 
             if (pipeline)
             {
+                pipeline->UnregisterView(pipelineView);
                 pipeline->SetDefaultView(pipelineView);
             }
         }


### PR DESCRIPTION
## What does this PR do?

This fixes a bug that can happen in a scenario with multiple active cameras, where the view-tags are different when in play mode vs editor mode: 
The pipeline-view of the editor-camera is assigned to one of the pipeline views upon game start. 
Upon exit, the editor-camera is registered as the default view for the pipeline, but that does not de-register the camera from the already registered pipelineview with potentially a different tag. 
This previously led to a case where a single view is registered for multiple view-tags, which doesn't work.

## How was this PR tested?

Starting and stopping the Game-Mode from the editor with a custom render-pipeline that has multiple views, and with the MainPipeline to ensure normal behaviour is unchanged.
