### PR TITLE
Multi-device RPI final transition

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
@@ -39,6 +39,7 @@ namespace AZ
             bool UpdateBuffer(const T* data, uint32_t elementCount);
             template <typename T>
             bool UpdateBuffer(const AZStd::vector<T>& data);
+            bool UpdateBuffer(const AZStd::unordered_map<int, const void*>& data, uint32_t elementCount);
 
             void UpdateSrg(RPI::ShaderResourceGroup* srg) const;
 
@@ -58,7 +59,6 @@ namespace AZ
             uint32_t m_elementCount = 0;
             uint32_t m_elementSize = 0;
         };
-
         template <typename T>
         bool GpuBufferHandler::UpdateBuffer(const T* data, uint32_t elementCount)
         {

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.cpp
@@ -105,10 +105,7 @@ namespace AZ
                     }
                 }
 
-                if (m_fence)
-                {
-                    m_fence->Reset();
-                }
+                m_fence->Reset();
             }
             );
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldCopyFocusDepthToCpuPass.h
@@ -51,6 +51,8 @@ namespace AZ
             Data::Instance<RPI::Buffer> m_readbackBuffer;
             RHI::MultiDeviceCopyBufferDescriptor m_copyDescriptor;
             bool m_needsInitialize = true;
+            RHI::Ptr<RHI::MultiDeviceFence> m_fence;
+            float m_lastFocusDepth = 0;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -121,8 +121,6 @@ namespace AZ
 
         void RayTracingAccelerationStructurePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             RPI::Scene* scene = m_pipeline->GetScene();
             RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -324,6 +324,8 @@ namespace AZ
             // [GHI-16945] Feature Request - Add GPU timestamp and pipeline statistic support for scopes
             ExecuteOnTimestampQuery(endQuery);
             ExecuteOnPipelineStatisticsQuery(endQuery);
+
+            m_lastDeviceIndex = context.GetDeviceIndex();
         }
 
         void RayTracingAccelerationStructurePass::ReadbackScopeQueryResults()
@@ -333,14 +335,14 @@ namespace AZ
                 {
                   const uint32_t TimestampResultQueryCount{ 2u };
                   uint64_t timestampResult[TimestampResultQueryCount] = { 0 };
-                  query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount);
+                  query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount, m_lastDeviceIndex);
                   m_timestampResult = RPI::TimestampResult(timestampResult[0], timestampResult[1], RHI::HardwareQueueClass::Graphics);
                 });
 
             ExecuteOnPipelineStatisticsQuery(
                 [this](const RHI::Ptr<RPI::Query>& query)
                 {
-                  query->GetLatestResult(&m_statisticsResult, sizeof(RPI::PipelineStatisticsResult));
+                  query->GetLatestResult(&m_statisticsResult, sizeof(RPI::PipelineStatisticsResult), m_lastDeviceIndex);
                 });
         }
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -33,8 +33,7 @@ namespace AZ
             : Pass(descriptor)
         {
             // disable this pass if we're on a platform that doesn't support raytracing
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices)
             {
                 SetEnabled(false);
             }
@@ -154,7 +153,7 @@ namespace AZ
 
                     // create the TLAS buffers based on the descriptor
                     RHI::Ptr<RHI::MultiDeviceRayTracingTlas>& rayTracingTlas = rayTracingFeatureProcessor->GetTlas();
-                    rayTracingTlas->CreateBuffers(RHI::MultiDevice::AllDevices, &tlasDescriptor, rayTracingBufferPools);
+                    rayTracingTlas->CreateBuffers(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &tlasDescriptor, rayTracingBufferPools);
 
                     // import and attach the TLAS buffer
                     const RHI::Ptr<RHI::MultiDeviceBuffer>& rayTracingTlasBuffer = rayTracingTlas->GetTlasBuffer();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
@@ -89,6 +89,9 @@ namespace AZ
             // Readback results from the PipelineStatistics queries
             AZ::RPI::PipelineStatisticsResult m_statisticsResult;
 
+            // The device index the pass ran on during the last frame, necessary to read the queries.
+            int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
+
             // For each ScopeProducer an instance of the ScopeQuery is created, which consists
             // of a Timestamp and PipelineStatistic query.
             ScopeQuery m_scopeQueries;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -101,8 +101,6 @@ namespace AZ
                 return;
             }
 
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             // lock the mutex to protect the mesh and BLAS lists
             AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -56,9 +56,12 @@ namespace AZ
 
             for (auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
             {
-                m_meshBufferIndices[deviceIndex] = {};
-                m_materialTextureIndices[deviceIndex] = {};
-                m_materialInfos[deviceIndex] = {};
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                {
+                    m_meshBufferIndices[deviceIndex] = {};
+                    m_materialTextureIndices[deviceIndex] = {};
+                    m_materialInfos[deviceIndex] = {};
+                }
             }
 
             // create TLAS attachmentId

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -39,10 +39,9 @@ namespace AZ
 
         void RayTracingFeatureProcessor::Activate()
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            m_rayTracingEnabled = device->GetFeatures().m_rayTracing;
+            auto deviceMask{RHI::RHISystemInterface::Get()->GetRayTracingSupport()};
 
-            if (!m_rayTracingEnabled)
+            if (deviceMask == RHI::MultiDevice::NoDevices)
             {
                 return;
             }
@@ -51,7 +50,7 @@ namespace AZ
 
             // initialize the ray tracing buffer pools
             m_bufferPools = aznew RHI::MultiDeviceRayTracingBufferPools;
-            m_bufferPools->Init(RHI::MultiDevice::AllDevices);
+            m_bufferPools->Init(deviceMask);
 
             auto deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
 
@@ -198,7 +197,7 @@ namespace AZ
                     itMeshBlasInstance->second.m_subMeshes.push_back({ rayTracingBlas });
 
                     // create the buffers from the BLAS descriptor
-                    rayTracingBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &blasDescriptor, *m_bufferPools);
+                    rayTracingBlas->CreateBuffers(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &blasDescriptor, *m_bufferPools);
 
                     // store the BLAS in the mesh
                     subMesh.m_blas = rayTracingBlas;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -362,7 +362,7 @@ namespace AZ
 
             // vector of MaterialInfo, transferred to the materialInfoGpuBuffer
             using MaterialInfoVector = AZStd::vector<MaterialInfo>;
-            MaterialInfoVector m_materialInfos;
+            AZStd::unordered_map<int, MaterialInfoVector> m_materialInfos;
             Data::Instance<RPI::Buffer> m_materialInfoGpuBuffer[BufferFrameCount];
             uint32_t m_currentMaterialInfoFrameIndex = 0;
 
@@ -389,10 +389,10 @@ namespace AZ
 
             // mesh buffer and material texture index lists, which contain the array indices of the mesh resources
             static const uint32_t NumMeshBuffersPerMesh = 6;
-            RayTracingIndexList<NumMeshBuffersPerMesh> m_meshBufferIndices;
+            AZStd::unordered_map<int, RayTracingIndexList<NumMeshBuffersPerMesh>> m_meshBufferIndices;
 
             static const uint32_t NumMaterialTexturesPerMesh = 5;
-            RayTracingIndexList<NumMaterialTexturesPerMesh> m_materialTextureIndices;
+            AZStd::unordered_map<int, RayTracingIndexList<NumMaterialTexturesPerMesh>> m_materialTextureIndices;
 
             // Gpu buffers for the mesh and material index lists
             Data::Instance<RPI::Buffer> m_meshBufferIndicesGpuBuffer[BufferFrameCount];

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -58,8 +58,6 @@ namespace AZ
 
         void RayTracingPass::Init()
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             m_passData = RPI::PassUtils::GetPassData<RayTracingPassData>(m_passDescriptor);
             if (m_passData == nullptr)
             {
@@ -231,7 +229,6 @@ namespace AZ
 
             if (!m_rayTracingShaderTable)
             {
-                RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
                 RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -40,8 +40,7 @@ namespace AZ
             : RenderPass(descriptor)
             , m_passDescriptor(descriptor)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices)
             {
                 // raytracing is not supported on this platform
                 SetEnabled(false);
@@ -165,7 +164,7 @@ namespace AZ
 
             // create the ray tracing pipeline state object
             m_rayTracingPipelineState = aznew RHI::MultiDeviceRayTracingPipelineState;
-            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
+            m_rayTracingPipelineState->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), descriptor);
 
             // make sure the shader table rebuilds if we're hotreloading
             m_rayTracingRevision = 0;
@@ -232,7 +231,7 @@ namespace AZ
                 RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;
-                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
+                m_rayTracingShaderTable->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), rayTracingBufferPools);
             }
 
             RPI::RenderPass::FrameBeginInternal(params);

--- a/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
@@ -56,11 +56,8 @@ namespace AZ
 
         void SpecularReflectionsFeatureProcessor::UpdatePasses()
         {
-            RHI::RHISystemInterface* rhiSystem = RHI::RHISystemInterface::Get();
-            RHI::Ptr<RHI::Device> device = rhiSystem->GetDevice();
-
             // disable raytracing if the platform does not support it
-            m_ssrOptions.m_rayTracing &= device->GetFeatures().m_rayTracing;
+            m_ssrOptions.m_rayTracing &= RHI::RHISystemInterface::Get()->GetRayTracingSupport() != RHI::MultiDevice::NoDevices;
 
             // determine size multiplier to pass to the shaders
             float sizeMultiplier = m_ssrOptions.m_halfResolution ? 0.5f : 1.0f;

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/GpuBufferHandler.cpp
@@ -86,6 +86,31 @@ namespace AZ
             return true;
         }
 
+        bool GpuBufferHandler::UpdateBuffer(const AZStd::unordered_map<int, const void*>& data, uint32_t elementCount)
+        {
+            if (!IsValid())
+            {
+                return false;
+            }
+
+            m_elementCount = elementCount;
+
+            AZ::u64 currentByteCount = m_buffer->GetBufferSize();
+            uint32_t dataSize = elementCount * m_elementSize;
+
+            if (dataSize > currentByteCount)
+            {
+                uint32_t byteCount = RHI::NextPowerOfTwo(GetMax<uint32_t>(BufferMinSize, dataSize));
+                m_buffer->Resize(byteCount);
+            }
+
+            if (dataSize > 0)
+            {
+                return m_buffer->UpdateData(data, dataSize, 0);
+            }
+            return true;
+        }
+
         void GpuBufferHandler::UpdateSrg(RPI::ShaderResourceGroup* srg) const
         {
             if (m_bufferIndex.IsValid())

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -93,6 +93,7 @@ namespace AZ::RHI
         {
         };
         AZ_DEFINE_ENUM_BITWISE_OPERATORS(DeviceMask);
+        constexpr DeviceMask NoDevices{ 0u };
         constexpr DeviceMask AllDevices{ static_cast<DeviceMask>(AZStd::numeric_limits<uint32_t>::max()) };
         constexpr DeviceMask DefaultDevice{ 1u };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuter.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuter.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     //! Fill this descriptor when initializing a FrameScheduler instance.
     struct FrameGraphExecuterDescriptor
     {
-        ConstPtr<PlatformLimitsDescriptor> m_platformLimitsDescriptor = nullptr;
+        AZStd::unordered_map<int, ConstPtr<PlatformLimitsDescriptor>> m_platformLimitsDescriptors;
     };
 
     //! FrameGraphExecuter is a context for executing the scopes of a compiled FrameGraph

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -34,10 +34,10 @@ namespace AZ::RHI
     struct FrameSchedulerDescriptor
     {
         // The descriptor used to initialize the transient attachment pool.
-        TransientAttachmentPoolDescriptor m_transientAttachmentPoolDescriptor;
+        AZStd::unordered_map<int, TransientAttachmentPoolDescriptor> m_transientAttachmentPoolDescriptors;
 
         // Platform specific limits
-        ConstPtr<PlatformLimitsDescriptor> m_platformLimitsDescriptor = nullptr;
+        AZStd::unordered_map<int, ConstPtr<PlatformLimitsDescriptor>> m_platformLimitsDescriptors;
     };
 
     //! @brief Fill and provide this request structure when invoking FrameScheduler::Compile.
@@ -178,7 +178,7 @@ namespace AZ::RHI
         ScopeId GetRootScopeId() const;
 
         //! Returns the descriptor which has information on the properties of a MultiDeviceTransientAttachmentPool.
-        const TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const;
+        const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* GetTransientAttachmentPoolDescriptor() const;
 
         //! Adds a SingleDeviceRayTracingShaderTable to be built this frame
         void QueueRayTracingShaderTableForBuild(SingleDeviceRayTracingShaderTable* rayTracingShaderTable);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceTransientAttachmentPool.h
@@ -45,7 +45,8 @@ namespace AZ::RHI
         virtual ~MultiDeviceTransientAttachmentPool() = default;
 
         //! Called to initialize the pool.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const TransientAttachmentPoolDescriptor& descriptor);
+        ResultCode Init(
+            MultiDevice::DeviceMask deviceMask, const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>& descriptors);
 
         //! Called to shutdown the pool.
         void Shutdown();
@@ -88,7 +89,7 @@ namespace AZ::RHI
         AZStd::unordered_map<int, TransientAttachmentStatistics> GetStatistics() const;
 
         //! Get pool descriptor
-        const TransientAttachmentPoolDescriptor& GetDescriptor() const;
+        const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>& GetDescriptor() const;
 
         //! Get the compile flags being used during the allocation of resources.
         TransientAttachmentPoolCompileFlags GetCompileFlags() const;
@@ -97,7 +98,7 @@ namespace AZ::RHI
         //! Remove the entry related to the provided attachmentId from the cache as it is probably stale now
         void RemoveFromCache(RHI::AttachmentId attachmentId);
 
-        TransientAttachmentPoolDescriptor m_descriptor;
+        AZStd::unordered_map<int, TransientAttachmentPoolDescriptor> m_descriptors;
         TransientAttachmentPoolCompileFlags m_compileFlags = TransientAttachmentPoolCompileFlags::None;
 
         //! MultiDeviceImage/Buffers added as attachments to scopes are tracked in an internal cache

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -67,6 +67,7 @@ namespace AZ::RHI
         //! Add a new virtual device (referencing the same physical device as an existing device marked by deviceIndexToVirtualize)
         [[nodiscard]] AZStd::optional<int> AddVirtualDevice(int deviceIndexToVirtualize = MultiDevice::DefaultDeviceIndex) override;
         int GetDeviceCount() override;
+        MultiDevice::DeviceMask GetRayTracingSupport() override;
         RHI::DrawListTagRegistry* GetDrawListTagRegistry() override;
         RHI::PipelineStateCache* GetPipelineStateCache() override;
         void ModifyFrameSchedulerStatisticsFlags(RHI::FrameSchedulerStatisticsFlags statisticsFlags, bool enableFlags) override;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -71,7 +71,7 @@ namespace AZ::RHI
         RHI::PipelineStateCache* GetPipelineStateCache() override;
         void ModifyFrameSchedulerStatisticsFlags(RHI::FrameSchedulerStatisticsFlags statisticsFlags, bool enableFlags) override;
         double GetCpuFrameTime() const override;
-        const RHI::TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const override;
+        const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* GetTransientAttachmentPoolDescriptor() const override;
         ConstPtr<PlatformLimitsDescriptor> GetPlatformLimitsDescriptor(int deviceIndex = MultiDevice::DefaultDeviceIndex) const override;
         void QueueRayTracingShaderTableForBuild(SingleDeviceRayTracingShaderTable* rayTracingShaderTable) override;
         XRRenderingInterface* GetXRSystem() const override;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -60,7 +60,7 @@ namespace AZ::RHI
 
         virtual uint16_t GetNumActiveRenderPipelines() const = 0;
 
-        virtual const RHI::TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const = 0;
+        virtual const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* GetTransientAttachmentPoolDescriptor() const = 0;
 
         virtual ConstPtr<PlatformLimitsDescriptor> GetPlatformLimitsDescriptor(int deviceIndex = MultiDevice::DefaultDeviceIndex) const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -50,6 +50,8 @@ namespace AZ::RHI
 
         virtual int GetDeviceCount() = 0;
 
+        virtual MultiDevice::DeviceMask GetRayTracingSupport() = 0;
+
         virtual RHI::DrawListTagRegistry* GetDrawListTagRegistry() = 0;
 
         virtual RHI::PipelineStateCache* GetPipelineStateCache() = 0;

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -679,15 +679,19 @@ namespace AZ::RHI
         };
 
         AZStd::optional<TransientAttachmentStatistics::MemoryUsage> memoryUsage;
-        // Check if we need to do two passes (one for calculating the size and the second one for allocating the resources)
-        if (transientAttachmentPool.GetDescriptor().m_heapParameters.m_type == HeapAllocationStrategy::MemoryHint)
+
+        for (auto& [deviceIndex, descriptor] : transientAttachmentPool.GetDescriptor())
         {
-            // First pass to calculate size needed.
-            processCommands(TransientAttachmentPoolCompileFlags::GatherStatistics | TransientAttachmentPoolCompileFlags::DontAllocateResources);
-            auto statistics = transientAttachmentPool.GetStatistics();
-            for (auto& [deviceIndex, deviceStatistics] : statistics)
+            // Check if we need to do two passes (one for calculating the size and the second one for allocating the resources)
+            if (descriptor.m_heapParameters.m_type == HeapAllocationStrategy::MemoryHint)
             {
-                memoryUsage = deviceStatistics.m_reservedMemory;
+                // First pass to calculate size needed.
+                processCommands(TransientAttachmentPoolCompileFlags::GatherStatistics | TransientAttachmentPoolCompileFlags::DontAllocateResources);
+                auto statistics = transientAttachmentPool.GetStatistics();
+                for (auto& [deviceIndex, deviceStatistics] : statistics)
+                {
+                    memoryUsage = deviceStatistics.m_reservedMemory;
+                }
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -687,11 +687,8 @@ namespace AZ::RHI
             {
                 // First pass to calculate size needed.
                 processCommands(TransientAttachmentPoolCompileFlags::GatherStatistics | TransientAttachmentPoolCompileFlags::DontAllocateResources);
-                auto statistics = transientAttachmentPool.GetStatistics();
-                for (auto& [deviceIndex, deviceStatistics] : statistics)
-                {
-                    memoryUsage = deviceStatistics.m_reservedMemory;
-                }
+                auto statistics = transientAttachmentPool.GetDeviceTransientAttachmentPool(deviceIndex)->GetStatistics();
+                memoryUsage = statistics.m_reservedMemory;
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -66,9 +66,9 @@ namespace AZ::RHI
 
         RHI::MultiDevice::DeviceMask transientAttachmentPoolDeviceMask{0};
 
-        for (auto& [deviceIndex, descriptor] : descriptor.m_transientAttachmentPoolDescriptors)
+        for (auto& [deviceIndex, transientAttachmentPoolDescriptor] : descriptor.m_transientAttachmentPoolDescriptors)
         {
-            if (SingleDeviceTransientAttachmentPool::NeedsTransientAttachmentPool(descriptor))
+            if (SingleDeviceTransientAttachmentPool::NeedsTransientAttachmentPool(transientAttachmentPoolDescriptor))
             {
                 transientAttachmentPoolDeviceMask |= static_cast<RHI::MultiDevice::DeviceMask>(1 << deviceIndex);
             }

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -57,44 +57,48 @@ namespace AZ::RHI
         m_drawListTagRegistry = RHI::DrawListTagRegistry::Create();
         m_pipelineStateCache = RHI::PipelineStateCache::Create(RHI::MultiDevice::AllDevices);
 
-        frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_renderTargetBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_renderTargetBudgetInBytes;
-        frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_imageBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_imageBudgetInBytes;
-        frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_bufferBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_bufferBudgetInBytes;
-
-        switch (platformLimitsDescriptor->m_heapAllocationStrategy)
+        for (int deviceIndex{0}; deviceIndex < GetDeviceCount(); ++deviceIndex)
         {
-            case HeapAllocationStrategy::Fixed:
+            frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_renderTargetBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_renderTargetBudgetInBytes;
+            frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_imageBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_imageBudgetInBytes;
+            frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_bufferBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_bufferBudgetInBytes;
+
+            switch (platformLimitsDescriptor->m_heapAllocationStrategy)
             {
-                frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_heapParameters = RHI::HeapAllocationParameters();
-                break;
+                case HeapAllocationStrategy::Fixed:
+                {
+                    frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_heapParameters = RHI::HeapAllocationParameters();
+                    break;
+                }
+                case  HeapAllocationStrategy::Paging:
+                {
+                    RHI::HeapPagingParameters heapAllocationParameters;
+                    heapAllocationParameters.m_collectLatency = platformLimitsDescriptor->m_pagingParameters.m_collectLatency;
+                    heapAllocationParameters.m_initialAllocationPercentage = platformLimitsDescriptor->m_pagingParameters.m_initialAllocationPercentage;
+                    heapAllocationParameters.m_pageSizeInBytes = platformLimitsDescriptor->m_pagingParameters.m_pageSizeInBytes;
+                    frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_heapParameters = RHI::HeapAllocationParameters(heapAllocationParameters);
+                    break;
+                }
+                case HeapAllocationStrategy::MemoryHint:
+                {
+                    RHI::HeapMemoryHintParameters heapAllocationParameters;
+                    heapAllocationParameters.m_heapSizeScaleFactor = platformLimitsDescriptor->m_usageHintParameters.m_heapSizeScaleFactor;
+                    heapAllocationParameters.m_collectLatency = platformLimitsDescriptor->m_usageHintParameters.m_collectLatency;
+                    heapAllocationParameters.m_maxHeapWastedPercentage = platformLimitsDescriptor->m_usageHintParameters.m_maxHeapWastedPercentage;
+                    heapAllocationParameters.m_minHeapSizeInBytes = platformLimitsDescriptor->m_usageHintParameters.m_minHeapSizeInBytes;
+                    frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_heapParameters = RHI::HeapAllocationParameters(heapAllocationParameters);
+                    break;
+                }
+                default:
+                {
+                    AZ_Assert(false, "UnSupported type");
+                    break;
+                }
             }
-            case  HeapAllocationStrategy::Paging:
-            {
-                RHI::HeapPagingParameters heapAllocationParameters;
-                heapAllocationParameters.m_collectLatency = platformLimitsDescriptor->m_pagingParameters.m_collectLatency;
-                heapAllocationParameters.m_initialAllocationPercentage = platformLimitsDescriptor->m_pagingParameters.m_initialAllocationPercentage;
-                heapAllocationParameters.m_pageSizeInBytes = platformLimitsDescriptor->m_pagingParameters.m_pageSizeInBytes;
-                frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_heapParameters = RHI::HeapAllocationParameters(heapAllocationParameters);
-                break;
-            }
-            case HeapAllocationStrategy::MemoryHint:
-            {
-                RHI::HeapMemoryHintParameters heapAllocationParameters;
-                heapAllocationParameters.m_heapSizeScaleFactor = platformLimitsDescriptor->m_usageHintParameters.m_heapSizeScaleFactor;
-                heapAllocationParameters.m_collectLatency = platformLimitsDescriptor->m_usageHintParameters.m_collectLatency;
-                heapAllocationParameters.m_maxHeapWastedPercentage = platformLimitsDescriptor->m_usageHintParameters.m_maxHeapWastedPercentage;
-                heapAllocationParameters.m_minHeapSizeInBytes = platformLimitsDescriptor->m_usageHintParameters.m_minHeapSizeInBytes;
-                frameSchedulerDescriptor.m_transientAttachmentPoolDescriptor.m_heapParameters = RHI::HeapAllocationParameters(heapAllocationParameters);
-                break;
-            }
-            default:
-            {
-                AZ_Assert(false, "UnSupported type");
-                break;
-            }
+
+            frameSchedulerDescriptor.m_platformLimitsDescriptors[deviceIndex] = platformLimitsDescriptor;
         }
 
-        frameSchedulerDescriptor.m_platformLimitsDescriptor = platformLimitsDescriptor;
         m_frameScheduler.Init(MultiDevice::AllDevices, frameSchedulerDescriptor);
 
         RHISystemNotificationBus::Broadcast(&RHISystemNotificationBus::Events::OnRHISystemInitialized);
@@ -325,7 +329,7 @@ namespace AZ::RHI
     }
 
 
-    const AZ::RHI::TransientAttachmentPoolDescriptor* RHISystem::GetTransientAttachmentPoolDescriptor() const
+    const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* RHISystem::GetTransientAttachmentPoolDescriptor() const
     {
         return m_frameScheduler.GetTransientAttachmentPoolDescriptor();
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -50,8 +50,6 @@ namespace AZ::RHI
             AZ_Assert(false, "RHISystem", "Bindless SRG was not initialized.\n");
         }
 
-        Ptr<RHI::PlatformLimitsDescriptor> platformLimitsDescriptor = m_devices[MultiDevice::DefaultDeviceIndex]->GetDescriptor().m_platformLimitsDescriptor;
-
         RHI::FrameSchedulerDescriptor frameSchedulerDescriptor;
 
         m_drawListTagRegistry = RHI::DrawListTagRegistry::Create();
@@ -59,6 +57,8 @@ namespace AZ::RHI
 
         for (int deviceIndex{0}; deviceIndex < GetDeviceCount(); ++deviceIndex)
         {
+            Ptr<RHI::PlatformLimitsDescriptor> platformLimitsDescriptor = m_devices[deviceIndex]->GetDescriptor().m_platformLimitsDescriptor;
+
             frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_renderTargetBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_renderTargetBudgetInBytes;
             frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_imageBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_imageBudgetInBytes;
             frameSchedulerDescriptor.m_transientAttachmentPoolDescriptors[deviceIndex].m_bufferBudgetInBytes = platformLimitsDescriptor->m_transientAttachmentPoolBudgets.m_bufferBudgetInBytes;

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -45,9 +45,16 @@ namespace AZ::RHI
     void RHISystem::Init(RHI::Ptr<RHI::ShaderResourceGroupLayout> bindlessSrgLayout)
     {
         //! If a bindless srg layout is not provided we simply skip initialization with the assumption that no one will use bindless srg
-        if (bindlessSrgLayout && m_devices[MultiDevice::DefaultDeviceIndex]->InitBindlessSrg(bindlessSrgLayout) != RHI::ResultCode::Success)
+        if (bindlessSrgLayout)
         {
-            AZ_Assert(false, "RHISystem", "Bindless SRG was not initialized.\n");
+            bool success = true;
+
+            for (auto device : m_devices)
+            {
+                success &= device->InitBindlessSrg(bindlessSrgLayout) == RHI::ResultCode::Success;
+            }
+
+            AZ_Assert(success, "RHISystem", "Bindless SRG was not initialized.\n");
         }
 
         RHI::FrameSchedulerDescriptor frameSchedulerDescriptor;

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -312,6 +312,21 @@ namespace AZ::RHI
         return static_cast<int>(m_devices.size());
     }
 
+    MultiDevice::DeviceMask RHISystem::GetRayTracingSupport()
+    {
+        MultiDevice::DeviceMask result{0};
+
+        for (int deviceIndex{0}; deviceIndex < m_devices.size(); ++deviceIndex)
+        {
+            if (m_devices[deviceIndex]->GetFeatures().m_rayTracing)
+            {
+                result |= static_cast<MultiDevice::DeviceMask>(1 << deviceIndex);
+            }
+        }
+
+        return result;
+    }
+
     RHI::PipelineStateCache* RHISystem::GetPipelineStateCache()
     {
         return m_pipelineStateCache.get();

--- a/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
@@ -241,7 +241,7 @@ namespace UnitTest
             RHI::FrameScheduler frameScheduler;
 
             RHI::FrameSchedulerDescriptor descriptor;
-            descriptor.m_transientAttachmentPoolDescriptor.m_bufferBudgetInBytes = 80 * 1024 * 1024;
+            descriptor.m_transientAttachmentPoolDescriptors[RHI::MultiDevice::DefaultDeviceIndex].m_bufferBudgetInBytes = 80 * 1024 * 1024;
             frameScheduler.Init(RHI::MultiDevice::DefaultDevice, descriptor);
 
             RHI::ImageScopeAttachmentDescriptor imageBindingDescs[2];

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -34,10 +34,13 @@ namespace AZ
 
         RHI::ResultCode FrameGraphExecuter::InitInternal(const RHI::FrameGraphExecuterDescriptor& descriptor)
         {
-            const RHI::ConstPtr<RHI::PlatformLimitsDescriptor> rhiPlatformLimitsDescriptor = descriptor.m_platformLimitsDescriptor;
-            if (RHI::ConstPtr<PlatformLimitsDescriptor> dx12PlatformLimitsDesc = azrtti_cast<const PlatformLimitsDescriptor*>(rhiPlatformLimitsDescriptor))
+            for (auto& [deviceIndex, platformLimitsDescriptor] : descriptor.m_platformLimitsDescriptors)
             {
-                m_frameGraphExecuterData = dx12PlatformLimitsDesc->m_frameGraphExecuterData;
+                const RHI::ConstPtr<RHI::PlatformLimitsDescriptor> rhiPlatformLimitsDescriptor = platformLimitsDescriptor;
+                if (RHI::ConstPtr<PlatformLimitsDescriptor> dx12PlatformLimitsDesc = azrtti_cast<const PlatformLimitsDescriptor*>(rhiPlatformLimitsDescriptor))
+                {
+                    m_frameGraphExecuterData[deviceIndex] = dx12PlatformLimitsDesc->m_frameGraphExecuterData;
+                }
             }
 
             return RHI::ResultCode::Success;
@@ -83,14 +86,14 @@ namespace AZ
 
                 const uint32_t CommandListCostThreshold =
                     AZStd::max(
-                        m_frameGraphExecuterData.m_commandListCostThresholdMin,
-                        AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData.m_commandListsPerScopeMax));
+                        m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
+                        AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
 
                 // Computes a cost heuristic based on the number of items and number of attachments in
                 // the scope. This cost is used to partition command list generation.
                 const uint32_t totalScopeCost =
-                    estimatedItemCount * m_frameGraphExecuterData.m_itemCost +
-                    static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData.m_attachmentCost;
+                    estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
+                    static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
 
                 const uint32_t swapchainCount = static_cast<uint32_t>(scope.GetSwapChainsToPresent().size());
 
@@ -100,7 +103,7 @@ namespace AZ
                     const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
 
                     // Check if the swap chains fit into this group.
-                    const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData.m_swapChainsPerCommandList;
+                    const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
 
                     // Check if the hardware queue classes match.
                     const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.h
@@ -41,7 +41,7 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
 
             const RHI::ScopeId m_mergedScopeId{"Merged"};
-            FrameGraphExecuterData m_frameGraphExecuterData;
+            AZStd::unordered_map<int, FrameGraphExecuterData> m_frameGraphExecuterData;
         };
     }
 }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.h
@@ -40,7 +40,7 @@ namespace AZ
             void ExecuteGroupInternal(RHI::FrameGraphExecuteGroup& group) override;
             void EndInternal() override {}
             
-            FrameGraphExecuterData m_frameGraphExecuterData;
+            AZStd::unordered_map<int, FrameGraphExecuterData> m_frameGraphExecuterData;
 
         };
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.h
@@ -46,7 +46,7 @@ namespace AZ
 
             // List of handlers for execute groups.
             AZStd::unordered_map<RHI::GraphGroupId, AZStd::unique_ptr<FrameGraphExecuteGroupHandler>> m_groupHandlers;
-            FrameGraphExecuterData m_frameGraphExecuterData;
+            AZStd::unordered_map<int, FrameGraphExecuterData> m_frameGraphExecuterData;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -56,6 +56,9 @@ namespace AZ
             //! Update buffer's content with sourceData at an offset of bufferByteOffset
             bool UpdateData(const void* sourceData, uint64_t sourceDataSizeInBytes, uint64_t bufferByteOffset = 0);
 
+            //! Update buffer's content with sourceData for each device at an offset of bufferByteOffset
+            bool UpdateData(const AZStd::unordered_map<int, const void*> sourceData, uint64_t sourceDataSizeInBytes, uint64_t bufferByteOffset = 0);
+
             //! Reallocate a new block of memory for this buffer. The previous allocated
             //! memory will be discarded once the GPU is done using it. This only works
             //! for buffers with host heap memory level.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicBuffer.h
@@ -62,7 +62,7 @@ namespace AZ
             DynamicBuffer() = default;
 
             // initialize function called by DynamicBufferAllocator which to initialize this buffer
-            void Initialize(AZStd::unordered_map<int, void*> address, uint32_t size);
+            void Initialize(const AZStd::unordered_map<int, void*>& address, uint32_t size);
 
             AZStd::unordered_map<int, void*> m_address;
             uint32_t m_size;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/Query.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/Query.h
@@ -91,17 +91,17 @@ namespace AZ
             //! QueryCode::Fail.
             //! @param[out] queryResult The user provided structure where the data is copied to.
             //! @param[in] resultSizeInBytes The size of the data in bytes.
-            QueryResultCode GetLatestResult(void* queryResult, uint32_t resultSizeInBytes);
+            QueryResultCode GetLatestResult(void* queryResult, uint32_t resultSizeInBytes, int deviceIndex);
 
             //! Returns the earliest possible query result without stalling the thread. Result might be a few frames old.
             //! Note: When trying to retrieve query results without any queries being ready for readback, the system will return
             //! QueryCode::Fail.
             //! @param[in/out] queryResult The user provided structure where the data is copied to.
             template<typename T>
-            QueryResultCode GetLatestResult(T& queryResult)
+            QueryResultCode GetLatestResult(T& queryResult, int deviceIndex)
             {
                 void* resultData = static_cast<void*>(&queryResult);
-                return GetLatestResult(resultData, sizeof(T));
+                return GetLatestResult(resultData, sizeof(T), deviceIndex);
             }
 
             //! Returns the result of the earliest possible query. It might stall the calling thread, depending if the query result is available for polling
@@ -111,7 +111,7 @@ namespace AZ
             //! to make sure the pool isn't deleted while the thread is stalling.
             //! @param[out] queryResult The user provided pointer where the data is copied to.
             //! @param[in] resultSizeInBytes The size of the data in bytes.
-            QueryResultCode GetLatestResultAndWait(void* queryResult, uint32_t resultSizeInBytes);
+            QueryResultCode GetLatestResultAndWait(void* queryResult, uint32_t resultSizeInBytes, int deviceIndex);
 
             //! Returns the result of the earliest possible query. It might stall the calling thread, depending if the query result is available for polling
             //! Note1: When trying to retrieve query results without any queries being ready for readback, the system will return
@@ -120,10 +120,10 @@ namespace AZ
             //! to make sure the pool isn't deleted while the thread is stalling.
             //! @param[in/out] queryResult The user provided pointer where the data is copied to.
             template<typename T>
-            QueryResultCode GetLatestResultAndWait(T& queryResult)
+            QueryResultCode GetLatestResultAndWait(T& queryResult, int deviceIndex)
             {
                 void* resultData = static_cast<void*>(&queryResult);
-                return GetLatestResultAndWait(resultData, sizeof(T));
+                return GetLatestResultAndWait(resultData, sizeof(T), deviceIndex);
             }
 
             //! Removes the reference of this instance in the RPI QueryPool where it was created.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/QueryPool.h
@@ -69,10 +69,10 @@ namespace AZ
             // Returns a span of RHI Queries depending on the indices that are provided.
             AZStd::span<const RHI::Ptr<RHI::MultiDeviceQuery>> GetRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
             // Returns an array of raw RHI Query pointers depending on the indices that are provided.
-            AZStd::vector<RHI::MultiDeviceQuery*> GetRawRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices) const;
+            AZStd::vector<AZ::RHI::SingleDeviceQuery*> GetRawRhiQueriesFromInterval(const RHI::Interval& rhiQueryIndices, int deviceIndex) const;
 
             // Readback results from the provided RHI Query indices.
-            QueryResultCode GetQueryResultFromIndices(uint64_t* result, RHI::Interval rhiQueryIndices, RHI::QueryResultFlagBits queryResultFlag);
+            QueryResultCode GetQueryResultFromIndices(uint64_t* result, RHI::Interval rhiQueryIndices, RHI::QueryResultFlagBits queryResultFlag, int deviceIndex);
 
             // Depending on the QueryType, the method to poll data from the queries vary.
             virtual RHI::ResultCode BeginQueryInternal(RHI::Interval rhiQueryIndices, const RHI::FrameGraphExecuteContext& context);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/AttachmentReadback.h
@@ -121,7 +121,7 @@ namespace AZ
             void DecomposeExecute(const RHI::FrameGraphExecuteContext& context);
 
             // copy data from the read back buffer (m_readbackBuffer) to the data buffer (m_dataBuffer)
-            bool CopyBufferData(uint32_t readbackBufferIndex);
+            bool CopyBufferData(uint32_t readbackBufferIndex, int deviceIndex);
 
             // Get read back data in a structure
             struct ReadbackItem;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -143,6 +143,8 @@ namespace AZ
             TimestampResult m_timestampResult;
             // Readback results from the PipelineStatistics queries
             PipelineStatisticsResult m_statisticsResult;
+            // The device index the pass ran on during the last frame, necessary to read the queries.
+            int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
 
             // For each ScopeProducer an instance of the ScopeQuery is created, which consists
             // of an Timestamp and PipelineStatistic query.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -305,11 +305,40 @@ namespace AZ
             if (auto buf = Map(sourceDataSize, bufferByteOffset); buf.size())
             {
                 auto partialResult{false};
-                for (auto index{ 0u }; index < buf.size(); ++index)
+                for (auto& [deviceIndex, buffer] : buf)
                 {
-                    if(buf[index] != nullptr)
+                    if(buffer != nullptr)
                     {
-                        memcpy(buf[index], sourceData, sourceDataSize);
+                        memcpy(buffer, sourceData, sourceDataSize);
+                        partialResult = true;
+                    }
+                }
+
+                if(partialResult)
+                {
+                    Unmap();
+                }
+                return partialResult;
+            }
+
+            return false;
+        }
+
+        bool Buffer::UpdateData(const AZStd::unordered_map<int, const void*> sourceData, uint64_t sourceDataSize, uint64_t bufferByteOffset)
+        {
+            if (sourceDataSize == 0)
+            {
+                return true;
+            }
+
+            if (auto buf = Map(sourceDataSize, bufferByteOffset); buf.size())
+            {
+                auto partialResult{false};
+                for (auto& [deviceIndex, source] : sourceData)
+                {
+                    if(buf[deviceIndex] != nullptr)
+                    {
+                        memcpy(buf[deviceIndex], source, sourceDataSize);
                         partialResult = true;
                     }
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicBuffer.cpp
@@ -47,7 +47,7 @@ namespace AZ
             return m_allocator->GetStreamBufferView(this, strideByteCount);
         }
 
-        void DynamicBuffer::Initialize(AZStd::unordered_map<int, void*> address, uint32_t size)
+        void DynamicBuffer::Initialize(const AZStd::unordered_map<int, void*>& address, uint32_t size)
         {
             m_address = address;
             m_size = size;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
@@ -137,7 +137,7 @@ namespace AZ
             return QueryResultCode::Success;
         }
 
-        QueryResultCode Query::GetLatestResultAndWait(void* queryResult, uint32_t resultSizeInBytes)
+        QueryResultCode Query::GetLatestResultAndWait(void* queryResult, uint32_t resultSizeInBytes, int deviceIndex)
         {
             if (resultSizeInBytes < m_queryPool->GetQueryResultSize())
             {
@@ -156,10 +156,10 @@ namespace AZ
             const SubQuery& recentSubQuery = m_subQueryArray[recentSubQueryIndex];
 
             // This may stall the calling thread; depending if the query result is already available for polling.
-            return m_queryPool->GetQueryResultFromIndices(static_cast<uint64_t*>(queryResult), recentSubQuery.m_rhiQueryIndices, RHI::QueryResultFlagBits::Wait);
+            return m_queryPool->GetQueryResultFromIndices(static_cast<uint64_t*>(queryResult), recentSubQuery.m_rhiQueryIndices, RHI::QueryResultFlagBits::Wait, deviceIndex);
         }
 
-        QueryResultCode Query::GetLatestResult(void* queryResult, uint32_t resultSizeInBytes)
+        QueryResultCode Query::GetLatestResult(void* queryResult, uint32_t resultSizeInBytes, int deviceIndex)
         {
             if (resultSizeInBytes < m_queryPool->GetQueryResultSize())
             {
@@ -176,7 +176,7 @@ namespace AZ
             }
 
             SubQuery& subQuery = m_subQueryArray[latestQueryIndex];
-            return m_queryPool->GetQueryResultFromIndices(static_cast<uint64_t*>(queryResult), subQuery.m_rhiQueryIndices, RHI::QueryResultFlagBits::None);
+            return m_queryPool->GetQueryResultFromIndices(static_cast<uint64_t*>(queryResult), subQuery.m_rhiQueryIndices, RHI::QueryResultFlagBits::None, deviceIndex);
         }
 
         bool Query::AssignNewFrameIndexToSubQuery(uint64_t poolFrameIndex)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -119,7 +119,6 @@ namespace AZ
             }
             
             // Create fence
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             m_fence = aznew RHI::MultiDeviceFence;
             AZ_Assert(m_fence != nullptr, "AttachmentReadback failed to create a fence");
             [[maybe_unused]] RHI::ResultCode result = m_fence->Init(RHI::MultiDevice::AllDevices, RHI::FenceState::Reset);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -440,44 +440,42 @@ namespace AZ
                     RHI::ImageAspectFlags imageAspectFlags = RHI::GetImageAspectFlags(m_imageDescriptor.m_format);
                     if (RHI::CheckBitsAll(imageAspectFlags, RHI::ImageAspectFlags::Depth))
                     {
-                    imageAspect = RHI::ImageAspect::Depth;
-                    range.m_aspectFlags = RHI::ImageAspectFlags::Depth;
-                        }
+                        imageAspect = RHI::ImageAspect::Depth;
+                        range.m_aspectFlags = RHI::ImageAspectFlags::Depth;
+                    }
 
-                        AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
-                        imageSubresourceLayouts.resize_no_construct(m_imageDescriptor.m_mipLevels);
-                        size_t totalSizeInBytes = 0;
-                        image->GetDeviceImage(context.GetDeviceIndex())
-                            ->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), &totalSizeInBytes);
-                        AZ::u64 byteCount = totalSizeInBytes;
+                    AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
+                    imageSubresourceLayouts.resize_no_construct(m_imageDescriptor.m_mipLevels);
+                    size_t totalSizeInBytes = 0;
+                    image->GetDeviceImage(context.GetDeviceIndex())->GetSubresourceLayouts(range, imageSubresourceLayouts.data(), &totalSizeInBytes);
+                    AZ::u64 byteCount = totalSizeInBytes;
 
-                        RPI::CommonBufferDescriptor desc;
-                        desc.m_poolType = RPI::CommonBufferPoolType::ReadBack;
-                        desc.m_bufferName = m_readbackName.GetStringView();
-                        desc.m_byteCount = byteCount;
+                    RPI::CommonBufferDescriptor desc;
+                    desc.m_poolType = RPI::CommonBufferPoolType::ReadBack;
+                    desc.m_bufferName = m_readbackName.GetStringView();
+                    desc.m_byteCount = byteCount;
 
-                        readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex] =
-                            BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+                    readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex] =
+                        BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
 
-                        // Use the aspect format as output format, this format is also used as copy destination's format
-                        m_imageDescriptor.m_format = FindFormatForAspect(m_imageDescriptor.m_format, imageAspect);
+                    // Use the aspect format as output format, this format is also used as copy destination's format
+                    m_imageDescriptor.m_format = FindFormatForAspect(m_imageDescriptor.m_format, imageAspect);
 
-                        // copy descriptor for copying image to buffer
-                        RHI::MultiDeviceCopyImageToBufferDescriptor copyImageToBuffer;
-                        copyImageToBuffer.m_mdSourceImage = image;
-                        copyImageToBuffer.m_sourceSize = imageSubresourceLayouts[mipSlice].m_size;
-                        copyImageToBuffer.m_sourceSubresource = RHI::ImageSubresource(mipSlice, 0 /*arraySlice*/, imageAspect);
-                        copyImageToBuffer.m_destinationOffset = 0;
-                        copyImageToBuffer.m_destinationBytesPerRow = imageSubresourceLayouts[mipSlice].m_bytesPerRow;
-                        copyImageToBuffer.m_destinationBytesPerImage = imageSubresourceLayouts[mipSlice].m_bytesPerImage;
-                        copyImageToBuffer.m_mdDestinationBuffer =
-                            readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
-                        copyImageToBuffer.m_destinationFormat = m_imageDescriptor.m_format;
+                    // copy descriptor for copying image to buffer
+                    RHI::MultiDeviceCopyImageToBufferDescriptor copyImageToBuffer;
+                    copyImageToBuffer.m_mdSourceImage = image;
+                    copyImageToBuffer.m_sourceSize = imageSubresourceLayouts[mipSlice].m_size;
+                    copyImageToBuffer.m_sourceSubresource = RHI::ImageSubresource(mipSlice, 0 /*arraySlice*/, imageAspect);
+                    copyImageToBuffer.m_destinationOffset = 0;
+                    copyImageToBuffer.m_destinationBytesPerRow = imageSubresourceLayouts[mipSlice].m_bytesPerRow;
+                    copyImageToBuffer.m_destinationBytesPerImage = imageSubresourceLayouts[mipSlice].m_bytesPerImage;
+                    copyImageToBuffer.m_mdDestinationBuffer = readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex]->GetRHIBuffer();
+                    copyImageToBuffer.m_destinationFormat = m_imageDescriptor.m_format;
 
-                        readbackItem.m_mipInfo.m_slice = mipSlice;
-                        readbackItem.m_mipInfo.m_size = imageSubresourceLayouts[mipSlice].m_size;
+                    readbackItem.m_mipInfo.m_slice = mipSlice;
+                    readbackItem.m_mipInfo.m_size = imageSubresourceLayouts[mipSlice].m_size;
 
-                        readbackItem.m_copyItem = copyImageToBuffer;
+                    readbackItem.m_copyItem = copyImageToBuffer;
                 }
 
                 if (readbackItem.m_readbackBufferArray[m_readbackBufferCurrentIndex])

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -222,6 +222,8 @@ namespace AZ
             BeginScopeQuery(context);
             BuildCommandListInternal(context);
             EndScopeQuery(context);
+
+            m_lastDeviceIndex = context.GetDeviceIndex();
         }
 
         void RenderPass::DeclareAttachmentsToFrameGraph(RHI::FrameGraphInterface frameGraph) const
@@ -567,13 +569,13 @@ namespace AZ
             {
                 const uint32_t TimestampResultQueryCount = 2u;
                 uint64_t timestampResult[TimestampResultQueryCount] = {0};
-                query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount);
+                query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount, m_lastDeviceIndex);
                 m_timestampResult = TimestampResult(timestampResult[0], timestampResult[1], RHI::HardwareQueueClass::Graphics);
             });
 
             ExecuteOnPipelineStatisticsQuery([this](RHI::Ptr<Query> query)
             {
-                query->GetLatestResult(&m_statisticsResult, sizeof(PipelineStatisticsResult));
+                query->GetLatestResult(&m_statisticsResult, sizeof(PipelineStatisticsResult), m_lastDeviceIndex);
             });
         }
     }   // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -90,9 +90,6 @@ namespace AZ
                 AZStd::string uuidString;
                 assetId.m_guid.ToString<AZStd::string>(uuidString, false, false);
 
-                RHI::RHISystemInterface* rhiSystem = RHI::RHISystemInterface::Get();
-                RHI::PhysicalDeviceDescriptor physicalDeviceDesc = rhiSystem->GetDevice()->GetPhysicalDevice().GetDescriptor();
-
                 AZStd::string configString;
                 if (RHI::BuildOptions::IsDebugBuild)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroupPool.cpp
@@ -47,8 +47,6 @@ namespace AZ
         RHI::ResultCode ShaderResourceGroupPool::Init(
             ShaderAsset& shaderAsset, const SupervariantIndex& supervariantIndex, const AZ::Name& srgName)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             m_pool = aznew RHI::MultiDeviceShaderResourceGroupPool;
             if (!m_pool)
             {

--- a/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
@@ -109,7 +109,7 @@ namespace UnitTest
             EXPECT_EQ(resultCode, QueryResultCode::Success);
             void* data = nullptr;
             // Query type of the pool is occlusion, which expects a result size of sizeof(uint64_t).
-            resultCode = query->GetLatestResult(data, sizeof(uint32_t));
+            resultCode = query->GetLatestResult(data, sizeof(uint32_t), RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Fail);
         }
 
@@ -185,9 +185,9 @@ namespace UnitTest
             }
 
             void* data = reinterpret_cast<void*>(&mockData);
-            resultCode = query->GetLatestResult(data, ResultSize);
+            resultCode = query->GetLatestResult(data, ResultSize, context.GetDeviceIndex());
             EXPECT_EQ(resultCode, QueryResultCode::Success);
-            resultCode = query->GetLatestResultAndWait(data, ResultSize);
+            resultCode = query->GetLatestResultAndWait(data, ResultSize, context.GetDeviceIndex());
             EXPECT_EQ(resultCode, QueryResultCode::Success);
         }
     }
@@ -232,7 +232,7 @@ namespace UnitTest
             EXPECT_EQ(resultCode, QueryResultCode::Success);
             void* data = nullptr;
             // Query type of the pool is statistics, which expects a result size of sizeof(uint64_t) * number of active flags.
-            resultCode = query->GetLatestResult(data, sizeof(uint64_t) * 3u);
+            resultCode = query->GetLatestResult(data, sizeof(uint64_t) * 3u, RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Fail);
         }
 
@@ -258,9 +258,9 @@ namespace UnitTest
             }
 
             void* data = reinterpret_cast<void*>(&mockData);
-            resultCode = query->GetLatestResult(data, ResultSize);
+            resultCode = query->GetLatestResult(data, ResultSize, RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Success);
-            resultCode = query->GetLatestResultAndWait(data, ResultSize);
+            resultCode = query->GetLatestResultAndWait(data, ResultSize, RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Success);
         }
     }
@@ -304,9 +304,9 @@ namespace UnitTest
             }
 
             void* data = reinterpret_cast<void*>(&mockData);
-            resultCode = query->GetLatestResult(data, ResultSize);
+            resultCode = query->GetLatestResult(data, ResultSize, RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Success);
-            resultCode = query->GetLatestResultAndWait(data, ResultSize);
+            resultCode = query->GetLatestResultAndWait(data, ResultSize, RHI::MultiDevice::DefaultDeviceIndex);
             EXPECT_EQ(resultCode, QueryResultCode::Success);
         }
     }

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiTransientAttachmentProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiTransientAttachmentProfiler.inl
@@ -31,7 +31,7 @@ namespace AZ
                         memoryUsage = deviceStatistics.m_reservedMemory;
                     }
 
-                    ImGui::Text("Strategy: %s", ToString(RHI::RHISystemInterface::Get()->GetTransientAttachmentPoolDescriptor()->m_heapParameters.m_type));
+                    ImGui::Text("Strategy: %s", ToString(RHI::RHISystemInterface::Get()->GetTransientAttachmentPoolDescriptor()->begin()->second.m_heapParameters.m_type));
                     ImGui::Text("Buffer Memory: %.1f MB", static_cast<double>(memoryUsage.m_bufferMemoryInBytes * BytesToMB));
                     ImGui::Text("Image Memory: %.1f MB", static_cast<double>(memoryUsage.m_imageMemoryInBytes * BytesToMB));
                     ImGui::Text("Rendertarget Memory: %.1f MB", static_cast<double>(memoryUsage.m_rendertargetMemoryInBytes * BytesToMB));

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -332,8 +332,6 @@ namespace AZ
                 return;
             }
 
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             uint32_t probeCountX;
             uint32_t probeCountY;
             GetTexture2DProbeCount(probeCountX, probeCountY);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -205,8 +205,7 @@ namespace AZ
             // handle auto-select
             if (mode == DiffuseProbeGridMode::AutoSelect)
             {
-                RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-                m_mode = (device->GetFeatures().m_rayTracing) ? DiffuseProbeGridMode::RealTime : DiffuseProbeGridMode::Baked;
+                m_mode = (RHI::RHISystemInterface::Get()->GetRayTracingSupport() != RHI::MultiDevice::NoDevices) ? DiffuseProbeGridMode::RealTime : DiffuseProbeGridMode::Baked;
             }
             else
             {

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -48,7 +48,7 @@ namespace AZ
                 return;
             }
 
-            auto deviceMask = RHI::RHISystemInterface::Get()->GetRayTracingSupport();
+            auto rayTracingDeviceMask = RHI::RHISystemInterface::Get()->GetRayTracingSupport();
 
             m_diffuseProbeGrids.reserve(InitialProbeGridAllocationSize);
             m_realTimeDiffuseProbeGrids.reserve(InitialProbeGridAllocationSize);
@@ -59,7 +59,7 @@ namespace AZ
 
             m_bufferPool = aznew RHI::MultiDeviceBufferPool;
             m_bufferPool->SetName(Name("DiffuseProbeGridBoxBufferPool"));
-            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(deviceMask, desc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(RHI::MultiDevice::AllDevices, desc);
             AZ_Error("DiffuseProbeGridFeatureProcessor", resultCode == RHI::ResultCode::Success, "Failed to initialize buffer pool");
 
             // create box mesh vertices and indices
@@ -72,7 +72,7 @@ namespace AZ
 
                 m_probeGridRenderData.m_imagePool = aznew RHI::MultiDeviceImagePool;
                 m_probeGridRenderData.m_imagePool->SetName(Name("DiffuseProbeGridRenderImageData"));
-                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(deviceMask, imagePoolDesc);
+                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
             }
 
@@ -83,7 +83,7 @@ namespace AZ
 
                 m_probeGridRenderData.m_bufferPool = aznew RHI::MultiDeviceBufferPool;
                 m_probeGridRenderData.m_bufferPool->SetName(Name("DiffuseProbeGridRenderBufferData"));
-                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_bufferPool->Init(deviceMask, bufferPoolDesc);
+                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output buffer pool");
             }
 
@@ -115,11 +115,11 @@ namespace AZ
                 AZ_Error("DiffuseProbeGridFeatureProcessor", m_probeGridRenderData.m_srgLayout != nullptr, "Failed to find ObjectSrg layout");
             }
 
-            if (deviceMask != RHI::MultiDevice::NoDevices)
+            if (rayTracingDeviceMask != RHI::MultiDevice::NoDevices)
             {
                 // initialize the buffer pools for the DiffuseProbeGrid visualization
                 m_visualizationBufferPools = aznew RHI::MultiDeviceRayTracingBufferPools;
-                m_visualizationBufferPools->Init(deviceMask);
+                m_visualizationBufferPools->Init(rayTracingDeviceMask);
 
                 // load probe visualization model, the BLAS will be created in OnAssetReady()
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -38,8 +38,7 @@ namespace AZ
         DiffuseProbeGridRayTracingPass::DiffuseProbeGridRayTracingPass(const RPI::PassDescriptor& descriptor)
             : RPI::RenderPass(descriptor)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
             {
                 // raytracing or GI is not supported on this platform
                 SetEnabled(false);
@@ -140,8 +139,7 @@ namespace AZ
 
         void DiffuseProbeGridRayTracingPass::BuildInternal()
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() != RHI::MultiDevice::NoDevices)
             {
                 CreateRayTracingPipelineState();
             }
@@ -154,7 +152,6 @@ namespace AZ
 
             if (!m_rayTracingShaderTable)
             {
-                RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
                 RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -48,8 +48,6 @@ namespace AZ
 
         void DiffuseProbeGridRayTracingPass::CreateRayTracingPipelineState()
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             // load the ray tracing shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracing.azshader";

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
@@ -75,7 +75,6 @@ namespace AZ
 
         void DiffuseProbeGridRenderPass::FrameBeginInternal(FramePrepareParams params)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             RPI::Scene* scene = m_pipeline->GetScene();
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
 
@@ -93,8 +92,8 @@ namespace AZ
 
             Base::FrameBeginInternal(params);
 
-            // process attachment readback for RealTime grids, if raytracing is supported on this device            
-            if (device->GetFeatures().m_rayTracing)
+            // process attachment readback for RealTime grids, if raytracing is supported on this device
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() != RHI::MultiDevice::NoDevices)
             {
                 for (auto& diffuseProbeGrid : diffuseProbeGridFeatureProcessor->GetRealTimeProbeGrids())
                 {
@@ -209,8 +208,6 @@ namespace AZ
 
         bool DiffuseProbeGridRenderPass::ShouldRender(const AZStd::shared_ptr<DiffuseProbeGrid>& diffuseProbeGrid)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             // check for baked mode with no valid textures
             if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::Baked &&
                 !diffuseProbeGrid->HasValidBakedTextures())
@@ -220,7 +217,7 @@ namespace AZ
 
             // check for RealTime mode without ray tracing
             if (diffuseProbeGrid->GetMode() == DiffuseProbeGridMode::RealTime &&
-                !device->GetFeatures().m_rayTracing)
+                (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices))
             {
                 return false;
             }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -82,7 +82,6 @@ namespace AZ
 
         void DiffuseProbeGridVisualizationAccelerationStructurePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             RPI::Scene* scene = m_pipeline->GetScene();
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -30,8 +30,7 @@ namespace AZ
             : Pass(descriptor)
         {
             // disable this pass if we're on a platform that doesn't support raytracing
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
             {
                 SetEnabled(false);
             }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -30,8 +30,7 @@ namespace AZ
             : RenderPass(descriptor)
         {
             // disable this pass if we're on a platform that doesn't support raytracing
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
             {
                 SetEnabled(false);
             }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -103,7 +103,6 @@ namespace AZ
 
         void DiffuseProbeGridVisualizationPreparePass::FrameBeginInternal(FramePrepareParams params)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             RPI::Scene* scene = m_pipeline->GetScene();
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -32,8 +32,7 @@ namespace AZ
         DiffuseProbeGridVisualizationRayTracingPass::DiffuseProbeGridVisualizationRayTracingPass(const RPI::PassDescriptor& descriptor)
             : RPI::RenderPass(descriptor)
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-            if (device->GetFeatures().m_rayTracing == false || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
+            if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices || !AZ_TRAIT_DIFFUSE_GI_PASSES_SUPPORTED)
             {
                 // raytracing or GI is not supported on this platform
                 SetEnabled(false);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -42,8 +42,6 @@ namespace AZ
 
         void DiffuseProbeGridVisualizationRayTracingPass::CreateRayTracingPipelineState()
         {
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
-
             // load the ray tracing shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridVisualizationRayTracing.azshader";
@@ -142,7 +140,6 @@ namespace AZ
 
             if (!m_rayTracingShaderTable)
             {
-                RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
                 RHI::MultiDeviceRayTracingBufferPools& rayTracingBufferPools = diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -559,10 +559,10 @@ namespace NvCloth
             MappedBuffer<AZ::Vector4> destTangents(subMesh.GetSemanticBufferAssetView(tangentSemantic), numVertices, AZ::RHI::Format::R32G32B32A32_FLOAT);
             MappedBuffer<AZ::PackedVector3f> destBitangents(subMesh.GetSemanticBufferAssetView(bitangentSemantic), numVertices, AZ::RHI::Format::R32G32B32_FLOAT);
 
-            auto destVerticesData = destVertices.GetBuffer();
-            auto destNormalsData = destNormals.GetBuffer();
-            auto destTangentsData = destTangents.GetBuffer();
-            auto destBitangentsData = destBitangents.GetBuffer();
+            const auto& destVerticesData = destVertices.GetBuffer();
+            const auto& destNormalsData = destNormals.GetBuffer();
+            const auto& destTangentsData = destTangents.GetBuffer();
+            const auto& destBitangentsData = destBitangents.GetBuffer();
 
             if (!destVerticesData.empty())
             {

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Console/Console.h>
 #include <AzCore/std/parallel/semaphore.h>
 
+#include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
@@ -111,6 +112,17 @@ namespace Terrain
             return;
         }
 
+        auto deviceMask{AZStd::to_underlying(terrainSrg->GetRHIShaderResourceGroup()->GetDeviceMask())};
+        auto deviceCount = AZ::RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+        for (auto deviceIndex{0}; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            if (deviceMask & (1 << deviceIndex))
+            {
+                m_detailMaterialShaderData[deviceIndex] = {};
+            }
+        }
+
         m_terrainMaterial = terrainMaterial;
         UpdateTerrainMaterial();
 
@@ -196,8 +208,13 @@ namespace Terrain
         m_detailTextureImage = {};
         m_detailMaterials.Clear();
         m_detailMaterialRegions.Clear();
-        m_detailMaterialShaderData.Clear();
+        m_detailMaterialShaderIndex.Clear();
         m_detailMaterialDataBuffer.Release();
+
+        for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
+        {
+            data.clear();
+        }
 
         m_dirtyDetailRegion = AZ::Aabb::CreateNull();
 
@@ -220,7 +237,15 @@ namespace Terrain
         if (m_detailMaterialBufferNeedsUpdate)
         {
             m_detailMaterialBufferNeedsUpdate = false;
-            m_detailMaterialDataBuffer.UpdateBuffer(m_detailMaterialShaderData.GetRawData(), aznumeric_cast<uint32_t>(m_detailMaterialShaderData.GetSize()));
+
+            AZStd::unordered_map<int, const void*> rawData;
+
+            for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
+            {
+                rawData[deviceIndex] = data.data();
+            }
+
+            m_detailMaterialDataBuffer.UpdateBuffer(rawData, aznumeric_cast<uint32_t>(m_detailMaterialShaderIndex.GetSize()));
         }
 
         CheckUpdateDetailTexture(cameraPosition);
@@ -516,7 +541,7 @@ namespace Terrain
         if (--detailMaterialData.m_refCount == 0)
         {
             uint16_t bufferIndex = detailMaterialData.m_detailMaterialBufferIndex;
-            m_detailMaterialShaderData.Release(bufferIndex);
+            m_detailMaterialShaderIndex.Release(bufferIndex);
             m_detailMaterials.RemoveIndex(detailMaterialId);
 
             m_detailMaterialBufferNeedsUpdate = true;
@@ -538,13 +563,13 @@ namespace Terrain
             }
         }
 
-        AZ_Assert(m_detailMaterialShaderData.GetSize() < 0xFF, "Only 255 detail materials supported.");
+        AZ_Assert(m_detailMaterialShaderIndex.GetSize() < 0xFF, "Only 255 detail materials supported.");
 
-        if (detailMaterialId == InvalidDetailMaterial && m_detailMaterialShaderData.GetSize() < 0xFF)
+        if (detailMaterialId == InvalidDetailMaterial && m_detailMaterialShaderIndex.GetSize() < 0xFF)
         {
             detailMaterialId = m_detailMaterials.GetFreeSlotIndex();
             auto& detailMaterialData = m_detailMaterials.GetData(detailMaterialId);
-            detailMaterialData.m_detailMaterialBufferIndex = aznumeric_cast<uint16_t>(m_detailMaterialShaderData.Reserve());
+            detailMaterialData.m_detailMaterialBufferIndex = aznumeric_cast<uint16_t>(m_detailMaterialShaderIndex.Reserve());
             UpdateDetailMaterialData(detailMaterialId, material);
         }
         return detailMaterialId;
@@ -555,193 +580,197 @@ namespace Terrain
         DetailMaterialData& materialData = m_detailMaterials.GetData(detailMaterialIndex);
         materialData.m_assetId = material->GetAssetId();
         
-        DetailMaterialShaderData& shaderData = m_detailMaterialShaderData.GetElement(materialData.m_detailMaterialBufferIndex);
-        shaderData = DetailMaterialShaderData();
 
-        DetailTextureFlags& flags = shaderData.m_flags;
-        flags = DetailTextureFlags::None;
-            
-        auto getIndex = [&](const char* const indexName) -> AZ::RPI::MaterialPropertyIndex
+        for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
         {
-            const AZ::RPI::MaterialPropertyIndex index = material->FindPropertyIndex(AZ::Name(indexName));
-            AZ_Warning(TerrainDetailMaterialManagerName, index.IsValid(), "Failed to find shader input constant %s.", indexName);
-            return index;
-        };
+            auto& shaderData = data.at(materialData.m_detailMaterialBufferIndex);
+            shaderData = DetailMaterialShaderData();
 
-        auto applyProperty = [&](const char* const indexName, auto& ref) -> void
-        {
-            const auto index = getIndex(indexName);
-            if (index.IsValid())
+            DetailTextureFlags& flags = shaderData.m_flags;
+            flags = DetailTextureFlags::None;
+
+            auto getIndex = [&](const char* const indexName) -> AZ::RPI::MaterialPropertyIndex
             {
-                // GetValue<T>() expects the actual type, not a reference type, so the reference needs to be removed.
-                using TypeRefRemoved = AZStd::remove_cvref_t<decltype(ref)>;
-                ref = material->GetPropertyValue(index).GetValue<TypeRefRemoved>();
-            }
-        };
+                const AZ::RPI::MaterialPropertyIndex index = material->FindPropertyIndex(AZ::Name(indexName));
+                AZ_Warning(TerrainDetailMaterialManagerName, index.IsValid(), "Failed to find shader input constant %s.", indexName);
+                return index;
+            };
 
-        auto applyImage = [&](const char* const indexName, AZ::Data::Instance<AZ::RPI::Image>& ref, const char* const usingFlagName, DetailTextureFlags flagToSet, uint32_t& imageIndex) -> void
-        {
-            // Determine if an image exists and if its using flag allows it to be used.
-            const auto index = getIndex(indexName);
-            const auto useTextureIndex = getIndex(usingFlagName);
-            bool useTextureValue = true;
-
-            if (useTextureIndex.IsValid())
+            auto applyProperty = [&](const char* const indexName, auto& ref) -> void
             {
-                useTextureValue = material->GetPropertyValue(useTextureIndex).GetValue<bool>();
-            }
-            if (index.IsValid() && useTextureValue)
+                const auto index = getIndex(indexName);
+                if (index.IsValid())
+                {
+                    // GetValue<T>() expects the actual type, not a reference type, so the reference needs to be removed.
+                    using TypeRefRemoved = AZStd::remove_cvref_t<decltype(ref)>;
+                    ref = material->GetPropertyValue(index).GetValue<TypeRefRemoved>();
+                }
+            };
+
+            auto applyImage = [&](const char* const indexName, AZ::Data::Instance<AZ::RPI::Image>& ref, const char* const usingFlagName, DetailTextureFlags flagToSet, uint32_t& imageIndex, int deviceIndex) -> void
             {
-                ref = material->GetPropertyValue(index).GetValue<AZ::Data::Instance<AZ::RPI::Image>>();
-            }
-            useTextureValue = useTextureValue && ref;
-            flags = DetailTextureFlags(useTextureValue ? (flags | flagToSet) : (flags & ~flagToSet));
+                // Determine if an image exists and if its using flag allows it to be used.
+                const auto index = getIndex(indexName);
+                const auto useTextureIndex = getIndex(usingFlagName);
+                bool useTextureValue = true;
 
-            if (ref)
+                if (useTextureIndex.IsValid())
+                {
+                    useTextureValue = material->GetPropertyValue(useTextureIndex).GetValue<bool>();
+                }
+                if (index.IsValid() && useTextureValue)
+                {
+                    ref = material->GetPropertyValue(index).GetValue<AZ::Data::Instance<AZ::RPI::Image>>();
+                }
+                useTextureValue = useTextureValue && ref;
+                flags = DetailTextureFlags(useTextureValue ? (flags | flagToSet) : (flags & ~flagToSet));
+
+                if (ref)
+                {
+                    imageIndex = ref->GetImageView()->GetDeviceImageView(deviceIndex)->GetBindlessReadIndex();
+                }
+                else if (imageIndex != InvalidImageIndex)
+                {
+                    imageIndex = InvalidImageIndex;
+                }
+            };
+
+            auto applyFlag = [&](const char* const indexName, DetailTextureFlags flagToSet) -> void
             {
-                imageIndex = ref->GetImageView()->GetDeviceImageView(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex();
-            }
-            else if (imageIndex != InvalidImageIndex)
+                const auto index = getIndex(indexName);
+                if (index.IsValid())
+                {
+                    bool flagValue = material->GetPropertyValue(index).GetValue<bool>();
+                    flags = DetailTextureFlags(flagValue ? flags | flagToSet : flags);
+                }
+            };
+
+            auto getEnumName = [&](const char* const indexName) -> const AZStd::string_view
             {
-                imageIndex = InvalidImageIndex;
-            }
-        };
-            
-        auto applyFlag = [&](const char* const indexName, DetailTextureFlags flagToSet) -> void
-        {
-            const auto index = getIndex(indexName);
-            if (index.IsValid())
+                const auto index = getIndex(indexName);
+                if (index.IsValid())
+                {
+                    uint32_t enumIndex = material->GetPropertyValue(index).GetValue<uint32_t>();
+                    const AZ::Name& enumName = material->GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetEnumName(enumIndex);
+                    return enumName.GetStringView();
+                }
+                return "";
+            };
+
+            using namespace DetailMaterialInputs;
+            applyImage(BaseColorMap, materialData.m_colorImage, BaseColorUseTexture, DetailTextureFlags::UseTextureBaseColor, shaderData.m_colorImageIndex, deviceIndex);
+            applyProperty(BaseColorFactor, shaderData.m_baseColorFactor);
+
+            const auto baseColorIndex = getIndex(BaseColorColor);
+            if (baseColorIndex.IsValid())
             {
-                bool flagValue = material->GetPropertyValue(index).GetValue<bool>();
-                flags = DetailTextureFlags(flagValue ? flags | flagToSet : flags);
+                const AZ::Color baseColor = material->GetPropertyValue(baseColorIndex).GetValue<AZ::Color>();
+                shaderData.m_baseColorRed = baseColor.GetR();
+                shaderData.m_baseColorGreen = baseColor.GetG();
+                shaderData.m_baseColorBlue = baseColor.GetB();
             }
-        };
 
-        auto getEnumName = [&](const char* const indexName) -> const AZStd::string_view
-        {
-            const auto index = getIndex(indexName);
-            if (index.IsValid())
+            const AZStd::string_view& blendModeString = getEnumName(BaseColorBlendMode);
+            if (blendModeString == "Multiply")
             {
-                uint32_t enumIndex = material->GetPropertyValue(index).GetValue<uint32_t>();
-                const AZ::Name& enumName = material->GetMaterialPropertiesLayout()->GetPropertyDescriptor(index)->GetEnumName(enumIndex);
-                return enumName.GetStringView();
+                flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeMultiply);
             }
-            return "";
-        };
+            else if (blendModeString == "LinearLight")
+            {
+                flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeLinearLight);
+            }
+            else if (blendModeString == "Lerp")
+            {
+                flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeLerp);
+            }
+            else if (blendModeString == "Overlay")
+            {
+                flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeOverlay);
+            }
 
-        using namespace DetailMaterialInputs;
-        applyImage(BaseColorMap, materialData.m_colorImage, BaseColorUseTexture, DetailTextureFlags::UseTextureBaseColor, shaderData.m_colorImageIndex);
-        applyProperty(BaseColorFactor, shaderData.m_baseColorFactor);
+            applyImage(MetallicMap, materialData.m_metalnessImage, MetallicUseTexture, DetailTextureFlags::UseTextureMetallic, shaderData.m_metalnessImageIndex, deviceIndex);
+            applyProperty(MetallicFactor, shaderData.m_metalFactor);
 
-        const auto baseColorIndex = getIndex(BaseColorColor);
-        if (baseColorIndex.IsValid())
-        {
-            const AZ::Color baseColor = material->GetPropertyValue(baseColorIndex).GetValue<AZ::Color>();
-            shaderData.m_baseColorRed = baseColor.GetR();
-            shaderData.m_baseColorGreen = baseColor.GetG();
-            shaderData.m_baseColorBlue = baseColor.GetB();
-        }
+            applyImage(RoughnessMap, materialData.m_roughnessImage, RoughnessUseTexture, DetailTextureFlags::UseTextureRoughness, shaderData.m_roughnessImageIndex, deviceIndex);
 
-        const AZStd::string_view& blendModeString = getEnumName(BaseColorBlendMode);
-        if (blendModeString == "Multiply")
-        {
-            flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeMultiply);
-        }
-        else if (blendModeString == "LinearLight")
-        {
-            flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeLinearLight);
-        }
-        else if (blendModeString == "Lerp")
-        {
-            flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeLerp);
-        }
-        else if (blendModeString == "Overlay")
-        {
-            flags = DetailTextureFlags(flags | DetailTextureFlags::BlendModeOverlay);
-        }
-            
-        applyImage(MetallicMap, materialData.m_metalnessImage, MetallicUseTexture, DetailTextureFlags::UseTextureMetallic, shaderData.m_metalnessImageIndex);
-        applyProperty(MetallicFactor, shaderData.m_metalFactor);
-            
-        applyImage(RoughnessMap, materialData.m_roughnessImage, RoughnessUseTexture, DetailTextureFlags::UseTextureRoughness, shaderData.m_roughnessImageIndex);
+            if ((flags & DetailTextureFlags::UseTextureRoughness) > 0)
+            {
+                float lowerBound = 0.0;
+                float upperBound = 1.0;
+                applyProperty(RoughnessLowerBound, lowerBound);
+                applyProperty(RoughnessUpperBound, upperBound);
+                shaderData.m_roughnessBias = lowerBound;
+                shaderData.m_roughnessScale = upperBound - lowerBound;
+            }
+            else
+            {
+                shaderData.m_roughnessBias = 0.0;
+                applyProperty(RoughnessFactor, shaderData.m_roughnessScale);
+            }
 
-        if ((flags & DetailTextureFlags::UseTextureRoughness) > 0)
-        {
-            float lowerBound = 0.0;
-            float upperBound = 1.0;
-            applyProperty(RoughnessLowerBound, lowerBound);
-            applyProperty(RoughnessUpperBound, upperBound);
-            shaderData.m_roughnessBias = lowerBound;
-            shaderData.m_roughnessScale = upperBound - lowerBound;
+            applyImage(SpecularF0Map, materialData.m_specularF0Image, SpecularF0UseTexture, DetailTextureFlags::UseTextureSpecularF0, shaderData.m_specularF0ImageIndex, deviceIndex);
+            applyProperty(SpecularF0Factor, shaderData.m_specularF0Factor);
+
+            applyImage(NormalMap, materialData.m_normalImage, NormalUseTexture, DetailTextureFlags::UseTextureNormal, shaderData.m_normalImageIndex, deviceIndex);
+            applyProperty(NormalFactor, shaderData.m_normalFactor);
+            applyFlag(NormalFlipX, DetailTextureFlags::FlipNormalX);
+            applyFlag(NormalFlipY, DetailTextureFlags::FlipNormalY);
+
+            applyImage(DiffuseOcclusionMap, materialData.m_occlusionImage, DiffuseOcclusionUseTexture, DetailTextureFlags::UseTextureOcclusion, shaderData.m_occlusionImageIndex, deviceIndex);
+            applyProperty(DiffuseOcclusionFactor, shaderData.m_occlusionFactor);
+
+            applyImage(HeightMap, materialData.m_heightImage, HeightUseTexture, DetailTextureFlags::UseTextureHeight, shaderData.m_heightImageIndex, deviceIndex);
+
+            bool terrainSettingsOverrideParallax = false;
+            applyProperty(TerrainSettingsOverrideParallax, terrainSettingsOverrideParallax);
+
+            if (terrainSettingsOverrideParallax)
+            {
+                applyProperty(TerrainHeightFactor, shaderData.m_heightFactor);
+                applyProperty(TerrainHeightOffset, shaderData.m_heightOffset);
+            }
+            else
+            {
+                // Parallax ranges from 0 to 0.1, so multiply by 10 to be in the 0-1 range.
+                applyProperty(ParallaxHeightFactor, shaderData.m_heightFactor);
+                shaderData.m_heightFactor *= 10.0f;
+                applyProperty(ParallaxHeightOffset, shaderData.m_heightOffset);
+                shaderData.m_heightOffset *= 10.0f;
+            }
+            applyProperty(HeightBlendFactor, shaderData.m_heightBlendFactor);
+            applyProperty(HeightWeightClampFactor, shaderData.m_heightWeightClampFactor);
+            shaderData.m_heightWeightClampFactor = 1.0f / AZStd::GetMax(0.0001f, shaderData.m_heightWeightClampFactor);
+
+            AZ::Render::UvTransformDescriptor transformDescriptor;
+            applyProperty(UvCenter, transformDescriptor.m_center);
+            applyProperty(UvScale, transformDescriptor.m_scale);
+            applyProperty(UvTileU, transformDescriptor.m_scaleX);
+            applyProperty(UvTileV, transformDescriptor.m_scaleY);
+            applyProperty(UvOffsetU, transformDescriptor.m_translateX);
+            applyProperty(UvOffsetV, transformDescriptor.m_translateY);
+            applyProperty(UvRotateDegrees, transformDescriptor.m_rotateDegrees);
+
+            AZStd::array<AZ::Render::TransformType, 3> order =
+            {
+                AZ::Render::TransformType::Rotate,
+                AZ::Render::TransformType::Translate,
+                AZ::Render::TransformType::Scale,
+            };
+
+            AZ::Matrix3x3 uvTransformMatrix = AZ::Render::CreateUvTransformMatrix(transformDescriptor, order);
+            uvTransformMatrix.GetRow(0).StoreToFloat3(&shaderData.m_uvTransform[0]);
+            uvTransformMatrix.GetRow(1).StoreToFloat3(&shaderData.m_uvTransform[4]);
+            uvTransformMatrix.GetRow(2).StoreToFloat3(&shaderData.m_uvTransform[8]);
+
+            // Store a hash of the matrix in element in an unused portion for quick comparisons in the shader
+            size_t hash64 = 0;
+            for (float value : shaderData.m_uvTransform)
+            {
+                AZStd::hash_combine(hash64, value);
+            }
+            uint32_t hash32 = uint32_t((hash64 ^ (hash64 >> 32)) & 0xFFFFFFFF);
+            shaderData.m_uvTransform[3] = *reinterpret_cast<float*>(&hash32);
         }
-        else
-        {
-            shaderData.m_roughnessBias = 0.0;
-            applyProperty(RoughnessFactor, shaderData.m_roughnessScale);
-        }
-            
-        applyImage(SpecularF0Map, materialData.m_specularF0Image, SpecularF0UseTexture, DetailTextureFlags::UseTextureSpecularF0, shaderData.m_specularF0ImageIndex);
-        applyProperty(SpecularF0Factor, shaderData.m_specularF0Factor);
-            
-        applyImage(NormalMap, materialData.m_normalImage, NormalUseTexture, DetailTextureFlags::UseTextureNormal, shaderData.m_normalImageIndex);
-        applyProperty(NormalFactor, shaderData.m_normalFactor);
-        applyFlag(NormalFlipX, DetailTextureFlags::FlipNormalX);
-        applyFlag(NormalFlipY, DetailTextureFlags::FlipNormalY);
-            
-        applyImage(DiffuseOcclusionMap, materialData.m_occlusionImage, DiffuseOcclusionUseTexture, DetailTextureFlags::UseTextureOcclusion, shaderData.m_occlusionImageIndex);
-        applyProperty(DiffuseOcclusionFactor, shaderData.m_occlusionFactor);
-            
-        applyImage(HeightMap, materialData.m_heightImage, HeightUseTexture, DetailTextureFlags::UseTextureHeight, shaderData.m_heightImageIndex);
-
-        bool terrainSettingsOverrideParallax = false;
-        applyProperty(TerrainSettingsOverrideParallax, terrainSettingsOverrideParallax);
-
-        if (terrainSettingsOverrideParallax)
-        {
-            applyProperty(TerrainHeightFactor, shaderData.m_heightFactor);
-            applyProperty(TerrainHeightOffset, shaderData.m_heightOffset);
-        }
-        else
-        {
-            // Parallax ranges from 0 to 0.1, so multiply by 10 to be in the 0-1 range.
-            applyProperty(ParallaxHeightFactor, shaderData.m_heightFactor);
-            shaderData.m_heightFactor *= 10.0f;
-            applyProperty(ParallaxHeightOffset, shaderData.m_heightOffset);
-            shaderData.m_heightOffset *= 10.0f;
-        }
-        applyProperty(HeightBlendFactor, shaderData.m_heightBlendFactor);
-        applyProperty(HeightWeightClampFactor, shaderData.m_heightWeightClampFactor);
-        shaderData.m_heightWeightClampFactor = 1.0f / AZStd::GetMax(0.0001f, shaderData.m_heightWeightClampFactor);
-
-        AZ::Render::UvTransformDescriptor transformDescriptor;
-        applyProperty(UvCenter, transformDescriptor.m_center);
-        applyProperty(UvScale, transformDescriptor.m_scale);
-        applyProperty(UvTileU, transformDescriptor.m_scaleX);
-        applyProperty(UvTileV, transformDescriptor.m_scaleY);
-        applyProperty(UvOffsetU, transformDescriptor.m_translateX);
-        applyProperty(UvOffsetV, transformDescriptor.m_translateY);
-        applyProperty(UvRotateDegrees, transformDescriptor.m_rotateDegrees);
-
-        AZStd::array<AZ::Render::TransformType, 3> order =
-        {
-            AZ::Render::TransformType::Rotate,
-            AZ::Render::TransformType::Translate,
-            AZ::Render::TransformType::Scale,
-        };
-
-        AZ::Matrix3x3 uvTransformMatrix = AZ::Render::CreateUvTransformMatrix(transformDescriptor, order);
-        uvTransformMatrix.GetRow(0).StoreToFloat3(&shaderData.m_uvTransform[0]);
-        uvTransformMatrix.GetRow(1).StoreToFloat3(&shaderData.m_uvTransform[4]);
-        uvTransformMatrix.GetRow(2).StoreToFloat3(&shaderData.m_uvTransform[8]);
-
-        // Store a hash of the matrix in element in an unused portion for quick comparisons in the shader
-        size_t hash64 = 0;
-        for (float value : shaderData.m_uvTransform)
-        {
-            AZStd::hash_combine(hash64, value);
-        }
-        uint32_t hash32 = uint32_t((hash64 ^ (hash64 >> 32)) & 0xFFFFFFFF);
-        shaderData.m_uvTransform[3] = *reinterpret_cast<float*>(&hash32);
 
         m_detailMaterialBufferNeedsUpdate = true;
     }
@@ -954,10 +983,14 @@ namespace Terrain
 
     void TerrainDetailMaterialManager::InitializePassthroughDetailMaterial()
     {
-        m_passthroughMaterialId = aznumeric_cast<uint8_t>(m_detailMaterialShaderData.Reserve());
-        DetailMaterialShaderData& materialShaderData = m_detailMaterialShaderData.GetElement(m_passthroughMaterialId);
-        // Material defaults to white (1.0, 1.0, 1.0), set the blend mode to multiply so it passes through to the macro material.
-        materialShaderData.m_flags = DetailTextureFlags::BlendModeMultiply;
+        m_passthroughMaterialId = aznumeric_cast<uint8_t>(m_detailMaterialShaderIndex.Reserve());
+
+        for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
+        {
+            auto& materialShaderData = data.at(m_passthroughMaterialId);
+            // Material defaults to white (1.0, 1.0, 1.0), set the blend mode to multiply so it passes through to the macro material.
+            materialShaderData.m_flags = DetailTextureFlags::BlendModeMultiply;
+        }
     }
 
     auto TerrainDetailMaterialManager::FindByEntityId(AZ::EntityId entityId, AZ::Render::IndexedDataVector<DetailMaterialListRegion>& container)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -583,6 +583,11 @@ namespace Terrain
 
         for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
         {
+            if (m_detailMaterialShaderIndex.GetSize() > data.size())
+            {
+                data.resize(m_detailMaterialShaderIndex.GetSize());
+            }
+
             auto& shaderData = data.at(materialData.m_detailMaterialBufferIndex);
             shaderData = DetailMaterialShaderData();
 
@@ -987,6 +992,11 @@ namespace Terrain
 
         for (auto& [deviceIndex, data] : m_detailMaterialShaderData)
         {
+            if (m_detailMaterialShaderIndex.GetSize() > data.size())
+            {
+                data.resize(m_detailMaterialShaderIndex.GetSize());
+            }
+
             auto& materialShaderData = data.at(m_passthroughMaterialId);
             // Material defaults to white (1.0, 1.0, 1.0), set the blend mode to multiply so it passes through to the macro material.
             materialShaderData.m_flags = DetailTextureFlags::BlendModeMultiply;

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.h
@@ -242,7 +242,8 @@ namespace Terrain
 
         DetailMaterialContainer m_detailMaterials;
         AZ::Render::IndexedDataVector<DetailMaterialListRegion> m_detailMaterialRegions;
-        AZ::Render::SparseVector<DetailMaterialShaderData> m_detailMaterialShaderData;
+        AZ::Render::SparseVector<size_t> m_detailMaterialShaderIndex;
+        AZStd::unordered_map<int, AZStd::vector<DetailMaterialShaderData>> m_detailMaterialShaderData;
         AZ::Render::GpuBufferHandler m_detailMaterialDataBuffer;
         uint8_t m_passthroughMaterialId = 0;
 

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMacroMaterialManager.h
@@ -14,7 +14,7 @@
 #include <Atom/RPI.Public/Base.h>
 
 #include <Atom/Feature/Utils/GpuBufferHandler.h>
-#include <Atom/Feature/Utils/MultiSparseVector.h>
+#include <Atom/Feature/Utils/SparseVector.h>
 
 #include <TerrainRenderer/TerrainMacroMaterialBus.h>
 #include <TerrainRenderer/Vector2i.h>
@@ -117,7 +117,8 @@ namespace Terrain
 
         // Macro materials stored in a grid of (MacroMaterialGridCount * MacroMaterialGridCount) where each tile in the grid covers
         // an area of (MacroMaterialGridSize * MacroMaterialGridSize) and each tile can hold MacroMaterialsPerTile macro materials
-        AZ::Render::MultiSparseVector<MacroMaterialShaderData, MacroMaterialPriority> m_materialData; // Info about the macro material itself.
+        AZ::Render::SparseVector<MacroMaterialPriority> m_materialPriorityData; // Priority info about the macro material itself.
+        AZStd::unordered_map<int, AZStd::vector<MacroMaterialShaderData>> m_materialShaderData; // Shader info about the macro material itself.
         AZStd::vector<TileMaterials> m_materialRefGridShaderData; // A grid of macro material references that covers the world.
 
         AZStd::map<AZ::EntityId, MaterialHandle> m_entityToMaterialHandle; // Used for looking up macro materials by entity id when the data isn't provided by a bus.

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -79,9 +79,8 @@ namespace Terrain
         
         m_meshMovedFlag = m_parentScene->GetViewTagBitRegistry().AcquireTag(AZ::Render::MeshCommon::MeshMovedName);
 
-        AZ::RHI::Ptr<AZ::RHI::Device> rhiDevice = AZ::RHI::RHISystemInterface::Get()->GetDevice();
         m_rayTracingFeatureProcessor = m_parentScene->GetFeatureProcessor<AZ::Render::RayTracingFeatureProcessor>();
-        m_rayTracingEnabled = rhiDevice->GetFeatures().m_rayTracing && m_rayTracingFeatureProcessor;
+        m_rayTracingEnabled = (AZ::RHI::RHISystemInterface::Get()->GetRayTracingSupport() != AZ::RHI::MultiDevice::NoDevices) && m_rayTracingFeatureProcessor;
 
         m_isInitialized = true;
     }


### PR DESCRIPTION
## What does this PR do?

This PR is part of a much bigger effort of multiple PRs mentioned as commit 4 in [this RFC](https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/MultiDeviceSupport/MultiDeviceResources.md#planned-git-history). These PRs are designed to have an easier time transitioning the RPI to the new MultiDevice classes. Everything could be transitioned at once using a [single big commit](https://github.com/o3de/o3de/pull/14079), however that is clearly very hard to review with more than 600 files being touched. Therefore, we decided to split the merge request into multiple smaller ones to make reviewing easier even though that increases the amount of changes a little (see below why). The reviewed PRs will be merged into a [branch of o3de](https://github.com/o3de/o3de/tree/multi-device-resources) and NOT directly into development. The merge to development will happen at the very end. A few things need to be considered that stem from the complexity and amount of changes to be made and thus need also be kept in mind while reviewing these changes:

- We renamed all classes/structs of which MultiDevice* versions have been introduced to SingleDevice* automatically using a script. This allows us to better find/see where we are still using the single device versions in code, i.e., where we still need to change to MultiDevice*. This may or may not be the final naming that we will use when everything is merged into development. At least this naming convention allows us to easily rename everything in the end.
- The various classes are highly dependent on each other, sometimes there are even circular dependencies that are difficult to resolve separately. We nevertheless try to do our best here to create small changesets. This however means that we have to introduce quite some changes that will be reverted in later commits. For example, we will often hardcode the use of `->GetDevice*(RHI::MultiDevice::DefaultDeviceIndex)` to get a SingleDevice* from a MultiDevice* to be used in some code that has not been refactored yet. In the end of everything there should be little to no uses of this left, but it will take some time until we can clean all this up.
- The actual switch from MultiDevice* to SingleDevice* is planned to happen between Compile and Execute of the FrameGraph. The Scope (and thus each Pass) will decide which Device it will run on, i.e., we will add a device index to the Scope in a later commit. In the beginning we want to keep using `RHI::MultiDevice::DefaultDeviceIndex` everywhere because it simplifies the transition.
- Also note, that not all MultiDevice* classes are in development yet since they are still being reviewed. However all are in the [mentioned multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) already.

**This specific PR finalizes the transitions to support mulit-device-resources. This should be almost ready for merging to development.**

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`
