### PR TITLE
A few small improvements for the editor startup time

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1223,6 +1223,9 @@ void CCryEditApp::CompileCriticalAssets() const
                 assetCatalogRequests->LoadCatalog(assetCatalogPath.c_str());
             }
         };
+
+        CCryEditApp::OutputStartupMessage(QString("Loading Asset Catalog..."));
+
         AZ::Data::AssetCatalogRequestBus::Broadcast(AZStd::move(LoadCatalog));
 
         // Only signal the event *after* the asset catalog has been loaded.
@@ -1605,6 +1608,8 @@ bool CCryEditApp::InitInstance()
     // It will be launched if not running
     ConnectToAssetProcessor();
 
+    CCryEditApp::OutputStartupMessage(QString("Initializing Game System..."));
+
     auto initGameSystemOutcome = InitGameSystem(mainWindowWrapperHwnd);
     if (!initGameSystemOutcome.IsSuccess())
     {
@@ -1641,6 +1646,8 @@ bool CCryEditApp::InitInstance()
 
     // Meant to be called before MainWindow::Initialize
     InitPlugins();
+
+    CCryEditApp::OutputStartupMessage(QString("Initializing Main Window..."));
 
     mainWindow->Initialize();
 
@@ -1691,6 +1698,8 @@ bool CCryEditApp::InitInstance()
     SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectDisplayName().c_str(), nullptr);
     m_pEditor->InitFinished();
 
+    CCryEditApp::OutputStartupMessage(QString("Activating Python..."));
+
     // Make sure Python is started before we attempt to restore the Editor layout, since the user
     // might have custom view panes in the saved layout that will need to be registered.
     auto editorPythonEventsInterface = AZ::Interface<AzToolsFramework::EditorPythonEventsInterface>::Get();
@@ -1698,6 +1707,9 @@ bool CCryEditApp::InitInstance()
     {
         editorPythonEventsInterface->StartPython();
     }
+
+    CCryEditApp::OutputStartupMessage(QString("")); // add a blank line so that python is not blamed for anything that happens here
+
 
     if (!GetIEditor()->IsInConsolewMode())
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -264,7 +264,7 @@ namespace AzToolsFramework
             const AssetBrowserEntry* item = static_cast<const AssetBrowserEntry*>(parent.internalPointer());
 
             // We should only have an item as a folder but will check
-            if (item && (item->RTTI_IsTypeOf(FolderAssetBrowserEntry::RTTI_Type())))
+            if (item && (item->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder))
             {
                 AZStd::vector<const AssetBrowserEntry*> entries;
 
@@ -581,7 +581,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            if (azrtti_istypeof<RootAssetBrowserEntry*>(entry))
+            if (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Root)
             {
                 index = QModelIndex();
                 return true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.h
@@ -39,10 +39,11 @@ namespace AzToolsFramework
             TableIterator TableBegin();
             TableIterator TableEnd();
             bool Empty() const;
+            void Reserve(TableMap::size_type size);
             bool TreeContains(TableType map) const;
             TreeType TreeToTable(TableType map) const;
             bool RemoveFromTree(TableType map);
-            TreeIterator Insert(TableType tmap, TreeType row);
+            void Insert(TableType tmap, TreeType row);
             void Clear();
 
         protected:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -438,13 +438,14 @@ namespace AzToolsFramework
         bool AssetBrowserEntry::lessThan(const AssetBrowserEntry* other, const AssetEntrySortMode sortMode, const QCollator& collator) const
         {
             // folders should always come first
-            if (azrtti_istypeof<const FolderAssetBrowserEntry*>(this) && azrtti_istypeof<const SourceAssetBrowserEntry*>(other))
-            {
-                return false;
-            }
-            if (azrtti_istypeof<const SourceAssetBrowserEntry*>(this) && azrtti_istypeof<const FolderAssetBrowserEntry*>(other))
+            if (GetEntryType() == AssetEntryType::Folder && other->GetEntryType() != AssetEntryType::Folder)
             {
                 return true;
+            }
+
+            if (GetEntryType() != AssetEntryType::Folder && other->GetEntryType() == AssetEntryType::Folder)
+            {
+                return false;
             }
 
             switch (sortMode)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -241,7 +241,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            auto source = azrtti_cast<SourceAssetBrowserEntry*>(itFile->second);
+            auto source = static_cast<SourceAssetBrowserEntry*>(itFile->second); // it MUST be a source to get here.
             source->m_sourceId = sourceWithFileIdEntry.second.m_sourceID;
             source->m_sourceUuid = sourceWithFileIdEntry.second.m_sourceGuid;
             source->PathsUpdated(); // update thumbnailkey to valid uuid
@@ -424,11 +424,12 @@ namespace AzToolsFramework
         {
             auto it = AZStd::find_if(parent->m_children.begin(), parent->m_children.end(), [folderName](AssetBrowserEntry* entry)
             {
-                return azrtti_istypeof<FolderAssetBrowserEntry*>(entry) && AZ::IO::PathView(entry->m_name) == AZ::IO::PathView(folderName);
+                return (entry->GetEntryType() == AssetEntryType::Folder) && AZ::IO::PathView(entry->m_name) == AZ::IO::PathView(folderName);
             });
+            
             if (it != parent->m_children.end())
             {
-                return azrtti_cast<FolderAssetBrowserEntry*>(*it);
+                return static_cast<FolderAssetBrowserEntry*>(*it); // RTTI Cast is not necessary since find_if only returns folders.
             }
 
             auto folder = aznew FolderAssetBrowserEntry();


### PR DESCRIPTION
## What does this PR do?

Just a slight improvement to editor startup time and smoothness once its started.  

Created by using the valgrind + callgrind profiler, and then doing micro-optimizations on the resulting hot spots.
The real problem is that the actual structure / behavior of that sort filter model needs a full replacement.

For me on linux, this improved the amount of time Editor was frozen up in profile on AutomatedTesting from about 8 seconds on startup, to about 5 seconds on startup.  Not huge, but I imagine if you have a big project that might be significant percentage faster.

## How was this PR tested?

Just manual testing - starting editor in dev branch vs this other branch, poking around at the Asset Browser UI, making sure it behaved about the same as before but without as much impact on performance.