### PR TITLE
Set different max path lenghts for the different platforms

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Linux/AssetProcessor_Traits_Linux.h
+++ b/Code/Tools/AssetProcessor/Platform/Linux/AssetProcessor_Traits_Linux.h
@@ -7,5 +7,13 @@
  */
 #pragma once
 
+#include <climits>
+
+#ifndef PATH_MAX
+#pragma message "PATH_MAX not defined in <climits>. Setting it to 4096."
+#define PATH_MAX 4096
+#endif
+
 #define ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM true
 #define ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES 5
+#define ASSETPROCESSOR_TRAIT_MAX_PATH_LEN PATH_MAX

--- a/Code/Tools/AssetProcessor/Platform/Mac/AssetProcessor_Traits_Mac.h
+++ b/Code/Tools/AssetProcessor/Platform/Mac/AssetProcessor_Traits_Mac.h
@@ -7,5 +7,13 @@
  */
 #pragma once
 
+#include <sys/syslimits.h>
+
+#ifndef PATH_MAX
+#pragma message "PATH_MAX not defined in <sys/syslimits.h>. Setting it to 4096."
+#define PATH_MAX 4096
+#endif
+
 #define ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM false
 #define ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES 1
+#define ASSETPROCESSOR_TRAIT_MAX_PATH_LEN PATH_MAX

--- a/Code/Tools/AssetProcessor/Platform/Windows/AssetProcessor_Traits_Windows.h
+++ b/Code/Tools/AssetProcessor/Platform/Windows/AssetProcessor_Traits_Windows.h
@@ -9,3 +9,8 @@
 
 #define ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM false
 #define ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES 1
+
+// Even though AP can handle files with path length greater than window's legacy path length limit, we have some 3rdparty sdk's
+// which do not handle this case, therefore we will make AP fail any jobs whose either source file or output file name exceeds the windows
+// legacy path length limit
+#define ASSETPROCESSOR_TRAIT_MAX_PATH_LEN 260

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -339,7 +339,9 @@ namespace AssetProcessor
 
         if (jobInfo.m_status == JobStatus::Failed_InvalidSourceNameExceedsMaxLimit)
         {
-            response.m_jobLog.append(AZStd::string::format("Warn: Source file name exceeds the maximum length allowed (%d).", AP_MAX_PATH_LEN).c_str());
+            response.m_jobLog.append(
+                AZStd::string::format("Warn: Source file name exceeds the maximum length allowed (%d).", ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
+                    .c_str());
             response.m_isSuccess = true;
             return;
         }
@@ -804,7 +806,8 @@ namespace AssetProcessor
 
         QString fullPath = jobEntry.GetAbsoluteSourcePath();
         //set the new status
-        job.m_status = fullPath.length() < AP_MAX_PATH_LEN ? JobStatus::Failed : JobStatus::Failed_InvalidSourceNameExceedsMaxLimit;
+        job.m_status =
+            fullPath.length() < ASSETPROCESSOR_TRAIT_MAX_PATH_LEN ? JobStatus::Failed : JobStatus::Failed_InvalidSourceNameExceedsMaxLimit;
 
         JobDiagnosticInfo info{};
         JobDiagnosticRequestBus::BroadcastResult(info, &JobDiagnosticRequestBus::Events::GetDiagnosticInfo, job.m_jobRunKey);
@@ -2885,7 +2888,7 @@ namespace AssetProcessor
             if (isProductFile)
             {
                 // its a product file.
-                if (normalizedPath.length() >= AP_MAX_PATH_LEN)
+                if (normalizedPath.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
                 {
                     // if we are here it means that we have found a cache file whose filepath is greater than the maximum path length allowed
                     continue;
@@ -2954,10 +2957,15 @@ namespace AssetProcessor
                     m_knownFolders.insert(sourceAssetReference.ScanFolderPath().c_str());
                 }
 
-                if (normalizedPath.length() >= AP_MAX_PATH_LEN)
+                if (normalizedPath.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
                 {
                     // if we are here it means that we have found a source file whose filepath is greater than the maximum path length allowed
-                    AZ_TracePrintf(AssetProcessor::ConsoleChannel, "ProcessFilesToExamineQueue: %s filepath length %d exceeds the maximum path length (%d) allowed.\n", normalizedPath.toUtf8().constData(), normalizedPath.length(), AP_MAX_PATH_LEN);
+                    AZ_TracePrintf(
+                        AssetProcessor::ConsoleChannel,
+                        "ProcessFilesToExamineQueue: %s filepath length %d exceeds the maximum path length (%d) allowed.\n",
+                        normalizedPath.toUtf8().constData(),
+                        normalizedPath.length(),
+                        ASSETPROCESSOR_TRAIT_MAX_PATH_LEN);
 
                     JobInfoContainer jobInfos;
                     m_stateData->GetJobInfoBySourceNameScanFolderId(sourceAssetReference.RelativePath().c_str(), scanFolderInfo->ScanFolderID(), jobInfos);

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -41,9 +41,6 @@ namespace AssetProcessor
     const unsigned int g_RetriesForFenceFile = 5; // number of retries for fencing
     constexpr int RetriesForJobLostConnection = ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES; // number of times to retry a job when a network error due to network issues or a crashed AssetBuilder process is determined to have caused a job failure
     [[maybe_unused]] constexpr const char* IntermediateAssetsFolderName = "Intermediate Assets"; // name of the intermediate assets folder
-    // Even though AP can handle files with path length greater than window's legacy path length limit, we have some 3rdparty sdk's
-    // which do not handle this case ,therefore we will make AP fail any jobs whose either source file or output file name exceeds the windows legacy path length limit
-#define AP_MAX_PATH_LEN 260
 
     //! a shared convenience typedef for requests that have come over the network
     //! The first element is the connection id it came from and the second element is the serial number

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -42,6 +42,11 @@ namespace AssetProcessor
     constexpr int RetriesForJobLostConnection = ASSETPROCESSOR_TRAIT_ASSET_BUILDER_LOST_CONNECTION_RETRIES; // number of times to retry a job when a network error due to network issues or a crashed AssetBuilder process is determined to have caused a job failure
     [[maybe_unused]] constexpr const char* IntermediateAssetsFolderName = "Intermediate Assets"; // name of the intermediate assets folder
 
+    // Even though AP can handle files with path length greater than window's legacy path length limit, we have some 3rdparty sdk's
+    // which do not handle this case, therefore we will make AP warn about jobs whose either source file or output file name exceeds the windows legacy path length limit
+    // on all platforms
+#define ASSETPROCESSOR_WARN_PATH_LEN 260
+
     //! a shared convenience typedef for requests that have come over the network
     //! The first element is the connection id it came from and the second element is the serial number
     //! which can be used to send a response.

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -509,6 +509,16 @@ namespace AssetProcessor
 
             QString sourceFullPath(builderParams.m_processJobRequest.m_fullPath.c_str());
 
+            if (sourceFullPath.length() >= ASSETPROCESSOR_WARN_PATH_LEN && sourceFullPath.length() < ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
+            {
+                AZ_Warning(
+                    AssetBuilderSDK::WarningWindow,
+                    false,
+                    "Source Asset: %s filepath length %d exceeds the suggested max path length (%d). This may not work on all platforms.\n",
+                    sourceFullPath.toUtf8().data(),
+                    sourceFullPath.length(),
+                    ASSETPROCESSOR_WARN_PATH_LEN);
+            }
             if (sourceFullPath.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
             {
                 AZ_Warning(
@@ -977,6 +987,17 @@ namespace AssetProcessor
         // Don't make productFile all lowercase for case-insensitive as this
         // breaks macOS. The case is already setup properly when the job
         // was created.
+
+        if (productFile.length() >= ASSETPROCESSOR_WARN_PATH_LEN && productFile.length() < ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
+        {
+            AZ_Warning(
+                AssetBuilderSDK::WarningWindow,
+                false,
+                "Product '%s' path length (%d) exceeds the suggested max path length (%d). This may not work on all platforms.\n",
+                productFile.toUtf8().data(),
+                productFile.length(),
+                ASSETPROCESSOR_WARN_PATH_LEN);
+        }
 
         if (productFile.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
         {

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -509,9 +509,15 @@ namespace AssetProcessor
 
             QString sourceFullPath(builderParams.m_processJobRequest.m_fullPath.c_str());
 
-            if (sourceFullPath.length() >= AP_MAX_PATH_LEN)
+            if (sourceFullPath.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
             {
-                AZ_Warning(AssetBuilderSDK::WarningWindow, false, "Source Asset: %s filepath length %d exceeds the maximum path length (%d) allowed.\n", sourceFullPath.toUtf8().data(), sourceFullPath.length(), AP_MAX_PATH_LEN);
+                AZ_Warning(
+                    AssetBuilderSDK::WarningWindow,
+                    false,
+                    "Source Asset: %s filepath length %d exceeds the maximum path length (%d) allowed.\n",
+                    sourceFullPath.toUtf8().data(),
+                    sourceFullPath.length(),
+                    ASSETPROCESSOR_TRAIT_MAX_PATH_LEN);
                 result.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
             }
             else
@@ -972,12 +978,15 @@ namespace AssetProcessor
         // breaks macOS. The case is already setup properly when the job
         // was created.
 
-        if (productFile.length() >= AP_MAX_PATH_LEN)
+        if (productFile.length() >= ASSETPROCESSOR_TRAIT_MAX_PATH_LEN)
         {
             AZ_Error(
-                AssetBuilderSDK::ErrorWindow, false,
+                AssetBuilderSDK::ErrorWindow,
+                false,
                 "Cannot copy file: Product '%s' path length (%d) exceeds the max path length (%d) allowed on disk\n",
-                productFile.toUtf8().data(), productFile.length(), AP_MAX_PATH_LEN);
+                productFile.toUtf8().data(),
+                productFile.length(),
+                ASSETPROCESSOR_TRAIT_MAX_PATH_LEN);
             return false;
         }
 


### PR DESCRIPTION
## What does this PR do?

Moved the `AP_MAX_PATH_LEN` define into the platform-specific files. Mostly because our linux CI has longer paths than 260 chars, and that limitation shouldn't be a problem on linux, even for thirdparty - libraries

## How was this PR tested?

Compile and build assets on windows and linux. I have no opportunity to test this on mac.