### PR TITLE
Fix Physics Material Assets in PhysXCommon to be processed in the AssetProcessor

### DIFF
--- a/Gems/PhysX/Common/CMakeLists.txt
+++ b/Gems/PhysX/Common/CMakeLists.txt
@@ -6,6 +6,10 @@
 #
 #
 
+add_subdirectory(Code)
+
 o3de_gem_setup("PhysXCommon")
 
-add_subdirectory(Code)
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
+endif()

--- a/Templates/DefaultProject/Template/project.json
+++ b/Templates/DefaultProject/Template/project.json
@@ -33,7 +33,6 @@
         "LyShine",
         "MiniAudio",
         "PhysX",
-        "PhysXCommon",
         "PrimitiveAssets",
         "PrefabBuilder",
         "SaveData",

--- a/Templates/DefaultProject/Template/project.json
+++ b/Templates/DefaultProject/Template/project.json
@@ -33,6 +33,7 @@
         "LyShine",
         "MiniAudio",
         "PhysX",
+        "PhysXCommon",
         "PrimitiveAssets",
         "PrefabBuilder",
         "SaveData",

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -80,12 +80,11 @@ macro(o3de_gem_setup default_gem_name)
     o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 endmacro()
 
-# resolve_all_dependent_gem_names_recursive
+# get_all_gem_dependencies
 #
-# Inspect a gem's dependencies recursively to collect of the list of gem names that the gem depends on
+# Determine all of the gem dependencies (recursively) for a given gem.
 #
 # \arg:gem_name(STRING) - Gem name whose "dependencies" will be queried from its gem.json
-# \arg:input_resolved_gem_names(LIST) - The current list of resolved gem name dependencies
 # \arg:output_resolved_gem_names(LIST) - The updated list of resolved gem name dependencies
 function(get_all_gem_dependencies gem_name output_resolved_gem_names)
 


### PR DESCRIPTION
## What does this PR do?
This fixes the situation where the Assets in the enabled 'PhysXCommon' gem was not being picked up by the Asset Processor as source assets. 

fixes https://github.com/o3de/o3de/issues/17700
fixes https://github.com/o3de/o3de/issues/17671 

## How was this PR tested?
On a new project with PhysX, PhysXCommon enabled, ran Asset Processor and confirmed the Physics Materials are processed.
