### PR TITLE
Fix sphere intersection attributes not being in object space

### DIFF
--- a/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
+++ b/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
@@ -68,8 +68,8 @@ void SphereIntersection()
     if (IntersectRaySphere(WorldRayOrigin(), WorldRayDirection(), sphereCenterWS, sphereRadiusWS, t))
     {
         ProceduralGeometryIntersectionAttributes attrib;
-        attrib.m_position = WorldRayOrigin() + WorldRayDirection() * t;
-        attrib.m_normal = half3(normalize(attrib.m_position - sphereCenterWS));
+        attrib.m_position = ObjectRayOrigin() + ObjectRayDirection() * t;
+        attrib.m_normal = half3(normalize(attrib.m_position - sphereCenter));
         attrib.m_uv = half2(0, 0);
         attrib.m_tangent = half4(1, 0, 0, 1);
         ReportHit(t, 0, attrib);


### PR DESCRIPTION
## What does this PR do?

This PR fixes the calculation of the hit position of the new sphere intersection shader introduced in #17734. The values of `ProceduralGeometryIntersectionAttributes` are supposed to be stored in object (BLAS) space, but were stored in world space, which leads to wrong shadows in raytraced reflection.
Left image: old code, right image: new code; the shadow in the reflection of the red sphere now looks more correct.
![world-pos-fix](https://github.com/o3de/o3de/assets/113582781/87f26664-5d91-4c89-8f54-23db38d2831e)

## How was this PR tested?

Create a small scene (image above), move the shapes around and see if the shadows look plausible.
