### PR TITLE
Proper handling of TLASBuffers

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h
@@ -226,6 +226,9 @@ namespace AZ::RHI
         const RHI::Ptr<RHI::MultiDeviceBuffer> GetTlasInstancesBuffer() const;
 
     private:
+        //! Safe-guard access to creation of buffers cache during parallel access
+        mutable AZStd::mutex m_tlasBufferMutex;
+        mutable AZStd::mutex m_tlasInstancesBufferMutex;
         MultiDeviceRayTracingTlasDescriptor m_mdDescriptor;
         mutable RHI::Ptr<RHI::MultiDeviceBuffer> m_tlasBuffer;
         mutable RHI::Ptr<RHI::MultiDeviceBuffer> m_tlasInstancesBuffer;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceRayTracingAccelerationStructure.cpp
@@ -257,11 +257,16 @@ namespace AZ::RHI
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
         }
 
+        // Each call to CreateBuffers advances m_currentBufferIndex internally, reset buffers to always receive currently active
+        m_tlasBuffer.reset();
+        m_tlasInstancesBuffer.reset();
+
         return resultCode;
     }
 
     const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasBuffer() const
     {
+        AZStd::lock_guard lock(m_tlasBufferMutex);
         if (m_deviceObjects.empty())
         {
             return nullptr;
@@ -295,6 +300,8 @@ namespace AZ::RHI
 
     const RHI::Ptr<RHI::MultiDeviceBuffer> MultiDeviceRayTracingTlas::GetTlasInstancesBuffer() const
     {
+        AZStd::lock_guard lock(m_tlasInstancesBufferMutex);
+
         if (m_deviceObjects.empty())
         {
             return nullptr;


### PR DESCRIPTION
This commit fixes handling of the `TLAS*Buffers`, which are created in the `CreateBuffers()` call, and need to be cached in the multi-device case (as a `Shutdown()` triggers the buffers to be invalidated).
A repeated call to `CreateBuffers()` internally advances the `m_currentBufferIndex`, hence the single-device variants of the `TLAS*Buffers` need to be retrieved anew.
Second, the creation of the multi-device buffers is now guarded with a `lock_guard`.
