### PR TITLE
Fix build issue with Python unit test.

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/PythonLoaderTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PythonLoaderTests.cpp
@@ -81,7 +81,7 @@ namespace UnitTest
         AZStd::vector<AZStd::string> expectedResults;
         expectedResults.emplace_back(testFullSiteLIbsPath.LexicallyNormal().Native());
 
-        static constexpr AZStd::array<const char*, 3ui64> testEggLinkPaths({ "/lib/path/one", "/lib/path/two", "/lib/path/three" });
+        static constexpr AZStd::array<const char*, 3> testEggLinkPaths({ "/lib/path/one", "/lib/path/two", "/lib/path/three" });
         int index = 0;
         for (const char* testEggLinkPath : testEggLinkPaths)
         {

--- a/Code/Framework/AzToolsFramework/Tests/PythonLoaderTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PythonLoaderTests.cpp
@@ -81,7 +81,7 @@ namespace UnitTest
         AZStd::vector<AZStd::string> expectedResults;
         expectedResults.emplace_back(testFullSiteLIbsPath.LexicallyNormal().Native());
 
-        static constexpr auto testEggLinkPaths = AZStd::to_array<const char*>({ "/lib/path/one", "/lib/path/two", "/lib/path/three" });
+        static constexpr AZStd::array<const char*, 3ui64> testEggLinkPaths({ "/lib/path/one", "/lib/path/two", "/lib/path/three" });
         int index = 0;
         for (const char* testEggLinkPath : testEggLinkPaths)
         {


### PR DESCRIPTION
## What does this PR do?

Since it was introduced, this test won't build correctly on my machine
```
TEST_F(AzToolsFrameworkPythonLoaderFixture, TestReadPythonEggLinkPaths_Valid)
```

The problem relates to this line:
```
static constexpr auto testEggLinkPaths = AZStd::to_array<const char*>({ "/lib/path/one", "/lib/path/two", "/lib/path/three" });
```
which triggers this error during the build:
```
fatal error C1001: Internal compiler error.
```

Up to now I resorted to just commenting out this test whenever I had to build the tests locally.
I've played around with the definition though and it looks like using the constructor instead of `AZStd::to_array` fixes the issue.

## How was this PR tested?

Ran test locally to verify it passes (while it would not build before this change)
