### PR TITLE
Fix PythonBehaviorDescription function signatures from triggering warnings in some compilers

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
@@ -1222,7 +1222,7 @@ namespace EditorPythonBindings
         }
 
         AZStd::string PythonBehaviorDescription::PropertyDefinition(
-            AZStd::string_view propertyName, int level, const AZ::BehaviorProperty& property, const AZ::BehaviorClass* behaviorClass)
+            AZStd::string_view propertyName, int level, const AZ::BehaviorProperty& property, [[maybe_unused]] const AZ::BehaviorClass* behaviorClass)
         {
             AZStd::string buffer;
             Internal::Indent(level, buffer);
@@ -1249,7 +1249,7 @@ namespace EditorPythonBindings
         }
 
         AZStd::string PythonBehaviorDescription::GlobalPropertyDefinition(
-            const AZStd::string_view& moduleName,
+            [[maybe_unused]] const AZStd::string_view& moduleName,
             const AZStd::string_view& propertyName,
             const AZ::BehaviorProperty& behaviorProperty,
             bool needsHeader)


### PR DESCRIPTION
Fixes code that can trigger warnings in some compilers introduced by this PR: https://github.com/o3de/o3de/pull/17589