### PR TITLE
Windows build script errorlevel fixes

### DIFF
--- a/scripts/build/Platform/Windows/build_windows.cmd
+++ b/scripts/build/Platform/Windows/build_windows.cmd
@@ -50,7 +50,7 @@ IF NOT EXIST CMakeCache.txt (
 IF DEFINED RUN_CONFIGURE (
     call ECHO [ci_build] %CONFIGURE_CMD%
     call %CONFIGURE_CMD%
-    IF NOT !ERRORLEVEL!==0 GOTO :error
+    IF NOT !ERRORLEVEL! EQU 0 GOTO :error
     ECHO !CONFIGURE_CMD!> %LAST_CONFIGURE_CMD_FILE%
 )
 
@@ -58,7 +58,7 @@ REM Split the configuration on semi-colon and use the cmake --build wrapper to r
 FOR %%C in (%CONFIGURATION%) do (
     call ECHO [ci_build] cmake --build . --target %CMAKE_TARGET% --config %%C %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
     call cmake --build . --target %CMAKE_TARGET% --config %%C %CMAKE_BUILD_ARGS% -- %CMAKE_NATIVE_BUILD_ARGS%
-    IF NOT %ERRORLEVEL%==0 GOTO :error
+    IF NOT !ERRORLEVEL! EQU 0 GOTO :error
 )
 
 POPD


### PR DESCRIPTION
## What does this PR do?

A number of fixes to resolve issues found in: https://github.com/o3de/o3de/issues/17791

- Changes the errorlevel variable in the Windows build script to enforce expansion
- Changes Windows build errorlevel comparators to numeric

## How was this PR tested?

Tested in sandbox Jenkins
