### PR TITLE
Inspector | Fix asset dropping into asset input fields

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -194,7 +194,7 @@ namespace AzAssetBrowserRequestHandlerPrivate
         return validEntries[0];
     }
 
-    // return true if a given product has an asociated component type.
+    // return true if a given product has an associated component type.
     bool ProductHasAssociatedComponent(const ProductAssetBrowserEntry* product)
     {
         if (!product)

--- a/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetTypeInfoBus.h
@@ -61,10 +61,10 @@ namespace AZ
         
         //! Used to assign a sort order to assets in the case where the user
         //! drags and drops a source file (like a FBX, but others too) which result in many
-        //! different products of different types.  Creating entities for each will cause a jumbled
+        //! different products of different types. Creating entities for each will cause a jumbled
         //! mess, so instead, the products will be sorted using this value as a hint
         //! and the first one in the resulting list will be picked to represent the drop operation.
-        //! Highest number wins.   In the case of ties, the list will also be sorted alphabetically
+        //! Highest number wins. In the case of ties, the list will also be sorted alphabetically
         //! and give a higher weight to assets with the same name as the source file that produced them.
         virtual int GetAssetTypeDragAndDropCreationPriority() const { return s_NormalPriority; }
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -91,6 +91,7 @@ namespace AzToolsFramework
         pLayout->setContentsMargins(0, 0, 0, 0);
         pLayout->setSpacing(2);
 
+        m_browseEdit->lineEdit()->setAcceptDrops(false);
         setAcceptDrops(true);
 
         m_thumbnail = new ThumbnailPropertyCtrl(this);


### PR DESCRIPTION
## What does this PR do?

The PropertyAssetCtrl widget would incorrectly detect assets being dragged as text drags when the lineedit was hovered, which resulted in incorrect drops and a very small area where the drop operation would be successful. Dragging text into the field is not very helpful to the UX since the autocompleter is not triggered, so even dropping a correct path or asset name in the field would not result in the asset being selected without additional interactions.

This said, I just removed text dropping onto the PropertyAssetCtrl LineEdit so that asset drops are detected correctly on the whole field.

## How was this PR tested?

Manual UX testing.

### BEFORE
![AssetDropBefore](https://github.com/o3de/o3de/assets/82231674/341f2964-d948-4be0-88f2-8e10478e2f82)

### AFTER
![AssetDropFix](https://github.com/o3de/o3de/assets/82231674/792434e8-5abc-4731-874b-6f4750e017c7)