### PR TITLE
Fix the proportions of the Editor splashscreen for 23.10.3

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d682eb3cd7db2a8cf6a671071a1b5499e8d4d6cd4cc876ca976e2cf2ec07a6dc
-size 3702659
+oid sha256:079c6d28fab15dfe624307d2be81d7008cc582de496f486a604186404ca818ab
+size 903037

--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:746adf79fe5d0b1cc99e529f9280b79bf9de4d3a2b99f42c6b30ca55f46a35cd
-size 3390470
+oid sha256:d682eb3cd7db2a8cf6a671071a1b5499e8d4d6cd4cc876ca976e2cf2ec07a6dc
+size 3702659


### PR DESCRIPTION
## What does this PR do?

Fixes the proportions of the splash image for the Editor.
Note that the previous image had the wrong size, which meant that it was stretched to fit. The new proportions are how it was meant to look, and centered correctly so that the logo is framed.

(Note that this will be cherry-picked to the point release branch once it's approved in development)

Before:
![image](https://github.com/o3de/o3de/assets/82231674/751564ab-8cb5-4c22-aa9c-9b9631ebf327)

After:
![splash_after](https://github.com/o3de/o3de/assets/82231674/abc40b52-7f06-4af8-bee4-a70e26543ac7)