### PR TITLE
Renamed variable from interface to avoid compile error

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -210,7 +210,7 @@ class TestHelper:
                 TestHelper.wait_for_condition(lambda : multiplayer_helper.editorConnectionAttemptCount > 0, 10.0)
                 Report.critical_result(("Multiplayer Editor attempting server connection.", "Multiplayer Editor never tried connecting to the server."), multiplayer_helper.editorConnectionAttemptCount > 0)
 
-                TestHelper.wait_for_condition(lambda : multiplayer_helper.editorSendingLevelData, 106.0)
+                TestHelper.wait_for_condition(lambda : multiplayer_helper.editorSendingLevelData, 300.0)
                 Report.critical_result(("Multiplayer Editor sent level data to the server.", "Multiplayer Editor never sent the level to the server."), multiplayer_helper.editorSendingLevelData)
 
                 TestHelper.wait_for_condition(lambda : multiplayer_helper.connectToSimulationSuccess, 20.0)

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1459,8 +1459,8 @@ namespace ScriptCanvasEditor
                         AZ::AttributeReader attributeReader(nullptr, assetTypeAttribute);
                         AZ::Data::AssetType assetType;
                         attributeReader.Read<AZ::Data::AssetType>(assetType);
-                        ScriptCanvasAssetIdDataInterface* interface = static_cast<ScriptCanvasAssetIdDataInterface*>(dataInterface);
-                        interface->SetAssetType(assetType);
+                        ScriptCanvasAssetIdDataInterface* assetIdinterface = static_cast<ScriptCanvasAssetIdDataInterface*>(dataInterface);
+                        assetIdinterface->SetAssetType(assetType);
                     }
 
                     if (AZ::Attribute* sourceAssetFilterAttribute = FindAttribute(AZ::Edit::Attributes::SourceAssetFilterPattern, method->GetMethod()->m_attributes))
@@ -1468,8 +1468,8 @@ namespace ScriptCanvasEditor
                         AZ::AttributeReader attributeReader(nullptr, sourceAssetFilterAttribute);
                         AZStd::string filterPattern;
                         attributeReader.Read<AZStd::string>(filterPattern);
-                        ScriptCanvasAssetIdDataInterface* interface = static_cast<ScriptCanvasAssetIdDataInterface*>(dataInterface);
-                        interface->SetStringFilter(filterPattern);
+                        ScriptCanvasAssetIdDataInterface* assetIdinterface = static_cast<ScriptCanvasAssetIdDataInterface*>(dataInterface);
+                        assetIdinterface->SetStringFilter(filterPattern);
                     }
                 }
 


### PR DESCRIPTION
## What does this PR do?

The `interface` name is a reserved keyword for some compilers, renamed it to avoid compile errors