### PR TITLE
Slice Level UI Removal | Inspector and Asset Browser cleanup

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -251,7 +251,7 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
     {
         // If this was a sequence that was selected by the user in Track View
         // and it was "No Sequence" clear the m_mostRecentSequenceId so the sequence
-        // will not be reselected at unwanted events like a slice reload or an undo operation.
+        // will not be reselected at unwanted events like an undo operation.
         m_mostRecentSequenceId.SetInvalid();
     }
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -43,12 +43,9 @@
 #include <AzToolsFramework/AssetEditor/AssetEditorBus.h>
 #include <AzToolsFramework/Commands/EntityStateCommand.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
-#include <AzToolsFramework/Entity/SliceEditorEntityOwnershipServiceBus.h>
-#include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
-#include <AzToolsFramework/UI/Slice/SliceRelationshipBus.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
 // AzQtComponents
@@ -201,11 +198,6 @@ namespace AzAssetBrowserRequestHandlerPrivate
             return false;
         }
 
-        if (product->GetAssetType() == AZ::AzTypeInfo<AZ::SliceAsset>::Uuid())
-        {
-            return true; // we can always instantiate slices.
-        }
-
         bool canCreateComponent = false;
         AZ::AssetTypeInfoBus::EventResult(canCreateComponent, product->GetAssetType(), &AZ::AssetTypeInfo::CanCreateComponent, product->GetAssetId());
         if (!canCreateComponent)
@@ -231,8 +223,7 @@ namespace AzAssetBrowserRequestHandlerPrivate
         AZStd::vector<const ProductAssetBrowserEntry*> products,
         AZ::Vector3 location,
         AZ::EntityId parentEntityId, // if valid, will treat the location as a local transform relative to this entity.
-        EntityIdList& createdEntities,
-        AzFramework::SliceInstantiationTicket& sliceTicket)
+        EntityIdList& createdEntities)
     {
         if (products.empty())
         {
@@ -259,96 +250,80 @@ namespace AzAssetBrowserRequestHandlerPrivate
 
         for (const AzToolsFramework::AssetBrowser::ProductAssetBrowserEntry* product : products)
         {
-            // Handle instantiation of slices.
-            if (product->GetAssetType() == AZ::AzTypeInfo<AZ::SliceAsset>::Uuid())
+            AZ::Uuid componentTypeId = AZ::Uuid::CreateNull();
+            AZ::AssetTypeInfoBus::EventResult(componentTypeId, product->GetAssetType(), &AZ::AssetTypeInfo::GetComponentTypeId);
+            if (!componentTypeId.IsNull())
             {
-                // Instantiate the slice at the specified location.
-                AZ::Data::Asset<AZ::SliceAsset> asset = AZ::Data::AssetManager::Instance().FindOrCreateAsset<AZ::SliceAsset>(
-                    product->GetAssetId(), AZ::Data::AssetLoadBehavior::Default);
-                if (asset)
+                AZ::IO::Path entryPath(product->GetName());
+                AZStd::string entityName = entryPath.Stem().Native();
+                if (entityName.empty())
                 {
-                    SliceEditorEntityOwnershipServiceRequestBus::BroadcastResult(
-                        sliceTicket, &SliceEditorEntityOwnershipServiceRequests::InstantiateEditorSlice, asset, worldTransform);
-                }
-            }
-            else
-            {
-                // non-slices, regular entities:
-
-                AZ::Uuid componentTypeId = AZ::Uuid::CreateNull();
-                AZ::AssetTypeInfoBus::EventResult(componentTypeId, product->GetAssetType(), &AZ::AssetTypeInfo::GetComponentTypeId);
-                if (!componentTypeId.IsNull())
-                {
-                    AZ::IO::Path entryPath(product->GetName());
-                    AZStd::string entityName = entryPath.Stem().Native();
+                    // if we can't use the file name, use the type of asset like "Model".
+                    AZ::AssetTypeInfoBus::EventResult(entityName, product->GetAssetType(), &AZ::AssetTypeInfo::GetAssetTypeDisplayName);
                     if (entityName.empty())
                     {
-                        // if we can't use the file name, use the type of asset like "Model".
-                        AZ::AssetTypeInfoBus::EventResult(entityName, product->GetAssetType(), &AZ::AssetTypeInfo::GetAssetTypeDisplayName);
-                        if (entityName.empty())
-                        {
-                            entityName = "Entity";
-                        }
+                        entityName = "Entity";
                     }
-
-                    AZ::EntityId targetEntityId;
-                    EditorRequests::Bus::BroadcastResult(
-                        targetEntityId, &EditorRequests::CreateNewEntityAtPosition, worldTransform.GetTranslation(), parentEntityId);
-
-                    AZ::Entity* newEntity = nullptr;
-                    AZ::ComponentApplicationBus::BroadcastResult(newEntity, &AZ::ComponentApplicationRequests::FindEntity, targetEntityId);
-
-                    if (newEntity == nullptr)
-                    {
-                        QMessageBox::warning(
-                            mainWindow,
-                            QObject::tr("Asset Drop Failed"),
-                            QStringLiteral("Could not create entity from selected asset(s)."));
-                        return;
-                    }
-
-                    // Deactivate the entity so the properties on the components can be set.
-                    newEntity->Deactivate();
-
-                    newEntity->SetName(entityName);
-
-                    AZ::ComponentTypeList componentsToAdd;
-                    componentsToAdd.push_back(componentTypeId);
-
-                     // Add the product as components to this entity.
-                    AZStd::vector<AZ::EntityId> entityIds = { targetEntityId };
-                    EntityCompositionRequests::AddComponentsOutcome addComponentsOutcome = AZ::Failure(AZStd::string());
-                    EntityCompositionRequestBus::BroadcastResult(
-                        addComponentsOutcome, &EntityCompositionRequests::AddComponentsToEntities, entityIds, componentsToAdd);
-                    
-                    if (!addComponentsOutcome.IsSuccess())
-                    {
-                        AZ_Error(
-                            "AssetBrowser",
-                            false,
-                            "Could not create the requested components from the selected assets: %s",
-                            addComponentsOutcome.GetError().c_str());
-                        EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequests::DestroyEditorEntity, targetEntityId);
-                        return;
-                    }
-                    // activate the entity first, so that the primary asset change is done in the context of it being awake.
-                    newEntity->Activate();
-
-                    AZ::Component* componentAdded = newEntity->FindComponent(componentTypeId);
-                    if (componentAdded)
-                    {
-                        Components::EditorComponentBase* editorComponent = GetEditorComponent(componentAdded);
-                        if (editorComponent)
-                        {
-                            editorComponent->SetPrimaryAsset(product->GetAssetId());
-                        }
-                    }
-
-                    ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::AddDirtyEntity, newEntity->GetId());
-                    createdEntities.push_back(newEntity->GetId());
                 }
+
+                AZ::EntityId targetEntityId;
+                EditorRequests::Bus::BroadcastResult(
+                    targetEntityId, &EditorRequests::CreateNewEntityAtPosition, worldTransform.GetTranslation(), parentEntityId);
+
+                AZ::Entity* newEntity = nullptr;
+                AZ::ComponentApplicationBus::BroadcastResult(newEntity, &AZ::ComponentApplicationRequests::FindEntity, targetEntityId);
+
+                if (newEntity == nullptr)
+                {
+                    QMessageBox::warning(
+                        mainWindow,
+                        QObject::tr("Asset Drop Failed"),
+                        QStringLiteral("Could not create entity from selected asset(s)."));
+                    return;
+                }
+
+                // Deactivate the entity so the properties on the components can be set.
+                newEntity->Deactivate();
+
+                newEntity->SetName(entityName);
+
+                AZ::ComponentTypeList componentsToAdd;
+                componentsToAdd.push_back(componentTypeId);
+
+                    // Add the product as components to this entity.
+                AZStd::vector<AZ::EntityId> entityIds = { targetEntityId };
+                EntityCompositionRequests::AddComponentsOutcome addComponentsOutcome = AZ::Failure(AZStd::string());
+                EntityCompositionRequestBus::BroadcastResult(
+                    addComponentsOutcome, &EntityCompositionRequests::AddComponentsToEntities, entityIds, componentsToAdd);
+                    
+                if (!addComponentsOutcome.IsSuccess())
+                {
+                    AZ_Error(
+                        "AssetBrowser",
+                        false,
+                        "Could not create the requested components from the selected assets: %s",
+                        addComponentsOutcome.GetError().c_str());
+                    EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequests::DestroyEditorEntity, targetEntityId);
+                    return;
+                }
+                // activate the entity first, so that the primary asset change is done in the context of it being awake.
+                newEntity->Activate();
+
+                AZ::Component* componentAdded = newEntity->FindComponent(componentTypeId);
+                if (componentAdded)
+                {
+                    Components::EditorComponentBase* editorComponent = GetEditorComponent(componentAdded);
+                    if (editorComponent)
+                    {
+                        editorComponent->SetPrimaryAsset(product->GetAssetId());
+                    }
+                }
+
+                ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::AddDirtyEntity, newEntity->GetId());
+                createdEntities.push_back(newEntity->GetId());
             }
         }
+
         // Select the new entity (and deselect others).
         if (!createdEntities.empty())
         {
@@ -699,29 +674,6 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
 
             AZStd::vector<const ProductAssetBrowserEntry*> products;
             entry->GetChildrenRecursively<ProductAssetBrowserEntry>(products);
-
-            // slice source files need to react by adding additional menu items, regardless of status of compile or presence of products.
-            if (AzFramework::StringFunc::Equal(extension.c_str(), AzToolsFramework::SliceUtilities::GetSliceFileExtension().c_str(), false))
-            {
-                AzToolsFramework::SliceUtilities::CreateSliceAssetContextMenu(menu, fullFilePath);
-
-                // SliceUtilities is in AZToolsFramework and can't open viewports, so add the relationship view open command here.
-                if (!products.empty())
-                {
-                    const ProductAssetBrowserEntry* productEntry = products[0];
-                    menu->addAction(
-                        "Open in Slice Relationship View",
-                        [productEntry]()
-                        {
-                            QtViewPaneManager::instance()->OpenPane(LyViewPane::SliceRelationships);
-
-                            const ProductAssetBrowserEntry* product = azrtti_cast<const ProductAssetBrowserEntry*>(productEntry);
-
-                            AzToolsFramework::SliceRelationshipRequestBus::Broadcast(
-                                &AzToolsFramework::SliceRelationshipRequests::OnSliceRelationshipViewRequested, product->GetAssetId());
-                        });
-                }
-            }
 
             if (!products.empty() || (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source))
             {
@@ -1082,8 +1034,7 @@ void AzAssetBrowserRequestHandler::DoDropItemView(bool& accepted, AzQtComponents
             }
 
             EntityIdList createdEntities;
-            AzFramework::SliceInstantiationTicket sliceTicket;
-            CreateEntitiesAtPoint(products, createLocation, outlinerContext->m_parentEntity, createdEntities, sliceTicket);
+            CreateEntitiesAtPoint(products, createLocation, outlinerContext->m_parentEntity, createdEntities);
         }
     }
 }
@@ -1114,9 +1065,7 @@ void AzAssetBrowserRequestHandler::Drop(QDropEvent* event, AzQtComponents::DragA
     event->setAccepted(true);
 
     EntityIdList createdEntities;
-    AzFramework::SliceInstantiationTicket sliceTicket;
-
-    CreateEntitiesAtPoint(products, viewportDragContext->m_hitLocation, AZ::EntityId(), createdEntities, sliceTicket);
+    CreateEntitiesAtPoint(products, viewportDragContext->m_hitLocation, AZ::EntityId(), createdEntities);
 }
 
 void AzAssetBrowserRequestHandler::AddSourceFileOpeners(

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -67,7 +67,6 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/UI/UICore/ProgressShield.hxx>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
-#include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
@@ -728,17 +727,15 @@ CCrySingleDocTemplate::Confidence CCrySingleDocTemplate::MatchDocType(const char
     }
 
     // see if it matches our default suffix
-
     const QString strFilterExt = EditorUtils::LevelFile::GetDefaultFileExtension();
     const QString strOldFilterExt = EditorUtils::LevelFile::GetOldCryFileExtension();
-    const QString strSliceFilterExt = AzToolsFramework::SliceUtilities::GetSliceFileExtension().c_str();
 
     // see if extension matches
     assert(strFilterExt[0] == '.');
     QString strDot = "." + Path::GetExt(lpszPathName);
     if (!strDot.isEmpty())
     {
-        if(strDot == strFilterExt || strDot == strOldFilterExt || strDot == strSliceFilterExt)
+        if(strDot == strFilterExt || strDot == strOldFilterExt)
         {
             return yesAttemptNative; // extension matches, looks like ours
         }
@@ -1122,10 +1119,6 @@ void CCryEditApp::InitLevel(const CEditCommandLineInfo& cmdInfo)
                         }
                     }
                     ;
-                }
-                else if (levelName == "new slice")
-                {
-                    QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Not implemented", "New Slice is not yet implemented.");
                 }
                 else
                 {
@@ -1912,10 +1905,6 @@ void CCryEditApp::OnAppShowWelcomeScreen()
                 levelName.clear();
             }
         }
-        else if (levelName == "new slice")
-        {
-            QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Not implemented", "New Slice is not yet implemented.");
-        }
         else
         {
             // The user has selected an existing level to open
@@ -2425,139 +2414,6 @@ void CCryEditApp::OnFileEditLogFile()
     QDesktopServices::openUrl(QUrl::fromLocalFile(fullPathName));
 }
 
-#ifdef ENABLE_SLICE_EDITOR
-void CCryEditApp::OnFileResaveSlices()
-{
-    AZStd::vector<AZ::Data::AssetInfo> sliceAssetInfos;
-    sliceAssetInfos.reserve(5000);
-    AZ::Data::AssetCatalogRequests::AssetEnumerationCB sliceCountCb = [&sliceAssetInfos]([[maybe_unused]] const AZ::Data::AssetId id, const AZ::Data::AssetInfo& info)
-    {
-        // Only add slices and nothing that has been temporarily added to the catalog with a macro in it (ie @engroot@)
-        if (info.m_assetType == azrtti_typeid<AZ::SliceAsset>() && info.m_relativePath[0] != '@')
-        {
-            sliceAssetInfos.push_back(info);
-        }
-    };
-    AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, sliceCountCb, nullptr);
-
-    QString warningMessage = QString("Resaving all slices can be *extremely* slow depending on source control and on the number of slices in your project!\n\nYou can speed this up dramatically by checking out all your slices before starting this!\n\n Your project has %1 slices.\n\nDo you want to continue?").arg(sliceAssetInfos.size());
-
-    if (QMessageBox::Cancel == QMessageBox::warning(MainWindow::instance(), tr("!!!WARNING!!!"), warningMessage, QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel))
-    {
-        return;
-    }
-
-    AZ::SerializeContext* serialize = nullptr;
-    AZ::ComponentApplicationBus::BroadcastResult(serialize, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-
-    if (!serialize)
-    {
-        AZ_TracePrintf("Resave Slices", "Couldn't get the serialize context.  Something is very wrong.  Aborting!!!");
-        return;
-    }
-
-    AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance();
-    if (!fileIO)
-    {
-        AZ_Error("Resave Slices", false, "File IO is not initialized.");
-        return;
-    }
-
-    int numFailures = 0;
-
-    // Create a lambda for load & save logic to make the lambda below easier to read
-    auto LoadAndSaveSlice = [serialize, &numFailures](const AZStd::string& filePath)
-    {
-        AZ::Entity* newRootEntity = nullptr;
-
-        // Read in the slice file first
-        {
-            AZ::IO::FileIOStream readStream(filePath.c_str(), AZ::IO::OpenMode::ModeRead);
-            newRootEntity = AZ::Utils::LoadObjectFromStream<AZ::Entity>(readStream, serialize, AZ::ObjectStream::FilterDescriptor(AZ::Data::AssetFilterNoAssetLoading));
-        }
-
-        // If we successfully loaded the file
-        if (newRootEntity)
-        {
-            if (!AZ::Utils::SaveObjectToFile(filePath, AZ::DataStream::ST_XML, newRootEntity))
-            {
-                AZ_TracePrintf("Resave Slices", "Unable to serialize the slice (%s) out to a file.  Unable to resave this slice\n", filePath.c_str());
-                numFailures++;
-            }
-        }
-        else
-        {
-            AZ_TracePrintf("Resave Slices", "Unable to read a slice (%s) file from disk.  Unable to resave this slice.\n", filePath.c_str());
-            numFailures++;
-        }
-    };
-
-    const size_t numSlices = sliceAssetInfos.size();
-    int slicesProcessed = 0;
-    int slicesRequestedForProcessing = 0;
-
-    if (numSlices > 0)
-    {
-        AzToolsFramework::ProgressShield::LegacyShowAndWait(MainWindow::instance(), tr("Checking out and resaving slices..."),
-            [numSlices, &slicesProcessed, &sliceAssetInfos, &LoadAndSaveSlice, &slicesRequestedForProcessing, &numFailures](int& current, int& max)
-            {
-                const static int numToProcessPerCall = 5;
-
-                if (slicesRequestedForProcessing < numSlices)
-                {
-                    for (int index = 0; index < numToProcessPerCall; index++)
-                    {
-                        if (slicesRequestedForProcessing < numSlices)
-                        {
-                            AZStd::string sourceFile;
-                            AzToolsFramework::AssetSystemRequestBus::Broadcast(&AzToolsFramework::AssetSystemRequestBus::Events::GetFullSourcePathFromRelativeProductPath, sliceAssetInfos[slicesRequestedForProcessing].m_relativePath, sourceFile);
-
-                            AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequestBus::Events::RequestEditForFile, sourceFile.c_str(), [&slicesProcessed, sourceFile, &LoadAndSaveSlice, &numFailures](bool success)
-                                {
-                                    slicesProcessed++;
-
-                                    if (success)
-                                    {
-                                        LoadAndSaveSlice(sourceFile);
-                                    }
-                                    else
-                                    {
-                                        AZ_TracePrintf("Resave Slices", "Unable to check a slice (%s) out of source control.  Unable to resave this slice\n", sourceFile.c_str());
-                                        numFailures++;
-                                    }
-                                }
-                            );
-                            slicesRequestedForProcessing++;
-                        }
-                    }
-                }
-
-                current = slicesProcessed;
-                max = static_cast<int>(numSlices);
-                return slicesProcessed == numSlices;
-            }
-        );
-
-        QString completeMessage;
-        if (numFailures > 0)
-        {
-            completeMessage = QString("All slices processed.  There were %1 slices that could not be resaved.  Please check the console for details.").arg(numFailures);
-        }
-        else
-        {
-            completeMessage = QString("All slices successfully process and re-saved!");
-        }
-
-        QMessageBox::information(MainWindow::instance(), tr("Re-saving complete"), completeMessage, QMessageBox::Ok);
-    }
-    else
-    {
-        QMessageBox::information(MainWindow::instance(), tr("No slices found"), tr("There were no slices found to resave."), QMessageBox::Ok);
-    }
-
-}
-#endif
-
 //////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnFileEditEditorini()
 {
@@ -2990,12 +2846,6 @@ bool CCryEditApp::CreateLevel(bool& wasCreateLevelOperationCancelled)
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnCreateSlice()
-{
-    QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Not implemented", "New Slice is not yet implemented.");
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnOpenLevel()
 {
     CLevelFileDialog levelFileDialog(true);
@@ -3005,20 +2855,6 @@ void CCryEditApp::OnOpenLevel()
     if (levelFileDialog.exec() == QDialog::Accepted)
     {
         OpenDocumentFile(levelFileDialog.GetFileName().toUtf8().data(), true, COpenSameLevelOptions::ReopenLevelIfSame);
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnOpenSlice()
-{
-    QString fileName = QFileDialog::getOpenFileName(MainWindow::instance(),
-        tr("Open Slice"),
-        Path::GetEditingGameDataFolder().c_str(),
-        tr("Slice (*.slice)"));
-
-    if (!fileName.isEmpty())
-    {
-        OpenDocumentFile(fileName.toUtf8().data());
     }
 }
 

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -175,8 +175,6 @@ public:
     // Implementation
     void OnCreateLevel();
     void OnOpenLevel();
-    void OnCreateSlice();
-    void OnOpenSlice();
     void OnAppAbout();
     void OnAppShowWelcomeScreen();
     void OnUpdateShowWelcomeScreen(QAction* action);
@@ -202,7 +200,6 @@ public:
     void OnOpenAssetImporter();
     void OnEditLevelData();
     void OnFileEditLogFile();
-    void OnFileResaveSlices();
     void OnFileEditEditorini();
     void OnPreferences();
     void OnOpenProjectManagerSettings();

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -29,7 +29,6 @@
 
 // AzToolsFramework
 #include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
-#include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/API/EditorLevelNotificationBus.h>
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1565,49 +1565,6 @@ void EditorViewportWidget::CenterOnAABB(const AABB& aabb)
     SetViewTM(newTM);
 }
 
-void EditorViewportWidget::CenterOnSliceInstance()
-{
-    AzToolsFramework::EntityIdList selectedEntityList;
-    AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
-        selectedEntityList, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
-
-    AZ::SliceComponent::SliceInstanceAddress sliceAddress;
-    AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
-        sliceAddress, &AzToolsFramework::ToolsApplicationRequestBus::Events::FindCommonSliceInstanceAddress, selectedEntityList);
-
-    if (!sliceAddress.IsValid())
-    {
-        return;
-    }
-
-    AZ::EntityId sliceRootEntityId;
-    AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
-        sliceRootEntityId, &AzToolsFramework::ToolsApplicationRequestBus::Events::GetRootEntityIdOfSliceInstance, sliceAddress);
-
-    if (!sliceRootEntityId.IsValid())
-    {
-        return;
-    }
-
-    AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
-        &AzToolsFramework::ToolsApplicationRequestBus::Events::SetSelectedEntities, AzToolsFramework::EntityIdList{ sliceRootEntityId });
-
-    const AZ::SliceComponent::InstantiatedContainer* instantiatedContainer = sliceAddress.GetInstance()->GetInstantiated();
-
-    AABB aabb(Vec3(std::numeric_limits<float>::max()), Vec3(-std::numeric_limits<float>::max()));
-    for (AZ::Entity* entity : instantiatedContainer->m_entities)
-    {
-        CEntityObject* entityObject = nullptr;
-        AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
-            entityObject, entity->GetId(), &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
-        AABB box;
-        entityObject->GetBoundBox(box);
-        aabb.Add(box.min);
-        aabb.Add(box.max);
-    }
-    CenterOnAABB(aabb);
-}
-
 //////////////////////////////////////////////////////////////////////////
 void EditorViewportWidget::SetFOV(const float fov)
 {

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -195,7 +195,6 @@ private:
     bool HitTest(const QPoint& point, HitContext& hitInfo) override;
     bool IsBoundsVisible(const AABB& box) const override;
     void CenterOnAABB(const AABB& aabb) override;
-    void CenterOnSliceInstance() override;
     void OnTitleMenu(QMenu* menu) override;
     void SetViewTM(const Matrix34& tm) override;
     const Matrix34& GetViewTM() const override;

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -1162,19 +1162,6 @@ void MainWindow::OnGotoSelected()
     AzToolsFramework::EditorRequestBus::Broadcast(&AzToolsFramework::EditorRequestBus::Events::GoToSelectedEntitiesInViewports);
 }
 
-void MainWindow::OnGotoSliceRoot()
-{
-    int numViews = GetIEditor()->GetViewManager()->GetViewCount();
-    for (int i = 0; i < numViews; ++i)
-    {
-        CViewport* viewport = GetIEditor()->GetViewManager()->GetView(i);
-        if (viewport)
-        {
-            viewport->CenterOnSliceInstance();
-        }
-    }
-}
-
 // don't want to eat escape as if it were a shortcut, as it would eat it for other windows that also care about escape
 // and are reading it as an event rather.
 void MainWindow::keyPressEvent(QKeyEvent* e)

--- a/Code/Editor/MainWindow.h
+++ b/Code/Editor/MainWindow.h
@@ -152,7 +152,6 @@ public:
 
     bool event(QEvent* event) override;
 
-    void OnGotoSliceRoot();
 Q_SIGNALS:
     void ToggleRefCoordSys();
     void UpdateRefCoordSys();

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
@@ -23,7 +23,6 @@
 
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
-#include <AzToolsFramework/UI/Slice/SliceRelationshipWidget.hxx>
 
 #include "SandboxIntegration.h"
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -20,7 +20,6 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <AzCore/Slice/SliceAsset.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>

--- a/Code/Editor/Resource.h
+++ b/Code/Editor/Resource.h
@@ -236,13 +236,7 @@
 #define ID_FILE_SAVE_LEVEL                         34197
 #define ID_TV_SYNC_TO_BASE                         34199
 #define ID_TV_SYNC_FROM_BASE                       34200
-#ifdef ENABLE_SLICE_EDITOR
-#define ID_FILE_NEW_SLICE                          34201
-#define ID_FILE_OPEN_SLICE                         34202
-#endif
-#define ID_FILE_SAVE_SELECTED_SLICE                34203
 #define ID_FILE_SAVESETTINGS                       34204
-#define ID_FILE_SAVE_SLICE_TO_ROOT                 34205
 #define ID_SET_TIME_TO_KEY                         34206
 #define ID_TOGGLE_SCRUB_UNITS                      34207
 #define ID_TOGGLE_PREVIEW_UNITS                    34208
@@ -285,7 +279,6 @@
 #define ID_DOCUMENTATION_FEEDBACK                    36043
 #define ID_OPEN_SUBSTANCE_EDITOR                     36060
 #define ID_IMPORT_ASSET                              36069
-#define ID_FILE_RESAVESLICES                        36210
 #define FIRST_QT_ACTION                      50000
 #define ID_VIEW_CONSOLEWINDOW                50001
 #define ID_TOOLBAR_SEPARATOR                 50002

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -2213,7 +2213,6 @@ void CTrackViewDialog::OnEntityDestruction(const AZ::EntityId& entityId)
     if (m_currentSequenceEntityId == entityId)
     {
         // The currently selected sequence is about to be deleted, make sure to clear the selection right now.
-        // Clearing it here will make sure it is clear in slice work flow edge cases.
         GetIEditor()->GetAnimation()->SetSequence(nullptr, false, false);
 
         // Refresh the records in m_wndNodesCtrl, the sequence will not be selected in Track View

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -2264,10 +2264,9 @@ void CTrackViewNodesCtrl::ShowNextResult()
 void CTrackViewNodesCtrl::Update()
 {
     // Update the Track UI elements with the latest names of the Tracks.
-    // In some cases (save slice overrides) the Track names (param names)
-    // may not be available at the time of the Sequence activation because
-    // they come from the animated entities (which may not be active). So
-    // just update them once a frame to make sure they are the latest.
+    // In some cases the Track names (param names) may not be available at the time
+    // of the Sequence activation because they come from the animated entities (which may not be active).
+    // So just update them once a frame to make sure they are the latest.
     for (auto iter = m_nodeToRecordMap.begin(); iter != m_nodeToRecordMap.end(); ++iter)
     {
         const CTrackViewNode* node = iter->first;

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -207,8 +207,6 @@ public:
     virtual void CenterOnSelection() = 0;
     virtual void CenterOnAABB(const AABB& aabb) = 0;
 
-    virtual void CenterOnSliceInstance() = 0;
-
     /** Set ID of this viewport
     */
     virtual void SetViewportId(int id) { m_nCurViewportID = id; };
@@ -416,8 +414,6 @@ public:
     //! Center viewport on selection.
     void CenterOnSelection() override {}
     void CenterOnAABB([[maybe_unused]] const AABB& aabb) override {}
-
-    void CenterOnSliceInstance() override {}
 
     //! Performs hit testing of 2d point in view to find which object hit.
     bool HitTest(const QPoint& point, HitContext& hitInfo) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -23,7 +23,6 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
-#include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/UserSettings/UserSettings.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/sort.h>
@@ -43,7 +42,6 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/Entity/EditorEntityRuntimeActivationBus.h>
-#include <AzToolsFramework/Entity/SliceEditorEntityOwnershipServiceBus.h>
 #include <AzToolsFramework/FocusMode/FocusModeInterface.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
@@ -59,9 +57,6 @@ AZ_POP_DISABLE_WARNING
 #include <AzToolsFramework/Prefab/PrefabEditorPreferences.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
-#include <AzToolsFramework/Slice/SliceDataFlagsCommand.h>
-#include <AzToolsFramework/Slice/SliceMetadataEntityContextBus.h>
-#include <AzToolsFramework/Slice/SliceUtilities.h>
 #include <AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.h>
 #include <AzToolsFramework/ToolsComponents/ComponentMimeData.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
@@ -505,8 +500,7 @@ namespace AzToolsFramework
         int m_dropIndicatorRowWidgetOffset;
     };
 
-    EntityPropertyEditor::SharedComponentInfo::SharedComponentInfo(AZ::Component* component, AZ::Component* sliceReferenceComponent)
-        : m_sliceReferenceComponent(sliceReferenceComponent)
+    EntityPropertyEditor::SharedComponentInfo::SharedComponentInfo(AZ::Component* component)
     {
         m_instances.push_back(component);
     }
@@ -1228,10 +1222,6 @@ namespace AzToolsFramework
         setUpdatesEnabled(false);
 
         m_isBuildingProperties = true;
-        m_sliceCompareToEntity.reset();
-
-        // Wait to clear this until after the reset(), just in case any components try to call RefreshTree when we clear
-        // the m_sliceCompareToEntity entity.
         m_isAlreadyQueuedRefresh = false;
 
         HideComponentPalette();
@@ -1621,43 +1611,6 @@ namespace AzToolsFramework
         return nullptr;
     }
 
-    bool EntityPropertyEditor::SelectedEntitiesAreFromSameSourceSliceEntity() const
-    {
-        AZ::EntityId commonAncestorId;
-
-        for (AZ::EntityId id : m_selectedEntityIds)
-        {
-            AZ::SliceComponent::SliceInstanceAddress sliceInstanceAddress;
-            AzFramework::SliceEntityRequestBus::EventResult(sliceInstanceAddress, id,
-                &AzFramework::SliceEntityRequests::GetOwningSlice);
-            auto sliceReference = sliceInstanceAddress.GetReference();
-            if (!sliceReference)
-            {
-                return false;
-            }
-            else
-            {
-                AZ::SliceComponent::EntityAncestorList ancestors;
-                sliceReference->GetInstanceEntityAncestry(id, ancestors, 1);
-                if (ancestors.empty() || !ancestors[0].m_entity)
-                {
-                    return false;
-                }
-
-                if (!commonAncestorId.IsValid())
-                {
-                    commonAncestorId = ancestors[0].m_entity->GetId();
-                }
-                else if (ancestors[0].m_entity->GetId() != commonAncestorId)
-                {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
     void EntityPropertyEditor::BuildSharedComponentArray(SharedComponentArray& sharedComponentArray, bool containsLayerEntity)
     {
         AZ_Assert(!m_selectedEntityIds.empty(), "BuildSharedComponentArray should only be called if there are entities being displayed");
@@ -1671,31 +1624,7 @@ namespace AzToolsFramework
             return;
         }
 
-        // For single selection of a slice-instanced entity, gather the direct slice ancestor
-        // so we can visualize per-component differences.
-        m_sliceCompareToEntity.reset();
-        if (SelectedEntitiesAreFromSameSourceSliceEntity())
-        {
-            AZ::SliceComponent::SliceInstanceAddress sliceInstanceAddress;
-
-            AzFramework::SliceEntityRequestBus::EventResult(sliceInstanceAddress, entityId,
-                &AzFramework::SliceEntityRequests::GetOwningSlice);
-            auto sliceReference = sliceInstanceAddress.GetReference();
-            auto sliceInstance = sliceInstanceAddress.GetInstance();
-            if (sliceReference)
-            {
-                AZ::SliceComponent::EntityAncestorList ancestors;
-                sliceReference->GetInstanceEntityAncestry(entityId, ancestors, 1);
-
-                if (!ancestors.empty())
-                {
-                    m_sliceCompareToEntity = SliceUtilities::CloneSliceEntityForComparison(*ancestors[0].m_entity, *sliceInstance, *m_serializeContext);
-                }
-            }
-        }
-
         // Gather initial list of eligible display components from the first entity
-
         AZ::Entity::ComponentArrayType entityComponents;
         GetAllComponentsForEntityInOrder(entity, entityComponents);
 
@@ -1719,10 +1648,7 @@ namespace AzToolsFramework
                 }
             }
 
-            // Grab the slice reference component, if we have a slice compare entity
-            auto sliceReferenceComponent = m_sliceCompareToEntity ? m_sliceCompareToEntity->FindComponent(component->GetId()) : nullptr;
-
-            sharedComponentArray.push_back(SharedComponentInfo(component, sliceReferenceComponent));
+            sharedComponentArray.push_back(SharedComponentInfo(component));
         }
 
         // Now loop over the other entities
@@ -1797,9 +1723,7 @@ namespace AzToolsFramework
                 // non-first instances are aggregated under the first instance
                 AZ::Component* aggregateInstance = componentInstance != componentInstances.front() ? componentInstances.front() : nullptr;
 
-                // Reference the slice entity if we are a slice so we can indicate differences from base
-                AZ::Component* referenceComponentInstance = sharedComponentInfo.m_sliceReferenceComponent;
-                componentEditor->AddInstance(componentInstance, aggregateInstance, referenceComponentInstance);
+                componentEditor->AddInstance(componentInstance, aggregateInstance, nullptr);
             }
 
             // Set up other entity property editor customization
@@ -1921,7 +1845,6 @@ namespace AzToolsFramework
             connect(componentEditor, &ComponentEditor::OnRequestRequiredComponents, this, &EntityPropertyEditor::OnRequestRequiredComponents);
             connect(componentEditor, &ComponentEditor::OnRequestRemoveComponents, this, [this](AZStd::span<AZ::Component* const> components) {DeleteComponents(components); });
             connect(componentEditor, &ComponentEditor::OnRequestDisableComponents, this, [this](AZStd::span<AZ::Component* const> components) {DisableComponents(components); });
-            componentEditor->GetPropertyEditor()->SetValueComparisonFunction([this](const InstanceDataNode* source, const InstanceDataNode* target) { return InstanceNodeValueHasNoPushableChange(source, target); });
             componentEditor->GetPropertyEditor()->SetReadOnlyQueryFunction([this](const InstanceDataNode* node) { return QueryInstanceDataNodeReadOnlyStatus(node); });
             componentEditor->GetPropertyEditor()->SetHiddenQueryFunction([this](const InstanceDataNode* node) { return QueryInstanceDataNodeHiddenStatus(node); });
             componentEditor->GetPropertyEditor()->SetIndicatorQueryFunction([this](const InstanceDataNode* node) { return GetAppropriateIndicator(node); });
@@ -2382,8 +2305,6 @@ namespace AzToolsFramework
 
                 AddMenuOptionsForFields(node, componentNode, componentClassData, menu);
 
-                AddMenuOptionsForRevert(node, componentNode, componentClassData, menu);
-
                 AzToolsFramework::Components::EditorComponentBase* editorComponent = static_cast<AzToolsFramework::Components::EditorComponentBase*>(component);
 
                 if (editorComponent)
@@ -2427,157 +2348,10 @@ namespace AzToolsFramework
             fieldNode = fieldNode->GetParent();
             AZ_Assert(fieldNode && fieldNode->GetClassMetadata() && fieldNode->GetClassMetadata()->m_container, "New element should be a child of a container.");
         }
-
-        // Generate slice data push/pull options.
-        AZ::Component* componentInstance = m_serializeContext->Cast<AZ::Component*>(
-            componentNode->FirstInstance(), componentClassData->m_typeId);
+        
+        AZ::Component* componentInstance =
+            m_serializeContext->Cast<AZ::Component*>(componentNode->FirstInstance(), componentClassData->m_typeId);
         AZ_Assert(componentInstance, "Failed to cast component instance.");
-
-        // With the entity the property ultimately belongs to, we can look up slice ancestry for push/pull options.
-        AZ::Entity* entity = componentInstance->GetEntity();
-
-        AzFramework::EntityContextId contextId = AzFramework::EntityContextId::CreateNull();
-        AzFramework::EntityIdContextQueryBus::EventResult(contextId, entity->GetId(), &AzFramework::EntityIdContextQueryBus::Events::GetOwningContextId);
-        if (contextId.IsNull())
-        {
-            AZ_Error("PropertyEditor", false, "Entity \"%s\" does not belong to any context.", entity->GetName().c_str());
-            return;
-        }
-
-        // If prefabs are enabled, there will be no root slice so bail out here since we don't need
-        // to show any slice options in the menu
-        AZ::SliceComponent* rootSlice = nullptr;
-        AzFramework::SliceEntityOwnershipServiceRequestBus::EventResult(rootSlice, contextId,
-            &AzFramework::SliceEntityOwnershipServiceRequestBus::Events::GetRootSlice);
-        if (rootSlice)
-        {
-            AZ::SliceComponent::SliceInstanceAddress address;
-            AzFramework::SliceEntityRequestBus::EventResult(address, entity->GetId(), &AzFramework::SliceEntityRequests::GetOwningSlice);
-            AZ::SliceComponent::SliceReference* sliceReference = address.GetReference();
-            if (sliceReference)
-            {
-                // This entity is instanced from a slice, so show data push/pull options
-                AZ::SliceComponent::EntityAncestorList ancestors;
-                sliceReference->GetInstanceEntityAncestry(entity->GetId(), ancestors);
-
-                AZ_Error(
-                    "PropertyEditor", !ancestors.empty(), "Entity \"%s\" belongs to a slice, but its source entity could not be located.",
-                    entity->GetName().c_str());
-                if (!ancestors.empty())
-                {
-                    menu.addSeparator();
-
-                    // Populate slice push options.
-                    // Address should start with the fully-addressable component Id to resolve within the target entity.
-                    InstanceDataHierarchy::Address pushFieldAddress;
-                    CalculateAndAdjustNodeAddress(*fieldNode, AddressRootType::RootAtEntity, pushFieldAddress);
-                    if (!pushFieldAddress.empty())
-                    {
-                        SliceUtilities::PopulateQuickPushMenu(
-                            menu, entity->GetId(), pushFieldAddress,
-                            SliceUtilities::QuickPushMenuOptions(
-                                "Save field override",
-                                SliceUtilities::QuickPushMenuOverrideDisplayCount::ShowOverrideCountOnlyWhenMultiple));
-                    }
-                }
-            }
-
-            menu.addSeparator();
-
-            // by leaf node, we mean a visual leaf node in the property editor (ie, we do not have any visible children)
-            bool isLeafNode = !fieldNode->GetClassMetadata() || !fieldNode->GetClassMetadata()->m_container;
-
-            if (isLeafNode)
-            {
-                for (const InstanceDataNode& childNode : fieldNode->GetChildren())
-                {
-                    if (HasAnyVisibleElements(childNode))
-                    {
-                        // If we have any visible children, we must not be a leaf node
-                        isLeafNode = false;
-                        break;
-                    }
-                }
-            }
-
-#ifdef ENABLE_SLICE_EDITOR
-            // Show PreventOverride & HideProperty options
-            if (GetEntityDataPatchAddress(fieldNode, m_dataPatchAddressBuffer))
-            {
-                AZ::DataPatch::Flags nodeFlags = rootSlice->GetEntityDataFlagsAtAddress(entity->GetId(), m_dataPatchAddressBuffer);
-
-                if (nodeFlags & AZ::DataPatch::Flag::PreventOverrideSet)
-                {
-                    QAction* PreventOverrideAction = menu.addAction(tr("Allow property override"));
-                    PreventOverrideAction->setEnabled(isLeafNode);
-                    connect(
-                        PreventOverrideAction, &QAction::triggered, this,
-                        [this, fieldNode]
-                        {
-                            ContextMenuActionSetDataFlag(fieldNode, AZ::DataPatch::Flag::PreventOverrideSet, false);
-                            InvalidatePropertyDisplay(Refresh_AttributesAndValues);
-                        });
-                }
-                else
-                {
-                    QAction* PreventOverrideAction = menu.addAction(tr("Prevent property override"));
-                    PreventOverrideAction->setEnabled(isLeafNode);
-                    connect(
-                        PreventOverrideAction, &QAction::triggered, this,
-                        [this, fieldNode]
-                        {
-                            ContextMenuActionSetDataFlag(fieldNode, AZ::DataPatch::Flag::PreventOverrideSet, true);
-                            InvalidatePropertyDisplay(Refresh_AttributesAndValues);
-                        });
-                }
-
-                if (nodeFlags & AZ::DataPatch::Flag::HidePropertySet)
-                {
-                    QAction* HideProperyAction = menu.addAction(tr("Show property on instances"));
-                    HideProperyAction->setEnabled(isLeafNode);
-                    connect(
-                        HideProperyAction, &QAction::triggered, this,
-                        [this, fieldNode]
-                        {
-                            ContextMenuActionSetDataFlag(fieldNode, AZ::DataPatch::Flag::HidePropertySet, false);
-                            InvalidatePropertyDisplay(Refresh_AttributesAndValues);
-                        });
-                }
-                else
-                {
-                    QAction* HideProperyAction = menu.addAction(tr("Hide property on instances"));
-                    HideProperyAction->setEnabled(isLeafNode);
-                    connect(
-                        HideProperyAction, &QAction::triggered, this,
-                        [this, fieldNode]
-                        {
-                            ContextMenuActionSetDataFlag(fieldNode, AZ::DataPatch::Flag::HidePropertySet, true);
-                            InvalidatePropertyDisplay(Refresh_AttributesAndValues);
-                        });
-                }
-            }
-#endif
-
-            if (sliceReference)
-            {
-                // This entity is referenced from a slice, so show property override options
-                bool hasChanges = fieldNode->HasChangesVersusComparison(false);
-
-                if (!hasChanges && isLeafNode)
-                {
-                    // Add an option to set the ForceOverride flag for this field
-                    menu.setToolTipsVisible(true);
-                    QAction* forceOverrideAction = menu.addAction(tr("Force property override"));
-                    forceOverrideAction->setToolTip(tr("Prevents a property from inheriting from its source slice"));
-                    connect(
-                        forceOverrideAction, &QAction::triggered, this,
-                        [this, fieldNode]()
-                        {
-                            ContextMenuActionSetDataFlag(fieldNode, AZ::DataPatch::Flag::ForceOverrideSet, true);
-                        });
-                }
-            }
-        }
 
         m_reorderRowWidget = nullptr;
         // Add move up/down actions if appropriate
@@ -2643,301 +2417,6 @@ namespace AzToolsFramework
 
 
         return false;
-    }
-
-    void EntityPropertyEditor::AddMenuOptionsForRevert(InstanceDataNode* fieldNode, InstanceDataNode* componentNode, const AZ::SerializeContext::ClassData* componentClassData, QMenu& menu)
-    {
-        QMenu* revertMenu = nullptr;
-
-        auto addRevertMenu = [&menu]()
-            {
-                QMenu* revertOverridesMenu = menu.addMenu(tr("Revert overrides"));
-                revertOverridesMenu->setToolTipsVisible(true);
-                return revertOverridesMenu;
-            };
-
-        //check for changes on selected property
-        if (componentClassData)
-        {
-            AZ::SliceComponent::SliceInstanceAddress address;
-
-            AZ::Component* componentInstance = m_serializeContext->Cast<AZ::Component*>(
-                componentNode->FirstInstance(), componentClassData->m_typeId);
-            AZ_Assert(componentInstance, "Failed to cast component instance.");
-            AZ::Entity* entity = componentInstance->GetEntity();
-
-            AzFramework::SliceEntityRequestBus::EventResult(address, entity->GetId(),
-                &AzFramework::SliceEntityRequests::GetOwningSlice);
-            AZ::SliceComponent::SliceReference* sliceReference = address.GetReference();
-
-            if (!sliceReference)
-            {
-                return;
-            }
-
-            // Only add the "Revert overrides" menu option if it belongs to a slice
-            revertMenu = addRevertMenu();
-            revertMenu->setEnabled(false);
-
-            if (fieldNode)
-            {
-                bool hasChanges = fieldNode->HasChangesVersusComparison(false);
-
-                if (hasChanges)
-                {
-                    bool isLeafNode = !fieldNode->GetClassMetadata()->m_container;
-
-                    if (isLeafNode)
-                    {
-                        for (const InstanceDataNode& childNode : fieldNode->GetChildren())
-                        {
-                            if (HasAnyVisibleElements(childNode))
-                            {
-                                // If we have any visible children, we must not be a leaf node
-                                isLeafNode = false;
-                                break;
-                            }
-                        }
-
-                        if (isLeafNode)
-                        {
-                            revertMenu->setEnabled(true);
-
-                            // Add an option to pull data from the first level of the slice (clear the override).
-                            QAction* revertAction = revertMenu->addAction(tr("Property"));
-                            revertAction->setToolTip(tr("Revert the value for this property to the last saved state."));
-                            revertAction->setEnabled(true);
-                            connect(revertAction, &QAction::triggered, this, [this, componentInstance, fieldNode]()
-                                {
-                                    ContextMenuActionPullFieldData(componentInstance, fieldNode);
-                                }
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        //check for changes on selected component(s)
-        bool hasSliceChanges = false;
-        bool isPartOfSlice = false;
-
-        const auto& componentsToEdit = GetSelectedComponents();
-
-        for (auto component : componentsToEdit)
-        {
-            AZ_Assert(component, "Parent component is invalid.");
-            auto componentEditorIterator = m_componentToEditorMap.find(component);
-            AZ_Assert(componentEditorIterator != m_componentToEditorMap.end(), "Unable to find a component editor for the given component");
-            if (componentEditorIterator != m_componentToEditorMap.end())
-            {
-                auto componentEditor = componentEditorIterator->second;
-                componentEditor->GetPropertyEditor()->EnumerateInstances(
-                    [&hasSliceChanges, &isPartOfSlice](InstanceDataHierarchy& hierarchy)
-                    {
-                        InstanceDataNode* root = hierarchy.GetRootNode();
-                        if (root && root->GetComparisonNode())
-                        {
-                            isPartOfSlice = true;
-                            if (root->HasChangesVersusComparison(true))
-                            {
-                                hasSliceChanges = true;
-                            }
-                        }
-                    });
-            }
-        }
-
-        if (isPartOfSlice && hasSliceChanges)
-        {
-            if (!revertMenu)
-            {
-                revertMenu = addRevertMenu();
-            }
-            revertMenu->setEnabled(true);
-
-            QAction* revertComponentAction = revertMenu->addAction(tr("Component"));
-            revertComponentAction->setToolTip(tr("Revert all properties for this component to their last saved state."));
-            connect(revertComponentAction, &QAction::triggered, this, [this]()
-                {
-                    ResetToSlice();
-                });
-        }
-
-        //check for changes on selected entities
-        EntityIdList selectedEntityIds;
-        GetSelectedEntities(selectedEntityIds);
-
-        bool canRevert = false;
-
-        for (AZ::EntityId id : m_selectedEntityIds)
-        {
-            bool entityHasOverrides = false;
-            AzToolsFramework::EditorEntityInfoRequestBus::EventResult(entityHasOverrides, id, &AzToolsFramework::EditorEntityInfoRequestBus::Events::HasSliceEntityOverrides);
-            if (entityHasOverrides)
-            {
-                canRevert = true;
-                break;
-            }
-        }
-
-        if (canRevert && !selectedEntityIds.empty())
-        {
-            //check for changes in the slice
-            EntityIdSet relevantEntitiesSet;
-            ToolsApplicationRequestBus::BroadcastResult(relevantEntitiesSet, &ToolsApplicationRequestBus::Events::GatherEntitiesAndAllDescendents, selectedEntityIds);
-
-            EntityIdList relevantEntities;
-            relevantEntities.reserve(relevantEntitiesSet.size());
-            for (AZ::EntityId& id : relevantEntitiesSet)
-            {
-                relevantEntities.push_back(id);
-            }
-
-            if (!revertMenu)
-            {
-                revertMenu = addRevertMenu();
-            }
-            revertMenu->setEnabled(true);
-            QAction* revertAction = revertMenu->addAction(QObject::tr("Entity"));
-            revertAction->setToolTip(QObject::tr("This will revert all component properties on this entity to the last saved."));
-
-            QObject::connect(revertAction, &QAction::triggered, [relevantEntities]
-                {
-                    SliceEditorEntityOwnershipServiceRequestBus::Broadcast(
-                        &SliceEditorEntityOwnershipServiceRequests::ResetEntitiesToSliceDefaults, relevantEntities);
-                });
-        }
-    }
-
-
-    void EntityPropertyEditor::ContextMenuActionPullFieldData(AZ::Component* parentComponent, InstanceDataNode* fieldNode)
-    {
-        AZ_Assert(fieldNode && fieldNode->GetComparisonNode(), "Invalid node for slice data pull.");
-        if (!fieldNode->GetComparisonNode())
-        {
-            return;
-        }
-
-        BeforePropertyModified(fieldNode);
-
-        // Clear any slice data flags for this field
-        if (GetEntityDataPatchAddress(fieldNode, m_dataPatchAddressBuffer))
-        {
-            auto clearDataFlagsCommand = aznew ClearSliceDataFlagsBelowAddressCommand(parentComponent->GetEntityId(), m_dataPatchAddressBuffer, "Clear data flags");
-            clearDataFlagsCommand->SetParent(m_currentUndoOperation);
-        }
-
-        AZStd::unordered_set<InstanceDataNode*> targetContainerNodesWithNewElements;
-        InstanceDataHierarchy::CopyInstanceData(fieldNode->GetComparisonNode(), fieldNode, m_serializeContext,
-            // Target container child node being removed callback
-            nullptr,
-
-            // Source container child node being created callback
-            [&targetContainerNodesWithNewElements](const InstanceDataNode* sourceNode, InstanceDataNode* targetNodeParent)
-            {
-                (void)sourceNode;
-
-                targetContainerNodesWithNewElements.insert(targetNodeParent);
-            }
-        );
-
-        // Invoke Add notifiers
-        for (InstanceDataNode* targetContainerNode : targetContainerNodesWithNewElements)
-        {
-            AZ_Assert(targetContainerNode->GetClassMetadata()->m_container, "Target container node isn't a container!");
-            for (const AZ::Edit::AttributePair& attribute : targetContainerNode->GetElementEditMetadata()->m_attributes)
-            {
-                if (attribute.first == AZ::Edit::Attributes::AddNotify)
-                {
-                    AZ::Edit::AttributeFunction<void()>* func = azdynamic_cast<AZ::Edit::AttributeFunction<void()>*>(attribute.second);
-                    if (func)
-                    {
-                        InstanceDataNode* parentNode = targetContainerNode->GetParent();
-                        if (parentNode)
-                        {
-                            for (size_t idx = 0; idx < parentNode->GetNumInstances(); ++idx)
-                            {
-                                func->Invoke(parentNode->GetInstance(idx));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Make sure change notifiers are invoked for the change across any changed nodes in sub-hierarchy
-        // under the affected node.
-        AZ_Assert(parentComponent, "Parent component is invalid.");
-        auto componentEditorIterator = m_componentToEditorMap.find(parentComponent);
-        AZ_Assert(componentEditorIterator != m_componentToEditorMap.end(), "Unable to find a component editor for the given component");
-        if (componentEditorIterator != m_componentToEditorMap.end())
-        {
-            AZStd::vector<PropertyRowWidget*> widgetStack;
-            AZStd::vector<PropertyRowWidget*> widgetsToNotify;
-            widgetStack.reserve(64);
-            widgetsToNotify.reserve(64);
-
-            auto componentEditor = componentEditorIterator->second;
-            PropertyRowWidget* widget = componentEditor->GetPropertyEditor()->GetWidgetFromNode(fieldNode);
-            if (widget)
-            {
-                widgetStack.push_back(widget);
-
-                while (!widgetStack.empty())
-                {
-                    PropertyRowWidget* top = widgetStack.back();
-                    widgetStack.pop_back();
-
-                    InstanceDataNode* topWidgetNode = top->GetNode();
-                    if (topWidgetNode && topWidgetNode->HasChangesVersusComparison(false))
-                    {
-                        widgetsToNotify.push_back(top);
-                    }
-
-                    // Only add children widgets for notification if the newly updated parent has children
-                    // otherwise the instance data nodes will have disappeared out from under the widgets
-                    // They will be cleaned up when we refresh the entire tree after the notifications go out
-                    if (!topWidgetNode || topWidgetNode->GetChildren().size() > 0)
-                    {
-                        for (auto* childWidget : top->GetChildrenRows())
-                        {
-                            widgetStack.push_back(childWidget);
-                        }
-                    }
-                }
-
-                // Issue property notifications, starting with leaf widgets first.
-                for (auto iter = widgetsToNotify.rbegin(); iter != widgetsToNotify.rend(); ++iter)
-                {
-                    (*iter)->DoPropertyNotify();
-                }
-            }
-        }
-
-        AfterPropertyModified(fieldNode);
-        SetPropertyEditingComplete(fieldNode);
-
-        // We must refresh the entire tree, because restoring previous entity state may've had major structural effects.
-        InvalidatePropertyDisplay(Refresh_EntireTree);
-    }
-
-    void EntityPropertyEditor::ContextMenuActionSetDataFlag(InstanceDataNode* node, AZ::DataPatch::Flag flag, bool additive)
-    {
-        // Attempt to get Entity and DataPatch address from this node.
-        AZ::EntityId entityId;
-        if (GetEntityDataPatchAddress(node, m_dataPatchAddressBuffer, &entityId))
-        {
-            BeforePropertyModified(node);
-
-            auto command = aznew SliceDataFlagsCommand(entityId, m_dataPatchAddressBuffer, flag, additive, "Set slice data flag");
-            command->SetParent(m_currentUndoOperation);
-
-            AfterPropertyModified(node);
-            SetPropertyEditingComplete(node);
-
-            InvalidatePropertyDisplay(Refresh_AttributesAndValues);
-        }
     }
 
     void EntityPropertyEditor::BeginMoveRowWidgetFade()
@@ -3108,48 +2587,6 @@ namespace AzToolsFramework
         }
 
         return false;
-    }
-
-    bool EntityPropertyEditor::InstanceNodeValueHasNoPushableChange(const InstanceDataNode* sourceNode, const InstanceDataNode* targetNode)
-    {
-        if (targetNode == nullptr)
-        {
-            return sourceNode == nullptr;
-        }
-        // If target node is affected by ForceOverride flag, consider it different from source.
-        AZ::EntityId entityId;
-        if (GetEntityDataPatchAddress(targetNode, m_dataPatchAddressBuffer, &entityId))
-        {
-            if (AZ::SliceComponent* rootSlice = GetEntityRootSlice(entityId))
-            {
-                AZ::DataPatch::Flags flags = rootSlice->GetEntityDataFlagsAtAddress(entityId, m_dataPatchAddressBuffer);
-                if (flags & AZ::DataPatch::Flag::ForceOverrideSet)
-                {
-                    return false;
-                }
-            }
-        }
-
-        // Verify that this is a field that can be pushed into the slice.
-        if (InstanceDataNode* componentNode = targetNode->GetRoot())
-        {
-            AZ::Component* component = m_serializeContext->Cast<AZ::Component*>(
-                componentNode->FirstInstance(), componentNode->GetClassMetadata()->m_typeId);
-            if (component)
-            {
-                AZ::Entity* entity = component->GetEntity();
-                bool isRootEntity = entity ? SliceUtilities::IsRootEntity(*entity) : false;
-                if (!SliceUtilities::IsNodePushable(*targetNode, isRootEntity))
-                {
-                    // If this field is one that can't be pushed into the slice, then
-                    // return true to signify that here is no pushable change on this field.
-                    return true;
-                }
-            }
-        }
-
-        // Otherwise, do the default value comparison.
-        return InstanceDataHierarchy::DefaultValueComparisonFunction(sourceNode, targetNode);
     }
 
     bool EntityPropertyEditor::QueryInstanceDataNodeReadOnlyStatus(const InstanceDataNode* node)
@@ -3382,8 +2819,6 @@ namespace AzToolsFramework
         {
             menu.addSeparator();
         }
-
-        AddMenuOptionsForRevert(nullptr, nullptr, nullptr, menu);
 
         const auto& componentsToEdit = GetSelectedComponents();
         if (componentsToEdit.size() > 0)
@@ -4073,37 +3508,6 @@ namespace AzToolsFramework
         ComponentEditorVector componentEditors = m_componentEditors;
         AZStd::reverse(componentEditors.begin(), componentEditors.end());
         return IsMoveAllowed(componentEditors);
-    }
-
-    void EntityPropertyEditor::ResetToSlice()
-    {
-        // Reset selected components to slice values
-        const auto& componentsToEdit = GetSelectedComponents();
-
-        if (!componentsToEdit.empty())
-        {
-            ScopedUndoBatch undoBatch("Resetting components to slice defaults.");
-
-            for (auto component : componentsToEdit)
-            {
-                AZ_Assert(component, "Component is invalid.");
-                auto componentEditorIterator = m_componentToEditorMap.find(component);
-                AZ_Assert(componentEditorIterator != m_componentToEditorMap.end(), "Unable to find a component editor for the given component");
-                if (componentEditorIterator != m_componentToEditorMap.end())
-                {
-                    auto componentEditor = componentEditorIterator->second;
-                    componentEditor->GetPropertyEditor()->EnumerateInstances(
-                        [this, &component](InstanceDataHierarchy& hierarchy)
-                        {
-                            InstanceDataNode* root = hierarchy.GetRootNode();
-                            ContextMenuActionPullFieldData(component, root);
-                        }
-                        );
-                }
-            }
-
-            QueuePropertyRefresh();
-        }
     }
 
     bool EntityPropertyEditor::DoesOwnFocus() const
@@ -5965,13 +5369,6 @@ namespace AzToolsFramework
 
     AZ::Entity* EntityPropertyEditor::GetSelectedEntityById(AZ::EntityId& entityId) const
     {
-        if (m_isLevelEntityEditor)
-        {
-            AZ::Entity* entity = nullptr;
-            SliceMetadataEntityContextRequestBus::BroadcastResult(entity, &SliceMetadataEntityContextRequestBus::Events::GetMetadataEntity, entityId);
-            return entity;
-        }
-
         return GetEntityById(entityId);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -22,30 +22,32 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Console/IConsoleTypes.h>
 #include <AzCore/Asset/AssetCommon.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
-#include <AzToolsFramework/Undo/UndoSystem.h>
+
 #include <AzToolsFramework/API/EditorWindowRequestBus.h>
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/API/EntityPropertyEditorRequestsBus.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
-#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
+#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityBus.h>
 #include <AzToolsFramework/FocusMode/FocusModeNotificationBus.h>
 #include <AzToolsFramework/ToolsComponents/ComponentMimeData.h>
 #include <AzToolsFramework/ToolsComponents/EditorInspectorComponentBus.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
+
 #include <AzQtComponents/Components/O3DEStylesheet.h>
 
-#include <QtWidgets/QWidget>
-#include <QtGui/QIcon>
 #include <QComboBox>
+#include <QtGui/QIcon>
+#include <QtWidgets/QWidget>
 #endif
 
 class QLabel;
-class QSpacerItem;
 class QMenu;
 class QMimeData;
+class QSpacerItem;
 class QStandardItem;
 
 namespace Ui
@@ -210,9 +212,8 @@ namespace AzToolsFramework
 
         struct SharedComponentInfo
         {
-            SharedComponentInfo(AZ::Component* component, AZ::Component* sliceReferenceComponent);
+            SharedComponentInfo(AZ::Component* component);
             AZ::Entity::ComponentArrayType m_instances;
-            AZ::Component* m_sliceReferenceComponent;
         };
 
         using SharedComponentArray = AZStd::vector<SharedComponentInfo>;
@@ -305,12 +306,8 @@ namespace AzToolsFramework
 
         void AddMenuOptionsForComponents(QMenu& menu, const QPoint& position);
         void AddMenuOptionsForFields(InstanceDataNode* fieldNode, InstanceDataNode* componentNode, const AZ::SerializeContext::ClassData* componentClassData, QMenu& menu);
-        void AddMenuOptionsForRevert(InstanceDataNode* fieldNode, InstanceDataNode* componentNode, const AZ::SerializeContext::ClassData* componentClassData, QMenu& menu);
 
         bool HasAnyVisibleElements(const InstanceDataNode& node);
-
-        void ContextMenuActionPullFieldData(AZ::Component* parentComponent, InstanceDataNode* fieldNode);
-        void ContextMenuActionSetDataFlag(InstanceDataNode* node, AZ::DataPatch::Flag flag, bool additive);
 
         void GenerateRowWidgetIndexMapToChildIndex(PropertyRowWidget* parent, int destIndex);
         void ContextMenuActionMoveItemUp(ComponentEditor* componentEditor, PropertyRowWidget* rowWidget);
@@ -331,9 +328,6 @@ namespace AzToolsFramework
         // \param rootType type of root the address should be adjusted to. See \ref AddressRootType.
         // \param outAddress output parameter to be populated with the adjusted node address.
         void CalculateAndAdjustNodeAddress(const InstanceDataNode& componentFieldNode, AddressRootType rootType, InstanceDataNode::Address& outAddress) const;
-
-        // Custom function for comparing values of InstanceDataNodes
-        bool InstanceNodeValueHasNoPushableChange(const InstanceDataNode* sourceNode, const InstanceDataNode* targetNode);
 
         // Custom function for determining whether InstanceDataNodes are read-only
         bool QueryInstanceDataNodeReadOnlyStatus(const InstanceDataNode* node);
@@ -449,8 +443,6 @@ namespace AzToolsFramework
 
         bool IsMoveComponentsUpAllowed() const;
         bool IsMoveComponentsDownAllowed() const;
-
-        void ResetToSlice();
 
         bool DoesOwnFocus() const;
         AZ::u32 GetHeightOfRowAndVisibleChildren(const PropertyRowWidget* row) const;
@@ -605,7 +597,7 @@ namespace AzToolsFramework
         enum class InspectorLayout
         {
             Entity = 0,                     // All selected entities are regular entities.
-            Level,                          // The selected entity is the prefab container entity for the level prefab, or the slice level entity.
+            Level,                          // The selected entity is the prefab container entity for the level prefab.
             ContainerEntityOfFocusedPrefab, // The selected entity is the prefab container entity for the focused prefab.
             Invalid                         // Other entities are selected alongside the level prefab container entity.
         };
@@ -627,9 +619,6 @@ namespace AzToolsFramework
         // Tracks if a custom filter has been set. A comparison operator is not available for
         // the filter, so it can't be checked if it's the default filter.
         bool m_customFilterSet = false;
-
-        // Pointer to entity that first entity is compared against for the purpose of rendering deltas vs. slice in the property grid.
-        AZStd::unique_ptr<AZ::Entity> m_sliceCompareToEntity;
 
         // Temporary buffer to use when calculating a data patch address.
         AZ::DataPatch::AddressType m_dataPatchAddressBuffer;
@@ -696,8 +685,6 @@ namespace AzToolsFramework
         void ClearSearchFilter();
 
         void OpenPinnedInspector();
-
-        bool SelectedEntitiesAreFromSameSourceSliceEntity() const;
 
         void DragStopped();
 


### PR DESCRIPTION
## What does this PR do?

Removes more references to slices in the level editor UI.

Inspector cleanup will simplify other refactoring efforts related to prefab overrides and action manager support.

## How was this PR tested?

Manual testing.