### PR TITLE
change the error about unused scope attachments to a warning

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -106,7 +106,7 @@ namespace AZ::RHI
                 if (attachment->GetFirstScopeAttachment() == nullptr)
                 {
                     //We allow the rendering to continue even if an attachment is not used.
-                    AZ_ErrorOnce(
+                    AZ_WarningOnce(
                         "FrameGraph", false,
                         "Invalid State: attachment '%s' was added but never used!",
                         attachment->GetId().GetCStr());


### PR DESCRIPTION
## What does this PR do?

Turn the ErrorOnce into WarnOnce, because this situation can happen in our pipeline legitimately, and our CI doesn't like errors, but tolerates warnings.
