### PR TITLE
Add installer node label to install_mono_release

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -451,7 +451,7 @@
   },
   "install_mono_release": {
     "TAGS": [],
-    "PIPELINE_ENV":{
+    "PIPELINE_ENV": {
       "NODE_LABEL":"windows-packaging"
     },
     "COMMAND": "build_windows.cmd",

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -451,6 +451,9 @@
   },
   "install_mono_release": {
     "TAGS": [],
+    "PIPELINE_ENV":{
+      "NODE_LABEL":"windows-packaging"
+    },
     "COMMAND": "build_windows.cmd",
     "PARAMETERS": {
       "CONFIGURATION": "release",
@@ -473,7 +476,7 @@
   },
   "installer": {
     "TAGS": [],
-    "PIPELINE_ENV":{
+    "PIPELINE_ENV": {
       "NODE_LABEL":"windows-packaging"
     },
     "COMMAND": "build_installer_windows.cmd",
@@ -489,7 +492,7 @@
   },
   "installer_test": {
     "TAGS": [],
-    "PIPELINE_ENV":{
+    "PIPELINE_ENV": {
       "NODE_LABEL":"windows-installer-test"
     },
     "COMMAND": "pytest_windows.cmd",


### PR DESCRIPTION
## What does this PR do?

Adds the installer node label to the Windows `install_mono_release` build. 

Due to changes in https://github.com/o3de/o3de/pull/17623, the python venv location is now in the home path of "C:\\users\\builduser\\.o3de\\.venv" instead of the AR workspace path of "D:\\workspace\\{python_venv_path}\\.venv". This causes python path issues if the build pipeline utilizes a new instance between build steps, since the python venv runtime is not pulled again in the new instance

This change will maintain the same instance across the Windows installer pipeline to retain the venv path

## How was this PR tested?

Tested in a sandbox installer job: https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE-test_nightly-installer/detail/O3DE-test_nightly-installer/59/pipeline/485
