### PR TITLE
`MultiDeviceIndirectBufferView` Fix

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceIndirectBufferView.h
@@ -52,6 +52,8 @@ namespace AZ::RHI
             this->m_byteCount = other.m_byteCount;
             this->m_byteStride = other.m_byteStride;
 
+            m_cache.clear();
+
             return *this;
         }
 


### PR DESCRIPTION
## What does this PR do?

Forgot to clear the cache for copy assignment operations on `MultiDeviceIndirectBufferView`, which, if not done, would lead to wrong results from the cache if the object being assigned to already had cache entries.
