### PR TITLE
feat: remove unused save logic for SequenceObject

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -302,26 +302,6 @@ void CCryEditDoc::Load(TDocMultiArchive& /* arrXmlAr */, const QString& szFilena
         }
 
         {
-            // support old version of sequences
-            IMovieSystem* pMs = GetIEditor()->GetMovieSystem();
-
-            if (pMs)
-            {
-                for (int k = 0; k < pMs->GetNumSequences(); ++k)
-                {
-                    IAnimSequence* seq = pMs->GetSequence(k);
-                    QString fullname = seq->GetName();
-                    CBaseObject* pObj = GetIEditor()->GetObjectManager()->FindObject(fullname);
-
-                    if (!pObj)
-                    {
-                        pObj = GetIEditor()->GetObjectManager()->NewObject("SequenceObject", nullptr, fullname);
-                    }
-                }
-            }
-        }
-
-        {
             CAutoLogTime logtime("Post Load");
 
             // Notify listeners.


### PR DESCRIPTION
## What does this PR do?

I can't find where SequenceObject would be registered against  CClassFactory. this is the last call to NewObject so ObjectManager is completely unused going forward. 
