### PR TITLE
new: Project manager add project dialog to target project.json instead of any directory

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -303,14 +303,14 @@ namespace O3DE::ProjectManager
             else if (const auto& incompatibleObjects = incompatibleObjectsResult.GetValue(); !incompatibleObjects.isEmpty())
             {
                 // provide a couple more user friendly error messages for uncommon cases
-                if (incompatibleObjects.at(0).contains("engine.json", Qt::CaseInsensitive))
+                if (incompatibleObjects.at(0).contains(EngineJsonFilename.data(), Qt::CaseInsensitive))
                 {
-                    errorTitle = "Failed to read engine.json";
+                    errorTitle = errorTitle.format("Failed to read %s", EngineJsonFilename.data());
                     generalError = "The projects compatibility with this engine could not be checked because the engine.json could not be read";
                 }
-                else if (incompatibleObjects.at(0).contains("project.json", Qt::CaseInsensitive))
+                else if (incompatibleObjects.at(0).contains(ProjectJsonFilename.data(), Qt::CaseInsensitive))
                 {
-                    errorTitle = "Invalid project, failed to read project.json";
+                    errorTitle = errorTitle.format("Invalid project, failed to read %s", ProjectJsonFilename.data());
                     generalError = "The projects compatibility with this engine could not be checked because the project.json could not be read.";
                 }
                 else

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -20,11 +20,15 @@
 #include <AzCore/Dependency/Dependency.h>
 #include <AzCore/IO/Path/Path_fwd.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string_view.h>
 
 namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
+        static constexpr AZStd::string_view EngineJsonFilename = "engine.json";
+        static constexpr AZStd::string_view ProjectJsonFilename = "project.json";
+
         bool RegisterProject(const QString& path, QWidget* parent = nullptr);
         bool UnregisterProject(const QString& path, QWidget* parent = nullptr);
         bool CopyProjectDialog(const QString& origPath, ProjectInfo& newProjectInfo, QWidget* parent = nullptr);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -451,7 +451,7 @@ namespace O3DE::ProjectManager
 
     void ProjectsScreen::HandleAddProjectButton()
     {
-        QString title{ QObject::tr("Select Project Directory") };
+        QString title{ QObject::tr("Select Project File") };
         QString defaultPath;
 
         // get the default path to look for new projects in
@@ -461,12 +461,13 @@ namespace O3DE::ProjectManager
             defaultPath = engineInfoResult.GetValue().m_defaultProjectsFolder;
         }
 
-        QString path = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, title, defaultPath));
+        QString path = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, title, defaultPath, ProjectUtils::ProjectJsonFilename.data()));
         if (!path.isEmpty())
         {
             // RegisterProject will check compatibility and prompt user to continue if issues found
             // it will also handle detailed error messaging
-            if(ProjectUtils::RegisterProject(path, this))
+            path.remove(ProjectUtils::ProjectJsonFilename.data());
+            if (ProjectUtils::RegisterProject(path, this))
             {
                 // notify the user the project was added successfully
                 emit ChangeScreenRequest(ProjectManagerScreen::Projects);

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <ProjectGemCatalogScreen.h>
+#include <ProjectUtils.h>
 #include <GemRepo/GemRepoScreen.h>
 #include <CreateAGemScreen.h>
 #include <ProjectManagerDefs.h>
@@ -313,12 +314,12 @@ namespace O3DE::ProjectManager
                 else if (const auto& incompatibleObjects = incompatibleObjectsResult.GetValue(); !incompatibleObjects.isEmpty())
                 {
                     // provide a couple more user friendly error messages for uncommon cases
-                    if (incompatibleObjects.at(0).contains("engine.json", Qt::CaseInsensitive))
+                    if (incompatibleObjects.at(0).contains(ProjectUtils::EngineJsonFilename.data(), Qt::CaseInsensitive))
                     {
                         errorTitle = "Failed to read engine.json";
                         generalError = "The projects compatibility with the new engine could not be checked because the engine.json could not be read";
                     }
-                    else if (incompatibleObjects.at(0).contains("project.json", Qt::CaseInsensitive))
+                    else if (incompatibleObjects.at(0).contains(ProjectUtils::ProjectJsonFilename.data(), Qt::CaseInsensitive))
                     {
                         errorTitle = "Invalid project, failed to read project.json";
                         generalError = "The projects compatibility with the new engine could not be checked because the project.json could not be read.";


### PR DESCRIPTION
## What does this PR do?

Make the "Open existing project" dialog on the project manager target a "project.json" file instead of any directory. 

This change will prevent user mistakes after cloning repository for an O3DE project, this way we know for sure when we are in the right directory. (I recently [tried out most of the O3DE samples out there](https://github.com/o3de/o3de.org/issues/2549), and as the project is sometimes in a subdirectory I made the mistake a few times)

Also used this change to make a small refacto so that "project.json" and "engine.json" used in the project manager project use the same constant.

![image](https://github.com/o3de/o3de/assets/19243508/1006cde4-8d93-40d7-90f2-da9f93e05181)

![image](https://github.com/o3de/o3de/assets/19243508/59d51865-7f84-4f66-a818-910071f8322e)


## How was this PR tested?

Tested locally by adding a project using my change (and checked the values via debugger)
