### PR TITLE
add GetShaderResourceGroup() to RPI::Material

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -131,6 +131,8 @@ namespace AZ
             //! Do not set this in the shipping runtime unless you know what you are doing.
             void SetPsoHandlingOverride(MaterialPropertyPsoHandling psoHandlingOverride);
 
+            Data::Instance<RPI::ShaderResourceGroup> GetShaderResourceGroup();
+
             const RHI::ShaderResourceGroup* GetRHIShaderResourceGroup() const;
 
             const Data::Asset<MaterialAsset>& GetAsset() const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -857,5 +857,9 @@ namespace AZ
         {
             return m_materialProperties.GetMaterialPropertiesLayout();
         }
+        Data::Instance<RPI::ShaderResourceGroup> Material::GetShaderResourceGroup()
+        {
+            return m_shaderResourceGroup;
+        }
     } // namespace RPI
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

Add a interface function to get access to the `RPI::ShaderResourceGroup` for the MaterialSRG of a material.

## How was this PR tested?

Use the interface function in a custom gem.
