### PR TITLE
Fix Clang-17 compile error about enum-constexpr-conversion on Windows

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -101,13 +101,10 @@ namespace AZ
                  D3D12_RESOURCE_STATE_COPY_DEST |
                  D3D12_RESOURCE_STATE_COPY_SOURCE);
 
-            constexpr D3D12_RESOURCE_STATES VALID_GRAPHICS_QUEUE_RESOURCE_STATES =
-                (D3D12_RESOURCE_STATES)DX12_RESOURCE_STATE_VALID_API_MASK;
-
             switch (GetHardwareQueueClass())
             {
             case RHI::HardwareQueueClass::Graphics:
-                return RHI::CheckBitsAll(VALID_GRAPHICS_QUEUE_RESOURCE_STATES, state);
+                return RHI::CheckBitsAll(state, (D3D12_RESOURCE_STATES)DX12_RESOURCE_STATE_VALID_API_MASK);
 
             case RHI::HardwareQueueClass::Compute:
                 return RHI::CheckBitsAll(VALID_COMPUTE_QUEUE_RESOURCE_STATES, state);


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following compile error on Windows with Clang-17:
```
.../o3de/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp:103:17: error:
integer value 2147483647 is outside the valid range of values [0, 33554431]
for the enumeration type 'D3D12_RESOURCE_STATES' [-Wenum-constexpr-conversion]
  103 |                 (D3D12_RESOURCE_STATES)DX12_RESOURCE_STATE_VALID_API_MASK;
      |                 ^
```
The problem is that the value of `DX12_RESOURCE_STATE_VALID_API_MASK` is calculated as `~0x80000000`, which is too large for the enum since the max allowes size is basically all defined enum values or-ed together, which is `0x1FFFFFF` (33554431). The size of the `D3D12_RESOURCE_STATES` enum cannot be specified explicitly since it is defined in the system header `d3d12.h`.

Other solutions to fix this error would be:
-  Make the variable not constexpr (const, const static)
- Add the `-Wno-enum-constexpr-conversion` commandline option to Clang

## How was this PR tested?

Compile with Clang and MSVC
