### PR TITLE
Fixes a possible "Shadowed Variable" warning.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1597,7 +1597,7 @@ namespace AzToolsFramework
 
             AZ_PROFILE_FUNCTION(AzToolsFramework);
             {
-                ScopedUndoBatch undoBatch("Detach Prefab");  // outer undo is for the entire thing - detach AND (optional) delete
+                ScopedUndoBatch outerUndoBatch("Detach Prefab");  // outer undo is for the entire thing - detach AND (optional) delete
 
                 {
                     ScopedUndoBatch undoBatch("Detach Prefab - Actual Detach"); // inner undo is just for the detach part.


### PR DESCRIPTION
## What does this PR do?
Fixes a _potential_ warning generated for some compilers

This warning did not occur to me nor did it in AR, (I'm on Linux Clang16) but it could on some compilers.

## How was this PR tested?

Compiling and running
