### PR TITLE
Fix for ScriptCanvas Upgrade Tool nullptr crash

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Graph.cpp
@@ -180,7 +180,7 @@ namespace ScriptCanvas
     {
         for (auto& nodeRef : m_graphData.m_nodes)
         {
-            if (auto node = FindNode(nodeRef->GetId()); node->IsDeprecated())
+            if (auto node = FindNode(nodeRef->GetId()); node && node->IsDeprecated())
             {
                 return true;
             }


### PR DESCRIPTION
## What does this PR do?

Fixes a nullptr crash when running the ScriptCanvas upgrade tool.

## How was this PR tested?

Locally on PC by running the ScriptCanvas upgrade tool
