### PR TITLE
feat: migrate math types from Variable to AZ::Vector/Quaternion

### DIFF
--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
@@ -332,9 +332,9 @@ void ReflectedPropertyControl::CreateItems(XmlNodeRef node, CVarBlockPtr& outBlo
             }
             else if (!azstricmp(type, "vector"))
             {
-                CSmartVariable<Vec3> vec3Var;
+                CSmartVariable<AZ::Vector3> vec3Var;
                 AddVariable(group, vec3Var, child->getTag(), humanReadableName.toUtf8().data(), strDescription.toUtf8().data(), func, pUserData);
-                Vec3 vValue(0, 0, 0);
+                AZ::Vector3 vValue(0, 0, 0);
                 if (child->getAttr("value", vValue))
                 {
                     vec3Var->Set(vValue);

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyItem.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyItem.cpp
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.hxx>
 
 // Editor
+#include "MathConversion.h"
 #include "ReflectedVarWrapper.h"
 #include "ReflectedPropertyCtrl.h"
 #include "Undo/UndoVariableChange.h"
@@ -608,7 +609,8 @@ void ReflectedPropertyItem::SetValue(const QString& sValue, bool bRecordUndo, bo
                 ColorF color = StringToColor(value);
                 if (m_pVariable->GetType() == IVariable::VECTOR)
                 {
-                    m_pVariable->Set(color.toVec3());
+
+                    m_pVariable->Set(LYVec3ToAZVec3(color.toVec3()));
                 }
                 else
                 {

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.cpp
@@ -262,9 +262,9 @@ void ReflectedVarVector2Adapter::SetVariable(IVariable *pVariable)
 
 void ReflectedVarVector2Adapter::SyncReflectedVarToIVar(IVariable *pVariable)
 {
-    Vec2 vec;
+    AZ::Vector2 vec;
     pVariable->Get(vec);
-    m_reflectedVar->m_value = AZ::Vector2(vec.x, vec.y);
+    m_reflectedVar->m_value = vec;
 }
 
 void ReflectedVarVector2Adapter::SyncIVarToReflectedVar(IVariable *pVariable)
@@ -282,9 +282,7 @@ void ReflectedVarVector3Adapter::SetVariable(IVariable *pVariable)
 
 void ReflectedVarVector3Adapter::SyncReflectedVarToIVar(IVariable *pVariable)
 {
-    Vec3 vec;
-    pVariable->Get(vec);
-    m_reflectedVar->m_value = AZ::Vector3(vec.x, vec.y, vec.z);
+    pVariable->Get(m_reflectedVar->m_value);
 }
 
 void ReflectedVarVector3Adapter::SyncIVarToReflectedVar(IVariable *pVariable)
@@ -302,14 +300,12 @@ void ReflectedVarVector4Adapter::SetVariable(IVariable *pVariable)
 
 void ReflectedVarVector4Adapter::SyncReflectedVarToIVar(IVariable *pVariable)
 {
-    Vec4 vec;
-    pVariable->Get(vec);
-    m_reflectedVar->m_value = AZ::Vector4(vec.x, vec.y, vec.z, vec.w);
+    pVariable->Get(m_reflectedVar->m_value);
 }
 
 void ReflectedVarVector4Adapter::SyncIVarToReflectedVar(IVariable *pVariable)
 {
-    pVariable->Set(Vec4(m_reflectedVar->m_value.GetX(), m_reflectedVar->m_value.GetY(), m_reflectedVar->m_value.GetZ(), m_reflectedVar->m_value.GetW()));
+    pVariable->Set(m_reflectedVar->m_value);
 }
 
 void ReflectedVarResourceAdapter::SetVariable(IVariable *pVariable)

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -1453,9 +1453,9 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
 
     if (pVar->GetDataType() == IVariable::DT_COLOR)
     {
-        Vec3 value;
+        AZ::Vector3 value;
         pVar->Get(value);
-        QColor gammaColor = ColorLinearToGamma(ColorF(value.x, value.y, value.z));
+        QColor gammaColor = ColorLinearToGamma(ColorF(value.GetX(), value.GetY(), value.GetZ()));
         childValue = QStringLiteral("%1,%2,%3").arg(gammaColor.red()).arg(gammaColor.green()).arg(gammaColor.blue());
     }
     else

--- a/Code/Editor/TrackView/CommentKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CommentKeyUIControls.cpp
@@ -39,7 +39,7 @@ bool CCommentKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& sele
             mv_duration = commentKey.m_duration;
             mv_size = commentKey.m_size;
             mv_font = commentKey.m_strFont.c_str();
-            mv_color = Vec3(commentKey.m_color.GetR(), commentKey.m_color.GetG(), commentKey.m_color.GetB());
+            mv_color = AZ::Vector3(commentKey.m_color.GetR(), commentKey.m_color.GetG(), commentKey.m_color.GetB());
             mv_align = commentKey.m_align;
 
             bAssigned = true;
@@ -85,9 +85,9 @@ void CCommentKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sel
             }
 
             SyncValue(mv_duration, commentKey.m_duration, false, pVar);
-            Vec3 color(commentKey.m_color.GetR(), commentKey.m_color.GetG(), commentKey.m_color.GetB());
+            AZ::Vector3 color(commentKey.m_color.GetR(), commentKey.m_color.GetG(), commentKey.m_color.GetB());
             SyncValue(mv_color, color, false, pVar);
-            commentKey.m_color.Set(color.x, color.y, color.z, commentKey.m_color.GetA());
+            commentKey.m_color.Set(color.GetX(), color.GetY(), color.GetZ(), commentKey.m_color.GetA());
             SyncValue(mv_size, commentKey.m_size, false, pVar);
 
             bool isDuringUndo = false;

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -170,7 +170,7 @@ public:
     CSmartVariable<QString> mv_comment;
     CSmartVariable<float> mv_duration;
     CSmartVariable<float> mv_size;
-    CSmartVariable<Vec3> mv_color;
+    CSmartVariable<AZ::Vector3> mv_color;
     CSmartVariableEnum<int> mv_align;
     CSmartVariableEnum<QString> mv_font;
 
@@ -347,7 +347,7 @@ class CScreenFaderKeyUIControls
 {
     CSmartVariableArray     mv_table;
     CSmartVariable<float>   mv_fadeTime;
-    CSmartVariable<Vec3>    mv_fadeColor;
+    CSmartVariable<AZ::Vector3>    mv_fadeColor;
     CSmartVariable<QString> mv_strTexture;
     CSmartVariable<bool>    mv_bUseCurColor;
     CSmartVariableEnum<int> mv_fadeType;
@@ -520,7 +520,7 @@ public:
     CSmartVariable<QString> mv_startTrigger;
     CSmartVariable<QString> mv_stopTrigger;
     CSmartVariable<float> mv_duration;
-    CSmartVariable<Vec3> mv_customColor;
+    CSmartVariable<AZ::Vector3> mv_customColor;
 
     void OnCreateVars() override
     {

--- a/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
+++ b/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
@@ -37,7 +37,7 @@ bool CScreenFaderKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& 
             keyHandle.GetKey(&screenFaderKey);
 
             mv_fadeTime = screenFaderKey.m_fadeTime;
-            mv_fadeColor = Vec3(screenFaderKey.m_fadeColor.GetR(), screenFaderKey.m_fadeColor.GetG(), screenFaderKey.m_fadeColor.GetB());
+            mv_fadeColor = AZ::Vector3(screenFaderKey.m_fadeColor.GetR(), screenFaderKey.m_fadeColor.GetG(), screenFaderKey.m_fadeColor.GetB());
             mv_strTexture = screenFaderKey.m_strTexture.c_str();
             mv_bUseCurColor = screenFaderKey.m_bUseCurColor;
             mv_fadeType = (int)screenFaderKey.m_fadeType;
@@ -90,8 +90,8 @@ void CScreenFaderKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle&
             }
             else if (pVar == mv_fadeColor.GetVar())
             {
-                Vec3 color = mv_fadeColor;
-                screenFaderKey.m_fadeColor = AZ::Color(color.x, color.y, color.z, screenFaderKey.m_fadeType == IScreenFaderKey::eFT_FadeIn ? 1.f : 0.f);
+                AZ::Vector3 color = mv_fadeColor;
+                screenFaderKey.m_fadeColor = AZ::Color(color.GetX(), color.GetY(), color.GetZ(), screenFaderKey.m_fadeType == IScreenFaderKey::eFT_FadeIn ? 1.f : 0.f);
             }
 
             selectedKey.SetKey(&screenFaderKey);

--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -3519,7 +3519,7 @@ void CTrackViewDopeSheetBase::DrawKeyDuration(CTrackViewTrack* pTrack, QPainter*
     {
         ISoundKey soundKey;
         keyHandle.GetKey(&soundKey);
-        colorFrom.setRgbF(soundKey.customColor.x, soundKey.customColor.y, soundKey.customColor.z);
+        colorFrom.setRgbF(soundKey.customColor.GetX(), soundKey.customColor.GetY(), soundKey.customColor.GetZ());
     }
     QLinearGradient gradient(x, rc.top() + 3, x, rc.bottom() - 3);
     gradient.setColorAt(0, colorFrom);

--- a/Code/Editor/Util/Variable.h
+++ b/Code/Editor/Util/Variable.h
@@ -22,6 +22,11 @@ AZ_PUSH_DISABLE_WARNING(4458, "-Wunknown-warning-option")
 AZ_POP_DISABLE_WARNING
 #include <QVariant>
 
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/Quaternion.h>
+
 #include <StlUtils.h>
 
 inline const char* to_c_str(const char* str) { return str; }
@@ -257,11 +262,10 @@ struct IVariable
     virtual void Set(bool value) = 0;
     virtual void Set(float value) = 0;
     virtual void Set(double value) = 0;
-    virtual void Set(const Vec2& value) = 0;
-    virtual void Set(const Vec3& value) = 0;
-    virtual void Set(const Vec4& value) = 0;
-    virtual void Set(const Ang3& value) = 0;
-    virtual void Set(const Quat& value) = 0;
+    virtual void Set(const AZ::Vector2& value) = 0;
+    virtual void Set(const AZ::Vector3& value) = 0;
+    virtual void Set(const AZ::Vector4& value) = 0;
+    virtual void Set(const AZ::Quaternion& value) = 0;
     virtual void Set(const QString& value) = 0;
     virtual void Set(const char* value) = 0;
     virtual void SetDisplayValue(const QString& value) = 0;
@@ -276,11 +280,10 @@ struct IVariable
     virtual void Get(bool& value) const  = 0;
     virtual void Get(float& value) const  = 0;
     virtual void Get(double& value) const = 0;
-    virtual void Get(Vec2& value) const  = 0;
-    virtual void Get(Vec3& value) const  = 0;
-    virtual void Get(Vec4& value) const  = 0;
-    virtual void Get(Ang3& value) const  = 0;
-    virtual void Get(Quat& value) const  = 0;
+    virtual void Get(AZ::Vector2& value) const  = 0;
+    virtual void Get(AZ::Vector3& value) const  = 0;
+    virtual void Get(AZ::Vector4& value) const  = 0;
+    virtual void Get(AZ::Quaternion& value) const  = 0;
     virtual void Get(QString& value) const = 0;
     virtual QString GetDisplayValue() const = 0;
     virtual bool HasDefaultValue() const = 0;
@@ -419,11 +422,10 @@ public:
     void Set([[maybe_unused]] bool value) override                  { assert(0); }
     void Set([[maybe_unused]] float value) override                 { assert(0); }
     void Set([[maybe_unused]] double value) override                { assert(0); }
-    void Set([[maybe_unused]] const Vec2& value) override           { assert(0); }
-    void Set([[maybe_unused]] const Vec3& value) override           { assert(0); }
-    void Set([[maybe_unused]] const Vec4& value) override           { assert(0); }
-    void Set([[maybe_unused]] const Ang3& value) override           { assert(0); }
-    void Set([[maybe_unused]] const Quat& value) override           { assert(0); }
+    void Set([[maybe_unused]] const AZ::Vector2& value) override           { assert(0); }
+    void Set([[maybe_unused]] const AZ::Vector3& value) override           { assert(0); }
+    void Set([[maybe_unused]] const AZ::Vector4& value) override           { assert(0); }
+    void Set([[maybe_unused]] const AZ::Quaternion& value) override           { assert(0); }
     void Set([[maybe_unused]] const QString& value) override        { assert(0); }
     void Set([[maybe_unused]] const char* value) override            { assert(0); }
     void SetDisplayValue(const QString& value) override    { Set(value); }
@@ -435,11 +437,10 @@ public:
     void Get([[maybe_unused]] bool& value) const override       { assert(0); }
     void Get([[maybe_unused]] float& value) const override      { assert(0); }
     void Get([[maybe_unused]] double& value) const override     { assert(0); }
-    void Get([[maybe_unused]] Vec2& value) const override       { assert(0); }
-    void Get([[maybe_unused]] Vec3& value) const override       { assert(0); }
-    void Get([[maybe_unused]] Vec4& value) const override       { assert(0); }
-    void Get([[maybe_unused]] Ang3& value) const override       { assert(0); }
-    void Get([[maybe_unused]] Quat& value) const override       { assert(0); }
+    void Get([[maybe_unused]] AZ::Vector2& value) const override       { assert(0); }
+    void Get([[maybe_unused]] AZ::Vector3& value) const override       { assert(0); }
+    void Get([[maybe_unused]] AZ::Vector4& value) const override       { assert(0); }
+    void Get([[maybe_unused]] AZ::Quaternion& value) const override       { assert(0); }
     void Get([[maybe_unused]] QString& value) const override    { assert(0); }
     QString GetDisplayValue() const override     { QString val; Get(val); return val; }
 
@@ -887,16 +888,16 @@ namespace var_type
     struct type_traits<double>
         : public type_traits_base<IVariable::DOUBLE, true, false, false, true>{};
     template<>
-    struct type_traits<Vec2>
+    struct type_traits<AZ::Vector2>
         : public type_traits_base<IVariable::VECTOR2, false, false, false, false> {};
     template<>
-    struct type_traits<Vec3>
+    struct type_traits<AZ::Vector3>
         : public type_traits_base<IVariable::VECTOR, false, false, false, false> {};
     template<>
-    struct type_traits<Vec4>
+    struct type_traits<AZ::Vector4>
         : public type_traits_base<IVariable::VECTOR4, false, false, false, false> {};
     template<>
-    struct type_traits<Quat>
+    struct type_traits<AZ::Quaternion>
         : public type_traits_base<IVariable::QUAT, false, false, false, false> {};
     template<>
     struct type_traits<QString>
@@ -927,80 +928,59 @@ namespace var_type
         void operator()(const double& from, bool& to) const { to = from != 0; }
         void operator()(const double& from, float& to) const { to = aznumeric_cast<float>(from); }
 
-        void operator()(const Vec2& from, Vec2& to) const { to = from; }
-        void operator()(const Vec3& from, Vec3& to) const { to = from; }
-        void operator()(const Vec4& from, Vec4& to) const { to = from; }
-        void operator()(const Quat& from, Quat& to) const { to = from; }
+        void operator()(const AZ::Vector2& from, AZ::Vector2& to) const { to = from; }
+        void operator()(const AZ::Vector3& from, AZ::Vector3& to) const { to = from; }
+        void operator()(const AZ::Vector4& from, AZ::Vector4& to) const { to = from; }
+        void operator()(const AZ::Quaternion& from, AZ::Quaternion& to) const { to = from; }
         void operator()(const QString& from, QString& to) const { to = from; }
 
         void operator()(bool value, QString& to) const { to = QString::number((value) ? (int)1 : (int)0); }
         void operator()(int value, QString& to) const { to = QString::number(value); }
         void operator()(float value, QString& to) const { to = QString::number(value); };
         void operator()(double value, QString& to) const { to = QString::number(value); };
-        void operator()(const Vec2& value, QString& to) const { to = QString::fromLatin1("%1,%2").arg(value.x).arg(value.y); }
-        void operator()(const Vec3& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3").arg(value.x).arg(value.y).arg(value.z); }
-        void operator()(const Vec4& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3,%4").arg(value.x).arg(value.y).arg(value.z).arg(value.w); }
-        void operator()(const Ang3& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3").arg(value.x).arg(value.y).arg(value.z); }
-        void operator()(const Quat& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3,%4").arg(value.w).arg(value.v.x).arg(value.v.y).arg(value.v.z); }
+        void operator()(const AZ::Vector2& value, QString& to) const { to = QString::fromLatin1("%1,%2").arg(value.GetX()).arg(value.GetY()); }
+        void operator()(const AZ::Vector3& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3").arg(value.GetX()).arg(value.GetY()).arg(value.GetZ()); }
+        void operator()(const AZ::Vector4& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3,%4").arg(value.GetX()).arg(value.GetY()).arg(value.GetZ()).arg(value.GetW()); }
+        void operator()(const AZ::Quaternion& value, QString& to) const { to = QString::fromLatin1("%1,%2,%3,%4").arg(value.GetW()).arg(value.GetX()).arg(value.GetY()).arg(value.GetZ()); }
 
         void operator()(const QString& from, int& value) const { value = from.toInt(); }
         void operator()(const QString& from, bool& value) const { value = from.toInt() != 0; }
         void operator()(const QString& from, float& value) const { value = from.toFloat(); }
-        void operator()(const QString& from, Vec2& value) const
+        void operator()(const QString& from, AZ::Vector2& value) const
         {
             QStringList parts = from.split(QStringLiteral(","));
             while (parts.size() < 2)
             {
                 parts.push_back(QString());
             }
-            value.x = parts[0].toFloat();
-            value.y = parts[1].toFloat();
+            value.Set(parts[0].toFloat(), parts[1].toFloat());
         };
-        void operator()(const QString& from, Vec3& value) const
+        void operator()(const QString& from, AZ::Vector3& value) const
         {
             QStringList parts = from.split(QStringLiteral(","));
             while (parts.size() < 3)
             {
                 parts.push_back(QString());
             }
-            value.x = parts[0].toFloat();
-            value.y = parts[1].toFloat();
-            value.z = parts[2].toFloat();
+           value.Set(parts[0].toFloat(),parts[1].toFloat(),parts[2].toFloat());
         };
-        void operator()(const QString& from, Vec4& value) const
+        void operator()(const QString& from, AZ::Vector4& value) const
         {
             QStringList parts = from.split(QStringLiteral(","));
             while (parts.size() < 4)
             {
                 parts.push_back(QString());
             }
-            value.x = parts[0].toFloat();
-            value.y = parts[1].toFloat();
-            value.z = parts[2].toFloat();
-            value.w = parts[3].toFloat();
+            value.Set(parts[0].toFloat(), parts[1].toFloat(), parts[2].toFloat(), parts[3].toFloat());
         };
-        void operator()(const QString& from, Ang3& value) const
-        {
-            QStringList parts = from.split(QStringLiteral(","));
-            while (parts.size() < 3)
-            {
-                parts.push_back(QString());
-            }
-            value.x = parts[0].toFloat();
-            value.y = parts[1].toFloat();
-            value.z = parts[2].toFloat();
-        };
-        void operator()(const QString& from, Quat& value) const
+        void operator()(const QString& from, AZ::Quaternion& value) const
         {
             QStringList parts = from.split(QStringLiteral(","));
             while (parts.size() < 4)
             {
                 parts.push_back(QString());
             }
-            value.w = parts[0].toFloat();
-            value.v.x = parts[1].toFloat();
-            value.v.y = parts[2].toFloat();
-            value.v.z = parts[3].toFloat();
+            value.Set(parts[0].toFloat(), parts[1].toFloat(), parts[2].toFloat(), parts[3].toFloat());
         };
     };
 
@@ -1012,25 +992,21 @@ namespace var_type
     {
         return arg1 == arg2;
     };
-    inline bool compare(const Vec2& v1, const Vec2& v2)
+    inline bool compare(const AZ::Vector2& v1, const AZ::Vector2& v2)
     {
-        return v1.x == v2.x && v1.y == v2.y;
+        return v1 == v2;
     }
-    inline bool compare(const Vec3& v1, const Vec3& v2)
+    inline bool compare(const AZ::Vector3& v1, const AZ::Vector3& v2)
     {
-        return v1.x == v2.x && v1.y == v2.y && v1.z == v2.z;
+        return v1 == v2;
     }
-    inline bool compare(const Vec4& v1, const Vec4& v2)
+    inline bool compare(const AZ::Vector4& v1, const AZ::Vector4& v2)
     {
-        return v1.x == v2.x && v1.y == v2.y && v1.z == v2.z && v1.w == v2.w;
+        return v1 == v2;
     }
-    inline bool compare(const Ang3& v1, const Ang3& v2)
+    inline bool compare(const AZ::Quaternion& q1, const AZ::Quaternion& q2)
     {
-        return v1.x == v2.x && v1.y == v2.y && v1.z == v2.z;
-    }
-    inline bool compare(const Quat& q1, const Quat& q2)
-    {
-        return q1.v.x == q2.v.x && q1.v.y == q2.v.y && q1.v.z == q2.v.z && q1.w == q2.w;
+        return q1 == q2;
     }
     inline bool compare(const char* s1, const char* s2)
     {
@@ -1046,16 +1022,12 @@ namespace var_type
     {
         val = 0;
     };
-    inline void init(Vec2& val)   {   val.x = 0; val.y = 0;   };
-    inline void init(Vec3& val)   {   val.x = 0; val.y = 0; val.z = 0; };
-    inline void init(Vec4& val)   {   val.x = 0; val.y = 0; val.z = 0; val.w = 0;  };
-    inline void init(Ang3& val)   {   val.x = 0; val.y = 0; val.z = 0; };
-    inline void init(Quat& val)
+    inline void init(AZ::Vector2& val)   {   val.Set(0.0f);   };
+    inline void init(AZ::Vector3& val)   {   val.Set(0.0f); };
+    inline void init(AZ::Vector4& val)   {   val.Set(0.0f);  };
+    inline void init(AZ::Quaternion& val)
     {
-        val.v.x = 0;
-        val.v.y = 0;
-        val.v.z = 0;
-        val.w = 0;
+        val.Set(0.0f);
     };
     inline void init(const char*& val)
     {
@@ -1068,23 +1040,6 @@ namespace var_type
     //////////////////////////////////////////////////////////////////////////
 };
 
-//////////////////////////////////////////////////////////////////////////
-// Void variable does not contain any value.
-//////////////////////////////////////////////////////////////////////////
-class CVariableVoid
-    : public CVariableBase
-{
-public:
-    CVariableVoid(){};
-    EType GetType() const override { return IVariable::UNKNOWN; };
-    IVariable* Clone([[maybe_unused]] bool bRecursive) const override { return new CVariableVoid(*this); }
-    void CopyValue([[maybe_unused]] IVariable* fromVar) override {};
-    bool HasDefaultValue() const override { return true; }
-    void ResetToDefault() override {};
-protected:
-    CVariableVoid(const CVariableVoid& v)
-        : CVariableBase(v) {};
-};
 
 //////////////////////////////////////////////////////////////////////////
 template <class T>
@@ -1120,29 +1075,28 @@ public:
     //////////////////////////////////////////////////////////////////////////
     // Set methods.
     //////////////////////////////////////////////////////////////////////////
-    void Set(int value) override                           { SetValue(value); }
-    void Set(bool value) override                      { SetValue(value); }
-    void Set(float value) override                     { SetValue(value); }
-    void Set(double value) override                { SetValue(value); }
-    void Set(const Vec2& value) override           { SetValue(value); }
-    void Set(const Vec3& value) override           { SetValue(value); }
-    void Set(const Vec4& value) override           { SetValue(value); }
-    void Set(const Ang3& value) override           { SetValue(value); }
-    void Set(const Quat& value) override           { SetValue(value); }
-    void Set(const QString& value) override    { SetValue(value); }
-    void Set(const char* value) override      { SetValue(QString(value)); }
+    void Set(int value) override                          { SetValue(value); }
+    void Set(bool value) override                         { SetValue(value); }
+    void Set(float value) override                        { SetValue(value); }
+    void Set(double value) override                       { SetValue(value); }
+    void Set(const AZ::Vector2& value) override           { SetValue(value); }
+    void Set(const AZ::Vector3& value) override           { SetValue(value); }
+    void Set(const AZ::Vector4& value) override           { SetValue(value); }
+    void Set(const AZ::Quaternion& value) override        { SetValue(value); }
+    void Set(const QString& value) override               { SetValue(value); }
+    void Set(const char* value) override                  { SetValue(QString(value)); }
 
     //////////////////////////////////////////////////////////////////////////
     // Get methods.
     //////////////////////////////////////////////////////////////////////////
-    void Get(int& value) const override                        { GetValue(value); }
+    void Get(int& value) const override                    { GetValue(value); }
     void Get(bool& value) const override                   { GetValue(value); }
     void Get(float& value) const override                  { GetValue(value); }
-    void Get(double& value) const override                  { GetValue(value); }
-    void Get(Vec2& value) const override                   { GetValue(value); }
-    void Get(Vec3& value) const override                   { GetValue(value); }
-    void Get(Vec4& value) const override                   { GetValue(value); }
-    void Get(Quat& value) const override                   { GetValue(value); }
+    void Get(double& value) const override                 { GetValue(value); }
+    void Get(AZ::Vector2& value) const override            { GetValue(value); }
+    void Get(AZ::Vector3& value) const override            { GetValue(value); }
+    void Get(AZ::Vector4& value) const override            { GetValue(value); }
+    void Get(AZ::Quaternion& value) const override         { GetValue(value); }
     void Get(QString& value) const override                { GetValue(value); }
     bool HasDefaultValue() const override
     {

--- a/Code/Legacy/CryCommon/AnimKey.h
+++ b/Code/Legacy/CryCommon/AnimKey.h
@@ -192,15 +192,13 @@ struct ISoundKey
     ISoundKey()
         : fDuration(0.0f)
     {
-        customColor.x = Col_TrackviewDefault.r;
-        customColor.y = Col_TrackviewDefault.g;
-        customColor.z = Col_TrackviewDefault.b;
+        customColor.Set(Col_TrackviewDefault.r,Col_TrackviewDefault.g,Col_TrackviewDefault.b);
     }
 
     AZStd::string sStartTrigger;
     AZStd::string sStopTrigger;
     float         fDuration;
-    Vec3          customColor;
+    AZ::Vector3   customColor;
 };
 
 /** ITimeRangeKey used in time ranges animation track.

--- a/Code/Legacy/CryCommon/IXml.h
+++ b/Code/Legacy/CryCommon/IXml.h
@@ -305,6 +305,12 @@ public:
     virtual void setAttr(const char* key, const Vec3& value) = 0;
     virtual void setAttr(const char* key, const Vec4& value) = 0;
     virtual void setAttr(const char* key, const Quat& value) = 0;
+
+    virtual void setAttr(const char* key, const AZ::Vector4& value) = 0;
+    virtual void setAttr(const char* key, const AZ::Vector3& value) = 0;
+    virtual void setAttr(const char* key, const AZ::Vector2& value) = 0;
+    virtual void setAttr(const char* key, const AZ::Quaternion& value) = 0;
+    
 #if defined(LINUX64) || defined(APPLE)
     // Compatibility functions, on Linux and Mac long int is the default int64_t
     ILINE void setAttr(const char* key, unsigned long int value, bool useHexFormat = true)
@@ -347,6 +353,12 @@ public:
     virtual bool getAttr(const char* key, uint64& value, bool useHexFormat = true) const = 0;
     virtual bool getAttr(const char* key, float& value) const = 0;
     virtual bool getAttr(const char* key, double& value) const = 0;
+
+    virtual bool getAttr(const char* key, AZ::Vector2& value) const = 0;
+    virtual bool getAttr(const char* key, AZ::Vector3& value) const = 0;
+    virtual bool getAttr(const char* key, AZ::Vector4& value) const = 0;
+    virtual bool getAttr(const char* key, AZ::Quaternion& value) const = 0;
+    
     virtual bool getAttr(const char* key, Vec2& value) const = 0;
     virtual bool getAttr(const char* key, Ang3& value) const = 0;
     virtual bool getAttr(const char* key, Vec3& value) const = 0;

--- a/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
+++ b/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
@@ -194,6 +194,66 @@ bool CBinaryXmlNode::getAttr(const char* key, Ang3& value) const
     return false;
 }
 
+bool CBinaryXmlNode::getAttr(const char* key, AZ::Vector3& value) const
+{
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        float x, y, z;
+        if (azsscanf(svalue, "%f,%f,%f", &x, &y, &z) == 3)
+        {
+            value.Set(x, y, z);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CBinaryXmlNode::getAttr(const char* key, AZ::Vector4& value) const
+{
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        float x, y, z, w;
+        if (azsscanf(svalue, "%f,%f,%f,%f", &x, &y, &z, &w) == 4)
+        {
+            value.Set(x, y, z, w);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CBinaryXmlNode::getAttr(const char* key, AZ::Vector2& value) const
+{
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        float x, y;
+        if (azsscanf(svalue, "%f,%f", &x, &y) == 2)
+        {
+            value.Set(x, y);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CBinaryXmlNode::getAttr(const char* key, AZ::Quaternion& value) const
+{
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        float w, x, y, z;
+        if (azsscanf(svalue, "%f,%f,%f,%f", &w, &x, &y, &z) == 4)
+        {
+            value.Set(w, x, y, z);
+            return true;
+        }
+    }
+    return false;
+}
+
 //////////////////////////////////////////////////////////////////////////
 bool CBinaryXmlNode::getAttr(const char* key, Vec3& value) const
 {

--- a/Code/Legacy/CrySystem/XML/XMLBinaryNode.h
+++ b/Code/Legacy/CrySystem/XML/XMLBinaryNode.h
@@ -150,6 +150,10 @@ public:
     void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const Vec3& value) override { assert(0); };
     void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const Vec4& value) override { assert(0); };
     void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const Quat& value) override { assert(0); };
+    void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const AZ::Vector4& value) override { assert(0); };
+    void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const AZ::Vector3& value) override { assert(0); };
+    void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const AZ::Vector2& value) override { assert(0); };
+    void setAttr([[maybe_unused]] const char* key, [[maybe_unused]] const AZ::Quaternion& value) override { assert(0); };
     void delAttr([[maybe_unused]] const char* key) override { assert(0); };
     void removeAllAttributes() override { assert(0); };
 
@@ -168,6 +172,12 @@ public:
     bool getAttr(const char* key, Vec4& value) const override;
     bool getAttr(const char* key, Quat& value) const override;
     bool getAttr(const char* key, ColorB& value) const override;
+
+
+    bool getAttr(const char* key, AZ::Vector2& value) const override;
+    bool getAttr(const char* key, AZ::Vector3& value) const override;
+    bool getAttr(const char* key, AZ::Vector4& value) const override;
+    bool getAttr(const char* key, AZ::Quaternion& value) const override;
 
 private:
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -330,6 +330,39 @@ void CXmlNode::setAttr(const char* key, const Vec4& value)
     setAttr(key, str);
 }
 
+
+void CXmlNode::setAttr(const char* key, const AZ::Vector2& value)
+{
+    char str[128];
+    SCOPED_LOCALE_RESETTER;
+    sprintf_s(str, FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY());
+    setAttr(key, str);
+}
+
+void CXmlNode::setAttr(const char* key, const AZ::Vector3& value)
+{
+    char str[128];
+    SCOPED_LOCALE_RESETTER;
+    sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY(), value.GetZ());
+    setAttr(key, str);
+}
+
+void CXmlNode::setAttr(const char* key, const AZ::Vector4& value)
+{
+    char str[128];
+    SCOPED_LOCALE_RESETTER;
+    sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY(), value.GetZ(), value.GetW());
+    setAttr(key, str);
+}
+
+void CXmlNode::setAttr(const char* key, const AZ::Quaternion& value)
+{
+    char str[128];
+    SCOPED_LOCALE_RESETTER;
+    sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetW(), value.GetX(), value.GetY(), value.GetZ());
+    setAttr(key, str);
+}
+
 void CXmlNode::setAttr(const char* key, const Vec2& value)
 {
     char str[128];
@@ -450,6 +483,7 @@ bool CXmlNode::getAttr(const char* key, Ang3& value) const
         {
             value(x, y, z);
             return true;
+
         }
     }
     return false;
@@ -487,6 +521,70 @@ bool CXmlNode::getAttr(const char* key, Vec4& value) const
         }
     }
 
+    return false;
+}
+
+bool CXmlNode::getAttr(const char* key, AZ::Vector2& value) const {
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        SCOPED_LOCALE_RESETTER;
+        float x, y;
+        if (azsscanf(svalue, "%f,%f", &x, &y) == 2)
+        {
+            value.Set(x, y);
+            return true;
+        }
+    }
+    return false;
+
+}
+
+bool CXmlNode::getAttr(const char* key, AZ::Vector3& value) const {
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        float x, y, z;
+        if (azsscanf(svalue, "%f,%f,%f", &x, &y, &z) == 3)
+        {
+            value.Set(x, y, z);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CXmlNode::getAttr(const char* key, AZ::Vector4& value) const {
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        SCOPED_LOCALE_RESETTER;
+        float x, y, z, w;
+        if (azsscanf(svalue, "%f,%f,%f,%f", &x, &y, &z, &w) == 4)
+        {
+            value.Set(x, y, z, w);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool CXmlNode::getAttr(const char* key, AZ::Quaternion& value) const {
+    const char* svalue = GetValue(key);
+    if (svalue)
+    {
+        SCOPED_LOCALE_RESETTER;
+        float w, x, y, z;
+        if (azsscanf(svalue, "%f,%f,%f,%f", &w, &x, &y, &z) == 4)
+        {
+            if (fabs(w) > VEC_EPSILON || fabs(x) > VEC_EPSILON || fabs(y) > VEC_EPSILON || fabs(z) > VEC_EPSILON)
+            {
+                value.Set(x,y,z,w);
+                return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -334,7 +334,6 @@ void CXmlNode::setAttr(const char* key, const Vec4& value)
 void CXmlNode::setAttr(const char* key, const AZ::Vector2& value)
 {
     char str[128];
-    SCOPED_LOCALE_RESETTER;
     sprintf_s(str, FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY());
     setAttr(key, str);
 }
@@ -342,7 +341,6 @@ void CXmlNode::setAttr(const char* key, const AZ::Vector2& value)
 void CXmlNode::setAttr(const char* key, const AZ::Vector3& value)
 {
     char str[128];
-    SCOPED_LOCALE_RESETTER;
     sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY(), value.GetZ());
     setAttr(key, str);
 }
@@ -350,7 +348,6 @@ void CXmlNode::setAttr(const char* key, const AZ::Vector3& value)
 void CXmlNode::setAttr(const char* key, const AZ::Vector4& value)
 {
     char str[128];
-    SCOPED_LOCALE_RESETTER;
     sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetX(), value.GetY(), value.GetZ(), value.GetW());
     setAttr(key, str);
 }
@@ -358,7 +355,6 @@ void CXmlNode::setAttr(const char* key, const AZ::Vector4& value)
 void CXmlNode::setAttr(const char* key, const AZ::Quaternion& value)
 {
     char str[128];
-    SCOPED_LOCALE_RESETTER;
     sprintf_s(str, FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT "," FLOAT_FMT, value.GetW(), value.GetX(), value.GetY(), value.GetZ());
     setAttr(key, str);
 }
@@ -528,7 +524,6 @@ bool CXmlNode::getAttr(const char* key, AZ::Vector2& value) const {
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        SCOPED_LOCALE_RESETTER;
         float x, y;
         if (azsscanf(svalue, "%f,%f", &x, &y) == 2)
         {
@@ -558,7 +553,6 @@ bool CXmlNode::getAttr(const char* key, AZ::Vector4& value) const {
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        SCOPED_LOCALE_RESETTER;
         float x, y, z, w;
         if (azsscanf(svalue, "%f,%f,%f,%f", &x, &y, &z, &w) == 4)
         {
@@ -574,7 +568,6 @@ bool CXmlNode::getAttr(const char* key, AZ::Quaternion& value) const {
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        SCOPED_LOCALE_RESETTER;
         float w, x, y, z;
         if (azsscanf(svalue, "%f,%f,%f,%f", &w, &x, &y, &z) == 4)
         {
@@ -1813,7 +1806,4 @@ void CXmlNodePool::OnRelease(int iRefCount, void* pThis)
         }
     }
 }
-
-#undef SCOPED_LOCALE_RESETTER
-
 

--- a/Code/Legacy/CrySystem/XML/xml.h
+++ b/Code/Legacy/CrySystem/XML/xml.h
@@ -209,6 +209,11 @@ public:
     void setAttr(const char* key, const Vec4& value) override;
     void setAttr(const char* key, const Quat& value) override;
 
+    void setAttr(const char* key, const AZ::Vector2& value) override;
+    void setAttr(const char* key, const AZ::Vector3& value) override;
+    void setAttr(const char* key, const AZ::Vector4& value) override;
+    void setAttr(const char* key, const AZ::Quaternion& value) override;
+
     //! Delete attrbute.
     void delAttr(const char* key) override;
     //! Remove all node attributes.
@@ -225,6 +230,11 @@ public:
 
     bool getAttr(const char* key, XmlString& value) const override
     {const char*    v(NULL); bool  boHasAttribute(getAttr(key, &v)); value = v; return boHasAttribute; }
+
+    virtual bool getAttr(const char* key, AZ::Quaternion& value) const override;
+    virtual bool getAttr(const char* key, AZ::Vector2& value) const override;
+    virtual bool getAttr(const char* key, AZ::Vector3& value) const override;
+    virtual bool getAttr(const char* key, AZ::Vector4& value) const override;
 
     bool getAttr(const char* key, Vec2& value) const override;
     bool getAttr(const char* key, Ang3& value) const override;


### PR DESCRIPTION
## What does this PR do?
Migrated math types under Variable.h to AZ Math type. Doesn't seem like CEntityObject is used too much in the code might be better to omit this change and start pruning the other uses and remove this piece wholesale. All the variables under Export does not seem to be called from anywhere in the repository so I can safely remove this wholesale, then I don't have to try and migrate any of the Variable types used here. 

CSmartVariable/Variable types are still used quite a lot. 
