### PR TITLE
Reduce MultiDevice::DefaultDeviceIndex

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DepthExponentiationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DepthExponentiationPass.cpp
@@ -89,7 +89,7 @@ namespace AZ
         void DepthExponentiationPass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
         {
             const uint32_t typeIndex = aznumeric_cast<uint32_t>(m_shadowmapType);
-            m_dispatchItem.m_pipelineState = m_shaderVariant[typeIndex].m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
+            m_dispatchItem.SetPipelineState(m_shaderVariant[typeIndex].m_pipelineState);
 
             Base::BuildCommandListInternal(context);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -150,11 +150,14 @@ namespace AZ
             SetSrgsForDispatch(context);
 
             RHI::Size res = GetDepthBufferResolution();
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = res.m_width;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = res.m_height;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
 
-            commandList->Submit(m_dispatchItem);
+            auto arguments{m_dispatchItem.GetArguments()};
+            arguments.m_direct.m_totalNumberOfThreadsX = res.m_width;
+            arguments.m_direct.m_totalNumberOfThreadsY = res.m_height;
+            arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            m_dispatchItem.SetArguments(arguments);
+
+            commandList->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
         }
 
         void LightCullingPass::ResetInternal()

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -147,7 +147,7 @@ namespace AZ
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            SetSrgsForDispatch(commandList);
+            SetSrgsForDispatch(context);
 
             RHI::Size res = GetDepthBufferResolution();
             m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = res.m_width;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
@@ -77,11 +77,13 @@ namespace AZ
             SetSrgsForDispatch(context);
 
             // Each tile gets 32 threads to process indices
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = m_tileDim.m_width * m_dispatchItem.m_arguments.m_direct.m_threadsPerGroupX;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = m_tileDim.m_height;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            auto arguments{m_dispatchItem.GetArguments()};
+            arguments.m_direct.m_totalNumberOfThreadsX = m_tileDim.m_width * arguments.m_direct.m_threadsPerGroupX;
+            arguments.m_direct.m_totalNumberOfThreadsY = m_tileDim.m_height;
+            arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            m_dispatchItem.SetArguments(arguments);
 
-            commandList->Submit(m_dispatchItem);
+            commandList->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
         }
 
         void LightCullingRemap::ResetInternal()

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
@@ -74,7 +74,7 @@ namespace AZ
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            SetSrgsForDispatch(commandList);
+            SetSrgsForDispatch(context);
 
             // Each tile gets 32 threads to process indices
             m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = m_tileDim.m_width * m_dispatchItem.m_arguments.m_direct.m_threadsPerGroupX;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
@@ -47,7 +47,7 @@ namespace AZ
         {
             // Dispatch one compute shader thread per depth buffer pixel. These threads are divided into thread-groups that analyze one tile. (Typically 16x16 pixel tiles)
             RHI::CommandList* commandList = context.GetCommandList();
-            SetSrgsForDispatch(commandList);
+            SetSrgsForDispatch(context);
 
             RHI::Size resolution = GetDepthBufferDimensions();
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
@@ -51,11 +51,13 @@ namespace AZ
 
             RHI::Size resolution = GetDepthBufferDimensions();
 
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = resolution.m_width;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = resolution.m_height;
-            m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
-            m_dispatchItem.m_pipelineState = m_msaaPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-            commandList->Submit(m_dispatchItem);
+            auto arguments{m_dispatchItem.GetArguments()};
+            arguments.m_direct.m_totalNumberOfThreadsX = resolution.m_width;
+            arguments.m_direct.m_totalNumberOfThreadsY = resolution.m_height;
+            arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+            m_dispatchItem.SetArguments(arguments);
+            m_dispatchItem.SetPipelineState(m_msaaPipelineState.get());
+            commandList->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
         }
 
         AZ::RHI::Size LightCullingTilePreparePass::GetDepthBufferDimensions()

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -83,9 +83,9 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
+            m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 
-            commandList->Submit(m_item);
+            commandList->Submit(m_item.GetDeviceDrawItem(context.GetDeviceIndex()));
         }
 
         void OutputTransformPass::SetToneMapperType(const ToneMapperType& toneMapperType)

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -81,7 +81,7 @@ namespace AZ
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);
 
-            SetSrgsForDraw(commandList);
+            SetSrgsForDraw(context);
 
             m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -732,8 +732,8 @@ namespace AZ
                 return 0;
             }
 
-            ImDrawIdx* indexBufferData = static_cast<ImDrawIdx*>(indexBuffer->GetBufferAddress());
-            ImDrawVert* vertexBufferData = static_cast<ImDrawVert*>(vertexBuffer->GetBufferAddress());
+            auto indexBufferDataAddress = indexBuffer->GetBufferAddress();
+            auto vertexBufferDataAddress = vertexBuffer->GetBufferAddress();
 
             uint32_t drawCount = 0;
             uint32_t indexBufferOffset = 0;
@@ -746,11 +746,17 @@ namespace AZ
                     const ImDrawList* drawList = drawData.CmdLists[cmdListIndex];
 
                     const uint32_t indexBufferByteSize = drawList->IdxBuffer.size() * indexSize;
-                    memcpy(indexBufferData + indexBufferOffset, drawList->IdxBuffer.Data, indexBufferByteSize);
+                    for(auto [deviceIndex, indexBufferData] : indexBufferDataAddress)
+                    {
+                        memcpy(static_cast<ImDrawIdx*>(indexBufferData) + indexBufferOffset, drawList->IdxBuffer.Data, indexBufferByteSize);
+                    }
                     indexBufferOffset += drawList->IdxBuffer.size();
 
                     const uint32_t vertexBufferByteSize = drawList->VtxBuffer.size() * vertexSize;
-                    memcpy(vertexBufferData + vertexBufferOffset, drawList->VtxBuffer.Data, vertexBufferByteSize);
+                    for(auto [deviceIndex, vertexBufferData] : vertexBufferDataAddress)
+                    {
+                        memcpy(static_cast<ImDrawVert*>(vertexBufferData) + vertexBufferOffset, drawList->VtxBuffer.Data, vertexBufferByteSize);
+                    }
                     vertexBufferOffset += drawList->VtxBuffer.size();
 
                     drawCount += drawList->CmdBuffer.size();

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -678,12 +678,18 @@ namespace AZ
 
             for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
             {
+                auto indexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
+                AZStd::array<RHI::SingleDeviceStreamBufferView, 2> vertexBufferView{
+                    m_vertexBufferView[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_vertexBufferView[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
+
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = m_draws.at(i).m_drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetRHIPipelineState()->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &m_indexBufferView;
+                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_streamBufferViewCount = 2;
-                drawItem.m_streamBufferViews = m_vertexBufferView.data();
+                drawItem.m_streamBufferViews = vertexBufferView.data();
                 drawItem.m_scissorsCount = 1;
                 drawItem.m_scissors = &m_draws.at(i).m_scissor;
 
@@ -752,9 +758,9 @@ namespace AZ
             }
 
             static_assert(indexSize == 2, "Expected index size from ImGui to be 2 to match RHI::IndexFormat::Uint16");
-            m_indexBufferView = indexBuffer->GetIndexBufferView(RHI::IndexFormat::Uint16).GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex);
-            m_vertexBufferView[0] = vertexBuffer->GetStreamBufferView(vertexSize).GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
-            m_vertexBufferView[1] = m_instanceBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex);
+            m_indexBufferView = indexBuffer->GetIndexBufferView(RHI::IndexFormat::Uint16);
+            m_vertexBufferView[0] = vertexBuffer->GetStreamBufferView(vertexSize);
+            m_vertexBufferView[1] = m_instanceBufferView;
 
             RHI::ValidateStreamBufferViews(m_pipelineState->ConstDescriptor().m_inputStreamLayout, m_vertexBufferView);
 

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -151,8 +151,8 @@ namespace AZ
             RHI::ShaderInputNameIndex m_projectionMatrixIndex = "m_projectionMatrix";
             RHI::Viewport m_viewportState;
 
-            RHI::SingleDeviceIndexBufferView m_indexBufferView;
-            AZStd::array<RHI::SingleDeviceStreamBufferView, 2> m_vertexBufferView; // For vertex buffer and instance data
+            RHI::MultiDeviceIndexBufferView m_indexBufferView;
+            AZStd::array<RHI::MultiDeviceStreamBufferView, 2> m_vertexBufferView; // For vertex buffer and instance data
             AZStd::vector<DrawInfo> m_draws;
             Data::Instance<RPI::StreamingImage> m_fontAtlas;
 

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
@@ -65,7 +65,7 @@ namespace AZ
 
                 SetSrgsForDispatch(commandList);
 
-                m_skinnedMeshFeatureProcessor->SubmitMorphTargetDispatchItems(commandList, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
+                m_skinnedMeshFeatureProcessor->SubmitMorphTargetDispatchItems(context, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
             }
         }
     }   // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.cpp
@@ -61,9 +61,7 @@ namespace AZ
         {
             if (m_skinnedMeshFeatureProcessor)
             {
-                RHI::CommandList* commandList = context.GetCommandList();
-
-                SetSrgsForDispatch(commandList);
+                SetSrgsForDispatch(context);
 
                 m_skinnedMeshFeatureProcessor->SubmitMorphTargetDispatchItems(context, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -210,7 +210,7 @@ namespace AZ
         {
             if (m_needToUpdateLut && m_blendedLut.m_lutImage && m_currentShaderVariantIndex <= LookModificationSettings::MaxBlendLuts)
             {
-                m_dispatchItem.m_pipelineState = m_shaderVariant[m_currentShaderVariantIndex].m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
+                m_dispatchItem.SetPipelineState(m_shaderVariant[m_currentShaderVariantIndex].m_pipelineState);
 
                 ComputePass::BuildCommandListInternal(context);
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
@@ -174,9 +174,9 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
+            m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 
-            commandList->Submit(m_item);
+            commandList->Submit(m_item.GetDeviceDrawItem(context.GetDeviceIndex()));
         }
 
         void DepthOfFieldBokehBlurPass::SetRadiusMinMax(float min, float max)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldBokehBlurPass.cpp
@@ -172,7 +172,7 @@ namespace AZ
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);
 
-            SetSrgsForDraw(commandList);
+            SetSrgsForDraw(context);
 
             m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
@@ -143,9 +143,9 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
+            m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 
-            commandList->Submit(m_item);
+            commandList->Submit(m_item.GetDeviceDrawItem(context.GetDeviceIndex()));
         }
 
         void DepthOfFieldCompositePass::SetEnabledDebugColoring(bool enabled)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCompositePass.cpp
@@ -141,7 +141,7 @@ namespace AZ
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);
 
-            SetSrgsForDraw(commandList);
+            SetSrgsForDraw(context);
 
             m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -249,9 +249,9 @@ namespace AZ
 
             SetSrgsForDraw(commandList);
 
-            m_item.m_pipelineState = GetPipelineStateFromShaderVariant()->GetDevicePipelineState(context.GetDeviceIndex()).get();
+            m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 
-            commandList->Submit(m_item);
+            commandList->Submit(m_item.GetDeviceDrawItem(context.GetDeviceIndex()));
         }
 
         void LookModificationCompositePass::SetShaperParameters(const ShaperParams& shaperParams)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -247,7 +247,7 @@ namespace AZ
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);
 
-            SetSrgsForDraw(commandList);
+            SetSrgsForDraw(context);
 
             m_item.SetPipelineState(GetPipelineStateFromShaderVariant());
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
@@ -53,7 +53,7 @@ namespace AZ
             const RHI::Size resolution = GetColorBufferResolution();
             SetTargetThreadCounts(resolution.m_width, resolution.m_height, 1);
 
-            commandList->Submit(m_dispatchItem);
+            commandList->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
         }
 
         void LuminanceHistogramGeneratorPass::CreateHistogramBuffer()

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
@@ -48,7 +48,7 @@ namespace AZ
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            SetSrgsForDispatch(commandList);
+            SetSrgsForDispatch(context);
 
             const RHI::Size resolution = GetColorBufferResolution();
             SetTargetThreadCounts(resolution.m_width, resolution.m_height, 1);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -261,11 +261,11 @@ namespace AZ
                     subMesh.m_roughnessImageView.get() ? subMesh.m_roughnessImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex,
                     subMesh.m_emissiveImageView.get() ? subMesh.m_emissiveImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex
 #else
-                    m_materialTextures.AddResource(subMesh.m_baseColorImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
-                    m_materialTextures.AddResource(subMesh.m_normalImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
-                    m_materialTextures.AddResource(subMesh.m_metallicImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
-                    m_materialTextures.AddResource(subMesh.m_roughnessImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get()),
-                    m_materialTextures.AddResource(subMesh.m_emissiveImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get())
+                    m_materialTextures.AddResource(subMesh.m_baseColorImageView.get()),
+                    m_materialTextures.AddResource(subMesh.m_normalImageView.get()),
+                    m_materialTextures.AddResource(subMesh.m_metallicImageView.get()),
+                    m_materialTextures.AddResource(subMesh.m_roughnessImageView.get()),
+                    m_materialTextures.AddResource(subMesh.m_emissiveImageView.get())
 #endif
                 });
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
@@ -58,7 +58,7 @@ namespace AZ
 
                 SetSrgsForDispatch(commandList);
 
-                m_skinnedMeshFeatureProcessor->SubmitSkinningDispatchItems(commandList, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
+                m_skinnedMeshFeatureProcessor->SubmitSkinningDispatchItems(context, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.cpp
@@ -54,9 +54,7 @@ namespace AZ
         {
             if (m_skinnedMeshFeatureProcessor)
             {
-                RHI::CommandList* commandList = context.GetCommandList();
-
-                SetSrgsForDispatch(commandList);
+                SetSrgsForDispatch(context);
 
                 m_skinnedMeshFeatureProcessor->SubmitSkinningDispatchItems(context, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -446,7 +446,7 @@ namespace AZ
             }
         }
 
-        void SkinnedMeshFeatureProcessor::SubmitSkinningDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex)
+        void SkinnedMeshFeatureProcessor::SubmitSkinningDispatchItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex)
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
@@ -455,11 +455,12 @@ namespace AZ
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
                 const auto* dispatchItem = *it;
-                commandList->Submit(dispatchItem->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex), index);
+                context.GetCommandList()->Submit(dispatchItem->GetDeviceDispatchItem(context.GetDeviceIndex()), index);
             }
         }
 
-        void SkinnedMeshFeatureProcessor::SubmitMorphTargetDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex)
+        void SkinnedMeshFeatureProcessor::SubmitMorphTargetDispatchItems(
+            const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex)
         {
             AZStd::lock_guard lock(m_dispatchItemMutex);
 
@@ -468,7 +469,7 @@ namespace AZ
             for (uint32_t index = startIndex; index < endIndex; ++index, ++it)
             {
                 const auto* dispatchItem = *it;
-                commandList->Submit(dispatchItem->GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex), index);
+                context.GetCommandList()->Submit(dispatchItem->GetDeviceDispatchItem(context.GetDeviceIndex()), index);
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -13,6 +13,7 @@
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshFeatureProcessorInterface.h>
 
 #include <Atom/RHI/FrameGraphInterface.h>
+#include <Atom/RHI/FrameGraphExecuteContext.h>
 
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
@@ -66,11 +67,11 @@ namespace AZ
             Data::Instance<RPI::Shader> GetSkinningShader() const;
             RPI::ShaderOptionGroup CreateSkinningShaderOptionGroup(const SkinnedMeshShaderOptions shaderOptions, SkinnedMeshShaderOptionNotificationBus::Handler& shaderReinitializedHandler);
             void OnSkinningShaderReinitialized(const Data::Instance<RPI::Shader> skinningShader);
-            void SubmitSkinningDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex);
+            void SubmitSkinningDispatchItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex);
             void SetupSkinningScope(RHI::FrameGraphInterface frameGraph);
 
             Data::Instance<RPI::Shader> GetMorphTargetShader() const;
-            void SubmitMorphTargetDispatchItems(RHI::CommandList* commandList, uint32_t startIndex, uint32_t endIndex);
+            void SubmitMorphTargetDispatchItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex);
             void SetupMorphTargetScope(RHI::FrameGraphInterface frameGraph);
 
         private:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     struct MultiDeviceBufferMapResponse
     {
         //! Will hold the mapped data for each device selected in the MultiDeviceBuffer
-        AZStd::vector<void*> m_data;
+        AZStd::unordered_map<int, void*> m_data;
     };
 
     using MultiDeviceBufferInitRequest = BufferInitRequestTemplate<MultiDeviceBuffer>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -100,9 +100,17 @@ namespace AZ::RHI
             return m_deviceDispatchItems.at(deviceIndex);
         }
 
+        //! Retrieve arguments specifing a dispatch type.
+        const MultiDeviceDispatchArguments& GetArguments() const
+        {
+            return m_arguments;
+        }
+
         //! Arguments specific to a dispatch type.
         void SetArguments(const MultiDeviceDispatchArguments& arguments)
         {
+            m_arguments = arguments;
+
             for (auto& [deviceIndex, dispatchItem] : m_deviceDispatchItems)
             {
                 dispatchItem.m_arguments = arguments.GetDeviceDispatchArguments(deviceIndex);
@@ -162,6 +170,8 @@ namespace AZ::RHI
     private:
         //! A DeviceMask denoting on which devices a device-specific SingleDeviceDispatchItem should be generated
         MultiDevice::DeviceMask m_deviceMask{ MultiDevice::DefaultDevice };
+        //! Caching the arguments for the corresponding getter.
+        MultiDeviceDispatchArguments m_arguments;
         //! A map of all device-specific SingleDeviceDispatchItem, indexed by the device index
         AZStd::unordered_map<int, SingleDeviceDispatchItem> m_deviceDispatchItems;
     };

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -134,7 +134,7 @@ namespace AZ::RHI
         {
             if (auto* lastScope = attachment->GetLastScope())
             {
-                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain()->GetDeviceSwapChain(RHI::MultiDevice::DefaultDeviceIndex).get());
+                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain()->GetDeviceSwapChain(lastScope->GetDeviceIndex()).get());
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -230,7 +230,7 @@ namespace AZ::RHI
             }
             else
             {
-                response.m_data.push_back(deviceMapResponse.m_data);
+                response.m_data[deviceIndex] = deviceMapResponse.m_data;
             }
 
             return resultCode;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -67,7 +67,7 @@ namespace AZ
 
             //! Maps all buffers in the underlying multi-device buffer and returns a vector
             //! with mapped addresses, one per device.
-            AZStd::vector<void*> Map(size_t byteCount, uint64_t byteOffset);
+            AZStd::unordered_map<int, void*> Map(size_t byteCount, uint64_t byteOffset);
             void Unmap();
 
             //! Get attachment id if this buffer is used as scope attachment

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
@@ -47,8 +47,8 @@ namespace AZ
             //! Get the buffer's size
             uint32_t GetSize();
 
-            //! Get the buffer's address. User can write data to the address. 
-            void* GetBufferAddress();
+            //! Get the buffer's address. User can write data to the address.
+            AZStd::unordered_map<int, void*> GetBufferAddress();
 
             //! Get IndexBufferView if this buffer is used as index buffer
             RHI::MultiDeviceIndexBufferView GetIndexBufferView(RHI::IndexFormat format);
@@ -62,9 +62,9 @@ namespace AZ
             DynamicBuffer() = default;
 
             // initialize function called by DynamicBufferAllocator which to initialize this buffer
-            void Initialize(void* address, uint32_t size);
+            void Initialize(AZStd::unordered_map<int, void*> address, uint32_t size);
 
-            void* m_address = nullptr;
+            AZStd::unordered_map<int, void*> m_address;
             uint32_t m_size;
 
             // The allocator which allocated this DyanmicBuffer. 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
@@ -48,7 +48,7 @@ namespace AZ
             uint32_t GetSize();
 
             //! Get the buffer's address. User can write data to the address.
-            AZStd::unordered_map<int, void*> GetBufferAddress();
+            const AZStd::unordered_map<int, void*>& GetBufferAddress();
 
             //! Get IndexBufferView if this buffer is used as index buffer
             RHI::MultiDeviceIndexBufferView GetIndexBufferView(RHI::IndexFormat format);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
@@ -71,7 +71,7 @@ namespace AZ
             uint32_t m_currentAllocatedSize = 0;
 
             uint32_t m_ringBufferSize = 0;
-            void* m_ringBufferStartAddress = 0;
+            AZStd::unordered_map<int, void*> m_ringBufferStartAddress;
             Data::Instance<Buffer> m_ringBuffer;
 
             // Allocation history which are in use by GPU. 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBufferAllocator.h
@@ -71,7 +71,7 @@ namespace AZ
             uint32_t m_currentAllocatedSize = 0;
 
             uint32_t m_ringBufferSize = 0;
-            AZStd::unordered_map<int, void*> m_ringBufferStartAddress;
+            AZStd::unordered_map<int, void*> m_ringBufferStartAddresses;
             Data::Instance<Buffer> m_ringBuffer;
 
             // Allocation history which are in use by GPU. 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
@@ -75,8 +75,8 @@ namespace AZ
             QueryResultCode GetQueryResultFromIndices(uint64_t* result, RHI::Interval rhiQueryIndices, RHI::QueryResultFlagBits queryResultFlag);
 
             // Depending on the QueryType, the method to poll data from the queries vary.
-            virtual RHI::ResultCode BeginQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList);
-            virtual RHI::ResultCode EndQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList);
+            virtual RHI::ResultCode BeginQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context);
+            virtual RHI::ResultCode EndQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context);
 
             // Calculate the query result size in bytes. The size of the result depends on the QueryType.
             void CalculateResultSize();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/TimestampQueryPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/TimestampQueryPool.h
@@ -30,8 +30,8 @@ namespace AZ
 
         protected:
             // RPI::QueryPool overrides...
-            RHI::ResultCode BeginQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList);
-            RHI::ResultCode EndQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList);
+            RHI::ResultCode BeginQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context);
+            RHI::ResultCode EndQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context);
 
         private:
             TimestampQueryPool(uint32_t queryCapacity, uint32_t queriesPerResult, RHI::QueryType queryType, RHI::PipelineStatisticsFlags statisticsFlags);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -102,9 +102,9 @@ namespace AZ
             // The per-object shader resource group
             Data::Instance<ShaderResourceGroup> m_objectSrg;
 
-            // We hold ConstPtr<RHI::SingleDeviceShaderResourceGroup> instead of Instance<RPI::ShaderResourceGroup> because the Material class
+            // We hold ConstPtr<RHI::MultiDeviceShaderResourceGroup> instead of Instance<RPI::ShaderResourceGroup> because the Material class
             // does not allow public access to its Instance<RPI::ShaderResourceGroup>.
-            ConstPtr<RHI::SingleDeviceShaderResourceGroup> m_materialSrg;
+            ConstPtr<RHI::MultiDeviceShaderResourceGroup> m_materialSrg;
 
             AZStd::fixed_vector<Data::Instance<ShaderResourceGroup>, RHI::MultiDeviceDrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 
-#include <Atom/RHI/SingleDeviceDispatchItem.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
 
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
@@ -73,7 +73,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> m_drawSrg = nullptr;
 
             // The draw item submitted by this pass
-            RHI::SingleDeviceDispatchItem m_dispatchItem;
+            RHI::MultiDeviceDispatchItem m_dispatchItem;
 
             // Whether or not to make the pass a full-screen compute pass. If set to true, the dispatch group counts will
             // be automatically calculated from the size of the first output attachment and the group size dimensions.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI/SingleDeviceCopyItem.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
 #include <Atom/RHI.Reflect/Scissor.h>
 #include <Atom/RHI.Reflect/Viewport.h>
@@ -54,7 +54,7 @@ namespace AZ
             RHI::CopyItemType GetCopyItemType();
 
             // The copy item submitted to the command list
-            RHI::SingleDeviceCopyItem m_copyItem;
+            RHI::MultiDeviceCopyItem m_copyItem;
 
             // Potential data provided by the PassRequest
             CopyPassData m_data;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/FullscreenTrianglePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/FullscreenTrianglePass.h
@@ -74,7 +74,7 @@ namespace AZ
             PipelineStateForDraw m_pipelineStateForDraw;
 
             // The draw item submitted by this pass
-            RHI::SingleDeviceDrawItem m_item;
+            RHI::MultiDeviceDrawItem m_item;
 
             // The stencil reference value for the draw item
             uint32_t m_stencilRef;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -97,8 +97,8 @@ namespace AZ
             void ResetSrgs();
 
             // Set srgs for pass's execution
-            void SetSrgsForDraw(RHI::CommandList* commandList);
-            void SetSrgsForDispatch(RHI::CommandList* commandList);
+            void SetSrgsForDraw(const RHI::FrameGraphExecuteContext& context);
+            void SetSrgsForDispatch(const RHI::FrameGraphExecuteContext& context);
 
             // Set PipelineViewTag associated for this pass
             // If the View bound to the tag exists,the view's srg will be collected to pass' srg bind list

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
@@ -9,7 +9,7 @@
 
 #include <AtomCore/Instance/Instance.h>
 
-#include <Atom/RHI/SingleDeviceCopyItem.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RPI.Public/Buffer/Buffer.h>
@@ -58,7 +58,7 @@ namespace AZ
             u16 m_sourceArraySlice = 0;
 
             // Copy item to be submitted to command list
-            RHI::SingleDeviceCopyItem m_copyItem;
+            RHI::MultiDeviceCopyItem m_copyItem;
         };
 
         //! Render preview of specified image attachment to the selected output attachment.
@@ -134,7 +134,7 @@ namespace AZ
                 // Cached pipeline state descriptor
                 RHI::PipelineStateDescriptorForDraw m_pipelineStateDescriptor;
                 // The draw item for drawing the image preview for this type of image
-                RHI::SingleDeviceDrawItem m_item;
+                RHI::MultiDeviceDrawItem m_item{RHI::MultiDevice::AllDevices};
 
                 // Key to pass to the SRG when desired shader variant isn't found
                 ShaderVariantKey m_shaderVariantKeyFallback;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -216,7 +216,7 @@ namespace AZ
             }
         }
 
-        AZStd::vector<void*> Buffer::Map(size_t byteCount, uint64_t byteOffset)
+        AZStd::unordered_map<int, void*> Buffer::Map(size_t byteCount, uint64_t byteOffset)
         {
             if (byteOffset + byteCount > m_rhiBuffer->GetDescriptor().m_byteCount)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
@@ -17,7 +17,7 @@ namespace AZ
         {
             if (m_size >= size)
             {
-                for(auto [deviceIndex, address] : m_address)
+                for(auto& [deviceIndex, address] : m_address)
                 {
                     memcpy(address, data, size);
                 }
@@ -32,7 +32,7 @@ namespace AZ
             return m_size;
         }
 
-        AZStd::unordered_map<int, void*> DynamicBuffer::GetBufferAddress()
+        const AZStd::unordered_map<int, void*>& DynamicBuffer::GetBufferAddress()
         {
             return m_address;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
@@ -17,7 +17,10 @@ namespace AZ
         {
             if (m_size >= size)
             {
-                memcpy(m_address, data, size);
+                for(auto [deviceIndex, address] : m_address)
+                {
+                    memcpy(address, data, size);
+                }
                 return true;
             }
             AZ_Assert(false, "Can't write data out of range");
@@ -29,7 +32,7 @@ namespace AZ
             return m_size;
         }
 
-        void* DynamicBuffer::GetBufferAddress()
+        AZStd::unordered_map<int, void*> DynamicBuffer::GetBufferAddress()
         {
             return m_address;
         }
@@ -44,7 +47,7 @@ namespace AZ
             return m_allocator->GetStreamBufferView(this, strideByteCount);
         }
 
-        void DynamicBuffer::Initialize(void* address, uint32_t size)
+        void DynamicBuffer::Initialize(AZStd::unordered_map<int, void*> address, uint32_t size)
         {
             m_address = address;
             m_size = size;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
@@ -39,7 +39,7 @@ namespace AZ
             
             m_ringBufferSize = ringBufferSize;
 
-            m_ringBufferStartAddress = m_ringBuffer->Map(m_ringBufferSize, 0);
+            m_ringBufferStartAddresses = m_ringBuffer->Map(m_ringBufferSize, 0);
             
             m_currentPosition = 0;
             m_endPositionLimit = 0;
@@ -54,7 +54,7 @@ namespace AZ
         {
             m_ringBuffer->Unmap();
             m_ringBuffer = nullptr;
-            m_ringBufferStartAddress.clear();
+            m_ringBufferStartAddresses.clear();
         }
 
         // [GFX TODO][ATOM-13182] Add unit tests for DynamicBufferAllocator's Allocate function 
@@ -64,7 +64,7 @@ namespace AZ
             uint32_t allocatePosition = 0;
 
             //m_ringBufferStartAddress can be null for Null back end
-            if (m_ringBufferStartAddress.empty())
+            if (m_ringBufferStartAddresses.empty())
             {
                 return nullptr;
             }
@@ -124,7 +124,7 @@ namespace AZ
             m_currentAllocatedSize += size;
 
             RHI::Ptr<DynamicBuffer> allocatedBuffer = aznew DynamicBuffer();
-            for(auto [deviceIndex, address] : m_ringBufferStartAddress)
+            for(auto [deviceIndex, address] : m_ringBufferStartAddresses)
             {
                 allocatedBuffer->m_address[deviceIndex] = (uint8_t*)address + allocatePosition;
             }
@@ -155,9 +155,9 @@ namespace AZ
 
         uint32_t DynamicBufferAllocator::GetBufferAddressOffset(RHI::Ptr<DynamicBuffer> dynamicBuffer)
         {
-            AZ_Error("DynamicBufferAllocator", !m_ringBufferStartAddress.empty(), "No addresses available!");
+            AZ_Error("DynamicBufferAllocator", !m_ringBufferStartAddresses.empty(), "No addresses available!");
 
-            auto it = m_ringBufferStartAddress.begin();
+            auto it = m_ringBufferStartAddresses.begin();
 
             return aznumeric_cast<uint32_t>((uint8_t*)dynamicBuffer->m_address[it->first] - (uint8_t*)it->second);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBufferAllocator.cpp
@@ -39,7 +39,13 @@ namespace AZ
             
             m_ringBufferSize = ringBufferSize;
 
-            m_ringBufferStartAddresses = m_ringBuffer->Map(m_ringBufferSize, 0);
+            for (auto& [deviceIndex, address] : m_ringBuffer->Map(m_ringBufferSize, 0))
+            {
+                if (address != nullptr)
+                {
+                    m_ringBufferStartAddresses[deviceIndex] = address;
+                }
+            }
             
             m_currentPosition = 0;
             m_endPositionLimit = 0;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
@@ -98,7 +98,7 @@ namespace AZ
                 return QueryResultCode::Fail;
             }
 
-            [[maybe_unused]] RHI::ResultCode resultCode = m_queryPool->BeginQueryInternal(rhiQueryIndices.value(), *context.GetCommandList());
+            [[maybe_unused]] RHI::ResultCode resultCode = m_queryPool->BeginQueryInternal(rhiQueryIndices.value(), context);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to begin recording the query");
 
             m_cachedScopeId = context.GetScopeId();
@@ -131,7 +131,7 @@ namespace AZ
                 return QueryResultCode::Fail;
             }
 
-            [[maybe_unused]] RHI::ResultCode resultCode = m_queryPool->EndQueryInternal(rhiQueryIndices.value(), *context.GetCommandList());
+            [[maybe_unused]] RHI::ResultCode resultCode = m_queryPool->EndQueryInternal(rhiQueryIndices.value(), context);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to end recording the query");
 
             return QueryResultCode::Success;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/RHI/Factory.h>
+#include <Atom/RHI/FrameGraphExecuteContext.h>
 #include <Atom/RHI/FrameGraphInterface.h>
 #include <Atom/RHI/MultiDeviceQuery.h>
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
@@ -154,20 +154,20 @@ namespace AZ
             m_queryRegistry.erase(query);
         }
 
-        RHI::ResultCode QueryPool::BeginQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
+        RHI::ResultCode QueryPool::BeginQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context)
         {
             auto rhiQueryArray = GetRhiQueryArray();
             RHI::Ptr<RHI::MultiDeviceQuery> beginQuery = rhiQueryArray[rhiQueryIndices.m_min];
 
-            return beginQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->Begin(commandList);
+            return beginQuery->GetDeviceQuery(context.GetDeviceIndex())->Begin(*context.GetCommandList());
         }
 
-        RHI::ResultCode QueryPool::EndQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
+        RHI::ResultCode QueryPool::EndQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context)
         {
             auto rhiQueryArray = GetRhiQueryArray();
             RHI::Ptr<RHI::MultiDeviceQuery> endQuery = rhiQueryArray[rhiQueryIndices.m_max];
 
-            return endQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->End(commandList);
+            return endQuery->GetDeviceQuery(context.GetDeviceIndex())->End(*context.GetCommandList());
         }
 
         AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> RPI::QueryPool::GetRhiQueryArray() const

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <Atom/RHI/FrameGraphExecuteContext.h>
+
 #include <Atom/RPI.Public/GpuQuery/TimestampQueryPool.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
@@ -24,20 +24,20 @@ namespace AZ
             return AZStd::unique_ptr<QueryPool>(aznew TimestampQueryPool(queryCount, RhiQueriesPerTimestampResult, RHI::QueryType::Timestamp, RHI::PipelineStatisticsFlags::None));
         }
 
-        RHI::ResultCode TimestampQueryPool::BeginQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
+        RHI::ResultCode TimestampQueryPool::BeginQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context)
         {
             AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
             AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> beginQuery = rhiQueryArray[rhiQueryIndices.m_min];
 
-            return beginQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->WriteTimestamp(commandList);
+            return beginQuery->GetDeviceQuery(context.GetDeviceIndex())->WriteTimestamp(*context.GetCommandList());
         }
 
-        RHI::ResultCode TimestampQueryPool::EndQueryInternal(RHI::Interval rhiQueryIndices, RHI::CommandList& commandList)
+        RHI::ResultCode TimestampQueryPool::EndQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context)
         {
             AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> rhiQueryArray = GetRhiQueryArray();
             AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> endQuery = rhiQueryArray[rhiQueryIndices.m_max];
 
-            return endQuery->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->WriteTimestamp(commandList);
+            return endQuery->GetDeviceQuery(context.GetDeviceIndex())->WriteTimestamp(*context.GetCommandList());
         }
     };  // Namespace RPI
 };  // Namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -469,7 +469,7 @@ namespace AZ
             if (m_drawPacket)
             {
                 m_activeShaders = shaderList;
-                m_materialSrg = m_material->GetRHIShaderResourceGroup() ? m_material->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex): nullptr;
+                m_materialSrg = m_material->GetRHIShaderResourceGroup();
                 return true;
             }
             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -458,7 +458,7 @@ namespace AZ
             {
                 if (readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex])
                 {
-                    context.GetCommandList()->Submit(readbackItem.m_copyItem.GetDeviceCopyItem(RHI::MultiDevice::DefaultDeviceIndex));
+                    context.GetCommandList()->Submit(readbackItem.m_copyItem.GetDeviceCopyItem(context.GetDeviceIndex()));
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -300,7 +300,7 @@ namespace AZ
 
         void AttachmentReadback::DecomposeExecute(const RHI::FrameGraphExecuteContext& context)
         {
-            context.GetCommandList()->Submit(m_dispatchItem.GetDeviceDispatchItem(RHI::MultiDevice::DefaultDeviceIndex));
+            context.GetCommandList()->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
         }
         
         void AttachmentReadback::CopyPrepare(RHI::FrameGraphInterface frameGraph)
@@ -416,7 +416,10 @@ namespace AZ
                     AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
                     imageSubresourceLayouts.resize_no_construct(m_imageDescriptor.m_mipLevels);
                     size_t totalSizeInBytes = 0;
-                    image->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex)
+                    // compute lowest device index from mask
+                    int deviceIndex = static_cast<int>(image->GetDeviceMask());
+                    deviceIndex = AZ::Log2(deviceIndex & -deviceIndex);
+                    image->GetDeviceImage(deviceIndex)
                         ->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), &totalSizeInBytes);
                     AZ::u64 byteCount = totalSizeInBytes;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -169,7 +169,7 @@ namespace AZ
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            SetSrgsForDispatch(commandList);
+            SetSrgsForDispatch(context);
 
             commandList->Submit(m_dispatchItem);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -142,7 +142,7 @@ namespace AZ
         {
             if (m_copyItem.m_type != RHI::CopyItemType::Invalid)
             {
-                context.GetCommandList()->Submit(m_copyItem);
+                context.GetCommandList()->Submit(m_copyItem.GetDeviceCopyItem(context.GetDeviceIndex()));
             }
         }
 
@@ -150,18 +150,18 @@ namespace AZ
 
         void CopyPass::CopyBuffer(const RHI::FrameGraphCompileContext& context)
         {
-            RHI::SingleDeviceCopyBufferDescriptor copyDesc;
+            RHI::MultiDeviceCopyBufferDescriptor copyDesc;
 
             // Source Buffer
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
-            copyDesc.m_sourceBuffer = sourceBuffer;
+            const AZ::RHI::MultiDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId());
+            copyDesc.m_mdSourceBuffer = sourceBuffer;
             copyDesc.m_size = static_cast<uint32_t>(sourceBuffer->GetDescriptor().m_byteCount);
             copyDesc.m_sourceOffset = m_data.m_bufferSourceOffset;
 
             // Destination Buffer
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
+            copyDesc.m_mdDestinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId());
             copyDesc.m_destinationOffset = m_data.m_bufferDestinationOffset;
 
             m_copyItem = copyDesc;
@@ -169,19 +169,19 @@ namespace AZ
 
         void CopyPass::CopyImage(const RHI::FrameGraphCompileContext& context)
         {
-            RHI::SingleDeviceCopyImageDescriptor copyDesc;
+            RHI::MultiDeviceCopyImageDescriptor copyDesc;
 
             // Source Image
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
-            copyDesc.m_sourceImage = sourceImage;
+            const AZ::RHI::MultiDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId());
+            copyDesc.m_mdSourceImage = sourceImage;
             copyDesc.m_sourceSize = sourceImage->GetDescriptor().m_size;
             copyDesc.m_sourceOrigin = m_data.m_imageSourceOrigin;
             copyDesc.m_sourceSubresource = m_data.m_imageSourceSubresource;
 
             // Destination Image
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
+            copyDesc.m_mdDestinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId());
             copyDesc.m_destinationOrigin = m_data.m_imageDestinationOrigin;
             copyDesc.m_destinationSubresource = m_data.m_imageDestinationSubresource;
 
@@ -190,12 +190,12 @@ namespace AZ
 
         void CopyPass::CopyBufferToImage(const RHI::FrameGraphCompileContext& context)
         {
-            RHI::SingleDeviceCopyBufferToImageDescriptor copyDesc;
+            RHI::MultiDeviceCopyBufferToImageDescriptor copyDesc;
 
             // Source Buffer
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
-            copyDesc.m_sourceBuffer = sourceBuffer;
+            const AZ::RHI::MultiDeviceBuffer* sourceBuffer = context.GetBuffer(copySource.GetAttachment()->GetAttachmentId());
+            copyDesc.m_mdSourceBuffer = sourceBuffer;
             copyDesc.m_sourceSize = m_data.m_sourceSize;
             copyDesc.m_sourceOffset = m_data.m_bufferSourceOffset;
             copyDesc.m_sourceBytesPerRow = m_data.m_bufferSourceBytesPerRow;
@@ -203,7 +203,7 @@ namespace AZ
 
             // Destination Image
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
+            copyDesc.m_mdDestinationImage = context.GetImage(copyDest.GetAttachment()->GetAttachmentId());
             copyDesc.m_destinationOrigin = m_data.m_imageDestinationOrigin;
             copyDesc.m_destinationSubresource = m_data.m_imageDestinationSubresource;
 
@@ -212,19 +212,19 @@ namespace AZ
 
         void CopyPass::CopyImageToBuffer(const RHI::FrameGraphCompileContext& context)
         {
-            RHI::SingleDeviceCopyImageToBufferDescriptor copyDesc;
+            RHI::MultiDeviceCopyImageToBufferDescriptor copyDesc;
 
             // Source Image
             PassAttachmentBinding& copySource = GetInputBinding(0);
-            const AZ::RHI::SingleDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId())->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex).get();
-            copyDesc.m_sourceImage = sourceImage;
+            const AZ::RHI::MultiDeviceImage* sourceImage = context.GetImage(copySource.GetAttachment()->GetAttachmentId());
+            copyDesc.m_mdSourceImage = sourceImage;
             copyDesc.m_sourceSize = sourceImage->GetDescriptor().m_size;
             copyDesc.m_sourceOrigin = m_data.m_imageSourceOrigin;
             copyDesc.m_sourceSubresource = m_data.m_imageSourceSubresource;
 
             // Destination Buffer
             PassAttachmentBinding& copyDest = GetOutputBinding(0);
-            copyDesc.m_destinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId())->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
+            copyDesc.m_mdDestinationBuffer = context.GetBuffer(copyDest.GetAttachment()->GetAttachmentId());
             copyDesc.m_destinationOffset = m_data.m_bufferDestinationOffset;
             copyDesc.m_destinationBytesPerRow = m_data.m_bufferDestinationBytesPerRow;
             copyDesc.m_destinationBytesPerImage = m_data.m_bufferDestinationBytesPerImage;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -179,9 +179,9 @@ namespace AZ
             RHI::DrawLinear draw = RHI::DrawLinear();
             draw.m_vertexCount = 3;
 
-            m_item.m_arguments = RHI::SingleDeviceDrawArguments(draw);
-            m_item.m_pipelineState = m_pipelineStateForDraw.Finalize()->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            m_item.m_stencilRef = static_cast<uint8_t>(m_stencilRef);
+            m_item.SetArguments(RHI::MultiDeviceDrawArguments(draw));
+            m_item.SetPipelineState(m_pipelineStateForDraw.Finalize());
+            m_item.SetStencilRef(static_cast<uint8_t>(m_stencilRef));
         }
 
         void FullscreenTrianglePass::UpdateShaderOptions(const ShaderOptionList& shaderOptions)
@@ -297,7 +297,7 @@ namespace AZ
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);
 
-            commandList->Submit(m_item);
+            commandList->Submit(m_item.GetDeviceDrawItem(context.GetDeviceIndex()));
         }
         
     }   // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -36,6 +36,7 @@ namespace AZ
 
         FullscreenTrianglePass::FullscreenTrianglePass(const PassDescriptor& descriptor)
             : RenderPass(descriptor)
+            , m_item(RHI::MultiDevice::AllDevices)
             , m_passDescriptor(descriptor)
         {
             LoadShader();
@@ -292,7 +293,7 @@ namespace AZ
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            SetSrgsForDraw(commandList);
+            SetSrgsForDraw(context);
 
             commandList->SetViewport(m_viewportState);
             commandList->SetScissor(m_scissorState);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -280,7 +280,7 @@ namespace AZ
             {
                 commandList->SetViewport(m_viewportState);
                 commandList->SetScissor(m_scissorState);
-                SetSrgsForDraw(commandList);
+                SetSrgsForDraw(context);
                 SubmitDrawItems(context, context.GetSubmitRange().m_startIndex, context.GetSubmitRange().m_endIndex, 0);
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -410,19 +410,20 @@ namespace AZ
             }
         }
 
-        void RenderPass::SetSrgsForDraw(RHI::CommandList* commandList)
+        void RenderPass::SetSrgsForDraw(const RHI::FrameGraphExecuteContext& context)
         {
             for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDraw(*(itr.second->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex)));
+                context.GetCommandList()->SetShaderResourceGroupForDraw(*(itr.second->GetDeviceShaderResourceGroup(context.GetDeviceIndex())));
             }
         }
 
-        void RenderPass::SetSrgsForDispatch(RHI::CommandList* commandList)
+        void RenderPass::SetSrgsForDispatch(const RHI::FrameGraphExecuteContext& context)
         {
             for (auto itr : m_shaderResourceGroupsToBind)
             {
-                commandList->SetShaderResourceGroupForDispatch(*(itr.second->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex)));
+                context.GetCommandList()->SetShaderResourceGroupForDispatch(
+                    *(itr.second->GetDeviceShaderResourceGroup(context.GetDeviceIndex())));
             }
         }
 

--- a/Gems/AtomTressFX/Code/Passes/HairSkinningComputePass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairSkinningComputePass.cpp
@@ -230,7 +230,7 @@ namespace AZ
                 // The following will bind all registered Srgs set in m_shaderResourceGroupsToBind
                 // and sends them to the command list ahead of the dispatch.
                 // This includes the PerView, PerScene and PerPass srgs (what about per draw?)
-                SetSrgsForDispatch(commandList);
+                SetSrgsForDispatch(context);
 
                 auto it = m_dispatchItems.begin();
                 AZStd::advance(it, context.GetSubmitRange().m_startIndex);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
@@ -174,44 +174,48 @@ namespace AZ
                 {
                     SubmitItem& submitItem = m_submitItems.emplace_back();
                     submitItem.m_shaderResourceGroup = diffuseProbeGrid->GetBorderUpdateRowIrradianceSrg()->GetRHIShaderResourceGroup();
-                    submitItem.m_dispatchItem.m_arguments = m_rowDispatchArgs;
-                    submitItem.m_dispatchItem.m_pipelineState = m_rowPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX * (DiffuseProbeGrid::DefaultNumIrradianceTexels + 2);
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY;
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+                    auto arguments = m_columnDispatchArgs;
+                    arguments.m_totalNumberOfThreadsX = probeCountX * (DiffuseProbeGrid::DefaultNumIrradianceTexels + 2);
+                    arguments.m_totalNumberOfThreadsY = probeCountY;
+                    arguments.m_totalNumberOfThreadsZ = 1;
+                    submitItem.m_dispatchItem.SetPipelineState(m_rowPipelineState);
+                    submitItem.m_dispatchItem.SetArguments(arguments);
                 }
 
                 // column irradiance
                 {
                     SubmitItem& submitItem = m_submitItems.emplace_back();
                     submitItem.m_shaderResourceGroup = diffuseProbeGrid->GetBorderUpdateColumnIrradianceSrg()->GetRHIShaderResourceGroup();
-                    submitItem.m_dispatchItem.m_arguments = m_columnDispatchArgs;
-                    submitItem.m_dispatchItem.m_pipelineState = m_columnPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX;
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY * (DiffuseProbeGrid::DefaultNumIrradianceTexels + 2);
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+                    auto arguments = m_columnDispatchArgs;
+                    arguments.m_totalNumberOfThreadsX = probeCountX;
+                    arguments.m_totalNumberOfThreadsY = probeCountY * (DiffuseProbeGrid::DefaultNumIrradianceTexels + 2);
+                    arguments.m_totalNumberOfThreadsZ = 1;
+                    submitItem.m_dispatchItem.SetPipelineState(m_columnPipelineState);
+                    submitItem.m_dispatchItem.SetArguments(arguments);
                 }
 
                 // row distance
                 {
                     SubmitItem& submitItem = m_submitItems.emplace_back();
                     submitItem.m_shaderResourceGroup = diffuseProbeGrid->GetBorderUpdateRowDistanceSrg()->GetRHIShaderResourceGroup();
-                    submitItem.m_dispatchItem.m_arguments = m_rowDispatchArgs;
-                    submitItem.m_dispatchItem.m_pipelineState = m_rowPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX * (DiffuseProbeGrid::DefaultNumDistanceTexels + 2);
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY;
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+                    auto arguments = m_columnDispatchArgs;
+                    arguments.m_totalNumberOfThreadsX = probeCountX * (DiffuseProbeGrid::DefaultNumDistanceTexels + 2);
+                    arguments.m_totalNumberOfThreadsY = probeCountY;
+                    arguments.m_totalNumberOfThreadsZ = 1;
+                    submitItem.m_dispatchItem.SetPipelineState(m_rowPipelineState);
+                    submitItem.m_dispatchItem.SetArguments(arguments);
                 }
 
                 // column distance
                 {
                     SubmitItem& submitItem = m_submitItems.emplace_back();
                     submitItem.m_shaderResourceGroup = diffuseProbeGrid->GetBorderUpdateColumnDistanceSrg()->GetRHIShaderResourceGroup();
-                    submitItem.m_dispatchItem.m_arguments = m_columnDispatchArgs;
-                    submitItem.m_dispatchItem.m_pipelineState = m_columnPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX = probeCountX;
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY = probeCountY * (DiffuseProbeGrid::DefaultNumDistanceTexels + 2);
-                    submitItem.m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ = 1;
+                    auto arguments = m_columnDispatchArgs;
+                    arguments.m_totalNumberOfThreadsX = probeCountX;
+                    arguments.m_totalNumberOfThreadsY = probeCountY * (DiffuseProbeGrid::DefaultNumDistanceTexels + 2);
+                    arguments.m_totalNumberOfThreadsZ = 1;
+                    submitItem.m_dispatchItem.SetPipelineState(m_columnPipelineState);
+                    submitItem.m_dispatchItem.SetArguments(arguments);
                 }
             }     
         }
@@ -227,7 +231,7 @@ namespace AZ
                 SubmitItem& submitItem = m_submitItems[index];
 
                 commandList->SetShaderResourceGroupForDispatch(*submitItem.m_shaderResourceGroup->GetDeviceShaderResourceGroup(context.GetDeviceIndex()));
-                commandList->Submit(submitItem.m_dispatchItem, index++);
+                commandList->Submit(submitItem.m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()), index++);
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <Atom/RHI/CommandList.h>
+#include <Atom/RHI/MultiDeviceDispatchItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -49,8 +50,8 @@ namespace AZ
             // the data for submits in this pass are pre-built to properly handle submitting on multiple threads
             struct SubmitItem
             {
-                RHI::MultiDeviceShaderResourceGroup* m_shaderResourceGroup = nullptr;
-                RHI::SingleDeviceDispatchItem m_dispatchItem;
+                RHI::MultiDeviceShaderResourceGroup* m_shaderResourceGroup{nullptr};
+                RHI::MultiDeviceDispatchItem m_dispatchItem{RHI::MultiDevice::AllDevices};
             };
 
             AZStd::vector<SubmitItem> m_submitItems;

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.cpp
@@ -35,12 +35,8 @@ namespace AZ
                 MESHLETS_THREAD_GROUP_SIZE, 1, 1
             );
 
-            m_dispatchItem.m_arguments = dispatchArgs;
-            m_dispatchItem.m_shaderResourceGroupCount = 1;      // Per pass srg can be added by the individual passes
-            m_dispatchItem.m_shaderResourceGroups =
-            {
-                meshletsDataSrg->GetRHIShaderResourceGroup()
-            };
+            m_dispatchItem.SetArguments(dispatchArgs);
+            m_dispatchItem.SetShaderResourceGroups({meshletsDataSrg->GetRHIShaderResourceGroup(), 1});       // Per pass srg can be added by the individual passes
             m_meshletsDataSrg = meshletsDataSrg;    // can also be retrieve directly from the m_dispatchItem
 
             m_shader = shader;
@@ -48,7 +44,7 @@ namespace AZ
             {
                 RHI::PipelineStateDescriptorForDispatch pipelineDesc;
                 m_shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
-                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                m_dispatchItem.SetPipelineState(m_shader->AcquirePipelineState(pipelineDesc));
             }
         }
 
@@ -59,7 +55,7 @@ namespace AZ
             {
                 RHI::PipelineStateDescriptorForDispatch pipelineDesc;
                 m_shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
-                m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineDesc)->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                m_dispatchItem.SetPipelineState(m_shader->AcquirePipelineState(pipelineDesc));
             }
         }
 

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.h
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsDispatchItem.h
@@ -49,7 +49,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> GetMeshletDataSrg() { return m_meshletsDataSrg;  }
 
         private:
-            RHI::MultiDeviceDispatchItem m_dispatchItem;
+            RHI::MultiDeviceDispatchItem m_dispatchItem{RHI::MultiDevice::AllDevices};
             Data::Instance<RPI::ShaderResourceGroup> m_meshletsDataSrg;
             RPI::Shader* m_shader;
         };

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
@@ -397,7 +397,7 @@ namespace AZ
 
                         RHI::ShaderInputBufferIndex indexHandle = meshRenderData.RenderObjectSrg->FindShaderInputBufferIndex(bufferDesc.m_paramNameInSrg);
                         bufferDesc.m_resourceShaderIndex = indexHandle.GetIndex();
-                        if (!meshRenderData.RenderObjectSrg->SetBufferView(indexHandle, meshRenderData.RenderBuffersViews[stream]->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+                        if (!meshRenderData.RenderObjectSrg->SetBufferView(indexHandle, meshRenderData.RenderBuffersViews[stream]))
                         {
                             AZ_Error("Meshlets", false, "Failed to bind render buffer view for %s", bufferDesc.m_bufferName.GetCStr());
                             return false;
@@ -409,7 +409,7 @@ namespace AZ
                         bufferDesc.m_viewOffsetInBytes = meshRenderData.ComputeBuffersDescriptors[mappedIdx].m_viewOffsetInBytes;
 
                         meshRenderData.IndexBufferView = RHI::MultiDeviceIndexBufferView(
-                            *meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                            *meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer(),
                             bufferDesc.m_viewOffsetInBytes,
                             (uint64_t)bufferDesc.m_elementCount * bufferDesc.m_elementSize,
                             (bufferDesc.m_elementFormat == RHI::Format::R32_UINT) ? RHI::IndexFormat::Uint32 : RHI::IndexFormat::Uint16);

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
@@ -120,7 +120,7 @@ namespace AZ
                 return false;
             }
 
-            if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+            if (!srg->SetBufferView(bufferIndex, buffer->GetBufferView()))
             {
                 AZ_Error(warningHeader, false, "Failed to bind buffer view for [%s]", bufferDesc.m_bufferName.GetCStr());
                 return false;
@@ -196,7 +196,7 @@ namespace AZ
                 return false;
             }
 
-            if (!srg->SetBufferView(bufferIndex, bufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get()))
+            if (!srg->SetBufferView(bufferIndex, bufferView))
             {
                 AZ_Error(warningHeader, false, "Failed to bind buffer view for [%s]", bufferDesc.m_bufferName.GetCStr());
                 return false;

--- a/Gems/Meshlets/Code/Source/Meshlets/MultiDispatchComputePass.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MultiDispatchComputePass.cpp
@@ -117,7 +117,7 @@ namespace AZ
                 // The following will bind all registered Srgs set in m_shaderResourceGroupsToBind
                 // and sends them to the command list ahead of the dispatch.
                 // This includes the PerView, PerScene and PerPass srgs.
-                SetSrgsForDispatch(commandList);
+                SetSrgsForDispatch(context);
 
                 // In a similar way, add the dispatch high frequencies srgs.
                 for (uint32_t srg = 0; srg < dispatchItem->m_shaderResourceGroupCount; ++srg)

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -51,7 +51,7 @@ namespace NvCloth
             const AZ::RHI::Format expectedElementFormat);
         ~MappedBuffer();
 
-        AZStd::unordered_map<int, T*> GetBuffer()
+        const AZStd::unordered_map<int, T*>& GetBuffer()
         {
             return m_buffer;
         }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Passes/TerrainClipmapComputePass.cpp
@@ -58,10 +58,12 @@ namespace Terrain
         {
             const TerrainClipmapManager& clipmapManager = terrainFeatureProcessor->GetClipmapManager();
 
+            auto arguments{m_dispatchItem.GetArguments()};
             clipmapManager.GetMacroDispatchThreadNum(
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX,
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY,
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ);
+                arguments.m_direct.m_totalNumberOfThreadsX,
+                arguments.m_direct.m_totalNumberOfThreadsY,
+                arguments.m_direct.m_totalNumberOfThreadsZ);
+            m_dispatchItem.SetArguments(arguments);
 
             auto terrainSrg = terrainFeatureProcessor->GetTerrainShaderResourceGroup();
             if (terrainSrg)
@@ -182,10 +184,12 @@ namespace Terrain
         {
             const TerrainClipmapManager& clipmapManager = terrainFeatureProcessor->GetClipmapManager();
 
-            clipmapManager.GetDetailDispatchThreadNum(
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsX,
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsY,
-                m_dispatchItem.m_arguments.m_direct.m_totalNumberOfThreadsZ);
+            auto arguments{m_dispatchItem.GetArguments()};
+            clipmapManager.GetMacroDispatchThreadNum(
+                arguments.m_direct.m_totalNumberOfThreadsX,
+                arguments.m_direct.m_totalNumberOfThreadsY,
+                arguments.m_direct.m_totalNumberOfThreadsZ);
+            m_dispatchItem.SetArguments(arguments);
 
             auto terrainSrg = terrainFeatureProcessor->GetTerrainShaderResourceGroup();
             if (terrainSrg)


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

**This specific PR uses the `deviceIndex` into the `Scope` class and the `FrameGraphExecuteContext` introduced in the last commit in as many places as possible at the moment. This includes transitioning more `SingleDevice*` occurrences to `MultiDevice*` where we previously thought they are not necessary.**

We have 2 more PRs upcoming building on this one:
1. Completely transitioning `FrameScheduler` and `FrameGraph*` including backends to support mulit-device-resources.
2. Finalize everything with remaining transitions.

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`
