### PR TITLE
CHERRY-PICK from dev to point-release/23103 PR #17526

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/FileIO.h
+++ b/Code/Framework/AzCore/AzCore/IO/FileIO.h
@@ -33,6 +33,10 @@ namespace AZ
         /// like "*.bat" or "blah??.pak" or "test*.exe" and such.
         bool NameMatchesFilter(AZStd::string_view name, AZStd::string_view filter);
 
+        //! Converts the operating-specific values returned by AZ::IO::FileIO API
+        //! to independent units representing the milliseconds since 1/1/1970 0:00 UTC
+        AZ::u64 FileTimeToMSecsSincePosixEpoch(AZ::u64 fileTime);
+
         using HandleType = AZ::u32;
         static const HandleType InvalidHandle = 0;
 

--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -35,6 +35,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
     ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+    ../Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/FileIO.h>
+
+namespace AZ::IO
+{
+    // On posix compatible systems, file times are in time_t, that is, 
+    // number of seconds since posix epoch.  Converting this just means converting from
+    // seconds to milliseconds
+    AZ::u64 FileTimeToMSecsSincePosixEpoch(AZ::u64 fileTime)
+    { 
+        return fileTime * 1000;
+    }
+}

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/FileIO_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/IO/FileIO_WinAPI.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/IO/FileIO.h>
+
+namespace AZ::IO
+{
+    // There are no leap seconds from the start of the win32 file epoch
+    // which begins Jan 1 1601, until the posix epoch begins.  So to convert
+    // it can just be offset.
+    // see Code\Legacy\CrySystem\LocalizedStringManager.cpp for example of where these constants
+    // came from.
+    // it represents the number of 100-nanosecond intervals between the two epocs.
+    // since win32 file time is in 100-nanosecond intervals.
+    AZ::u64 FileTimeToMSecsSincePosixEpoch(AZ::u64 fileTime)
+    { 
+        static constexpr const AZ::u64 differenceBetweenEpochs = 116444736000000000;
+        if (fileTime <= differenceBetweenEpochs)
+        {
+            return 0; // before the epoch
+        }
+        
+        fileTime = fileTime - differenceBetweenEpochs; 
+        // convert second      to millisecond = * 1,000
+        // convert millisecond to millisecond = * 1
+        // convert microsecond to millisecond = / 1,000
+        // convert nanosecond  to millisecond = / 1,000,000 , therefore
+        // convert 100 nanosec to millisecond = /    10,000   (1,000,000 / 100)
+        fileTime = fileTime / 10000; // convert from 100-nanosecond interval to seconds
+        return fileTime;
+    }
+}

--- a/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
@@ -36,6 +36,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
     ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+    ../Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
@@ -37,6 +37,7 @@ set(FILES
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.cpp
     ../Common/Default/AzCore/IO/Streamer/StreamerContext_Default.h
     ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+    ../Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
@@ -35,6 +35,7 @@ set(FILES
     AzCore/Debug/StackTracer_Windows.cpp
     ../Common/WinAPI/AzCore/Debug/Trace_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/AnsiTerminalUtils_WinAPI.cpp
+    ../Common/WinAPI/AzCore/IO/FileIO_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/Streamer/StreamerContext_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/Streamer/StreamerContext_WinAPI.h
     ../Common/WinAPI/AzCore/IO/SystemFile_WinAPI.cpp

--- a/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
@@ -37,6 +37,7 @@ set(FILES
     ../Common/Apple/AzCore/IO/SystemFile_Apple.cpp
     ../Common/Apple/AzCore/IO/SystemFile_Apple.h
     ../Common/UnixLike/AzCore/IO/AnsiTerminalUtils_UnixLike.cpp
+    ../Common/UnixLike/AzCore/IO/FileIO_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/SystemFile_UnixLike.cpp
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.h
     ../Common/UnixLike/AzCore/IO/Internal/SystemFileUtils_UnixLike.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.cpp
@@ -241,8 +241,24 @@ namespace AzToolsFramework::AssetUtils
         return configFiles;
     }
 
-    bool UpdateFilePathToCorrectCase(AZStd::string_view rootPath, AZStd::string& relPathFromRoot)
+    bool UpdateFilePathToCorrectCase(AZStd::string_view rootPath, AZStd::string& relPathFromRoot, bool checkEntirePath /* = true */)
     {
+        // The reason this is so expensive is that it could also be the case that the DIRECTORY path is the wrong case.
+        // For example, the actual path might be /SomeFolder/textures/whatever/texture.dat
+        // but the real file on disk is actually /SomeFolder/Textures/Whatever/texture.dat 
+        // Note the case difference of the directories.  If you were to ask the operating system just to list all of
+        // the files in the input folder (/SomeFolder/textures/whatever/*) it would not find any since the directory 
+        // does not itself exist.  Not only that, but many operating system calls on case-insensitive file systems
+        // actually use the input given in their return - that is, if you ask a WINAPI call to construct an absolute path
+        // to a file and give it the wrong case as input, the output absolute path will also be the wrong case.
+        // Thus, to actually correct a path it has to start at the bottom and whenever it encounters
+        // a path segment, it has to do a read of the actual directory information to see which files exist in that
+        // directory, and whether a file or directory exists with the correct name but with different case.
+
+        // if checkEntirePath is false, we only check the file name, and nothing else.  This is for the case where
+        // the path is known to be good except for the file name, such as when the relPathFromRoot comes from just
+        // taking an existing, known-good file and replacing its extension only.
+
         AZ::StringFunc::Path::Normalize(relPathFromRoot);
         AZStd::vector<AZStd::string> tokens;
         AZ::StringFunc::Tokenize(relPathFromRoot.c_str(), tokens, AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING);
@@ -261,6 +277,15 @@ namespace AzToolsFramework::AssetUtils
 
         for (int idx = 0; idx < tokens.size(); idx++)
         {
+            if (!checkEntirePath)
+            {
+                if (idx != tokens.size() - 1)
+                {
+                    // only the last token is potentially incorrect, we can skip filenames before that
+                    validatedPath /= tokens[idx]; // go one step deeper.
+                    continue;
+                }
+            }
             AZStd::string element = tokens[idx];
             bool foundAMatch = false;
             AZ::IO::FileIOBase::GetInstance()->FindFiles(validatedPath.c_str(), "*", [&](const char* file)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetUtils.h
@@ -49,7 +49,11 @@ namespace AzToolsFramework::AssetUtils
     //! @param root a trusted already-case-correct path (will not be case corrected). If empty it will be set to appRoot.
     //! @param relativePathFromRoot a non-trusted (may be incorrect case) path relative to rootPath,
     //!        which will be normalized and updated to be correct casing.
+    //! @param checkEntirePath Optimization - set this to false if the caller is absolutely sure the path
+    //!                             is correct and only the last element (file name or extension) is potentially incorrect, this can happen
+    //!                             when for example taking a real file found from a real file directory that is already correct and
+    //!                             replacing the file extension or file name only.
     //! @return if such a file does NOT exist, it returns FALSE, else returns TRUE.
     //! @note A very expensive function!  Call sparingly.
-    bool UpdateFilePathToCorrectCase(AZStd::string_view root, AZStd::string& relativePathFromRoot);
+    bool UpdateFilePathToCorrectCase(AZStd::string_view root, AZStd::string& relativePathFromRoot, bool checkEntirePath = true);
 } //namespace AzToolsFramework::AssetUtils

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
@@ -95,6 +95,7 @@ namespace AssetProcessor
                         if (m_platformConfig->IsFileExcluded(pathMatch))
                         {
                             // Add the folder to the list and do not proceed any deeper
+                            pathMatch = AssetUtilities::NormalizeFilePath(pathMatch);
                             excludedFolders.emplace(pathMatch.toUtf8().constData());
                         }
                         else if (scanFolderInfo.RecurseSubFolders())
@@ -122,14 +123,20 @@ namespace AssetProcessor
 
         if (!pendingAdds.empty())
         {
-            m_excludedFolders.insert(pendingAdds.begin(), pendingAdds.end());
+            for (const auto& pendingAdd : pendingAdds)
+            {
+                QString normalizedAdd = AssetUtilities::NormalizeFilePath(QString::fromUtf8(pendingAdd.c_str()));
+                m_excludedFolders.insert(normalizedAdd.toUtf8().constData());
+
+            }
         }
 
         if (!pendingDeletes.empty())
         {
             for (const auto& pendingDelete : pendingDeletes)
             {
-                m_excludedFolders.erase(pendingDelete);
+                QString normalizedDelete = AssetUtilities::NormalizeFilePath(QString::fromUtf8(pendingDelete.c_str()));
+                m_excludedFolders.erase(normalizedDelete.toUtf8().constData());
             }
         }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
@@ -257,7 +257,7 @@ namespace AssetProcessor
         }
         else if constexpr (!ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM)
         {
-            // if the file does NOT exist and its a a case-insensitive file system
+            // if the file does NOT exist and its a case-insensitive file system
             // it means that it wont exist with any casing.  We can early out here.
             return false;
         }

--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
@@ -9,20 +9,30 @@
 #include "FileStateCache.h"
 #include "native/utilities/assetUtils.h"
 #include <AssetProcessor_Traits_Platform.h>
+#include <AzToolsFramework/Asset/AssetUtils.h>
 
 #include <QDir>
+#include <QDateTime>
+#include <QTimeZone>
 
 namespace AssetProcessor
 {
-
+    // Note that the file state cache operates on the assumption that it is automatically loaded and kept
+    // up to date by the file scanner (initially) and the file watcher (thereafter).  This is why all these
+    // functions do not check the physical device for the file state, but rather rely on the cache.
     bool FileStateCache::GetFileInfo(const QString& absolutePath, FileStateInfo* foundFileInfo) const
     {
+        AZ_Assert(!m_fileInfoMap.empty(), "FileStateCache::GetFileInfo called before cache is initialized!");
+
         LockGuardType scopeLock(m_mapMutex);
         auto itr = m_fileInfoMap.find(PathToKey(absolutePath));
 
         if (itr != m_fileInfoMap.end())
         {
-            *foundFileInfo = itr.value();
+            if (foundFileInfo)
+            {
+                *foundFileInfo = itr.value();
+            }
             return true;
         }
 
@@ -32,9 +42,8 @@ namespace AssetProcessor
     bool FileStateCache::Exists(const QString& absolutePath) const
     {
         LockGuardType scopeLock(m_mapMutex);
-        auto itr = m_fileInfoMap.find(PathToKey(absolutePath));
-
-        return itr != m_fileInfoMap.end();
+        AZ_Assert(!m_fileInfoMap.empty(), "FileStateCache::Exists called before cache is initialized!");
+        return GetFileInfo(absolutePath, nullptr);
     }
 
     void FileStateCache::WarmUpCache(const AssetFileInfo& existingInfo, const FileHash hash)
@@ -56,6 +65,7 @@ namespace AssetProcessor
 
     bool FileStateCache::GetHash(const QString& absolutePath, FileHash* foundHash)
     {
+        AZ_Assert(!m_fileInfoMap.empty(), "FileStateCache::Exists called before cache is initialized!");
         LockGuardType scopeLock(m_mapMutex);
         auto fileInfoItr = m_fileInfoMap.find(PathToKey(absolutePath));
 
@@ -174,10 +184,12 @@ namespace AssetProcessor
 
         QString normalized = AssetUtilities::NormalizeFilePath(absolutePath);
 
-        if constexpr (!ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM)
-        {
-            normalized = normalized.toLower();
-        }
+        // Its possible for this API to be called on a case sensitive and case-insensitive file system for files
+        // with the wrong case.  For example, a source asset might have another source asset listed in its dependency json
+        // but with incorrect case.  If it were to call "Exists" or "GetFileInfo" with the wrong case, it would fail even
+        // though the file actually does exist, and its a case insensitive system.  The API contract for this class demands
+        // that it act as if case-insensitive, so the map MUST be lowercase.
+        normalized = normalized.toLower();
 
         m_keyCache[absolutePath] = normalized;
         return normalized;
@@ -206,14 +218,66 @@ namespace AssetProcessor
 
     //////////////////////////////////////////////////////////////////////////
 
+    static void PopulateFileInfoFromFileIO(const char* absolutePath, FileStateInfo* fileInfo, AZ::IO::FileIOBase* fileIO)
+    {
+        if ((!fileInfo) || (!fileIO))
+        {
+            return;
+        }
+
+        AZ::u64 modTime = AZ::IO::FileTimeToMSecsSincePosixEpoch(fileIO->ModificationTime(absolutePath));
+        AZ::u64 fileSize = 0;
+        fileIO->Size(absolutePath, fileSize);
+        bool isDir = fileIO->IsDirectory(absolutePath);
+        *fileInfo = FileStateInfo(absolutePath, QDateTime::fromMSecsSinceEpoch(modTime, QTimeZone::utc()), fileSize, isDir);
+    }
+
     bool FileStatePassthrough::GetFileInfo(const QString& absolutePath, FileStateInfo* foundFileInfo) const
     {
-        QFileInfo fileInfo(absolutePath);
-
-        if (fileInfo.exists())
+        // note that this interface is also used against dummy file systems in unit tests
+        // which means it cannot rely on Qt / QFileInfo or other operations that would use the actual file system
+        AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance();
+        AZ_Assert(fileIO, "A file IO system must be installed in order to get file info for a file.");
+        if (!fileIO)
         {
-            *foundFileInfo = FileStateInfo(fileInfo.absoluteFilePath(), fileInfo.lastModified(), fileInfo.size(), fileInfo.isDir());
+            return false;
+        }
 
+        AZStd::string absolutePathStr(absolutePath.toUtf8().constData()); // cache to avoid utf8 encoding multiple times
+        bool fileExists = fileIO->Exists(absolutePathStr.c_str());
+        if (fileExists)
+        {
+            // on a case-sensitive file system, the existence of the file means that the entire path and file
+            // name is already correct and we can early out.
+            if constexpr (ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM)
+            {
+                PopulateFileInfoFromFileIO(absolutePathStr.c_str(), foundFileInfo, fileIO);
+                return true;
+            }
+        }
+        else if constexpr (!ASSETPROCESSOR_TRAIT_CASE_SENSITIVE_FILESYSTEM)
+        {
+            // if the file does NOT exist and its a a case-insensitive file system
+            // it means that it wont exist with any casing.  We can early out here.
+            return false;
+        }
+
+        // On case-insensitive systems where the file was found, or
+        // on case-sensitive systems where the file was NOT found, 
+        // it is necessary to consult the actual file directory, since in the former case, the file may be found
+        // but will potentially have the wrong case, but in the latter case, the file may not be found because it does
+        // exist with different case.  Note that file operations like QFileInfo will not correct the case, we MUST
+        // consult the directory table to find the actual case of the file since that is the only place the information
+        // is recorded.
+
+        AZ::IO::Path correctedPath(absolutePath.toUtf8().constData());
+        correctedPath.MakePreferred();
+        AZStd::string rootPath = correctedPath.RootPath().Native();
+        AZStd::string correctedPathStr = correctedPath.Native().substr(rootPath.size());
+        if (AzToolsFramework::AssetUtils::UpdateFilePathToCorrectCase(rootPath.c_str(), correctedPathStr, true))
+        {
+            QString reassembledPath = QString::fromUtf8((AZ::IO::Path(rootPath) / correctedPathStr).Native().c_str());
+            PopulateFileInfoFromFileIO(reassembledPath.toUtf8().constData(), foundFileInfo, fileIO);
             return true;
         }
 
@@ -222,17 +286,18 @@ namespace AssetProcessor
 
     bool FileStatePassthrough::Exists(const QString& absolutePath) const
     {
-        return QFile(absolutePath).exists();
+        return GetFileInfo(absolutePath, nullptr);
     }
 
     bool FileStatePassthrough::GetHash(const QString& absolutePath, FileHash* foundHash)
     {
-        if(!Exists(absolutePath))
+        FileStateInfo fileInfo;
+        if(!GetFileInfo(absolutePath, &fileInfo))
         {
             return false;
         }
 
-        *foundHash = AssetUtilities::GetFileHash(absolutePath.toUtf8().constData(), true);
+        *foundHash = AssetUtilities::GetFileHash(fileInfo.m_absolutePath.toUtf8().constData(), true);
 
         return true;
     }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3524,9 +3524,6 @@ namespace AssetProcessor
         }
 
         AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Received %i files from the scanner.  Assessing...\n", static_cast<int>(filePaths.size()));
-        AssetProcessor::StatsCapture::BeginCaptureStat("WarmingFileCache");
-        WarmUpFileCache(filePaths);
-        AssetProcessor::StatsCapture::EndCaptureStat("WarmingFileCache");
 
         [[maybe_unused]] int processedFileCount = 0;
 
@@ -3581,6 +3578,11 @@ namespace AssetProcessor
     {
         m_scannerFiles = filePaths;
 
+        AssetProcessor::StatsCapture::BeginCaptureStat("WarmingFileCache");
+        WarmUpFileCache(filePaths);
+        AssetProcessor::StatsCapture::EndCaptureStat("WarmingFileCache");
+
+        Q_EMIT FileCacheIsReady();
         CheckReadyToAssessScanFiles();
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -309,6 +309,8 @@ namespace AssetProcessor
         //! Fired when a previously-delayed file has begun processing.
         void ProcessingResumed(QString filePath);
 
+        void FileCacheIsReady();
+
     public Q_SLOTS:
         void AssetProcessed(JobEntry jobEntry, AssetBuilderSDK::ProcessJobResponse response);
         void AssetProcessed_Impl();

--- a/Code/Tools/AssetProcessor/native/tests/FileStateCache/FileStateCacheTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/FileStateCache/FileStateCacheTests.cpp
@@ -9,6 +9,7 @@
 #include <native/tests/FileStateCache/FileStateCacheTests.h>
 #include <native/utilities/assetUtils.h>
 #include <native/unittests/UnitTestUtils.h>
+#include <AzFramework/IO/LocalFileIO.h>
 
 namespace UnitTests
 {
@@ -17,12 +18,15 @@ namespace UnitTests
     void FileStateCacheTests::SetUp()
     {
         m_temporarySourceDir = QDir(m_temporaryDir.path());
+        AZ::IO::FileIOBase::SetInstance(aznew AZ::IO::LocalFileIO());
         m_fileStateCache = AZStd::make_unique<AssetProcessor::FileStateCache>();
     }
 
     void FileStateCacheTests::TearDown()
     {
         m_fileStateCache = nullptr;
+        delete AZ::IO::FileIOBase::GetInstance();
+        AZ::IO::FileIOBase::SetInstance(nullptr);
     }
 
     void FileStateCacheTests::CheckForFile(QString path, bool shouldExist)

--- a/Code/Tools/AssetProcessor/native/tests/MissingDependencyScannerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/MissingDependencyScannerTests.cpp
@@ -73,6 +73,13 @@ namespace AssetProcessor
             {
                 return AZ::Failure(AZStd::string::format("Could not set create scan folder %s", scanFolderName.c_str()));
             }
+            // update the mock scan folder info as well, or else it will be using the default "c:/somepath" as the scan folder
+            // which only works if we are using a mock file IO, which this test is not using.  It would fail on posix systems otherwise.
+            ScanFolderInfo info{QString::fromUtf8(scanFolderPath.c_str()),
+                                QString::fromUtf8(scanFolderName.c_str()),
+                                QString::fromUtf8(scanFolderName.c_str()),
+                                true, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, 1 };
+            m_data->m_pathConversion.SetScanFolder(info);
             return AZ::Success(scanFolder.m_scanFolderID);
         }
 

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
@@ -10,6 +10,89 @@
 
 namespace UnitTests
 {
+    MockComponentApplication::MockComponentApplication()
+    {
+        AZ::ComponentApplicationBus::Handler::BusConnect();
+        AZ::Interface<AZ::ComponentApplicationRequests>::Register(this);
+    }
+
+    MockComponentApplication::~MockComponentApplication()
+    {
+        AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
+        AZ::ComponentApplicationBus::Handler::BusDisconnect();
+    }
+
+    MockPathConversion::MockPathConversion(const char* scanfolder /*= "c:/somepath" */)
+    {
+        m_scanFolderInfo = AssetProcessor::ScanFolderInfo{ scanfolder, "scanfolder", "scanfolder", true, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, 1 };
+    }
+
+    void MockPathConversion::SetScanFolder(const AssetProcessor::ScanFolderInfo& scanFolderInfo)
+    {
+        m_scanFolderInfo = scanFolderInfo;
+    }
+
+    bool MockPathConversion::ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const
+    {
+        EXPECT_TRUE(fullFileName.startsWith(m_scanFolderInfo.ScanPath(), Qt::CaseInsensitive));
+
+        scanFolderName = m_scanFolderInfo.ScanPath();
+        databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);
+
+        return true;
+    }
+
+    const AssetProcessor::ScanFolderInfo* MockPathConversion::GetScanFolderForFile(const QString& /*fullFileName*/) const
+    {
+        return &m_scanFolderInfo;
+    }
+
+    const AssetProcessor::ScanFolderInfo* MockPathConversion::GetScanFolderById(AZ::s64 /*id*/) const
+    {
+        return &m_scanFolderInfo;
+    }
+
+    bool MockMultiPathConversion::ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const
+    {
+        auto scanfolder = GetScanFolderForFile(fullFileName);
+        EXPECT_TRUE(scanfolder);
+
+        scanFolderName = scanfolder->ScanPath();
+        databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);
+
+        return true;
+    }
+
+    const AssetProcessor::ScanFolderInfo* MockMultiPathConversion::GetScanFolderForFile(const QString& fullFileName) const
+    {
+        for (const auto& scanfolder : m_scanFolderInfo)
+        {
+            if (AZ::IO::PathView(fullFileName.toUtf8().constData())
+                .IsRelativeTo(AZ::IO::PathView(scanfolder.ScanPath().toUtf8().constData())))
+            {
+                return &scanfolder;
+            }
+        }
+
+        return nullptr;
+    }
+
+    const AssetProcessor::ScanFolderInfo* MockMultiPathConversion::GetScanFolderById(AZ::s64 id) const
+    {
+        return &m_scanFolderInfo[id - 1];
+    }
+
+    void MockMultiPathConversion::AddScanfolder(QString path, QString name)
+    {
+        m_scanFolderInfo.push_back(
+            AssetProcessor::ScanFolderInfo(path, name, name, false, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, m_scanFolderInfo.size() + 1));
+    }
+    
+    constexpr AZ::u32 MockVirtualFileIO::ComputeHandle(AZ::IO::PathView path)
+    {
+        return AZ::u32(AZStd::hash<AZ::IO::PathView>{}(path));
+    }
+
     MockMultiBuilderInfoHandler::~MockMultiBuilderInfoHandler()
     {
         BusDisconnect();
@@ -226,6 +309,270 @@ namespace UnitTests
         m_suppressedMessages.push_back(errorMessage);
     }
 
+    MockVirtualFileIO::MockVirtualFileIO()
+    {
+        // Cache the existing file io instance and build our mock file io
+        m_priorFileIO = AZ::IO::FileIOBase::GetInstance();
+        m_fileIOMock = AZStd::make_unique<testing::NiceMock<AZ::IO::MockFileIOBase>>();
+
+        // Swap out current file io instance for our mock
+        AZ::IO::FileIOBase::SetInstance(nullptr);
+        AZ::IO::FileIOBase::SetInstance(m_fileIOMock.get());
+
+        // Setup the default returns for our mock file io calls
+        AZ::IO::MockFileIOBase::InstallDefaultReturns(*m_fileIOMock.get());
+
+        using namespace ::testing;
+        using namespace AZ;
+
+        ON_CALL(*m_fileIOMock, Open(_, _, _))
+            .WillByDefault(Invoke(
+                [this](auto filePath, IO::OpenMode mode, IO::HandleType& handle)
+                {
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+                    handle = ComputeHandle(AZ::IO::PathView(normalizedPath));
+
+                    int systemMode = AZ::IO::TranslateOpenModeToSystemFileMode(normalizedPath.c_str(), mode);
+
+                    // Any mode besides OPEN_READ_ONLY creates a file
+                    if ((systemMode & ~int(IO::SystemFile::SF_OPEN_READ_ONLY)) > 0)
+                    {
+                        m_mockFiles[handle] = { normalizedPath, "" };
+                    }
+
+                    return AZ::IO::Result(AZ::IO::ResultCode::Success);
+                }));
+
+        ON_CALL(*m_fileIOMock, Tell(_, _))
+            .WillByDefault(Invoke(
+                [](auto, auto& offset)
+                {
+                    offset = 0;
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, Size(An<AZ::IO::HandleType>(), _))
+            .WillByDefault(Invoke(
+                [this](auto handle, AZ::u64& size)
+                {
+                    auto itr = m_mockFiles.find(handle);
+
+                    size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
+
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, Size(An<const char*>(), _))
+            .WillByDefault(Invoke(
+                [this](const char* filePath, AZ::u64& size)
+                {
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+                    auto handle = ComputeHandle(AZ::IO::PathView(normalizedPath));
+                    auto itr = m_mockFiles.find(handle);
+
+                    size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
+
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, Exists(_))
+            .WillByDefault(Invoke(
+                [this](const char* filePath)
+                {
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+                    auto handle = ComputeHandle(AZ::IO::PathView(normalizedPath));
+                    auto itr = m_mockFiles.find(handle);
+                    return itr != m_mockFiles.end();
+                }));
+
+        ON_CALL(*m_fileIOMock, Rename(_, _))
+            .WillByDefault(Invoke(
+                [this](const char* originalPath, const char* newPath)
+                {
+                    AZStd::string normalizedOriginalPath(originalPath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedOriginalPath);
+                    auto originalHandle = ComputeHandle(AZ::IO::PathView(normalizedOriginalPath));
+
+                    AZStd::string normalizedNewPath(newPath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedNewPath);
+                    auto newHandle = ComputeHandle(AZ::IO::PathView(normalizedNewPath));
+
+                    auto itr = m_mockFiles.find(originalHandle);
+
+                    if (itr != m_mockFiles.end())
+                    {
+                        auto& [path, contents] = itr->second;
+                        path = normalizedNewPath;
+
+                        if (originalHandle != newHandle)
+                        {
+                            m_mockFiles[newHandle] = itr->second;
+                            m_mockFiles.erase(itr);
+                        }
+
+                        return AZ::IO::ResultCode::Success;
+                    }
+
+                    return AZ::IO::ResultCode::Error;
+                }));
+
+        ON_CALL(*m_fileIOMock, Remove(_))
+            .WillByDefault(Invoke(
+                [this](const char* filePath)
+                {
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+                    auto handle = ComputeHandle(AZ::IO::PathView(normalizedPath));
+
+                    m_mockFiles.erase(handle);
+
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, Read(_, _, _, _, _))
+            .WillByDefault(Invoke(
+                [this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
+                {
+                    auto itr = m_mockFiles.find(handle);
+
+                    if (itr == m_mockFiles.end())
+                    {
+                        return AZ::IO::ResultCode::Error;
+                    }
+
+                    memcpy(buffer, itr->second.second.c_str(), itr->second.second.size());
+                    *bytesRead = itr->second.second.size();
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, Write(_, _, _, _))
+            .WillByDefault(Invoke(
+                [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
+                {
+                    auto& pair = m_mockFiles[fileHandle];
+
+                    pair.second.resize(size);
+                    memcpy((void*)pair.second.c_str(), buffer, size);
+
+                    if (bytesWritten)
+                    {
+                        *bytesWritten = size;
+                    }
+
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, FindFiles(_, _, _))
+            .WillByDefault(Invoke(
+                [this](const char* filePath, const char* filter, auto callback)
+                {
+                    if ((!filePath)||(filePath[0] == 0))
+                    {
+                        return AZ::IO::ResultCode::Error;
+                    }
+
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+
+                    size_t filePathLen = normalizedPath.length();
+
+                    // there is unfortunately an extra special case here
+                    // This function could be called with filePath being something like "c:/" for the root of the file system
+                    // so the wildcard search term has to be "c:/{filter}" 
+                    // but could also be called without a trailing slash for all other folders
+                    // like "c:/somepath", and thus the formatting string to combine them must have a trailing slash.
+                    // We are specifically AVOIDING using AZ::IO::Path here because these are mock paths that might
+                    // be invalid paths on posix (for example, a unit test could ask for "c:/whatever" - the file system
+                    // is also a mock file system.)
+                    const char endingChar = normalizedPath[filePathLen - 1];
+                    bool filePathHasTrailingSlash = endingChar == AZ_CORRECT_FILESYSTEM_SEPARATOR;
+                    AZStd::string formatter = filePathHasTrailingSlash ? "%s%s" : "%s" AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING "%s";
+
+                    // mockFiles contains only files, but this function is expected to output directories as well
+                    // we will emit any directory that is a substring of a stored file path.
+                    // this will cause it to emit the same one multiple times, but this is enough for emulation.
+                    for (const auto& [hash, pair] : m_mockFiles)
+                    {
+                        const auto& [path, contents] = pair;
+                        
+                        if (AZStd::wildcard_match(AZStd::string::format(formatter.c_str(), normalizedPath.c_str(), filter), path))
+                        {
+                            // path is a full path to a file, but we need to emulate directory traversal
+                            // e.g. normalizedPath is a path like "c:/" and the path in the cache might be something like
+                            // "c:/somepath/somefile.txt".  For this to function correctly, we must behave as if
+                            // we return "c:/somepath" here, indicating that the contents of "c:/" is "somepath"
+                            //  and not "c:/somepath/somefile.txt" as this is NOT a recursive call.
+
+                            AZStd::string pathWithoutRoot = path.substr(filePathHasTrailingSlash ? filePathLen : filePathLen + 1);
+                            size_t slashPos = pathWithoutRoot.find_first_of(AZ_CORRECT_FILESYSTEM_SEPARATOR);
+                            // eg, input: "c:/", we found "c:/somepath/somefile.txt" in our cache,
+                            // so the pathWithoutRoot is "somepath/somefile.txt".
+                            if (slashPos != AZStd::string::npos)
+                            {
+                                // if we get here, it means that the path we found in our hash is deeper
+                                // in the virtual file tree than the local we are virtually traversing,
+                                // so we return just the folder name after adding the root back in the front:
+                                AZStd::string reassembled = AZStd::string::format(formatter.c_str(), filePath, pathWithoutRoot.substr(0, slashPos).c_str());
+                                if (!callback(reassembled.c_str()))
+                                {
+                                    return AZ::IO::ResultCode::Success;
+                                }
+                            }
+                            else
+                            {
+                                if(!callback(path.c_str()))
+                                {
+                                    return AZ::IO::ResultCode::Success;
+                                }
+                            }
+                        }
+                    }
+                    return AZ::IO::ResultCode::Success;
+                }));
+
+        ON_CALL(*m_fileIOMock, IsDirectory(_))
+            .WillByDefault(Invoke(
+                [this](const char* filePath)
+                {
+                    AZStd::string normalizedPath(filePath);
+                    AzFramework::StringFunc::Path::Normalize(normalizedPath);
+                    for (const auto& [hash, pair] : m_mockFiles)
+                    {
+                        const auto& [path, contents] = pair;
+                        // if the given path is a prefix of the file path, it could be a directory
+                        if (path.find(normalizedPath.c_str()) == 0)
+                        {
+                            // its not a directory if the path is the exact same as the file path
+                            if (path.compare(normalizedPath.c_str()) == 0)
+                            {
+                                return false; // we found an exact match, so its not a directory, its a file.
+                            }
+
+                            // if we get here, path starts with filePath must logically be longer than filePath
+                            // since it did not match exactly but started with it.
+                            // It is a directory if there is a slash immediately after filePath inside path
+                            if (path[normalizedPath.length()] == AZ_CORRECT_FILESYSTEM_SEPARATOR)
+                            {
+                                // if we get here, we have positively identified a file path in the cache that
+                                // has the given filePath as a substring of it and the character
+                                // after the substring in the cache is a slash... it must be a directory.
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }));
+        }
+
+        MockVirtualFileIO::~MockVirtualFileIO()
+        {
+            AZ::IO::FileIOBase::SetInstance(nullptr);
+            AZ::IO::FileIOBase::SetInstance(m_priorFileIO);
+        }
+
     void MockFileStateCache::RegisterForDeleteEvent(AZ::Event<AssetProcessor::FileStateInfo>::Handler& handler)
     {
         handler.Connect(m_deleteEvent);
@@ -241,5 +588,81 @@ namespace UnitTests
         *foundHash = AssetUtilities::GetFileHash(absolutePath.toUtf8().constData(), true);
 
         return true;
+    }
+
+    // this MockFileStateCache has to be permissive for the case where on posix systems the unit tests
+    // still ask for non-posix paths like "c:/whatever" and expect the rootpath to be "c:/".  Calling Path::RootPath
+    // actually fails on those operating systems (correctly!) because "c:/something" on those systems
+    // is a relative path, representing '${PWD}/c:/something' with c: being just another directory name.
+    // To get around this we have to manually split the path here.
+    static void MockAbsoluteSplit(const QString& absolutePath, AZStd::string& rootPath, AZStd::string& relPathFromRoot)
+    {
+        qsizetype firstSlash = absolutePath.indexOf("/"); // we assume normalized forward slashes.
+        if (firstSlash == -1)
+        {
+            rootPath = AZStd::string();
+            relPathFromRoot = absolutePath.toUtf8().constData();
+            return;
+        }
+
+        rootPath = absolutePath.left(firstSlash + 1).toUtf8().constData();;
+        relPathFromRoot = absolutePath.mid(firstSlash + 1).toUtf8().constData();;
+    }
+
+    bool MockFileStateCache::GetFileInfo(const QString& absolutePath, AssetProcessor::FileStateInfo* foundFileInfo) const
+    {
+        if (Exists(absolutePath))
+        {
+            auto* io = AZ::IO::FileIOBase::GetInstance();
+            AZ::u64 size;
+            io->Size(absolutePath.toUtf8().constData(), size);
+
+            AZStd::string rootPath;
+            AZStd::string relPathFromRoot;
+            MockAbsoluteSplit(absolutePath, rootPath, relPathFromRoot);
+
+            // convert the path to the correct case (to emulate GetFileInfo actual).  
+            // Note that calling AssetUtilities::UpdateToCorrectCase would
+            // cause a stack overflow since it would call this function again.
+            // Instead, call the underlying AzToolsFramework function.
+            AzToolsFramework::AssetUtils::UpdateFilePathToCorrectCase(rootPath.c_str(), relPathFromRoot);
+
+            AZ::IO::FixedMaxPath correctedPath{rootPath};
+            correctedPath /= relPathFromRoot;
+
+            *foundFileInfo = AssetProcessor::FileStateInfo(
+                correctedPath.c_str(),
+                QDateTime::fromMSecsSinceEpoch(io->ModificationTime(absolutePath.toUtf8().constData())),
+                size,
+                io->IsDirectory(absolutePath.toUtf8().constData()));
+
+            return true;
+        }
+
+        return false;
+    }
+
+    bool MockFileStateCache::Exists(const QString& absolutePath) const
+    {
+        // this API needs to be case insensitive to be satisfied, so on case sensitive file systems, we should
+        // double check.  Note that UpdateFilePathToCorrectCase is very expensive, so we only use it as a fallback
+        // and prefer if the initial if statement passes and returns true
+        if (AZ::IO::FileIOBase::GetInstance()->Exists(absolutePath.toUtf8().constData()))
+        {
+            return true;
+        }
+
+        // note that during Mock unit test operations, the above FileIOBase might be a mock file io base, 
+        // which uses a cache of files and is itself case sensitive.  So even on case-insensitive file systems
+        // this mock still has to do the below de-sensitizing.
+        AZStd::string rootPath;
+        AZStd::string relPathFromRoot;
+        MockAbsoluteSplit(absolutePath, rootPath, relPathFromRoot);
+
+        if (AzToolsFramework::AssetUtils::UpdateFilePathToCorrectCase(rootPath, relPathFromRoot))
+        {
+            return true;
+        }
+        return false;
     }
 } // namespace UnitTests

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -15,7 +15,7 @@
 #include <gmock/gmock.h>
 #include <AzCore/UnitTest/Mocks/MockFileIOBase.h>
 #include <AssetManager/FileStateCache.h>
-#include <QDir>
+#include <AzToolsFramework/Asset/AssetUtils.h>
 
 namespace UnitTests
 {
@@ -97,17 +97,8 @@ namespace UnitTests
         : public AZ::ComponentApplicationBus::Handler
     {
     public:
-        MockComponentApplication()
-        {
-            AZ::ComponentApplicationBus::Handler::BusConnect();
-            AZ::Interface<AZ::ComponentApplicationRequests>::Register(this);
-        }
-
-        ~MockComponentApplication()
-        {
-            AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
-            AZ::ComponentApplicationBus::Handler::BusDisconnect();
-        }
+        MockComponentApplication();
+        ~MockComponentApplication();
 
     public:
         MOCK_METHOD1(FindEntity, AZ::Entity* (const AZ::EntityId&));
@@ -136,30 +127,11 @@ namespace UnitTests
 
     struct MockPathConversion : AZ::Interface<AssetProcessor::IPathConversion>::Registrar
     {
-        MockPathConversion(const char* scanfolder = "c:/somepath")
-        {
-            m_scanFolderInfo = AssetProcessor::ScanFolderInfo{ scanfolder, "scanfolder", "scanfolder", true, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, 1 };
-        }
-
-        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override
-        {
-            EXPECT_TRUE(fullFileName.startsWith(m_scanFolderInfo.ScanPath(), Qt::CaseInsensitive));
-
-            scanFolderName = m_scanFolderInfo.ScanPath();
-            databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);
-
-            return true;
-        }
-
-        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& /*fullFileName*/) const override
-        {
-            return &m_scanFolderInfo;
-        }
-
-        const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 /*id*/) const override
-        {
-            return &m_scanFolderInfo;
-        }
+        MockPathConversion(const char* scanfolder = "c:/somepath");
+        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override;
+        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& /*fullFileName*/) const override;
+        const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 /*id*/) const override;
+        void SetScanFolder(const AssetProcessor::ScanFolderInfo& scanFolderInfo);
 
     private:
         AssetProcessor::ScanFolderInfo m_scanFolderInfo;
@@ -167,41 +139,10 @@ namespace UnitTests
 
     struct MockMultiPathConversion : AZ::Interface<AssetProcessor::IPathConversion>::Registrar
     {
-        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override
-        {
-            auto scanfolder = GetScanFolderForFile(fullFileName);
-            EXPECT_TRUE(scanfolder);
-
-            scanFolderName = scanfolder->ScanPath();
-            databaseSourceName = fullFileName.mid(scanFolderName.size() + 1);
-
-            return true;
-        }
-
-        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const override
-        {
-            for (const auto& scanfolder : m_scanFolderInfo)
-            {
-                if (AZ::IO::PathView(fullFileName.toUtf8().constData())
-                    .IsRelativeTo(AZ::IO::PathView(scanfolder.ScanPath().toUtf8().constData())))
-                {
-                    return &scanfolder;
-                }
-            }
-
-            return nullptr;
-        }
-
-        const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const override
-        {
-            return &m_scanFolderInfo[id - 1];
-        }
-
-        void AddScanfolder(QString path, QString name)
-        {
-            m_scanFolderInfo.push_back(
-                AssetProcessor::ScanFolderInfo(path, name, name, false, true, { AssetBuilderSDK::PlatformInfo{ "pc", {} } }, 0, m_scanFolderInfo.size() + 1));
-        }
+        bool ConvertToRelativePath(QString fullFileName, QString& databaseSourceName, QString& scanFolderName) const override;
+        const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const override;
+        const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const override;
+        void AddScanfolder(QString path, QString name);
 
     private:
         AZStd::vector<AssetProcessor::ScanFolderInfo> m_scanFolderInfo;
@@ -209,177 +150,10 @@ namespace UnitTests
 
     struct MockVirtualFileIO
     {
-        static constexpr AZ::u32 ComputeHandle(AZ::IO::PathView path)
-        {
-            return AZ::u32(AZStd::hash<AZ::IO::PathView>{}(path));
-        }
+        static constexpr AZ::u32 ComputeHandle(AZ::IO::PathView path);
 
-        MockVirtualFileIO()
-        {
-            // Cache the existing file io instance and build our mock file io
-            m_priorFileIO = AZ::IO::FileIOBase::GetInstance();
-            m_fileIOMock = AZStd::make_unique<testing::NiceMock<AZ::IO::MockFileIOBase>>();
-
-            // Swap out current file io instance for our mock
-            AZ::IO::FileIOBase::SetInstance(nullptr);
-            AZ::IO::FileIOBase::SetInstance(m_fileIOMock.get());
-
-            // Setup the default returns for our mock file io calls
-            AZ::IO::MockFileIOBase::InstallDefaultReturns(*m_fileIOMock.get());
-
-            using namespace ::testing;
-            using namespace AZ;
-
-            ON_CALL(*m_fileIOMock, Open(_, _, _))
-                .WillByDefault(Invoke(
-                    [this](auto filePath, IO::OpenMode mode, IO::HandleType& handle)
-                    {
-                        handle = ComputeHandle(filePath);
-
-                        int systemMode = AZ::IO::TranslateOpenModeToSystemFileMode(filePath, mode);
-
-                        // Any mode besides OPEN_READ_ONLY creates a file
-                        if ((systemMode & ~int(IO::SystemFile::SF_OPEN_READ_ONLY)) > 0)
-                        {
-                            m_mockFiles[handle] = { filePath, "" };
-                        }
-
-                        return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                    }));
-
-            ON_CALL(*m_fileIOMock, Tell(_, _))
-                .WillByDefault(Invoke(
-                    [](auto, auto& offset)
-                    {
-                        offset = 0;
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Size(An<AZ::IO::HandleType>(), _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, AZ::u64& size)
-                    {
-                        auto itr = m_mockFiles.find(handle);
-
-                        size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
-
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Size(An<const char*>(), _))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath, AZ::u64& size)
-                    {
-                        auto handle = ComputeHandle(filePath);
-                        auto itr = m_mockFiles.find(handle);
-
-                        size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
-
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Exists(_))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath)
-                    {
-                        auto handle = ComputeHandle(filePath);
-                        auto itr = m_mockFiles.find(handle);
-                        return itr != m_mockFiles.end();
-                    }));
-
-            ON_CALL(*m_fileIOMock, Rename(_, _))
-                .WillByDefault(Invoke(
-                    [this](const char* originalPath, const char* newPath)
-                    {
-                        auto originalHandle = ComputeHandle(originalPath);
-                        auto newHandle = ComputeHandle(newPath);
-                        auto itr = m_mockFiles.find(originalHandle);
-
-                        if (itr != m_mockFiles.end())
-                        {
-                            auto& [path, contents] = itr->second;
-                            path = newPath;
-
-                            if (originalHandle != newHandle)
-                            {
-                                m_mockFiles[newHandle] = itr->second;
-                                m_mockFiles.erase(itr);
-                            }
-
-                            return AZ::IO::ResultCode::Success;
-                        }
-
-                        return AZ::IO::ResultCode::Error;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Remove(_))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath)
-                    {
-                        auto handle = ComputeHandle(filePath);
-
-                        m_mockFiles.erase(handle);
-
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Read(_, _, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
-                    {
-                        auto itr = m_mockFiles.find(handle);
-
-                        if (itr == m_mockFiles.end())
-                        {
-                            return AZ::IO::ResultCode::Error;
-                        }
-
-                        memcpy(buffer, itr->second.second.c_str(), itr->second.second.size());
-                        *bytesRead = itr->second.second.size();
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, Write(_, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
-                    {
-                        auto& pair = m_mockFiles[fileHandle];
-
-                        pair.second.resize(size);
-                        memcpy((void*)pair.second.c_str(), buffer, size);
-
-                        if (bytesWritten)
-                        {
-                            *bytesWritten = size;
-                        }
-
-                        return AZ::IO::ResultCode::Success;
-                    }));
-
-            ON_CALL(*m_fileIOMock, FindFiles(_, _, _))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath, const char* filter, auto callback)
-                    {
-                        for (const auto& [hash, pair] : m_mockFiles)
-                        {
-                            const auto& [path, contents] = pair;
-                            if(AZStd::wildcard_match(AZStd::string::format("%s%s", filePath, filter), path))
-                            {
-                                if(!callback(path.c_str()))
-                                {
-                                    return AZ::IO::ResultCode::Success;
-                                }
-                            }
-                        }
-
-                        return AZ::IO::ResultCode::Success;
-                    }));
-        }
-        ~MockVirtualFileIO()
-        {
-            AZ::IO::FileIOBase::SetInstance(nullptr);
-            AZ::IO::FileIOBase::SetInstance(m_priorFileIO);
-        }
+        MockVirtualFileIO();
+        ~MockVirtualFileIO();
 
         AZ::IO::FileIOBase* m_priorFileIO = nullptr;
         AZStd::unordered_map<AZ::IO::HandleType, AZStd::pair<AZStd::string, AZStd::string>> m_mockFiles;
@@ -388,37 +162,8 @@ namespace UnitTests
 
     struct MockFileStateCache : AssetProcessor::FileStateBase
     {
-        bool GetFileInfo(const QString& absolutePath, AssetProcessor::FileStateInfo* foundFileInfo) const override
-        {
-            if (Exists(absolutePath))
-            {
-                auto* io = AZ::IO::FileIOBase::GetInstance();
-                AZ::u64 size;
-                io->Size(absolutePath.toUtf8().constData(), size);
-
-                QString parentPath = AZ::IO::FixedMaxPath(absolutePath.toUtf8().constData()).ParentPath().FixedMaxPathStringAsPosix().c_str();
-                QString relPath = AZ::IO::FixedMaxPath(absolutePath.toUtf8().constData()).Filename().FixedMaxPathStringAsPosix().c_str();
-                AssetUtilities::UpdateToCorrectCase(parentPath, relPath);
-
-                AZ::IO::FixedMaxPath correctedPath{parentPath.toUtf8().constData()};
-                correctedPath /= relPath.toUtf8().constData();
-
-                *foundFileInfo = AssetProcessor::FileStateInfo(
-                    correctedPath.c_str(),
-                    QDateTime::fromMSecsSinceEpoch(io->ModificationTime(absolutePath.toUtf8().constData())),
-                    size,
-                    io->IsDirectory(absolutePath.toUtf8().constData()));
-
-                return true;
-            }
-
-            return false;
-        }
-
-        bool Exists(const QString& absolutePath) const override
-        {
-            return AZ::IO::FileIOBase::GetInstance()->Exists(absolutePath.toUtf8().constData());
-        }
+        bool GetFileInfo(const QString& absolutePath, AssetProcessor::FileStateInfo* foundFileInfo) const override;
+        bool Exists(const QString& absolutePath) const override;
 
         bool GetHash(const QString& absolutePath, FileHash* foundHash) override;
         void RegisterForDeleteEvent(AZ::Event<AssetProcessor::FileStateInfo>::Handler& handler) override;

--- a/Code/Tools/AssetProcessor/native/tests/utilities/assetUtilsTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/assetUtilsTest.cpp
@@ -118,11 +118,7 @@ TEST_F(AssetUtilitiesTest, UpdateToCorrectCase_MissingFile_ReturnsFalse)
     EXPECT_FALSE(AssetUtilities::UpdateToCorrectCase(canonicalTempDirPath, fileName));
 }
 
-#if AZ_TRAIT_DISABLE_FAILED_ASSET_PROCESSOR_TESTS
-TEST_F(AssetUtilitiesTest, DISABLED_UpdateToCorrectCase_ExistingFile_ReturnsTrue_CorrectsCase)
-#else
 TEST_F(AssetUtilitiesTest, UpdateToCorrectCase_ExistingFile_ReturnsTrue_CorrectsCase)
-#endif // AZ_TRAIT_DISABLE_FAILED_ASSET_PROCESSOR_TESTS
 {
     QTemporaryDir dir;
     QDir tempPath(dir.path());

--- a/Code/Tools/AssetProcessor/native/unittests/UnitTestUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/UnitTestUtils.cpp
@@ -42,7 +42,7 @@ namespace UnitTestUtils
 
     bool CreateDummyFileAZ(AZ::IO::PathView fullPathToFile, AZStd::string_view contents)
     {
-        AZ::IO::FileIOStream stream(fullPathToFile.FixedMaxPathString().c_str(), AZ::IO::OpenMode::ModeWrite);
+        AZ::IO::FileIOStream stream(fullPathToFile.FixedMaxPathString().c_str(), AZ::IO::OpenMode::ModeWrite|AZ::IO::OpenMode::ModeCreatePath);
 
         if (!stream.IsOpen())
         {

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -53,6 +53,7 @@ ApplicationManagerBase::ApplicationManagerBase(int* argc, char*** argv, QObject*
     : ApplicationManager(argc, argv, parent)
 {
     qRegisterMetaType<AZ::u32>("AZ::u32");
+    qRegisterMetaType<AZ::u32>("AZ::s64");
     qRegisterMetaType<AZ::Uuid>("AZ::Uuid");
 }
 
@@ -397,17 +398,14 @@ void ApplicationManagerBase::InitAssetScanner()
     using namespace AssetProcessor;
     m_assetScanner = new AssetScanner(m_platformConfiguration);
 
-    // asset processor manager
+    // // wait until file cache is ready before attempting to build the catalog.
     QObject::connect(
-        m_assetScanner,
-        &AssetScanner::AssetScanningStatusChanged,
         m_assetProcessorManager,
-        [this](auto status)
+        &AssetProcessorManager::FileCacheIsReady, 
+        m_assetProcessorManager,
+        [this]()
         {
-            if (status == AssetProcessor::AssetScanningStatus::Completed)
-            {
-                InitAssetCatalog();
-            }
+            InitAssetCatalog();
         });
     QObject::connect(m_assetScanner, &AssetScanner::AssetScanningStatusChanged, m_assetProcessorManager, &AssetProcessorManager::OnAssetScannerStatusChange);
     QObject::connect(m_assetScanner, &AssetScanner::FilesFound,                 m_assetProcessorManager, &AssetProcessorManager::RecordFilesFromScanner);

--- a/Code/Tools/AssetProcessor/native/utilities/UuidManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/UuidManager.cpp
@@ -273,7 +273,11 @@ namespace AssetProcessor
             {
                 QString parentPath = QString::fromStdString(AZStd::string(metadataFilePath.ParentPath().Native()).c_str());
                 QString caseCorrectedMetadataRelPath = QString::fromStdString(AZStd::string(metadataFilePath.Filename().Native()).c_str());
-                metadataFileExists = AssetUtilities::UpdateToCorrectCase(parentPath, caseCorrectedMetadataRelPath);
+
+                // in this case, we got the file name and path from a real existing file that has already got the correct case
+                // so the only case correction we may need to do is for the last part (the meta file name)
+                // so we can set the checkEntirePath param to false.
+                metadataFileExists = AssetUtilities::UpdateToCorrectCase(parentPath, caseCorrectedMetadataRelPath, false);
 
                 if (metadataFileExists)
                 {

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -251,7 +251,10 @@ namespace AssetUtilities
     QString GuessProductNameInDatabase(QString path, QString platform, AssetProcessor::AssetDatabaseConnection* databaseConnection);
 
     //! A utility function which checks the given path starting at the root and updates the relative path to be the actual case correct path.
-    bool UpdateToCorrectCase(const QString& rootPath, QString& relativePathFromRoot);
+    //! Set checkEntirePath to false if the caller is absolutely sure the path is correct and only the last element (file name or extension)
+    //! is potentially wrong. This can happen when for example taking a real file found from a real file directory that is already correct
+    //! and modifying just the file path or extension.  It is significantly faster to avoid checking the entire path.
+    bool UpdateToCorrectCase(const QString& rootPath, QString& relativePathFromRoot, bool checkEntirePath = true);
 
     //! Returns true if the path is in the cachePath and *not* in the intermediate assets folder.
     //! If cachePath is empty, it will be computed using ComputeProjectCacheRoot.


### PR DESCRIPTION
Improve ap startup on linux (#17526)

* Improves the startup time of AP on linux.

Note that this could also potentially improve it on mac and windows, as well as metafile processing in general.

Most of this change is just moving the initialization of the catalog until the file cache is warmed up and then using the file cache to fix path cases on case sensitive file systems.

The rest of it is fixing the unit tests to account for this - the mock for the file system wasn't sufficient to actually use this new code as it would do things like always answer false for "is directory".

With this change, all unit tests pass in debug on linux, with no unexpected assertions and no failures.  In addition, AP starts and idles very quickly without any long freezes during startup.



* Fixes a warning I'm not sure I created

During Createjobs,  Asset Processor Manager does this:
```cpp
Q_EMIT CreateJobsDurationChanged(sourceAsset.RelativePath().c_str(), sourceAsset.ScanFolderId());
```

However, scan folder ID of type AZ::s64 which hasn't been registered to Qt serializer's meta object system, so it does not know how to convert it to a byte array to emit messages across threads.  This causes warnings and probably causes that message not to be emitted.

* Fixes for windows

Most of the problems were in oversights in existing tests. For example the asset catalog tests use a virtual file system but were using CreateDummyFile which makes real files.

Likewise, the asset catalog was using SystemFile instead of FileIO which was the mock file IO.  So it would be making mock files in memory but then checking real files on disk, etc.

Note that the Pass-thru file cache is only used in unit tests, or when specifically asked for by a command line parameter, which is not used in any of the test scripts.

