### PR TITLE
Fixes crash when full refreshing AssetProcessor

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -298,6 +298,9 @@ namespace AzToolsFramework
 
             virtual void BeginRemoveEntry(AssetBrowserEntry* entry) = 0;
             virtual void EndRemoveEntry() = 0;
+
+            virtual void BeginReset() = 0;
+            virtual void EndReset() = 0;
         };
 
         using AssetBrowserModelRequestBus = AZ::EBus<AssetBrowserModelRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -177,7 +177,7 @@ namespace AzToolsFramework
                 AssetBrowserComponentNotificationBus::Broadcast(&AssetBrowserComponentNotifications::OnAssetBrowserComponentReady);
             }
 
-            if ((m_isResetting)&&(m_changesApplied))
+            if (m_isResetting && m_changesApplied)
             {
                 m_isResetting = false;
                 m_changesApplied = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -47,6 +47,8 @@ namespace AzToolsFramework
             , m_dbReady(false)
             , m_waitingForMore(false)
             , m_disposed(false)
+            , m_isResetting(false)
+            , m_changesApplied(false)
             , m_assetBrowserModel(aznew AssetBrowserModel)
             , m_changeset(new AssetEntryChangeset(m_databaseConnection, m_rootEntry))
         {
@@ -173,6 +175,13 @@ namespace AzToolsFramework
             {
                 m_entriesReady = true;
                 AssetBrowserComponentNotificationBus::Broadcast(&AssetBrowserComponentNotifications::OnAssetBrowserComponentReady);
+            }
+
+            if ((m_isResetting)&&(m_changesApplied))
+            {
+                m_isResetting = false;
+                m_changesApplied = false;
+                m_assetBrowserModel->EndReset();
             }
         }
 
@@ -390,6 +399,11 @@ namespace AzToolsFramework
 
         void AssetBrowserComponent::PopulateAssets()
         {
+            // populating the assets is a complete reset of the model.
+            m_isResetting = true;
+            m_changesApplied = false;
+            m_assetBrowserModel->BeginReset();
+            m_rootEntry->PrepareForReset();
             m_changeset->PopulateEntries();
             NotifyUpdateThread();
         }
@@ -414,6 +428,7 @@ namespace AzToolsFramework
                 if (m_dbReady)
                 {
                     m_changeset->Update();
+                    m_changesApplied = true;
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
@@ -124,6 +124,8 @@ namespace AzToolsFramework
             AZStd::atomic_bool m_waitingForMore;
             //! should the query thread stop
             AZStd::atomic_bool m_disposed;
+            AZStd::atomic_bool m_isResetting;
+            AZStd::atomic_bool m_changesApplied;
 
             AZStd::unique_ptr<AssetBrowserModel> m_assetBrowserModel;
             AZStd::shared_ptr<AssetEntryChangeset> m_changeset;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -472,21 +472,31 @@ namespace AzToolsFramework
 
         void AssetBrowserModel::BeginAddEntry(AssetBrowserEntry* parent)
         {
+            if (m_isResetting)
+            {
+                return; // don't notify during reset.
+            }
+
             QModelIndex parentIndex;
             if (GetEntryIndex(parent, parentIndex))
             {
                 m_addingEntry = true;
                 int row = parent->GetChildCount();
-                beginInsertRows(parentIndex, row, row);
+                Q_EMIT beginInsertRows(parentIndex, row, row);
             }
         }
 
         void AssetBrowserModel::EndAddEntry(AssetBrowserEntry* parent)
         {
+            if (m_isResetting)
+            {
+                return; // don't notify during reset.
+            }
+
             if (m_addingEntry)
             {
                 m_addingEntry = false;
-                endInsertRows();
+                Q_EMIT endInsertRows();
 
                 // we have to also invalidate our parent all the way up the chain.
                 // since in this model, the children's data is actually relevant to the filtering of a parent
@@ -517,22 +527,44 @@ namespace AzToolsFramework
 
         void AssetBrowserModel::BeginRemoveEntry(AssetBrowserEntry* entry)
         {
+            if (m_isResetting)
+            {
+                return; // don't notify during reset.
+            }
+            
             int row = entry->row();
             QModelIndex parentIndex;
             if (GetEntryIndex(entry->m_parentAssetEntry, parentIndex))
             {
                 m_removingEntry = true;
-                beginRemoveRows(parentIndex, row, row);
+                Q_EMIT beginRemoveRows(parentIndex, row, row);
             }
         }
 
         void AssetBrowserModel::EndRemoveEntry()
         {
+            if (m_isResetting)
+            {
+                return; // don't notify during reset.
+            }
+
             if (m_removingEntry)
             {
                 m_removingEntry = false;
-                endRemoveRows();
+                Q_EMIT endRemoveRows();
             }
+        }
+
+        void AssetBrowserModel::BeginReset()
+        {
+            Q_EMIT beginResetModel();
+            m_isResetting = true;
+        }
+
+        void AssetBrowserModel::EndReset()
+        {
+            m_isResetting = false;
+            Q_EMIT endResetModel();
         }
 
         void AssetBrowserModel::HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId, const bool initialFilenameChange)
@@ -542,7 +574,7 @@ namespace AzToolsFramework
                 QModelIndex index = findIndex(assetPath.c_str());
                 if (index.isValid())
                 {
-                    emit RequestOpenItemForEditing(index);
+                    Q_EMIT RequestOpenItemForEditing(index);
                 }
                 else
                 {
@@ -616,7 +648,7 @@ namespace AzToolsFramework
                         QModelIndex index;
                         if (GetEntryIndex(entry, index))
                         {
-                            emit RequestOpenItemForEditing(index);
+                            Q_EMIT RequestOpenItemForEditing(index);
                         }
                     });
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -85,6 +85,9 @@ namespace AzToolsFramework
             void BeginRemoveEntry(AssetBrowserEntry* entry) override;
             void EndRemoveEntry() override;
 
+            void BeginReset() override;
+            void EndReset() override;
+
             //////////////////////////////////////////////////////////////////////////
             // TickBus
             //////////////////////////////////////////////////////////////////////////
@@ -119,6 +122,8 @@ namespace AzToolsFramework
             AZStd::unordered_map<AZStd::string, AZ::Crc32> m_newlyCreatedAssetPathsToCreatorBusIds;
 
             void WatchForExpectedAssets(AssetBrowserEntry* entry);
+
+            bool m_isResetting = false;
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -123,6 +123,9 @@ namespace AzToolsFramework
             child->m_parentAssetEntry = nullptr;
             AssetBrowserModelRequestBus::Broadcast(&AssetBrowserModelRequests::EndRemoveEntry);
             AssetBrowserModelNotificationBus::Broadcast(&AssetBrowserModelNotifications::EntryRemoved, childToRemove.get());
+
+            // before we allow the destructor of AssetBrowserEntry to run, we must remove its children, etc.
+            childToRemove->RemoveChildren();
         }
 
         void AssetBrowserEntry::RemoveChildren()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -50,13 +50,16 @@ namespace AzToolsFramework
             return AssetEntryType::Root;
         }
 
-        void RootAssetBrowserEntry::Update(const char* enginePath)
+
+        void RootAssetBrowserEntry::PrepareForReset()
         {
             RemoveChildren();
-
             auto entryCache = EntryCache::GetInstance();
             entryCache->Clear();
+        }
 
+        void RootAssetBrowserEntry::Update(const char* enginePath)
+        {
             m_enginePath = AZ::IO::Path(enginePath).LexicallyNormal();
             m_projectPath = AZ::IO::Path(AZ::Utils::GetProjectPath()).LexicallyNormal();
             SetFullPath(m_enginePath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.h
@@ -71,6 +71,7 @@ namespace AzToolsFramework
 
             bool IsInitialUpdate() const;
             void SetInitialUpdate(bool newValue);
+            void PrepareForReset();
 
         protected:
             void UpdateChildPaths(AssetBrowserEntry* child) const override;


### PR DESCRIPTION
## What does this PR do?

Fixes crash when full refreshing AssetProcessor
Also fixes a crash when deleting elements out of the file system
Also fixes a crash when clicking on thumbnails while they are generating.

## How was this PR tested?
All three of the cases above were easy to repro 100%
1. Click the Rescan All button in AP -> crash
2. Duplicate any folder in the asset tree using Windows Explorer or Linux or whatever.  Then delete it.  Crash
3. Click in AB on "Editor" -> "Icons" -> Crash.
 
_Please describe any testing performed._
Testing all three of the above cases to ensure no crash anymore.
Testing duplicating/adding new script canvas assets to ensure they appear.
Deleting assets and ensuring they disappear
Clicking around in the AB while icons are generating
Doing the same in "list view" / search result mode.
