### PR TITLE
Fix decal material loading when asset is already loaded

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -124,6 +124,7 @@ namespace AZ
             bool RemoveDecalFromTextureArrays(const DecalLocation decalLocation);
             AZ::Data::AssetId GetMaterialUsedByDecal(const DecalHandle handle) const;
             void PackTexureArrays();
+            void SetMaterialToDecals(RPI::MaterialAsset* materialAsset, const AZStd::vector<DecalHandle>& decalsThatUseThisMaterial);
 
             IndexedDataVector<DecalData> m_decalData;
 


### PR DESCRIPTION
## What does this PR do?

Fix a bug when using a material that is already loaded for a decal. The DecalTextureArrayFeatureProcessor::OnAssetReady function expects the assetId of the material asset to be in the material load tracker. Since the material was already loaded, it wasn't in the tracker, so the texture location wasn't being set for the decal. Added the tracking to the material load tracker before calling the OnAssetReady function. That function will remove it from the tracker once it finish processing the material.

Fixes https://github.com/o3de/o3de/issues/17617

## How was this PR tested?

Run PC DX12 and Vulkan with a level that has a decal component.