### PR TITLE
feat: remove unused call for IsLightClass

### DIFF
--- a/Code/Editor/Include/IObjectManager.h
+++ b/Code/Editor/Include/IObjectManager.h
@@ -105,6 +105,4 @@ public:
     //////////////////////////////////////////////////////////////////////////
     // Gathers all resources used by all objects.
     virtual void GatherUsedResources(CUsedResources& resources) = 0;
-
-    virtual bool IsLightClass(CBaseObject* pObject) = 0;
 };

--- a/Code/Editor/Objects/EntityObject.cpp
+++ b/Code/Editor/Objects/EntityObject.cpp
@@ -564,44 +564,6 @@ struct IVariableType<Vec3>
     };
 };
 
-void CEntityObject::DrawExtraLightInfo(DisplayContext& dc)
-{
-    IObjectManager* objMan = GetIEditor()->GetObjectManager();
-
-    if (objMan)
-    {
-        if (objMan->IsLightClass(this) && GetProperties())
-        {
-            QString csText("");
-
-            if (GetEntityPropertyBool("bAmbient"))
-            {
-                csText += "A";
-            }
-
-            if (!GetEntityPropertyString("texture_Texture").isEmpty())
-            {
-                csText += "P";
-            }
-
-            int nLightType = GetEntityPropertyInteger("nCastShadows");
-            if (nLightType > 0)
-            {
-                csText += "S";
-            }
-
-            float fScale = GetIEditor()->GetViewManager()->GetView(ET_ViewportUnknown)->GetScreenScaleFactor(GetWorldPos());
-            Vec3 vDrawPos(GetWorldPos());
-            vDrawPos.z += fScale / 25;
-
-            ColorB col(255, 255, 255);
-            dc.SetColor(col);
-            dc.DrawTextLabel(vDrawPos, 1.3f, csText.toUtf8().data());
-        }
-    }
-}
-
-
 //////////////////////////////////////////////////////////////////////////
 void CEntityObject::DrawProjectorPyramid(DisplayContext& dc, float dist)
 {

--- a/Code/Editor/Objects/EntityObject.h
+++ b/Code/Editor/Objects/EntityObject.h
@@ -20,10 +20,6 @@
 #include <QObject>
 #endif
 
-#define CLASS_LIGHT "Light"
-#define CLASS_DESTROYABLE_LIGHT "DestroyableLight"
-#define CLASS_RIGIDBODY_LIGHT "RigidBodyLight"
-
 class CEntityObject;
 class QMenu;
 
@@ -79,7 +75,6 @@ public:
     void InitVariables() override;
     void Done() override;
 
-    void DrawExtraLightInfo (DisplayContext& disp);
 
     bool GetEntityPropertyBool(const char* name) const;
     int GetEntityPropertyInteger(const char* name) const;

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -791,32 +791,6 @@ void CObjectManager::GatherUsedResources(CUsedResources& resources)
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CObjectManager::IsLightClass(CBaseObject* pObject)
-{
-    if (qobject_cast<CEntityObject*>(pObject))
-    {
-        CEntityObject* pEntity = (CEntityObject*)pObject;
-        if (pEntity)
-        {
-            if (pEntity->GetEntityClass().compare(CLASS_LIGHT) == 0)
-            {
-                return true;
-            }
-            if (pEntity->GetEntityClass().compare(CLASS_RIGIDBODY_LIGHT) == 0)
-            {
-                return true;
-            }
-            if (pEntity->GetEntityClass().compare(CLASS_DESTROYABLE_LIGHT) == 0)
-            {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-//////////////////////////////////////////////////////////////////////////
 namespace
 {
     AZStd::vector<AZStd::string> PyGetAllObjects()

--- a/Code/Editor/Objects/ObjectManager.h
+++ b/Code/Editor/Objects/ObjectManager.h
@@ -106,8 +106,6 @@ public:
     // Gathers all resources used by all objects.
     void GatherUsedResources(CUsedResources& resources) override;
 
-    bool IsLightClass(CBaseObject* pObject) override;
-
     int GetAxisHelperHitRadius() const override { return m_axisHelperHitRadius; }
 
 private:


### PR DESCRIPTION
## What does this PR do?

These methods: DrawExtraLightInfo and IsLightClass is unused.  this can be easily removed from EntityObject. 