### PR TITLE
Fixes in FrameGraph* for backends

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -403,8 +403,6 @@ namespace AZ
 #else
             ResourceTransitionLoggerNull logger(bufferFrameAttachment.GetId());
 #endif
-
-            Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer()->GetDeviceBuffer(rootScope->GetDeviceIndex()));
             RHI::BufferScopeAttachment* scopeAttachment = bufferFrameAttachment.GetFirstScopeAttachment();
 
             if (scopeAttachment == nullptr)
@@ -413,13 +411,15 @@ namespace AZ
                 return;
             }
 
+            Scope& firstScope = static_cast<Scope&>(scopeAttachment->GetScope());
+            Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer()->GetDeviceBuffer(firstScope.GetDeviceIndex()));
+
             D3D12_RESOURCE_TRANSITION_BARRIER transition;
             transition.pResource = buffer.GetMemoryView().GetMemory();
             transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
             transition.StateBefore = buffer.m_initialAttachmentState;
             logger.SetStateBefore(transition.StateBefore);
 
-            Scope& firstScope = static_cast<Scope&>(scopeAttachment->GetScope());
             if (firstScope.IsResourceDiscarded(*scopeAttachment))
             {
                 auto afterState = GetDiscardResourceState(*scopeAttachment, ConvertBufferBindFlags(buffer.GetDescriptor().m_bindFlags));

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -411,6 +411,12 @@ namespace AZ
                 return;
             }
 
+            // TODO:
+            // As the FrameGraph currently does not track ScopeAttachments per device but puts them all into one list,
+            // we currently insert transition barriers between resources on different devices.
+            // As this cannot be solved with the information at this point, we defer this until we properly handle
+            // linking between ScopeAttachments on a per-device basis
+
             Scope& firstScope = static_cast<Scope&>(scopeAttachment->GetScope());
             Buffer& buffer = static_cast<Buffer&>(*bufferFrameAttachment.GetBuffer()->GetDeviceBuffer(firstScope.GetDeviceIndex()));
 
@@ -484,6 +490,12 @@ namespace AZ
                 AZ_WarningOnce("RHI", false, "Imported ImageFrameAttachment isn't used in any Scope");
                 return;
             }
+
+            // TODO:
+            // As the FrameGraph currently does not track ScopeAttachments per device but puts them all into one list,
+            // we currently insert transition barriers between resources on different devices.
+            // As this cannot be solved with the information at this point, we defer this until we properly handle
+            // linking between ScopeAttachments on a per-device basis
 
             Scope& firstScope = static_cast<Scope&>(scopeAttachment->GetScope());
             Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage()->GetDeviceImage(firstScope.GetDeviceIndex()));

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -129,7 +129,7 @@ namespace AZ
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
                         mergedDeviceIndex = scope.GetDeviceIndex();
                         FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                        multiScopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
+                        multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
                     }
                 }
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -128,7 +128,7 @@ namespace AZ
                     mergedHardwareQueueClass = scope.GetHardwareQueueClass();
                     mergedDeviceIndex = scope.GetDeviceIndex();
                     FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                    multiScopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes), GetGroupCount());
+                    multiScopeContextGroup->Init(static_cast<Device&>(scopePrev.GetDevice()), AZStd::move(mergedScopes), GetGroupCount());
                 }
                 
                 // Attempt to merge the current scope.


### PR DESCRIPTION
This PR fixes smaller issues found while testing with `dx12` and includes
- Choosing the correct `DeviceBuffer` in `FrameGraphCompiler` (`dx12`)
- Choosing the correct `Scope` in `FrameGraphExecuter` (`dx12` & `metal`)
