### PR TITLE
Use project as root folder when opening a lua file.

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -209,7 +209,7 @@ namespace LUAEditor
 
         connect(m_gui->m_searchWidget, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this, &LUAEditorMainWindow::luaClassFilterTextChanged);
 
-        connect(m_gui->actionAssetBrowser, SIGNAL(triggered(bool)), this, SLOT(assetBrowserPressed()));
+        connect(m_gui->actionOpen, SIGNAL(triggered(bool)), this, SLOT(OnFileMenuOpen()));
 
         connect(m_gui->actionAutocomplete, SIGNAL(triggered(bool)), this, SLOT(OnAutocompleteChanged(bool)));
 
@@ -241,7 +241,7 @@ namespace LUAEditor
 
             HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUALinesUpTranspose", 0xafc899ef), m_gui->actionLinesUpTranspose);
             HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUALinesDnTranspose", 0xf9d733bf), m_gui->actionLinesDnTranspose);
-            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("GeneralOpenAssetBrowser", 0xa15ceb44), m_gui->actionAssetBrowser);
+            HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("GeneralOpenAssetBrowser", 0xa15ceb44), m_gui->actionOpen);
             HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAFind", 0xc62d8078), m_gui->actionFind);
             HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocal", 0x115cbcda), m_gui->actionFindLocal);
             HotkeyBus::Broadcast(&HotkeyBus::Events::RegisterActionToHotkey, AZ_CRC("LUAQuickFindLocalReverse", 0xdd8a0c22), m_gui->actionFindLocalReverse);
@@ -809,25 +809,19 @@ namespace LUAEditor
 
     //file menu
 
-    void LUAEditorMainWindow::assetBrowserPressed()
+    void LUAEditorMainWindow::OnFileMenuOpen()
     {
-        // w/out pulling in headers, AssetBrowserUI::AB_DEFAULT_CRC := 0
-        //EditorFramework::ShowAssetBrowserView( AZ::ScriptAsset::StaticAssetType(), AZ_CRC("LUA CONTEXT", 0xec76567e) );
-        //AZ_Assert(false, "No asset browser yet!");
-        const char* rootDirString;
-        AZ::ComponentApplicationBus::BroadcastResult(rootDirString, &AZ::ComponentApplicationBus::Events::GetExecutableFolder);
-
-        QDir rootDir;
-        rootDir.setPath(rootDirString);
-        rootDir.cdUp();
-
-        QString name = QFileDialog::getOpenFileName(this, "Open lua file", m_lastOpenFilePath.size() > 0 ? m_lastOpenFilePath.c_str() : rootDir.absolutePath(), "Lua files (*.lua)");
+        const QDir rootDir { AZ::Utils::GetProjectPath().c_str() };
+        const QString name = QFileDialog::getOpenFileName(this,
+                                                          "Open lua file",
+                                                          m_lastOpenFilePath.empty() ? rootDir.absolutePath() : m_lastOpenFilePath.c_str(),
+                                                          "Lua files (*.lua)");
         if (name.isEmpty())
         {
             return;
         }
 
-        AZStd::string assetId(name.toUtf8().data());
+        const AZStd::string assetId(name.toUtf8().data());
         Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
 
         AzFramework::StringFunc::Path::Split(assetId.c_str(), nullptr, &m_lastOpenFilePath);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
@@ -113,7 +113,7 @@ namespace LUAEditor
         void OnMenuCloseCurrentWindow();
 
         //file menu
-        void assetBrowserPressed();
+        void OnFileMenuOpen();
         void OnFileMenuNew();
         void OnFileMenuSave();
         void OnFileMenuSaveAs();

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.ui
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.ui
@@ -35,7 +35,7 @@
      <string>&amp;File</string>
     </property>
     <addaction name="actionNew"/>
-    <addaction name="actionAssetBrowser"/>
+    <addaction name="actionOpen"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
     <addaction name="actionSaveAll"/>
@@ -434,7 +434,7 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionAssetBrowser"/>
+   <addaction name="actionOpen"/>
    <addaction name="actionNew"/>
    <addaction name="actionSave"/>
    <addaction name="actionSaveAll"/>
@@ -1108,7 +1108,7 @@
     <string>Shift+F11</string>
    </property>
   </action>
-  <action name="actionAssetBrowser">
+  <action name="actionOpen">
    <property name="icon">
     <iconset resource="../../../../Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Resources/sharedResources.qrc">
      <normaloff>:/toolbar/AssetBrowserIcon.png</normaloff>:/toolbar/AssetBrowserIcon.png</iconset>


### PR DESCRIPTION
## What does this PR do?

The open file dialog of the LUA Editor initially defaults to the binary folder when opened for the first time. This can be inconvenient, as it may not be the desired location for storing Lua script files. This pull request resolves this issue by setting the default opening folder to the project's root directory. This behavior was inherited from the new file action.

Additionally, a member function has been renamed because the method name "assetBrowserPressed" is unclear and does not align with other provided functions.

## How was this PR tested?

Was compiled on my local Ubuntu 22.04 computer and run locally.
