### PR TITLE
Fix release compilation issues

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/PythonLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/PythonLoader.cpp
@@ -48,7 +48,7 @@ namespace AzToolsFramework::EmbeddedPython
         if (!isSdkEngine)
         {
             m_embeddedLibPythonModuleHandle = AZ::DynamicModuleHandle::Create(IMPLICIT_LOAD_PYTHON_SHARED_LIBRARY, false);
-            bool loadResult = m_embeddedLibPythonModuleHandle->Load(false, true);
+            [[maybe_unused]] bool loadResult = m_embeddedLibPythonModuleHandle->Load(false, true);
             AZ_Error("PythonLoader", loadResult, "Failed to load " IMPLICIT_LOAD_PYTHON_SHARED_LIBRARY "\n");
         }
         #endif // IMPLICIT_LOAD_PYTHON_SHARED_LIBRARY
@@ -122,7 +122,7 @@ namespace AzToolsFramework::EmbeddedPython
             }
             return true;
         };
-        const auto parseOutcome = AZ::Settings::ParseConfigFile(systemFileStream, parserSettings);
+        [[maybe_unused]] const auto parseOutcome = AZ::Settings::ParseConfigFile(systemFileStream, parserSettings);
         AZ_Error("python", parseOutcome, "Python venv file at %s missing home key. Make sure to run python/get_python.", pythonVenvConfig.c_str());
 
         return AZ::IO::FixedMaxPath(pythonHome);


### PR DESCRIPTION
## What does this PR do?
Fixes the following build errors:

```
n file included from /home/spham/O3DE/Projects/Test1/build/linux/o3de/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.dir/Unity/unity_3_cxx.cxx:3:
/home/spham/github/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/API/PythonLoader.cpp:51:18: error: unused variable 'loadResult' [-Werror,-Wunused-variable]
            bool loadResult = m_embeddedLibPythonModuleHandle->Load(false, true);
                 ^
/home/spham/github/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/API/PythonLoader.cpp:125:20: error: unused variable 'parseOutcome' [-Werror,-Wunused-variable]
        const auto parseOutcome = AZ::Settings::ParseConfigFile(systemFileStream, parserSettings);
                   ^
2 errors generated.
```

## How was this PR tested?
Project built in release and launched the Game Launcher

