### PR TITLE
Fixes to virtual device initialization

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/PhysicalDevice_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/PhysicalDevice_Windows.cpp
@@ -26,6 +26,15 @@ namespace AZ
                 DX12Ptr<IDXGIAdapterX> dxgiAdapterX;
                 dxgiAdapter->QueryInterface(IID_GRAPHICS_PPV_ARGS(dxgiAdapterX.GetAddressOf()));
 
+                DXGI_ADAPTER_DESC1 adapterDesc;
+                dxgiAdapterX->GetDesc1(&adapterDesc);
+
+                // Skip devices with software rasterization
+                if(RHI::CheckBitsAny(adapterDesc.Flags, static_cast<UINT>(DXGI_ADAPTER_FLAG::DXGI_ADAPTER_FLAG_SOFTWARE)))
+                {
+                    continue;
+                }
+
                 PhysicalDevice* physicalDevice = aznew PhysicalDevice;
                 physicalDevice->Init(dxgiFactory.Get(), dxgiAdapterX.Get());
                 physicalDeviceList.emplace_back(physicalDevice);


### PR DESCRIPTION
## What does this PR do?

This PR fixes issues with device virtualization that showed when testing with `dx12`, which includes
- `dx12` returns more devices than are present in a system (including the same GPU twice
- `dx12` (and `metal`) do not store their list of physical devices but create them anew
- `dx12` might add a software rasterizer (which does not work with `Atom`) to the list of devices

This PR only takes as many GPUs from the list as is indicated by the `device-count` parameter, does not iterate over the pointers any longer (as they might be different) and does not add devices which carry the `DXGI_ADAPTER_FLAG_SOFTWARE` to the list of devices.
