### PR TITLE
AWSNativeSDKInit::PreventAwsEC2MetadataCalls Default Param Compiler Error Fix

### DIFF
--- a/Code/Tools/AWSNativeSDKInit/include/AWSNativeSDKInit/AWSNativeSDKInit.h
+++ b/Code/Tools/AWSNativeSDKInit/include/AWSNativeSDKInit/AWSNativeSDKInit.h
@@ -54,7 +54,7 @@ namespace AWSNativeSDKInit
         //! Note: This is a helper function for managing the environment variable, AWS_EC2_METADATA_DISABLED, but impacts just the current application's environment.
         //! @param force If true, always set AWS_EC2_METADATA_DISABLED to true, otherwise only set if environment variable is not set.
         //! @returns True if env var was set or currently prevents calls, False otherwise 
-        static bool PreventAwsEC2MetadataCalls(bool force);
+        static bool PreventAwsEC2MetadataCalls(bool force = false);
 
     private:    
         void InitializeAwsApiInternal();

--- a/Code/Tools/AWSNativeSDKInit/source/AWSNativeSDKInit.cpp
+++ b/Code/Tools/AWSNativeSDKInit/source/AWSNativeSDKInit.cpp
@@ -85,7 +85,7 @@ namespace AWSNativeSDKInit
 #endif // #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
     }
 
-    bool InitializationManager::PreventAwsEC2MetadataCalls(bool force = false)
+    bool InitializationManager::PreventAwsEC2MetadataCalls(bool force)
     {
         bool prevented = false;
 #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)


### PR DESCRIPTION
Fix AWSNativeSDKInit interface so that users can call the status PreventAwsEC2MetadataCalls with default parameters

Tested by
Invoking AWSNativeSDKInit::PreventAwsEC2MetadataCalls() without any compiler errors