### PR TITLE
feat: add packed vector variants for 2/4 with unit tests

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/PackedVector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/PackedVector2.h
@@ -7,59 +7,56 @@
  */
 
 #pragma once
-#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector2.h>
 #include <AzCore/RTTI/TypeInfo.h>
 
 namespace AZ
 {
     template<typename TYPE>
-    class PackedVector3
+    class PackedVector2
     {
     public:
         //===============================================================
         // Constructors.
         //===============================================================
-        PackedVector3();
-        explicit PackedVector3(TYPE initValue);
-        PackedVector3(TYPE x, TYPE y, TYPE z);
-        explicit PackedVector3(const AZ::Vector3& rhs);
-        explicit PackedVector3(const TYPE* initData);
+        PackedVector2();
+        explicit PackedVector2(TYPE initValue);
+        PackedVector2(TYPE x, TYPE y);
+        explicit PackedVector2(const AZ::Vector2& rhs);
+        explicit PackedVector2(const TYPE* initData);
 
         //===============================================================
         // Conversions.
         //===============================================================
         explicit operator TYPE* ();
         explicit operator const TYPE* () const;
-        explicit operator AZ::Vector3() const;
+        explicit operator AZ::Vector2() const;
 
         //===============================================================
         // Interface.
         //===============================================================
-        void Set(TYPE x, TYPE y, TYPE z);
+        void Set(TYPE x, TYPE y);
 
         TYPE GetElement(size_t index) const;
         void SetElement(size_t index, TYPE val);
 
         TYPE GetX() const;
         TYPE GetY() const;
-        TYPE GetZ() const;
         void SetX(TYPE v);
         void SetY(TYPE v);
-        void SetZ(TYPE v);
 
     private:
         TYPE m_x;
         TYPE m_y;
-        TYPE m_z;
     };
 
-    AZ_TYPE_INFO_TEMPLATE(PackedVector3, "{AE80F5E2-F809-4E2A-AE63-39F171C62819}", AZ_TYPE_INFO_TYPENAME);
+    AZ_TYPE_INFO_TEMPLATE(PackedVector2, "{C20DBD4B-5542-4FAE-9BE2-BD1DD3027417}", AZ_TYPE_INFO_TYPENAME);
 
     //===============================================================
     // Standard type variations.
     //===============================================================
-    using PackedVector3f = PackedVector3<float>;
-    using PackedVector3i = PackedVector3<int32_t>;
+    using PackedVector2f = PackedVector2<float>;
+    using PackedVector2i = PackedVector2<int32_t>;
 
 
     //===============================================================
@@ -67,110 +64,94 @@ namespace AZ
     //===============================================================
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3()
+    PackedVector2<TYPE>::PackedVector2()
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(TYPE initValue)
+    PackedVector2<TYPE>::PackedVector2(TYPE initValue)
         : m_x(initValue)
         , m_y(initValue)
-        , m_z(initValue)
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(TYPE x, TYPE y, TYPE z)
+    PackedVector2<TYPE>::PackedVector2(TYPE x, TYPE y)
         : m_x(x)
         , m_y(y)
-        , m_z(z)
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(const AZ::Vector3& rhs)
+    PackedVector2<TYPE>::PackedVector2(const AZ::Vector2& rhs)
         : m_x(rhs.GetX())
         , m_y(rhs.GetY())
-        , m_z(rhs.GetZ())
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(const TYPE* initData)
+    PackedVector2<TYPE>::PackedVector2(const TYPE* initData)
         : m_x(initData[0])
         , m_y(initData[1])
-        , m_z(initData[2])
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator TYPE* ()
+    PackedVector2<TYPE>::operator TYPE* ()
     {
         return &m_x;
     }
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator const TYPE* () const
+    PackedVector2<TYPE>::operator const TYPE* () const
     {
         return &m_x;
     }
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator AZ::Vector3() const
+    PackedVector2<TYPE>::operator AZ::Vector2() const
     {
-        return AZ::Vector3(m_x, m_y, m_z);
+        return AZ::Vector2(m_x, m_y);
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::Set(TYPE x, TYPE y, TYPE z)
+    void PackedVector2<TYPE>::Set(TYPE x, TYPE y)
     {
         m_x = x;
         m_y = y;
-        m_z = z;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetElement(size_t index) const
+    TYPE PackedVector2<TYPE>::GetElement(size_t index) const
     {
-        AZ_MATH_ASSERT(index < 3, "access beyond bounds of PackedVector3");
+        AZ_MATH_ASSERT(index < 2, "access beyond bounds of PackedVector4");
         return reinterpret_cast<const TYPE*>(this)[index];
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetElement(size_t index, TYPE val)
+    void PackedVector2<TYPE>::SetElement(size_t index, TYPE val)
     {
-        AZ_MATH_ASSERT(index < 3, "access beyond bounds of PackedVector3");
+        AZ_MATH_ASSERT(index < 2, "access beyond bounds of PackedVector4");
         reinterpret_cast<TYPE*>(this)[index] = val;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetX() const
+    TYPE PackedVector2<TYPE>::GetX() const
     {
         return m_x;
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetX(TYPE v)
+    void PackedVector2<TYPE>::SetX(TYPE v)
     {
         m_x = v;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetY() const
+    TYPE PackedVector2<TYPE>::GetY() const
     {
         return m_y;
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetY(TYPE v)
+    void PackedVector2<TYPE>::SetY(TYPE v)
     {
         m_y = v;
     }
-
-    template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetZ() const
-    {
-        return m_z;
-    }
-
-    template<typename TYPE>
-    void PackedVector3<TYPE>::SetZ(TYPE v)
-    {
-        m_z = v;
-    }
 }
+

--- a/Code/Framework/AzCore/AzCore/Math/PackedVector4.h
+++ b/Code/Framework/AzCore/AzCore/Math/PackedVector4.h
@@ -7,35 +7,35 @@
  */
 
 #pragma once
-#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector4.h>
 #include <AzCore/RTTI/TypeInfo.h>
 
 namespace AZ
 {
     template<typename TYPE>
-    class PackedVector3
+    class PackedVector4
     {
     public:
         //===============================================================
         // Constructors.
         //===============================================================
-        PackedVector3();
-        explicit PackedVector3(TYPE initValue);
-        PackedVector3(TYPE x, TYPE y, TYPE z);
-        explicit PackedVector3(const AZ::Vector3& rhs);
-        explicit PackedVector3(const TYPE* initData);
+        PackedVector4();
+        explicit PackedVector4(TYPE initValue);
+        PackedVector4(TYPE x, TYPE y, TYPE z, TYPE w);
+        explicit PackedVector4(const AZ::Vector4& rhs);
+        explicit PackedVector4(const TYPE* initData);
 
         //===============================================================
         // Conversions.
         //===============================================================
         explicit operator TYPE* ();
         explicit operator const TYPE* () const;
-        explicit operator AZ::Vector3() const;
+        explicit operator AZ::Vector4() const;
 
         //===============================================================
         // Interface.
-        //===============================================================
-        void Set(TYPE x, TYPE y, TYPE z);
+        //======================
+        void Set(TYPE x, TYPE y, TYPE z, TYPE w);
 
         TYPE GetElement(size_t index) const;
         void SetElement(size_t index, TYPE val);
@@ -43,23 +43,26 @@ namespace AZ
         TYPE GetX() const;
         TYPE GetY() const;
         TYPE GetZ() const;
+        TYPE GetW() const;
         void SetX(TYPE v);
         void SetY(TYPE v);
         void SetZ(TYPE v);
+        void SetW(TYPE v);
 
     private:
         TYPE m_x;
         TYPE m_y;
         TYPE m_z;
+        TYPE m_w;
     };
 
-    AZ_TYPE_INFO_TEMPLATE(PackedVector3, "{AE80F5E2-F809-4E2A-AE63-39F171C62819}", AZ_TYPE_INFO_TYPENAME);
+    AZ_TYPE_INFO_TEMPLATE(PackedVector4, "{E01FF5C3-0346-4B84-912A-967CB9A21EDB}", AZ_TYPE_INFO_TYPENAME);
 
     //===============================================================
     // Standard type variations.
     //===============================================================
-    using PackedVector3f = PackedVector3<float>;
-    using PackedVector3i = PackedVector3<int32_t>;
+    using PackedVector4f = PackedVector4<float>;
+    using PackedVector4i = PackedVector4<int32_t>;
 
 
     //===============================================================
@@ -67,110 +70,129 @@ namespace AZ
     //===============================================================
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3()
+    PackedVector4<TYPE>::PackedVector4()
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(TYPE initValue)
+    PackedVector4<TYPE>::PackedVector4(TYPE initValue)
         : m_x(initValue)
         , m_y(initValue)
         , m_z(initValue)
+        , m_w(initValue)
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(TYPE x, TYPE y, TYPE z)
+    PackedVector4<TYPE>::PackedVector4(TYPE x, TYPE y, TYPE z, TYPE w)
         : m_x(x)
         , m_y(y)
         , m_z(z)
+        , m_w(w)
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(const AZ::Vector3& rhs)
+    PackedVector4<TYPE>::PackedVector4(const AZ::Vector4& rhs)
         : m_x(rhs.GetX())
         , m_y(rhs.GetY())
         , m_z(rhs.GetZ())
+        , m_w(rhs.GetW())
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::PackedVector3(const TYPE* initData)
+    PackedVector4<TYPE>::PackedVector4(const TYPE* initData)
         : m_x(initData[0])
         , m_y(initData[1])
         , m_z(initData[2])
+        , m_w(initData[3])
     {}
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator TYPE* ()
+    PackedVector4<TYPE>::operator TYPE* ()
     {
         return &m_x;
     }
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator const TYPE* () const
+    PackedVector4<TYPE>::operator const TYPE* () const
     {
         return &m_x;
     }
 
     template<typename TYPE>
-    PackedVector3<TYPE>::operator AZ::Vector3() const
+    PackedVector4<TYPE>::operator AZ::Vector4() const
     {
-        return AZ::Vector3(m_x, m_y, m_z);
+        return AZ::Vector4(m_x, m_y, m_z, m_w);
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::Set(TYPE x, TYPE y, TYPE z)
+    void PackedVector4<TYPE>::Set(TYPE x, TYPE y, TYPE z, TYPE w)
     {
         m_x = x;
         m_y = y;
         m_z = z;
+        m_w = w;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetElement(size_t index) const
+    TYPE PackedVector4<TYPE>::GetElement(size_t index) const
     {
-        AZ_MATH_ASSERT(index < 3, "access beyond bounds of PackedVector3");
+        AZ_MATH_ASSERT(index < 4, "access beyond bounds of PackedVector4");
         return reinterpret_cast<const TYPE*>(this)[index];
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetElement(size_t index, TYPE val)
+    void PackedVector4<TYPE>::SetElement(size_t index, TYPE val)
     {
-        AZ_MATH_ASSERT(index < 3, "access beyond bounds of PackedVector3");
+        AZ_MATH_ASSERT(index < 4, "access beyond bounds of PackedVector4");
         reinterpret_cast<TYPE*>(this)[index] = val;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetX() const
+    TYPE PackedVector4<TYPE>::GetX() const
     {
         return m_x;
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetX(TYPE v)
+    void PackedVector4<TYPE>::SetX(TYPE v)
     {
         m_x = v;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetY() const
+    TYPE PackedVector4<TYPE>::GetY() const
     {
         return m_y;
     }
 
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetY(TYPE v)
+    void PackedVector4<TYPE>::SetY(TYPE v)
     {
         m_y = v;
     }
 
     template<typename TYPE>
-    TYPE PackedVector3<TYPE>::GetZ() const
+    TYPE PackedVector4<TYPE>::GetZ() const
     {
         return m_z;
     }
 
+
     template<typename TYPE>
-    void PackedVector3<TYPE>::SetZ(TYPE v)
+    void PackedVector4<TYPE>::SetZ(TYPE v)
     {
         m_z = v;
     }
+
+template<typename TYPE>
+    void PackedVector4<TYPE>::SetW(TYPE v)
+    {
+        m_w = v;
+    }
+
+    template<typename TYPE>
+    TYPE PackedVector4<TYPE>::GetW() const
+    {
+        return m_w;
+    }
 }
+

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -401,7 +401,9 @@ set(FILES
     Math/VertexContainer.h
     Math/VertexContainer.cpp
     Math/VertexContainerInterface.h
+    Math/PackedVector2.h
     Math/PackedVector3.h
+    Math/PackedVector4.h
     Math/Color.h
     Math/Color.cpp
     Math/ColorSerializer.h

--- a/Code/Framework/AzCore/Tests/Math/PackedVectorTest.cpp
+++ b/Code/Framework/AzCore/Tests/Math/PackedVectorTest.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/PackedVector4.h>
+#include <AzCore/Math/PackedVector3.h>
+#include <AzCore/Math/PackedVector2.h>
+#include <Math/MathTest.h>
+
+namespace UnitTest
+{
+    TEST(MATH_PackedVector2, TestConstructors)
+    {
+        EXPECT_THAT(static_cast<AZ::Vector2>(AZ::PackedVector2f(1.0f, 3.0f)), IsClose(AZ::Vector2(1.0f, 3.0f)));
+        EXPECT_THAT(static_cast<AZ::Vector2>(AZ::PackedVector2f(1.0f)), IsClose(AZ::Vector2(1.0f, 1.0f)));
+
+        AZ::PackedVector2f vC(1.0f, 2.0f);
+        EXPECT_FLOAT_EQ(vC.GetX(), 1.0f);
+        EXPECT_FLOAT_EQ(vC.GetY(), 2.0f);
+
+        AZ::PackedVector2f vb(1.0f, 2.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(0), 1.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(1), 2.0f);
+    }
+
+    TEST(MATH_PackedVector2, TestStoreFloat)
+    {
+        AZ::PackedVector2f values(0.0f, 0.0f);
+
+        AZ::Vector2 vA(1.0f, 2.0f);
+        vA.StoreToFloat2(static_cast<float*>(values));
+        EXPECT_EQ(values.GetX(), 1.0f);
+        EXPECT_EQ(values.GetY(), 2.0f);
+    }
+
+    TEST(MATH_PackedVector3, TestConstructors)
+    {
+        EXPECT_THAT(static_cast<AZ::Vector3>(AZ::PackedVector3f(1.0f, 3.0f, 2.0f)), IsClose(AZ::Vector3(1.0f, 3.0f, 2.0f)));
+        EXPECT_THAT(static_cast<AZ::Vector3>(AZ::PackedVector3f(1.0f)), IsClose(AZ::Vector3(1.0f, 1.0f, 1.0f)));
+
+        AZ::PackedVector3f vC(1.0f, 2.0f, 4.0f);
+        EXPECT_FLOAT_EQ(vC.GetX(), 1.0f);
+        EXPECT_FLOAT_EQ(vC.GetY(), 2.0f);
+        EXPECT_FLOAT_EQ(vC.GetZ(), 4.0f);
+
+        AZ::PackedVector3f vb(1.0f, 2.0f, 4.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(0), 1.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(1), 2.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(2), 4.0f);
+    }
+
+    TEST(MATH_PackedVector3, TestStoreFloat)
+    {
+        AZ::PackedVector3f values(0.0f, 0.0f, 0.0f);
+
+        AZ::Vector3 vA(1.0f, 2.0f, 5.0f);
+        vA.StoreToFloat3(static_cast<float*>(values));
+        EXPECT_EQ(values.GetX(), 1.0f);
+        EXPECT_EQ(values.GetY(), 2.0f);
+        EXPECT_EQ(values.GetZ(), 5.0f);
+    }
+
+    TEST(MATH_PackedVector4, TestConstructors)
+    {
+        EXPECT_THAT(static_cast<AZ::Vector4>(AZ::PackedVector4f(1.0f, 3.0f, 5.0f, 1.0f)), IsClose(AZ::Vector4(1.0f, 3.0f, 5.0f, 1.0f)));
+        EXPECT_THAT(static_cast<AZ::Vector4>(AZ::PackedVector4f(1.0f)), IsClose(AZ::Vector4(1.0f, 1.0f, 1.0f, 1.0f)));
+
+        AZ::PackedVector4f vC(1.0f, 2.0f, 5.0f, 3.0f);
+        EXPECT_FLOAT_EQ(vC.GetX(), 1.0f);
+        EXPECT_FLOAT_EQ(vC.GetY(), 2.0f);
+        EXPECT_FLOAT_EQ(vC.GetZ(), 5.0f);
+        EXPECT_FLOAT_EQ(vC.GetW(), 3.0f);
+
+        AZ::PackedVector4f vb(1.0f, 2.0f, 5.0f, 3.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(0), 1.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(1), 2.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(2), 5.0f);
+        EXPECT_FLOAT_EQ(vb.GetElement(3), 3.0f);
+    }
+
+    TEST(MATH_PackedVector4, TestStoreFloat)
+    {
+        AZ::PackedVector4f values(0.0f, 0.0f, 0.0f, 0.0f);
+
+        AZ::Vector4 vA(1.0f, 2.0f, 5.0f, 6.0f);
+        vA.StoreToFloat4(static_cast<float*>(values));
+        EXPECT_EQ(values.GetX(), 1.0f);
+        EXPECT_EQ(values.GetY(), 2.0f);
+        EXPECT_EQ(values.GetZ(), 5.0f);
+        EXPECT_EQ(values.GetW(), 6.0f);
+    }
+
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -163,6 +163,7 @@ set(FILES
     Math/Vector4Tests.cpp
     Math/VectorNTests.cpp
     Math/VectorNPerformanceTests.cpp
+    Math/PackedVectorTest.cpp
     Memory/AllocatorBenchmarks.cpp
     Memory/HphaAllocator.cpp
     Memory/HphaAllocatorErrorDetection.cpp

--- a/scripts/commit_validation/commit_validation/pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/pal_allowedlist.txt
@@ -6,6 +6,8 @@
 */Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
 */Code/Framework/AzCore/AzCore/Math/Obb.h
 */Code/Framework/AzCore/AzCore/Math/PackedVector3.h
+*/Code/Framework/AzCore/AzCore/Math/PackedVector2.h
+*/Code/Framework/AzCore/AzCore/Math/PackedVector4.h
 */Code/Framework/AzCore/AzCore/Math/Plane.h
 */Code/Framework/AzCore/AzCore/Math/Quaternion.h
 */Code/Framework/AzCore/AzCore/Math/Transform.h


### PR DESCRIPTION
## What does this PR do?
introducing a packed variants for vector2/4 seems to make a lot of sense. its not too uncommon to have a packed float4 stream or some variants or a 2/2. 

probably should for the struct to be packed because  because depending on the system padding might be inserted before or after or between member variables. for 64 bit systems its multiples of 4 so 3 uint16 with have an extra uint16 added at the end for alignment I believe. 

## How was this PR tested?

run unit test included