### PR TITLE
Fix SMC validation error spam related to MSAA count

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
@@ -74,6 +74,7 @@ namespace AZ
             Scene* GetScene(const SceneId& sceneId) const override;
             Scene* GetSceneByName(const AZ::Name& name) const override;
             ScenePtr GetDefaultScene() const override;
+            uint32_t GetNumScenes() const override;
             RenderPipelinePtr GetRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle) override;
             Data::Asset<ShaderAsset> GetCommonShaderAssetForSrgs() const override;
             RHI::Ptr<RHI::ShaderResourceGroupLayout> GetSceneSrgLayout() const override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystemInterface.h
@@ -60,6 +60,9 @@ namespace AZ
             //! Get scene by using scene name.
             virtual Scene* GetSceneByName(const AZ::Name& name) const = 0;
 
+            //! Return the number of registered scenes
+            virtual uint32_t GetNumScenes() const = 0;
+
             //! Get the render pipeline created for a window
             virtual RenderPipelinePtr GetRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle) = 0;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -206,6 +206,11 @@ namespace AZ
             }
             return nullptr;
         }
+
+        uint32_t RPISystem::GetNumScenes() const
+        {
+            return aznumeric_cast<uint32_t>(m_scenes.size());
+        }
         
         ScenePtr RPISystem::GetDefaultScene() const
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -64,8 +64,19 @@ namespace AtomToolsFramework
         pipelineDesc.m_mainViewTagName = "MainCamera";
         pipelineDesc.m_name = pipelineName;
         pipelineDesc.m_rootPassTemplate = "ToolsPipelineRenderToTexture";
-        pipelineDesc.m_renderSettings.m_multisampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
-
+        
+        uint32_t numRegisteredScenes = AZ::RPI::RPISystemInterface::Get()->GetNumScenes();
+        //If there are existing registered scenes use the msaa settings set by them
+        //otherwise broadcast default settings.
+        if (numRegisteredScenes > 0)
+        {
+            pipelineDesc.m_renderSettings.m_multisampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
+        }
+        else
+        {
+            AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(pipelineDesc.m_renderSettings.m_multisampleState);
+        }
+        
         m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipeline(pipelineDesc);
         m_scene->AddRenderPipeline(m_renderPipeline);
         m_scene->Activate();


### PR DESCRIPTION

## What does this PR do?

Shader Management Console (SMC) has error validation spam because it was loading shader with MSAA enabled and then a pass later on would try to bind a texture with MSAA count of 1 (i.e non-msaa resource). This would spam each frame. This was happening because the PreviewRender pipeline was relying on other scenes to set the correct msaa count but in the case of SMC there are no other scenes. Hence we added a check for that and broadcast the default settings before initializing the pipeline.

## How was this PR tested?

Tested Editor, Material Editor, Material Canvas, Shader Management Console on PC