### PR TITLE
[WIP] Prefabs | Display list of overrides on prefab container

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -70,6 +70,7 @@ namespace AzToolsFramework::Prefab
     {
         m_overridden = false;
         m_textLabel->setText(QString());
+        m_textLabel->setToolTip(QString());
         m_textLabel->setProperty(OverriddenPropertyName, false);
         m_iconButton->setIcon(*m_emptyIcon);
         m_iconButton->setIconSize(kIconSize);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
@@ -24,33 +24,15 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
-        EditorPrefabOverride::EditorPrefabOverride(AZStd::string label, AZStd::string value)
-            : m_label(AZStd::move(label))
-            , m_value(AZStd::move(value))
+        AZStd::string EditorPrefabComponent::GetLabelForIndex(int index) const
         {
-        }
+            AZStd::string label = m_overrides[index].GetPropertyPath();
 
-        void EditorPrefabOverride::Reflect(AZ::ReflectContext* context)
-        {
-            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-            {
-                serializeContext->Class<EditorPrefabOverride>()
-                    ->Field("label", &EditorPrefabOverride::m_label)
-                    ->Field("value", &EditorPrefabOverride::m_value)
-                    ;
+            // Resize to 128 or it will not fit the label for the DPE.
+            // TODO - Find a more elegant way to do this (elision?) or at least show the full path in the tooltip.
+            label.resize(128);
 
-                AZ::EditContext* editContext = serializeContext->GetEditContext();
-                if (editContext)
-                {
-                    editContext->Class<EditorPrefabOverride>("Prefab Override", "")
-                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        //->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabOverride::m_value, "Patch", "")
-                        ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &EditorPrefabOverride::m_label)
-                        //->Attribute(AZ::Edit::Attributes::ReadOnly, true)
-                        ;
-                }
-            }
+            return label;
         }
 
         void EditorPrefabComponent::Reflect(AZ::ReflectContext* context)
@@ -60,7 +42,7 @@ namespace AzToolsFramework
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<EditorPrefabComponent, EditorComponentBase>()
-                    ->Field("patches", &EditorPrefabComponent::m_patches);
+                    ->Field("overrides", &EditorPrefabComponent::m_overrides);
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
@@ -72,8 +54,9 @@ namespace AzToolsFramework
                             AZ::Edit::Attributes::SliceFlags,
                             AZ::Edit::SliceFlags::HideOnAdd | AZ::Edit::SliceFlags::PushWhenHidden |
                                 AZ::Edit::SliceFlags::DontGatherReference)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabComponent::m_patches, "Patches", "")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabComponent::m_overrides, "Overrides", "Overrides applied by the currently focused prefab to this prefab instance.")
+                        ->Attribute(AZ::Edit::Attributes::IndexedChildNameLabelOverride, &EditorPrefabComponent::GetLabelForIndex)
+                        //->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                         ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
@@ -103,7 +86,10 @@ namespace AzToolsFramework
             PrefabInstanceContainerNotificationBus::Broadcast(
                 &PrefabInstanceContainerNotifications::OnPrefabComponentActivate, GetEntityId());
 
-            // Fetch all patches from direct parent (for now)
+            // TODO - Fetch all patches applied to this prefab from the currently focused prefab.
+            // If the prefab is accessible in the Inspector, the focused prefab should always be an ancestor.
+            
+            // TODO - This function should be run again whenever prefab focus changes.
             AZ::EntityId entityId = m_entity->GetId();
 
             // Find LinkId to direct parent
@@ -124,9 +110,37 @@ namespace AzToolsFramework
                     for (const auto& patch : linkPatches.GetArray())
                     {
                         AZStd::string pathString = patch.GetObject().FindMember("path")->value.GetString();
-                        AZ::IO::Path path (pathString.c_str(), '/');
 
-                        m_patches.push_back({ path.RootName().String(), "123" });
+                        if (pathString.starts_with("/ContainerEntity"))
+                        {
+                            continue;
+                        }
+
+                        AZ::IO::Path path (pathString.c_str(), '/');
+                        AZStd::string value;
+
+                        auto& valueObj = patch.GetObject().FindMember("value")->value;
+                        if (valueObj.IsString())
+                        {
+                            value = valueObj.GetString();
+                        }
+                        else if (valueObj.IsNumber())
+                        {
+                            value = AZStd::to_string(valueObj.GetDouble());
+                        }
+                        else if (valueObj.IsBool())
+                        {
+                            if (valueObj.GetBool())
+                            {
+                                value = "True";
+                            }
+                            else
+                            {
+                                value = "False";
+                            }
+                        }
+
+                        m_overrides.push_back({ AZStd::move(path), value });
                     }
                 }
             }
@@ -136,6 +150,42 @@ namespace AzToolsFramework
         {
             PrefabInstanceContainerNotificationBus::Broadcast(
                 &PrefabInstanceContainerNotifications::OnPrefabComponentDeactivate, GetEntityId());
+        }
+
+        EditorPrefabComponent::EditorPrefabOverride::EditorPrefabOverride(AZ::IO::Path path, AZStd::string value)
+            : m_path(AZStd::move(path))
+            , m_value(AZStd::move(value))
+        {
+        }
+
+        AZStd::string EditorPrefabComponent::EditorPrefabOverride::GetPropertyName() const
+        {
+            return m_path.Filename().String();
+        }
+
+        AZStd::string EditorPrefabComponent::EditorPrefabOverride::GetPropertyPath() const
+        {
+            return m_path.String();
+        }
+
+        void EditorPrefabComponent::EditorPrefabOverride::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<EditorPrefabOverride>()
+                    ->Field("path", &EditorPrefabOverride::m_path)
+                    ->Field("value", &EditorPrefabOverride::m_value);
+
+                AZ::EditContext* editContext = serializeContext->GetEditContext();
+                if (editContext)
+                {
+                    editContext->Class<EditorPrefabOverride>("Prefab Override", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabOverride::m_value, "Value", "")
+                        ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &EditorPrefabOverride::GetPropertyName)
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true);
+                }
+            }
         }
 
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
@@ -10,10 +10,13 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Math/Uuid.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
+#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/UI/EditorEntityUi/EditorEntityUiInterface.h>
 #include <AzToolsFramework/UI/Prefab/PrefabIntegrationBus.h>
 
@@ -21,23 +24,59 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
-        void EditorPrefabComponent::Reflect(AZ::ReflectContext* context)
+        EditorPrefabOverride::EditorPrefabOverride(AZStd::string label, AZStd::string value)
+            : m_label(AZStd::move(label))
+            , m_value(AZStd::move(value))
+        {
+        }
+
+        void EditorPrefabOverride::Reflect(AZ::ReflectContext* context)
         {
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serializeContext->Class<EditorPrefabComponent, EditorComponentBase>();
+                serializeContext->Class<EditorPrefabOverride>()
+                    ->Field("label", &EditorPrefabOverride::m_label)
+                    ->Field("value", &EditorPrefabOverride::m_value)
+                    ;
+
+                AZ::EditContext* editContext = serializeContext->GetEditContext();
+                if (editContext)
+                {
+                    editContext->Class<EditorPrefabOverride>("Prefab Override", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        //->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabOverride::m_value, "Patch", "")
+                        ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &EditorPrefabOverride::m_label)
+                        //->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ;
+                }
+            }
+        }
+
+        void EditorPrefabComponent::Reflect(AZ::ReflectContext* context)
+        {
+            EditorPrefabOverride::Reflect(context);
+
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<EditorPrefabComponent, EditorComponentBase>()
+                    ->Field("patches", &EditorPrefabComponent::m_patches);
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
                     editContext->Class<EditorPrefabComponent>("Prefab Component", "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
-                        ->Attribute(AZ::Edit::Attributes::HideIcon, true)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ->Attribute(
                             AZ::Edit::Attributes::SliceFlags,
                             AZ::Edit::SliceFlags::HideOnAdd | AZ::Edit::SliceFlags::PushWhenHidden |
-                                AZ::Edit::SliceFlags::DontGatherReference);
+                                AZ::Edit::SliceFlags::DontGatherReference)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorPrefabComponent::m_patches, "Patches", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                        ->Attribute(AZ::Edit::Attributes::ContainerReorderAllow, false)
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
                 }
             }
 
@@ -63,6 +102,34 @@ namespace AzToolsFramework
         {
             PrefabInstanceContainerNotificationBus::Broadcast(
                 &PrefabInstanceContainerNotifications::OnPrefabComponentActivate, GetEntityId());
+
+            // Fetch all patches from direct parent (for now)
+            AZ::EntityId entityId = m_entity->GetId();
+
+            // Find LinkId to direct parent
+            auto instanceEntityMapperInterface = AZ::Interface<Prefab::InstanceEntityMapperInterface>::Get();
+            if (auto owningInstance = instanceEntityMapperInterface->FindOwningInstance(entityId); owningInstance.has_value())
+            {
+                auto linkId = owningInstance->get().GetLinkId();
+
+                // Get Link
+                auto prefabSystemComponentInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabSystemComponentInterface>::Get();
+                auto findLinkResult = prefabSystemComponentInterface->FindLink(linkId);
+
+                if (findLinkResult.has_value())
+                {
+                    [[maybe_unused]] PrefabDom linkPatches;
+                    findLinkResult->get().GetLinkPatches(linkPatches, linkPatches.GetAllocator());
+
+                    for (const auto& patch : linkPatches.GetArray())
+                    {
+                        AZStd::string pathString = patch.GetObject().FindMember("path")->value.GetString();
+                        AZ::IO::Path path (pathString.c_str(), '/');
+
+                        m_patches.push_back({ path.RootName().String(), "123" });
+                    }
+                }
+            }
         }
 
         void EditorPrefabComponent::Deactivate()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.h
@@ -15,20 +15,6 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
-        struct EditorPrefabOverride final
-        {
-            AZ_RTTI(EditorPrefabOverride, "{348F250E-1EA9-4AA0-A02F-9D32D9B9B585}");
-            AZ_CLASS_ALLOCATOR(EditorPrefabOverride, AZ::SystemAllocator);
-
-            EditorPrefabOverride() = default;
-            EditorPrefabOverride(AZStd::string label, AZStd::string value);
-
-            static void Reflect(AZ::ReflectContext* context);
-
-            AZStd::string m_label;
-            AZStd::string m_value;
-        };
-
         class EditorPrefabComponent
             : public AzToolsFramework::Components::EditorComponentBase
         {
@@ -41,11 +27,35 @@ namespace AzToolsFramework
             static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& services);
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& services);
 
+            AZStd::string GetLabelForIndex(int index) const;
+
         private:
             void Activate() override;
             void Deactivate() override;
 
-            AZStd::vector<EditorPrefabOverride> m_patches;
+            // Overrides UI
+            struct EditorPrefabOverride final
+            {
+                AZ_RTTI(EditorPrefabOverride, "{56D1C6B9-7096-4CD5-8E18-66330A43E0E1}");
+                AZ_CLASS_ALLOCATOR(EditorPrefabOverride, AZ::SystemAllocator);
+
+                EditorPrefabOverride() = default;
+                EditorPrefabOverride(AZ::IO::Path path, AZStd::string value);
+
+                static void Reflect(AZ::ReflectContext* context);
+
+                AZStd::string GetPropertyName() const;
+                AZStd::string GetPropertyPath() const;
+
+                AZ::IO::Path m_path;
+                AZStd::string m_value;
+            };
+
+            //void GenerateOverridesList();
+
+            // TODO - Ensure this does not get serialized to JSON.
+            // This is just an Editor component and the data shown is instance-dependent.
+            AZStd::vector<EditorPrefabOverride> m_overrides;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.h
@@ -7,13 +7,30 @@
  */
 #pragma once
 
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/string/string.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace AzToolsFramework
 {
     namespace Prefab
     {
-        class EditorPrefabComponent : public AzToolsFramework::Components::EditorComponentBase
+        struct EditorPrefabOverride final
+        {
+            AZ_RTTI(EditorPrefabOverride, "{348F250E-1EA9-4AA0-A02F-9D32D9B9B585}");
+            AZ_CLASS_ALLOCATOR(EditorPrefabOverride, AZ::SystemAllocator);
+
+            EditorPrefabOverride() = default;
+            EditorPrefabOverride(AZStd::string label, AZStd::string value);
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            AZStd::string m_label;
+            AZStd::string m_value;
+        };
+
+        class EditorPrefabComponent
+            : public AzToolsFramework::Components::EditorComponentBase
         {
         public:
             static inline constexpr AZ::TypeId EditorPrefabComponentTypeId{ "{756E5F9C-3E08-4F8D-855C-A5AEEFB6FCDD}" };
@@ -27,6 +44,8 @@ namespace AzToolsFramework
         private:
             void Activate() override;
             void Deactivate() override;
+
+            AZStd::vector<EditorPrefabOverride> m_patches;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/LabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/LabelHandler.cpp
@@ -27,6 +27,7 @@ namespace AzToolsFramework
     bool LabelHandler::ResetGUIToDefaults(QLabel* GUI)
     {
         GUI->setText(QString());
+        GUI->setToolTip(QString());
         return true;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
@@ -34,6 +34,7 @@ namespace AzToolsFramework
         QString blankString;
         GUI->setPlaceholderText(blankString);
         GUI->setText(blankString);
+        GUI->setToolTip(blankString);
         GUI->setReadOnly(false);
         return true;
     }


### PR DESCRIPTION
## What does this PR do?
This introduces changes to the `EditorPrefabComponent` to display a list of all overrides applied to it.
Right now this only displays overrides applied by the direct parent prefab.

### Current state
![image](https://github.com/o3de/o3de/assets/82231674/2ea166ec-e3fe-40c5-87c6-578d2caaa8ec)

### Work in progress
- Determine which overrides should be displayed (applied by the direct parent? by the focused prefab? by all ancestors, separated by link?)
- Ensure the lists are updated whenever prefab focus changes
- Fix path display (right now it truncates to 128 to prevent a crash in the label, should be able to elide the label elegantly and display the full path in the tooltip)
- Ensure this data is not stored in the prefabs on save

### Additional fixes
Fixes tooltip not being correctly cleared when label widgets are reused in the DPE.

## How was this PR tested?
Manual testing

## Follow-ups
- Introduce a button that allows users to revert all/individual patches from this panel.
- Introduce a button that allows users to apply all/individual patches from this panel.

(reverting/applying all patches is likely the MVP, individual patches will need a UX pass)