### PR TITLE
Viewport | Allow direct selection of entities inside prefabs in Entity Pick mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
@@ -87,26 +87,7 @@ namespace AzToolsFramework
         const int viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
 
         const AzFramework::CameraState cameraState = GetCameraState(viewportId);
-
-        auto result = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction);
-
-        // is entity pick mode enabled?
-        bool isEntityPickModeEnabled = false;
-        if (auto viewportEditorModeTracker = AZ::Interface<AzToolsFramework::ViewportEditorModeTrackerInterface>::Get())
-        {
-            isEntityPickModeEnabled = viewportEditorModeTracker->GetViewportEditorModes({ AzToolsFramework::GetEntityContextId() })
-                                          ->IsModeActive(AzToolsFramework::ViewportEditorMode::Pick);
-        }
-
-        // If entity pick mode is enabled, just select the entity itself.
-        if (isEntityPickModeEnabled)
-        {
-            m_cachedEntityIdUnderCursor = result.EntityIdUnderCursor();
-        }
-        else
-        {
-            m_cachedEntityIdUnderCursor = result.ContainerAncestorEntityId();
-        }
+        m_cachedEntityIdUnderCursor = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction).ContainerAncestorEntityId();
 
         // when left clicking, if we successfully clicked an entity, assign that
         // to the entity field selected in the entity inspector (RPE)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
@@ -88,7 +88,25 @@ namespace AzToolsFramework
 
         const AzFramework::CameraState cameraState = GetCameraState(viewportId);
 
-        m_cachedEntityIdUnderCursor = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction).ContainerAncestorEntityId();
+        auto result = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction);
+
+        // is entity pick mode enabled?
+        bool isEntityPickModeEnabled = false;
+        if (auto viewportEditorModeTracker = AZ::Interface<AzToolsFramework::ViewportEditorModeTrackerInterface>::Get())
+        {
+            isEntityPickModeEnabled = viewportEditorModeTracker->GetViewportEditorModes({ AzToolsFramework::GetEntityContextId() })
+                                          ->IsModeActive(AzToolsFramework::ViewportEditorMode::Pick);
+        }
+
+        // If entity pick mode is enabled, just select the entity itself.
+        if (isEntityPickModeEnabled)
+        {
+            m_cachedEntityIdUnderCursor = result.EntityIdUnderCursor();
+        }
+        else
+        {
+            m_cachedEntityIdUnderCursor = result.ContainerAncestorEntityId();
+        }
 
         // when left clicking, if we successfully clicked an entity, assign that
         // to the entity field selected in the entity inspector (RPE)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
@@ -87,6 +87,7 @@ namespace AzToolsFramework
         const int viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
 
         const AzFramework::CameraState cameraState = GetCameraState(viewportId);
+
         m_cachedEntityIdUnderCursor = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction).ContainerAncestorEntityId();
 
         // when left clicking, if we successfully clicked an entity, assign that


### PR DESCRIPTION
## What does this PR do?

Clicking on an entity with a mesh in the Editor, the selection will cycle through all prefabs that contain that entity, from the top one down to the entity itself.

This behavior makes sense for selection, but in the case of entity pick we would want to directly select the clicked entity, if accessible.

The change also fixes an issue where it was possible to select entities inside closed containers.

## How was this PR tested?

Manual testing.
