### PR TITLE
Allow passing customized derivatives to texture sampling functions for a possible deferred render pipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -303,7 +303,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
 
     //! Processes the set of Standard material inputs for a single layer.
     //! The FILL_STANDARD_MATERIAL_INPUTS() macro below can be used to fill the StandardMaterialInputs struct.
-    ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inputs)
+    ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inputs, float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
     {
         ProcessedMaterialInputs result;
     
@@ -312,17 +312,17 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         transformedUv[1] = inputs.m_vertexUv[1];
     
         real3x3 normalUvMatrix = inputs.m_normalMapUvIndex == 0 ? real3x3(inputs.m_uvMatrix) : real3x3(CreateIdentity3x3());
-        result.m_normalTS = GetNormalInputTS(inputs.m_normalMap, inputs.m_sampler, transformedUv[inputs.m_normalMapUvIndex], inputs.m_flipNormalX, inputs.m_flipNormalY, normalUvMatrix, inputs.m_normal_useTexture, real(inputs.m_normalFactor));
+        result.m_normalTS = GetNormalInputTS(inputs.m_normalMap, inputs.m_sampler, transformedUv[inputs.m_normalMapUvIndex], inputs.m_flipNormalX, inputs.m_flipNormalY, normalUvMatrix, inputs.m_normal_useTexture, real(inputs.m_normalFactor), uvDxDy, customDerivatives);
     
-        real3 sampledBaseColor = GetBaseColorInput(inputs.m_baseColorMap, inputs.m_sampler, transformedUv[inputs.m_baseColorMapUvIndex], real3(inputs.m_baseColor.rgb), inputs.m_baseColor_useTexture);
+        real3 sampledBaseColor = GetBaseColorInput(inputs.m_baseColorMap, inputs.m_sampler, transformedUv[inputs.m_baseColorMapUvIndex], real3(inputs.m_baseColor.rgb), inputs.m_baseColor_useTexture, uvDxDy, customDerivatives);
         result.m_baseColor = BlendBaseColor(sampledBaseColor, real3(inputs.m_baseColor.rgb), real(inputs.m_baseColorFactor), inputs.m_baseColorTextureBlendMode, inputs.m_baseColor_useTexture);
-        result.m_specularF0Factor = GetSpecularInput(inputs.m_specularF0Map, inputs.m_sampler, transformedUv[inputs.m_specularF0MapUvIndex], real(inputs.m_specularF0Factor), inputs.m_specularF0_useTexture);
-        result.m_metallic = GetMetallicInput(inputs.m_metallicMap, inputs.m_sampler, transformedUv[inputs.m_metallicMapUvIndex], real(inputs.m_metallicFactor), inputs.m_metallic_useTexture);
-        result.m_roughness = GetRoughnessInput(inputs.m_roughnessMap, MaterialSrg::m_sampler, transformedUv[inputs.m_roughnessMapUvIndex], real(inputs.m_roughnessFactor), real(inputs.m_roughnessLowerBound), real(inputs.m_roughnessUpperBound), inputs.m_roughness_useTexture);
+        result.m_specularF0Factor = GetSpecularInput(inputs.m_specularF0Map, inputs.m_sampler, transformedUv[inputs.m_specularF0MapUvIndex], real(inputs.m_specularF0Factor), inputs.m_specularF0_useTexture, uvDxDy, customDerivatives);
+        result.m_metallic = GetMetallicInput(inputs.m_metallicMap, inputs.m_sampler, transformedUv[inputs.m_metallicMapUvIndex], real(inputs.m_metallicFactor), inputs.m_metallic_useTexture, uvDxDy, customDerivatives);
+        result.m_roughness = GetRoughnessInput(inputs.m_roughnessMap, MaterialSrg::m_sampler, transformedUv[inputs.m_roughnessMapUvIndex], real(inputs.m_roughnessFactor), real(inputs.m_roughnessLowerBound), real(inputs.m_roughnessUpperBound), inputs.m_roughness_useTexture, uvDxDy, customDerivatives);
 
-        result.m_emissiveLighting = GetEmissiveInput(inputs.m_emissiveMap, inputs.m_sampler, transformedUv[inputs.m_emissiveMapUvIndex], real(inputs.m_emissiveIntensity), real3(inputs.m_emissiveColor.rgb), 0.0, 1.0, inputs.m_emissiveEnabled, inputs.m_emissive_useTexture);
-        result.m_diffuseAmbientOcclusion = GetOcclusionInput(inputs.m_diffuseOcclusionMap, inputs.m_sampler, transformedUv[inputs.m_diffuseOcclusionMapUvIndex], real(inputs.m_diffuseOcclusionFactor), inputs.m_diffuseOcclusion_useTexture);
-        result.m_specularOcclusion = GetOcclusionInput(inputs.m_specularOcclusionMap, MaterialSrg::m_sampler, transformedUv[inputs.m_specularOcclusionMapUvIndex], real(inputs.m_specularOcclusionFactor), inputs.m_specularOcclusion_useTexture);
+        result.m_emissiveLighting = GetEmissiveInput(inputs.m_emissiveMap, inputs.m_sampler, transformedUv[inputs.m_emissiveMapUvIndex], real(inputs.m_emissiveIntensity), real3(inputs.m_emissiveColor.rgb), 0.0, 1.0, inputs.m_emissiveEnabled, inputs.m_emissive_useTexture, uvDxDy, customDerivatives);
+        result.m_diffuseAmbientOcclusion = GetOcclusionInput(inputs.m_diffuseOcclusionMap, inputs.m_sampler, transformedUv[inputs.m_diffuseOcclusionMapUvIndex], real(inputs.m_diffuseOcclusionFactor), inputs.m_diffuseOcclusion_useTexture, uvDxDy, customDerivatives);
+        result.m_specularOcclusion = GetOcclusionInput(inputs.m_specularOcclusionMap, MaterialSrg::m_sampler, transformedUv[inputs.m_specularOcclusionMapUvIndex], real(inputs.m_specularOcclusionFactor), inputs.m_specularOcclusion_useTexture, uvDxDy, customDerivatives);
     
     #if ENABLE_CLEAR_COAT
         result.m_clearCoat.InitializeToZero();
@@ -335,7 +335,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
                                 inputs.m_clearCoatNormalMap,    transformedUv[inputs.m_clearCoatNormalMapUvIndex], inputs.m_normal, inputs.m_clearCoat_normal_useTexture, real(inputs.m_clearCoatNormalStrength),
                                 clearCoatUvMatrix, inputs.m_tangents[inputs.m_clearCoatNormalMapUvIndex], inputs.m_bitangents[inputs.m_clearCoatNormalMapUvIndex],
                                 inputs.m_sampler, inputs.m_isFrontFace,
-                                result.m_clearCoat.factor, result.m_clearCoat.roughness, result.m_clearCoat.normal);
+                                result.m_clearCoat.factor, result.m_clearCoat.roughness, result.m_clearCoat.normal, uvDxDy, customDerivatives);
         }
     #endif
 
@@ -427,7 +427,9 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         float2 uvs[UvSetCount],
         bool isFrontFace,
         bool isDisplacementClipped,
-        float3 vertexBlendMask)
+        float3 vertexBlendMask,
+        float4 uvDxDy,
+        bool customDerivatives)
     {        
         LayerBlendSource blendSource = GetFinalLayerBlendSource();
         
@@ -435,7 +437,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
 
         if(o_debugDrawMode == DebugDrawMode::BlendMask)
         {
-            float3 blendMaskValues = GetApplicableBlendMaskValues(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask);
+            float3 blendMaskValues = GetApplicableBlendMaskValues(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask, uvDxDy, customDerivatives);
             return MakeDebugSurface(positionWS, normalWS, real3(blendMaskValues));
         }
     
@@ -450,14 +452,31 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
     
         if(o_debugDrawMode == DebugDrawMode::FinalBlendWeights)
         {
-            float3 blendWeights = GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask);
+            float3 blendWeights;
+            if (customDerivatives)
+            {
+                blendWeights = GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask, uvDxDy, customDerivatives);
+            }
+            else
+            {
+                blendWeights = GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask, float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+            }
             return MakeDebugSurface(positionWS, normalWS, real3(blendWeights));
         }
 
         // ------- Calculate Layer Blend Mask Values -------
     
         // Now that any parallax has been calculated, we calculate the blend factors for any layers that are impacted by the parallax.
-        real3 blendWeights = (GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask));
+        real3 blendWeights;
+        if (customDerivatives)
+        {
+            blendWeights = real3(GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask, uvDxDy, customDerivatives));
+        }
+        else
+        {
+            blendWeights = real3(GetBlendWeights(blendSource, uvs[MaterialSrg::m_blendMaskUvIndex], vertexBlendMask, float4(0.0f, 0.0f, 0.0f, 0.0f), false));
+        }
+        
         
         // ------- Layer 1 (base layer) -----------
 
@@ -467,7 +486,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             StandardMaterialInputs inputs;
             FILL_STANDARD_MATERIAL_INPUTS(inputs, MaterialSrg::m_layer1_, o_layer1_, blendWeights.r)
             FILL_STANDARD_MATERIAL_INPUTS_CLEAR_COAT(inputs, MaterialSrg::m_layer1_, o_layer1_, blendWeights.r)
-            lightingInputLayer1 = ProcessStandardMaterialInputs(inputs);
+            lightingInputLayer1 = ProcessStandardMaterialInputs(inputs, uvDxDy, customDerivatives);
         }
         else
         {
@@ -483,7 +502,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             StandardMaterialInputs inputs;
             FILL_STANDARD_MATERIAL_INPUTS(inputs, MaterialSrg::m_layer2_, o_layer2_, blendWeights.g)
             FILL_STANDARD_MATERIAL_INPUTS_CLEAR_COAT(inputs, MaterialSrg::m_layer2_, o_layer2_, blendWeights.g)
-            lightingInputLayer2 = ProcessStandardMaterialInputs(inputs);
+            lightingInputLayer2 = ProcessStandardMaterialInputs(inputs, uvDxDy, customDerivatives);
         }
         else
         {
@@ -499,7 +518,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             StandardMaterialInputs inputs;
             FILL_STANDARD_MATERIAL_INPUTS(inputs, MaterialSrg::m_layer3_, o_layer3_, blendWeights.b)
             FILL_STANDARD_MATERIAL_INPUTS_CLEAR_COAT(inputs, MaterialSrg::m_layer3_, o_layer3_, blendWeights.b)
-            lightingInputLayer3 = ProcessStandardMaterialInputs(inputs);
+            lightingInputLayer3 = ProcessStandardMaterialInputs(inputs, uvDxDy, customDerivatives);
         }
         else
         {
@@ -572,6 +591,46 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         return surface;
     }
 
+    // helper function to keep compatible with the previous version
+    // because dxc compiler doesn't allow default parameters on functions with overloads
+    Surface EvaluateSurface_StandardMultilayerPBR(
+        float3 positionWS,
+        real3 normalWS,
+        real3 tangents[UvSetCount],
+        real3 bitangents[UvSetCount],
+        float2 uvs[UvSetCount],
+        bool isFrontFace,
+        bool isDisplacementClipped,
+        float3 vertexBlendMask)
+    {
+        return EvaluateSurface_StandardMultilayerPBR(
+            positionWS,
+            normalWS,
+            tangents,
+            bitangents,
+            uvs,
+            isFrontFace,
+            isDisplacementClipped,
+            vertexBlendMask,
+            float4(0.0f, 0.0f, 0.0f, 0.0f),
+            false);
+    }
+
+    Surface EvaluateSurface_StandardMultilayerPBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+    {
+        return EvaluateSurface_StandardMultilayerPBR(
+            geoData.positionWS,
+            geoData.vertexNormal,
+            geoData.tangents,
+            geoData.bitangents,
+            geoData.uvs,
+            geoData.isFrontFace,
+            geoData.isDisplacementClipped,
+            geoData.m_vertexBlendMask,
+            uvDxDy,
+            customDerivatives);
+    }
+
     Surface EvaluateSurface_StandardMultilayerPBR(VsOutput IN, PixelGeometryData geoData)
     {
         return EvaluateSurface_StandardMultilayerPBR(
@@ -582,7 +641,9 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
             geoData.uvs,
             geoData.isFrontFace,
             geoData.isDisplacementClipped,
-            geoData.m_vertexBlendMask);
+            geoData.m_vertexBlendMask,
+            float4(0.0f, 0.0f, 0.0f, 0.0f),
+            false);
     }
 
 #elif MATERIALPIPELINE_SHADER_HAS_GEOMETRIC_PIXEL_STAGE

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -23,7 +23,9 @@ Surface EvaluateSurface_BasePBR(
     real3 tangents[UvSetCount],
     real3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
-    bool isFrontFace)
+    bool isFrontFace,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     Surface surface;
     surface.position = positionWS;
@@ -33,24 +35,32 @@ Surface EvaluateSurface_BasePBR(
     surface.vertexNormal = vertexNormal;
     float2 normalUv = uvs[MaterialSrg::m_normalMapUvIndex];
     real3x3 uvMatrix = MaterialSrg::m_normalMapUvIndex == 0 ? real3x3(MaterialSrg::m_uvMatrix) : real3x3(CreateIdentity3x3()); // By design, only UV0 is allowed to apply transforms.
-    surface.normal = GetNormalInputWS(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, isFrontFace, vertexNormal,
-                                       tangents[MaterialSrg::m_normalMapUvIndex], bitangents[MaterialSrg::m_normalMapUvIndex], uvMatrix, o_normal_useTexture, real(MaterialSrg::m_normalFactor));
+    if (customDerivatives)
+    {
+        surface.normal = GetNormalInputWS(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, isFrontFace, vertexNormal,
+                                           tangents[MaterialSrg::m_normalMapUvIndex], bitangents[MaterialSrg::m_normalMapUvIndex], uvMatrix, o_normal_useTexture, real(MaterialSrg::m_normalFactor), uvDxDy, customDerivatives);
+    }
+    else
+    {
+        surface.normal = GetNormalInputWS(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, isFrontFace, vertexNormal,
+                                           tangents[MaterialSrg::m_normalMapUvIndex], bitangents[MaterialSrg::m_normalMapUvIndex], uvMatrix, o_normal_useTexture, real(MaterialSrg::m_normalFactor), float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+    }
 
     // ------- Base Color -------
 
     float2 baseColorUv = uvs[MaterialSrg::m_baseColorMapUvIndex];
-    real3 sampledColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, real3(MaterialSrg::m_baseColor.rgb), o_baseColor_useTexture);
+    real3 sampledColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, real3(MaterialSrg::m_baseColor.rgb), o_baseColor_useTexture, uvDxDy, customDerivatives);
     real3 baseColor = BlendBaseColor(sampledColor, real3(MaterialSrg::m_baseColor.rgb), real(MaterialSrg::m_baseColorFactor), o_baseColorTextureBlendMode, o_baseColor_useTexture);
     
     // ------- Metallic -------
 
     float2 metallicUv = uvs[MaterialSrg::m_metallicMapUvIndex];
-    real metallic = GetMetallicInput(MaterialSrg::m_metallicMap, MaterialSrg::m_sampler, metallicUv, real(MaterialSrg::m_metallicFactor), o_metallic_useTexture);
+    real metallic = GetMetallicInput(MaterialSrg::m_metallicMap, MaterialSrg::m_sampler, metallicUv, real(MaterialSrg::m_metallicFactor), o_metallic_useTexture, uvDxDy, customDerivatives);
 
     // ------- Specular -------
 
     float2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
-    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture);
+    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture, uvDxDy, customDerivatives);
 
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
 
@@ -58,10 +68,44 @@ Surface EvaluateSurface_BasePBR(
 
     float2 roughnessUv = uvs[MaterialSrg::m_roughnessMapUvIndex];
     surface.roughnessLinear = GetRoughnessInput(MaterialSrg::m_roughnessMap, MaterialSrg::m_sampler, roughnessUv, real(MaterialSrg::m_roughnessFactor),
-                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture);
+                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture, uvDxDy, customDerivatives);
     surface.CalculateRoughnessA();
 
     return surface;
+}
+
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_BasePBR(
+    float3 positionWS,
+    real3 vertexNormal,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace)
+{
+    return EvaluateSurface_BasePBR(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_BasePBR(
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.isFrontFace,
+        uvDxDy,
+        customDerivatives);
 }
 
 Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData)
@@ -72,5 +116,7 @@ Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData)
         geoData.tangents,
         geoData.bitangents,
         geoData.uvs,
-        geoData.isFrontFace);
+        geoData.isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -26,7 +26,9 @@ Surface EvaluateSurface_EnhancedPBR(
     float2 uvs[UvSetCount],
     float2 detailUvs[UvSetCount],
     bool isFrontFace,
-    bool isDisplacementClipped)
+    bool isDisplacementClipped,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     Surface surface;
     surface.position = positionWS;
@@ -45,7 +47,9 @@ Surface EvaluateSurface_EnhancedPBR(
         MaterialSrg::m_sampler,
         detailBlendMaskUv,
         o_detail_blendMask_useTexture,
-        real(MaterialSrg::m_detail_blendFactor));
+        real(MaterialSrg::m_detail_blendFactor),
+        uvDxDy,
+        customDerivatives);
 
     // ------- Normal -------
     
@@ -56,7 +60,8 @@ Surface EvaluateSurface_EnhancedPBR(
     surface.normal = GetDetailedNormalInputWS(
         isFrontFace, normalWS,
         real3(tangents[MaterialSrg::m_normalMapUvIndex]),      real3(bitangents[MaterialSrg::m_normalMapUvIndex]),      MaterialSrg::m_normalMap,             MaterialSrg::m_sampler, normalUv, real(MaterialSrg::m_normalFactor),  MaterialSrg::m_flipNormalX,         MaterialSrg::m_flipNormalY,         uvMatrix,                               o_normal_useTexture,
-        real3(tangents[MaterialSrg::m_detail_allMapsUvIndex]), real3(bitangents[MaterialSrg::m_detail_allMapsUvIndex]), MaterialSrg::m_detail_normal_texture, MaterialSrg::m_sampler, detailUv, detailLayerNormalFactor,           MaterialSrg::m_detail_normal_flipX,  MaterialSrg::m_detail_normal_flipY, real3x3(MaterialSrg::m_detailUvMatrix), o_detail_normal_useTexture);
+        real3(tangents[MaterialSrg::m_detail_allMapsUvIndex]), real3(bitangents[MaterialSrg::m_detail_allMapsUvIndex]), MaterialSrg::m_detail_normal_texture, MaterialSrg::m_sampler, detailUv, detailLayerNormalFactor,           MaterialSrg::m_detail_normal_flipX,  MaterialSrg::m_detail_normal_flipY, real3x3(MaterialSrg::m_detailUvMatrix), o_detail_normal_useTexture,
+        uvDxDy, customDerivatives);
 
     // ------- Base Color -------
 
@@ -65,7 +70,7 @@ Surface EvaluateSurface_EnhancedPBR(
 
     real3 baseColor = GetDetailedBaseColorInput(
         MaterialSrg::m_baseColorMap,             MaterialSrg::m_sampler, baseColorUv, o_baseColor_useTexture,        real3(MaterialSrg::m_baseColor),  real(MaterialSrg::m_baseColorFactor), o_baseColorTextureBlendMode,
-        MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, detailUv,    o_detail_baseColor_useTexture, detailLayerBaseColorFactor);
+        MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, detailUv,    o_detail_baseColor_useTexture, detailLayerBaseColorFactor, uvDxDy, customDerivatives);
     
     // ------- Parallax Clipping -------
 
@@ -77,7 +82,7 @@ Surface EvaluateSurface_EnhancedPBR(
     // ------- Alpha & Clip -------
 
     // TODO: this often invokes a separate sample of the base color texture which is wasteful
-    surface.alpha = GetAlphaAndClip(uvs);
+    surface.alpha = GetAlphaAndClip(uvs, uvDxDy, customDerivatives);
 
     // ------- Metallic -------
 
@@ -85,13 +90,13 @@ Surface EvaluateSurface_EnhancedPBR(
     if(!o_enableSubsurfaceScattering)   // If subsurface scattering is enabled skip texture lookup for metallic, as this quantity won't be used anyway
     {
         float2 metallicUv = uvs[MaterialSrg::m_metallicMapUvIndex];
-        metallic = GetMetallicInput(MaterialSrg::m_metallicMap, MaterialSrg::m_sampler, metallicUv, real(MaterialSrg::m_metallicFactor), o_metallic_useTexture);
+        metallic = GetMetallicInput(MaterialSrg::m_metallicMap, MaterialSrg::m_sampler, metallicUv, real(MaterialSrg::m_metallicFactor), o_metallic_useTexture, uvDxDy, customDerivatives);
     }
 
     // ------- Specular -------
 
     float2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
-    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture);
+    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture, uvDxDy, customDerivatives);
 
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
 
@@ -99,13 +104,13 @@ Surface EvaluateSurface_EnhancedPBR(
 
     float2 roughnessUv = uvs[MaterialSrg::m_roughnessMapUvIndex];
     surface.roughnessLinear = GetRoughnessInput(MaterialSrg::m_roughnessMap, MaterialSrg::m_sampler, roughnessUv, real(MaterialSrg::m_roughnessFactor),
-                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture);
+                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture, uvDxDy, customDerivatives);
     surface.CalculateRoughnessA();
 
     // ------- Subsurface -------
 
     float2 subsurfaceUv = uvs[MaterialSrg::m_subsurfaceScatteringInfluenceMapUvIndex];
-    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor));
+    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor), uvDxDy, customDerivatives);
     surface.subsurfaceScatteringQuality = real(MaterialSrg::m_subsurfaceScatteringQuality);
     surface.scatterDistance = real3(MaterialSrg::m_scatterDistance);
 
@@ -113,7 +118,7 @@ Surface EvaluateSurface_EnhancedPBR(
     
 #if ENABLE_TRANSMISSION
     float2 transmissionUv = uvs[MaterialSrg::m_transmissionThicknessMapUvIndex];
-    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness));
+    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness), uvDxDy, customDerivatives);
     surface.transmission.tint = transmissionTintThickness.rgb;
     surface.transmission.thickness = transmissionTintThickness.w;
     surface.transmission.transmissionParams = real4(MaterialSrg::m_transmissionParams);
@@ -133,12 +138,12 @@ Surface EvaluateSurface_EnhancedPBR(
     // ------- Emissive -------
 
     float2 emissiveUv = uvs[MaterialSrg::m_emissiveMapUvIndex];
-    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, real(MaterialSrg::m_emissiveIntensity), real3(MaterialSrg::m_emissiveColor.rgb), real(MaterialSrg::m_emissiveAffectedByAlpha), surface.alpha,  o_emissiveEnabled, o_emissive_useTexture);
+    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, real(MaterialSrg::m_emissiveIntensity), real3(MaterialSrg::m_emissiveColor.rgb), real(MaterialSrg::m_emissiveAffectedByAlpha), surface.alpha,  o_emissiveEnabled, o_emissive_useTexture, uvDxDy, customDerivatives);
 
     // ------- Occlusion -------
     
-    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture);
-    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture);
+    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture, uvDxDy, customDerivatives);
+    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture, uvDxDy, customDerivatives);
 
     // ------- Clearcoat -------
     
@@ -154,7 +159,7 @@ Surface EvaluateSurface_EnhancedPBR(
                                MaterialSrg::m_clearCoatNormalMap,    uvs[MaterialSrg::m_clearCoatNormalMapUvIndex], normalWS, o_clearCoat_normal_useTexture, real(MaterialSrg::m_clearCoatNormalStrength),
                                uvMatrix, tangents[MaterialSrg::m_clearCoatNormalMapUvIndex], bitangents[MaterialSrg::m_clearCoatNormalMapUvIndex],
                                MaterialSrg::m_sampler, isFrontFace,
-                               surface.clearCoat.factor, surface.clearCoat.roughness, surface.clearCoat.normal);
+                               surface.clearCoat.factor, surface.clearCoat.roughness, surface.clearCoat.normal, uvDxDy, customDerivatives);
         }
         
         ApplyClearCoatToSpecularF0(surface.specularF0, surface.clearCoat.factor);
@@ -168,6 +173,46 @@ Surface EvaluateSurface_EnhancedPBR(
     return surface;
 }
 
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_EnhancedPBR(
+    float3 positionWS,
+    real3 normalWS,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    float2 detailUvs[UvSetCount],
+    bool isFrontFace,
+    bool isDisplacementClipped)
+{
+    return EvaluateSurface_EnhancedPBR(
+        positionWS,
+        normalWS,
+        tangents,
+        bitangents,
+        uvs,
+        detailUvs,
+        isFrontFace,
+        isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_EnhancedPBR(
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.detailUvs,
+        geoData.isFrontFace,
+        geoData.isDisplacementClipped,
+        uvDxDy,
+        customDerivatives);
+}
+
 Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_EnhancedPBR(
@@ -178,5 +223,7 @@ Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData)
         geoData.uvs,
         geoData.detailUvs,
         geoData.isFrontFace,
-        geoData.isDisplacementClipped);
+        geoData.isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_SurfaceEval.azsli
@@ -55,7 +55,9 @@ Surface EvaluateSurface_Eye(
     float3 localPosition,
     bool isFrontFace,
     real4x4 worldMatrix,
-    real3x3 worldMatrixIT)
+    real3x3 worldMatrixIT,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     Surface surface;
     surface.position = positionWS;
@@ -87,12 +89,25 @@ Surface EvaluateSurface_Eye(
 
     // Get surface normal for each layer (iris/sclera) and blend using the mask defined above
     real2 irisNormalUv = uvs[MaterialSrg::m_iris_m_normalMapUvIndex];
-    real3 irisNormal = GetNormalInputWS(MaterialSrg::m_iris_m_normalMap, MaterialSrg::m_sampler, irisNormalUv, MaterialSrg::m_iris_m_flipNormalX, MaterialSrg::m_iris_m_flipNormalY, isFrontFace, surface.vertexNormal,
-                                    tangents[MaterialSrg::m_iris_m_normalMapUvIndex], bitangents[MaterialSrg::m_iris_m_normalMapUvIndex], uvMatrix, o_iris_o_normal_useTexture, real(MaterialSrg::m_iris_m_normalFactor));
-
     real2 scleraNormalUv = uvs[MaterialSrg::m_sclera_m_normalMapUvIndex];
-    real3 scleraNormal = GetNormalInputWS(MaterialSrg::m_sclera_m_normalMap, MaterialSrg::m_sampler, scleraNormalUv, MaterialSrg::m_sclera_m_flipNormalX, MaterialSrg::m_sclera_m_flipNormalY, isFrontFace, surface.vertexNormal,
-                                    tangents[MaterialSrg::m_sclera_m_normalMapUvIndex], bitangents[MaterialSrg::m_sclera_m_normalMapUvIndex], uvMatrix, o_sclera_o_normal_useTexture, real(MaterialSrg::m_sclera_m_normalFactor));
+    real3 irisNormal, scleraNormal;
+    
+    if (customDerivatives)
+    {
+        irisNormal = GetNormalInputWS(MaterialSrg::m_iris_m_normalMap, MaterialSrg::m_sampler, irisNormalUv, MaterialSrg::m_iris_m_flipNormalX, MaterialSrg::m_iris_m_flipNormalY, isFrontFace, surface.vertexNormal,
+                                        tangents[MaterialSrg::m_iris_m_normalMapUvIndex], bitangents[MaterialSrg::m_iris_m_normalMapUvIndex], uvMatrix, o_iris_o_normal_useTexture, real(MaterialSrg::m_iris_m_normalFactor), uvDxDy, customDerivatives);
+
+        scleraNormal = GetNormalInputWS(MaterialSrg::m_sclera_m_normalMap, MaterialSrg::m_sampler, scleraNormalUv, MaterialSrg::m_sclera_m_flipNormalX, MaterialSrg::m_sclera_m_flipNormalY, isFrontFace, surface.vertexNormal,
+                                        tangents[MaterialSrg::m_sclera_m_normalMapUvIndex], bitangents[MaterialSrg::m_sclera_m_normalMapUvIndex], uvMatrix, o_sclera_o_normal_useTexture, real(MaterialSrg::m_sclera_m_normalFactor), uvDxDy, customDerivatives);
+    }
+    else
+    {
+        irisNormal = GetNormalInputWS(MaterialSrg::m_iris_m_normalMap, MaterialSrg::m_sampler, irisNormalUv, MaterialSrg::m_iris_m_flipNormalX, MaterialSrg::m_iris_m_flipNormalY, isFrontFace, surface.vertexNormal,
+                                        tangents[MaterialSrg::m_iris_m_normalMapUvIndex], bitangents[MaterialSrg::m_iris_m_normalMapUvIndex], uvMatrix, o_iris_o_normal_useTexture, real(MaterialSrg::m_iris_m_normalFactor), float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+
+        scleraNormal = GetNormalInputWS(MaterialSrg::m_sclera_m_normalMap, MaterialSrg::m_sampler, scleraNormalUv, MaterialSrg::m_sclera_m_flipNormalX, MaterialSrg::m_sclera_m_flipNormalY, isFrontFace, surface.vertexNormal,
+                                        tangents[MaterialSrg::m_sclera_m_normalMapUvIndex], bitangents[MaterialSrg::m_sclera_m_normalMapUvIndex], uvMatrix, o_sclera_o_normal_useTexture, real(MaterialSrg::m_sclera_m_normalFactor), float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+    }
 
     surface.normal = normalize(lerp(irisNormal, scleraNormal, mask));
 
@@ -162,12 +177,12 @@ Surface EvaluateSurface_Eye(
 
     // Sample iris color map and blend with the base iris color
     real2 irisBaseColorUv = irisRefractionUv;
-    real3 irisSampledColor = GetBaseColorInput(MaterialSrg::m_iris_m_baseColorMap, MaterialSrg::m_sampler, irisBaseColorUv, real3(MaterialSrg::m_iris_m_baseColor), o_iris_o_baseColor_useTexture);
+    real3 irisSampledColor = GetBaseColorInput(MaterialSrg::m_iris_m_baseColorMap, MaterialSrg::m_sampler, irisBaseColorUv, real3(MaterialSrg::m_iris_m_baseColor), o_iris_o_baseColor_useTexture, uvDxDy, customDerivatives);
     real3 irisColor = BlendBaseColor(irisSampledColor, real3(MaterialSrg::m_iris_m_baseColor), real(MaterialSrg::m_iris_m_baseColorFactor), o_iris_o_baseColorTextureBlendMode, o_iris_o_baseColor_useTexture);
 
     // Sample sclera color map and blend with the base sclera color
     real2 scleraBaseColorUv = uvs[MaterialSrg::m_sclera_m_baseColorMapUvIndex];
-    real3 scleraSampledColor = GetBaseColorInput(MaterialSrg::m_sclera_m_baseColorMap, MaterialSrg::m_sampler, scleraBaseColorUv, real3(MaterialSrg::m_sclera_m_baseColor), o_sclera_o_baseColor_useTexture);
+    real3 scleraSampledColor = GetBaseColorInput(MaterialSrg::m_sclera_m_baseColorMap, MaterialSrg::m_sampler, scleraBaseColorUv, real3(MaterialSrg::m_sclera_m_baseColor), o_sclera_o_baseColor_useTexture, uvDxDy, customDerivatives);
     real3 scleraColor = BlendBaseColor(scleraSampledColor, real3(MaterialSrg::m_sclera_m_baseColor), real(MaterialSrg::m_sclera_m_baseColorFactor), o_sclera_o_baseColorTextureBlendMode, o_sclera_o_baseColor_useTexture);
 
     // Blend iris and sclera output colors
@@ -176,7 +191,7 @@ Surface EvaluateSurface_Eye(
     // ------- Specular -------
 
     real2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
-    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture);
+    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture, uvDxDy, customDerivatives);
 
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor);
 
@@ -185,11 +200,11 @@ Surface EvaluateSurface_Eye(
     // Get surface roughness for each layer (iris/sclera) and blend using the mask defined above
     real2 irisRoughnessUv = irisRefractionUv;
     real irisRoughnessLinear = GetRoughnessInput(MaterialSrg::m_iris_m_roughnessMap, MaterialSrg::m_sampler, irisRoughnessUv, real(MaterialSrg::m_iris_m_roughnessFactor),
-                                        real(MaterialSrg::m_iris_m_roughnessLowerBound), real(MaterialSrg::m_iris_m_roughnessUpperBound), o_iris_o_roughness_useTexture);
+                                        real(MaterialSrg::m_iris_m_roughnessLowerBound), real(MaterialSrg::m_iris_m_roughnessUpperBound), o_iris_o_roughness_useTexture, uvDxDy, customDerivatives);
 
     real2 scleraRoughnessUv = uvs[MaterialSrg::m_sclera_m_roughnessMapUvIndex];
     real scleraRoughnessLinear = GetRoughnessInput(MaterialSrg::m_sclera_m_roughnessMap, MaterialSrg::m_sampler, scleraRoughnessUv, real(MaterialSrg::m_sclera_m_roughnessFactor),
-                                        real(MaterialSrg::m_sclera_m_roughnessLowerBound), real(MaterialSrg::m_sclera_m_roughnessUpperBound), o_sclera_o_roughness_useTexture);
+                                        real(MaterialSrg::m_sclera_m_roughnessLowerBound), real(MaterialSrg::m_sclera_m_roughnessUpperBound), o_sclera_o_roughness_useTexture, uvDxDy, customDerivatives);
 
     surface.roughnessLinear = lerp(irisRoughnessLinear, scleraRoughnessLinear, mask);
     surface.CalculateRoughnessA();
@@ -203,20 +218,20 @@ Surface EvaluateSurface_Eye(
     // ------- Subsurface -------
 
     real2 subsurfaceUv = uvs[MaterialSrg::m_subsurfaceScatteringInfluenceMapUvIndex];
-    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor));
+    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor), uvDxDy, customDerivatives);
     surface.subsurfaceScatteringQuality = real(MaterialSrg::m_subsurfaceScatteringQuality);
     surface.scatterDistance = real3(MaterialSrg::m_scatterDistance);
 
     // ------- Occlusion -------
     
-    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture);
-    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture);
+    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture, uvDxDy, customDerivatives);
+    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture, uvDxDy, customDerivatives);
 
     // ------- Transmission -------
 
 #if ENABLE_TRANSMISSION
     real2 transmissionUv = uvs[MaterialSrg::m_transmissionThicknessMapUvIndex];
-    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness));
+    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness), uvDxDy, customDerivatives);
     surface.transmission.tint = transmissionTintThickness.rgb;
     surface.transmission.thickness = transmissionTintThickness.w;
     surface.transmission.transmissionParams = real4(MaterialSrg::m_transmissionParams);
@@ -224,6 +239,49 @@ Surface EvaluateSurface_Eye(
 #endif
 
     return surface;
+}
+
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_Eye(
+    float3 positionWS,
+    real3 vertexNormal,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    float3 localPosition,
+    bool isFrontFace,
+    real4x4 worldMatrix,
+    real3x3 worldMatrixIT)
+{
+    return EvaluateSurface_Eye(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        localPosition,
+        isFrontFace,
+        worldMatrix,
+        worldMatrixIT,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_Eye(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_Eye(
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.localPosition,
+        geoData.isFrontFace,
+        geoData.objectToWorld,
+        geoData.objectToWorldIT,
+        uvDxDy,
+        customDerivatives);
 }
 
 Surface EvaluateSurface_Eye(VsOutput IN, PixelGeometryData geoData)
@@ -237,5 +295,7 @@ Surface EvaluateSurface_Eye(VsOutput IN, PixelGeometryData geoData)
         geoData.localPosition,
         geoData.isFrontFace,
         geoData.objectToWorld,
-        geoData.objectToWorldIT);
+        geoData.objectToWorldIT,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli
@@ -10,12 +10,12 @@
 
 #include "../MaterialInputs/AlphaInput.azsli"
 
-real GetAlphaAndClip(float2 uvs[UvSetCount])
+real GetAlphaAndClip(float2 uvs[UvSetCount], float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
     // Alpha
     float2 baseColorUV = uvs[MaterialSrg::m_baseColorMapUvIndex];
     float2 opacityUV = uvs[MaterialSrg::m_opacityMapUvIndex];
-    real alpha = SampleAlpha(MaterialSrg::m_baseColorMap, MaterialSrg::m_opacityMap, baseColorUV, opacityUV, MaterialSrg::m_sampler, o_opacity_source);
+    real alpha = SampleAlpha(MaterialSrg::m_baseColorMap, MaterialSrg::m_opacityMap, baseColorUV, opacityUV, MaterialSrg::m_sampler, o_opacity_source, uvDxDy, customDerivatives);
     CheckClipping(alpha, real(MaterialSrg::m_opacityFactor));
     return real(MaterialSrg::m_opacityFactor) * alpha;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/AlphaInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/AlphaInput.azsli
@@ -13,19 +13,33 @@
 enum class OpacitySource {Packed, Split, None};
 option OpacitySource o_opacity_source;
 
-real SampleAlpha(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorUv, float2 opacityUv, sampler mapSampler, OpacitySource opacitySource)
+real SampleAlpha(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorUv, float2 opacityUv, sampler mapSampler, OpacitySource opacitySource, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     real alpha = 1.0;
     switch(opacitySource)
     {
         case OpacitySource::Packed:
         {
-            alpha = real(baseColorMap.Sample(mapSampler, baseColorUv).a);
+            if (customDerivatives)
+            {
+                alpha = real(baseColorMap.SampleGrad(mapSampler, baseColorUv, uvDxDy.xy, uvDxDy.zw).a);
+            }
+            else
+            {
+                alpha = real(baseColorMap.Sample(mapSampler, baseColorUv).a);
+            }
             break;
         }
         case OpacitySource::Split:  
         {
-            alpha = real(opacityMap.Sample(mapSampler, opacityUv).r);
+            if (customDerivatives)
+            {
+                alpha = real(opacityMap.SampleGrad(mapSampler, opacityUv, uvDxDy.xy, uvDxDy.zw).r);
+            }
+            else
+            {
+                alpha = real(opacityMap.Sample(mapSampler, opacityUv).r);
+            }
             break;
         }
         case OpacitySource::None:
@@ -34,9 +48,9 @@ real SampleAlpha(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorU
     return alpha;
 }
 
-real GetAlphaInputAndClip(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorUv, float2 opacityUv, sampler mapSampler, real opacityFactor, OpacitySource opacitySource)
+real GetAlphaInputAndClip(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorUv, float2 opacityUv, sampler mapSampler, real opacityFactor, OpacitySource opacitySource, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
-    real alpha = SampleAlpha(baseColorMap, opacityMap, baseColorUv, opacityUv, mapSampler, opacitySource);
+    real alpha = SampleAlpha(baseColorMap, opacityMap, baseColorUv, opacityUv, mapSampler, opacitySource, uvDxDy, customDerivatives);
     CheckClipping(alpha, opacityFactor);
     return (alpha * opacityFactor);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
@@ -28,7 +28,7 @@ Texture2D prefix##m_baseColorMap;
 option bool prefix##o_baseColor_useTexture; \
 option TextureBlendMode prefix##o_baseColorTextureBlendMode = TextureBlendMode::Multiply;
 
-real3 GetBaseColorInput(Texture2D map, sampler mapSampler, float2 uv, real3 baseColor, bool useTexture)
+real3 GetBaseColorInput(Texture2D map, sampler mapSampler, float2 uv, real3 baseColor, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if(OverrideBaseColorEnabled())
     {
@@ -37,7 +37,15 @@ real3 GetBaseColorInput(Texture2D map, sampler mapSampler, float2 uv, real3 base
 
     if(useTexture)
     {
-        real3 sampledAbledo = real3(map.Sample(mapSampler, uv).rgb);
+        real3 sampledAbledo;
+        if (customDerivatives)
+        {
+            sampledAbledo = real3(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).rgb);
+        }
+        else
+        {
+            sampledAbledo = real3(map.Sample(mapSampler, uv).rgb);
+        }
         //Convert to ACEScg as that is our intermediate working space. 
         //Todo - We should data drive this color space
         return LinearSrgb_To_AcesCg(sampledAbledo);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/ClearCoatInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/ClearCoatInput.azsli
@@ -38,21 +38,44 @@ void GetClearCoatInputs(Texture2D influenceMap, float2 influenceUV, real clearCo
                         Texture2D normalMap, float2 normalUV, real3 normal, bool useNormalMap, real normalStrength,
                         real3x3 uvMatrix, real3 tangent, real3 bitangent,
                         sampler mapSampler, bool isFrontFace,
-                        inout real finalClearCoatFactor, inout real clearCoatRoughness, inout real3 clearCoatNormal)
+                        inout real finalClearCoatFactor, inout real clearCoatRoughness, inout real3 clearCoatNormal,
+                        float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
     if(useInfluenceMap)
     {
-        clearCoatFactor *= real(influenceMap.Sample(mapSampler, influenceUV).r);
+        if (customDerivatives)
+        {
+            clearCoatFactor *= real(influenceMap.SampleGrad(mapSampler, influenceUV, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            clearCoatFactor *= real(influenceMap.Sample(mapSampler, influenceUV).r);
+        }
     }
     
     if(useRoughnessMap)
     {
-        roughness *= real(roughnessMap.Sample(mapSampler, roughnessUV).r);
+        if (customDerivatives)
+        {
+            roughness *= real(roughnessMap.SampleGrad(mapSampler, roughnessUV, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            roughness *= real(roughnessMap.Sample(mapSampler, roughnessUV).r);
+        }
     }
     
     if (useNormalMap)
     {  
-        real4 sampledValue = real4(normalMap.Sample(mapSampler, normalUV));
+        real4 sampledValue;
+        if (customDerivatives)
+        {
+            sampledValue = real4(normalMap.SampleGrad(mapSampler, normalUV, uvDxDy.xy, uvDxDy.zw));
+        }
+        else
+        {
+            sampledValue = real4(normalMap.Sample(mapSampler, normalUV));
+        }
         clearCoatNormal = GetWorldSpaceNormal(sampledValue.xy, normal, tangent, bitangent, uvMatrix, normalStrength);
     }
     else

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
@@ -50,11 +50,18 @@ option bool o_detail_baseColor_useTexture;   \
 option bool o_detail_normal_useTexture;
 
 
-real GetDetailLayerBlendFactor(Texture2D detailLayerBlendMask, sampler detailLayerBlendMaskSampler, float2 detailLayerBlendMaskUv, bool useDetailLayerBlendMask, real detailLayerBlendFactor)
+real GetDetailLayerBlendFactor(Texture2D detailLayerBlendMask, sampler detailLayerBlendMaskSampler, float2 detailLayerBlendMaskUv, bool useDetailLayerBlendMask, real detailLayerBlendFactor, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if (useDetailLayerBlendMask)
     {
-        detailLayerBlendFactor *= real(detailLayerBlendMask.Sample(detailLayerBlendMaskSampler, detailLayerBlendMaskUv).r);
+        if (customDerivatives)
+        {
+            detailLayerBlendFactor *= real(detailLayerBlendMask.SampleGrad(detailLayerBlendMaskSampler, detailLayerBlendMaskUv, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            detailLayerBlendFactor *= real(detailLayerBlendMask.Sample(detailLayerBlendMaskSampler, detailLayerBlendMaskUv).r);
+        }
     }
 
     return detailLayerBlendFactor;
@@ -64,12 +71,12 @@ real GetDetailLayerBlendFactor(Texture2D detailLayerBlendMask, sampler detailLay
 //! @return a new normal vector in the same tangent space as mainNormalTS.
 real3 ApplyNormalMapOverlayTS(bool applyOverlay, real3 vertexNormalWS, real3 mainNormalTS, real3 mainTangent, real3 mainBitangent, 
     Texture2D overlayNormalMap, sampler overlayMapSampler, float2 overlayUv, bool flipOverlayNormalX, bool flipOverlayNormalY, real overlayFactor, 
-    real3 overlayTangent, real3 overlayBitangent, real3x3 overlayNormalUvMatrix)
+    real3 overlayTangent, real3 overlayBitangent, real3x3 overlayNormalUvMatrix, float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
     if(applyOverlay && AreDetailNormalMapsEnabled())
     {
         // Get overlay normal in its local tangent space
-        real3 overlayNormalTS = GetNormalInputTS(overlayNormalMap, overlayMapSampler, overlayUv, flipOverlayNormalX, flipOverlayNormalY, overlayNormalUvMatrix, true, overlayFactor);
+        real3 overlayNormalTS = GetNormalInputTS(overlayNormalMap, overlayMapSampler, overlayUv, flipOverlayNormalX, flipOverlayNormalY, overlayNormalUvMatrix, true, overlayFactor, uvDxDy, customDerivatives);
         
         // [GFX TODO][ATOM-15111]: Find a more efficient way to do this.
 
@@ -92,11 +99,11 @@ real3 ApplyNormalMapOverlayTS(bool applyOverlay, real3 vertexNormalWS, real3 mai
 //! @return a new normal vector in world space.
 real3 ApplyNormalMapOverlayWS(bool applyOverlay, real3 vertexNormalWS, real3 mainNormalTS, real3 mainTangent, real3 mainBitangent, 
     Texture2D overlayNormalMap, sampler overlayMapSampler, float2 overlayUv, bool flipOverlayNormalX, bool flipOverlayNormalY, real overlayFactor, 
-    real3 overlayTangent, real3 overlayBitangent, real3x3 overlayNormalUvMatrix)
+    real3 overlayTangent, real3 overlayBitangent, real3x3 overlayNormalUvMatrix, float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
     if(applyOverlay && AreDetailNormalMapsEnabled())
     {
-        real3 normalTS = ApplyNormalMapOverlayTS(applyOverlay, vertexNormalWS, mainNormalTS, mainTangent, mainBitangent, overlayNormalMap, overlayMapSampler, overlayUv, flipOverlayNormalX, flipOverlayNormalY, overlayFactor, overlayTangent, overlayBitangent, overlayNormalUvMatrix);
+        real3 normalTS = ApplyNormalMapOverlayTS(applyOverlay, vertexNormalWS, mainNormalTS, mainTangent, mainBitangent, overlayNormalMap, overlayMapSampler, overlayUv, flipOverlayNormalX, flipOverlayNormalY, overlayFactor, overlayTangent, overlayBitangent, overlayNormalUvMatrix, uvDxDy, customDerivatives);
         real3 normalWS = normalize( TangentSpaceToWorld(normalTS, vertexNormalWS, mainTangent, mainBitangent) );
         return normalWS;
     }
@@ -108,7 +115,8 @@ real3 ApplyNormalMapOverlayWS(bool applyOverlay, real3 vertexNormalWS, real3 mai
 
 real3 GetDetailedNormalInputWS(bool isFrontFace, real3 vertexNormalWS,
                                 real3 mainTangent,   real3 mainBitangent,   Texture2D mainNormalMap,   sampler mainSampler,   float2 mainUv,   real mainNormalFactor,   bool flipMainNormalX,   bool flipMainNormalY,   real3x3 mainNormalUvMatrix,   bool useMainNormalMap,
-                                real3 detailTangent, real3 detailBitangent, Texture2D detailNormalMap, sampler detailSampler, float2 detailUv, real detailNormalFactor, bool flipDetailNormalX, bool flipDetailNormalY, real3x3 detailNormalUvMatrix, bool useDetailNormalMap)
+                                real3 detailTangent, real3 detailBitangent, Texture2D detailNormalMap, sampler detailSampler, float2 detailUv, real detailNormalFactor, bool flipDetailNormalX, bool flipDetailNormalY, real3x3 detailNormalUvMatrix, bool useDetailNormalMap,
+                                float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
     real3 normal;
     
@@ -119,29 +127,45 @@ real3 GetDetailedNormalInputWS(bool isFrontFace, real3 vertexNormalWS,
     {
         // Get normal in tangent space
         real3 mainNormalTS = GetNormalInputTS(mainNormalMap, mainSampler, mainUv, flipMainNormalX, flipMainNormalY, 
-                                            mainNormalUvMatrix, useMainNormalMap, mainNormalFactor);
+                                            mainNormalUvMatrix, useMainNormalMap, mainNormalFactor, uvDxDy, customDerivatives);
         
         bool applyOverlay = true;
         normal = ApplyNormalMapOverlayWS(applyOverlay, vertexNormalWS, mainNormalTS, mainTangent, mainBitangent,
-            detailNormalMap, detailSampler, detailUv, flipDetailNormalX, flipDetailNormalY, detailNormalFactor, detailTangent, detailBitangent, detailNormalUvMatrix);
+            detailNormalMap, detailSampler, detailUv, flipDetailNormalX, flipDetailNormalY, detailNormalFactor, detailTangent, detailBitangent, detailNormalUvMatrix, uvDxDy, customDerivatives);
 
         normal = AdjustBackFaceNormal(normal, isFrontFace);
     }
     else
     {
-        // TODO: Re-order these parameters to match GetDetailedNormalInputWS 
-        normal = GetNormalInputWS(mainNormalMap, mainSampler, mainUv, flipMainNormalX, flipMainNormalY, isFrontFace, vertexNormalWS,
-                                  mainTangent, mainBitangent, mainNormalUvMatrix, useMainNormalMap, mainNormalFactor);
+        if (customDerivatives)
+        {
+            // TODO: Re-order these parameters to match GetDetailedNormalInputWS 
+            normal = GetNormalInputWS(mainNormalMap, mainSampler, mainUv, flipMainNormalX, flipMainNormalY, isFrontFace, vertexNormalWS,
+                                    mainTangent, mainBitangent, mainNormalUvMatrix, useMainNormalMap, mainNormalFactor, uvDxDy, customDerivatives);
+        }
+        else
+        {
+            normal = GetNormalInputWS(mainNormalMap, mainSampler, mainUv, flipMainNormalX, flipMainNormalY, isFrontFace, vertexNormalWS,
+                                    mainTangent, mainBitangent, mainNormalUvMatrix, useMainNormalMap, mainNormalFactor, float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+        }
     }
 
     return normal;
 }
 
-real3 ApplyTextureOverlay(bool applyOverlay, real3 baseColor, Texture2D map, sampler mapSampler, float2 uv, real factor)
+real3 ApplyTextureOverlay(bool applyOverlay, real3 baseColor, Texture2D map, sampler mapSampler, float2 uv, real factor, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if (applyOverlay)
     {
-        real3 sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+        real3 sampledColor;
+        if (customDerivatives)
+        {
+            sampledColor = real3(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).rgb);
+        }
+        else
+        {
+            sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+        }
         sampledColor = TransformColor(sampledColor, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         return ApplyTextureBlend(baseColor, sampledColor, factor, TextureBlendMode::Overlay);
     }
@@ -152,10 +176,11 @@ real3 ApplyTextureOverlay(bool applyOverlay, real3 baseColor, Texture2D map, sam
 }
 
 real3 GetDetailedBaseColorInput(Texture2D mainBaseColorMap,     sampler mainBaseColorMapSampler,     float2 mainBaseColorUv,        bool useMainBaseColorMap,     real3 mainBaseColor, real mainBaseColorFactor, TextureBlendMode mainBaseColorBlendMode,
-                                Texture2D detailBaseColorMap,   sampler detailBaseColorMapSampler,   float2 detailBaseColorUv,      bool useDetailBaseColorMap,   real detailBaseColorBlendFactor)
+                                Texture2D detailBaseColorMap,   sampler detailBaseColorMapSampler,   float2 detailBaseColorUv,      bool useDetailBaseColorMap,   real detailBaseColorBlendFactor,
+                                float4 uvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f), bool customDerivatives = false)
 {
-    real3 color = GetBaseColorInput(mainBaseColorMap, mainBaseColorMapSampler, mainBaseColorUv, mainBaseColor, useMainBaseColorMap);
+    real3 color = GetBaseColorInput(mainBaseColorMap, mainBaseColorMapSampler, mainBaseColorUv, mainBaseColor, useMainBaseColorMap, uvDxDy, customDerivatives);
     color = BlendBaseColor(color, mainBaseColor, mainBaseColorFactor, mainBaseColorBlendMode, useMainBaseColorMap);
-    color = ApplyTextureOverlay(useDetailBaseColorMap, color, detailBaseColorMap, detailBaseColorMapSampler, detailBaseColorUv, detailBaseColorBlendFactor);
+    color = ApplyTextureOverlay(useDetailBaseColorMap, color, detailBaseColorMap, detailBaseColorMapSampler, detailBaseColorUv, detailBaseColorBlendFactor, uvDxDy, customDerivatives);
     return color;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
@@ -27,7 +27,7 @@ uint        prefix##m_emissiveMapUvIndex;
 option bool prefix##o_emissiveEnabled; \
 option bool prefix##o_emissive_useTexture; 
 
-real3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, real factor, real3 emissiveColor, real emissiveAffectedByAlpha, real alpha, bool emissiveEnabled, bool useTexture)
+real3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, real factor, real3 emissiveColor, real emissiveAffectedByAlpha, real alpha, bool emissiveEnabled, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     real3 emissive = real3(0,0,0);
     if(emissiveEnabled)
@@ -35,7 +35,15 @@ real3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, real factor
         emissive = factor * lerp(1, alpha, emissiveAffectedByAlpha) * emissiveColor;
         if (useTexture)
         {
-            real3 sampledValue = real3(map.Sample(mapSampler, uv).rgb);
+            real3 sampledValue;
+            if (customDerivatives)
+            {
+                sampledValue = real3(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).rgb);
+            }
+            else
+            {
+                sampledValue = real3(map.Sample(mapSampler, uv).rgb);
+            }
             emissive *= TransformColor(sampledValue, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/MetallicInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/MetallicInput.azsli
@@ -24,7 +24,7 @@ uint        prefix##m_metallicMapUvIndex;
 #define COMMON_OPTIONS_METALLIC(prefix) \
 option bool prefix##o_metallic_useTexture; 
 
-real GetMetallicInput(Texture2D map, sampler mapSampler, float2 uv, real factor, bool useTexture)
+real GetMetallicInput(Texture2D map, sampler mapSampler, float2 uv, real factor, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if(OverrideMetallicEnabled())
     {
@@ -34,7 +34,14 @@ real GetMetallicInput(Texture2D map, sampler mapSampler, float2 uv, real factor,
     if (useTexture)
     {
        // [GFX TODO][ATOM-1793]: Figure out how we want our base material to expect channels to be encoded, and apply that to the way we pack metalness.
-       return real(map.Sample(mapSampler, uv).r);
+       if (customDerivatives)
+       {
+           return real(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r);
+       }
+       else
+       {
+           return real(map.Sample(mapSampler, uv).r);
+       }
     }
     return factor;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
@@ -30,14 +30,22 @@ option bool prefix##o_normal_useTexture;
 //! Samples the normal map and returns the XY values of the normal. 
 //! (Z must be reconstructed assuming length=1; this is handled by the various utility functions that take float2 in TangentSpace.azsli).
 //! The returned XY values will be in the range [-1,1].
-real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv)
+real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, float4 uvDxDy, bool customDerivatives)
 {
     if (!AreNormalMapsEnabled())
     {
         return real2(0, 0);
     }
 
-    real4 sampledValue = real4(map.Sample(mapSampler, uv));
+    real4 sampledValue;
+    if (customDerivatives)
+    {
+        sampledValue = real4(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw));
+    }
+    else
+    {
+        sampledValue = real4(map.Sample(mapSampler, uv));
+    }
     
 #if AZ_TRAIT_ASTC_COMPRESSION
     //Astc compression is unorm (0 to 1) so we need to accomodate for that. We are using BC5_SNORM (-1 - +1)for other platforms like pc
@@ -52,9 +60,9 @@ real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv)
 //! (Z must be reconstructed assuming length=1; this is handled by the various utility functions that take float2 in TangentSpace.azsli).
 //! The returned XY values will be in the range [-1,1].
 //! Also flips X and/or Y if requested.
-real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY)
+real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, float4 uvDxDy, bool customDerivatives)
 {
-    real2 sampledValue = real2(SampleNormalXY(map, mapSampler, uv));
+    real2 sampledValue = real2(SampleNormalXY(map, mapSampler, uv, uvDxDy, customDerivatives));
 
     // [GFX TODO][ATOM-2404] For some reason, the image build pipeline swaps the R and G channels
     if(flipX)
@@ -78,11 +86,11 @@ real3 AdjustBackFaceNormal(real3 normal, bool isFrontFace)
 
 // Get the input normal in world space
 real3 GetNormalInputWS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, bool isFrontFace,
-                        real3 normal, real3 tangent, real3 bitangent, real3x3 uvMatrix, bool useTexture, real normalStrength)
+                        real3 normal, real3 tangent, real3 bitangent, real3x3 uvMatrix, bool useTexture, real normalStrength, float4 uvDxDy, bool customDerivatives)
 {
     if (useTexture && AreNormalMapsEnabled())
     {
-        real2 sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY);
+        real2 sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY, uvDxDy, customDerivatives);
         normal = GetWorldSpaceNormal(sampledValue, normal, tangent, bitangent, uvMatrix, normalStrength);
     }
     else
@@ -95,11 +103,11 @@ real3 GetNormalInputWS(Texture2D map, sampler mapSampler, float2 uv, bool flipX,
 }
 
 // Get the input normal in tangent space
-real3 GetNormalInputTS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real3x3 uvMatrix, bool useTexture, real normalStrength)
+real3 GetNormalInputTS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real3x3 uvMatrix, bool useTexture, real normalStrength, float4 uvDxDy, bool customDerivatives)
 {
     if (useTexture && AreNormalMapsEnabled())
     {
-        real2 sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY);
+        real2 sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY, uvDxDy, customDerivatives);
         return GetTangentSpaceNormal(sampledValue, uvMatrix, normalStrength);
     }
     else
@@ -110,15 +118,15 @@ real3 GetNormalInputTS(Texture2D map, sampler mapSampler, float2 uv, bool flipX,
 
 // Helper with default normal strength = 1.0f
 real3 GetNormalInputWS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, bool isFrontFace,
-                        real3 normal, real3 tangent, real3 bitangent, real3x3 uvMatrix, bool useTexture)
+                        real3 normal, real3 tangent, real3 bitangent, real3x3 uvMatrix, bool useTexture, float4 uvDxDy, bool customDerivatives)
 {
     const real normalStrength = 1.0f;
-    return GetNormalInputWS(map, mapSampler, uv, flipX, flipY, isFrontFace, normal, tangent, bitangent, uvMatrix, useTexture, normalStrength);
+    return GetNormalInputWS(map, mapSampler, uv, flipX, flipY, isFrontFace, normal, tangent, bitangent, uvMatrix, useTexture, normalStrength, uvDxDy, customDerivatives);
 }
 
 // Helper with default normal strength = 1.0f
-real3 GetNormalInputTS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real3x3 uvMatrix, bool useTexture)
+real3 GetNormalInputTS(Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real3x3 uvMatrix, bool useTexture, float4 uvDxDy, bool customDerivatives)
 {
     const real normalStrength = 1.0f;
-    return GetNormalInputTS(map, mapSampler, uv, flipX, flipY, uvMatrix, useTexture, normalStrength);
+    return GetNormalInputTS(map, mapSampler, uv, flipX, flipY, uvMatrix, useTexture, normalStrength, uvDxDy, customDerivatives);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
@@ -26,12 +26,19 @@ uint        prefix##m_specularOcclusionMapUvIndex;
 option bool prefix##o_diffuseOcclusion_useTexture; \
 option bool prefix##o_specularOcclusion_useTexture; 
 
-real GetOcclusionInput(Texture2D map, sampler mapSampler, float2 uv, real factor, bool useTexture)
+real GetOcclusionInput(Texture2D map, sampler mapSampler, float2 uv, real factor, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     real occlusion = 1.0;
     if(useTexture)
     {
-        occlusion = map.Sample(mapSampler, uv).r;
+        if (customDerivatives)
+        {
+            occlusion = map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r;
+        }
+        else
+        {
+            occlusion = map.Sample(mapSampler, uv).r;
+        }
         occlusion = pow(occlusion, factor);
     }
     return occlusion;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
@@ -26,7 +26,7 @@ uint        prefix##m_roughnessMapUvIndex;
 #define COMMON_OPTIONS_ROUGHNESS(prefix) \
 option bool prefix##o_roughness_useTexture; 
 
-real GetRoughnessInput(Texture2D map, sampler mapSampler, float2 uv, real factor, real roughnessLowerBound, real roughnessUpperBound, bool useTexture)
+real GetRoughnessInput(Texture2D map, sampler mapSampler, float2 uv, real factor, real roughnessLowerBound, real roughnessUpperBound, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if(OverrideRoughnessEnabled())
     {
@@ -36,7 +36,15 @@ real GetRoughnessInput(Texture2D map, sampler mapSampler, float2 uv, real factor
     // [GFX TODO][ATOM-1793]: Figure out how we want our base material to expect channels to be encoded, and apply that to the way we pack roughness.
     if (useTexture)
     {
-        real sampledValue = real(map.Sample(mapSampler, uv).r);
+        real sampledValue;
+        if (customDerivatives)
+        {
+            sampledValue = real(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            sampledValue = real(map.Sample(mapSampler, uv).r);
+        }
         return lerp(roughnessLowerBound, roughnessUpperBound, sampledValue);
     }
     else

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
@@ -22,11 +22,18 @@ uint        prefix##m_specularF0MapUvIndex;
 #define COMMON_OPTIONS_SPECULAR_F0(prefix) \
 option bool prefix##o_specularF0_useTexture; 
 
-real GetSpecularInput(Texture2D map, sampler mapSampler, float2 uv, real specularFactor, bool useTexture)
+real GetSpecularInput(Texture2D map, sampler mapSampler, float2 uv, real specularFactor, bool useTexture, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if (useTexture)
     {
-        specularFactor *= real(map.Sample(mapSampler, uv).r);
+        if (customDerivatives)
+        {
+            specularFactor *= real(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            specularFactor *= real(map.Sample(mapSampler, uv).r);
+        }
     }
     return specularFactor;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SubsurfaceInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SubsurfaceInput.azsli
@@ -10,11 +10,18 @@
 
 option bool o_subsurfaceScattering_useTexture;
 
-real GetSubsurfaceInput(Texture2D map, sampler mapSampler, float2 uv, real surfaceScatteringFactor)
+real GetSubsurfaceInput(Texture2D map, sampler mapSampler, float2 uv, real surfaceScatteringFactor, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if(o_subsurfaceScattering_useTexture)
     {
-        surfaceScatteringFactor *= real(map.Sample(mapSampler, uv).r);
+        if (customDerivatives)
+        {
+            surfaceScatteringFactor *= real(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            surfaceScatteringFactor *= real(map.Sample(mapSampler, uv).r);
+        }
     }
     return surfaceScatteringFactor;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
@@ -10,11 +10,18 @@
 
 option bool o_transmission_useTexture;
 
-real4 GeTransmissionInput(Texture2D map, sampler mapSampler, float2 uv, real4 transmissionTintThickness)
+real4 GeTransmissionInput(Texture2D map, sampler mapSampler, float2 uv, real4 transmissionTintThickness, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if(o_transmission_useTexture)
     {
-        transmissionTintThickness.w *= real(map.Sample(mapSampler, uv).r);
+        if (customDerivatives)
+        {
+            transmissionTintThickness.w *= real(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).r);
+        }
+        else
+        {
+            transmissionTintThickness.w *= real(map.Sample(mapSampler, uv).r);
+        }
     }
     return transmissionTintThickness;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Common.azsli
@@ -176,8 +176,10 @@ LayerBlendSource GetFinalLayerBlendSource()
 //! @param blendSource indicates where to get the blend mask from
 //! @param blendMaskUv for sampling a blend mask texture, if that's the blend source
 //! @param blendMaskVertexColors the vertex color values to use for the blend mask, if that's the blend source
+//! @param uvDxDy for sampling the textures if derivatives are customized
+//! @param customDerivatives whether or not using customized derivatives
 //! @return the blend mask values, or 0 if there is no blend mask
-float3 GetApplicableBlendMaskValues(LayerBlendSource blendSource, float2 blendMaskUv, float3 blendMaskVertexColors)
+float3 GetApplicableBlendMaskValues(LayerBlendSource blendSource, float2 blendMaskUv, float3 blendMaskVertexColors, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     float3 blendSourceValues = float3(0,0,0);
 
@@ -191,7 +193,14 @@ float3 GetApplicableBlendMaskValues(LayerBlendSource blendSource, float2 blendMa
                 break;
             case LayerBlendSource::BlendMaskTexture:
             case LayerBlendSource::Displacement_With_BlendMaskTexture:
-                blendSourceValues = MaterialSrg::m_blendMaskTexture.Sample(MaterialSrg::m_sampler, blendMaskUv).rgb;
+                if (customDerivatives)
+                {
+                    blendSourceValues = MaterialSrg::m_blendMaskTexture.SampleGrad(MaterialSrg::m_sampler, blendMaskUv, uvDxDy.xy, uvDxDy.zw).rgb;
+                }
+                else
+                {
+                    blendSourceValues = MaterialSrg::m_blendMaskTexture.Sample(MaterialSrg::m_sampler, blendMaskUv).rgb;
+                }
                 break;
             case LayerBlendSource::BlendMaskVertexColors:
             case LayerBlendSource::Displacement_With_BlendMaskVertexColors:
@@ -319,11 +328,11 @@ float3 GetLayerDepthValues(float2 uv, float2 uv_ddx, float2 uv_ddy);
 //! Return the final blend weights to be used for rendering, based on the available data and configuration.
 //! Note this will sample the displacement maps in the case of LayerBlendSource::Displacement. If you have already
 //! the layer depth values, use the GetBlendWeights() overload that takes layerDepthValues instead.
-float3 GetBlendWeights(LayerBlendSource blendSource, float2 uv, float3 blendMaskVertexColors)
+float3 GetBlendWeights(LayerBlendSource blendSource, float2 uv, float3 blendMaskVertexColors, float4 uvDxDy, bool customDerivatives)
 {
     float3 layerDepthValues = float3(0,0,0);
     
-    float3 blendMaskValues = GetApplicableBlendMaskValues(blendSource, uv, blendMaskVertexColors);
+    float3 blendMaskValues = GetApplicableBlendMaskValues(blendSource, uv, blendMaskVertexColors, uvDxDy, customDerivatives);
 
     if(blendSource == LayerBlendSource::Displacement ||
        blendSource == LayerBlendSource::Displacement_With_BlendMaskTexture ||

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -43,22 +43,38 @@ option bool o_wrinkleLayers_showBlendMaskValues;
 #define ENABLE_TRANSMISSION 1
 #endif
 
-real3 ApplyBaseColorWrinkleMap(bool shouldApply, real3 baseColor, Texture2D map, sampler mapSampler, float2 uv, real factor)
+real3 ApplyBaseColorWrinkleMap(bool shouldApply, real3 baseColor, Texture2D map, sampler mapSampler, float2 uv, real factor, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if (shouldApply)
     {
-        real3 sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+        real3 sampledColor;
+        if (customDerivatives)
+        {
+            sampledColor = real3(map.SampleGrad(mapSampler, uv, uvDxDy.xy, uvDxDy.zw).rgb);
+        }
+        else
+        {
+            sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+        }
         sampledColor = TransformColor(sampledColor, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         return lerp(baseColor, sampledColor, factor);
     }
     return baseColor;
 }
 
-real2 ApplyNormalWrinkleMap(bool shouldApply, real2 baseNormalSample, Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real factor)
+real2 ApplyNormalWrinkleMap(bool shouldApply, real2 baseNormalSample, Texture2D map, sampler mapSampler, float2 uv, bool flipX, bool flipY, real factor, float4 uvDxDy = float4(0.0, 0.0, 0.0, 0.0), bool customDerivatives = false)
 {
     if (shouldApply)
     {
-        real2 sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY);
+        real2 sampledValue = real2(0.0, 0.0);
+        if (customDerivatives)
+        {
+            sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY, uvDxDy, customDerivatives);
+        }
+        else
+        {
+            sampledValue = SampleNormalXY(map, mapSampler, uv, flipX, flipY, float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+        }
         return lerp(baseNormalSample, sampledValue, factor);
     }
     return baseNormalSample;
@@ -72,7 +88,9 @@ Surface EvaluateSurface_Skin(
     float2 uvs[UvSetCount],
     float2 detailUv,
     real4 wrinkleBlendFactors,
-    bool isFrontFace)
+    bool isFrontFace,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     Surface surface;
     surface.position = positionWS;
@@ -84,7 +102,7 @@ Surface EvaluateSurface_Skin(
                                      detailUv : uvs[MaterialSrg::m_detail_blendMask_uvIndex];
         
     const real detailLayerBlendFactor = GetDetailLayerBlendFactor( MaterialSrg::m_detail_blendMask_texture, MaterialSrg::m_sampler,
-                                                                    detailBlendMaskUv, o_detail_blendMask_useTexture, real(MaterialSrg::m_detail_blendFactor));
+                                                                    detailBlendMaskUv, o_detail_blendMask_useTexture, real(MaterialSrg::m_detail_blendFactor), uvDxDy, customDerivatives);
   
     // ------- Wrinkle Map Setup -------
 
@@ -97,7 +115,14 @@ Surface EvaluateSurface_Skin(
         // Combine the optional per-morph target wrinkle masks
         for(uint wrinkleMaskIndex = 0; wrinkleMaskIndex < ObjectSrg::m_wrinkle_mask_count; ++wrinkleMaskIndex)
         {
-            wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].Sample(MaterialSrg::m_sampler, normalUv) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+            if (customDerivatives)
+            {
+                wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].SampleGrad(MaterialSrg::m_sampler, normalUv, uvDxDy.xy, uvDxDy.zw) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+            }
+            else
+            {
+                wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].Sample(MaterialSrg::m_sampler, normalUv) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+            }
         }
 
         // If texture based morph target driven masks are being used, use those values instead of the per-vertex colors
@@ -119,15 +144,22 @@ Surface EvaluateSurface_Skin(
     
     if(o_normal_useTexture)
     {
-        normalMapSample = SampleNormalXY(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY);
+        if (customDerivatives)
+        {
+            normalMapSample = SampleNormalXY(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, uvDxDy, customDerivatives);
+        }
+        else
+        {
+            normalMapSample = SampleNormalXY(MaterialSrg::m_normalMap, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, float4(0.0f, 0.0f, 0.0f, 0.0f), false);
+        }
     }
 
     if(o_wrinkleLayers_enabled && o_wrinkleLayers_normal_enabled)
     {
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture1, normalMapSample, MaterialSrg::m_wrinkle_normal_texture1, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.r);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture2, normalMapSample, MaterialSrg::m_wrinkle_normal_texture2, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.g);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture3, normalMapSample, MaterialSrg::m_wrinkle_normal_texture3, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.b);
-        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture4, normalMapSample, MaterialSrg::m_wrinkle_normal_texture4, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.a);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture1, normalMapSample, MaterialSrg::m_wrinkle_normal_texture1, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.r, uvDxDy, customDerivatives);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture2, normalMapSample, MaterialSrg::m_wrinkle_normal_texture2, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.g, uvDxDy, customDerivatives);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture3, normalMapSample, MaterialSrg::m_wrinkle_normal_texture3, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.b, uvDxDy, customDerivatives);
+        normalMapSample = ApplyNormalWrinkleMap(o_wrinkleLayers_normal_useTexture4, normalMapSample, MaterialSrg::m_wrinkle_normal_texture4, MaterialSrg::m_sampler, normalUv, MaterialSrg::m_flipNormalX, MaterialSrg::m_flipNormalY, wrinkleBlendFactors.a, uvDxDy, customDerivatives);
     }
 
     real3x3 uvMatrix = real3x3(CreateIdentity3x3());
@@ -139,7 +171,7 @@ Surface EvaluateSurface_Skin(
         bool applyOverlay = true;
         surface.normal = ApplyNormalMapOverlayWS(applyOverlay, vertexNormal, normalTS, tangents[MaterialSrg::m_normalMapUvIndex], bitangents[MaterialSrg::m_normalMapUvIndex], 
                                                  MaterialSrg::m_detail_normal_texture, MaterialSrg::m_sampler, detailUv, MaterialSrg::m_detail_normal_flipX, MaterialSrg::m_detail_normal_flipY, 
-                                                 detailLayerNormalFactor, tangents[MaterialSrg::m_detail_allMapsUvIndex], bitangents[MaterialSrg::m_detail_allMapsUvIndex], real3x3(MaterialSrg::m_detailUvMatrix));
+                                                 detailLayerNormalFactor, tangents[MaterialSrg::m_detail_allMapsUvIndex], bitangents[MaterialSrg::m_detail_allMapsUvIndex], real3x3(MaterialSrg::m_detailUvMatrix), uvDxDy, customDerivatives);
     }
     else
     {
@@ -152,7 +184,7 @@ Surface EvaluateSurface_Skin(
     float2 baseColorUv = uvs[MaterialSrg::m_baseColorMapUvIndex];
     real detailLayerBaseColorFactor = real(MaterialSrg::m_detail_baseColor_factor) * detailLayerBlendFactor;
     
-    real3 baseColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, real3(MaterialSrg::m_baseColor), o_baseColor_useTexture);
+    real3 baseColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, real3(MaterialSrg::m_baseColor), o_baseColor_useTexture, uvDxDy, customDerivatives);
     
     bool useSampledBaseColor = o_baseColor_useTexture;
     if(o_wrinkleLayers_enabled && o_wrinkleLayers_baseColor_enabled)
@@ -168,16 +200,16 @@ Surface EvaluateSurface_Skin(
             baseColor = real3(1,1,1);
         }
 
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture1, baseColor, MaterialSrg::m_wrinkle_baseColor_texture1, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.r);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture2, baseColor, MaterialSrg::m_wrinkle_baseColor_texture2, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.g);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture3, baseColor, MaterialSrg::m_wrinkle_baseColor_texture3, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.b);
-        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture4, baseColor, MaterialSrg::m_wrinkle_baseColor_texture4, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.a);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture1, baseColor, MaterialSrg::m_wrinkle_baseColor_texture1, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.r, uvDxDy, customDerivatives);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture2, baseColor, MaterialSrg::m_wrinkle_baseColor_texture2, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.g, uvDxDy, customDerivatives);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture3, baseColor, MaterialSrg::m_wrinkle_baseColor_texture3, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.b, uvDxDy, customDerivatives);
+        baseColor = ApplyBaseColorWrinkleMap(o_wrinkleLayers_baseColor_useTexture4, baseColor, MaterialSrg::m_wrinkle_baseColor_texture4, MaterialSrg::m_sampler, baseColorUv, wrinkleBlendFactors.a, uvDxDy, customDerivatives);
     
     }
     
     baseColor = BlendBaseColor(baseColor, real3(MaterialSrg::m_baseColor), real(MaterialSrg::m_baseColorFactor), o_baseColorTextureBlendMode, useSampledBaseColor);
     
-    baseColor = ApplyTextureOverlay(o_detail_baseColor_useTexture, baseColor, MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, detailUv, detailLayerBaseColorFactor);
+    baseColor = ApplyTextureOverlay(o_detail_baseColor_useTexture, baseColor, MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, detailUv, detailLayerBaseColorFactor, uvDxDy, customDerivatives);
 
     if(o_wrinkleLayers_enabled && o_wrinkleLayers_showBlendMaskValues)
     {
@@ -191,7 +223,7 @@ Surface EvaluateSurface_Skin(
     // ------- Specular -------
 
     float2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
-    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture);
+    real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture, uvDxDy, customDerivatives);
 
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor);
 
@@ -199,7 +231,7 @@ Surface EvaluateSurface_Skin(
 
     float2 roughnessUv = uvs[MaterialSrg::m_roughnessMapUvIndex];
     surface.roughnessLinear = GetRoughnessInput(MaterialSrg::m_roughnessMap, MaterialSrg::m_sampler, roughnessUv, real(MaterialSrg::m_roughnessFactor),
-                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture);
+                                        real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture, uvDxDy, customDerivatives);
     surface.CalculateRoughnessA();
 
     // ------- Dual Specular -------
@@ -211,20 +243,20 @@ Surface EvaluateSurface_Skin(
     // ------- Subsurface -------
 
     float2 subsurfaceUv = uvs[MaterialSrg::m_subsurfaceScatteringInfluenceMapUvIndex];
-    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor));
+    surface.subsurfaceScatteringFactor = GetSubsurfaceInput(MaterialSrg::m_subsurfaceScatteringInfluenceMap, MaterialSrg::m_sampler, subsurfaceUv, real(MaterialSrg::m_subsurfaceScatteringFactor), uvDxDy, customDerivatives);
     surface.subsurfaceScatteringQuality = real(MaterialSrg::m_subsurfaceScatteringQuality);
     surface.scatterDistance = real3(MaterialSrg::m_scatterDistance);
 
     // ------- Occlusion -------
     
-    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture);
-    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture);
+    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex], real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture, uvDxDy, customDerivatives);
+    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, uvs[MaterialSrg::m_specularOcclusionMapUvIndex], real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture, uvDxDy, customDerivatives);
 
     // ------- Transmission -------
 
 #if ENABLE_TRANSMISSION
     float2 transmissionUv = uvs[MaterialSrg::m_transmissionThicknessMapUvIndex];
-    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness));
+    real4 transmissionTintThickness = GeTransmissionInput(MaterialSrg::m_transmissionThicknessMap, MaterialSrg::m_sampler, transmissionUv, real4(MaterialSrg::m_transmissionTintThickness), uvDxDy, customDerivatives);
     surface.transmission.tint = transmissionTintThickness.rgb;
     surface.transmission.thickness = transmissionTintThickness.w;
     surface.transmission.transmissionParams = real4(MaterialSrg::m_transmissionParams);
@@ -232,6 +264,46 @@ Surface EvaluateSurface_Skin(
 #endif
 
     return surface;
+}
+
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_Skin(
+    float3 positionWS,
+    real3 vertexNormal,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    float2 detailUv,
+    real4 wrinkleBlendFactors,
+    bool isFrontFace)
+{
+    return EvaluateSurface_Skin(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        detailUv,
+        wrinkleBlendFactors,
+        isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_Skin(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_Skin(
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.detailUv,
+        geoData.wrinkleBlendFactors,
+        geoData.isFrontFace,
+        uvDxDy,
+        customDerivatives);
 }
 
 Surface EvaluateSurface_Skin(VsOutput IN, PixelGeometryData geoData)
@@ -244,5 +316,7 @@ Surface EvaluateSurface_Skin(VsOutput IN, PixelGeometryData geoData)
         geoData.uvs,
         geoData.detailUv,
         geoData.wrinkleBlendFactors,
-        geoData.isFrontFace);
+        geoData.isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -26,9 +26,11 @@ Surface EvaluateSurface_StandardPBR(
     real3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
     bool isFrontFace,
-    bool isDisplacementClipped)
+    bool isDisplacementClipped,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
-    Surface surface = EvaluateSurface_BasePBR(positionWS, vertexNormal, tangents, bitangents, uvs, isFrontFace);
+    Surface surface = EvaluateSurface_BasePBR(positionWS, vertexNormal, tangents, bitangents, uvs, isFrontFace, uvDxDy, customDerivatives);
 
     // ------- Parallax Clipping -------
 
@@ -40,17 +42,17 @@ Surface EvaluateSurface_StandardPBR(
     // ------- Alpha & Clip -------
 
     // TODO: this often invokes a separate sample of the base color texture which is wasteful
-    surface.alpha = GetAlphaAndClip(uvs);
+    surface.alpha = GetAlphaAndClip(uvs, uvDxDy, customDerivatives);
 
     // ------- Emissive -------
 
     float2 emissiveUv = uvs[MaterialSrg::m_emissiveMapUvIndex];
-    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, real(MaterialSrg::m_emissiveIntensity), real3(MaterialSrg::m_emissiveColor.rgb), real(MaterialSrg::m_emissiveAffectedByAlpha), real(surface.alpha), o_emissiveEnabled, o_emissive_useTexture);
+    surface.emissiveLighting = GetEmissiveInput(MaterialSrg::m_emissiveMap, MaterialSrg::m_sampler, emissiveUv, real(MaterialSrg::m_emissiveIntensity), real3(MaterialSrg::m_emissiveColor.rgb), real(MaterialSrg::m_emissiveAffectedByAlpha), real(surface.alpha), o_emissiveEnabled, o_emissive_useTexture, uvDxDy, customDerivatives);
 
     // ------- Occlusion -------
     
-    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, real2(uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex]), real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture);
-    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, real2(uvs[MaterialSrg::m_specularOcclusionMapUvIndex]), real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture);
+    surface.diffuseAmbientOcclusion = GetOcclusionInput(MaterialSrg::m_diffuseOcclusionMap, MaterialSrg::m_sampler, real2(uvs[MaterialSrg::m_diffuseOcclusionMapUvIndex]), real(MaterialSrg::m_diffuseOcclusionFactor), o_diffuseOcclusion_useTexture, uvDxDy, customDerivatives);
+    surface.specularOcclusion = GetOcclusionInput(MaterialSrg::m_specularOcclusionMap, MaterialSrg::m_sampler, real2(uvs[MaterialSrg::m_specularOcclusionMapUvIndex]), real(MaterialSrg::m_specularOcclusionFactor), o_specularOcclusion_useTexture, uvDxDy, customDerivatives);
 
     // ------- Clearcoat -------
 
@@ -66,7 +68,7 @@ Surface EvaluateSurface_StandardPBR(
                                MaterialSrg::m_clearCoatNormalMap,    uvs[MaterialSrg::m_clearCoatNormalMapUvIndex], vertexNormal, o_clearCoat_normal_useTexture, real(MaterialSrg::m_clearCoatNormalStrength),
                                uvMatrix, tangents[MaterialSrg::m_clearCoatNormalMapUvIndex], bitangents[MaterialSrg::m_clearCoatNormalMapUvIndex],
                                MaterialSrg::m_sampler, isFrontFace,
-                               surface.clearCoat.factor, surface.clearCoat.roughness, surface.clearCoat.normal);
+                               surface.clearCoat.factor, surface.clearCoat.roughness, surface.clearCoat.normal, uvDxDy, customDerivatives);
         }
 
         ApplyClearCoatToSpecularF0(surface.specularF0, surface.clearCoat.factor);
@@ -79,6 +81,43 @@ Surface EvaluateSurface_StandardPBR(
     return surface;
 }
 
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_StandardPBR(
+    float3 positionWS,
+    real3 vertexNormal,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace,
+    bool isDisplacementClipped)
+{
+    return EvaluateSurface_StandardPBR(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_StandardPBR(
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.isFrontFace,
+        geoData.isDisplacementClipped,
+        uvDxDy,
+        customDerivatives);
+}
+
 Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_StandardPBR(
@@ -88,5 +127,7 @@ Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData)
         geoData.bitangents,
         geoData.uvs,
         geoData.isFrontFace,
-        geoData.isDisplacementClipped);
+        geoData.isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -25,7 +25,9 @@ Surface EvaluateSurface_MaterialGraphName(
     real3 tangents[UvSetCount],
     real3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
-    bool isFrontFace)
+    bool isFrontFace,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     const float3 bitangent = cross((float3)IN.normal, (float3)IN.tangent);
     const float3 O3DE_MC_POSITION = (float3)IN.position;
@@ -63,6 +65,43 @@ Surface EvaluateSurface_MaterialGraphName(
     return surface;
 }
 
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_MaterialGraphName(
+    VsOutput IN,
+    float3 positionWS,
+    real3 normalWS,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace)
+{
+    return EvaluateSurface_MaterialGraphName(
+        IN,
+        positionWS,
+        normalWS,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
+}
+
+Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_MaterialGraphName(
+        IN,
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.isFrontFace,
+        uvDxDy,
+        customDerivatives);
+}
+
 Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
@@ -72,5 +111,7 @@ Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData
         geoData.tangents,
         geoData.bitangents,
         geoData.uvs,
-        geoData.isFrontFace);
+        geoData.isFrontFace,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -27,7 +27,9 @@ Surface EvaluateSurface_MaterialGraphName(
     real3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
     bool isFrontFace,
-    bool isDisplacementClipped)
+    bool isDisplacementClipped,
+    float4 uvDxDy,
+    bool customDerivatives)
 {
     const float3 bitangent = cross((float3)IN.normal, (float3)IN.tangent);
     const float3 O3DE_MC_POSITION = (float3)IN.position;
@@ -106,6 +108,47 @@ Surface EvaluateSurface_MaterialGraphName(
     return surface;
 }
 
+// helper function to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_MaterialGraphName(
+    VsOutput IN,
+    float3 positionWS,
+    real3 normalWS,
+    real3 tangents[UvSetCount],
+    real3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace,
+    bool isDisplacementClipped)
+{
+    return EvaluateSurface_MaterialGraphName(
+        IN,
+        positionWS,
+        normalWS,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false); 
+}
+
+
+Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
+{
+    return EvaluateSurface_MaterialGraphName(
+        IN,
+        geoData.positionWS,
+        geoData.vertexNormal,
+        geoData.tangents,
+        geoData.bitangents,
+        geoData.uvs,
+        geoData.isFrontFace,
+        geoData.isDisplacementClipped,
+        uvDxDy,
+        customDerivatives);
+}
+
 Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData)
 {
     return EvaluateSurface_MaterialGraphName(
@@ -116,5 +159,7 @@ Surface EvaluateSurface_MaterialGraphName(VsOutput IN, PixelGeometryData geoData
         geoData.bitangents,
         geoData.uvs,
         geoData.isFrontFace,
-        geoData.isDisplacementClipped);
+        geoData.isDisplacementClipped,
+        float4(0.0f, 0.0f, 0.0f, 0.0f),
+        false);
 }


### PR DESCRIPTION
## What does this PR do?

The current material texture sampling function inside `XXXInput.azsli` files is hard-coded to use `map.Sample(sampler, uv)`, this works in a forward rendering context since the draw-call is sent and rendered in an object-wise manner, the hard-ware can do the derivatives automatically for each object.

But consider a deferred render pipeline, where the shading draw calls are sent in a full-screen space manner (i.e., shading the G-Buffer), the hard-ware derivatives would be wrong. Actually I have noticed some artifacts caused by this mismatch in my prototype deferred pipeline (wrong sampled texture color in the border of frontier and background objects).

This PR adds a new parameter `uvDxDy` to new overloaded functions of those functions related to texture sampling, and pass the derivatives to it through the `EvaluateSurface` function call, and introduced a macro `USE_CUSTOM_SAMPLE_DERIVATIVES` to allow the user to decide whether or not using it. One can define the macro before including the material surface evaluate shader headers, and pass there derivatives to the `EvaluateSurface` function call.

To keep compatible with the existing projects/gems/materials, I would have to reserve some of the current functions of texture sampling without the derivatives parameter because dxc compiler doesn't allow default parameters on functions with overloads. I've seen some similar behavior in the current codes.

Please note that this version doesn't support customized derivatives on parallax inputs yet, it relates to EvaluatePixelGeometry so I think it would be better to get supported in another separated PR.

## How was this PR tested?

Tested in DX Windows, no shader compiling fails, tested in my prototype deferred pipeline, the derivatives actually fixed the artifacts I mentioned before.
