### PR TITLE
Ensure Collider widgets correctly signal when they're being edited

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
@@ -27,11 +27,12 @@ namespace AzToolsFramework
     class PropertyStringComboBoxCtrl
         : public GenericComboBoxCtrl<AZStd::string>
     {
+        Q_OBJECT
+        using ComboBoxBase = GenericComboBoxCtrl<AZStd::string>;
+
         friend class StringEnumPropertyComboBoxHandler;
         template<typename T>
         friend class PropertyComboBoxHandlerCommon;
-        Q_OBJECT
-        using ComboBoxBase = GenericComboBoxCtrl<AZStd::string>;
 
     public:
         AZ_RTTI(PropertyStringComboBoxCtrl, "{886E5B2C-46F5-4046-B0A3-89C28CB28B38}", ComboBoxBase);

--- a/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionGroupWidget.cpp
@@ -40,6 +40,8 @@ namespace PhysX
             {
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
                     &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, picker);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, picker);
             });
 
             connect(picker->GetEditButton(), &QToolButton::clicked, this, &CollisionGroupWidget::OnEditButtonClicked);

--- a/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
+++ b/Gems/PhysX/Code/Editor/CollisionLayerWidget.cpp
@@ -35,7 +35,9 @@ namespace PhysX
             connect(picker->GetComboBox(), &QComboBox::currentTextChanged, this, [picker]()
             {
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, picker);
+                        &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, picker);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
+                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, picker);
             });
 
             connect(picker->GetEditButton(), &QToolButton::clicked, this, &CollisionLayerWidget::OnEditButtonClicked);


### PR DESCRIPTION
Cherry-pick of https://github.com/o3de/o3de/pull/17543