### PR TITLE
[Lua Editor] Fix Lua Editor not handling load and save of the settings dialog

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -34,6 +34,8 @@
 #include <AzFramework/Asset/AssetCatalogComponent.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
+#include <AzCore/Utils/Utils.h>
+
 #ifdef AZ_PLATFORM_WINDOWS
 #include "shlobj.h"
 #endif
@@ -146,7 +148,7 @@ namespace LegacyFramework
 
     AZStd::string Application::GetApplicationGlobalStoragePath()
     {
-        return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toUtf8().data();
+        return AZ::Utils::GetProjectUserPath().c_str();
     }
 
     void Application::SetSettingsRegistrySpecializations(AZ::SettingsRegistryInterface::Specializations& specializations)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
@@ -23,6 +23,8 @@
 
 #include <Source/LUA/ui_LUAEditorSettingsDialog.h>
 
+#include <QPushButton>
+
 namespace
 {
 }
@@ -51,7 +53,6 @@ namespace LUAEditor
 
         m_gui->propertyEditor->Setup(context, nullptr, true, 420);
         m_gui->propertyEditor->AddInstance(syntaxStyleSettings.get(), syntaxStyleSettings->RTTI_GetType());
-
         m_gui->propertyEditor->setObjectName("m_gui->propertyEditor");
         m_gui->propertyEditor->setMinimumHeight(500);
         m_gui->propertyEditor->setMaximumHeight(1000);
@@ -61,17 +62,24 @@ namespace LUAEditor
 
         m_gui->propertyEditor->InvalidateAll();
         m_gui->propertyEditor->ExpandAll();
-
         m_gui->propertyEditor->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
-        QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setContentsMargins(0, 0, 0, 0);
-        layout->setSpacing(0);
-
+        auto* layout = new QVBoxLayout(this);
         layout->addWidget(m_gui->propertyEditor);
-        layout->addWidget(m_gui->cancelButton);
-        layout->addWidget(m_gui->saveButton);
-        layout->addWidget(m_gui->saveCloseButton);
+
+        auto* hlayout = new QHBoxLayout(this);
+        hlayout->addWidget(m_gui->applyButton);
+        hlayout->addItem(new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Fixed));
+        hlayout->addWidget(m_gui->saveButton);
+        hlayout->addWidget(m_gui->saveCloseButton);
+        hlayout->addWidget(m_gui->cancelButton);
+
+        layout->addLayout(hlayout);
+
+        QObject::connect(m_gui->saveButton, &QPushButton::clicked, this, &LUAEditorSettingsDialog::OnSave);
+        QObject::connect(m_gui->saveCloseButton, &QPushButton::clicked, this, &LUAEditorSettingsDialog::OnSaveClose);
+        QObject::connect(m_gui->cancelButton, &QPushButton::clicked, this, &LUAEditorSettingsDialog::OnCancel);
+        QObject::connect(m_gui->applyButton, &QPushButton::clicked, this, &LUAEditorSettingsDialog::OnApply);
 
         setLayout(layout);
     }
@@ -101,6 +109,11 @@ namespace LUAEditor
         close();
     }
 
+    void LUAEditorSettingsDialog::OnApply()
+    {
+        LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
+    }
+
     LUAEditorSettingsDialog::~LUAEditorSettingsDialog()
     {
         m_gui->propertyEditor->ClearInstances();
@@ -112,13 +125,10 @@ namespace LUAEditor
         if (event->key() == Qt::Key_Escape)
         {
             OnCancel();
-            return;
         }
-        else
-        if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
+        else if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
         {
             OnSaveClose();
-            return;
         }
     }
 }//namespace LUAEditor

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.hxx
@@ -39,6 +39,7 @@ namespace LUAEditor
         void OnSave();
         void OnSaveClose();
         void OnCancel();
+        void OnApply();
 
     private:
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.ui
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.ui
@@ -108,6 +108,31 @@
     <bool>false</bool>
    </property>
   </widget>
+  <widget class="QPushButton" name="applyButton">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>370</x>
+     <y>80</y>
+     <width>111</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <weight>75</weight>
+     <bold>true</bold>
+    </font>
+   </property>
+   <property name="text">
+    <string>Apply</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>
@@ -123,54 +148,5 @@
   <tabstop>saveCloseButton</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>LUAEditorSettingsDialog</receiver>
-   <slot>OnCancel()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>368</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>187</x>
-     <y>102</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>saveButton</sender>
-   <signal>clicked()</signal>
-   <receiver>LUAEditorSettingsDialog</receiver>
-   <slot>OnSave()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>368</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>187</x>
-     <y>102</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>saveCloseButton</sender>
-   <signal>clicked()</signal>
-   <receiver>LUAEditorSettingsDialog</receiver>
-   <slot>OnSaveClose()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>368</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>187</x>
-     <y>102</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
## What does this PR do?

This is handling https://github.com/o3de/o3de/issues/17840 . This could be also only Linux related but I am not sure. I only tested this issue on Linux.

## How was this PR tested?

Compiled and run on my local Ubuntu 22.04 computer.

## Thoughts

This PR is kind of a suggestion. As described in the issue, the fix I am providing is not using the 

QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)

function to retrieve the load/save folder the the settings. Instead using the projects user folder. So its not a real fix neither to understand why this strange behavior happens. But I thought having the settings files in the user folder is better so I leave it for now as a fix.

I also changed the locations of the 3 buttons for close, save and save & close.
From this:

![image](https://github.com/o3de/o3de/assets/7720708/7f768a6d-fbcd-4dc9-a861-2ffe83c892ae)

to this:

![image](https://github.com/o3de/o3de/assets/7720708/e6cadef7-96ca-4116-9a17-30bc3f79352c)


If the fix and/or the UI change isn't the wished approach, I will close the PR or change to the suggestions.

Any thoughts?
