### PR TITLE
feat: remove unused Viewport cvar from ObjectManager

### DIFF
--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -318,7 +318,6 @@ void CEditorImpl::SetGameEngine(CGameEngine* ge)
 
     m_templateRegistry.LoadTemplates("Editor");
     m_pObjectManager->LoadClassTemplates("Editor");
-    m_pObjectManager->RegisterCVars();
 
     m_pAnimationContext->Init();
 }
@@ -969,7 +968,7 @@ bool CEditorImpl::ExecuteConsoleApp(const QString& CommandLine, QString& OutputT
 
     // Wait for the process to finish
     process.waitForFinished();
-    
+
     OutputText += process.readAllStandardOutput();
     OutputText += process.readAllStandardError();
 

--- a/Code/Editor/Include/IObjectManager.h
+++ b/Code/Editor/Include/IObjectManager.h
@@ -61,10 +61,6 @@ public:
     //! @param layer if 0 get objects for all layers, or layer to get objects from.
     virtual void GetObjects(CBaseObjectsArray& objects) const = 0;
 
-    //! Gets a radius to be used for hit tests on the axis helpers, like the transform gizmo.
-    //! @return the axis helper hit radius.
-    virtual int GetAxisHelperHitRadius() const = 0;
-
     //! Send event to all objects.
     //! Will cause OnEvent handler to be called on all objects.
     virtual void SendEvent(ObjectEvent event) = 0;

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -727,16 +727,6 @@ void CObjectManager::LoadClassTemplates(const QString& path)
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CObjectManager::RegisterCVars()
-{
-    REGISTER_CVAR2("AxisHelperHitRadius",
-        &m_axisHelperHitRadius,
-        20,
-        VF_DEV_ONLY,
-        "Adjust the hit radius used for axis helpers, like the transform gizmo.");
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CObjectManager::InvalidateVisibleList()
 {
     if (m_isUpdateVisibilityList)

--- a/Code/Editor/Objects/ObjectManager.h
+++ b/Code/Editor/Objects/ObjectManager.h
@@ -106,8 +106,6 @@ public:
     // Gathers all resources used by all objects.
     void GatherUsedResources(CUsedResources& resources) override;
 
-    int GetAxisHelperHitRadius() const override { return m_axisHelperHitRadius; }
-
 private:
     friend CObjectArchive;
     friend class CBaseObject;
@@ -160,8 +158,6 @@ private:
     bool m_isUpdateVisibilityList;
 
     uint64 m_currentHideCount;
-
-    int m_axisHelperHitRadius = 20;
 };
 
 namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?
AxisHelperHitRadius is never referenced in the code, this cvar should be easily removed.
