### PR TITLE
Fix Gem Dependency checking with dependent gems that include versioning

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_test_helper.py
@@ -154,6 +154,7 @@ class EditorTestHelper:
     # Create a new empty level
     def create_level(
         self,
+        template_name: str,
         level_name: str,
         heightmap_resolution: int = 1024,
         heightmap_meters_per_pixel: int = 1,
@@ -161,9 +162,9 @@ class EditorTestHelper:
         use_terrain: bool = False,
         bypass_viewport_resize: bool = False,
     ) -> bool:
-        self.log(f"Creating level {level_name}")
+        self.log(f"Creating level {level_name} from template '{template_name}'")
         result = general.create_level_no_prompt(
-            level_name, heightmap_resolution, heightmap_meters_per_pixel, terrain_texture_resolution, use_terrain
+            template_name, level_name, heightmap_resolution, heightmap_meters_per_pixel, terrain_texture_resolution, use_terrain
         )
 
         # Result codes are ECreateLevelResult defined in CryEdit.h

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -42,7 +42,8 @@ class TestHelper:
         :param level_name: The name of the level to be created
         :return: True if ECreateLevelResult returns 0, False otherwise with logging to report reason
         """
-        Report.info(f"Creating level {level_name}")
+        template_name = "MinimalProject"
+        Report.info(f"Creating level {level_name} from template '{template_name}'")
 
         # Use these hardcoded values to pass expected values for old terrain system until new create_level API is
         # available
@@ -51,7 +52,7 @@ class TestHelper:
         terrain_texture_resolution = 4096
         use_terrain = False
 
-        result = general.create_level_no_prompt(level_name, heightmap_resolution, heightmap_meters_per_pixel,
+        result = general.create_level_no_prompt(template_name, level_name, heightmap_resolution, heightmap_meters_per_pixel,
                                                 terrain_texture_resolution, use_terrain)
 
         # Result codes are ECreateLevelResult defined in CryEdit.h

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -42,7 +42,7 @@ class TestHelper:
         :param level_name: The name of the level to be created
         :return: True if ECreateLevelResult returns 0, False otherwise with logging to report reason
         """
-        template_name = "DefaultProject"
+        template_name = "Prefabs/Default_Level.prefab"
         Report.info(f"Creating level {level_name} from template '{template_name}'")
 
         # Use these hardcoded values to pass expected values for old terrain system until new create_level API is

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -42,7 +42,7 @@ class TestHelper:
         :param level_name: The name of the level to be created
         :return: True if ECreateLevelResult returns 0, False otherwise with logging to report reason
         """
-        template_name = "MinimalProject"
+        template_name = "DefaultProject"
         Report.info(f"Creating level {level_name} from template '{template_name}'")
 
         # Use these hardcoded values to pass expected values for old terrain system until new create_level API is

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
@@ -71,9 +71,11 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
     with Tracer() as error_tracer:
         helper = EditorTestHelper(log_prefix="Editor Camera")
 
+        template_name = "Prefabs/Default_Level.prefab"
+
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        first_level_created = helper.create_level("DefaultProject", "tmp_level_1")
+        first_level_created = helper.create_level(template_name, "tmp_level_1")
         Report.critical_result(Tests.first_level_created, first_level_created)
 
         # record initial viewport position (new level default)
@@ -92,7 +94,7 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
 
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        second_level_created = helper.create_level("DefaultProject", "tmp_level_2")
+        second_level_created = helper.create_level(template_name, "tmp_level_2")
         Report.critical_result(
             Tests.second_level_created, second_level_created)
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
@@ -73,7 +73,7 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
 
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        first_level_created = helper.create_level("MinimalProject", "tmp_level_1")
+        first_level_created = helper.create_level("DefaultProject", "tmp_level_1")
         Report.critical_result(Tests.first_level_created, first_level_created)
 
         # record initial viewport position (new level default)
@@ -92,7 +92,7 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
 
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        second_level_created = helper.create_level("MinimalProject", "tmp_level_2")
+        second_level_created = helper.create_level("DefaultProject", "tmp_level_2")
         Report.critical_result(
             Tests.second_level_created, second_level_created)
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel.py
@@ -73,7 +73,7 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
 
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        first_level_created = helper.create_level("tmp_level_1")
+        first_level_created = helper.create_level("MinimalProject", "tmp_level_1")
         Report.critical_result(Tests.first_level_created, first_level_created)
 
         # record initial viewport position (new level default)
@@ -92,7 +92,7 @@ def EditorWorkflow_EditorCameraBeThisCameraIsClearedWhenChangingLevel():
 
         # note: level name needs to match name in parent TestSuite_Main file
         # see TestAutomation(EditorTestSuite)
-        second_level_created = helper.create_level("tmp_level_2")
+        second_level_created = helper.create_level("MinimalProject", "tmp_level_2")
         Report.critical_result(
             Tests.second_level_created, second_level_created)
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
@@ -74,9 +74,10 @@ def LayerBlender_E2E_Editor():
     from editor_python_test_tools.utils import TestHelper as helper
 
     # 1) Create a new, temporary level
+    lvl_template_name = "MinimalProject"
     lvl_name = "tmp_level"
     helper.init_idle()
-    level_created = helper.create_level(lvl_name)
+    level_created = helper.create_level(lvl_template_name, lvl_name)
     general.idle_wait(1.0)
     Report.critical_result(Tests.level_created, level_created)
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
@@ -74,7 +74,7 @@ def LayerBlender_E2E_Editor():
     from editor_python_test_tools.utils import TestHelper as helper
 
     # 1) Create a new, temporary level
-    lvl_template_name = "DefaultProject"
+    lvl_template_name = "Prefabs/Default_Level.prefab"
     lvl_name = "tmp_level"
     helper.init_idle()
     level_created = helper.create_level(lvl_template_name, lvl_name)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
@@ -74,10 +74,9 @@ def LayerBlender_E2E_Editor():
     from editor_python_test_tools.utils import TestHelper as helper
 
     # 1) Create a new, temporary level
-    lvl_template_name = "Prefabs/Default_Level.prefab"
     lvl_name = "tmp_level"
     helper.init_idle()
-    level_created = helper.create_level(lvl_template_name, lvl_name)
+    level_created = helper.create_level(lvl_name)
     general.idle_wait(1.0)
     Report.critical_result(Tests.level_created, level_created)
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerBlender_E2E_Editor.py
@@ -74,7 +74,7 @@ def LayerBlender_E2E_Editor():
     from editor_python_test_tools.utils import TestHelper as helper
 
     # 1) Create a new, temporary level
-    lvl_template_name = "MinimalProject"
+    lvl_template_name = "DefaultProject"
     lvl_name = "tmp_level"
     helper.init_idle()
     level_created = helper.create_level(lvl_template_name, lvl_name)

--- a/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
@@ -58,6 +58,7 @@ def Debugger_HappyPath_TargetMultipleEntities():
     from utils import TestHelper as helper
     from utils import Report
 
+    TEMPLATE_NAME ="MinimalProject"
     LEVEL_NAME = "tmp_level"
     ASSET_NAME_1 = "ScriptCanvas_TwoComponents0.scriptcanvas"
     ASSET_NAME_2 = "ScriptCanvas_TwoComponents1.scriptcanvas"

--- a/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
@@ -58,7 +58,7 @@ def Debugger_HappyPath_TargetMultipleEntities():
     from utils import TestHelper as helper
     from utils import Report
 
-    TEMPLATE_NAME ="DefaultProject"
+    TEMPLATE_NAME ="lvl_template_name"
     LEVEL_NAME = "tmp_level"
     ASSET_NAME_1 = "ScriptCanvas_TwoComponents0.scriptcanvas"
     ASSET_NAME_2 = "ScriptCanvas_TwoComponents1.scriptcanvas"
@@ -71,7 +71,7 @@ def Debugger_HappyPath_TargetMultipleEntities():
 
     # 1) Create temp level
     general.idle_enable(True)
-    result = general.create_level_no_prompt(LEVEL_NAME, 128, 1, 512, True)
+    result = general.create_level_no_prompt(TEMPLATE_NAME, LEVEL_NAME, 128, 1, 512, True)
     Report.critical_result(Tests.level_created, result == 0)
     helper.wait_for_condition(lambda: general.get_current_level_name() == LEVEL_NAME, WAIT_TIME)
     general.close_pane("Error Report")

--- a/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/Debugger_HappyPath_TargetMultipleEntities.py
@@ -58,7 +58,7 @@ def Debugger_HappyPath_TargetMultipleEntities():
     from utils import TestHelper as helper
     from utils import Report
 
-    TEMPLATE_NAME ="MinimalProject"
+    TEMPLATE_NAME ="DefaultProject"
     LEVEL_NAME = "tmp_level"
     ASSET_NAME_1 = "ScriptCanvas_TwoComponents0.scriptcanvas"
     ASSET_NAME_2 = "ScriptCanvas_TwoComponents1.scriptcanvas"

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -95,8 +95,19 @@ function(get_all_gem_dependencies gem_name output_resolved_gem_names)
         return()
     else()
         # The gem dependency for ${gem_name} has not been calculated. 
-        # First read in the dependencies from the gem.json ifpossible
-        get_property(gem_path GLOBAL PROPERTY "@GEMROOT:${gem_name}@")
+        # First read in the dependencies from the gem.json if possible
+
+        # Strip out any possible version specifier in order to lookup the gem path based on the cached
+        # global property "@GEMROOT:${gem_name}"
+        unset(gem_name_only)
+        o3de_get_name_and_version_specifier(${gem_name} gem_name_only ignore_spec_op ignore_spec_version)
+        get_property(gem_path GLOBAL PROPERTY "@GEMROOT:${gem_name_only}@")
+        if(NOT gem_path)
+            message(FATAL_ERROR "Unable to locate gem path for Gem \"${gem_name_only}\"."
+                    " Is the gem registered in either the ~/.o3de/o3de_manifest.json, ${LY_ROOT_FOLDER}/engine.json,"
+                    " any project.json or any gem.json which itself is registered?")
+        endif()
+
         o3de_read_json_array(gem_dependencies "${gem_path}/gem.json" "dependencies")
 
         # Keep track of the visited gems to prevent any dependency cycles that can


### PR DESCRIPTION
## What does this PR do?
This fixes the situation where the gem dependency check in cmake encounters a dependent gem that is tagged with a specific or minimum version in its dependeny list, i.e. [Ros2RoboticManipulationTemplate/project.json](https://github.com/o3de/o3de-extras/blob/c7b8a76003225731ba9f079ae29c5b26f6c13829/Templates/Ros2RoboticManipulationTemplate/Template/project.json#L43)

## Root Cause
During the dependency lookup, the process checks each gem in the gem dependency list for its `gem.json` file based on a path that is cached in a property [\@GEMROOT:${gem_name}](https://github.com/o3de/o3de/blob/6cc4b1c328a16dd441b5198d44642f901e02eb36/cmake/Gems.cmake#L100). But if a gem dependency includes a version restriction like in [Ros2RoboticManipulationTemplate/project.json](https://github.com/o3de/o3de-extras/blob/c7b8a76003225731ba9f079ae29c5b26f6c13829/Templates/Ros2RoboticManipulationTemplate/Template/project.json#L43), the `gem_name` also includes the version specifier, but only the raw gem name is cached. 

## How was this PR tested?
Created a new project based on `Ros2RoboticManipulationTemplate` and built from the project manager.
