### PR TITLE
fix python exceptions raised when a test case fails

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/cli/codeowners_hint.py
+++ b/Tools/LyTestTools/ly_test_tools/cli/codeowners_hint.py
@@ -26,7 +26,12 @@ def get_codeowners(target_path: pathlib.PurePath) -> (str|None, str|None, pathli
     :return: tuple of (matched_path_entry, matched_owner_aliases, found_codeowners_path) which are empty when missing
     """
     codeowners_path = find_github_codeowners(target_path)
-    matched_path, owner_aliases = get_codeowners_from(target_path, codeowners_path)
+    if codeowners_path:
+        matched_path, owner_aliases = get_codeowners_from(target_path, codeowners_path)
+    else:
+        matched_path = ""
+        owner_aliases = ""
+        codeowners_path = ""
     return matched_path, owner_aliases, codeowners_path
 
 

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -544,13 +544,13 @@ class AssetProcessor(object):
                     return False, None
             return True, None
         except BaseException as be:  # purposefully broad
-            logger.exception("Exception while starting Asset Processor", be)
+            logger.exception("Exception while starting Asset Processor")
             # clean up to avoid leaking open AP process to future tests
             try:
                 if self._ap_proc:
                     self._ap_proc.kill()
             except Exception as ex:
-                logger.exception("Ignoring exception while trying to terminate Asset Processor from LyTestTools ", ex)
+                logger.exception("Ignoring exception while trying to terminate Asset Processor from LyTestTools")
             raise exceptions.LyTestToolsFrameworkException from be  # raise whatever prompted us to clean up
 
     def connect_listen(self, timeout=DEFAULT_TIMEOUT_SECONDS):


### PR DESCRIPTION
## What does this PR do?

When a python testcase fails, and the codeowners are not set up properly, the test fail message will contain python - exceptions and a stack trace caused by the LyTestTool, which are unrelated to any exceptions or stack traces caused by the actual failure.

## How was this PR tested?

Run a failing test-case and review the test - output.