### PR TITLE
Fixes issue #14879 (Mouse input inconsistencies)

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -190,8 +190,9 @@ namespace AzFramework
         , m_rawMovementSampleRate()
         , m_rawButtonEventQueuesById()
         , m_rawMovementEventQueuesById()
-        , m_timeOfLastRawMovementSample(AZStd::chrono::steady_clock::now())
     {
+        m_timeOfLastRawMovementSample[0] = m_timeOfLastRawMovementSample[1] = m_timeOfLastRawMovementSample[2] = AZStd::chrono::steady_clock::now();
+
         SetRawMovementSampleRate(MovementSampleRateDefault);
     }
 
@@ -213,8 +214,15 @@ namespace AzFramework
     void InputDeviceMouse::Implementation::QueueRawMovementEvent(const InputChannelId& inputChannelId,
                                                                  float rawMovementDelta)
     {
-        auto now = AZStd::chrono::steady_clock::now();
-        auto deltaTime = now - m_timeOfLastRawMovementSample;
+        AZStd::chrono::steady_clock::time_point now = AZStd::chrono::steady_clock::now();
+        
+        AZStd::chrono::steady_clock::time_point& lastSampleForThisAxis = 
+            inputChannelId == Movement::X ? m_timeOfLastRawMovementSample[0] :
+            inputChannelId == Movement::Y ? m_timeOfLastRawMovementSample[1] : 
+            inputChannelId == Movement::Z ? m_timeOfLastRawMovementSample[2] : 
+            now;   // read and write to 'now' if its not a movement axis which is why 'now' is non-const
+
+        auto deltaTime = now - lastSampleForThisAxis;
         auto& rawEventQueue = m_rawMovementEventQueuesById[inputChannelId];
 
         // Depending on the movement sample rate, multiple mouse movements within a frame are either:
@@ -222,13 +230,14 @@ namespace AzFramework
         {
             // queued (to give a better response at low frame rates)
             rawEventQueue.push_back(rawMovementDelta);
-            m_timeOfLastRawMovementSample = now;
         }
         else
         {
             // or accumulated (to avoid flooding the event queue)
             rawEventQueue.back() += rawMovementDelta;
         }
+
+        lastSampleForThisAxis = now; // note:  this is intentionally tautology when its not a movement axis.
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -240,18 +249,29 @@ namespace AzFramework
         m_inputDevice.m_cursorPositionData2D->m_normalizedPosition = newNormalizedPosition;
         m_inputDevice.m_cursorPositionData2D->m_normalizedPositionDelta = newNormalizedPosition - oldNormalizedPosition;
 
+        // One issue with the way mouse events propagate is that the driver only sends events when the mouse physically moves.
+        // This can lead to the situation where the mouse starts moving, and so we get a movement "BEGIN" event,
+        // and it continues moving smoothly, each frame, correctly leading to a "Update" event many frames,
+        // but when it stops moving, no event occurs (from the driver).  Because only events ending up in the queue
+        // can cause transitions from UPDATE to IDLE, it can't ever settle and the "UPDATE" state will never end.
+
+        // we can detect the situation where the mouse has not moved this tick by seeing if any events were in the
+        // queue.  If there was no event for this game tick, we can assume the mouse has stopped moving.
+        for (const InputChannelId& movementChannelId : Movement::All)
+        {
+            // if the channel was already idle, there's no reason to add synthetic events to it.
+            if (!m_inputDevice.m_movementChannelsById[movementChannelId]->IsStateIdle())
+            {
+                if (m_rawMovementEventQueuesById[movementChannelId].empty())
+                {
+                    m_rawMovementEventQueuesById[movementChannelId].push_back(0.0f);
+                }
+            }
+        }
+
         // Process all raw input events that were queued since the last call to this function
         ProcessRawInputEventQueues(m_rawButtonEventQueuesById, m_inputDevice.m_buttonChannelsById);
         ProcessRawInputEventQueues(m_rawMovementEventQueuesById, m_inputDevice.m_movementChannelsById);
-
-        // Mouse movement events are distinct in that we may not receive an 'ended' event with delta
-        // value of zero when the mouse stops moving, so queueing one here ensures the channels will
-        // always correctly transition into the 'ended' state the next time this function is called,
-        // unless another movement delta is queued above in which case it will simply be added to 0.
-        for (const InputChannelId& movementChannelId : Movement::All)
-        {
-            QueueRawMovementEvent(movementChannelId, 0.0f);
-        }
 
         // Finally, update the cursor position input channel, treating it as active if it has moved
         const float distanceMoved = newNormalizedPosition.GetDistance(oldNormalizedPosition);

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -302,6 +302,8 @@ namespace AzFramework
             ///@{
             using RawButtonEventQueueByIdMap = AZStd::unordered_map<InputChannelId, AZStd::vector<bool>>;
             using RawMovementEventQueueByIdMap = AZStd::unordered_map<InputChannelId, AZStd::vector<float>>;
+            using LastSampleTimeArray = AZStd::array<AZStd::chrono::steady_clock::time_point, InputDeviceMouse::Movement::All.size()>;
+
             ///@}
 
         private:
@@ -311,7 +313,7 @@ namespace AzFramework
             AZStd::sys_time_t            m_rawMovementSampleRate;      //!< Raw movement sample rate
             RawButtonEventQueueByIdMap   m_rawButtonEventQueuesById;   //!< Raw button events by id
             RawMovementEventQueueByIdMap m_rawMovementEventQueuesById; //!< Raw movement events by id
-            AZStd::chrono::steady_clock::time_point m_timeOfLastRawMovementSample; //!< Time of the last raw movement sample
+            LastSampleTimeArray          m_timeOfLastRawMovementSample;  //!< Time of the last raw movement sample
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

Fixes issue #14879 

The issue was caused by the fact that the mouse input device was checking a variable that was tracking how much time since the last mouse input event, and considering things to be a new input event if more than a certain amount of time passed.

However, this function was being called for each axis on the Mouse (So X, Y, Z separately), but the "Time Since last event" variable was shared across the axes and thus would cause the X axis (the first) to act differently from the others.

The change does 2 things - one, it makes a per-axis time, and two, it only emits a "no movement" event artificially if there were no events this frame (and does so at the end of the frame), instead of what was happening before, which was to always emit a "no input" 0 axis event, at the begin of each frame, which interacts poorly with the device code which merges adjacent events.

This brings all the channels back into the same behavior - when you move the mouse, they all go into the "Pressed" state initially for one event delivery, and if you keep moving the mouse they remain in the "Updated" state, delivering events as updated, until you stop moving the mouse, at which point they go into the "released" state for one frame, followed by the "Idle" state until you start moving the mouse again. 
 
## How was this PR tested?

I created a script canvas script and input bindings which if dropped into a project with the setup shows the status going.

I also used the IMGUI (tilde button) input monitor to show it working.

The attached zip contains the script canvas and input bindings.  Unzip to a project folder, create an input component on an entity, assign the input, create a script canvas component on an entiy, assign the script canvas, and CTRL+G

[issue_14879.zip](https://github.com/o3de/o3de/files/14859107/issue_14879.zip)
