### PR TITLE
Remove bad check for RPI::Image to return an AssetID.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -873,10 +873,7 @@ namespace AZ
             {
                 return AZStd::any(AZStd::any_cast<AZ::Data::Asset<AZ::RPI::ImageAsset>>(value).GetId());
             }
-            if (value.is<AZ::Data::Instance<AZ::RPI::Image>>())
-            {
-                return AZStd::any(AZStd::any_cast<AZ::Data::Instance<AZ::RPI::Image>>(value)->GetAssetId());
-            }
+
             return value;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where setting a Material's image property will fail, as the value gets erroneously converted to an asset id.

## How was this PR tested?

On PC, using a custom shader & material with an image property.  Setting the property to a runtime create AttachmentImage now succeeds as expected.
