### PR TITLE
Fix ScriptCanvas crash when generic functions are invoked

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedOut.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedOut.cpp
@@ -133,21 +133,16 @@ namespace ScriptCanvas
             {
                 Execution::StackPush(m_lua, behaviorContext, argsBVPs[i]);
             }
+
             // Lua: lambda, args...
             const int result = InterpretedSafeCall(m_lua, numArguments, 1);
-            // Lua: ?
-            if (result != LUA_OK)
+
+            if(result == LUA_OK && resultBVP)
             {
-                // Lua: error
-                lua_pop(m_lua, 1);
-            }
-            else
-            {
-                // Lua: result
                 Execution::StackRead(m_lua, behaviorContext, -1, *resultBVP, nullptr);
-                lua_pop(m_lua, 1);
             }
-            // Lua:
+
+            lua_pop(m_lua, 1);
         }
     }
 }


### PR DESCRIPTION
Adds a null check to ExecutionInterpretedOut for when resultsBVP is null