### PR TITLE
Asset Browser | Clear selection on filter changes.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -672,8 +672,9 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
 
     if (hasFilter)
     {
-        m_ui->m_assetBrowserTreeViewWidget->selectionModel()->select(
-            m_ui->m_assetBrowserTreeViewWidget->model()->index(0, 0, {}), QItemSelectionModel::ClearAndSelect);
+        // Clear the selection when the filter is applied.
+        m_ui->m_assetBrowserTreeViewWidget->selectionModel()->clearSelection();
+        m_ui->m_searchWidget->SetSelectionCount(0);
     }
 
     if (ed_useNewAssetBrowserListView)


### PR DESCRIPTION
## What does this PR do?

Fixes #17509

Asset Browser would try to select the first element after the filter is changed, but that would result in an error in index conversion down the line.

Overall I don't think the functionality made much sense to begin with, so I just resorted to clearing the selection on filter changes.
This prevents the assert in debug mode.

## How was this PR tested?

Manual testing.
