### PR TITLE
Add support for ray-traced reflections in SpecularReflectionsFeatureProcessor

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHit.azsl
@@ -35,8 +35,8 @@ void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes
     float3 cameraToHit = normalize(positionWS - ViewSrg::m_worldPosition);
     bool behindCamera = dot(cameraToHit, -ViewSrg::m_viewMatrix[2].xyz) <= 0.0f;
 
-    payload.m_offScreen = offScreen || behindCamera;
-    if (payload.m_offScreen && !RayTracingGlobalSrg::m_rayTraceFallbackData)
+    payload.m_offScreen = offScreen || behindCamera || IsRayTracingOverrideEnabled();
+    if (payload.m_offScreen && !IsRayTracingFallbackEnabled())
     {
         // the hit is offscreen and we're not raytracing fallback data, report this as a miss
         payload.m_hitT = -1.0f;
@@ -108,7 +108,7 @@ void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes
         payload.m_obstructed = (secondaryPayload.m_hitT >= 0.0f);
     }
 
-    if (payload.m_obstructed && !RayTracingGlobalSrg::m_rayTraceFallbackData)
+    if (payload.m_obstructed && !IsRayTracingFallbackEnabled())
     {
         // the hit is obstructed and we're not raytracing fallback data, report this as a miss
         payload.m_hitT = -1.0f;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
@@ -38,6 +38,14 @@ struct PayloadData
     bool   m_lightVisibilityTrace;
 };
 
+enum class ReflectionMethod
+{
+    ScreenSpace,
+    Hybrid,
+    HybridWithFallback,
+    RayTracing
+};
+
 ShaderResourceGroup RayTracingGlobalSrg : SRG_RayTracingGlobal
 {
     Texture2DMS<float>    m_depth;
@@ -53,7 +61,7 @@ ShaderResourceGroup RayTracingGlobalSrg : SRG_RayTracingGlobal
     float m_invOutputScale;
     float m_maxRayLength;
     float m_maxRoughness;
-    bool  m_rayTraceFallbackData;
+    uint m_reflectionMethod;
     bool  m_rayTraceFallbackSpecular;
 
     Sampler PointSampler
@@ -695,4 +703,16 @@ float3 GetIblSpecular(
     }
 
     return outSpecular;
+}
+
+bool IsRayTracingFallbackEnabled()
+{
+    ReflectionMethod reflectionMethod = (ReflectionMethod)RayTracingGlobalSrg::m_reflectionMethod;
+    return reflectionMethod == ReflectionMethod::HybridWithFallback || reflectionMethod == ReflectionMethod::RayTracing;
+}
+
+bool IsRayTracingOverrideEnabled()
+{
+    ReflectionMethod reflectionMethod = (ReflectionMethod)RayTracingGlobalSrg::m_reflectionMethod;
+    return reflectionMethod == ReflectionMethod::RayTracing;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingMiss.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingMiss.azsl
@@ -22,7 +22,7 @@ void Miss(inout PayloadData payload)
         return;
     }
 
-    if (RayTracingGlobalSrg::m_rayTraceFallbackData)
+    if (IsRayTracingFallbackEnabled())
     {
         // query mip0 of the global cubemap for the fallback color
         float3 sampleDir = mul(WorldRayDirection(), (float3x3)SceneSrg::m_cubemapRotationMatrix);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SpecularReflections/SpecularReflectionsFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SpecularReflections/SpecularReflectionsFeatureProcessorInterface.h
@@ -20,6 +20,14 @@ namespace AZ
             AZ_RTTI(SSROptions, "{A3DE7EDD-3680-458F-A69C-FE7550B75652}");
             AZ_CLASS_ALLOCATOR(SSROptions, SystemAllocator, 0);
 
+            enum class ReflectionMethod
+            {
+                ScreenSpace,
+                Hybrid,
+                HybridWithFallback,
+                RayTracing
+            };
+
             static void Reflect(ReflectContext* context)
             {
                 if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -33,8 +41,7 @@ namespace AZ
                         ->Field("MaxRoughness", &SSROptions::m_maxRoughness)
                         ->Field("RoughnessBias", &SSROptions::m_roughnessBias)
                         ->Field("HalfResolution", &SSROptions::m_halfResolution)
-                        ->Field("RayTracing", &SSROptions::m_rayTracing)
-                        ->Field("RayTraceFallbackData", &SSROptions::m_rayTraceFallbackData)
+                        ->Field("ReflectionMethod", &SSROptions::m_reflectionMethod)
                         ->Field("RayTraceFallbackSpecular", &SSROptions::m_rayTraceFallbackSpecular)
                         ->Field("TemporalFiltering", &SSROptions::m_temporalFiltering)
                         ->Field("TemporalFilteringStrength", &SSROptions::m_temporalFilteringStrength)
@@ -45,8 +52,8 @@ namespace AZ
             }
 
             bool IsEnabled() const { return m_enable; }
-            bool IsRayTracingEnabled() const { return m_enable && m_rayTracing; }
-            bool IsRayTracingFallbackEnabled() const { return m_enable && m_rayTracing && m_rayTraceFallbackData; }
+            bool IsRayTracingEnabled() const { return m_enable && m_reflectionMethod != ReflectionMethod::ScreenSpace; }
+            bool IsRayTracingFallbackEnabled() const { return IsRayTracingEnabled() && m_reflectionMethod != ReflectionMethod::Hybrid; }
             bool IsLuminanceClampEnabled() const { return m_enable && m_luminanceClamp; }
             bool IsTemporalFilteringEnabled() const { return m_enable && m_temporalFiltering; }
             float GetOutputScale() const { return m_halfResolution ? 0.5f : 1.0f; }
@@ -58,8 +65,7 @@ namespace AZ
             float m_maxRoughness = 0.31f;
             float m_roughnessBias = 0.0f;
             bool  m_halfResolution = true;
-            bool  m_rayTracing = true;
-            bool  m_rayTraceFallbackData = true;
+            ReflectionMethod m_reflectionMethod = ReflectionMethod::HybridWithFallback;
             bool  m_rayTraceFallbackSpecular = false;
             bool  m_temporalFiltering = true;
             float m_temporalFilteringStrength = 1.0f;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
@@ -102,7 +102,7 @@ namespace AZ
             m_shaderResourceGroup->SetConstant(m_outputHeightNameIndex, outputImageDescriptor.m_size.m_height);
             m_shaderResourceGroup->SetConstant(m_mipLevelsNameIndex, aznumeric_cast<uint32_t>(reflectionImageDescriptor.m_mipLevels));
             m_shaderResourceGroup->SetConstant(m_coneTracingNameIndex, ssrOptions.m_coneTracing);
-            m_shaderResourceGroup->SetConstant(m_rayTracingNameIndex, ssrOptions.m_rayTracing);
+            m_shaderResourceGroup->SetConstant(m_rayTracingNameIndex, ssrOptions.IsRayTracingEnabled());
             m_shaderResourceGroup->SetConstant(m_temporalFilteringNameIndex, ssrOptions.m_temporalFiltering);
             m_shaderResourceGroup->SetConstant(m_invTemporalFilteringStrengthNameIndex, 1.0f / ssrOptions.m_temporalFilteringStrength);
             m_shaderResourceGroup->SetConstant(m_maxRoughnessNameIndex, ssrOptions.m_maxRoughness);

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
@@ -76,8 +76,8 @@ namespace AZ
             m_shaderResourceGroup->SetConstant(m_invOutputScaleNameIndex, 1.0f / ssrOptions.GetOutputScale());
             m_shaderResourceGroup->SetConstant(m_outputWidthNameIndex, outputImageSize.m_width);
             m_shaderResourceGroup->SetConstant(m_outputHeightNameIndex, outputImageSize.m_height);
-            m_shaderResourceGroup->SetConstant(m_rayTracingEnabledNameIndex, ssrOptions.m_rayTracing);
-            m_shaderResourceGroup->SetConstant(m_rayTraceFallbackDataNameIndex, ssrOptions.m_rayTraceFallbackData);
+            m_shaderResourceGroup->SetConstant(m_rayTracingEnabledNameIndex, ssrOptions.IsRayTracingEnabled());
+            m_shaderResourceGroup->SetConstant(m_rayTraceFallbackDataNameIndex, ssrOptions.IsRayTracingFallbackEnabled());
             m_shaderResourceGroup->SetConstant(m_maxRayDistanceNameIndex, ssrOptions.m_maxRayDistance);
             m_shaderResourceGroup->SetConstant(m_maxDepthThresholdNameIndex, ssrOptions.m_maxDepthThreshold);
             m_shaderResourceGroup->SetConstant(m_maxRoughnessNameIndex, ssrOptions.m_maxRoughness);

--- a/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.h
@@ -46,7 +46,7 @@ namespace AZ
 
             RHI::ShaderInputNameIndex m_invOutputScaleNameIndex = "m_invOutputScale";
             RHI::ShaderInputNameIndex m_maxRoughnessNameIndex = "m_maxRoughness";
-            RHI::ShaderInputNameIndex m_rayTraceFallbackDataNameIndex = "m_rayTraceFallbackData";
+            RHI::ShaderInputNameIndex m_reflectionMethodNameIndex = "m_reflectionMethod";
             RHI::ShaderInputNameIndex m_rayTraceFallbackSpecularNameIndex = "m_rayTraceFallbackSpecular";
         };
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SpecularReflections/SpecularReflectionsComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SpecularReflections/SpecularReflectionsComponentConfig.cpp
@@ -53,14 +53,16 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::Step, 0.1f)
                         ->DataElement(Edit::UIHandlers::CheckBox, &SSROptions::m_halfResolution, "Half Resolution", "Use half resolution in the reflected image, improves performance but may increase artifacts during camera motion")
                             ->Attribute(AZ::Edit::Attributes::Visibility, &SSROptions::IsEnabled)
-                        ->ClassElement(AZ::Edit::ClassElements::Group, "Ray Tracing")
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                            ->DataElement(Edit::UIHandlers::CheckBox, &SSROptions::m_rayTracing, "Hardware Ray Tracing", "Enable Hardware Ray Tracing for Hybrid SSR-RT, which improves hit detection quality and provides fallback data for occluded or off-screen surfaces")
+                            ->DataElement(Edit::UIHandlers::ComboBox, &SSROptions::m_reflectionMethod, "Reflection Method",
+                                      "Screen-space: Use screen-space reflections only\n\n"
+                                      "Hybrid SSR-RT: Use ray tracing for hit detection and screen-space data for surface evaluation\n\n"
+                                      "Hybrid SSR-RT + Ray Tracing fallback: Use screen-space reflection data when available and ray tracing when not\n\n"
+                                      "Ray Tracing: Use hardware ray tracing only")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::EntireTree)
-                                ->Attribute(AZ::Edit::Attributes::Visibility, &SSROptions::IsEnabled)
-                            ->DataElement(Edit::UIHandlers::CheckBox, &SSROptions::m_rayTraceFallbackData, "Ray Trace Fallback Data", "Generate fallback image data using hardware raytracing when the hit point is off-screen of obstructed by an object closer to the camera")
-                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::EntireTree)
-                                ->Attribute(AZ::Edit::Attributes::Visibility, &SSROptions::IsRayTracingEnabled)
+                                ->EnumAttribute(SSROptions::ReflectionMethod::ScreenSpace, "Screen Space")
+                                ->EnumAttribute(SSROptions::ReflectionMethod::Hybrid, "Hybrid SSR-RT")
+                                ->EnumAttribute(SSROptions::ReflectionMethod::HybridWithFallback, "Hybrid SSR-RT + Ray Tracing fallback")
+                                ->EnumAttribute(SSROptions::ReflectionMethod::RayTracing, "Ray Tracing")
                             ->DataElement(Edit::UIHandlers::CheckBox, &SSROptions::m_rayTraceFallbackSpecular, "Apply Fallback Specular Lighting", "Apply specular lighting in the fallback image, improves fallback image accuracy but may reduce performance and increase artifacts")
                                 ->Attribute(AZ::Edit::Attributes::Visibility, &SSROptions::IsRayTracingFallbackEnabled)
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Temporal Filtering")

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -159,7 +159,7 @@ namespace AZ
             if (m_specularReflectionsFeatureProcessor)
             {
                 const SSROptions& ssrOptions = m_specularReflectionsFeatureProcessor->GetSSROptions();
-                m_ssrRayTracingEnabled = ssrOptions.m_rayTracing;
+                m_ssrRayTracingEnabled = ssrOptions.IsRayTracingEnabled();
             }
 
             EnableSceneNotification();
@@ -258,9 +258,9 @@ namespace AZ
             if (m_specularReflectionsFeatureProcessor)
             {
                 const SSROptions& ssrOptions = m_specularReflectionsFeatureProcessor->GetSSROptions();
-                if (m_ssrRayTracingEnabled != ssrOptions.m_rayTracing)
+                if (m_ssrRayTracingEnabled != ssrOptions.IsRayTracingEnabled())
                 {
-                    m_ssrRayTracingEnabled = ssrOptions.m_rayTracing;
+                    m_ssrRayTracingEnabled = ssrOptions.IsRayTracingEnabled();
 
                     AZStd::vector<Name> passHierarchy = { Name("ReflectionScreenSpacePass"), Name("DiffuseProbeGridQueryFullscreenWithAlbedoPass") };
                     RPI::PassFilter passFilter = RPI::PassFilter::CreateWithPassHierarchy(passHierarchy);


### PR DESCRIPTION
## What does this PR do?

This PR adds the option to only use ray-traced reflections by selecting "Ray Tracing" in the "Specular Reflections" level component. This was previously not possible.

There are now 4 methods for specular reflections, where the first three are the same as before (when selecting [Hardware Ray Tracing][Ray Trace Fallback Data]-> [no][], [yes][no], [yes][yes]), left-to-right in following image which uses a different mesh LOD for ray tracing to see the difference between the methods:
* Screen-space: Use screen-space reflections only
* Hybrid SSR-RT: Use ray tracing for hit detection and screen-space data for surface evaluation (not entirely sure if this description is correct)
* Hybrid SSR-RT + Ray Tracing fallback: Use screen-space reflection data when available and ray tracing when not
* Ray Tracing: Use hardware ray tracing only

![reflection_comparison](https://github.com/o3de/o3de/assets/113582781/6ad813af-6529-4a7f-bbb6-a37500929bb7)

I changed the checkboxes for raytracing/fallback in the UI of the "Specular Reflections" component to allow for the new method (left original, right new), the Combobox contains all 4 options and shows the "Apply Fallback Specular Lighting" checkbox when ray tracing or hybrid+fallback is selected:
![reflection_component](https://github.com/o3de/o3de/assets/113582781/a4dd8668-f2f8-40df-8493-5291fdbdaeb7)


## How was this PR tested?

Manual test: Create a new level, add a mesh with two LODs and manually select LOD0 for the mesh, then switch between the 4 reflection methods (screenshots from above).
