### PR TITLE
Bugfix for MultiDeviceSwapChain which did not properly recreate images.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -75,7 +75,8 @@ namespace AZ::RHI
 
         //! Recreate the swapchain if it becomes invalid during presenting. This should happen at the end of the frame
         //! due to images being used as attachments in the frame graph.
-        virtual void ProcessRecreation() {};
+        virtual bool ProcessRecreation(){ return false; };
+
     protected:
         SwapChain();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceSwapChain.cpp
@@ -238,10 +238,18 @@ namespace AZ::RHI
 
     void MultiDeviceSwapChain::ProcessRecreation()
     {
-        IterateObjects<SwapChain>([]([[maybe_unused]] auto deviceIndex, auto deviceSwapChain)
+        auto recreated{ false };
+        IterateObjects<SwapChain>(
+            [&recreated]([[maybe_unused]] auto deviceIndex, auto deviceSwapChain)
+            {
+                recreated = deviceSwapChain->ProcessRecreation();
+            });
+
+        if (recreated)
         {
-            deviceSwapChain->ProcessRecreation();
-        });
+            ShutdownImages();
+            InitImages();
+        }
     }
 
     uint32_t MultiDeviceSwapChain::GetImageCount() const

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -70,7 +70,7 @@ namespace AZ
             m_swapChainBarrier.m_isValid = true;
         }
 
-        void SwapChain::ProcessRecreation()
+        bool SwapChain::ProcessRecreation()
         {
             if (m_pendingRecreation)
             {
@@ -82,7 +82,9 @@ namespace AZ
                 InitImages();
 
                 m_pendingRecreation = false;
+                return true;
             }
+            return false;
         }
 
         void SwapChain::SetVerticalSyncIntervalInternal(uint32_t previousVsyncInterval)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -51,7 +51,7 @@ namespace AZ
 
             void QueueBarrier(const VkPipelineStageFlags src, const VkPipelineStageFlags dst, const VkImageMemoryBarrier& imageBarrier);
 
-            void ProcessRecreation() override;
+            bool ProcessRecreation() override;
         private:
             SwapChain() = default;
 


### PR DESCRIPTION
## What does this PR do?

Images of the MultiDeviceSwapChain were stale when recreated, this is fixed in `ProcessRecreation` now.
Also removing unnecessary forwards of Shutdown calls,  since Shutdown got called twice so far. This doesn't have any stability impact, but is wasteful.

Note: there is still an issue that already exists in development, see: https://github.com/o3de/o3de/pull/15949#discussion_r1539086079

## How was this PR tested?

`Gem::Atom_RHI.Tests.main`