### PR TITLE
Multi-device: deviceIndex in Scope

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DepthExponentiationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DepthExponentiationPass.cpp
@@ -89,7 +89,7 @@ namespace AZ
         void DepthExponentiationPass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
         {
             const uint32_t typeIndex = aznumeric_cast<uint32_t>(m_shadowmapType);
-            m_dispatchItem.m_pipelineState = m_shaderVariant[typeIndex].m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_dispatchItem.m_pipelineState = m_shaderVariant[typeIndex].m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             Base::BuildCommandListInternal(context);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
@@ -54,7 +54,7 @@ namespace AZ
             m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = resolution.m_width;
             m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = resolution.m_height;
             m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
-            m_dispatchItem.m_pipelineState = m_msaaPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_dispatchItem.m_pipelineState = m_msaaPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
             commandList->Submit(m_dispatchItem);
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -201,7 +201,7 @@ namespace AZ
                 if (startIndex == 0)
                 {
                     RHI::CommandList* commandList = context.GetCommandList();
-                    commandList->Submit(m_clearShadowDrawPacket->GetDrawItemProperties(0).m_mdItem->GetDeviceDrawItem(RHI::MultiDevice::DefaultDeviceIndex), 0);
+                    commandList->Submit(m_clearShadowDrawPacket->GetDrawItemProperties(0).m_mdItem->GetDeviceDrawItem(context.GetDeviceIndex()), 0);
                 }
                 else
                 {

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -83,7 +83,7 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             commandList->Submit(m_item);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -674,13 +674,13 @@ namespace AZ
             AZ_PROFILE_SCOPE(AzRender, "ImGuiPass: BuildCommandListInternal");
 
             context.GetCommandList()->SetViewport(m_viewportState);
-            context.GetCommandList()->SetShaderResourceGroupForDraw(*m_resourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+            context.GetCommandList()->SetShaderResourceGroupForDraw(*m_resourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
             for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
             {
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = m_draws.at(i).m_drawIndexed;
-                drawItem.m_pipelineState = m_pipelineState->GetRHIPipelineState()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawItem.m_pipelineState = m_pipelineState->GetRHIPipelineState()->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &m_indexBufferView;
                 drawItem.m_streamBufferViewCount = 2;
                 drawItem.m_streamBufferViews = m_vertexBufferView.data();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -210,7 +210,7 @@ namespace AZ
         {
             if (m_needToUpdateLut && m_blendedLut.m_lutImage && m_currentShaderVariantIndex <= LookModificationSettings::MaxBlendLuts)
             {
-                m_dispatchItem.m_pipelineState = m_shaderVariant[m_currentShaderVariantIndex].m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                m_dispatchItem.m_pipelineState = m_shaderVariant[m_currentShaderVariantIndex].m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
                 ComputePass::BuildCommandListInternal(context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
@@ -174,7 +174,7 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             commandList->Submit(m_item);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
@@ -143,7 +143,7 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             commandList->Submit(m_item);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
@@ -98,7 +98,7 @@ namespace AZ
 
         void DepthOfFieldCopyFocusDepthToCpuPass::BuildCommandList(const RHI::FrameGraphExecuteContext& context)
         {
-            context.GetCommandList()->Submit(m_copyDescriptor.GetDeviceCopyBufferDescriptor(RHI::MultiDevice::DefaultDeviceIndex));
+            context.GetCommandList()->Submit(m_copyDescriptor.GetDeviceCopyBufferDescriptor(context.GetDeviceIndex()));
         }
 
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -249,7 +249,7 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             commandList->Submit(m_item);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -244,11 +244,11 @@ namespace AZ
                     for (auto submeshIndex = 0; submeshIndex < blasInstance.second.m_subMeshes.size(); ++submeshIndex)
                     {
                         auto& submeshBlasInstance = blasInstance.second.m_subMeshes[submeshIndex];
-                        changedBlasList.push_back(submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex).get());
+                        changedBlasList.push_back(submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()).get());
                         if (blasInstance.second.m_blasBuilt == false)
                         {
                             // Always build the BLAS, if it has not previously been built
-                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
+                            context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()));
                             continue;
                         }
 
@@ -261,13 +261,13 @@ namespace AZ
                         {
                             // Skinned mesh that simply needs an update
                             context.GetCommandList()->UpdateBottomLevelAccelerationStructure(
-                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
+                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()));
                         }
                         else
                         {
                             // Fall back to building the BLAS in any case
                             context.GetCommandList()->BuildBottomLevelAccelerationStructure(
-                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
+                                *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()));
                         }
                     }
 
@@ -276,7 +276,7 @@ namespace AZ
             }
 
             // build the TLAS object
-            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas()->GetDeviceRayTracingTlas(RHI::MultiDevice::DefaultDeviceIndex), changedBlasList);
+            context.GetCommandList()->BuildTopLevelAccelerationStructure(*rayTracingFeatureProcessor->GetTlas()->GetDeviceRayTracingTlas(context.GetDeviceIndex()), changedBlasList);
 
             ++m_frameCount;
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -367,11 +367,11 @@ namespace AZ
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs
             // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
-            AZStd::vector<RHI::SingleDeviceShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
+            AZStd::vector<RHI::SingleDeviceShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
 
             if (m_requiresRayTracingSceneSrg)
             {
-                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
             }
 
             if (m_requiresViewSrg)
@@ -379,26 +379,26 @@ namespace AZ
                 RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
                 if (view)
                 {
-                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
                 }
             }
 
             if (m_requiresSceneSrg)
             {
-                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
             }
 
             if (m_requiresRayTracingMaterialSrg)
             {
-                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
             }
 
             dispatchRaysItem.m_shaderResourceGroupCount = aznumeric_cast<uint32_t>(shaderResourceGroups.size());
             dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups.data();
             dispatchRaysItem.m_rayTracingPipelineState =
-                m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(RHI::MultiDevice::DefaultDeviceIndex).get();
-            dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(context.GetDeviceIndex()).get();
+            dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(context.GetDeviceIndex()).get();
+            dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             // submit the DispatchRays item
             context.GetCommandList()->Submit(dispatchRaysItem);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteContext.h
@@ -26,6 +26,7 @@ namespace AZ::RHI
         struct Descriptor
         {
             ScopeId m_scopeId;
+            int m_deviceIndex = MultiDevice::DefaultDeviceIndex;
             uint32_t m_commandListIndex = 0;
             uint32_t m_commandListCount = 0;
             CommandList* m_commandList = nullptr;
@@ -36,6 +37,9 @@ namespace AZ::RHI
 
         /// Returns the scope id associated with this context.
         const ScopeId& GetScopeId() const { return m_descriptor.m_scopeId; }
+
+        /// Returns the index of the device this batch runs on.
+        int GetDeviceIndex() const { return m_descriptor.m_deviceIndex; }
 
         /// Returns the index of the command list in the batch.
         uint32_t GetCommandListIndex() const { return m_descriptor.m_commandListIndex; }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteGroup.h
@@ -64,6 +64,9 @@ namespace AZ::RHI
             /// The scope id used for all the contexts in this group (one context for each command list).
             ScopeId m_scopeId;
 
+            /// The index of the device the group is running on.
+            int m_deviceIndex = MultiDevice::DefaultDeviceIndex;
+
             /// The submit count for the scope
             uint32_t m_submitCount = 0;
 
@@ -88,6 +91,9 @@ namespace AZ::RHI
             /// The command list shared by all scopes in the group. This can be null if the
             /// user wishes to fill in the command list at context creation time.
             CommandList* m_commandList = nullptr;
+
+            /// The index of the device the group is running on.
+            int m_deviceIndex = MultiDevice::DefaultDeviceIndex;
 
             struct ScopeEntry
             {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -53,6 +53,12 @@ namespace AZ::RHI
         //! Returns whether the scope is currently active on a frame.
         bool IsActive() const;
 
+        //! Returns the index of the device the scope is running on.
+        int GetDeviceIndex() const;
+
+        //! Returns the device the scope is running on.
+        Device& GetDevice() const;
+
         //! Returns the scope id associated with this scope.
         const ScopeId& GetId() const;
 
@@ -124,7 +130,7 @@ namespace AZ::RHI
         void Activate(const FrameGraph* frameGraph, uint32_t index, const GraphGroupId& groupId);
 
         //! Called when the scope is being compiled at the end of the graph-building phase.
-        void Compile(Device& device);
+        void Compile(int deviceIndex);
 
         //! Deactivates the scope for the current frame.
         void Deactivate();
@@ -167,7 +173,7 @@ namespace AZ::RHI
         virtual void ActivateInternal();
 
         /// Called when the scope is being compiled into platform-dependent actions (after graph compilation).
-        virtual void CompileInternal(Device& device);
+        virtual void CompileInternal();
 
         /// Called when the scope is deactivating at the end of the frame (after execution).
         virtual void DeactivateInternal();
@@ -210,6 +216,9 @@ namespace AZ::RHI
 
         /// Tracks whether the scope is active, which happens once per frame.
         bool m_isActive = false;
+
+        /// The device index the scope is running on.
+        int m_deviceIndex = MultiDevice::DefaultDeviceIndex;
 
         /// The cross-queue producers / consumers, indexed by hardware queue.
         AZStd::array<Scope*, HardwareQueueClassCount> m_producersByQueueLast = {{nullptr}};

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -146,7 +146,7 @@ namespace AZ::RHI
 
             for (Scope* scope : frameGraph.GetScopes())
             {
-                scope->Compile(GetDevice());
+                scope->Compile(MultiDevice::DefaultDeviceIndex);
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuteGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuteGroup.cpp
@@ -18,6 +18,7 @@ namespace AZ::RHI
         m_jobPolicy = JobPolicy::Serial;
 
         FrameGraphExecuteContext::Descriptor descriptor;
+        descriptor.m_deviceIndex = request.m_deviceIndex;
         descriptor.m_commandList = request.m_commandList;
         descriptor.m_commandListCount = 1;
         descriptor.m_commandListIndex = 0;
@@ -38,6 +39,7 @@ namespace AZ::RHI
 
         FrameGraphExecuteContext::Descriptor descriptor;
         descriptor.m_scopeId = request.m_scopeId;
+        descriptor.m_deviceIndex = request.m_deviceIndex;
         descriptor.m_commandListCount = request.m_commandListCount;
 
         // build the execute contexts

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -22,6 +22,16 @@ namespace AZ::RHI
         return m_isActive;
     }
 
+    int Scope::GetDeviceIndex() const
+    {
+        return m_deviceIndex;
+    }
+
+    Device& Scope::GetDevice() const
+    {
+        return *RHISystemInterface::Get()->GetDevice(m_deviceIndex);
+    }
+
     void Scope::Init(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass)
     {
         AZ_Assert(!scopeId.IsEmpty(), "Scope id is not valid.");
@@ -65,10 +75,11 @@ namespace AZ::RHI
         m_isActive = true;
     }
 
-    void Scope::Compile(Device& device)
+    void Scope::Compile(int deviceIndex)
     {
         AZ_Assert(m_isActive, "Scope being compiled but is not active");
-        CompileInternal(device);
+        m_deviceIndex = deviceIndex;
+        CompileInternal();
     }
 
     void Scope::Deactivate()
@@ -125,7 +136,7 @@ namespace AZ::RHI
 
     void Scope::InitInternal() {}
     void Scope::ActivateInternal() {}
-    void Scope::CompileInternal([[maybe_unused]] Device& device) {}
+    void Scope::CompileInternal() {}
     void Scope::DeactivateInternal() {}
     void Scope::ShutdownInternal() {}
 

--- a/Gems/Atom/RHI/Code/Tests/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Scope.cpp
@@ -21,7 +21,7 @@ namespace UnitTest
         AZ_Assert(IsActive() == false, "Is Active");
     }
 
-    void Scope::CompileInternal([[maybe_unused]] AZ::RHI::Device& device)
+    void Scope::CompileInternal()
     {
         for (const AZ::RHI::ScopeAttachment* scopeAttachment : GetAttachments())
         {

--- a/Gems/Atom/RHI/Code/Tests/Scope.h
+++ b/Gems/Atom/RHI/Code/Tests/Scope.h
@@ -26,7 +26,7 @@ namespace UnitTest
         // RHI::Scope
         void InitInternal() override;
         void ActivateInternal() override;
-        void CompileInternal(AZ::RHI::Device& device) override;
+        void CompileInternal() override;
         void DeactivateInternal() override;
         void ShutdownInternal() override;
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -193,7 +193,7 @@ namespace AZ
             }
         }
 
-        void Scope::CompileInternal([[maybe_unused]] RHI::Device& device)
+        void Scope::CompileInternal()
         {
             for (RHI::ResourcePoolResolver* resolvePolicyBase : GetResourcePoolResolves())
             {
@@ -207,7 +207,7 @@ namespace AZ
             for (const RHI::ImageScopeAttachment* scopeAttachment : GetImageAttachments())
             {
                 const AZStd::vector<RHI::ScopeAttachmentUsageAndAccess>& usagesAndAccesses = scopeAttachment->GetUsageAndAccess();
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(GetDeviceIndex()).get());
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
 
                 const bool isFullView           = imageView->IsFullView();
@@ -281,7 +281,7 @@ namespace AZ
             for (const RHI::BufferScopeAttachment* scopeAttachment : GetBufferAttachments())
             {
                 const AZStd::vector<RHI::ScopeAttachmentUsageAndAccess>& usagesAndAccesses = scopeAttachment->GetUsageAndAccess();
-                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                const BufferView* bufferView = static_cast<const BufferView*>(scopeAttachment->GetBufferView()->GetDeviceBufferView(GetDeviceIndex()).get());
                 const RHI::BufferScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
 
                 const bool isClearAction = bindingDescriptor.m_loadStoreAction.m_loadAction == RHI::AttachmentLoadAction::Clear;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.h
@@ -93,7 +93,7 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
             // RHI::Scope
             void DeactivateInternal() override;
-            void CompileInternal(RHI::Device& device) override;
+            void CompileInternal() override;
             //////////////////////////////////////////////////////////////////////////
 
             void CompileAttachmentInternal(

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -71,8 +71,9 @@ namespace AZ
             }
         }
     
-        void Scope::CompileInternal(RHI::Device& device)
+        void Scope::CompileInternal()
         {
+            RHI::Device& device = GetDevice();
             Device& mtlDevice = static_cast<Device&>(device);
             for (RHI::ResourcePoolResolver* resolvePolicyBase : GetResourcePoolResolves())
             {
@@ -120,7 +121,7 @@ namespace AZ
                     m_swapChainAttachment = scopeAttachment;
                 }
                 
-                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                const ImageView* imageView = static_cast<const ImageView*>(scopeAttachment->GetImageView()->GetDeviceImageView(GetDeviceIndex()).get());
                 const RHI::ImageScopeAttachmentDescriptor& bindingDescriptor = scopeAttachment->GetDescriptor();
                 id<MTLTexture> imageViewMtlTexture = imageView->GetMemoryView().GetGpuAddress<id<MTLTexture>>();
                 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
@@ -88,7 +88,7 @@ namespace AZ
             // RHI::Scope
             void InitInternal() override;
             void DeactivateInternal() override;
-            void CompileInternal(RHI::Device& device) override;
+            void CompileInternal() override;
             void AddQueryPoolUse(RHI::Ptr<RHI::SingleDeviceQueryPool> queryPool, const RHI::Interval& interval, RHI::ScopeAttachmentAccess access) override;
             //////////////////////////////////////////////////////////////////////////
             

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/Scope.h
@@ -30,7 +30,7 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
             // RHI::Scope
             void DeactivateInternal() override {}
-            void CompileInternal([[maybe_unused]] RHI::Device& device) override {}
+            void CompileInternal() override {}
             void AddQueryPoolUse([[maybe_unused]] RHI::Ptr<RHI::SingleDeviceQueryPool> queryPool, [[maybe_unused]] const RHI::Interval& interval, [[maybe_unused]] RHI::ScopeAttachmentAccess access) override {}
             //////////////////////////////////////////////////////////////////////////
         };

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -317,7 +317,7 @@ namespace AZ
             }
         }
 
-        void Scope::CompileInternal(RHI::Device& deviceBase)
+        void Scope::CompileInternal()
         {
             for (RHI::ResourcePoolResolver* resolvePolicyBase : GetResourcePoolResolves())
             {
@@ -334,6 +334,7 @@ namespace AZ
                 m_signalFences.push_back(AZStd::static_pointer_cast<Fence>(fence));
             }
 
+            RHI::Device& deviceBase = GetDevice();
             Device& device = static_cast<Device&>(deviceBase);
             m_deviceSupportedPipelineStageFlags = device.GetCommandQueueContext().GetCommandQueue(GetHardwareQueueClass()).GetSupportedPipelineStages();
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
@@ -161,7 +161,7 @@ namespace AZ
             // RHI::Scope
             void ActivateInternal() override;
             void DeactivateInternal() override;
-            void CompileInternal(RHI::Device& device) override;
+            void CompileInternal() override;
             void AddQueryPoolUse(RHI::Ptr<RHI::SingleDeviceQueryPool> queryPool, const RHI::Interval& interval, RHI::ScopeAttachmentAccess access) override;
             //////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -267,7 +267,7 @@ namespace AZ
                 const RHI::MultiDeviceDrawItemProperties& drawItemProperties = m_drawListView[index];
                 if (drawItemProperties.m_drawFilterMask & m_pipeline->GetDrawFilterMask())
                 {
-                    commandList->Submit(drawItemProperties.m_mdItem->GetDeviceDrawItem(RHI::MultiDevice::DefaultDeviceIndex), index + indexOffset);
+                    commandList->Submit(drawItemProperties.m_mdItem->GetDeviceDrawItem(context.GetDeviceIndex()), index + indexOffset);
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -544,7 +544,7 @@ namespace AZ
             commandList->SetScissor(m_scissor);
 
             // submit srg
-            commandList->SetShaderResourceGroupForDraw(*m_passSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+            commandList->SetShaderResourceGroupForDraw(*m_passSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
             // submit draw call
             for (uint32_t index = context.GetSubmitRange().m_startIndex; index < context.GetSubmitRange().m_endIndex; ++index)

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
@@ -316,7 +316,7 @@ namespace UnitTest
         private:
             void InitInternal() override {}
             void ActivateInternal() override {}
-            void CompileInternal([[maybe_unused]] AZ::RHI::Device& device) override {}
+            void CompileInternal() override {}
             void DeactivateInternal() override {}
             void ShutdownInternal() override {}
         };

--- a/Gems/AtomTressFX/Code/Passes/HairSkinningComputePass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairSkinningComputePass.cpp
@@ -237,7 +237,7 @@ namespace AZ
 
                 for (uint32_t index = context.GetSubmitRange().m_startIndex; index < context.GetSubmitRange().m_endIndex; ++index, ++it)
                 {
-                    commandList->Submit((*it)->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex), index);
+                    commandList->Submit((*it)->GetDeviceDispatchItem(context.GetDeviceIndex()), index);
                 }
 
                 // Clear the dispatch items. They will need to be re-populated next frame

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
@@ -187,7 +187,7 @@ namespace AZ
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendDistanceSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
                 uint32_t probeCountX;
                 uint32_t probeCountY;
@@ -197,7 +197,7 @@ namespace AZ
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = shader.m_dispatchArgs;
-                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX * dispatchItem.m_arguments.m_direct.m_threadsPerGroupX;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY * dispatchItem.m_arguments.m_direct.m_threadsPerGroupY;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
@@ -177,7 +177,7 @@ namespace AZ
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetBlendIrradianceSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
 
                 uint32_t probeCountX;
                 uint32_t probeCountY;
@@ -187,7 +187,7 @@ namespace AZ
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = shader.m_dispatchArgs;
-                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX * dispatchItem.m_arguments.m_direct.m_threadsPerGroupX;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY * dispatchItem.m_arguments.m_direct.m_threadsPerGroupY;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
@@ -226,7 +226,7 @@ namespace AZ
             {
                 SubmitItem& submitItem = m_submitItems[index];
 
-                commandList->SetShaderResourceGroupForDispatch(*submitItem.m_shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*submitItem.m_shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
                 commandList->Submit(submitItem.m_dispatchItem, index++);
             }
         }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
@@ -179,11 +179,11 @@ namespace AZ
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetClassificationSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = shader.m_dispatchArgs;
-                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = shader.m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = AZ::DivideAndRoundUp(diffuseProbeGrid->GetTotalProbeCount(), diffuseProbeGrid->GetFrameUpdateCount());
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
@@ -148,11 +148,11 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleProbeGrids()[index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetPrepareSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;
-                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
@@ -220,13 +220,13 @@ namespace AZ
                 const uint8_t srgCount = 3;
                 AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups =
                 {
-                    diffuseProbeGrid->GetQuerySrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                    diffuseProbeGrid->GetQuerySrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
-                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments = m_dispatchArgs;
                 dispatchItem.m_shaderResourceGroupCount = srgCount;
                 dispatchItem.m_shaderResourceGroups = shaderResourceGroups;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
@@ -251,11 +251,11 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleProbeGrids()[index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetQuerySrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;
-                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = diffuseProbeGridFeatureProcessor->GetIrradianceQueryCount();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -358,20 +358,20 @@ namespace AZ
                     AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
 
                     const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                        diffuseProbeGrid->GetRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                        rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                        rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
+                        diffuseProbeGrid->GetRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                        rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                        rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                     };
 
                     RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;
                     dispatchRaysItem.m_arguments.m_direct.m_width = diffuseProbeGrid->GetNumRaysPerProbe().m_rayCount;
                     dispatchRaysItem.m_arguments.m_direct.m_height = AZ::DivideAndRoundUp(diffuseProbeGrid->GetTotalProbeCount(), diffuseProbeGrid->GetFrameUpdateCount());
                     dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
-                    dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(context.GetDeviceIndex()).get();
+                    dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(context.GetDeviceIndex()).get();
                     dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);
                     dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups;
-                    dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
                     // submit the DispatchRays item
                     context.GetCommandList()->Submit(dispatchRaysItem, index);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
@@ -210,11 +210,11 @@ namespace AZ
                 AZStd::shared_ptr<DiffuseProbeGrid> diffuseProbeGrid = diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids()[index];
 
                 const RHI::MultiDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetRelocationSrg()->GetRHIShaderResourceGroup();
-                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex));
+                commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;
-                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = AZ::DivideAndRoundUp(diffuseProbeGrid->GetTotalProbeCount(), diffuseProbeGrid->GetFrameUpdateCount());
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -154,10 +154,10 @@ namespace AZ
             AZStd::vector<const RHI::SingleDeviceRayTracingBlas*> changedBlasList;
             if (m_visualizationBlasBuilt == false)
             {
-                context.GetCommandList()->BuildBottomLevelAccelerationStructure(*diffuseProbeGridFeatureProcessor->GetVisualizationBlas()->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex));
+                context.GetCommandList()->BuildBottomLevelAccelerationStructure(*diffuseProbeGridFeatureProcessor->GetVisualizationBlas()->GetDeviceRayTracingBlas(context.GetDeviceIndex()));
                 m_visualizationBlasBuilt = true;
                 changedBlasList.push_back(diffuseProbeGridFeatureProcessor->GetVisualizationBlas()
-                                              ->GetDeviceRayTracingBlas(RHI::MultiDevice::DefaultDeviceIndex)
+                                              ->GetDeviceRayTracingBlas(context.GetDeviceIndex())
                                               .get());
             }
 
@@ -176,7 +176,7 @@ namespace AZ
                 }
 
                 // build the TLAS object
-                context.GetCommandList()->BuildTopLevelAccelerationStructure(*diffuseProbeGrid->GetVisualizationTlas()->GetDeviceRayTracingTlas(RHI::MultiDevice::DefaultDeviceIndex), changedBlasList);
+                context.GetCommandList()->BuildTopLevelAccelerationStructure(*diffuseProbeGrid->GetVisualizationTlas()->GetDeviceRayTracingTlas(context.GetDeviceIndex()), changedBlasList);
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -268,12 +268,12 @@ namespace AZ
                     continue;
                 }
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetVisualizationPrepareSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroup = diffuseProbeGrid->GetVisualizationPrepareSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get();
                 commandList->SetShaderResourceGroupForDispatch(*shaderResourceGroup);
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
                 dispatchItem.m_arguments = m_dispatchArgs;
-                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = diffuseProbeGrid->GetTotalProbeCount();
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = 1;
                 dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -296,9 +296,9 @@ namespace AZ
                 }
 
                 const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    diffuseProbeGrid->GetVisualizationRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                    rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
-                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                    diffuseProbeGrid->GetVisualizationRayTraceSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    views[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
                 };
 
                 RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;
@@ -306,11 +306,11 @@ namespace AZ
                 dispatchRaysItem.m_arguments.m_direct.m_height = m_outputAttachmentSize.m_height;
                 dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
                 dispatchRaysItem.m_rayTracingPipelineState =
-                    m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(RHI::MultiDevice::DefaultDeviceIndex).get();
+                    m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(context.GetDeviceIndex()).get();
+                dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable->GetDeviceRayTracingShaderTable(context.GetDeviceIndex()).get();
                 dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);
                 dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups;
-                dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                dispatchRaysItem.m_globalPipelineState = m_globalPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
                 // submit the DispatchRays item
                 context.GetCommandList()->Submit(dispatchRaysItem, index);

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderPass.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderPass.cpp
@@ -180,7 +180,7 @@ namespace AZ
             }
 
             drawRequest.m_listTag = m_drawListTag;
-            drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
 
             return true;
         }


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

**This specific PR introduces a `deviceIndex` into the `Scope` class which is set during framegraph compilation and is later passed on to the FrameGraphExecuteContext. This is a partial change, not all locations where this `deviceIndex` should be used do so yet**

We have 3 more PRs upcoming building on this one:
1. More changes to use this `deviceIndex` including transitioning more `SingleDevice*` occurrences to `MultiDevice*` where we previously thought they are not necessary.
2. Completely transitioning `FrameScheduler` and `FrameGraph*` including backends to support mulit-device-resources.
3. Finalize everything with remaining transitions.

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`
