### PR TITLE
Fix a flaky test

### DIFF
--- a/Code/Framework/AzCore/Tests/SystemFileTest.cpp
+++ b/Code/Framework/AzCore/Tests/SystemFileTest.cpp
@@ -253,32 +253,54 @@ namespace UnitTest
 
     TEST_F(SystemFileTest, FileDescriptorCapturer_DoesNotDeadlock_WhenMoreThanPipeSizeContent_IsCaptured)
     {
-        AZStd::string stdoutData;
-        auto StoreStdout = [&stdoutData](AZStd::span<const AZStd::byte> capturedBytes)
+        using namespace AZ::IO;
+
+        AZStd::string capturedData;
+        auto StoreFromFile = [&capturedData](AZStd::span<const AZStd::byte> capturedBytes)
         {
             AZStd::string_view capturedStrView(reinterpret_cast<const char*>(capturedBytes.data()), capturedBytes.size());
-            stdoutData += capturedStrView;
+            capturedData += capturedStrView;
         };
 
         // The +1 to make sure the value isn't a power of 2, to try to catch any edge cases
         // with reading from a buffered pipe
         constexpr size_t charCountToWrite = AZ::IO::FileDescriptorCapturer::DefaultPipeSize * 2 + 1;
-        stdoutData.reserve(charCountToWrite);
+        capturedData.reserve(charCountToWrite);
 
-        // file descriptor 1 is stdout
-        constexpr int StdoutDescriptor = 1;
-        AZ::IO::FileDescriptorCapturer capturer(StdoutDescriptor);
-        capturer.Start(StoreStdout);
-        // Capture twice the DefaultPipeSize amount of bytes
+        // while it may be tempting to use stdout here, other processes and threads might be running
+        // in the same test run and also outputting to stdout.  This would cause an intermittent failure.
+        // Instead, write to a temp file.
+        AZ::Test::ScopedAutoTempDirectory tempDir;
+        auto srcFile = tempDir.Resolve("SystemFileTest_Source.txt");
+        int sourceFd = PosixInternal::Open(srcFile.c_str(),
+            PosixInternal::OpenFlags::Create | PosixInternal::OpenFlags::ReadWrite | PosixInternal::OpenFlags::Truncate,
+            PosixInternal::PermissionModeFlags::Read | PosixInternal::PermissionModeFlags::Write);
+        ASSERT_NE(sourceFd, -1);
+        AZ::IO::FileDescriptorCapturer capturer(sourceFd);
+
+        capturer.Start(StoreFromFile);
+        const char* dataToWrite = "a";
         for (size_t i = 0; i < charCountToWrite; ++i)
         {
-            fputc('a', stdout);
+            // this should cause the write function to fill up any buffer and then block if the pipe is full
+            // until the capturer reads from it.
+            // filling the pipe should NOT cause blocking here, since the capturer reads on a different thread.
+            PosixInternal::Write(sourceFd, dataToWrite, 1);
         }
-        fflush(stdout);
+        PosixInternal::Close(sourceFd);
         capturer.Stop();
 
         const AZStd::string expectedValue(charCountToWrite, 'a');
-        EXPECT_EQ(expectedValue, stdoutData);
+
+        // if the lengths are not equal, we DROPPED or invented data.
+        EXPECT_EQ(expectedValue.size(), capturedData.size()) << "FileDescriptorCapturer dropped or invented some of the data.";
+        
+        if (expectedValue.size() == capturedData.size())
+        {
+            // if the lengths are equal, but the strings are different, then the data is corrupt in some way (full of the
+            // wrong character, or nulls, or something).
+            EXPECT_TRUE(expectedValue == capturedData) << "FileDescriptorCapturer corrupted some of the data";
+        }
     }
 
     TEST_F(SystemFileTest, GetStdout_ReturnsHandle_ThatCanWriteToStdout_Succeeds)


### PR DESCRIPTION

## What does this PR do?
`FileDescriptorCapturer_DoesNotDeadlock_WhenMoreThanPipeSizeContent_IsCaptured`


My assumption here is that stdout was being spammed somehow by pytest or other threads running at the same time.  To fix this, I made it write to a temp file in a auto delete temp folder instead.

## How was this PR tested?

The above test was succeeding when run directly (even with repeat 1000), but was failing every single time for me when run in parallel by pytest.

After this change it no longer failed during local ci_build pytest runs.  I would assume its been flaky on jenkins but could be working by luck.
