### PR TITLE
Cherry-pick PR17420 from dev to point-release

### DIFF
--- a/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
@@ -49,6 +49,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             Gem::ScriptCanvasDeveloper.Static
+            Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
     RUNTIME_DEPENDENCIES
         Gem::ScriptCanvas
 )
@@ -85,6 +86,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::ScriptCanvasDeveloper.Static
                 Gem::ScriptCanvas.Editor.Static
                 Gem::GraphCanvasWidgets
+                Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
         RUNTIME_DEPENDENCIES
             Gem::ScriptCanvas.Editor
             Gem::GraphCanvasWidgets

--- a/Gems/ScriptCanvasDeveloper/Code/Include/ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h
+++ b/Gems/ScriptCanvasDeveloper/Code/Include/ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h
@@ -11,19 +11,14 @@
 #include <AzCore/Component/Component.h>
 
 #include <ScriptCanvas/PerformanceStatistician.h>
-
-#ifdef IMGUI_ENABLED
-#include <imgui/imgui.h>
 #include <ImGuiBus.h>
-#endif // IMGUI_ENABLED
+
 
 namespace ScriptCanvas::Developer
 {
     class SystemComponent
         : public AZ::Component
-#ifdef IMGUI_ENABLED
         , public ImGui::ImGuiUpdateListenerBus::Handler
-#endif // IMGUI_ENABLED
     {
     public:
         AZ_COMPONENT(SystemComponent, "{46BDD372-8E86-4C0F-B12C-DC271C5DCED1}");
@@ -39,17 +34,17 @@ namespace ScriptCanvas::Developer
         void Init() override;
         void Activate() override;
         void Deactivate() override;
-        ////
 
-#ifdef IMGUI_ENABLED
-
+        // Avoid using IMGUI_ENABLED in any situation that could alter the final vtable or size of this
+        // object, as this header may be compiled in different compile units with different defines
         void OnImGuiMainMenuUpdate() override;
 
+#if defined(IMGUI_ENABLED)  
+        // Non-overrides / non-virtuals are ok
         void GraphHistoryListBox();
-
         void FullPerformanceWindow();
-
 #endif // IMGUI_ENABLED
+
     private:
         ScriptCanvas::Execution::PerformanceStatistician  m_perfStatistician;
     };

--- a/Gems/ScriptCanvasDeveloper/Code/Source/ScriptCanvasDeveloperComponent.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Source/ScriptCanvasDeveloperComponent.cpp
@@ -11,6 +11,10 @@
 #include <ScriptCanvas/Core/Node.h>
 #include <ScriptCanvasDeveloper/ScriptCanvasDeveloperComponent.h>
 
+#if defined(IMGUI_ENABLED)
+#include <imgui/imgui.h>
+#endif
+
 namespace ScriptCanvasDeveloperComponentCpp
 {
     bool GetListEntryFromAZStdStringVector(void* data, int idx, const char** out_text)
@@ -58,18 +62,16 @@ namespace ScriptCanvas::Developer
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
 #endif // IMGUI_ENABLED
-
     }
 
     void SystemComponent::Deactivate()
     {
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusDisconnect();
-#endif // IMGUI_ENABLED
+#endif 
     }
 
 #ifdef IMGUI_ENABLED
-
     void SystemComponent::FullPerformanceWindow()
     {
         GraphHistoryListBox();
@@ -82,16 +84,17 @@ namespace ScriptCanvas::Developer
         const int k_HeightInItemCount = 30;
         ImGui::ListBox(":Graph", &index, &ScriptCanvasDeveloperComponentCpp::GetListEntryFromAZStdStringVector, &scriptHistory, aznumeric_cast<int>(scriptHistory.size()), k_HeightInItemCount);
     }
+#endif // IMGUI_ENABLED
 
     void SystemComponent::OnImGuiMainMenuUpdate()
     {
+#ifdef IMGUI_ENABLED
+
         if (ImGui::BeginMenu("Script Canvas"))
         {
             FullPerformanceWindow();
             ImGui::EndMenu();
         }
+#endif
     }
-
-#endif // IMGUI_ENABLED
-
 }


### PR DESCRIPTION
 Potential fix for ScriptCanvasDeveloper crash (#17420)
    
    CHERRY-PICK from 4eacb15 from development -> point-release/23103
    
    fixes issue #15959
    
    This fixes a potential memory stomp issue, where the size of an object in the dll that creates it does not match the size of the object in static library that contains code that uses it, causing it to modify memory in unexpected location and leading to an assert on linux during startup if the Script Canvas Developer gem (ScriptCanvasDeveloper) is active.
    
    Signed-off-by: Nicholas Lawson <70027408+nick-l-o3de@users.noreply.github.com>
