### PR TITLE
Cherrypick my linux/clang compile fixes from dev to point release

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
@@ -537,7 +537,9 @@ namespace AzNetworking
         SSL_CTX_set_cookie_verify_cb(context, VerifyCookieCallback);
 
         // Automatically generate parameters for elliptic-curve diffie-hellman (i.e. curve type and coefficients).
+        AZ_PUSH_DISABLE_WARNING(, "-Wunused-value", "-Wunused-value")
         SSL_CTX_set_ecdh_auto(context, 1);
+        AZ_POP_DISABLE_WARNING
 
         scopedFree.ReleaseSslContextWithoutFree();
         return context;

--- a/Gems/UiBasics/CMakeLists.txt
+++ b/Gems/UiBasics/CMakeLists.txt
@@ -7,7 +7,5 @@
 #
 
 # This will export its "SourcePaths" to the generated "cmake_dependencies.<project>.assetbuilder.setreg"
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME UiBasics.Builders NAMESPACE Gem)
-    ly_create_alias(NAME UiBasics.Tools NAMESPACE Gem)
-endif()
+ly_create_alias(NAME UiBasics.Builders NAMESPACE Gem)
+ly_create_alias(NAME UiBasics.Tools NAMESPACE Gem)


### PR DESCRIPTION
This is a combination of commit 4a613a0 and commit 6e77dfa9869 from development to this branch, fixing compile warnings/errors under linux in certain conditions (ie, release, profile, etc)

See https://github.com/o3de/o3de/pull/17098 for the one cherrypick
See https://github.com/o3de/o3de/pull/16645/files#diff-1d4eec4a38cbed22d33a569f28fa14d554ae1522f7a129cb3f6bba681a140465 for the other.

Note that the latter was part of the Script Only mode, but only the compile error fix was cherrypicked in here, not the feature itself.

Testing: Compile and run editor.  Changes are compile errors and it simply did not compile before.
