### PR TITLE
Reformat of the Asset Processor Metrics column

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/BuilderInfoMetricsModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderInfoMetricsModel.cpp
@@ -25,24 +25,24 @@ namespace AssetProcessor
         QTime duration = QTime::fromMSecsSinceStartOfDay(durationInMs % dayInMs);
         if (dayCount > 0)
         {
-            return duration.toString("zzz' ms, 'ss' sec, 'mm' min, 'hh' hr, %1 day'").arg(dayCount);
+            return duration.toString("'%1d 'hh'h 'mm'm 'ss's 'zzz'ms'").arg(dayCount);
         }
         
         if (duration.isValid())
         {
             if (duration.hour() > 0)
             {
-                return duration.toString("zzz' ms, 'ss' sec, 'mm' min, 'hh' hr'");
+                return duration.toString("hh'h 'mm'm 'ss's 'zzz'ms'");
             }
             if (duration.minute() > 0)
             {
-                return duration.toString("zzz' ms, 'ss' sec, 'mm' min'");
+                return duration.toString("mm'm 'ss's 'zzz'ms'");
             }
             if (duration.second() > 0)
             {
-                return duration.toString("zzz' ms, 'ss' sec'");
+                return duration.toString("ss's 'zzz'ms'");
             }
-            return duration.toString("zzz' ms'");
+            return duration.toString("zzz'ms'");
         }
 
         return QString();


### PR DESCRIPTION
## What does this PR do?

Changes the formatting of the Asset Processor metrics column from (e.g):

"123ms, 12s, 34m, 2h, 1d"
to
"1d 2h 23m 12s 123ms"

This makes the output a bit more readable (larger -> smaller metrics) and is a bit more common/expected in terms of duration output.

## How was this PR tested?

Locally, running windows version of Asset Processor.
