### PR TITLE
Update install to include missing CMakePresets.json

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -1131,6 +1131,7 @@ function(ly_setup_o3de_install)
         ${LY_ROOT_FOLDER}/pytest.ini
         ${LY_ROOT_FOLDER}/LICENSE.txt
         ${LY_ROOT_FOLDER}/README.md
+        ${LY_ROOT_FOLDER}/CMakePresets.json
         DESTINATION .
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )


### PR DESCRIPTION
## What does this PR do?
The CMakePresets.json from the root was missing from the install file list, so was never copied over.
This causes errors when trying to use them to build O3DE from the SDK version.

## How was this PR tested?

Built the install target, found the file copied over.  Now configuring a project using the installer with a preset file functions as expected.  Before, it would be missing, so none of the presets could be found.