### PR TITLE
feat: remove unused call GetSandboxObject

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -53,16 +53,6 @@ protected:
     {
         // Only switch camera when in Play mode.
         GUID camObjId = GUID_NULL;
-        if (Params.cameraEntityId.IsValid())
-        {
-            // Find owner editor entity.
-            CEntityObject* pEditorEntity = CEntityObject::FindFromEntityId(Params.cameraEntityId);
-            if (pEditorEntity)
-            {
-                camObjId = pEditorEntity->GetId();
-            }
-        }
-
         // Switch camera in active rendering view.
         if (GetIEditor()->GetViewManager())
         {

--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -49,17 +49,6 @@ protected:
         }
     }
 
-    void OnSetCamera(const SCameraParams& Params) override
-    {
-        // Only switch camera when in Play mode.
-        GUID camObjId = GUID_NULL;
-        // Switch camera in active rendering view.
-        if (GetIEditor()->GetViewManager())
-        {
-            GetIEditor()->GetViewManager()->SetCameraObjectId(camObjId);
-        }
-    };
-
     bool IsSequenceCamUsed() const override
     {
         if (gEnv->IsEditorGameMode() == true)
@@ -474,22 +463,6 @@ void CAnimationContext::Update()
     {
         ForceAnimation();
         m_bForceUpdateInNextFrame = false;
-    }
-
-    // If looking through camera object and recording animation, do not allow camera shake
-    if ((GetIEditor()->GetViewManager()->GetCameraObjectId() != GUID_NULL) && GetIEditor()->GetAnimation()->IsRecording())
-    {
-        if (GetIEditor()->GetMovieSystem())
-        {
-            GetIEditor()->GetMovieSystem()->EnableCameraShake(false);
-        }
-    }
-    else
-    {
-        if (GetIEditor()->GetMovieSystem())
-        {
-            GetIEditor()->GetMovieSystem()->EnableCameraShake(true);
-        }
     }
 
     if (m_paused > 0 || !(m_playing || m_bAutoRecording))

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1176,15 +1176,8 @@ void EditorViewportWidget::keyPressEvent(QKeyEvent* event)
 #endif // defined(AZ_PLATFORM_WINDOWS)
 }
 
-void EditorViewportWidget::SetViewTM(const Matrix34& tm)
+void EditorViewportWidget::SetViewTM(const Matrix34& camMatrix)
 {
-    SetViewTM(tm, false);
-}
-
-void EditorViewportWidget::SetViewTM(const Matrix34& camMatrix, bool bMoveOnly)
-{
-    AZ_Warning("EditorViewportWidget", !bMoveOnly, "'Move Only' mode is deprecated");
-
     GetCurrentAtomView()->SetCameraTransform(LYTransformToAZMatrix3x4(camMatrix));
 
     if (m_pressedKeyState == KeyPressedState::PressedThisFrame)

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1517,7 +1517,6 @@ void EditorViewportWidget::SetDefaultCamera()
 
     m_viewEntityId.SetInvalid();
     m_viewSourceType = ViewSourceType::None;
-    GetViewManager()->SetCameraObjectId(GUID_NULL);
     SetName(m_defaultViewName);
 
     // synchronize the configured editor viewport FOV to the default camera

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -304,9 +304,6 @@ private:
     QPoint ViewportToWidget(const QPoint& point) const;
     QSize WidgetToViewport(const QSize& size) const;
 
-
-    CBaseObject* GetCameraObject() const;
-
     void UnProjectFromScreen(float sx, float sy, float* px, float* py, float* pz) const;
     void ProjectToScreen(float ptx, float pty, float ptz, float* sx, float* sy) const;
 

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -245,7 +245,6 @@ private:
 
     ////////////////////////////////////////////////////////////////////////
     // Private helpers...
-    void SetViewTM(const Matrix34& tm, bool bMoveOnly);
     void SetDefaultCameraNearFar();
     void RenderAll();
 

--- a/Code/Editor/Include/HitContext.h
+++ b/Code/Editor/Include/HitContext.h
@@ -74,8 +74,6 @@ struct HitContext
     bool bOnlyGizmo;
     //! Test objects using advanced selection helpers.
     bool bUseSelectionHelpers;
-    //! an object excluded in hittest.
-    CBaseObject* pExcludedObject;
 
     // Input parameters.
 

--- a/Code/Editor/Objects/EntityObject.cpp
+++ b/Code/Editor/Objects/EntityObject.cpp
@@ -196,14 +196,6 @@ bool CEntityObject::Init(IEditor* pEditor, CBaseObject* pPrev, const QString& fi
 }
 
 //////////////////////////////////////////////////////////////////////////
-/*static*/ CEntityObject* CEntityObject::FindFromEntityId(const AZ::EntityId& id)
-{
-    CEntityObject* retEntity = nullptr;
-    AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(retEntity, id, &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
-    return retEntity;
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CEntityObject::SetTransformDelegate(ITransformDelegate* pTransformDelegate)
 {
     CBaseObject::SetTransformDelegate(pTransformDelegate);

--- a/Code/Editor/Objects/EntityObject.h
+++ b/Code/Editor/Objects/EntityObject.h
@@ -174,8 +174,6 @@ public:
 
     void Validate(IErrorReport* report) override;
 
-    // Find CEntity from AZ::EntityId, which can also handle legacy game Ids stored as AZ::EntityIds
-    static CEntityObject* FindFromEntityId(const AZ::EntityId& id);
 
     // Get the name of the light animation node assigned to this, if any.
     QString GetLightAnimation() const;

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -615,26 +615,6 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
 }
 
 //////////////////////////////////////////////////////////////////////////
-// Returns true if at least one non-layer entity was found.
-bool CollectEntityBoundingBoxesForZoom(const AZ::EntityId& entityId, AABB& selectionBounds)
-{
-    AABB entityBoundingBox;
-    CEntityObject* componentEntityObject = nullptr;
-    AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
-        /*result*/ componentEntityObject,
-        /*address*/ entityId,
-        &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
-
-    if (componentEntityObject)
-    {
-        componentEntityObject->GetBoundBox(entityBoundingBox);
-        selectionBounds.Add(entityBoundingBox.min);
-        selectionBounds.Add(entityBoundingBox.max);
-    }
-    return true;
-}
-
-//////////////////////////////////////////////////////////////////////////
 void SandboxIntegrationManager::GoToEntitiesInViewports(const AzToolsFramework::EntityIdList& entityIds)
 {
     if (entityIds.empty())

--- a/Code/Editor/ViewManager.cpp
+++ b/Code/Editor/ViewManager.cpp
@@ -54,8 +54,6 @@ CViewManager::CViewManager()
     m_origin2D(0, 0, 0);
     m_zoom2D = 1.0f;
 
-    m_cameraObjectId = GUID_NULL;
-
     m_updateRegion.min = Vec3(-100000, -100000, -100000);
     m_updateRegion.max = Vec3(100000, 100000, 100000);
 

--- a/Code/Editor/ViewManager.h
+++ b/Code/Editor/ViewManager.h
@@ -78,12 +78,6 @@ public:
     float GetZoom2D() const { return m_zoom2D; };
 
     //////////////////////////////////////////////////////////////////////////
-    //! Get currently active camera object id.
-    REFGUID GetCameraObjectId() const { return m_cameraObjectId; };
-    //! Sets currently active camera object id.
-    void SetCameraObjectId(REFGUID cameraObjectId) { m_cameraObjectId = cameraObjectId; };
-
-    //////////////////////////////////////////////////////////////////////////
     //! Get number of currently existing viewports.
     virtual int GetViewCount() { return static_cast<int>(m_viewports.size()); };
     //! Get viewport by index.
@@ -131,9 +125,6 @@ private:
     Vec3 m_origin2D;
     //! Zoom of 2d viewports.
     float m_zoom2D;
-
-    //! Id of camera object.
-    GUID m_cameraObjectId;
 
     int m_nGameViewports;
     bool m_bGameViewportsUpdated;

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -97,7 +97,7 @@ CLayoutViewPane::CLayoutViewPane(QWidget* parent)
     m_id = -1;
 }
 
-CLayoutViewPane::~CLayoutViewPane() 
+CLayoutViewPane::~CLayoutViewPane()
 {
     AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
 
@@ -110,7 +110,7 @@ CLayoutViewPane::~CLayoutViewPane()
         delete m_viewportScrollArea;
     }
 
-    OnDestroy(); 
+    OnDestroy();
 }
 
 void CLayoutViewPane::OnMenuRegistrationHook()
@@ -471,7 +471,7 @@ void CLayoutViewPane::OnMenuBindingHook()
                 m_menuManagerInterface->AddActionToMenu(
                     EditorIdentifiers::ViewportSizeRatioMenuIdentifier, actionIdentifier, SortKeySpacing * (aznumeric_cast<int>(i) + 1));
             }
-            
+
             m_menuManagerInterface->AddSeparatorToMenu(
                 EditorIdentifiers::ViewportSizeRatioMenuIdentifier, SortKeySpacing * (aznumeric_cast<int>(ViewportRatiosCount) + 1));
             m_menuManagerInterface->AddActionToMenu(
@@ -588,7 +588,7 @@ void CLayoutViewPane::SetViewportExpansionPolicy(ViewportExpansionPolicy policy)
                 m_viewport->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
                 // For some reason, the QScrollArea is adding a margin all around our viewable area,
-                // so we'll shrink our viewport by an appropriate offset (twice the margin thickness) 
+                // so we'll shrink our viewport by an appropriate offset (twice the margin thickness)
                 // so that it continues to fit without requiring scroll bars after switching size policies.
                 m_viewport->resize(m_viewport->width() - (scrollViewport->x() * 2), m_viewport->height() - (scrollViewport->y() * 2));
                 SetMainWidget(m_viewportScrollArea);
@@ -597,7 +597,7 @@ void CLayoutViewPane::SetViewportExpansionPolicy(ViewportExpansionPolicy policy)
             }
             break;
         // If the requested policy is "AutoExpand", just put the viewport area directly in the ViewPane.
-        // It will auto-resize with the main window, but requests to change the viewport size might not 
+        // It will auto-resize with the main window, but requests to change the viewport size might not
         // result in the exact size being requested, depending on main window size and layout.
         case ViewportExpansionPolicy::AutoExpand:
             {
@@ -705,15 +705,15 @@ void CLayoutViewPane::ResizeViewport(int width, int height)
     }
 
     // Make sure our requestedSize stays within "legal" bounds.
-    const QSize requestedSize = QSize(AZ::GetClamp(width, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES), 
+    const QSize requestedSize = QSize(AZ::GetClamp(width, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES),
                                       AZ::GetClamp(height, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES));
 
     // The delta between our current and requested size is going to be used to try and resize the main window
     // (either growing or shrinking) by the exact same amount so that the new viewport size is still completely
-    // visible without needing to adjust any other widget sizes.  
+    // visible without needing to adjust any other widget sizes.
     // Note that we're specifically taking the delta from the main widget, not the viewport.
     // In the "AutoResize" case, this will still directly take the delta from our viewport, but in the
-    // "FixedSize" case we need to take the delta from the scroll area's viewable area size, since that's actually 
+    // "FixedSize" case we need to take the delta from the scroll area's viewable area size, since that's actually
     // the one we need to grow/shrink proportional to.
     const QSize deltaSize = requestedSize - mainWidgetSize;
 
@@ -733,7 +733,7 @@ void CLayoutViewPane::ResizeViewport(int width, int height)
     }
 
     // Resize our main window by the amount that we want our viewport to change.
-    // This is intended to grow our viewport by the same amount.  However, this logic is a 
+    // This is intended to grow our viewport by the same amount.  However, this logic is a
     // little flawed and should get revisited at some point:
     // 1) It's possible that the mainWindow won't actually change to the requested size, if the requested
     // size is larger than the current display resolution (Qt::SetGeometry will fire a second resize event
@@ -787,10 +787,7 @@ void CLayoutViewPane::SetViewportFOV(const float fovDegrees)
         pRenderViewport->SetFOV(fovRadians);
 
         // if viewport camera is active, make selected fov new default
-        if (pRenderViewport->GetViewManager()->GetCameraObjectId() == GUID_NULL)
-        {
-            SandboxEditor::SetCameraDefaultFovRadians(fovRadians);
-        }
+        SandboxEditor::SetCameraDefaultFovRadians(fovRadians);
 
         OnFOVChanged(fovRadians);
     }

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -97,7 +97,7 @@ CLayoutViewPane::CLayoutViewPane(QWidget* parent)
     m_id = -1;
 }
 
-CLayoutViewPane::~CLayoutViewPane()
+CLayoutViewPane::~CLayoutViewPane() 
 {
     AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
 
@@ -110,7 +110,7 @@ CLayoutViewPane::~CLayoutViewPane()
         delete m_viewportScrollArea;
     }
 
-    OnDestroy();
+    OnDestroy(); 
 }
 
 void CLayoutViewPane::OnMenuRegistrationHook()
@@ -471,7 +471,7 @@ void CLayoutViewPane::OnMenuBindingHook()
                 m_menuManagerInterface->AddActionToMenu(
                     EditorIdentifiers::ViewportSizeRatioMenuIdentifier, actionIdentifier, SortKeySpacing * (aznumeric_cast<int>(i) + 1));
             }
-
+            
             m_menuManagerInterface->AddSeparatorToMenu(
                 EditorIdentifiers::ViewportSizeRatioMenuIdentifier, SortKeySpacing * (aznumeric_cast<int>(ViewportRatiosCount) + 1));
             m_menuManagerInterface->AddActionToMenu(
@@ -588,7 +588,7 @@ void CLayoutViewPane::SetViewportExpansionPolicy(ViewportExpansionPolicy policy)
                 m_viewport->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
                 // For some reason, the QScrollArea is adding a margin all around our viewable area,
-                // so we'll shrink our viewport by an appropriate offset (twice the margin thickness)
+                // so we'll shrink our viewport by an appropriate offset (twice the margin thickness) 
                 // so that it continues to fit without requiring scroll bars after switching size policies.
                 m_viewport->resize(m_viewport->width() - (scrollViewport->x() * 2), m_viewport->height() - (scrollViewport->y() * 2));
                 SetMainWidget(m_viewportScrollArea);
@@ -597,7 +597,7 @@ void CLayoutViewPane::SetViewportExpansionPolicy(ViewportExpansionPolicy policy)
             }
             break;
         // If the requested policy is "AutoExpand", just put the viewport area directly in the ViewPane.
-        // It will auto-resize with the main window, but requests to change the viewport size might not
+        // It will auto-resize with the main window, but requests to change the viewport size might not 
         // result in the exact size being requested, depending on main window size and layout.
         case ViewportExpansionPolicy::AutoExpand:
             {
@@ -705,15 +705,15 @@ void CLayoutViewPane::ResizeViewport(int width, int height)
     }
 
     // Make sure our requestedSize stays within "legal" bounds.
-    const QSize requestedSize = QSize(AZ::GetClamp(width, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES),
+    const QSize requestedSize = QSize(AZ::GetClamp(width, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES), 
                                       AZ::GetClamp(height, MIN_VIEWPORT_RES, MAX_VIEWPORT_RES));
 
     // The delta between our current and requested size is going to be used to try and resize the main window
     // (either growing or shrinking) by the exact same amount so that the new viewport size is still completely
-    // visible without needing to adjust any other widget sizes.
+    // visible without needing to adjust any other widget sizes.  
     // Note that we're specifically taking the delta from the main widget, not the viewport.
     // In the "AutoResize" case, this will still directly take the delta from our viewport, but in the
-    // "FixedSize" case we need to take the delta from the scroll area's viewable area size, since that's actually
+    // "FixedSize" case we need to take the delta from the scroll area's viewable area size, since that's actually 
     // the one we need to grow/shrink proportional to.
     const QSize deltaSize = requestedSize - mainWidgetSize;
 
@@ -733,7 +733,7 @@ void CLayoutViewPane::ResizeViewport(int width, int height)
     }
 
     // Resize our main window by the amount that we want our viewport to change.
-    // This is intended to grow our viewport by the same amount.  However, this logic is a
+    // This is intended to grow our viewport by the same amount.  However, this logic is a 
     // little flawed and should get revisited at some point:
     // 1) It's possible that the mainWindow won't actually change to the requested size, if the requested
     // size is larger than the current display resolution (Qt::SetGeometry will fire a second resize event

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntityObjectBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntityObjectBus.h
@@ -26,9 +26,6 @@ namespace AzToolsFramework
     public:
         virtual ~ComponentEntityEditorRequests() {}
 
-        /// Retrieve sandbox object associated with the entity.
-        virtual CEntityObject* GetSandboxObject() = 0;
-
         /// Returns true if the object is highlighted.
         virtual bool IsSandboxObjectHighlighted() = 0;
 

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -236,7 +236,6 @@ struct IMovieCallback
     virtual ~IMovieCallback(){}
     // Called by movie system.
     virtual void OnMovieCallback(ECallbackReason reason, IAnimNode* pNode) = 0;
-    virtual void OnSetCamera(const SCameraParams& Params) = 0;
     virtual bool IsSequenceCamUsed() const = 0;
     // </interfuscator:shuffle>
 };
@@ -1256,8 +1255,6 @@ struct IMovieSystem
     // While in recording mode any changes made to node will be added as keys to tracks.
     virtual void SetRecording(bool recording) = 0;
     virtual bool IsRecording() const = 0;
-
-    virtual void EnableCameraShake(bool bEnabled) = 0;
 
     // Pause any playing sequences.
     virtual void Pause() = 0;

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -208,7 +208,6 @@ CMovieSystem::CMovieSystem(ISystem* pSystem)
     m_pCallback = nullptr;
     m_pUser = nullptr;
     m_bPaused = false;
-    m_bEnableCameraShake = true;
     m_bCutscenesPausedInEditor = true;
     m_sequenceStopBehavior = eSSB_GotoEndTime;
     m_lastUpdateTime = AZ::Time::ZeroTimeUs;
@@ -1219,11 +1218,6 @@ void CMovieSystem::SetCameraParams(const SCameraParams& Params)
     if (m_pUser)
     {
         m_pUser->SetActiveCamera(m_ActiveCameraParams);
-    }
-
-    if (m_pCallback)
-    {
-        m_pCallback->OnSetCamera(m_ActiveCameraParams);
     }
 }
 

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.h
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.h
@@ -124,8 +124,6 @@ public:
     void SetRecording(bool recording) override { m_bRecording = recording; };
     bool IsRecording() const override { return m_bRecording; };
 
-    void EnableCameraShake(bool bEnabled) override{ m_bEnableCameraShake = bEnabled; };
-
     void SetCallback(IMovieCallback* pCallback) override { m_pCallback = pCallback; }
     IMovieCallback* GetCallback() override { return m_pCallback; }
     void Callback(IMovieCallback::ECallbackReason Reason, IAnimNode* pNode);
@@ -229,7 +227,6 @@ private:
     bool    m_bRecording;
     bool    m_bPaused;
     bool    m_bCutscenesPausedInEditor;
-    bool    m_bEnableCameraShake;
 
     SCameraParams m_ActiveCameraParams;
 

--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -337,23 +337,7 @@ namespace Maestro
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
     bool EditorSequenceComponent::MarkEntityAsDirty() const
     {
-        bool retSuccess = false;
-        AZ::Entity* entity = nullptr;
-
-        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, GetEntityId());
-        if (entity)
-        {
-            CEntityObject* entityObject = nullptr;
-
-            AzToolsFramework::ComponentEntityEditorRequestBus::EventResult(
-                entityObject, GetEntityId(), &AzToolsFramework::ComponentEntityEditorRequestBus::Events::GetSandboxObject);
-            if (entityObject)
-            {
-                entityObject->SetModified(false);
-                retSuccess = true;
-            }
-        }
-        return retSuccess;
+        return false;
     }
 
     //=========================================================================


### PR DESCRIPTION
## What does this PR do?
I can't find where ComponentEntityEditorRequests gets bound to, looks like this EBus should be removed at some point. I was going to start with removing GetSandboxObject and just remove this call. also helps that CEntityObject constructor is never called.