### PR TITLE
Cherry pick fix for bootstrap.py files that are invoked from non-Editor tools (ie ShaderManagementConsole)

### DIFF
--- a/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
@@ -9,14 +9,19 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 Generated from O3DE PythonToolGem Template"""
 
 import az_qt_helpers
-import azlmbr.editor as editor
 from ${SanitizedNameLower}_dialog import ${SanitizedCppName}Dialog
 
 if __name__ == "__main__":
     print("${SanitizedCppName}.boostrap, Generated from O3DE PythonToolGem Template")
 
-    # Register our custom widget as a dockable tool with the Editor under an Examples sub-menu
-    options = editor.ViewPaneOptions()
-    options.showOnToolsToolbar = True
-    options.toolbarIcon = ":/${Name}/toolbar_icon.svg"
-    az_qt_helpers.register_view_pane('${SanitizedCppName}', ${SanitizedCppName}Dialog, category="Examples", options=options)
+    try:
+        import azlmbr.editor as editor
+        # Register our custom widget as a dockable tool with the Editor under an Examples sub-menu
+        options = editor.ViewPaneOptions()
+        options.showOnToolsToolbar = True
+        options.toolbarIcon = ":/${Name}/toolbar_icon.svg"
+        az_qt_helpers.register_view_pane('${SanitizedCppName}', ${SanitizedCppName}Dialog, category="Examples", options=options)
+    except:
+        # If the editor is not available (in the cases where this gem is activated outside of the Editor), then just 
+        # report it and continue.
+        print(f'Skipping registering view pane ${SanitizedCppName}, Editor is not available.')


### PR DESCRIPTION
## What does this PR do?
Cherry pick fix for bootstrap.py files that are invoked from non-Editor tools (ie ShaderManagementConsole) from https://github.com/o3de/o3de/pull/17707

## How was this PR tested?
Same steps as in https://github.com/o3de/o3de/pull/17707

