### PR TITLE
Fixes to multi-device resources

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectArguments.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectArguments.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
 
         IndirectArgumentsTemplate(
             uint32_t maxSequenceCount,
-            const IndirectBufferView& indirectBuffer,
+            const IndirectBufferViewClass& indirectBuffer,
             uint64_t indirectBufferByteOffset)
             : IndirectArgumentsTemplate(
                 maxSequenceCount,
@@ -32,9 +32,9 @@ namespace AZ::RHI
 
         IndirectArgumentsTemplate(
             uint32_t maxSequenceCount,
-            const IndirectBufferView& indirectBuffer,
+            const IndirectBufferViewClass& indirectBuffer,
             uint64_t indirectBufferByteOffset,
-            const Buffer* countBuffer,
+            const BufferClass* countBuffer,
             uint64_t countBufferByteOffset)
             : m_maxSequenceCount(maxSequenceCount)
             , m_indirectBufferView(&indirectBuffer)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceBufferPool.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     struct MultiDeviceBufferMapResponse
     {
         //! Will hold the mapped data for each device selected in the MultiDeviceBuffer
-        AZStd::vector<void*> m_data;
+        AZStd::unordered_map<int, void*> m_data;
     };
 
     using MultiDeviceBufferInitRequest = BufferInitRequestTemplate<MultiDeviceBuffer>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceDispatchItem.h
@@ -53,7 +53,7 @@ namespace AZ::RHI
             case DispatchType::Direct:
                 return DispatchArguments(m_direct);
             case DispatchType::Indirect:
-                return DispatchArguments(DispatchIndirect{m_mdIndirect.m_maxSequenceCount, m_mdIndirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_mdIndirect.m_indirectBufferByteOffset, m_mdIndirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get(), m_mdIndirect.m_countBufferByteOffset});
+                return DispatchArguments(DispatchIndirect{m_mdIndirect.m_maxSequenceCount, m_mdIndirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_mdIndirect.m_indirectBufferByteOffset, m_mdIndirect.m_countBuffer ? m_mdIndirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr, m_mdIndirect.m_countBufferByteOffset});
             default:
                 return DispatchArguments();
             }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
@@ -32,18 +32,55 @@ namespace AZ::RHI
             uint32_t byteCount,
             uint32_t byteStride);
 
+        //! The mutex stops the default generation
+        MultiDeviceIndirectBufferView(const MultiDeviceIndirectBufferView& other)
+            : m_hash{ other.m_hash }
+            , m_mdBuffer{ other.m_mdBuffer }
+            , m_mdSignature{ other.m_mdSignature }
+            , m_byteOffset{ other.m_byteOffset }
+            , m_byteCount{ other.m_byteCount }
+            , m_byteStride{ other.m_byteStride }
+        {
+        }
+
+        MultiDeviceIndirectBufferView& operator=(const MultiDeviceIndirectBufferView& other)
+        {
+            this->m_hash = other.m_hash;
+            this->m_mdBuffer = other.m_mdBuffer;
+            this->m_mdSignature = other.m_mdSignature;
+            this->m_byteOffset = other.m_byteOffset;
+            this->m_byteCount = other.m_byteCount;
+            this->m_byteStride = other.m_byteStride;
+
+            return *this;
+        }
+
         //! Returns the device-specific IndirectBufferView for the given index
-        IndirectBufferView GetDeviceIndirectBufferView(int deviceIndex) const
+        const IndirectBufferView& GetDeviceIndirectBufferView(int deviceIndex) const
         {
             AZ_Error("MultiDeviceIndirectBufferView", m_mdSignature, "No MultiDeviceIndirectBufferSignature available\n");
             AZ_Error("MultiDeviceIndirectBufferView", m_mdBuffer, "No MultiDeviceBuffer available\n");
 
-            return IndirectBufferView(
-                *m_mdBuffer->GetDeviceBuffer(deviceIndex),
-                *m_mdSignature->GetDeviceIndirectBufferSignature(deviceIndex),
-                m_byteOffset,
-                m_byteCount,
-                m_byteStride);
+            AZStd::lock_guard lock(m_bufferViewMutex);
+            auto iterator{ m_cache.find(deviceIndex) };
+            if (iterator == m_cache.end())
+            {
+                //! Buffer view is not yet in the cache
+                auto [new_iterator, inserted]{ m_cache.insert(AZStd::make_pair(
+                    deviceIndex,
+                    IndirectBufferView(
+                        *m_mdBuffer->GetDeviceBuffer(deviceIndex),
+                        *m_mdSignature->GetDeviceIndirectBufferSignature(deviceIndex),
+                        m_byteOffset,
+                        m_byteCount,
+                        m_byteStride))) };
+                if (inserted)
+                {
+                    return new_iterator->second;
+                }
+            }
+
+            return iterator->second;
         }
 
         //! Returns the hash of the view. This hash is precomputed at creation time.
@@ -72,5 +109,9 @@ namespace AZ::RHI
         uint32_t m_byteOffset = 0;
         uint32_t m_byteCount = 0;
         uint32_t m_byteStride = 0;
+
+        //! Safe-guard access to IndirectBufferView cache during parallel access
+        mutable AZStd::mutex m_bufferViewMutex{};
+        mutable AZStd::unordered_map<int, IndirectBufferView> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceShaderResourceGroupData.h
@@ -54,7 +54,7 @@ namespace AZ::RHI
         ShaderInputConstantIndex FindShaderInputConstantIndex(const Name& name) const;
 
         //! Sets one image view for the given shader input index.
-        bool SetImageView(ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex);
+        bool SetImageView(ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex = 0);
 
         //! Sets an array of image view for the given shader input index.
         bool SetImageViewArray(

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceSwapChain.h
@@ -40,6 +40,8 @@ namespace AZ::RHI
         //! it is explicitly initialized with just a deviceIndex
         ResultCode Init(int deviceIndex, const SwapChainDescriptor& descriptor);
 
+        Ptr<SwapChain> GetDeviceSwapChain() const;
+
         //! Presents the swap chain to the display, and rotates the images.
         void Present();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceBufferPool.cpp
@@ -230,7 +230,7 @@ namespace AZ::RHI
             }
             else
             {
-                response.m_data.push_back(deviceMapResponse.m_data);
+                response.m_data[deviceIndex] = deviceMapResponse.m_data;
             }
 
             return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceIndirectBufferSignature.cpp
@@ -16,8 +16,6 @@ namespace AZ::RHI
     IndirectBufferSignatureDescriptor MultiDeviceIndirectBufferSignatureDescriptor::GetDeviceIndirectBufferSignatureDescriptor(
         int deviceIndex) const
     {
-        AZ_Assert(m_pipelineState, "No MultiDevicePipelineState available\n");
-
         IndirectBufferSignatureDescriptor descriptor{ m_layout };
 
         if (m_pipelineState)

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceShaderResourceGroupData.cpp
@@ -75,7 +75,7 @@ namespace AZ::RHI
     }
 
     bool MultiDeviceShaderResourceGroupData::SetImageView(
-        ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex = 0)
+        ShaderInputImageIndex inputIndex, const MultiDeviceImageView* imageView, uint32_t arrayIndex)
     {
         AZStd::array<const MultiDeviceImageView* const, 1> imageViews = { { imageView } };
         return SetImageViewArray(inputIndex, imageViews, arrayIndex);

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -85,6 +85,12 @@ namespace AZ::RHI
         return resultCode;
     }
 
+    Ptr<SwapChain> MultiDeviceSwapChain::GetDeviceSwapChain() const
+    {
+        // As MultiDeviceSwapChain is always initialized for one single device, the method returns this single item by accessing map.begin()
+        return AZStd::static_pointer_cast<SwapChain>(m_deviceObjects.begin()->second);
+    }
+
     void MultiDeviceSwapChain::ShutdownImages()
     {
         // Shutdown existing set of images.

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
@@ -65,9 +65,7 @@ namespace UnitTest
             initRequest.m_descriptor.m_bindFlags = poolDesc.m_bindFlags;
             m_bufferPool->InitBuffer(initRequest);
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             m_writerSignature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 EXPECT_CALL(
@@ -215,45 +213,14 @@ namespace UnitTest
     {
         // Normal initialization
         {
-            AZ_TEST_START_TRACE_SUPPRESSION;
             auto signature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             EXPECT_TRUE(signature != nullptr);
             ValidateSignature(*signature);
         }
 
-        // ! Cannot tests this as we do not have access to device signatures here and cannot setup mock-call
-        // // Failure initializing.
-        // {
-        //     auto signature = CreateUnInitializedSignature();
-        //     RHI::MultiDeviceIndirectBufferSignatureDescriptor descriptor;
-        //     EXPECT_TRUE(signature->Init(DeviceMask, descriptor) == RHI::ResultCode::InvalidOperation);
-        //     EXPECT_FALSE(signature->IsInitialized());
-        // }
-
-        // ! Cannot tests this as we do not have access to device signatures here and cannot setup mock-call
-        // // GetByteStride()
-        // {
-        //     AZ_TEST_START_TRACE_SUPPRESSION;
-        //     auto signature = CreateInitializedSignature();
-        //     AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
-        //     uint32_t byteStride = 1337;
-        //     for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
-        //     {
-        //         EXPECT_CALL(
-        //             *static_cast<IndirectBufferSignature*>(signature->GetDeviceIndirectBufferSignature(deviceIndex).get()),
-        //             GetByteStrideInternal())
-        //             .Times(1)
-        //             .WillOnce(testing::Return(byteStride));
-        //     }
-        //     EXPECT_EQ(signature->GetByteStride(), byteStride);
-        // }
-
         // GetByteStride() on uninitialized signature.
         {
             auto signature = CreateUnInitializedSignature();
-            // ! Do not have access to members, cannot setup mock-call
-            // EXPECT_CALL(*signature, GetByteStrideInternal()).Times(1).WillOnce(testing::Return(0));
             AZ_TEST_START_TRACE_SUPPRESSION;
             signature->GetByteStride();
             AZ_TEST_STOP_TRACE_SUPPRESSION(1);
@@ -261,9 +228,7 @@ namespace UnitTest
 
         // GetOffset()
         {
-            AZ_TEST_START_TRACE_SUPPRESSION;
             auto signature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             uint32_t offset = 1337;
             RHI::IndirectCommandIndex index(m_commands.size() - 1);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
@@ -279,9 +244,7 @@ namespace UnitTest
 
         // GetOffset with null index
         {
-            AZ_TEST_START_TRACE_SUPPRESSION;
             auto signature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             RHI::IndirectCommandIndex index = RHI::IndirectCommandIndex::Null;
             AZ_TEST_START_TRACE_SUPPRESSION;
             signature->GetOffset(index);
@@ -290,9 +253,7 @@ namespace UnitTest
 
         // GetOffset with invalid index
         {
-            AZ_TEST_START_TRACE_SUPPRESSION;
             auto signature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             RHI::IndirectCommandIndex index(m_commands.size());
             AZ_TEST_START_TRACE_SUPPRESSION;
             signature->GetOffset(index);
@@ -301,9 +262,7 @@ namespace UnitTest
 
         // Shutdown
         {
-            AZ_TEST_START_TRACE_SUPPRESSION;
             auto signature = CreateInitializedSignature();
-            AZ_TEST_STOP_TRACE_SUPPRESSION(DeviceCount);
             for (auto deviceIndex{ 0 }; deviceIndex < DeviceCount; ++deviceIndex)
             {
                 EXPECT_CALL(


### PR DESCRIPTION
This PR fixes a few issues in the multi-device classes that have been found during our on-going testing in the `multi-device-resources` branch:

- `IndirectArguments.h`
  - Previously the template arguments have not been used properly in the constructors
- `MultiDeviceBufferPool`
  - `MapBuffer` now returns a map of pointers (instead of a vector), one per device, indexed by the `deviceIndex`
- `MultiDeviceDispatchItem`
  - `DispatchItem` can also work without a `m_countBuffer`
- `MultiDeviceIndirectBufferView`
  - Due to the `*Items` holding a raw pointer to a `IndirectBufferView`, someone needs to hold the memory now, which is now done with a cache guarded by a mutex
- `MultiDeviceShaderResourceGroupData`
  - Moved the default parameter to the header
- `MultiDeviceSwapChain`
  - Need the ability to retrieve the device-specific `SwapChain`
- `MultiDeviceIndirectBufferSignatureDescriptor`
  - The assert is unnecessary, as it can be used without a `PipelineState`
