### PR TITLE
Revert the ImGUI key back to home from ~

### DIFF
--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -452,8 +452,8 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
         // Handle Keyboard Hotkeys
         if (inputChannel.IsStateBegan())
         {
-            // Cycle through ImGui Menu Bar States on ~ button press
-            if (inputChannelId == InputDeviceKeyboard::Key::PunctuationTilde)
+            // Cycle through ImGui Menu Bar States on Home button press
+            if (inputChannelId == InputDeviceKeyboard::Key::NavigationHome)
             {
                 ToggleThroughImGuiVisibleState();
             }


### PR DESCRIPTION
The reason for this is that on some international keyboards, e.g. German ones, the ~ key is a dead-key and thus either doesn't work at all or at least needs to be pressed twice.

Note: This was changed from home to tilde in 89fe77d780d