### PR TITLE
add extra commandline args for the asset processor when using pytest

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor_test_testing/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor_test_testing/TestSuite_Main.py
@@ -38,6 +38,7 @@ def get_editor_launcher_platform():
 class TestEditorTest:
 
     args = []
+    assetprocessor_extra_params = None
     path = None
 
     @classmethod
@@ -81,7 +82,7 @@ class TestEditorTest:
         if cls._asset_processor is None:
             if not process_utils.process_exists("AssetProcessor", ignore_extensions=True):
                 cls._asset_processor = AssetProcessor(workspace)
-                cls._asset_processor.start()
+                cls._asset_processor.start(extra_params=cls.assetprocessor_extra_params)
 
         pytester.makepyfile(
             f"""
@@ -139,7 +140,7 @@ class TestEditorTest:
         if cls._asset_processor is None:
             if not process_utils.process_exists("AssetProcessor", ignore_extensions=True):
                 cls._asset_processor = AssetProcessor(workspace)
-                cls._asset_processor.start()
+                cls._asset_processor.start(extra_params=cls.assetprocessor_extra_params)
 
         pytester.makepyfile(
             f"""

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -95,8 +95,8 @@ class AssetProcessor(object):
 
     # Starts AP but does not by default run until idle.
     def start(self, connection_timeout=30, quitonidle=False, add_gem_scan_folders=None, add_config_scan_folders=None,
-              accept_input=True, run_until_idle=False, scan_folder_pattern=None, connect_to_ap=False):
-        self.gui_process(quitonidle=quitonidle, add_gem_scan_folders=add_gem_scan_folders,
+              accept_input=True, run_until_idle=False, scan_folder_pattern=None, connect_to_ap=False, extra_params=None):
+        self.gui_process(extra_params=extra_params, quitonidle=quitonidle, add_gem_scan_folders=add_gem_scan_folders,
                          add_config_scan_folders=add_config_scan_folders, timeout=connection_timeout,
                          connect_to_ap=connect_to_ap, accept_input=accept_input, run_until_idle=run_until_idle,
                          scan_folder_pattern=scan_folder_pattern)

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -136,6 +136,8 @@ class EditorTestSuite(MultiTestSuite):
     """
     # Extra cmdline arguments to supply for every Editor for this test suite.
     global_extra_cmdline_args = ["-BatchMode", "-autotest_mode"]
+    # Extra commandline arguments to supply to the asset-processor for this test suite
+    global_assetprocessor_extra_cmdline_args = None
     # Tests usually run with no renderer, however some tests require a renderer and will disable this.
     use_null_renderer = True
     # Maximum time in seconds for a single Editor to stay open across the set of shared tests.

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test_utils.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test_utils.py
@@ -288,7 +288,7 @@ def _check_log_errors_warnings(log_path: str) -> bool:
 
 
 def prepare_asset_processor(workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
-                            collected_test_data: TestData) -> None:
+                            collected_test_data: TestData, extra_params=None) -> None:
     """
     Prepares the asset processor for the test depending on whether the process is open and if the current test owns it.
     :param workspace: The workspace object in case an AssetProcessor object needs to be created
@@ -301,11 +301,11 @@ def prepare_asset_processor(workspace: ly_test_tools._internal.managers.workspac
             if not process_utils.process_exists("AssetProcessor", ignore_extensions=True):
                 kill_all_ly_processes(include_asset_processor=True)
                 collected_test_data.asset_processor = AssetProcessor(workspace)
-                collected_test_data.asset_processor.start()
+                collected_test_data.asset_processor.start(extra_params=extra_params)
             else:  # If another AP process already exists, do not kill it as we do not manage it
                 kill_all_ly_processes(include_asset_processor=False)
         else:  # Make sure existing asset processor wasn't closed by accident
-            collected_test_data.asset_processor.start()
+            collected_test_data.asset_processor.start(extra_params=extra_params)
     except Exception as ex:
         collected_test_data.asset_processor = None
         raise EditorToolsFrameworkException from ex

--- a/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/multi_test_framework.py
@@ -326,6 +326,8 @@ class MultiTestSuite(object):
     # When this object is inherited, add any custom attributes as needed.
     # Extra cmdline arguments to supply for every executable instance for this test suite
     global_extra_cmdline_args = ["-BatchMode", "-autotest_mode"]
+    # Extra commandline arguments to supply to the asset-processor for this test suite
+    global_assetprocessor_extra_cmdline_args = None
     # Tests usually run with no renderer, however some tests require a renderer and will disable this
     use_null_renderer = True
     # Maximum time in seconds for a single executable to stay open across the set of shared tests
@@ -747,7 +749,7 @@ class MultiTestSuite(object):
         self.executable.workspace = workspace
 
         # Setup AP, kill processes, and configure the executable.
-        editor_utils.prepare_asset_processor(workspace, collected_test_data)
+        editor_utils.prepare_asset_processor(workspace, collected_test_data, extra_params=self.global_assetprocessor_extra_cmdline_args)
         editor_utils.kill_all_ly_processes(include_asset_processor=False)
         self.executable.configure_settings()
 


### PR DESCRIPTION
## What does this PR do?

Allow a python testcase to add (optional) extra parameters to the command line for the AssetProcessor  , which is necessary if e.g. the Test-Project is in a non-standard location and the AssetProcessor would not be able to find the corrrect project otherwise.

## How was this PR tested?

Run a Python - Tests for an external Gem with a Test-Project that is not the AutomatedTesting - Project.  