### PR TITLE
Fix Linux build failure introduced with cmake 3.28.3

### DIFF
--- a/Gems/Archive/Code/CMakeLists.txt
+++ b/Gems/Archive/Code/CMakeLists.txt
@@ -135,7 +135,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 AZ::AzToolsFramework
                 ${gem_name}.Editor.API
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/Compression/Code/CMakeLists.txt
+++ b/Gems/Compression/Code/CMakeLists.txt
@@ -124,7 +124,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -132,7 +132,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 AZ::AzToolsFramework
                 AZ::AssetBuilderSDK
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
             PRIVATE
                  3rdParty::miniaudio
                  3rdParty::stb_vorbis

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -141,7 +141,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(


### PR DESCRIPTION
## What does this PR do?

This fixes a cmake build error that was introduced with cmake 3.28.3 on Linux which is caused specifically by Gems that use the following for its build dependencies:
```
$<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
```
This causes errors such as
```
ninja: error: 'External/MiniAudio-ff9acb01/Code/CMakeFiles/MiniAudio.Private.Object.dir/profile/Source/Clients/MiniAudioListenerComponent.cpp.o', needed by 'bin/profile/libMiniAudio.Editor.so', missing and no known rule to make it
```

## How was this PR tested?
Built on Ubuntu with 3.28.3 installed as well as cmake 3.22.1

fixes https://github.com/o3de/o3de/issues/17592 


