### PR TITLE
Cherry pick fix for Linux build failure with cmake 3.28.3

### DIFF
--- a/Gems/Archive/Code/CMakeLists.txt
+++ b/Gems/Archive/Code/CMakeLists.txt
@@ -126,7 +126,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 AZ::AzToolsFramework
                 ${gem_name}.Editor.API
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/Compression/Code/CMakeLists.txt
+++ b/Gems/Compression/Code/CMakeLists.txt
@@ -115,7 +115,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::Compression.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -130,7 +130,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 AZ::AzToolsFramework
                 AZ::AssetBuilderSDK
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
             PRIVATE
                  3rdParty::miniaudio
                  3rdParty::stb_vorbis

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -128,7 +128,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(


### PR DESCRIPTION
## What does this PR do?
Cherry pick for fixing a build failure on Linux introduced by cmake 3.28.3 from https://github.com/o3de/o3de/pull/17605

## How was this PR tested?
Built with cmake 3.28.3 on Linux