### PR TITLE
Naming clash fix that happens with newest cmake.

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
@@ -25,11 +25,11 @@ namespace AssetProcessor
     using namespace AzToolsFramework::AssetSystem;
     using namespace AzToolsFramework::AssetDatabase;
 
-    class AssetProcessorManager_Test
+    class AssetProcessorManagerUnit_Test
         : public AssetProcessorManager
     {
     public:
-        explicit AssetProcessorManager_Test(PlatformConfiguration* config, QObject* parent = 0)
+        explicit AssetProcessorManagerUnit_Test(PlatformConfiguration* config, QObject* parent = 0)
             : AssetProcessorManager(config, parent)
         {}
 
@@ -105,7 +105,7 @@ namespace AssetProcessor
         m_config.AddMetaDataType("exportsettings", QString());
 
         // Configure asset processor manager
-        m_assetProcessorManager = AZStd::make_unique<AssetProcessorManager_Test>(&m_config);  // note, this will 'push' the scan folders in to the db.
+        m_assetProcessorManager = AZStd::make_unique<AssetProcessorManagerUnit_Test>(&m_config);  // note, this will 'push' the scan folders in to the db.
 
         m_assetProcessorConnections.append(connect(m_assetProcessorManager.get(), &AssetProcessorManager::AssetToProcess,
             this, [&](JobDetails details)
@@ -2505,7 +2505,7 @@ namespace AssetProcessor
 
         {
             // create this, which will write those scan folders into the db as-is
-            AssetProcessorManager_Test apm(&config2);
+            AssetProcessorManagerUnit_Test apm(&config2);
             apm.CheckMissingFiles();
         }
 

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.h
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.h
@@ -18,7 +18,7 @@
 
 namespace AssetProcessor
 {
-    class AssetProcessorManager_Test;
+    class AssetProcessorManagerUnit_Test;
 
     class AssetProcessorManagerUnitTests
         : public QObject
@@ -55,7 +55,7 @@ namespace AssetProcessor
         QList<QPair<QString, QString>> m_changedInputResults;
         QList<AzFramework::AssetSystem::AssetNotificationMessage> m_assetMessages;
 
-        AZStd::unique_ptr<AssetProcessorManager_Test> m_assetProcessorManager;
+        AZStd::unique_ptr<AssetProcessorManagerUnit_Test> m_assetProcessorManager;
         PlatformConfiguration m_config;
     };
 } // namespace assetprocessor


### PR DESCRIPTION
Caused by this file being compiled with AssetProcessorManagerTest.h/cpp which also has the AssetProcessorManager_Test class when using unity build.
Happens with cmake-2.28.4 and newer.
