### PR TITLE
Asset Editor | Allow "Save As" to be selected when asset is not dirty.

### DIFF
--- a/Code/Editor/AssetEditor/AssetEditorWindow.cpp
+++ b/Code/Editor/AssetEditor/AssetEditorWindow.cpp
@@ -112,7 +112,7 @@ void AssetEditorWindow::SaveAssetAs(const AZStd::string_view assetPath)
 void AssetEditorWindow::RegisterViewClass()
 {
     AzToolsFramework::ViewPaneOptions options;
-    options.preferedDockingArea = Qt::LeftDockWidgetArea;
+    options.preferedDockingArea = Qt::NoDockWidgetArea;
     options.showOnToolsToolbar = true;
     options.toolbarIcon = ":/Menu/asset_editor.svg";
     AzToolsFramework::RegisterViewPane<AssetEditorWindow>(LyViewPane::AssetEditor, LyViewPane::CategoryTools, options);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -172,10 +172,12 @@ namespace AzToolsFramework
                 }
             }
 
-            QAction* openAssetAction = fileMenu->addAction("&Open");
+            QAction* openAssetAction = fileMenu->addAction("&Open...");
             connect(openAssetAction, &QAction::triggered, this, &AssetEditorWidget::OpenAssetWithDialog);
 
             m_recentFileMenu = fileMenu->addMenu("Open Recent");
+
+            fileMenu->addSeparator();
 
             m_saveAssetAction = fileMenu->addAction("&Save");
             m_saveAssetAction->setShortcut(QKeySequence::Save);
@@ -707,12 +709,15 @@ namespace AzToolsFramework
 
             m_saveAllAssetsAction->setEnabled(haveDirtyTabs);
 
-            // Enable the single save options depending on whether the current tab is dirty.
+            // Current tab
             AssetEditorTab* tab = qobject_cast<AssetEditorTab*>(m_tabs->currentWidget());
             if (tab)
             {
+                // Enable the Save option depending on whether the current tab is dirty.
                 m_saveAssetAction->setEnabled(tab->IsDirty());
-                m_saveAsAssetAction->setEnabled(tab->IsDirty());
+
+                // Always enable Save As... if a tab is active.
+                m_saveAsAssetAction->setEnabled(true);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16351

Assets in the Asset Editor can be duplicated via "Save As..." even when they have no unsaved changes.
Also changes the Asset Editor to start as its own window as default instead of in the top left window area, disrupting the layout.

## How was this PR tested?

Manual testing.