### PR TITLE
Added support for visibility setting on Directional Lights

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -52,6 +52,8 @@ class LightingData
     // Normal . View
     real NdotV;
 
+    bool isVisible;
+
     // Occlusion factors
     // 0 = dark, 1 = light
     real diffuseAmbientOcclusion;
@@ -74,6 +76,7 @@ void LightingData::Init(real3 positionWS, real3 normal, real roughnessLinear, fl
     emissiveLighting = real3(0.0, 0.0, 0.0);
     diffuseAmbientOcclusion = 1.0;
     specularOcclusion = 1.0;
+    isVisible = true;
     
     lightingChannels = 0xFFFFFFFF;
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
@@ -186,6 +186,9 @@ namespace AZ
 
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
+
+            //! Sets whether the light is visible
+            virtual void SetVisible(LightHandle handle, bool visible) = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
@@ -66,6 +66,7 @@ namespace AZ
             float m_shadowFarClipDistance = 20.0f;
             ShadowmapSize m_shadowmapSize = ShadowmapSize::Size2048;
             bool m_enableShadowDebugColoring = false;
+            bool m_visible = true;
         };
 
         //! LightingPreset describes a lighting environment that can be applied to the viewport

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -73,12 +73,11 @@ namespace AZ
             AZStd::array<float, 3> m_direction = { { 1.0f, 0.0f, 0.0f } };
             float m_angularRadius = 0.0f;
             AZStd::array<float, 3> m_rgbIntensity = { { 0.0f, 0.0f, 0.0f } };
+            bool m_isVisible = true;
             float m_affectsGIFactor = 1.0f;
-
             bool m_affectsGI = true;
             uint32_t m_lightingChannelMask = 1;
             float m_padding0 = 0.0f;
-            float m_padding1 = 0.0f;
         };
 
         // [GFX TODO][ATOM-15172] Look into compacting struct DirectionalLightShadowData
@@ -251,6 +250,7 @@ namespace AZ
             void SetAffectsGI(LightHandle handle, bool affectsGI) override;
             void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
+            void SetVisible(LightHandle handle, bool visible) override;
 
             const Data::Instance<RPI::Buffer> GetLightBuffer() const { return m_lightBufferHandler.GetBuffer(); }
             uint32_t GetLightCount() const { return m_lightBufferHandler.GetElementCount(); }
@@ -407,6 +407,9 @@ namespace AZ
             bool m_previousExcludeCvarValue = false;
             uint32_t m_shadowBufferNameIndex = 0;
             uint32_t m_shadowmapIndexTableBufferNameIndex = 0;
+
+            // used to restore m_affectsGI to the configured value when restoring visibility
+            bool m_cachedAffectsGIValue = true;
 
             Name m_lightTypeName = Name("directional");
             Name m_directionalShadowFilteringMethodName = Name("o_directional_shadow_filtering_method");

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/LightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/LightingPreset.cpp
@@ -69,6 +69,7 @@ namespace AZ
                     ->Field("shadowFarClipDistance", &LightConfig::m_shadowFarClipDistance)
                     ->Field("shadowmapSize", &LightConfig::m_shadowmapSize)
                     ->Field("enableShadowDebugColoring", &LightConfig::m_enableShadowDebugColoring)
+                    ->Field("visible", &LightConfig::m_visible)
                     ;
             }
 
@@ -88,6 +89,7 @@ namespace AZ
                     ->Property("shadowFarClipDistance", BehaviorValueProperty(&LightConfig::m_shadowFarClipDistance))
                     ->Property("shadowmapSize", BehaviorValueProperty(&LightConfig::m_shadowmapSize))
                     ->Property("enableShadowDebugColoring", BehaviorValueProperty(&LightConfig::m_enableShadowDebugColoring))
+                    ->Property("visible", BehaviorValueProperty(&LightConfig::m_visible))
                     ;
             }
         }
@@ -191,6 +193,7 @@ namespace AZ
                     directionalLightFeatureProcessor->SetShadowmapFrustumSplitSchemeRatio(lightHandle, lightConfig.m_shadowRatioLogarithmUniform);
                     directionalLightFeatureProcessor->SetShadowFarClipDistance(lightHandle, lightConfig.m_shadowFarClipDistance);
                     directionalLightFeatureProcessor->SetShadowmapSize(lightHandle, lightConfig.m_shadowmapSize);
+                    directionalLightFeatureProcessor->SetVisible(lightHandle, lightConfig.m_visible);
 
                     int flags = lightConfig.m_enableShadowDebugColoring ?
                         DirectionalLightFeatureProcessorInterface::DebugDrawFlags::DebugDrawAll :

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
@@ -219,6 +219,12 @@ namespace AZ
             //! Returns the lighting channel mask
             virtual uint32_t GetLightingChannelMask() const = 0;
 
+            //! Sets whether this light will be visible/enabled
+            virtual void SetVisible(bool visible) = 0;
+
+            //! Returns whether the light is visible/enabled
+            virtual bool IsVisible() const = 0;
+
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(uint32_t lightingChannelMask) = 0;
             //! when the user modifies the component properties in the Inspector panel. 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
@@ -142,6 +142,9 @@ namespace AZ
             bool m_affectsGI = true;
             float m_affectsGIFactor = 1.0f;
 
+            // Visibility
+            bool m_isVisible = true;
+
             // Lighting channel
             AZ::Render::LightingChannelConfiguration m_lightingChannelConfig;
             bool IsSplitManual() const;
@@ -151,6 +154,7 @@ namespace AZ
             bool IsShadowFilteringDisabled() const;
             bool IsShadowPcfDisabled() const;
             bool IsEsmDisabled() const;
+            bool IsVisible() const;
             AZ::Crc32 UpdateCascadeFarDepths();
         };
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
@@ -21,7 +21,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<DirectionalLightComponentConfig, ComponentConfig>()
-                    ->Version(10) // Added AffectsGI
+                    ->Version(11) // Added Visible
                     ->Field("Color", &DirectionalLightComponentConfig::m_color)
                     ->Field("IntensityMode", &DirectionalLightComponentConfig::m_intensityMode)
                     ->Field("Intensity", &DirectionalLightComponentConfig::m_intensity)
@@ -49,6 +49,7 @@ namespace AZ
                     ->Field("Affects GI", &DirectionalLightComponentConfig::m_affectsGI)
                     ->Field("Affects GI Factor", &DirectionalLightComponentConfig::m_affectsGIFactor)
                     ->Field("LightingChannelConfig", &DirectionalLightComponentConfig::m_lightingChannelConfig)
+                    ->Field("Visible", &DirectionalLightComponentConfig::m_isVisible)
                     ;
             }
         }
@@ -133,6 +134,11 @@ namespace AZ
         bool DirectionalLightComponentConfig::IsEsmDisabled() const
         {
             return !m_shadowEnabled || (m_shadowFilterMethod != ShadowFilterMethod::Esm && m_shadowFilterMethod != ShadowFilterMethod::EsmPcf);
+        }
+
+        bool DirectionalLightComponentConfig::IsVisible() const
+        {
+            return m_isVisible;
         }
 
         AZ::Crc32 DirectionalLightComponentConfig::UpdateCascadeFarDepths()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
@@ -96,6 +96,8 @@ namespace AZ
                     ->Event("SetAffectsGIFactor", &DirectionalLightRequestBus::Events::SetAffectsGIFactor)
                     ->Event("GetLightingChannelMask", &DirectionalLightRequestBus::Events::GetLightingChannelMask)
                     ->Event("SetLightingChannelMask", &DirectionalLightRequestBus::Events::SetLightingChannelMask)
+                    ->Event("SetVisible", &DirectionalLightRequestBus::Events::SetVisible)
+                    ->Event("IsVisible", &DirectionalLightRequestBus::Events::IsVisible)
                     ->VirtualProperty("Color", "GetColor", "SetColor")
                     ->VirtualProperty("Intensity", "GetIntensity", "SetIntensity")
                     ->VirtualProperty("AngularDiameter", "GetAngularDiameter", "SetAngularDiameter")
@@ -491,7 +493,7 @@ namespace AZ
 
         bool DirectionalLightComponentController::GetAffectsGI() const
         {
-            return m_configuration.m_affectsGI;
+            return m_configuration.m_affectsGI && m_configuration.m_isVisible;
         }
 
         void DirectionalLightComponentController::SetAffectsGI(bool affectsGI)
@@ -499,7 +501,7 @@ namespace AZ
             m_configuration.m_affectsGI = affectsGI;
             if (m_featureProcessor)
             {
-                m_featureProcessor->SetAffectsGI(m_lightHandle, m_configuration.m_affectsGI);
+                m_featureProcessor->SetAffectsGI(m_lightHandle, m_configuration.m_affectsGI && m_configuration.m_isVisible);
             }
         }
 
@@ -624,6 +626,7 @@ namespace AZ
             SetFullscreenBlurEnabled(m_configuration.m_fullscreenBlurEnabled);
             SetFullscreenBlurConstFalloff(m_configuration.m_fullscreenBlurConstFalloff);
             SetFullscreenBlurDepthFalloffStrength(m_configuration.m_fullscreenBlurDepthFalloffStrength);
+            SetVisible(m_configuration.m_isVisible);
             SetAffectsGI(m_configuration.m_affectsGI);
             SetAffectsGIFactor(m_configuration.m_affectsGIFactor);
             LightingChannelMaskChanged();
@@ -754,6 +757,17 @@ namespace AZ
         {
             m_configuration.m_cascadeBlendingEnabled = enable;
             m_featureProcessor->SetCascadeBlendingEnabled(m_lightHandle, enable);
+        }
+
+        void DirectionalLightComponentController::SetVisible(bool visible)
+        {
+            m_configuration.m_isVisible = visible;
+            m_featureProcessor->SetVisible(m_lightHandle, visible);
+        }
+
+        bool DirectionalLightComponentController::IsVisible() const
+        {
+            return m_configuration.m_isVisible;
         }
 
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
@@ -85,7 +85,7 @@ namespace AZ
             float GetShadowBias() const override;
             void SetShadowBias(float bias) override;
             float GetNormalShadowBias() const override;
-            void SetNormalShadowBias(float bias) override;            
+            void SetNormalShadowBias(float bias) override;
             bool GetCascadeBlendingEnabled() const override;
             void SetCascadeBlendingEnabled(bool enable) override;
             void SetFullscreenBlurEnabled(bool enable);
@@ -95,6 +95,8 @@ namespace AZ
             void SetAffectsGI(bool affectsGI) override;
             float GetAffectsGIFactor() const override;
             void SetAffectsGIFactor(float affectsGIFactor) override;
+            void SetVisible(bool visible) override;
+            bool IsVisible() const override;
             void BindConfigurationChangedEventHandler(DirectionalLightConfigurationChangedEvent::Handler& configurationChangedHandler) override;
             uint32_t GetLightingChannelMask() const override;
             void SetLightingChannelMask(const uint32_t mask) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -57,6 +57,8 @@ namespace AZ
 
                     editContext->Class<DirectionalLightComponentConfig>("DirectionalLightComponentConfig", "")
                         ->ClassElement(Edit::ClassElements::EditorData, "")
+                        ->DataElement(Edit::UIHandlers::CheckBox, &DirectionalLightComponentConfig::m_isVisible, "Visible", "Controls whether this light is visible.")
+
                         ->DataElement(Edit::UIHandlers::Color, &DirectionalLightComponentConfig::m_color, "Color", "Color of the light")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetLinearRgbEditorConfig())


### PR DESCRIPTION
## What does this PR do?

Adds support to set Directional Lights visible through an editor setting and through script.

https://github.com/o3de/o3de/assets/58790905/4c05cc14-d954-484c-9f8a-a5071bc25594

![image](https://github.com/o3de/o3de/assets/58790905/44f82c63-12fd-485b-a17a-0dfa7a66f77c)

Tested on Windows, testing on Linux pending

Note: This is a draft PR, feedback on the approach is welcome, I will have to apply the same paradigm to the other light types, so I want to make sure this is a good direction. Ideally, lights should've derived from the same base light data, but unfortunately it appears each light type was implemented independently, this means I will have to replicate this code accordingly.