### PR TITLE
Cherry-pick clang 17 compiler errors fix from development

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
@@ -76,7 +76,7 @@ namespace AzFramework
 
         if (qualityLevel == QualityLevel::Invalid)
         {
-            // handle enum pre-defined values 
+            // handle enum pre-defined values
             qualityLevel = FromEnum(value);
         }
 
@@ -94,7 +94,7 @@ namespace AzFramework
         int32_t intValue{ 0 };
         auto result = AZStd::from_chars(value.begin(), value.end(), intValue);
 
-        // don't allow values outside the known quality level ranges 
+        // don't allow values outside the known quality level ranges
         constexpr int32_t minValue = static_cast<int32_t>(QualityLevel::LevelFromDeviceRules);
         if (result.ec != AZStd::errc() || intValue >= m_numQualityLevels || intValue < minValue)
         {
@@ -214,9 +214,9 @@ namespace AzFramework
                 }
                 else if (!result)
                 {
-                    // the requested qualityLevel index wasn't found, use highest available 
+                    // the requested qualityLevel index wasn't found, use highest available
                     PerformConsoleCommand(command, FixedValueString::format("%.*s/%d",
-                        AZ_STRING_ARG(visitArgs.m_jsonKeyPath), currentQualityLevel));
+                        AZ_STRING_ARG(visitArgs.m_jsonKeyPath), static_cast<int>(currentQualityLevel)));
                 }
             }
             else

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugAuditTrail.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugAuditTrail.cpp
@@ -67,7 +67,7 @@ namespace Multiplayer
         const float TEXT_BASE_WIDTH = ImGui::CalcTextSize("A").x;
         const ImGuiTableFlags flags = ImGuiTableFlags_BordersV
             | ImGuiTableFlags_BordersOuterH
-            | ImGuiTableFlags_Resizable 
+            | ImGuiTableFlags_Resizable
             | ImGuiTableFlags_SizingStretchSame
             | ImGuiTableFlags_RowBg
             | ImGuiTableFlags_NoBordersInBody;
@@ -89,7 +89,7 @@ namespace Multiplayer
             for (auto elem = auditTrailElems.begin(); elem != auditTrailElems.end(); ++elem)
             {
                 if (elem == auditTrailElems.begin() && elem->m_category != AuditCategory::Desync)
-                {                   
+                {
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     atRootLevel = !ImGui::TreeNodeEx("HEAD", ImGuiTreeNodeFlags_SpanFullWidth);
@@ -124,9 +124,9 @@ namespace Multiplayer
                                 AZStd::string::format(nodeTitle, elem->m_name.c_str()).c_str(),
                                 (ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanFullWidth));
                             ImGui::TableNextColumn();
-                            ImGui::Text("%hu", elem->m_inputId);
+                            ImGui::Text("%hu", static_cast<unsigned short>(elem->m_inputId));
                             ImGui::TableNextColumn();
-                            ImGui::Text("%d", elem->m_hostFrameId);
+                            ImGui::Text("%d", static_cast<int>(elem->m_hostFrameId));
                             ImGui::TableNextColumn();
                             ImGui::Text("%s", cliServValues.first.c_str());
                             ImGui::TableNextColumn();
@@ -141,9 +141,9 @@ namespace Multiplayer
                     {
                         atRootLevel = false;
                         ImGui::TableNextColumn();
-                        ImGui::Text("%hu", elem->m_inputId);
+                        ImGui::Text("%hu", static_cast<unsigned short>(elem->m_inputId));
                         ImGui::TableNextColumn();
-                        ImGui::Text("%d", elem->m_hostFrameId);
+                        ImGui::Text("%d", static_cast<int>(elem->m_hostFrameId));
                         ImGui::TableNextColumn();
                         ImGui::TableNextColumn();
 
@@ -198,9 +198,9 @@ namespace Multiplayer
                     else
                     {
                         ImGui::TableNextColumn();
-                        ImGui::Text("%hu", elem->m_inputId);
+                        ImGui::Text("%hu", static_cast<unsigned short>(elem->m_inputId));
                         ImGui::TableNextColumn();
-                        ImGui::Text("%d", elem->m_hostFrameId);
+                        ImGui::Text("%d", static_cast<int>(elem->m_hostFrameId));
                         ImGui::TableNextColumn();
                         ImGui::TableNextColumn();
                         ImGui::TableNextRow();


### PR DESCRIPTION
Currently the 23.10.3 point-release branch can't be compiled on clang 17 due to compilation errors, this was already fixed at `development` thanks to the #17273 PR.

## What does this PR do?

This PR cherry-picks the 93c4b7a commit from the merge of the mentioned PR into the 23.10.3 point release branch.

## How was this PR tested?

I compiled and ran the editor by opening a project in my local machine.