### PR TITLE
Scope: Added feature to wait a fence to be triggered

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
@@ -96,6 +96,10 @@ namespace AZ::RHI
         //! Whether swapchain scaling support is available.
         RHI::ScalingFlags m_swapchainScalingFlags = RHI::ScalingFlags::None;
 
+        //! Whether fences can be signalled from the CPU
+        //! If this is false, the Fence::SignalOnCpu inserts the signal command into a queue
+        bool m_signalFenceFromCPU = false;
+
         /// Additional features here.
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
@@ -110,6 +110,7 @@ namespace AZ::RHI
         void ExecuteAfter(const ScopeId& scopeId);
         void ExecuteBefore(const ScopeId& scopeId);
         void SignalFence(Fence& fence);
+        void WaitFence(Fence& fence);
         void SetEstimatedItemCount(uint32_t itemCount);
         void SetHardwareQueueClass(HardwareQueueClass hardwareQueueClass);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
@@ -210,7 +210,7 @@ namespace AZ::RHI
         }
 
         //! Requests that the provided fence be waited for before the scope has started.
-        void WaitFence(SingleDeviceFence& fence)
+        void WaitFence(Fence& fence)
         {
             m_frameGraph.WaitFence(fence);
         }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphInterface.h
@@ -208,7 +208,13 @@ namespace AZ::RHI
         {
             m_frameGraph.SignalFence(fence);
         }
-            
+
+        //! Requests that the provided fence be waited for before the scope has started.
+        void WaitFence(SingleDeviceFence& fence)
+        {
+            m_frameGraph.WaitFence(fence);
+        }
+
         //! Sets the number of work items (Draw / Dispatch / etc) that will be processed by
         //! this scope. This value is used to load-balance the scope across command lists. A small
         //! value may result in the scope being merged onto a single command list, whereas a large

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -243,7 +243,7 @@ namespace AZ::RHI
         /// The set of fences to signal on scope completion.
         AZStd::vector<Ptr<Fence>>                m_fencesToSignal;
 
-        /// The set of fences to wait for scope completion.
+        /// The set of fences to wait for on scope completion.
         AZStd::vector<Ptr<Fence>> m_fencesToWaitFor;
 
         /// The set query pools.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -243,7 +243,7 @@ namespace AZ::RHI
         /// The set of fences to signal on scope completion.
         AZStd::vector<Ptr<Fence>>                m_fencesToSignal;
 
-        /// The set of fences to wait for on scope completion.
+        /// The set of fences to wait for before scope has started.
         AZStd::vector<Ptr<Fence>> m_fencesToWaitFor;
 
         /// The set query pools.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -117,6 +117,9 @@ namespace AZ::RHI
         //! Returns a list of fences to signal on completion of the scope.
         const AZStd::vector<Ptr<Fence>>& GetFencesToSignal() const;
 
+        //! Returns a list of fences to wait for before start of the scope.
+        const AZStd::vector<Ptr<Fence>>& GetFencesToWaitFor() const;
+
         //! Initializes the scope.
         void Init(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass = HardwareQueueClass::Graphics);
 
@@ -239,6 +242,9 @@ namespace AZ::RHI
 
         /// The set of fences to signal on scope completion.
         AZStd::vector<Ptr<Fence>>                m_fencesToSignal;
+
+        /// The set of fences to wait for scope completion.
+        AZStd::vector<Ptr<Fence>> m_fencesToWaitFor;
 
         /// The set query pools.
         AZStd::vector<Ptr<QueryPool>>                m_queryPools;

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -429,6 +429,11 @@ namespace AZ::RHI
         m_currentScope->m_fencesToSignal.push_back(&fence);
     }
 
+    void FrameGraph::WaitFence(Fence& fence)
+    {
+        m_currentScope->m_fencesToWaitFor.push_back(&fence);
+    }
+
     ResultCode FrameGraph::TopologicalSort()
     {
         struct NodeId

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -91,6 +91,7 @@ namespace AZ::RHI
         m_bufferAttachments.clear();
         m_swapChainsToPresent.clear();
         m_fencesToSignal.clear();
+        m_fencesToWaitFor.clear();
         m_resourcePoolResolves.clear();
         m_queryPools.clear();
     }
@@ -220,6 +221,11 @@ namespace AZ::RHI
     const AZStd::vector<Ptr<Fence>>& Scope::GetFencesToSignal() const
     {
         return m_fencesToSignal;
+    }
+
+    const AZStd::vector<Ptr<Fence>>& Scope::GetFencesToWaitFor() const
+    {
+        return m_fencesToWaitFor;
     }
 
     Scope* Scope::GetProducerByQueue(HardwareQueueClass hardwareQueueClass) const

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
@@ -144,6 +144,11 @@ namespace AZ
                 static const uint32_t CommandListCountMax = 128;
                 ID3D12CommandQueue* dx12CommandQueue = static_cast<ID3D12CommandQueue*>(commandQueue);
 
+                for (Fence* fence : request.m_userFencesToWaitFor)
+                {
+                    dx12CommandQueue->Wait(fence->Get(), fence->GetPendingValue());
+                }
+
                 for (size_t producerQueueIdx = 0; producerQueueIdx < request.m_waitFences.size(); ++producerQueueIdx)
                 {
                     if (const uint64_t fenceValue = request.m_waitFences[producerQueueIdx])

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
@@ -34,6 +34,9 @@ namespace AZ
 
             /// A set of user fences to signal after executing the command lists.
             AZStd::vector<Fence*> m_userFencesToSignal;
+
+            /// A set of user fences to wait for before executing the command lists.
+            AZStd::vector<Fence*> m_userFencesToWaitFor;
         };
 
         enum class HardwareQueueSubclass

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -298,6 +298,8 @@ namespace AZ
                     RHI::ShadingRateFlags::Rate4x4;
             }
 
+            m_features.m_signalFenceFromCPU = true;
+
             m_limits.m_shadingRateTileSize = RHI::Size(options6.ShadingRateImageTileSize, options6.ShadingRateImageTileSize, 1);
 #endif
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -54,6 +54,16 @@ namespace AZ
                         fencesToSignal.push_back(&static_cast<FenceImpl&>(*fence).Get());
                     }
                 }
+
+                {
+                    auto& fencesToWaitFor = m_workRequest.m_userFencesToWaitFor;
+
+                    fencesToWaitFor.reserve(fencesToWaitFor.size() + scope->GetFencesToWaitFor().size());
+                    for (const RHI::Ptr<RHI::Fence>& fence : scope->GetFencesToWaitFor())
+                    {
+                        fencesToWaitFor.push_back(&static_cast<FenceImpl&>(*fence).Get());
+                    }
+                }
             }
 
             InitMergedRequest request;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -114,8 +114,11 @@ namespace AZ
                     // Check if the hardware queue classes match.
                     const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
 
+                    bool hasUserFencesToWaitFor = !scope.GetFencesToWaitFor().empty();
+
                     // Check if we are straddling the boundary of a fence.
-                    const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) || hasUserFencesToSignal;
+                    const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) ||
+                        hasUserFencesToSignal || hasUserFencesToWaitFor;
 
                     // If we exceeded limits, then flush the group.
                     const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -504,7 +504,7 @@ namespace AZ
             {
                 semaphoresToSignal.push_back(semaphoreToSignal);
             }
-            queue->SubmitCommandBuffers(commandBuffers, semaphoresWaitInfo, semaphoresToSignal, framePacket.m_fence.get());
+            queue->SubmitCommandBuffers(commandBuffers, semaphoresWaitInfo, semaphoresToSignal, {}, framePacket.m_fence.get());
             queue->EndDebugLabel();
 
             m_frameIndex = (m_frameIndex + 1) % m_descriptor.m_frameCount;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -72,7 +72,12 @@ namespace AZ
                 }
 
                 // Submit commands to queue for the current frame.
-                vulkanQueue->SubmitCommandBuffers({request.m_commandList}, request.m_semaphoresToWait, request.m_semaphoresToSignal, fenceToSignal);
+                vulkanQueue->SubmitCommandBuffers(
+                    { request.m_commandList },
+                    request.m_semaphoresToWait,
+                    request.m_semaphoresToSignal,
+                    request.m_fencesToWaitFor,
+                    fenceToSignal);
                 // Need to signal all the other fences (other than the first one)
                 for (size_t i = 1; i < request.m_fencesToSignal.size(); ++ i)
                 {
@@ -106,8 +111,9 @@ namespace AZ
                 Queue* vulkanQueue = static_cast<Queue*>(queue);
                 vulkanQueue->SubmitCommandBuffers(
                     AZStd::vector<RHI::Ptr<CommandList>>(),
-                    AZStd::vector<Semaphore::WaitSemaphore>(), 
-                    AZStd::vector<RHI::Ptr<Semaphore>>(), 
+                    AZStd::vector<Semaphore::WaitSemaphore>(),
+                    AZStd::vector<RHI::Ptr<Semaphore>>(),
+                    {},
                     &fence);
             });
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.h
@@ -35,6 +35,9 @@ namespace AZ
             /// Fence to signal after execution of commands
             AZStd::vector<RHI::Ptr<Fence>> m_fencesToSignal;
 
+            /// Fence to wait for before execution of command
+            AZStd::vector<RHI::Ptr<Fence>> m_fencesToWaitFor;
+
             /// Debug label to insert during work execution
             AZStd::string m_debugLabel;
         };

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -273,7 +273,7 @@ namespace AZ
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
                 vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
                 vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
-                vulkan12Features.timelineSemaphore = true;
+                vulkan12Features.timelineSemaphore = physicalDevice.GetPhysicalDeviceVulkan12Features().timelineSemaphore;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
@@ -1186,11 +1186,7 @@ namespace AZ
             }
             m_features.m_swapchainScalingFlags = AZ_TRAIT_ATOM_VULKAN_SWAPCHAIN_SCALING_FLAGS;
 
-            const auto& physicalProperties = physicalDevice.GetPhysicalDeviceProperties();
-            uint32_t majorVersion = VK_VERSION_MAJOR(physicalProperties.apiVersion);
-            uint32_t minorVersion = VK_VERSION_MINOR(physicalProperties.apiVersion);
-            m_features.m_signalFenceFromCPU = (majorVersion >= 1 && minorVersion >= 2) ||
-                physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore);
+            m_features.m_signalFenceFromCPU = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
 
             const auto& deviceLimits = physicalDevice.GetDeviceLimits();
             m_limits.m_maxImageDimension1D = deviceLimits.maxImageDimension1D;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -273,6 +273,7 @@ namespace AZ
                 vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
                 vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
                 vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
+                vulkan12Features.timelineSemaphore = true;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
@@ -1184,6 +1185,12 @@ namespace AZ
                 }
             }
             m_features.m_swapchainScalingFlags = AZ_TRAIT_ATOM_VULKAN_SWAPCHAIN_SCALING_FLAGS;
+
+            const auto& physicalProperties = physicalDevice.GetPhysicalDeviceProperties();
+            uint32_t majorVersion = VK_VERSION_MAJOR(physicalProperties.apiVersion);
+            uint32_t minorVersion = VK_VERSION_MINOR(physicalProperties.apiVersion);
+            m_features.m_signalFenceFromCPU = (majorVersion >= 1 && minorVersion >= 2) ||
+                physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore);
 
             const auto& deviceLimits = physicalDevice.GetDeviceLimits();
             m_limits.m_maxImageDimension1D = deviceLimits.maxImageDimension1D;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
@@ -73,9 +73,9 @@ namespace AZ
             m_fenceType = FenceType::Invalid;
             if (device.GetFeatures().m_signalFenceFromCPU)
             {
-                VkSemaphoreTypeCreateInfo timelineCreateInfo;
+                VkSemaphoreTypeCreateInfo timelineCreateInfo{};
                 timelineCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
-                timelineCreateInfo.pNext = NULL;
+                timelineCreateInfo.pNext = nullptr;
                 timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
                 timelineCreateInfo.initialValue = 0;
 
@@ -174,7 +174,7 @@ namespace AZ
                 {
                     VkSemaphoreSignalInfo signalInfo;
                     signalInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
-                    signalInfo.pNext = NULL;
+                    signalInfo.pNext = nullptr;
                     signalInfo.semaphore = m_nativeSemaphore;
                     signalInfo.value = m_pendingValue;
 
@@ -202,9 +202,9 @@ namespace AZ
                 break;
             case FenceType::TimelineSemaphore:
                 {
-                    VkSemaphoreWaitInfo waitInfo;
+                    VkSemaphoreWaitInfo waitInfo{};
                     waitInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
-                    waitInfo.pNext = NULL;
+                    waitInfo.pNext = nullptr;
                     waitInfo.flags = 0;
                     waitInfo.semaphoreCount = 1;
                     waitInfo.pSemaphores = &m_nativeSemaphore;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
@@ -19,14 +19,42 @@ namespace AZ
             return aznew Fence();
         }
 
-        void Fence::SignalEvent()
+        FenceType Fence::GetFenceType() const
         {
-            m_signalEvent.Signal();
+            return m_fenceType;
         }
 
         VkFence Fence::GetNativeFence() const
         {
+            AZ_Assert(m_fenceType == FenceType::Fence, "Vulkan Fence::GetNativeFence: Invalid type");
             return m_nativeFence;
+        }
+
+        void Fence::SignalEvent()
+        {
+            switch (m_fenceType)
+            {
+            case FenceType::Fence:
+                m_signalEvent.Signal();
+                break;
+            case FenceType::TimelineSemaphore:
+                break; // Nothing to do as timeline semaphores can be waited for before they are submitted
+            default:
+                AZ_Assert(false, "Vulkan Fence::SignalEvent: Invalid fence type");
+                break;
+            }
+        }
+
+        VkSemaphore Fence::GetNativeSemaphore() const
+        {
+            AZ_Assert(m_fenceType == FenceType::TimelineSemaphore, "Vulkan Fence::GetNativeSemaphore: Invalid type");
+            return m_nativeSemaphore;
+        }
+
+        uint64_t Fence::GetPendingValue() const
+        {
+            AZ_Assert(m_fenceType == FenceType::TimelineSemaphore, "Vulkan Fence::GetPendingValue: Invalid type");
+            return m_pendingValue;
         }
 
         void Fence::SetNameInternal(const AZStd::string_view& name)
@@ -42,87 +70,215 @@ namespace AZ
             auto& device = static_cast<Device&>(baseDevice);
             DeviceObject::Init(baseDevice);
 
-            VkFenceCreateInfo createInfo{};
-            createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-            createInfo.pNext = nullptr;
-            bool readyToWait = false;
-            switch (initialState)
+            m_fenceType = FenceType::Invalid;
+            if (device.GetFeatures().m_signalFenceFromCPU)
             {
-            case RHI::FenceState::Reset:
-                readyToWait = false;
+                VkSemaphoreTypeCreateInfo timelineCreateInfo;
+                timelineCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+                timelineCreateInfo.pNext = NULL;
+                timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+                timelineCreateInfo.initialValue = 0;
+
+                VkSemaphoreCreateInfo createInfo{};
+                createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+                createInfo.pNext = &timelineCreateInfo;
                 createInfo.flags = 0;
-                break;
-            case RHI::FenceState::Signaled:
-                readyToWait = true;
-                createInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-                break;
-            default:
-                return RHI::ResultCode::InvalidArgument;
+
+                const VkResult result = device.GetContext().CreateSemaphore(
+                    device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeSemaphore);
+                AssertSuccess(result);
+
+                RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
+
+                m_pendingValue = (initialState == RHI::FenceState::Signaled) ? 0 : 1;
+                m_fenceType = FenceType::TimelineSemaphore;
+
+                return RHI::ResultCode::Success;
             }
+            else
+            {
+                VkFenceCreateInfo createInfo{};
+                createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+                createInfo.pNext = nullptr;
+                bool readyToWait = false;
+                switch (initialState)
+                {
+                case RHI::FenceState::Reset:
+                    readyToWait = false;
+                    createInfo.flags = 0;
+                    break;
+                case RHI::FenceState::Signaled:
+                    readyToWait = true;
+                    createInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+                    break;
+                default:
+                    return RHI::ResultCode::InvalidArgument;
+                }
 
-            const VkResult result =
-                device.GetContext().CreateFence(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeFence);
-            AssertSuccess(result);
+                const VkResult result =
+                    device.GetContext().CreateFence(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeFence);
+                AssertSuccess(result);
 
-            RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
-            m_signalEvent.SetValue(readyToWait);
-            SetName(GetName());
-            return RHI::ResultCode::Success;
+                RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
+                m_signalEvent.SetValue(readyToWait);
+                SetName(GetName());
+                m_fenceType = FenceType::Fence;
+                return RHI::ResultCode::Success;
+            }
         }
 
         void Fence::ShutdownInternal()
         {
-            if (m_nativeFence != VK_NULL_HANDLE)
+            switch (m_fenceType)
             {
-                auto& device = static_cast<Device&>(GetDevice());
-                device.GetContext().DestroyFence(device.GetNativeDevice(), m_nativeFence, VkSystemAllocator::Get());
-                m_nativeFence = VK_NULL_HANDLE;
+            case FenceType::Fence:
+                {
+                    if (m_nativeFence != VK_NULL_HANDLE)
+                    {
+                        auto& device = static_cast<Device&>(GetDevice());
+                        device.GetContext().DestroyFence(device.GetNativeDevice(), m_nativeFence, VkSystemAllocator::Get());
+                        m_nativeFence = VK_NULL_HANDLE;
+                    }
+                    // Signal any pending thread.
+                    m_signalEvent.Signal();
+                }
+                break;
+            case FenceType::TimelineSemaphore:
+                {
+                    if (m_nativeSemaphore != VK_NULL_HANDLE)
+                    {
+                        auto& device = static_cast<Device&>(GetDevice());
+                        device.GetContext().DestroySemaphore(device.GetNativeDevice(), m_nativeSemaphore, VkSystemAllocator::Get());
+                        m_nativeSemaphore = VK_NULL_HANDLE;
+                    }
+                }
+                break;
+            default:
+                break;
             }
-            // Signal any pending thread.
-            m_signalEvent.Signal();
         }
 
         void Fence::SignalOnCpuInternal()
         {
-            // Vulkan doesn't have an API to signal fences from CPU.
-            // Because of this we need to use a queue to signal the fence.
-            auto& device = static_cast<Device&>(GetDevice());
-            device.GetCommandQueueContext().GetCommandQueue(RHI::HardwareQueueClass::Graphics).Signal(*this);
+            switch (m_fenceType)
+            {
+            case FenceType::Fence:
+                {
+                    // Vulkan doesn't have an API to signal fences from CPU.
+                    // Because of this we need to use a queue to signal the fence.
+                    auto& device = static_cast<Device&>(GetDevice());
+                    device.GetCommandQueueContext().GetCommandQueue(RHI::HardwareQueueClass::Graphics).Signal(*this);
+                }
+                break;
+            case FenceType::TimelineSemaphore:
+                {
+                    VkSemaphoreSignalInfo signalInfo;
+                    signalInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+                    signalInfo.pNext = NULL;
+                    signalInfo.semaphore = m_nativeSemaphore;
+                    signalInfo.value = m_pendingValue;
+
+                    auto& device = static_cast<Device&>(GetDevice());
+                    device.GetContext().SignalSemaphore(device.GetNativeDevice(), &signalInfo);
+                }
+                break;
+            default:
+                AZ_Assert(false, "Vulkan Fence::SignalOnCpuInternal: Invalid fence type");
+                break;
+            }
         }
 
         void Fence::WaitOnCpuInternal() const
         {
-            // According to the standard we can't wait until the event (like VkSubmitQueue) happens first.
-            m_signalEvent.Wait();
-            auto& device = static_cast<Device&>(GetDevice());
-            AssertSuccess(device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX));
+            switch (m_fenceType)
+            {
+            case FenceType::Fence:
+                {
+                    // According to the standard we can't wait until the event (like VkSubmitQueue) happens first.
+                    m_signalEvent.Wait();
+                    auto& device = static_cast<Device&>(GetDevice());
+                    AssertSuccess(device.GetContext().WaitForFences(device.GetNativeDevice(), 1, &m_nativeFence, VK_FALSE, UINT64_MAX));
+                }
+                break;
+            case FenceType::TimelineSemaphore:
+                {
+                    VkSemaphoreWaitInfo waitInfo;
+                    waitInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+                    waitInfo.pNext = NULL;
+                    waitInfo.flags = 0;
+                    waitInfo.semaphoreCount = 1;
+                    waitInfo.pSemaphores = &m_nativeSemaphore;
+                    waitInfo.pValues = &m_pendingValue;
+
+                    auto& device = static_cast<Device&>(GetDevice());
+                    device.GetContext().WaitSemaphores(device.GetNativeDevice(), &waitInfo, AZStd::numeric_limits<uint64_t>::max());
+                }
+                break;
+            default:
+                AZ_Assert(false, "Vulkan Fence::WaitOnCpuInternal: Invalid fence type");
+                break;
+            }
         }
 
         void Fence::ResetInternal()
         {
-            m_signalEvent.SetValue(false);
-            auto& device = static_cast<Device&>(GetDevice());
-            AssertSuccess(device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence));
+            switch (m_fenceType)
+            {
+            case FenceType::Fence:
+                {
+                    m_signalEvent.SetValue(false);
+                    auto& device = static_cast<Device&>(GetDevice());
+                    AssertSuccess(device.GetContext().ResetFences(device.GetNativeDevice(), 1, &m_nativeFence));
+                }
+                break;
+            case FenceType::TimelineSemaphore:
+                {
+                    m_pendingValue++;
+                }
+                break;
+            default:
+                AZ_Assert(false, "Vulkan Fence::ResetInternal: Invalid fence type");
+                break;
+            }
         }
 
         RHI::FenceState Fence::GetFenceStateInternal() const
         {
-            auto& device = static_cast<Device&>(GetDevice());
-            VkResult result = device.GetContext().GetFenceStatus(device.GetNativeDevice(), m_nativeFence);
-            switch (result)
+            switch (m_fenceType)
             {
-            case VK_SUCCESS:
-                return RHI::FenceState::Signaled;
-            case VK_NOT_READY:
-                return RHI::FenceState::Reset;
-            case VK_ERROR_DEVICE_LOST:
-                AZ_Assert(false, "Device is lost.");
+            case FenceType::Fence:
+                {
+                    auto& device = static_cast<Device&>(GetDevice());
+                    VkResult result = device.GetContext().GetFenceStatus(device.GetNativeDevice(), m_nativeFence);
+                    switch (result)
+                    {
+                    case VK_SUCCESS:
+                        return RHI::FenceState::Signaled;
+                    case VK_NOT_READY:
+                        return RHI::FenceState::Reset;
+                    case VK_ERROR_DEVICE_LOST:
+                        AZ_Assert(false, "Device is lost.");
+                        break;
+                    default:
+                        AZ_Assert(false, "Fence state is unknown.");
+                        break;
+                    }
+                    return RHI::FenceState::Reset;
+                }
+                break;
+            case FenceType::TimelineSemaphore:
+                {
+                    auto& device = static_cast<Device&>(GetDevice());
+                    uint64_t completedValue = 0;
+                    device.GetContext().GetSemaphoreCounterValue(device.GetNativeDevice(), m_nativeSemaphore, &completedValue);
+                    return (m_pendingValue <= completedValue) ? RHI::FenceState::Signaled : RHI::FenceState::Reset;
+                }
                 break;
             default:
-                AZ_Assert(false, "Fence state is unknown.");
+                AZ_Assert(false, "Vulkan Fence::GetFenceStateInternal: Invalid fence type");
+                return RHI::FenceState::Reset;
                 break;
             }
-            return RHI::FenceState::Reset;
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
@@ -17,8 +17,21 @@ namespace AZ
     {
         class Device;
 
-        class Fence final
-            : public RHI::Fence
+        enum class FenceType
+        {
+            // Fence is based on VkFence
+            // Cannot natively be signalled from the CPU
+            // Signalling from the CPU is emulated by submitting a signal command to the Graphics queue
+            // The signal command must also be submitted before we can wait for the fence to be signalled
+            // Used if the device does not support timeline semaphores (Vulkan version < 1.2)
+            Fence,
+            // Fence is based on a timeline semaphore VkSemaphore
+            // Is used if the device supports it
+            TimelineSemaphore,
+            Invalid
+        };
+
+        class Fence final : public RHI::Fence
         {
             using Base = RHI::Fence;
 
@@ -29,11 +42,18 @@ namespace AZ
             static RHI::Ptr<Fence> Create();
             ~Fence() = default;
 
+            FenceType GetFenceType() const;
+
+            // VkFence functions
+            VkFence GetNativeFence() const;
             // According to the Vulkan Standard, fences can only be waited after the event
             // that will signal it is submitted. Because of this we need to tell the fence that it's
             // okay to start waiting on the native fence.
             void SignalEvent();
-            VkFence GetNativeFence() const;
+
+            // VkSemaphore functions
+            VkSemaphore GetNativeSemaphore() const;
+            uint64_t GetPendingValue() const;
 
         private:
             Fence() = default;
@@ -53,9 +73,13 @@ namespace AZ
             RHI::FenceState GetFenceStateInternal() const override;
             //////////////////////////////////////////////////////////////////////
 
-            VkFence m_nativeFence = VK_NULL_HANDLE;
+            FenceType m_fenceType = FenceType::Invalid;
 
+            VkFence m_nativeFence = VK_NULL_HANDLE;
             AZ::Vulkan::SignalEvent m_signalEvent;
+
+            VkSemaphore m_nativeSemaphore = VK_NULL_HANDLE;
+            uint64_t m_pendingValue = 0;
         };
-    }
-}
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
@@ -68,6 +68,7 @@ namespace AZ
             InsertWorkRequestElements(m_workRequest.m_semaphoresToWait, workRequest.m_semaphoresToWait);
             InsertWorkRequestElements(m_workRequest.m_semaphoresToSignal, workRequest.m_semaphoresToSignal);
             InsertWorkRequestElements(m_workRequest.m_fencesToSignal, workRequest.m_fencesToSignal);
+            InsertWorkRequestElements(m_workRequest.m_fencesToWaitFor, workRequest.m_fencesToWaitFor);
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupPrimary.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupPrimary.cpp
@@ -42,10 +42,12 @@ namespace AZ::Vulkan
             const auto& waitSemaphores = scope->GetWaitSemaphores();
             const auto& signalSemaphores = scope->GetSignalSemaphores();
             const auto& signalFences = scope->GetSignalFences();
+            const auto& waitFences = scope->GetWaitFences();
 
             m_workRequest.m_semaphoresToWait.insert(m_workRequest.m_semaphoresToWait.end(), waitSemaphores.begin(), waitSemaphores.end());
             m_workRequest.m_semaphoresToSignal.insert(m_workRequest.m_semaphoresToSignal.end(), signalSemaphores.begin(), signalSemaphores.end());
             m_workRequest.m_fencesToSignal.insert(m_workRequest.m_fencesToSignal.end(), signalFences.begin(), signalFences.end());
+            m_workRequest.m_fencesToWaitFor.insert(m_workRequest.m_fencesToWaitFor.end(), waitFences.begin(), waitFences.end());
         }
 
         InitMergedRequest request;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupSecondary.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupSecondary.cpp
@@ -35,7 +35,8 @@ namespace AZ::Vulkan
         m_workRequest.m_semaphoresToWait = scope.GetWaitSemaphores();
         m_workRequest.m_semaphoresToSignal = scope.GetSignalSemaphores();
         m_workRequest.m_fencesToSignal = scope.GetSignalFences();
-            
+        m_workRequest.m_fencesToWaitFor = scope.GetWaitFences();
+
         InitRequest request;
         request.m_scopeId = scope.GetId();
         request.m_submitCount = scope.GetEstimatedItemCount();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -142,7 +142,8 @@ namespace AZ
                     const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
 
                     // Check if we are straddling the boundary of a fence/semaphore.
-                    const bool onSyncBoundaries = !scope.GetWaitSemaphores().empty() || (scopePrev && (!scopePrev->GetSignalSemaphores().empty() || !scopePrev->GetSignalFences().empty()));
+                    const bool onSyncBoundaries = !scope.GetWaitSemaphores().empty() || !scope.GetWaitFences().empty() ||
+                        (scopePrev && (!scopePrev->GetSignalSemaphores().empty() || !scopePrev->GetSignalFences().empty()));
 
                     // If we exceeded limits, then flush the group.
                     const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onSyncBoundaries || subpassGroup;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/NullDescriptorManager.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/NullDescriptorManager.cpp
@@ -303,10 +303,7 @@ namespace AZ
             {
                 Queue* vulkanQueue = static_cast<Queue*>(queue);
                 vulkanQueue->SubmitCommandBuffers(
-                    { commandList },
-                    AZStd::vector<Semaphore::WaitSemaphore>(),
-                    AZStd::vector<RHI::Ptr<Semaphore>>(),
-                    nullptr);
+                    { commandList }, AZStd::vector<Semaphore::WaitSemaphore>(), AZStd::vector<RHI::Ptr<Semaphore>>(), {}, nullptr);
             });
 
             return RHI::ResultCode::Success;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -181,6 +181,11 @@ namespace AZ
             return m_bufferDeviceAddressFeatures;
         }
 
+        const VkPhysicalDeviceTimelineSemaphoreFeatures& PhysicalDevice::GetPhysicalDeviceTimelineSemaphoreFeatures() const
+        {
+            return m_timelineSemaphoreFeatures;
+        }
+
         const VkPhysicalDeviceVulkan12Features& PhysicalDevice::GetPhysicalDeviceVulkan12Features() const
         {
             return m_vulkan12Features;
@@ -375,6 +380,7 @@ namespace AZ
                 m_rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
                 m_shadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
                 m_fragmentDensityMapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT;
+                m_timelineSemaphoreFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
 
                 VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
                 deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
@@ -389,11 +395,12 @@ namespace AZ
                       &m_robutness2Features,
                       &m_float16Int8Features,
                       &m_separateDepthStencilFeatures,
-                      &m_vulkan12Features ,
+                      &m_vulkan12Features,
                       &m_accelerationStructureFeatures,
                       &m_rayTracingPipelineFeatures,
                       &m_shadingRateFeatures,
-                      &m_fragmentDensityMapFeatures});
+                      &m_fragmentDensityMapFeatures,
+                      &m_timelineSemaphoreFeatures });
 
                 context.GetPhysicalDeviceFeatures2KHR(vkPhysicalDevice, &deviceFeatures2);
                 m_deviceFeatures = deviceFeatures2.features;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -325,6 +325,7 @@ namespace AZ
                 VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME,
                 VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
                 VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
+                VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
             } };
 
             [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -105,7 +105,8 @@ namespace AZ
             const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& GetPhysicalDeviceFragmentDensityMapFeatures() const;
             const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& GetPhysicalDeviceFragmentDensityMapProperties() const;
             const VkPhysicalDeviceFragmentShadingRatePropertiesKHR& GetPhysicalDeviceFragmentShadingRateProperties() const;
-            
+            const VkPhysicalDeviceTimelineSemaphoreFeatures& GetPhysicalDeviceTimelineSemaphoreFeatures() const;
+
             VkFormatProperties GetFormatProperties(RHI::Format format, bool raiseAsserts = true) const;
             StringList GetDeviceLayerNames() const;
             StringList GetDeviceExtensionNames(const char* layerName = nullptr) const;
@@ -148,6 +149,7 @@ namespace AZ
             VkPhysicalDeviceFragmentDensityMapFeaturesEXT m_fragmentDensityMapFeatures{};
             VkPhysicalDeviceFragmentDensityMapPropertiesEXT m_fragmentDensityMapProperties{};
             VkPhysicalDeviceFragmentShadingRatePropertiesKHR m_fragmentShadingRateProperties{};
+            VkPhysicalDeviceTimelineSemaphoreFeatures m_timelineSemaphoreFeatures{};
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -62,6 +62,7 @@ namespace AZ
             FragmentShadingRate,
             FragmentDensityMap,
             Renderpass2,
+            TimelineSempahore,
             Count
         };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -48,7 +48,7 @@ namespace AZ
             AZStd::vector<VkSemaphore> vkSignalSemaphores;
 
             VkTimelineSemaphoreSubmitInfo timelineSemaphoresSubmitInfos = {};
-            uint64_t fenceToSignalValue = 0;
+            AZStd::vector<uint64_t> vkSignalSemaphoreValues;
             AZStd::vector<uint64_t> vkWaitSemaphoreValues;
 
             VkSubmitInfo submitInfo;
@@ -88,12 +88,14 @@ namespace AZ
 
                     if ((fenceToSignal && fenceToSignal->GetFenceType() == FenceType::TimelineSemaphore))
                     {
-                        fenceToSignalValue = fenceToSignal->GetPendingValue();
-                        timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = 1;
-                        timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = &fenceToSignalValue;
+                        vkSignalSemaphoreValues.resize(vkSignalSemaphores.size(), 0);
+                        vkSignalSemaphoreValues.push_back(fenceToSignal->GetPendingValue());
                         vkSignalSemaphores.push_back(fenceToSignal->GetNativeSemaphore());
+                        timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = vkSignalSemaphoreValues.size();
+                        timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = vkSignalSemaphoreValues.data();
                     }
 
+                    vkWaitSemaphoreValues.resize(vkWaitSemaphoreVector.size(), 0);
                     for (auto& fence : fencesToWaitFor)
                     {
                         AZ_Assert(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -88,14 +88,14 @@ namespace AZ
 
                     if ((fenceToSignal && fenceToSignal->GetFenceType() == FenceType::TimelineSemaphore))
                     {
-                        vkSignalSemaphoreValues.resize(vkSignalSemaphores.size(), 0);
+                        vkSignalSemaphoreValues.resize(vkSignalSemaphores.size(), 0); // Add 'dummy' values for binary sempahores
                         vkSignalSemaphoreValues.push_back(fenceToSignal->GetPendingValue());
                         vkSignalSemaphores.push_back(fenceToSignal->GetNativeSemaphore());
                         timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = vkSignalSemaphoreValues.size();
                         timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = vkSignalSemaphoreValues.data();
                     }
 
-                    vkWaitSemaphoreValues.resize(vkWaitSemaphoreVector.size(), 0);
+                    vkWaitSemaphoreValues.resize(vkWaitSemaphoreVector.size(), 0); // Add 'dummy' values for binary sempahores
                     for (auto& fence : fencesToWaitFor)
                     {
                         AZ_Assert(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -48,6 +48,7 @@ namespace AZ
             AZStd::vector<VkSemaphore> vkSignalSemaphores;
 
             VkTimelineSemaphoreSubmitInfo timelineSemaphoresSubmitInfos = {};
+            uint64_t fenceToSignalValue = 0;
             AZStd::vector<uint64_t> vkWaitSemaphoreValues;
 
             VkSubmitInfo submitInfo;
@@ -87,9 +88,9 @@ namespace AZ
 
                     if ((fenceToSignal && fenceToSignal->GetFenceType() == FenceType::TimelineSemaphore))
                     {
-                        uint64_t value = fenceToSignal->GetPendingValue();
+                        fenceToSignalValue = fenceToSignal->GetPendingValue();
                         timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = 1;
-                        timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = &value;
+                        timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = &fenceToSignalValue;
                         vkSignalSemaphores.push_back(fenceToSignal->GetNativeSemaphore());
                     }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -91,7 +91,7 @@ namespace AZ
                         vkSignalSemaphoreValues.resize(vkSignalSemaphores.size(), 0); // Add 'dummy' values for binary sempahores
                         vkSignalSemaphoreValues.push_back(fenceToSignal->GetPendingValue());
                         vkSignalSemaphores.push_back(fenceToSignal->GetNativeSemaphore());
-                        timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = vkSignalSemaphoreValues.size();
+                        timelineSemaphoresSubmitInfos.signalSemaphoreValueCount = static_cast<uint32_t>(vkSignalSemaphoreValues.size());
                         timelineSemaphoresSubmitInfos.pSignalSemaphoreValues = vkSignalSemaphoreValues.data();
                     }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.h
@@ -59,7 +59,8 @@ namespace AZ
             RHI::ResultCode SubmitCommandBuffers(
                 const AZStd::vector<RHI::Ptr<CommandList>>& commandBuffers,
                 const AZStd::vector<Semaphore::WaitSemaphore>& waitSemaphoresInfo,
-                const AZStd::vector< RHI::Ptr<Semaphore>>& semaphoresToSignal,
+                const AZStd::vector<RHI::Ptr<Semaphore>>& semaphoresToSignal,
+                const AZStd::vector<RHI::Ptr<Fence>>& fencesToWaitFor,
                 Fence* fenceToSignal);
 
             /// Waits (blocks) until all fences are signaled in the fence-list.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
@@ -102,6 +102,7 @@ namespace AZ
             const AZStd::vector<Semaphore::WaitSemaphore>& GetWaitSemaphores() const;
             const AZStd::vector<RHI::Ptr<Semaphore>>& GetSignalSemaphores() const;
             const AZStd::vector<RHI::Ptr<Fence>>& GetSignalFences() const;
+            const AZStd::vector<RHI::Ptr<Fence>>& GetWaitFences() const;
 
             //! Graphics scopes that draw items use a renderpass.
             //! Compute or copy scopes do not use a renderpass.
@@ -194,6 +195,7 @@ namespace AZ
             AZStd::vector<Semaphore::WaitSemaphore> m_waitSemaphores;
             AZStd::vector<RHI::Ptr<Semaphore>> m_signalSemaphores;
             AZStd::vector<RHI::Ptr<Fence>> m_signalFences;
+            AZStd::vector<RHI::Ptr<Fence>> m_waitFences;
             AZStd::vector<QueryPoolAttachment> m_queryPoolAttachments;
             bool m_usesRenderpass = false;
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -270,9 +270,10 @@ namespace AZ
                     // We wait until the swapchain image has finished being rendered to initialize the
                     // ownership transfer.
                     vulkanQueue->SubmitCommandBuffers(
-                        AZStd::vector<RHI::Ptr<CommandList>>{commandList},
-                        AZStd::vector<Semaphore::WaitSemaphore>{AZStd::make_pair(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, presentSemaphore)},
-                        AZStd::vector< RHI::Ptr<Semaphore>>{transferSemaphore},
+                        AZStd::vector<RHI::Ptr<CommandList>>{ commandList },
+                        AZStd::vector<Semaphore::WaitSemaphore>{ AZStd::make_pair(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, presentSemaphore) },
+                        AZStd::vector<RHI::Ptr<Semaphore>>{ transferSemaphore },
+                        {},
                         nullptr);
 
                     // The presentation engine must wait until the ownership transfer has completed.


### PR DESCRIPTION
## What does this PR do?

For a device -> device copy we need a GPU -> CPU -> GPU synchronization, if no vendor specific extensions are pesent. This PR introduces this synchronization via the already existing `Fence` class. It consists of two parts:

1. Use timeline semaphores instead of fences in Vulkan, if the device supports it. Timeline semaphores are available as a extensions and in Vulkan 1.2. So most desktop GPUs should support them. The fallback to `VkFence` is probably still needed for older Android devices. Fences for DX12 are very similar to Vulkan timeline semaphores, so almost nothing had to be changed there.
2. Add a list of fences a scope must wait for before executing. These fences can be signaled from the CPU.

## How was this PR tested?

This was tested in the branch https://github.com/msat-huawei/o3de/tree/wait-for-fences, where we added a device -> host -> device copy to the CopyPass (still WIP).
