### PR TITLE
Fix logic for determining the file extension for shader files

### DIFF
--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShader.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShader.py
@@ -5,6 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
+import os
 import sys
 import GenerateShaderVariantListUtil
 
@@ -16,9 +17,9 @@ def main():
         return
 
     inputPath = sys.argv[1]
-    suffix, extension = inputPath.split(".", 1)
-
-    if extension != "shader":
+    _, extension = os.path.splitext(inputPath)
+    
+    if extension != ".shader":
         print("The input argument for the script is not a valid .shader file")
         return
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInProjectFolder.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInProjectFolder.py
@@ -20,9 +20,8 @@ def main():
         return
 
     inputPath = sys.argv[1]
-    rootPath, extension = inputPath.split(".", 1)
-
-    if extension != "shader":
+    rootPath, extension = os.path.splitext(inputPath)
+    if extension != ".shader":
         print("The input argument for the script is not a valid .shader file")
         return
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInSameFolder.py
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Scripts/CreateShaderVariantListDocumentFromShaderInSameFolder.py
@@ -20,9 +20,9 @@ def main():
         return
 
     inputPath = sys.argv[1]
-    rootPath, extension = inputPath.split(".", 1)
+    rootPath, extension = os.path.splitext(inputPath)
 
-    if extension != "shader":
+    if extension != ".shader":
         print("The input argument for the script is not a valid .shader file")
         return
 


### PR DESCRIPTION
## What does this PR do?

Fixes an issue recognizing files as shader files on systems that have a "." in the full path. The original logic both uses the improper approach to determine a file extension and assumes that the only "." is used to deliminate the extension.

## How was this PR tested?
Run on the Shader Management Console on Linux (after applying a temporary fix for the python loading)


