### PR TITLE
Add methods for client configuration in HTTP Requestor gem

### DIFF
--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -177,11 +177,37 @@ namespace AWSClientAuthUnitTest
             AZ_UNUSED(callback);
         }
 
+        void AddRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(clientConfiguration);
+            AZ_UNUSED(callback);
+        }
+
         void AddRequestWithHeaders(const AZStd::string& URI, Aws::Http::HttpMethod method, const HttpRequestor::Headers& headers, const HttpRequestor::Callback& callback) override
         {
             AZ_UNUSED(URI);
             AZ_UNUSED(method);
             AZ_UNUSED(headers);
+            AZ_UNUSED(callback);
+        }
+
+        void AddRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::Headers& headers,
+            const HttpRequestor::Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(headers);
+            AZ_UNUSED(clientConfiguration);
             AZ_UNUSED(callback);
         }
 
@@ -205,10 +231,38 @@ namespace AWSClientAuthUnitTest
             callback(jsonView, code);
         }
 
+        void AddRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::Headers& headers,
+            const AZStd::string& body,
+            const HttpRequestor::Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(headers);
+            AZ_UNUSED(body);
+            AZ_UNUSED(clientConfiguration);
+            AZ_UNUSED(callback);
+        }
+
         void AddTextRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const HttpRequestor::TextCallback& callback) override
         {
             AZ_UNUSED(URI);
             AZ_UNUSED(method);
+            AZ_UNUSED(callback);
+        }
+
+        void AddTextRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::TextCallback& callback,
+            Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(clientConfiguration);
             AZ_UNUSED(callback);
         }
 
@@ -220,12 +274,42 @@ namespace AWSClientAuthUnitTest
             AZ_UNUSED(callback);
         }
 
+        void AddTextRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::Headers& headers,
+            const HttpRequestor::TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(headers);
+            AZ_UNUSED(clientConfiguration);
+            AZ_UNUSED(callback);
+        }
+
         void AddTextRequestWithHeadersAndBody(const AZStd::string& URI, Aws::Http::HttpMethod method, const HttpRequestor::Headers& headers, const AZStd::string& body, const HttpRequestor::TextCallback& callback) override
         {
             AZ_UNUSED(URI);
             AZ_UNUSED(method);
             AZ_UNUSED(headers);
             AZ_UNUSED(body);
+            AZ_UNUSED(callback);
+        }
+
+        void AddTextRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const HttpRequestor::Headers& headers,
+            const AZStd::string& body,
+            const HttpRequestor::TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override
+        {
+            AZ_UNUSED(URI);
+            AZ_UNUSED(method);
+            AZ_UNUSED(headers);
+            AZ_UNUSED(body);
+            AZ_UNUSED(clientConfiguration);
             AZ_UNUSED(callback);
         }
 

--- a/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpRequestParameters.h
+++ b/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpRequestParameters.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "HttpTypes.h"
+#include <aws/core/client/ClientConfiguration.h>
 
 namespace HttpRequestor
 {
@@ -22,25 +23,38 @@ namespace HttpRequestor
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to use, for example HTTP_GET.
         //! @param callback The callback method to receive a HTTP call's response.
-        Parameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const Callback& callback);
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        Parameters(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to use, for example HTTP_GET.
         //! @param headers A map of header names and values to use.
         //! @param callback The callback method to receive a HTTP call's response.
-        Parameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback);
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        Parameters(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to use, for example HTTP_POST.
         //! @param headers A map of header names and values to use.
         //! @param body An data to associate with an HTTP call.
         //! @param callback The callback method to receive a HTTP call's response.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
         Parameters(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const AZStd::string& body,
-            const Callback& callback);
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         // Defaults
         virtual ~Parameters() = default;
@@ -85,36 +99,61 @@ namespace HttpRequestor
             return m_callback;
         }
 
+        //! Get the client configuration to use for the HTTP request.
+        //! @return The client configuration to use for the HTTP request.
+        const Aws::Client::ClientConfiguration& GetClientConfiguration() const
+        {
+            return m_clientConfiguration;
+        }
+
     private:
         Aws::String m_URI;
         Aws::Http::HttpMethod m_method;
         Headers m_headers;
         std::shared_ptr<std::stringstream> m_bodyStream; // required by Aws::Http::HttpRequest
         Callback m_callback;
+        Aws::Client::ClientConfiguration m_clientConfiguration;
     };
 
-    inline Parameters::Parameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const Callback& callback)
+    inline Parameters::Parameters(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
         : m_URI(URI.c_str())
         , m_method(method)
         , m_callback(callback)
-    {
-    }
-
-    inline Parameters::Parameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback)
-        : m_URI(URI.c_str())
-        , m_method(method)
-        , m_headers(headers)
-        , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
     {
     }
 
     inline Parameters::Parameters(
-        const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const AZStd::string& body, const Callback& callback)
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
+        : m_URI(URI.c_str())
+        , m_method(method)
+        , m_headers(headers)
+        , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
+    {
+    }
+
+    inline Parameters::Parameters(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const AZStd::string& body,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
         : m_URI(URI.c_str())
         , m_method(method)
         , m_headers(headers)
         , m_bodyStream(std::make_shared<std::stringstream>(body.c_str()))
         , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
     {
     }
 }

--- a/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpRequestorBus.h
+++ b/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpRequestorBus.h
@@ -7,8 +7,9 @@
  */
 #pragma once
 
-#include <AzCore/EBus/EBus.h>
 #include "HttpTypes.h"
+#include <AzCore/EBus/EBus.h>
+#include <aws/core/client/ClientConfiguration.h>
 
 namespace HttpRequestor
 {
@@ -26,6 +27,17 @@ namespace HttpRequestor
         //! @param callback The callback method to receive the JSON response object.
         virtual void AddRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const Callback& callback) = 0;
 
+        //! Make a RESTful call to a HTTP(s) endpoint. Receive the response, via the supplied callback as JSON.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The HTTP method to use, for example HTTP_GET.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) = 0;
+
         //! Make a RESTful call to a HTTP(s) endpoint with customized headers. Receive the response, via the supplied callback as JSON.
         //! @param URI The universal resource indicator representing the endpoint to make the request to.
         //! @param method The HTTP method to use, for example HTTP_GET.
@@ -34,7 +46,21 @@ namespace HttpRequestor
         virtual void AddRequestWithHeaders(
             const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback) = 0;
 
-        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as JSON.
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers. Receive the response, via the supplied callback as JSON.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The HTTP method to use, for example HTTP_GET.
+        //! @param headers A map of header names and values to set on the request.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) = 0;
+
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as
+        //! JSON.
         //! @param URI The universal resource indicator representing the endpoint to make the request to.
         //! @param method The HTTP method to use, for example HTTP_POST.
         //! @param headers A map of header names and values to set on the request.
@@ -48,11 +74,39 @@ namespace HttpRequestor
             const AZStd::string& body,
             const Callback& callback) = 0;
 
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as
+        //! JSON.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The HTTP method to use, for example HTTP_POST.
+        //! @param headers A map of header names and values to set on the request.
+        //! @param body Any HTTP request data to include in the request. Use Content-Type and Content-Length headers to specify the nature
+        //! of the body payload.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) = 0;
+
         //! Make a RESTful call to a HTTP(s) endpoint. Receive the response, via the supplied callback as text.
         //! @param URI The universal resource indicator representing the endpoint to make the request to.
         //! @param method The http method to use, for example HTTP_GET.
         //! @param callback The callback method to receive the JSON response object.
         virtual void AddTextRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const TextCallback& callback) = 0;
+
+        //! Make a RESTful call to a HTTP(s) endpoint. Receive the response, via the supplied callback as text.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The http method to use, for example HTTP_GET.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddTextRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const TextCallback& callback,
+            Aws::Client::ClientConfiguration clientConfiguration) = 0;
 
         //! Make a RESTful call to a HTTP(s) endpoint with customized headers. Receive the response, via the supplied callback as text.
         //! @param URI The universal resource indicator representing the endpoint to make the request to.
@@ -62,11 +116,26 @@ namespace HttpRequestor
         virtual void AddTextRequestWithHeaders(
             const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback) = 0;
 
-        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as text.
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers. Receive the response, via the supplied callback as text.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The HTTP method to use, for example HTTP_GET.
+        //! @param headers A map of header names and values to set on the request.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddTextRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) = 0;
+
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as
+        //! text.
         //! @param URI The universal resource indicator representing the endpoint to make the request to.
         //! @param method The HTTP method to use, for example HTTP_POST.
         //! @param headers A map of header names and values to set on the request.
-        //! @param body Any HTTP request data to include in the request. Use Content-Type and Content-Length headers to specify the nature of the body payload.
+        //! @param body Any HTTP request data to include in the request. Use Content-Type and Content-Length headers to specify the nature
+        //! of the body payload.
         //! @param callback The callback method to receive the JSON response object.
         virtual void AddTextRequestWithHeadersAndBody(
             const AZStd::string& URI,
@@ -74,6 +143,23 @@ namespace HttpRequestor
             const Headers& headers,
             const AZStd::string& body,
             const TextCallback& callback) = 0;
+
+        //! Make a RESTful call to a HTTP(s) endpoint with customized headers and a body. Receive the response, via the supplied callback as
+        //! text.
+        //! @param URI The universal resource indicator representing the endpoint to make the request to.
+        //! @param method The HTTP method to use, for example HTTP_POST.
+        //! @param headers A map of header names and values to set on the request.
+        //! @param body Any HTTP request data to include in the request. Use Content-Type and Content-Length headers to specify the nature
+        //! of the body payload.
+        //! @param callback The callback method to receive the JSON response object.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        virtual void AddTextRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) = 0;
 
         //! Receive the round trip time of the last RESTful call made to a HTTP(s) endpoint.
         //! Call this method from inside the supplied callback to get the round trip time of the original request.

--- a/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpTextRequestParameters.h
+++ b/Gems/HttpRequestor/Code/Include/HttpRequestor/HttpTextRequestParameters.h
@@ -7,6 +7,7 @@
  */
 
 #include "HttpTypes.h"
+#include <aws/core/client/ClientConfiguration.h>
 #include <sstream>
 
 namespace HttpRequestor
@@ -21,25 +22,38 @@ namespace HttpRequestor
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to configure.
         //! @param callback The callback method to receive a HTTP call's response.
-        TextParameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const TextCallback& callback);
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        TextParameters(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to configure.
         //! @param headers A map of header names and values to use.
         //! @param callback The callback method to receive a HTTP call's response.
-        TextParameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback);
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
+        TextParameters(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         //! @param URI A universal resource indicator representing an endpoint.
         //! @param method The HTTP method to configure.
         //! @param headers A map of header names and values to use.
         //! @param body An data to associate with an HTTP call.
         //! @param callback The callback method to receive a HTTP call's response.
+        //! @param clientConfiguration The client configuration to use for the HTTP request.
         TextParameters(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const AZStd::string& body,
-            const TextCallback& callback);
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration());
 
         // Defaults
         ~TextParameters() = default;
@@ -84,27 +98,45 @@ namespace HttpRequestor
             return m_callback;
         }
 
+        //! Get the client configuration to use for the HTTP request.
+        //! @return The client configuration to use for the HTTP request.
+        const Aws::Client::ClientConfiguration& GetClientConfiguration() const
+        {
+            return m_clientConfiguration;
+        }
+
     private:
         Aws::String m_URI;
         Aws::Http::HttpMethod m_method;
         Headers m_headers;
         std::shared_ptr<std::stringstream> m_bodyStream;
         TextCallback m_callback;
+        Aws::Client::ClientConfiguration m_clientConfiguration;
     };
 
-    inline TextParameters::TextParameters(const AZStd::string& URI, Aws::Http::HttpMethod method, const TextCallback& callback)
+    inline TextParameters::TextParameters(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
         : m_URI(URI.c_str())
         , m_method(method)
         , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
     {
     }
 
     inline TextParameters::TextParameters(
-        const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback)
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
         : m_URI(URI.c_str())
         , m_method(method)
         , m_headers(headers)
         , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
     {
     }
 
@@ -113,12 +145,14 @@ namespace HttpRequestor
         Aws::Http::HttpMethod method,
         const Headers& headers,
         const AZStd::string& body,
-        const TextCallback& callback)
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration& clientConfiguration)
         : m_URI(URI.c_str())
         , m_method(method)
         , m_headers(headers)
         , m_bodyStream(std::make_shared<std::stringstream>(body.c_str()))
         , m_callback(callback)
+        , m_clientConfiguration(clientConfiguration)
     {
     }
 } // namespace HttpRequestor

--- a/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
@@ -135,7 +135,7 @@ namespace HttpRequestor
 
     void Manager::HandleRequest(const Parameters& httpRequestParameters)
     {
-        Aws::Client::ClientConfiguration config;
+        Aws::Client::ClientConfiguration config = httpRequestParameters.GetClientConfiguration();
         config.enableTcpKeepAlive = AZ_TRAIT_AZFRAMEWORK_AWS_ENABLE_TCP_KEEP_ALIVE_SUPPORTED;
         std::shared_ptr<Aws::Http::HttpClient> httpClient = Aws::Http::CreateHttpClient(config);
 
@@ -186,7 +186,7 @@ namespace HttpRequestor
 
     void Manager::HandleTextRequest(const TextParameters& httpRequestParameters)
     {
-        Aws::Client::ClientConfiguration config;
+        Aws::Client::ClientConfiguration config = httpRequestParameters.GetClientConfiguration();
         config.enableTcpKeepAlive = AZ_TRAIT_AZFRAMEWORK_AWS_ENABLE_TCP_KEEP_ALIVE_SUPPORTED;
         std::shared_ptr<Aws::Http::HttpClient> httpClient = Aws::Http::CreateHttpClient(config);
 

--- a/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
@@ -20,20 +20,58 @@ namespace HttpRequestor
             m_httpManager->AddRequest( Parameters(URI, method, callback) );
         }
     }
+    void HttpRequestorSystemComponent::AddRequestWithClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddRequest(Parameters(URI, method, callback, clientConfiguration));
+        }
+    }
 
-    void HttpRequestorSystemComponent::AddRequestWithHeaders(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const Callback& callback)
+    void HttpRequestorSystemComponent::AddRequestWithHeaders(
+        const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback)
     {
         if (m_httpManager != nullptr)
         {
             m_httpManager->AddRequest(Parameters(URI, method, headers, callback));
         }
     }
+    void HttpRequestorSystemComponent::AddRequestWithHeadersAndClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddRequest(Parameters(URI, method, headers, callback, clientConfiguration));
+        }
+    }
 
-    void HttpRequestorSystemComponent::AddRequestWithHeadersAndBody(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const AZStd::string& body, const Callback& callback)
+    void HttpRequestorSystemComponent::AddRequestWithHeadersAndBody(
+        const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const AZStd::string& body, const Callback& callback)
     {
         if (m_httpManager != nullptr)
         {
             m_httpManager->AddRequest(Parameters(URI, method, headers, body, callback));
+        }
+    }
+    void HttpRequestorSystemComponent::AddRequestWithHeadersBodyAndClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const AZStd::string& body,
+        const Callback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddRequest(Parameters(URI, method, headers, body, callback, clientConfiguration));
         }
     }
 
@@ -44,20 +82,62 @@ namespace HttpRequestor
             m_httpManager->AddTextRequest( TextParameters(URI, method, callback));
         }
     }
+    void HttpRequestorSystemComponent::AddTextRequestWithClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddTextRequest(TextParameters(URI, method, callback, clientConfiguration));
+        }
+    }
 
-    void HttpRequestorSystemComponent::AddTextRequestWithHeaders(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const TextCallback& callback)
+    void HttpRequestorSystemComponent::AddTextRequestWithHeaders(
+        const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback)
     {
         if (m_httpManager != nullptr)
         {
             m_httpManager->AddTextRequest(TextParameters(URI, method, headers, callback));
         }
     }
+    void HttpRequestorSystemComponent::AddTextRequestWithHeadersAndClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddTextRequest(TextParameters(URI, method, headers, callback, clientConfiguration));
+        }
+    }
 
-    void HttpRequestorSystemComponent::AddTextRequestWithHeadersAndBody(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const AZStd::string& body, const TextCallback& callback)
+    void HttpRequestorSystemComponent::AddTextRequestWithHeadersAndBody(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const AZStd::string& body,
+        const TextCallback& callback)
     {
         if (m_httpManager != nullptr)
         {
             m_httpManager->AddTextRequest(TextParameters(URI, method, headers, body, callback));
+        }
+    }
+    void HttpRequestorSystemComponent::AddTextRequestWithHeadersBodyAndClientConfiguration(
+        const AZStd::string& URI,
+        Aws::Http::HttpMethod method,
+        const Headers& headers,
+        const AZStd::string& body,
+        const TextCallback& callback,
+        const Aws::Client::ClientConfiguration clientConfiguration)
+    {
+        if (m_httpManager != nullptr)
+        {
+            m_httpManager->AddTextRequest(TextParameters(URI, method, headers, body, callback, clientConfiguration));
         }
     }
 

--- a/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.cpp
@@ -20,6 +20,7 @@ namespace HttpRequestor
             m_httpManager->AddRequest( Parameters(URI, method, callback) );
         }
     }
+
     void HttpRequestorSystemComponent::AddRequestWithClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,
@@ -40,6 +41,7 @@ namespace HttpRequestor
             m_httpManager->AddRequest(Parameters(URI, method, headers, callback));
         }
     }
+
     void HttpRequestorSystemComponent::AddRequestWithHeadersAndClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,
@@ -61,6 +63,7 @@ namespace HttpRequestor
             m_httpManager->AddRequest(Parameters(URI, method, headers, body, callback));
         }
     }
+
     void HttpRequestorSystemComponent::AddRequestWithHeadersBodyAndClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,
@@ -82,6 +85,7 @@ namespace HttpRequestor
             m_httpManager->AddTextRequest( TextParameters(URI, method, callback));
         }
     }
+
     void HttpRequestorSystemComponent::AddTextRequestWithClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,
@@ -102,6 +106,7 @@ namespace HttpRequestor
             m_httpManager->AddTextRequest(TextParameters(URI, method, headers, callback));
         }
     }
+
     void HttpRequestorSystemComponent::AddTextRequestWithHeadersAndClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,
@@ -127,6 +132,7 @@ namespace HttpRequestor
             m_httpManager->AddTextRequest(TextParameters(URI, method, headers, body, callback));
         }
     }
+
     void HttpRequestorSystemComponent::AddTextRequestWithHeadersBodyAndClientConfiguration(
         const AZStd::string& URI,
         Aws::Http::HttpMethod method,

--- a/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.h
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
+#include "HttpRequestManager.h"
 #include <AzCore/Component/Component.h>
 #include <HttpRequestor/HttpRequestorBus.h>
-#include "HttpRequestManager.h"
+#include <aws/core/client/ClientConfiguration.h>
 
 namespace HttpRequestor
 {
@@ -33,12 +34,60 @@ namespace HttpRequestor
         // HttpRequestorRequestBus interface implementation
         ////////////////////////////////////////////////////////////////////////
         void AddRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const Callback& callback) override;
-        void AddRequestWithHeaders(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const Callback& callback) override;
-        void AddRequestWithHeadersAndBody(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const AZStd::string& body, const Callback& callback) override;
+        void AddRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override;
+        void AddRequestWithHeaders(
+            const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback) override;
+        void AddRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override;
+        void AddRequestWithHeadersAndBody(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const Callback& callback) override;
+        void AddRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const Callback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override;
 
         void AddTextRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const TextCallback& callback) override;
-        void AddTextRequestWithHeaders(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const TextCallback& callback) override;
-        void AddTextRequestWithHeadersAndBody(const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers & headers, const AZStd::string& body, const TextCallback& callback) override;
+        void AddTextRequestWithClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration) override;
+        void AddTextRequestWithHeaders(
+            const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback) override;
+        void AddTextRequestWithHeadersAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration = Aws::Client::ClientConfiguration()) override;
+        void AddTextRequestWithHeadersAndBody(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const TextCallback& callback) override;
+        void AddTextRequestWithHeadersBodyAndClientConfiguration(
+            const AZStd::string& URI,
+            Aws::Http::HttpMethod method,
+            const Headers& headers,
+            const AZStd::string& body,
+            const TextCallback& callback,
+            const Aws::Client::ClientConfiguration clientConfiguration = Aws::Client::ClientConfiguration()) override;
 
         AZStd::chrono::milliseconds GetLastRoundTripTime() const override;
 

--- a/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.h
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestorSystemComponent.h
@@ -34,25 +34,30 @@ namespace HttpRequestor
         // HttpRequestorRequestBus interface implementation
         ////////////////////////////////////////////////////////////////////////
         void AddRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const Callback& callback) override;
+
         void AddRequestWithClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Callback& callback,
             const Aws::Client::ClientConfiguration clientConfiguration) override;
+
         void AddRequestWithHeaders(
             const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const Callback& callback) override;
+
         void AddRequestWithHeadersAndClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const Callback& callback,
             const Aws::Client::ClientConfiguration clientConfiguration) override;
+
         void AddRequestWithHeadersAndBody(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const AZStd::string& body,
             const Callback& callback) override;
+
         void AddRequestWithHeadersBodyAndClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
@@ -62,25 +67,30 @@ namespace HttpRequestor
             const Aws::Client::ClientConfiguration clientConfiguration) override;
 
         void AddTextRequest(const AZStd::string& URI, Aws::Http::HttpMethod method, const TextCallback& callback) override;
+
         void AddTextRequestWithClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const TextCallback& callback,
             const Aws::Client::ClientConfiguration clientConfiguration) override;
+
         void AddTextRequestWithHeaders(
             const AZStd::string& URI, Aws::Http::HttpMethod method, const Headers& headers, const TextCallback& callback) override;
+
         void AddTextRequestWithHeadersAndClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const TextCallback& callback,
             const Aws::Client::ClientConfiguration clientConfiguration = Aws::Client::ClientConfiguration()) override;
+
         void AddTextRequestWithHeadersAndBody(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,
             const Headers& headers,
             const AZStd::string& body,
             const TextCallback& callback) override;
+
         void AddTextRequestWithHeadersBodyAndClientConfiguration(
             const AZStd::string& URI,
             Aws::Http::HttpMethod method,


### PR DESCRIPTION
## What does this PR do?

This PR adds additional Bus functions in the HTTP Requestor Gem to allow the user to specify the client configuration.
This enables the user to change the configuration and for example change timeouts.

## How was this PR tested?

This PR was tested by adding different configurations for the HTTP Requestor gem with different timeouts.
