### PR TITLE
Cherry-pick pull request #17424 from dev to point-release/23103

### DIFF
--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
@@ -263,5 +263,8 @@ xcb_input_fp3232_t* xcb_input_raw_button_press_axisvalues_raw(const xcb_input_ra
 {
     return MockXcbInterface::Instance()->xcb_input_raw_button_press_axisvalues_raw(R);
 }
-
+uint32_t* xcb_input_raw_button_press_valuator_mask (const xcb_input_raw_button_press_event_t *R)
+{
+    return MockXcbInterface::Instance()->xcb_input_raw_button_press_valuator_mask(R);
+}
 }

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
@@ -142,6 +142,7 @@ public:
     MOCK_CONST_METHOD4(xcb_input_xi_select_events, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window, uint16_t num_mask, const xcb_input_event_mask_t* masks));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_length, int(const xcb_input_raw_button_press_event_t* R));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_raw, xcb_input_fp3232_t*(const xcb_input_raw_button_press_event_t* R));
+    MOCK_CONST_METHOD1(xcb_input_raw_button_press_valuator_mask, uint32_t*(const xcb_input_raw_button_press_event_t* R));
 
 private:
     static inline MockXcbInterface* self = nullptr;


### PR DESCRIPTION
Fix issue #14877 - mouse wheel being intepreted as x-axis movement on linux (#17424)

* Fix issue #14877 - mouse wheel being intepreted as x-axis movement on Linux
* Fixed existing tests and added a new test case

The old tests were not mocking the new function called inside xcb. I also added a new test that makes sure that this does not regress.