### PR TITLE
Entity Outliner | Prevent dropping an asset when no level is loaded.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -737,6 +737,12 @@ namespace AzToolsFramework
         [[maybe_unused]] int column,
         const QModelIndex& parent) const
     {
+        // Can only drop assets if a level is loaded!
+        if (rowCount() == 0)
+        {
+            return false;
+        }
+
         if (action != Qt::DropAction::CopyAction)
         {
             // we can only 'move' entityIds, and that will already be handled at this point


### PR DESCRIPTION
## What does this PR do?

Fixes an edge case that would cause a crash when an asset was dropped in the Outliner with no level loaded.

## How was this PR tested?

Manual testing.

![NoLevelDrop](https://github.com/o3de/o3de/assets/82231674/0e396d27-4f03-4f3e-8838-32c2ff547c6b)