### PR TITLE
Fix update of connected bindings when a child pass is disabled

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -405,6 +405,8 @@ namespace AZ
                 {
                     child->UpdateConnectedBindings();
                 }
+                // Need to update connected bindings again in case the children updated their fallback binding
+                Pass::UpdateConnectedBindings();
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

When disabling a pass, sometimes the parent pass didn't update its connected bindings, so it keeps pointing to a binding of a disabled pass. This generates an error because the parent pass was trying to use an attachment that is not registered in the framegraph (attachments of a disabled pass are not registered in the famegraph). In my case, the PostProcess parent pass wasn't updating properly its "Output" attachment binding after the "ContrastAdaptiveSharpeningPass" was disabled. It keeps pointing to the "ContrastAdaptiveSharpeningPass" (which was disabled).

Because of this, a second pass of updating connected bindings is needed after the children update their own connected bindings (and use any fallback bindings).  I'm not 100% this is the proper solution, but is the one that makes the most sense to me.

## How was this PR tested?

Run MPS on PC.