### PR TITLE
feat: remove UpdateAnimatedLights for AnimationContext

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -306,7 +306,6 @@ void CAnimationContext::SetTime(float t)
     m_currTime = t;
     m_fRecordingCurrTime = t;
     ForceAnimation();
-    UpdateAnimatedLights();
 
     NotifyTimeChangedListenersUsingCurrTime();
 }
@@ -577,7 +576,6 @@ void CAnimationContext::Update()
         NotifyTimeChangedListenersUsingCurrTime();
     }
 
-    UpdateAnimatedLights();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -671,34 +669,6 @@ void CAnimationContext::OnPostRender()
     }
 }
 
-//////////////////////////////////////////////////////////////////////////
-void CAnimationContext::UpdateAnimatedLights()
-{
-    bool bLightAnimationSetActive = m_pSequence && (m_pSequence->GetFlags() & IAnimSequence::eSeqFlags_LightAnimationSet);
-    if (bLightAnimationSetActive == false)
-    {
-        return;
-    }
-
-    std::vector<CBaseObject*> entityObjects;
-    GetIEditor()->GetObjectManager()->FindObjectsOfType(&CEntityObject::staticMetaObject, entityObjects);
-    std::for_each(std::begin(entityObjects), std::end(entityObjects),
-        [this](CBaseObject* pBaseObject)
-        {
-            CEntityObject* pEntityObject = static_cast<CEntityObject*>(pBaseObject);
-            bool bLight = pEntityObject && pEntityObject->GetEntityClass().compare("Light") == 0;
-            if (bLight)
-            {
-                bool bTimeScrubbing = pEntityObject->GetEntityPropertyBool("bTimeScrubbingInTrackView");
-                if (bTimeScrubbing)
-                {
-                    pEntityObject->SetEntityPropertyFloat("_fTimeScrubbed", m_currTime);
-                }
-            }
-        });
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CAnimationContext::BeginUndoTransaction()
 {
     m_bSavedRecordingState = m_recording;

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -187,9 +187,6 @@ public:
 private:
     static void GoToFrameCmd(IConsoleCmdArgs* pArgs);
 
-    // Updates the animation time of lights animated by the light animation set.
-    void UpdateAnimatedLights();
-
     void NotifyTimeChangedListenersUsingCurrTime() const;
 
     virtual void BeginUndoTransaction() override;


### PR DESCRIPTION
## What does this PR do?

There are not references to CEntityObject beyond referencing the object.  should be safe to remove this logic for UpdateAnimatedLights. 