### PR TITLE
Fixes crash on Quest devices

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -23,6 +23,12 @@ if(PAL_TRAIT_ATOM_RHI_VULKAN_TARGETS_ALREADY_DEFINED)
     return() # Vulkan targets already defined in PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
 endif()
 
+set(ANDROID_USE_OCULUS_OPENXR OFF CACHE BOOL "Allows for custom behavior in the RHI related with issues that only occur on Quest devices.")
+if(ANDROID_USE_OCULUS_OPENXR)
+    message(STATUS "Some quirks for Quest devices may apply in the Vulkan RHI.")
+    # It was found that as of April 2024 using Timeline Semaphores on Quest devices crashes the app.
+    set(DISABLE_TIMELINE_SEMAPHORES_DEFINE "DISABLE_TIMELINE_SEMAPHORES") # Disables Timeline Semaphores even if the device claims to support them. 
+endif()
 
 ly_add_target(
     NAME ${gem_name}.Glad.Static STATIC
@@ -148,6 +154,7 @@ ly_add_target(
     COMPILE_DEFINITIONS 
         PRIVATE
             ${USE_NSIGHT_AFTERMATH_DEFINE}
+            ${DISABLE_TIMELINE_SEMAPHORES_DEFINE}
 )
 
 ly_add_target(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1189,7 +1189,11 @@ namespace AZ
             }
             m_features.m_swapchainScalingFlags = AZ_TRAIT_ATOM_VULKAN_SWAPCHAIN_SCALING_FLAGS;
 
+#ifdef DISABLE_TIMELINE_SEMAPHORES
+            m_features.m_signalFenceFromCPU = false;
+#else
             m_features.m_signalFenceFromCPU = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
+#endif
 
             const auto& deviceLimits = physicalDevice.GetDeviceLimits();
             m_limits.m_maxImageDimension1D = deviceLimits.maxImageDimension1D;


### PR DESCRIPTION
## What does this PR do?

This PR disables timeline semaphores for Quest
devices only. Otherwise the runtime crashes.

This was accomplished by leveraging the fact that
the user must flag the Android project as target for Meta Quest device. The CMake variable `ANDROID_USE_OCULUS_OPENXR` is set to true and this fix leverages this CMake variable to define the new C++ macro
named DISABLE_TIMELINE_SEMAPHORES.

## How was this PR tested?

Tested on Quest Pro and Quest 3. Without this fix both of them crash.
