### PR TITLE
Multi-device: Using device indices in RenderPass

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -98,6 +98,7 @@ namespace AZ::RHI
         constexpr DeviceMask DefaultDevice{ 1u };
 
         constexpr int DefaultDeviceIndex{ 0 };
+        constexpr int InvalidDeviceIndex{ -1 };
     }
 
     constexpr int InvalidIndex = AZStd::numeric_limits<int>::max();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -174,8 +174,8 @@ namespace AZ::RHI
         //! Returns memory statistics for the previous frame.
         const MemoryStatistics* GetMemoryStatistics() const;
 
-        //! Returns the implicit root scope id.
-        ScopeId GetRootScopeId() const;
+        //! Returns the implicit root scope id for the given deviceIndex.
+        ScopeId GetRootScopeId(int deviceIndex = 0);
 
         //! Returns the descriptor which has information on the properties of a MultiDeviceTransientAttachmentPool.
         const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* GetTransientAttachmentPoolDescriptor() const;
@@ -187,7 +187,7 @@ namespace AZ::RHI
         const PhysicalDeviceDescriptor& GetPhysicalDeviceDescriptor();
 
     private:
-        const ScopeId m_rootScopeId{"Root"};
+        AZStd::unordered_map<int, AZStd::string> m_rootScopeIds;
 
         bool ValidateIsInitialized() const;
         bool ValidateIsProcessing() const;
@@ -225,8 +225,8 @@ namespace AZ::RHI
 
         FrameSchedulerCompileRequest m_compileRequest;
 
-        Scope* m_rootScope = nullptr;
-        AZStd::unique_ptr<ScopeProducerEmpty> m_rootScopeProducer;
+        AZStd::unordered_map<int, Scope*> m_rootScopes;
+        AZStd::unordered_map<int, AZStd::unique_ptr<ScopeProducerEmpty>> m_rootScopeProducers;
         AZStd::vector<ScopeProducer*> m_scopeProducers;
         AZStd::unordered_map<ScopeId, ScopeProducer*> m_scopeProducerLookup;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -187,7 +187,7 @@ namespace AZ::RHI
         const PhysicalDeviceDescriptor& GetPhysicalDeviceDescriptor();
 
     private:
-        AZStd::unordered_map<int, AZStd::string> m_rootScopeIds;
+        AZStd::unordered_map<int, ScopeId> m_rootScopeIds;
 
         bool ValidateIsInitialized() const;
         bool ValidateIsProcessing() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -55,6 +55,9 @@ namespace AZ::RHI
         //! Returns the index of the device the scope is running on.
         int GetDeviceIndex() const;
 
+        //! Sets the index of the device the scope is running on.
+        void SetDeviceIndex(int deviceIndex);
+
         //! Returns the device the scope is running on.
         Device& GetDevice() const;
 
@@ -132,7 +135,7 @@ namespace AZ::RHI
         void Activate(const FrameGraph* frameGraph, uint32_t index, const GraphGroupId& groupId);
 
         //! Called when the scope is being compiled at the end of the graph-building phase.
-        void Compile(int deviceIndex);
+        void Compile();
 
         //! Deactivates the scope for the current frame.
         void Deactivate();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
@@ -69,6 +69,10 @@ namespace AZ::RHI
         //! Returns the scope associated with this scope producer.
         const Scope* GetScope() const;
 
+        //! Returns the device index of the device the scope should run on.
+        //! May return InvalidDeviceIndex to signal that no device index is specified.
+        virtual int GetDeviceIndex() const;
+
     protected:
 
         //!  Protected default constructor for classes that inherit from
@@ -110,5 +114,6 @@ namespace AZ::RHI
 
         ScopeId m_scopeId;
         Ptr<Scope> m_scope;
+        int m_deviceIndex{MultiDevice::InvalidDeviceIndex};
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
@@ -61,7 +61,7 @@ namespace AZ::RHI
         friend class FrameScheduler;
     public:
         virtual ~ScopeProducer() = default;
-        ScopeProducer(const ScopeId& scopeId);
+        ScopeProducer(const ScopeId& scopeId, int deviceIndex = MultiDevice::InvalidDeviceIndex);
 
         //! Returns the scope id associated with this scope producer.
         const ScopeId& GetScopeId() const;
@@ -86,9 +86,9 @@ namespace AZ::RHI
         //!  @deprecated Use InitScope instead
         void SetScopeId(const ScopeId& scopeId);
 
-        //!  Initializes the scope with a ScopeId and HardwareQueueClass. 
+        //!  Initializes the scope with a ScopeId, HardwareQueueClass and device index.
         //!  Used by classes that inherit from ScopeProducer but can't supply a ScopeId at construction.
-        void InitScope(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass = HardwareQueueClass::Graphics);
+        void InitScope(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass = HardwareQueueClass::Graphics, int deviceIndex = MultiDevice::InvalidDeviceIndex);
 
     private:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducerEmpty.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducerEmpty.h
@@ -17,8 +17,8 @@ namespace AZ::RHI
     public:
         AZ_CLASS_ALLOCATOR(ScopeProducerEmpty, SystemAllocator);
 
-        ScopeProducerEmpty(const ScopeId& scopeId)
-            : ScopeProducer(scopeId)
+        ScopeProducerEmpty(const ScopeId& scopeId, int deviceIndex = MultiDevice::InvalidDeviceIndex)
+            : ScopeProducer(scopeId, deviceIndex)
         {}
 
     private:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducerFunction.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducerFunction.h
@@ -45,8 +45,9 @@ namespace AZ::RHI
             UserDataParam&& userData,
             PrepareFunction prepareFunction,
             CompileFunction compileFunction = CompileFunction(),
-            ExecuteFunction executeFunction = ExecuteFunction())
-            : ScopeProducer(scopeId)
+            ExecuteFunction executeFunction = ExecuteFunction(),
+            int deviceIndex = RHI::MultiDevice::InvalidDeviceIndex)
+            : ScopeProducer(scopeId, deviceIndex)
             , m_userData{AZStd::forward<UserDataParam>(userData)}
             , m_prepareFunction{AZStd::move(prepareFunction)}
             , m_compileFunction{AZStd::move(compileFunction)}

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -134,7 +134,7 @@ namespace AZ::RHI
         {
             if (auto* lastScope = attachment->GetLastScope())
             {
-                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain()->GetDeviceSwapChain(lastScope->GetDeviceIndex()).get());
+                lastScope->m_swapChainsToPresent.push_back(attachment->GetSwapChain()->GetDeviceSwapChain().get());
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -130,7 +130,12 @@ namespace AZ::RHI
 
             for (Scope* scope : frameGraph.GetScopes())
             {
-                scope->Compile(MultiDevice::DefaultDeviceIndex);
+                if (scope->GetDeviceIndex() == MultiDevice::InvalidDeviceIndex)
+                {
+                    scope->SetDeviceIndex(MultiDevice::DefaultDeviceIndex);
+                }
+
+                scope->Compile();
             }
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -167,7 +167,10 @@ namespace AZ::RHI
                 const uint32_t hardwareQueueClassIdx = static_cast<uint32_t>(consumer->GetHardwareQueueClass());
                 if (producer[hardwareQueueClassIdx])
                 {
-                    Scope::LinkProducerConsumerByQueues(producer[hardwareQueueClassIdx], consumer);
+                    if (producer[hardwareQueueClassIdx]->GetDeviceIndex() == consumer->GetDeviceIndex())
+                    {
+                        Scope::LinkProducerConsumerByQueues(producer[hardwareQueueClassIdx], consumer);
+                    }
                 }
                 producer[hardwareQueueClassIdx] = consumer;
             }
@@ -216,7 +219,10 @@ namespace AZ::RHI
 
                     if (foundEarlierConsumerOnSameQueue == false)
                     {
-                        Scope::LinkProducerConsumerByQueues(producerScopeLast, currentScope);
+                        if (producerScopeLast->GetDeviceIndex() == currentScope->GetDeviceIndex())
+                        {
+                            Scope::LinkProducerConsumerByQueues(producerScopeLast, currentScope);
+                        }
                     }
                 }
             }

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -95,7 +95,7 @@ namespace AZ::RHI
             {
                 continue;
             }
-            m_rootScopeProducers[deviceIndex].reset(aznew ScopeProducerEmpty(GetRootScopeId(deviceIndex)));
+            m_rootScopeProducers[deviceIndex].reset(aznew ScopeProducerEmpty(GetRootScopeId(deviceIndex), deviceIndex));
             m_rootScopes[deviceIndex] = m_rootScopeProducers[deviceIndex]->GetScope();
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -252,7 +252,11 @@ namespace AZ::RHI
         for (ScopeProducer* scopeProducer : m_scopeProducers)
         {
             RHI_PROFILE_SCOPE_VERBOSE("FrameScheduler: PrepareProducers: Scope %s", scopeProducer->GetScopeId().GetCStr());
-            m_frameGraph->BeginScope(*scopeProducer->GetScope());
+
+            auto scope = scopeProducer->GetScope();
+            scope->SetDeviceIndex(scopeProducer->GetDeviceIndex());
+
+            m_frameGraph->BeginScope(*scope);
             scopeProducer->SetupFrameGraphDependencies(*m_frameGraph);
                 
             // All scopes depend on the root scopes.

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -86,6 +86,8 @@ namespace AZ::RHI
             }
         }
 
+        m_deviceMask = deviceMask;
+
         auto deviceCount{RHI::RHISystemInterface::Get()->GetDeviceCount()};
         for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
         {
@@ -96,8 +98,6 @@ namespace AZ::RHI
             m_rootScopeProducers[deviceIndex].reset(aznew ScopeProducerEmpty(GetRootScopeId(deviceIndex)));
             m_rootScopes[deviceIndex] = m_rootScopeProducers[deviceIndex]->GetScope();
         }
-
-        m_deviceMask = deviceMask;
 
         m_taskGraphActive = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -721,13 +721,13 @@ namespace AZ::RHI
         if (iterator == m_rootScopeIds.end())
         {
             auto [new_iterator, inserted]{ m_rootScopeIds.insert(
-                AZStd::make_pair(deviceIndex, AZStd::string{AZStd::string("Root") + AZStd::to_string(deviceIndex)})) };
+                AZStd::make_pair(deviceIndex, ScopeId{AZStd::string("Root") + AZStd::to_string(deviceIndex)})) };
             if (inserted)
             {
-                return ScopeId{new_iterator->second};
+                return new_iterator->second;
             }
         }
-        return ScopeId(iterator->second);
+        return iterator->second;
     }
 
     const AZStd::unordered_map<int, TransientAttachmentPoolDescriptor>* FrameScheduler::GetTransientAttachmentPoolDescriptor() const

--- a/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Scope.cpp
@@ -27,6 +27,11 @@ namespace AZ::RHI
         return m_deviceIndex;
     }
 
+    void Scope::SetDeviceIndex(int deviceIndex)
+    {
+        m_deviceIndex = deviceIndex;
+    }
+
     Device& Scope::GetDevice() const
     {
         return *RHISystemInterface::Get()->GetDevice(m_deviceIndex);
@@ -75,10 +80,9 @@ namespace AZ::RHI
         m_isActive = true;
     }
 
-    void Scope::Compile(int deviceIndex)
+    void Scope::Compile()
     {
         AZ_Assert(m_isActive, "Scope being compiled but is not active");
-        m_deviceIndex = deviceIndex;
         CompileInternal();
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ScopeProducer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ScopeProducer.cpp
@@ -38,6 +38,11 @@ namespace AZ::RHI
         return m_scope.get();
     }
 
+    int ScopeProducer::GetDeviceIndex() const
+    {
+        return m_deviceIndex;
+    }
+
     void ScopeProducer::SetHardwareQueueClass(HardwareQueueClass hardwareQueueClass)
     {
         m_scope->SetHardwareQueueClass(hardwareQueueClass);

--- a/Gems/Atom/RHI/Code/Source/RHI/ScopeProducer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ScopeProducer.cpp
@@ -16,8 +16,9 @@ namespace AZ::RHI
         m_scope = Factory::Get().CreateScope();
     }
 
-    ScopeProducer::ScopeProducer(const ScopeId& scopeId)
-        : m_scopeId{scopeId}
+    ScopeProducer::ScopeProducer(const ScopeId& scopeId, int deviceIndex)
+        : m_scopeId{ scopeId }
+        , m_deviceIndex{ deviceIndex }
     {
         m_scope = Factory::Get().CreateScope();
         m_scope->Init(scopeId);
@@ -54,9 +55,10 @@ namespace AZ::RHI
         InitScope(scopeId);
     }
 
-    void ScopeProducer::InitScope(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass)
+    void ScopeProducer::InitScope(const ScopeId& scopeId, HardwareQueueClass hardwareQueueClass, int deviceIndex)
     {
         m_scopeId = scopeId;
+        m_deviceIndex = deviceIndex;
             
         if (m_scope->IsInitialized())
         {

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -68,6 +68,7 @@ namespace AZ
 #else
             bool hasUserFencesToSignal = false;
             RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
+            int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
             uint32_t mergedGroupCost = 0;
             uint32_t mergedSwapchainCount = 0;
 
@@ -114,8 +115,11 @@ namespace AZ
                     const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) ||
                         hasUserFencesToSignal || hasUserFencesToWaitFor;
 
+                    // Check if the devices match.
+                    const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
+
                     // If we exceeded limits, then flush the group.
-                    const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries;
+                    const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries || deviceMismatch;
 
                     if (flushMergedScopes && mergedScopes.size())
                     {
@@ -123,6 +127,7 @@ namespace AZ
                         mergedGroupCost = 0;
                         mergedSwapchainCount = 0;
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                        mergedDeviceIndex = scope.GetDeviceIndex();
                         FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
                         multiScopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
                     }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -143,6 +143,9 @@ namespace AZ
             TimestampResult m_timestampResult;
             // Readback results from the PipelineStatistics queries
             PipelineStatisticsResult m_statisticsResult;
+
+            // The device index the pass should run on. Can be invalid if it doesn't matter.
+            int m_deviceIndex{RHI::MultiDevice::InvalidDeviceIndex};
             // The device index the pass ran on during the last frame, necessary to read the queries.
             int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Limits.h>
 #include <Atom/RHI.Reflect/ShaderDataMappings.h>
 
 #include <Atom/RPI.Reflect/Pass/PassData.h>
@@ -31,6 +32,8 @@ namespace AZ
             RHI::ShaderDataMappings m_mappings;
 
             bool m_bindViewSrg = false;
+
+            int m_deviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -44,6 +44,10 @@ namespace AZ
             {
                 m_flags.m_bindViewSrg = true;
             }
+            if (passData && passData->m_deviceIndex > 0 && passData->m_deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount())
+            {
+                m_deviceIndex = passData->m_deviceIndex;
+            }
         }
 
         RenderPass::~RenderPass()
@@ -191,7 +195,7 @@ namespace AZ
             m_timestampResult = AZ::RPI::TimestampResult();
             if (GetScopeId().IsEmpty())
             {
-                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass);
+                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, m_deviceIndex);
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -44,7 +44,7 @@ namespace AZ
             {
                 m_flags.m_bindViewSrg = true;
             }
-            if (passData && passData->m_deviceIndex > 0 && passData->m_deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount())
+            if (passData && passData->m_deviceIndex >= 0 && passData->m_deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount())
             {
                 m_deviceIndex = passData->m_deviceIndex;
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -52,6 +52,7 @@ namespace AZ
             {
                 serializeContext->Class<RenderPassData, PassData>()
                     ->Version(1)
+                    ->Field("DeviceIndex", &RenderPassData::m_deviceIndex)
                     ->Field("BindViewSrg", &RenderPassData::m_bindViewSrg)
                     ->Field("ShaderDataMappings", &RenderPassData::m_mappings);
             }


### PR DESCRIPTION
## What does this PR do?

This PR introduces the device index to `ScopeProducer`s and consequently to the `RenderPass` data that allows to set the device index in json for each pass. By default, we introduce the invalid device index (-1) which makes sure the scope will get assigned to a device automatically (the default device with index 0 for now). This is necessary to implement a sample that actually runs stuff on multiple GPUs though without any synchronization or proper dependencies in the frame graph yet. These changes we would like to postpone until the [multi-device-resources branch](https://github.com/o3de/o3de/tree/multi-device-resources) has been merged to development. 

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`
`Gem::Atom_RPI.Tests.main`

