### PR TITLE
Fix manipulators showing up incorrectly after duplicate

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -18,6 +18,7 @@
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
+#include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/EditorPrefabComponent.h>
@@ -36,7 +37,7 @@
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.h>
 #include <AzToolsFramework/Prefab/PrefabUndoHelpers.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
-#include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
+#include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
 
 #include <QString>
 #include <QTimer>
@@ -45,6 +46,14 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
+        PrefabPublicHandler::PrefabPublicHandler()
+        {
+            // Detect whether this is being run in the Editor or during a Unit Test.
+            AZ::ApplicationTypeQuery appType;
+            AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+            m_isRunningInEditor = (!appType.IsValid() || appType.IsEditor());
+        }
+
         void PrefabPublicHandler::RegisterPrefabPublicHandlerInterface()
         {
             m_prefabFocusHandler.RegisterPrefabFocusInterface();
@@ -1342,14 +1351,24 @@ namespace AzToolsFramework
                 auto selectionUndo = aznew SelectionCommand(duplicatedEntityAndInstanceIds, "Select Duplicated Entities/Instances");
                 selectionUndo->SetParent(undoBatch.GetUndoBatch());
 
-                QTimer::singleShot(
-                    0,
-                    [duplicatedEntityAndInstanceIds]()
-                    {
-                        ToolsApplicationRequestBus::Broadcast(
-                            &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
-                    }
-                );
+                // Only delay selection in the Editor to ensure the manipulators in the viewport are refreshed correctly.
+                if (m_isRunningInEditor)
+                {
+                    QTimer::singleShot(
+                        0,
+                        [duplicatedEntityAndInstanceIds]()
+                        {
+                            ToolsApplicationRequestBus::Broadcast(
+                                &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
+                        }
+                    );
+                }
+                else
+                {
+                    ToolsApplicationRequestBus::Broadcast(
+                        &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
+                }
+
             }
 
             return AZ::Success(AZStd::move(duplicatedEntityAndInstanceIds));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -39,6 +39,7 @@
 #include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
 
 #include <QString>
+#include <QTimer>
 
 namespace AzToolsFramework
 {
@@ -1340,8 +1341,15 @@ namespace AzToolsFramework
                 // Select the duplicated entities/instances
                 auto selectionUndo = aznew SelectionCommand(duplicatedEntityAndInstanceIds, "Select Duplicated Entities/Instances");
                 selectionUndo->SetParent(undoBatch.GetUndoBatch());
-                ToolsApplicationRequestBus::Broadcast(
-                    &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
+
+                QTimer::singleShot(
+                    0,
+                    [duplicatedEntityAndInstanceIds]()
+                    {
+                        ToolsApplicationRequestBus::Broadcast(
+                            &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
+                    }
+                );
             }
 
             return AZ::Success(AZStd::move(duplicatedEntityAndInstanceIds));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -39,6 +39,8 @@ namespace AzToolsFramework
             AZ_CLASS_ALLOCATOR(PrefabPublicHandler, AZ::SystemAllocator);
             AZ_RTTI(PrefabPublicHandler, "{35802943-6B60-430F-9DED-075E3A576A25}", PrefabPublicInterface);
 
+            PrefabPublicHandler();
+
             void RegisterPrefabPublicHandlerInterface();
             void UnregisterPrefabPublicHandlerInterface();
 
@@ -212,6 +214,8 @@ namespace AzToolsFramework
             PrefabFocusHandler m_prefabFocusHandler;
 
             uint64_t m_newEntityCounter = 1;
+
+            bool m_isRunningInEditor = true;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?

Adds a one-frame delay after duplication to ensure manipulators are shown correctly on the newly duplicated entity.

## How was this PR tested?

Manual testing.

![DupFix](https://github.com/o3de/o3de/assets/82231674/230e3251-310a-4b14-a8c3-a74b16330242)
