### PR TITLE
Fix linux editor first time crash

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
@@ -36,6 +36,8 @@ namespace AZ
             { 
                 if (passRequest)
                 {
+                    // If the optional passRequest is passed in, create a copy of it and reference it with a smart pointer
+                    // rather than keeping a reference to the passRequest
                     m_passRequest = AZStd::make_shared<PassRequest>(*passRequest);
                 }
             }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
@@ -7,8 +7,10 @@
  */
 #pragma once
 
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 #include <Atom/RPI.Reflect/Pass/PassData.h>
-
+#include <Atom/RPI.Reflect/Pass/PassRequest.h>
 namespace AZ
 {
     namespace RPI
@@ -31,8 +33,12 @@ namespace AZ
             explicit PassDescriptor(Name name, const AZStd::shared_ptr<const PassTemplate> passTemplate = nullptr, const PassRequest* passRequest = nullptr)
                 : m_passName(name)
                 , m_passTemplate(passTemplate)
-                , m_passRequest(passRequest)
-            { }
+            { 
+                if (passRequest)
+                {
+                    m_passRequest = AZStd::make_shared<PassRequest>(*passRequest);
+                }
+            }
 
             //! Required: Every PassDescriptor must have a valid name before being used as an input for Pass construction
             Name m_passName;
@@ -42,7 +48,7 @@ namespace AZ
 
             //! Optional: The PassRequest used to construct a Pass. If this is valid then m_passTemplate 
             //! cannot be null and m_passTemplate must point to the same template used by the PassRequest.
-            const PassRequest* m_passRequest = nullptr;
+            AZStd::shared_ptr<PassRequest> m_passRequest;
 
             //! Optional: Custom data used for pass initialization. This data usually comes from the pass
             //! template or pass request. Only use this if you are initializing a pass without either of those.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -96,7 +96,15 @@ namespace AZ
             PassDescriptor desc;
             desc.m_passName = m_name;
             desc.m_passTemplate = m_template ? PassSystemInterface::Get()->GetPassTemplate(m_template->m_name) : nullptr;
-            desc.m_passRequest = m_flags.m_createdByPassRequest ? &m_request : nullptr;
+            if (m_flags.m_createdByPassRequest)
+            {
+                desc.m_passRequest = AZStd::make_shared<PassRequest>(m_request);
+            }
+            else
+            {
+                desc.m_passRequest.reset();
+            }
+            
             desc.m_passData = m_passData;
             return desc;
         }


### PR DESCRIPTION
## What does this PR do?
This fixes linux first time asset processing crash in the Editor caused by dangling pointer(`PassDescriptor::m_passRequest`) during attempts to access its `m_passData` in [PassUtils::GetPassData](https://github.com/o3de/o3de/blob/c895a337424e16c207ffd3033e6cf1d66893f06c/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassUtils.h#L48).

## Root Cause
This crash occurs only on first time startup of the Editor when there are no assets. In this situation, when feature processors adds render passes, it creates the `RPI::PassRequest` as a local variable and creates the pass from the Request. (i.e. in the [SilhouetteFeatureProcessor](https://github.com/o3de/o3de/blob/c895a337424e16c207ffd3033e6cf1d66893f06c/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp#L155-L165).  
It seems like access to the Render Pass is occurring outside of this method, probably due to deferral of its processing caused by a dependency issue perhaps. Regardless of the root cause, its not safe to hold on to naked pointers in objects that may live outside of a local function (dynamically allocated).

## Fix
The fix is to instead of holding on the naked pointer, we will create a copy of the PassRequest and hold onto it with a `shared_ptr`. An alternative to this is to force users of this structure to pass in a shared pointer instead of the raw pointer, but that would propogate more changes and introduce risk

## How was this PR tested?
Followed steps described in https://github.com/o3de/o3de/issues/17764

Fixes https://github.com/o3de/o3de/issues/17764 





