### PR TITLE
Shadow culling outside view frustum

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -686,8 +686,7 @@ namespace AZ::Render
                 {
                     uint16_t shadowIndex = shadowProperty.m_shadowId.GetIndex();
                     const FilterParameter& filterData = m_shadowData.GetElement<FilterParamIndex>(shadowIndex);
-                    bool needsRender = filterData.m_shadowmapSize != aznumeric_cast<uint32_t>(ShadowmapSize::None);
-                    if (!needsRender)
+                    if (filterData.m_shadowmapSize == aznumeric_cast<uint32_t>(ShadowmapSize::None))
                     {
                         continue;
                     }
@@ -695,10 +694,8 @@ namespace AZ::Render
                     if (cullShadowmapOutsideViewFrustum &&
                         !IsLightInsideAnyViewFrustum(mainViewFrustums, lightPosition, shadowProperty.m_desc.m_farPlaneDistance))
                     {
-                        shadowProperty.m_shadowmapPass->SetEnabled(false);
                         continue;
                     }
-                    shadowProperty.m_shadowmapPass->SetEnabled(true);
 
                     const RPI::PipelineViewTag& viewTag = shadowProperty.m_shadowmapPass->GetPipelineViewTag();
                     const RHI::DrawListMask drawListMask = renderPipeline->GetDrawListMask(viewTag);

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
@@ -39,7 +39,8 @@ namespace AZ::Render
         void Activate() override;
         void Deactivate() override;
         void Simulate(const SimulatePacket& packet) override;
-        void PrepareViews(const PrepareViewsPacket&, AZStd::vector<AZStd::pair<RPI::PipelineViewTag, RPI::ViewPtr>>&) override;
+        void PrepareViews(
+            const PrepareViewsPacket& prepareViewsPacket, AZStd::vector<AZStd::pair<RPI::PipelineViewTag, RPI::ViewPtr>>&) override;
         void Render(const RenderPacket& packet) override;
 
         // ProjectedShadowFeatureProcessorInterface overrides ...

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -48,9 +48,10 @@ namespace AZ
             friend class Scene;
         public:
 
-            // [GFX TODO]: now these structure are empty, but we will clean up them later when we are sure we won't have any members in them.
+        public:
             struct PrepareViewsPacket
             {
+                AZStd::map<ViewPtr, RHI::DrawListMask> m_persistentViews;
             };
 
             struct SimulatePacket
@@ -105,7 +106,8 @@ namespace AZ
             //! views (transient views) are views that must be rendered only to correctly render 
             //! the main views. This function is called per frame and it happens on main thread.
             //! Support views should be added to outViews with their associated pipeline view tags.
-            virtual void PrepareViews(const PrepareViewsPacket&, AZStd::vector<AZStd::pair<PipelineViewTag, ViewPtr>>& /* outViews*/) {}
+            virtual void PrepareViews(
+                const PrepareViewsPacket& /*prepareViewPacket*/, AZStd::vector<AZStd::pair<PipelineViewTag, ViewPtr>>& /*outViews*/) {}
 
             //! The feature processor should perform any internal simulation at this point - For 
             //! instance, updating a particle system or animation. Not every feature processor

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -46,7 +46,6 @@ namespace AZ
             : public SceneNotificationBus::Handler
         {
             friend class Scene;
-        public:
 
         public:
             struct PrepareViewsPacket

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -786,6 +786,7 @@ namespace AZ
             
                 // Collect transient views from each feature processor
                 FeatureProcessor::PrepareViewsPacket prepareViewPacket;
+                prepareViewPacket.m_persistentViews = persistentViews;
                 AZStd::vector<AZStd::pair<PipelineViewTag, ViewPtr>> transientViews;
                 for (auto& fp : m_featureProcessors)
                 {


### PR DESCRIPTION
## What does this PR do?

As of right now, when there are many lights on the scene, then usually most of them are outside the Camera frustum. Each light has a max range that it can cast shadow to. 
But current implementation always goes through object culling, shadowmap rendering etc. for all lights. This happens even if all shadows possibly casted from the light source are outside camera view.

This PR aims to improve performance by skipping unnecessary work for all shadows that won't be visible. 
This is achieved by culling light on the CPU to limit the amount of lights that processing is done for. 
Used intersection test: sphere (center=lightPosition, radius=maxRange) with view frustum of every persistent View.

There are other scenarios when culling shadows is also possible.
I hope that minimizing light impact on performance does not end here.
Potential further improvements:
- Free memory on the GPU for culled shadows
- Take culling planes and big objects into consideration when culling shadows
- etc.

CVAR `r_cullShadowmapOutsideViewFrustum` was added make this feature opt out if needed.

## How was this PR tested?
Manually by verifying on different scenes if shadows look the same with CVAR `r_cullShadowmapOutsideViewFrustum` set to 0/1.

After applying the PR to scene with 900 lights, avg 100 meshes for light. 
CPU usage from CullingScene drastically decreased.

## Visualization
Minimal example with single light.

Improvements because of this PR:
- Decrease in total draw item count 17 -> 15, scales with each mesh / light.

Light in view (culling enabled / disabled no difference)
![Screenshot from 2024-03-26 16-03-07](https://github.com/o3de/o3de/assets/45515109/900151a8-dbca-4326-83a9-2d8b04a00d33)

Light outside view (culling enabled)
![Screenshot from 2024-03-26 16-09-07](https://github.com/o3de/o3de/assets/45515109/1ea2181d-f39c-432c-a124-4c9e39056cba)

Light outside view (culling disabled)
![Screenshot from 2024-03-26 16-09-01](https://github.com/o3de/o3de/assets/45515109/129d07e9-ff48-4cf3-80f6-6a1f6173114a)
