### PR TITLE
initialize the transform for static camera-components properly

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -271,6 +271,12 @@ namespace Camera
             m_atomCameraViewGroup->Activate();
         }
 
+        // OnTransformChanged() is only called if the camera is actually moved, so make sure we call it at least once,
+        // so the camera-transform is also correct for static cameras even before they are made the active view
+        AZ::Transform local, world;
+        AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::GetLocalAndWorld, local, world);
+        OnTransformChanged(local, world);
+
         CameraRequestBus::Handler::BusConnect(m_entityId);
         AZ::TransformNotificationBus::Handler::BusConnect(m_entityId);
         CameraBus::Handler::BusConnect();


### PR DESCRIPTION
## What does this PR do?

re-apply the fix from #16265: If a camera-Component has no other components that update the transform of the entity, the camera-transform initialized with the wrong position, and never updated.

Seemingly the code got removed in #17042 
