### PR TITLE
Change setup of virtual device support

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -38,9 +38,9 @@ namespace AZ::RHI
         , public RHIMemoryStatisticsInterface
     {
     public:
-        //! This function just initializes the native device and RHI::Device as a result.
-        //! We can use this device to then query for device capabilities.
-        ResultCode InitDevices(InitDevicesFlags initializationVariant = InitDevicesFlags::SingleDevice);
+        //! This function just initializes the native devices and RHI::Device as a result.
+        //! We can use these devices to then query for device capabilities.
+        ResultCode InitDevices(int deviceCount = 1);
 
         //! This function initializes the rest of the RHI/RHI backend.
         //! bindlessSrgLayout in this case is layout associated with the bindless srg (Bindless.azsli).
@@ -97,7 +97,7 @@ namespace AZ::RHI
     private:
 
         //! Enumerates the Physical devices and picks one (or multiple) to be used to initialize the RHI::Device(s) with
-        ResultCode InitInternalDevices(InitDevicesFlags initializationVariant);
+        ResultCode InitInternalDevices(int deviceCount);
 
         AZStd::vector<DrawListTag> m_drawListTagsDisabledByDefault;
         AZStd::vector<RHI::Ptr<RHI::Device>> m_devices;

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -35,11 +35,11 @@ namespace AZ::RHI
         return Interface<RHIMemoryStatisticsInterface>::Get();
     }
 
-    ResultCode RHISystem::InitDevices(InitDevicesFlags initializationVariant)
+    ResultCode RHISystem::InitDevices(int deviceCount)
     {
         Interface<RHISystemInterface>::Register(this);
         Interface<RHIMemoryStatisticsInterface>::Register(this);
-        return InitInternalDevices(initializationVariant);
+        return InitInternalDevices(deviceCount);
     }
     
     void RHISystem::Init(RHI::Ptr<RHI::ShaderResourceGroupLayout> bindlessSrgLayout)
@@ -100,7 +100,7 @@ namespace AZ::RHI
         RHISystemNotificationBus::Broadcast(&RHISystemNotificationBus::Events::OnRHISystemInitialized);
     }
 
-    ResultCode RHISystem::InitInternalDevices(InitDevicesFlags initializationVariant)
+    ResultCode RHISystem::InitInternalDevices(int deviceCount)
     {
         RHI::PhysicalDeviceList physicalDevices = RHI::Factory::Get().EnumeratePhysicalDevices();
 
@@ -114,7 +114,7 @@ namespace AZ::RHI
 
         RHI::PhysicalDeviceList usePhysicalDevices;
 
-        if (initializationVariant == InitDevicesFlags::MultiDevice)
+        if (deviceCount > 1)
         {
             AZ_Printf("RHISystem", "\tUsing multiple devices\n");
 
@@ -195,6 +195,14 @@ namespace AZ::RHI
             {
                 m_devices.emplace_back(AZStd::move(device));
             }
+        }
+
+        for (auto index{ 0 }; m_devices.size() < deviceCount; index++)
+        {
+            // We do not have enough physical devices for the requested device count
+            // Virtualize the existing devices up to the required number
+            auto deviceIndex{ AddVirtualDevice(m_devices[index]->GetDeviceIndex()) };
+            AZ_Printf("RHISystem", "\tVirtualized device %d from device %d\n", deviceIndex.value(), m_devices[index]->GetDeviceIndex());
         }
 
         if (m_devices.empty())

--- a/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
@@ -178,7 +178,7 @@ namespace UnitTest
             m_drawListTagRegistry = RHI::DrawListTagRegistry::Create();
 
             m_rhiSystem.reset(aznew AZ::RHI::RHISystem);
-            m_rhiSystem->InitDevices(AZ::RHI::InitDevicesFlags::SingleDevice);
+            m_rhiSystem->InitDevices();
             m_rhiSystem->Init();
         }
 

--- a/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
+++ b/Gems/Atom/RHI/Code/Tests/RHITestFixture.h
@@ -22,6 +22,7 @@
 
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI/RHISystem.h>
+#include <Tests/Device.h>
 #include <Tests/Factory.h>
 
 namespace UnitTest
@@ -71,7 +72,7 @@ namespace UnitTest
 
             m_rhiSystem.reset(aznew AZ::RHI::RHISystem);
 
-            m_rhiSystem->InitDevices(AZ::RHI::InitDevicesFlags::MultiDevice);
+            m_rhiSystem->InitDevices(DeviceCount);
             m_rhiSystem->Init();
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -81,7 +81,8 @@ namespace AZ
         void RPISystem::Initialize(const RPISystemDescriptor& rpiSystemDescriptor)
         {
             // Init RHI device(s)
-            m_rhiSystem.InitDevices(AzFramework::StringFunc::Equal(RHI::GetCommandLineValue("enableMultipleDevices").c_str(), "enable") ? RHI::InitDevicesFlags::MultiDevice : RHI::InitDevicesFlags::SingleDevice);
+            auto commandLineMultipleDevicesValue{ RHI::GetCommandLineValue("device-count") };
+            m_rhiSystem.InitDevices((commandLineMultipleDevicesValue != "") ? AZStd::stoi(commandLineMultipleDevicesValue) : 1);
 
             // Gather asset handlers from sub-systems.
             ImageSystem::GetAssetHandlers(m_assetHandlers);


### PR DESCRIPTION
## What does this PR do?

During testing of multi-device resources in the `multi-device-resource` branch, one outcome was that the number of devices cannot easily be changed at run-time.
The previous method envisioned just adding a new virtual device at run-time, which does not work, as a number of common resources are initialized during the general setup and cannot easily be modified after the fact.

This new method changes this behavior to passing the number of devices as a flag `--device-count <count>`, which is then passed from `RPISystem` to `RHISystem`, which now still initializes a single device in case no flag or `1` is provided, which takes `count` of the physical devices (if available), but if `< count` physical devices are available, the existing physical devices are added as virtual devices in round-robin fashion.

E.g.: A system with 2 physical GPUs and the start-up flags `--device-count 4` will setup `m_devices` with `{0, 1, 0, 1}`.
