### PR TITLE
Fix Clang-17 nounity compile errors on Windows

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestRunner/Common/Run/TestImpactTestCoverageSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/TestRunner/Common/Run/TestImpactTestCoverageSerializer.cpp
@@ -6,8 +6,6 @@
  *
  */
 
-#pragma once
-
 #include <TestRunner/Common/Run/TestImpactTestCoverageSerializer.h>
 
 #include <AzCore/Date/DateFormat.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.cpp
@@ -6,8 +6,6 @@
  *
  */
 
-#pragma once
-
 #include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
 #include <TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h>
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.cpp
@@ -6,8 +6,6 @@
  *
  */
 
-#pragma once
-
 #include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
 #include <TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h>
 

--- a/Gems/Atom/RHI/DX12/External/AMD_D3D12MemoryAllocator/v2.0.1/dx12ma/D3D12MemAlloc.cpp
+++ b/Gems/Atom/RHI/DX12/External/AMD_D3D12MemoryAllocator/v2.0.1/dx12ma/D3D12MemAlloc.cpp
@@ -125,7 +125,7 @@ static constexpr UINT STANDARD_HEAP_TYPE_COUNT = 3; // Only DEFAULT, UPLOAD, REA
 static constexpr UINT DEFAULT_POOL_MAX_COUNT = 9;
 static const UINT NEW_BLOCK_SIZE_SHIFT_MAX = 3;
 // Minimum size of a free suballocation to register it in the free suballocation collection.
-static const UINT64 MIN_FREE_SUBALLOCATION_SIZE_TO_REGISTER = 16;
+[[maybe_unused]] static const UINT64 MIN_FREE_SUBALLOCATION_SIZE_TO_REGISTER = 16;
 
 static const WCHAR* const HeapTypeNames[] =
 {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -45,6 +45,8 @@ namespace AZ
             m_descriptor.m_platformLimitsDescriptor = RHI::Ptr<RHI::PlatformLimitsDescriptor>(platformLimitsDescriptor);
         }
 
+        Device::~Device() = default;
+
         RHI::Ptr<Device> Device::Create()
         {
             return aznew Device();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -76,7 +76,7 @@ namespace AZ
             AZ_RTTI(Device, "C77D578F-841F-41B0-84BB-EE5430FCF8BC", Base);
 
             static RHI::Ptr<Device> Create();
-            ~Device() = default;
+            ~Device();
 
             static StringList GetRequiredLayers();
             static StringList GetRequiredExtensions();


### PR DESCRIPTION
## What does this PR do?

This PR fixes some build errors with Clang-17 on Windows when using a no-unity build.
The change in `Device.cpp/.h` is necessary because `AsyncUploadQueue` is forward-declared in the header file but is used as a member variable with `RHI::Ptr<AsyncUploadQueue>`, so either AsyncUploadQueue needs to be included in the header file or the destructor needs to be implemented in the cpp file. I changed it to the latter option.

## How was this PR tested?

Compile code with unity and no-unity cmake option.
