### PR TITLE
Fix to ScriptCanvas' ExtractProperty failing on Linux when a property is of type int64_t

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -2243,7 +2243,7 @@ namespace ScriptCanvas
 
         if (!Data::IsValueType(m_type) && !SatisfiesTraits(static_cast<AZ::u8>(description.m_traits)))
         {
-            return AZ::Failure(AZStd::string("Attempting to convert null value to BehaviorArgument that expects reference or value"));
+            return AZ::Failure(AZStd::string::format("Attempting to convert null value %s to BehaviorArgument that expects reference or value", description.m_name));
         }
 
         if (IS_A(Data::Type::Number()))

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
@@ -96,7 +96,6 @@ namespace ScriptCanvas
                 }
             }
 
-            AZ_Error("ScriptCanvas", false, "Failed to find behavior class for typeID: %s", typeID.ToString<AZStd::string>().c_str());
             return "Invalid BehaviorContext::Class name";
         }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
@@ -96,6 +96,7 @@ namespace ScriptCanvas
                 }
             }
 
+            AZ_Error("ScriptCanvas", false, "Failed to find behavior class for typeID: %s", typeID.ToString<AZStd::string>().c_str());
             return "Invalid BehaviorContext::Class name";
         }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/DataTypeUtils.cpp
@@ -335,10 +335,10 @@ namespace ScriptCanvas
 
         bool IsNumber(const AZ::Uuid& type)
         {
-            return type == azrtti_typeid<AZ::s8>() || type == azrtti_typeid<AZ::s16>() || type == azrtti_typeid<AZ::s32>() ||
-                type == azrtti_typeid<AZ::s64>() || type == azrtti_typeid<AZ::u8>() || type == azrtti_typeid<AZ::u16>() ||
-                type == azrtti_typeid<AZ::u32>() || type == azrtti_typeid<AZ::u64>() || type == azrtti_typeid<unsigned long>() ||
-                type == azrtti_typeid<float>() || type == azrtti_typeid<double>();
+            return
+                type == azrtti_typeid<AZ::s8>() || type == azrtti_typeid<AZ::s16>() || type == azrtti_typeid<AZ::s32>() || type == azrtti_typeid<AZ::s64>() ||
+                type == azrtti_typeid<AZ::u8>() || type == azrtti_typeid<AZ::u16>() || type == azrtti_typeid<AZ::u32>() || type == azrtti_typeid<AZ::u64>() ||
+                type == azrtti_typeid<long>() || type == azrtti_typeid<unsigned long>() || type == azrtti_typeid<float>() || type == azrtti_typeid<double>();
         }
 
         bool IsNumber(const Type& type)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -2583,20 +2583,20 @@ namespace ScriptCanvas
                 Nodes::Core::FunctionCallNodeCompareConfig config;
                 const auto result = functionNode->IsOutOfDate(config, m_source.m_assetId.m_guid);
 
-                if (result == Nodes::Core::IsFunctionCallNodeOutOfDataResult::Yes)
+                if (result == Nodes::Core::IsFunctionCallNodeOutOfDateResult::Yes)
                 {
-                    AZ_Warning("ScriptCanvas", false, "%s node is out-of-date.", node.GetNodeName().c_str());
+                    AZ_Warning("ScriptCanvas", false, "FunctionCallNode '%s' is out-of-date.", node.GetNodeName().c_str());
                     AddError(nullptr, aznew NodeCompatiliblity::NodeOutOfDate(node.GetEntityId(), node.GetNodeName()));
                     return false;
                 }
-                else if (result == Nodes::Core::IsFunctionCallNodeOutOfDataResult::EvaluateAfterLocalDefinition)
+                else if (result == Nodes::Core::IsFunctionCallNodeOutOfDateResult::EvaluateAfterLocalDefinition)
                 {
                     m_locallyDefinedFunctionCallNodes.push_back(functionNode);
                 }
             }
             else if (node.IsOutOfDate(m_source.m_graph->GetVersion()))
             {
-                AZ_Warning("ScriptCanvas", false, "%s node is out-of-date.", node.GetNodeName().c_str());
+                AZ_Warning("ScriptCanvas", false, "Node '%s' is out-of-date.", node.GetNodeName().c_str());
                 AddError(nullptr, aznew NodeCompatiliblity::NodeOutOfDate(node.GetEntityId(), node.GetNodeName()));
                 return false;
             }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.cpp
@@ -98,17 +98,24 @@ namespace ScriptCanvas
             {
                 AZ_UNUSED(graphVersion);
 
-                bool isOutOfDate = false;
+                int numOutOfDate = 0;
                 for (auto propertyAccount : m_propertyAccounts)
                 {
                     if (!propertyAccount.m_getterFunction)
                     {
-                        isOutOfDate = true;
-                        break;
+                        // Print out the error message for each property that is out of date
+                        AZ_Warning("ScriptCanvas", false,"Node '%s':  Property (%s : %s) getter method could not be found in Data::PropertyMetadata.",
+                            this->GetDebugName().c_str(),
+                            propertyAccount.m_propertyName.c_str(),
+                            Data::GetName(propertyAccount.m_propertyType).c_str());
+
+                        numOutOfDate++;
                     }
                 }
 
-                return isOutOfDate;
+                AZ_Error("ScriptCanvas", numOutOfDate == 0, "Node '%s':  Out of date.  (%d/%d) properties are missing a getter function.", this->GetDebugName().c_str(), numOutOfDate, m_propertyAccounts.size());
+                return (numOutOfDate > 0);
+
             }
 
             UpdateResult ExtractProperty::OnUpdateNode()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
@@ -469,21 +469,21 @@ namespace ScriptCanvas
                 }
 
                 FunctionCallNodeCompareConfig config;
-                return IsOutOfDate(config, {}) != IsFunctionCallNodeOutOfDataResult::No;
+                return IsOutOfDate(config, {}) != IsFunctionCallNodeOutOfDateResult::No;
             }
 
-            IsFunctionCallNodeOutOfDataResult FunctionCallNode::IsOutOfDate(const FunctionCallNodeCompareConfig& config, const AZ::Uuid& graphId) const
+            IsFunctionCallNodeOutOfDateResult FunctionCallNode::IsOutOfDate(const FunctionCallNodeCompareConfig& config, const AZ::Uuid& graphId) const
             {
                 bool isUnitTestingInProgress = false;
                 ScriptCanvas::SystemRequestBus::BroadcastResult(isUnitTestingInProgress, &ScriptCanvas::SystemRequests::IsScriptUnitTestingInProgress);
                 if (isUnitTestingInProgress)
                 {
-                    return IsFunctionCallNodeOutOfDataResult::No;
+                    return IsFunctionCallNodeOutOfDateResult::No;
                 }
 
                 if ((!graphId.IsNull()) && graphId == m_asset.GetId().m_guid)
                 {
-                    return IsFunctionCallNodeOutOfDataResult::EvaluateAfterLocalDefinition;
+                    return IsFunctionCallNodeOutOfDateResult::EvaluateAfterLocalDefinition;
                 }
 
                 AZ::Data::AssetId interfaceAssetId(m_asset.GetId().m_guid, AZ_CRC("SubgraphInterface", 0xdfe6dc72));
@@ -498,18 +498,18 @@ namespace ScriptCanvas
                 if (!asset || !asset->IsReady())
                 {
                     AZ_Warning("ScriptCanvas", false, "FunctionCallNode %s failed to load source asset.", m_prettyName.data());
-                    return IsFunctionCallNodeOutOfDataResult::Yes;
+                    return IsFunctionCallNodeOutOfDateResult::Yes;
                 }
 
                 const Grammar::SubgraphInterface* latestAssetInterface = asset ? &asset.Get()->m_interfaceData.m_interface : nullptr;
                 if (!latestAssetInterface)
                 {
                     AZ_Warning("ScriptCanvas", false, "FunctionCallNode %s failed to load latest interface from the source asset.", m_prettyName.data());
-                    return IsFunctionCallNodeOutOfDataResult::Yes;
+                    return IsFunctionCallNodeOutOfDateResult::Yes;
                 }
 
-                IsFunctionCallOutOfDateConfig isOutOfDataConfig{ config, *this, m_slotExecutionMap, m_sourceId, m_slotExecutionMapSourceInterface, *latestAssetInterface };
-                return IsFunctionCallNodeOutOfDate(isOutOfDataConfig) ? IsFunctionCallNodeOutOfDataResult::Yes : IsFunctionCallNodeOutOfDataResult::No;
+                IsFunctionCallOutOfDateConfig isOutOfDateConfig{ config, *this, m_slotExecutionMap, m_sourceId, m_slotExecutionMapSourceInterface, *latestAssetInterface };
+                return IsFunctionCallNodeOutOfDate(isOutOfDateConfig) ? IsFunctionCallNodeOutOfDateResult::Yes : IsFunctionCallNodeOutOfDateResult::No;
             }
 
             UpdateResult FunctionCallNode::OnUpdateNode()
@@ -526,7 +526,7 @@ namespace ScriptCanvas
                 }
 
                 FunctionCallNodeCompareConfig config;
-                if (IsOutOfDate(config, m_asset.GetId().m_guid) != Nodes::Core::IsFunctionCallNodeOutOfDataResult::No)
+                if (IsOutOfDate(config, m_asset.GetId().m_guid) != Nodes::Core::IsFunctionCallNodeOutOfDateResult::No)
                 {
                     AZ_Warning("ScriptCanvas", false, "FunctionCallNode %s's source public interface has changed", m_prettyName.data());
                     this->AddNodeDisabledFlag(NodeDisabledFlag::ErrorInUpdate);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.h
@@ -36,7 +36,7 @@ namespace ScriptCanvas
         {
             struct FunctionCallNodeCompareConfig;
 
-            enum class IsFunctionCallNodeOutOfDataResult
+            enum class IsFunctionCallNodeOutOfDateResult
             {
                 No,
                 Yes,
@@ -80,7 +80,7 @@ namespace ScriptCanvas
 
                 bool IsOutOfDate(const VersionData& graphVersion) const override;
 
-                IsFunctionCallNodeOutOfDataResult IsOutOfDate(const FunctionCallNodeCompareConfig& config, const AZ::Uuid& graphId) const;
+                IsFunctionCallNodeOutOfDateResult IsOutOfDate(const FunctionCallNodeCompareConfig& config, const AZ::Uuid& graphId) const;
 
                 UpdateResult OnUpdateNode() override;
 


### PR DESCRIPTION
## What does this PR do?

Fixes an error where a ScriptCanvas "ExtractProperty" node will fail to process on linux, if one of the properties is a "int64_t" type.  On Linux, that type fails the "IsNumber" check in ScriptCanvas as linux treats "int64_t" as a "long", instead of "AZ:s64".  

Also adds some debugging and renaming that came as a result of tracking this thing down.

## How was this PR tested?

Building assets for Linux, PC, Android, and iOS
