### PR TITLE
Fixing bug where if a view had multiple pipelines, and …

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/LightCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/LightCommon.h
@@ -26,7 +26,7 @@ namespace AZ::Render::LightCommon
     // @param cpuCulledPipelinesPerView - Map of views -> pipelines in that view that need CPU culling (i.e. no GPU culling pass)
     bool NeedsCPUCulling(
         const RPI::ViewPtr& view,
-        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView);
+        const AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView);
 
     //! Cache pipelines that need CPU culling (i.e. no GPU culling pass) with their respective view, store in cpuCulledPipelinesPerView
     //! @param renderPipeline - Cache data associated with the passed RenderPipeline

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/LightCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/LightCommon.h
@@ -21,25 +21,23 @@ namespace AZ::Render::LightCommon
         return (invRadiusSqaured <= 0.0f) ? 1.0f : Sqrt(1.0f / invRadiusSqaured);
     }
 
-    // Check if a view is being used by a pipeline that has a GPU culling pass.
-    // @param parentScene - Parent Scene associated with a feature processor
-    // @param view - Check if gpu culling passes are part of this view
-    // @param gpuCullingData - Cached Unordered set of Render Pipelines and views that will contain the LightCullingPass which can be used for querying purposes
-    bool HasGPUCulling(
-        RPI::Scene* parentScene,
+    // Check if a view has a pipeline that needs CPU culling (i.e. doesn't have a GPU culling pass).
+    // @param view - The view we are checking against
+    // @param cpuCulledPipelinesPerView - Map of views -> pipelines in that view that need CPU culling (i.e. no GPU culling pass)
+    bool NeedsCPUCulling(
         const RPI::ViewPtr& view,
-        AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>>& gpuCullingData);
+        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView);
 
-    //! Update gpuCullingData to hold information related to gpu culling passes in order to Check if render pipeline is using GPU culling
+    //! Cache pipelines that need CPU culling (i.e. no GPU culling pass) with their respective view, store in cpuCulledPipelinesPerView
     //! @param renderPipeline - Cache data associated with the passed RenderPipeline
     //! @param newView The new view triggered from view changes via OnRenderPipelinePersistentViewChanged
     //! @param previousView The previous view triggered from view changes via OnRenderPipelinePersistentViewChanged
-    //! @param gpuCullingData - Update an Unordered set of Render Pipelines and views that will contain the LightCullingPass
-    void CacheGPUCullingPipelineInfo(
+    // @param cpuCulledPipelinesPerView - Map of views -> pipelines in that view that need CPU culling (i.e. no GPU culling pass)
+    void CacheCPUCulledPipelineInfo(
         RPI::RenderPipeline* renderPipeline,
         RPI::ViewPtr newView,
         RPI::ViewPtr previousView,
-        AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>>& gpuCullingData);
+        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView);
 
     //! Populate and cache multiple buffer handlers (one per view) that will be used to hold visibility data from cpu culling
     //! @param inputBufferName - Gpu Buffer name

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCommon.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCommon.cpp
@@ -13,12 +13,13 @@ namespace AZ::Render::LightCommon
 {
     bool NeedsCPUCulling(
         const RPI::ViewPtr& view,
-        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView)
+        const AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView)
     {
         auto viewPipelines = cpuCulledPipelinesPerView.find(view.get());
         if (viewPipelines == cpuCulledPipelinesPerView.end())
+        {
             return false;
-
+        }
         return (viewPipelines->second.size() > 0);
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCommon.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCommon.cpp
@@ -11,41 +11,37 @@
 
 namespace AZ::Render::LightCommon
 {
-    bool HasGPUCulling(
-        RPI::Scene* parentScene,
+    bool NeedsCPUCulling(
         const RPI::ViewPtr& view,
-        AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>>& gpuCullingData)
+        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView)
     {
-        for (const auto& renderPipeline : parentScene->GetRenderPipelines())
-        {
-            if (renderPipeline->NeedsRender() && gpuCullingData.contains(AZStd::pair(renderPipeline.get(), view.get())))
-            {
-                return true;
-            }
-        }
-        return false;
+        auto viewPipelines = cpuCulledPipelinesPerView.find(view.get());
+        if (viewPipelines == cpuCulledPipelinesPerView.end())
+            return false;
+
+        return (viewPipelines->second.size() > 0);
     }
 
-    void CacheGPUCullingPipelineInfo(
+    void CacheCPUCulledPipelineInfo(
         RPI::RenderPipeline* renderPipeline,
         RPI::ViewPtr newView,
         RPI::ViewPtr previousView,
-        AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>>& gpuCullingData)
+        AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>>& cpuCulledPipelinesPerView)
     {
         // Check if render pipeline is using GPU culling
-        if (!renderPipeline->FindFirstPass(AZ::Name("LightCullingPass")))
+        if (renderPipeline->FindFirstPass(AZ::Name("LightCullingPass")))
         {
             return;
         }
 
         if (previousView)
         {
-            gpuCullingData.erase(AZStd::make_pair(renderPipeline, previousView.get()));
+            erase(cpuCulledPipelinesPerView[previousView.get()], renderPipeline);
         }
 
         if (newView)
         {
-            gpuCullingData.insert(AZStd::make_pair(renderPipeline, newView.get()));
+            cpuCulledPipelinesPerView[newView.get()].emplace_back(renderPipeline);
         }
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.cpp
@@ -228,14 +228,13 @@ namespace AZ
             RPI::ViewPtr newView,
             RPI::ViewPtr previousView)
         {
-            
-            Render::LightCommon::CacheGPUCullingPipelineInfo(renderPipeline, newView, previousView, m_hasGPUCulling);
+            Render::LightCommon::CacheCPUCulledPipelineInfo(renderPipeline, newView, previousView, m_cpuCulledPipelinesPerView);
         }
 
         void SimplePointLightFeatureProcessor::CullLights(const RPI::ViewPtr& view)
         {
             if (!AZ::RHI::CheckBitsAll(view->GetUsageFlags(), RPI::View::UsageFlags::UsageCamera) ||
-                Render::LightCommon::HasGPUCulling(GetParentScene(), view, m_hasGPUCulling))
+                !Render::LightCommon::NeedsCPUCulling(view, m_cpuCulledPipelinesPerView))
             {
                 return;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
@@ -91,9 +91,8 @@ namespace AZ
             AZStd::vector<GpuBufferHandler> m_visiblePointLightsBufferHandlers;
             // Number of buffers being used for visibility in the current frame.
             uint32_t m_visiblePointLightsBufferUsedCount = 0;
-            // Views that have a GPU culling pass per render pipeline.
-            AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>> m_hasGPUCulling;
-
+            // Map of views -> pipelines in that view that need CPU culling (i.e. no GPU culling pass)
+            AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>> m_cpuCulledPipelinesPerView;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
@@ -462,15 +462,15 @@ namespace AZ
             RPI::ViewPtr newView,
             RPI::ViewPtr previousView)
         {
-            Render::LightCommon::CacheGPUCullingPipelineInfo(
+            Render::LightCommon::CacheCPUCulledPipelineInfo(
                 renderPipeline,
-                newView, previousView, m_hasGPUCulling);
+                newView, previousView, m_cpuCulledPipelinesPerView);
         }
 
         void SimpleSpotLightFeatureProcessor::CullLights(const RPI::ViewPtr& view)
         {
             if (!AZ::RHI::CheckBitsAll(view->GetUsageFlags(), RPI::View::UsageFlags::UsageCamera) ||
-                Render::LightCommon::HasGPUCulling(GetParentScene(), view, m_hasGPUCulling))
+                !Render::LightCommon::NeedsCPUCulling(view, m_cpuCulledPipelinesPerView))
             {
                 return;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
@@ -135,7 +135,7 @@ namespace AZ
             // Number of buffers being used for visibility in the current frame.
             uint32_t m_visibleSpotLightsBufferUsedCount = 0;
             // Views that have a GPU culling pass per render pipeline.
-            AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>> m_hasGPUCulling;
+            AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>> m_cpuCulledPipelinesPerView;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -423,7 +423,7 @@ namespace AZ
         void DecalTextureArrayFeatureProcessor::OnRenderPipelinePersistentViewChanged(
             RPI::RenderPipeline* renderPipeline, [[maybe_unused]] RPI::PipelineViewTag viewTag, RPI::ViewPtr newView, RPI::ViewPtr previousView)
         {
-            Render::LightCommon::CacheGPUCullingPipelineInfo(renderPipeline, newView, previousView, m_hasGPUCulling);
+            Render::LightCommon::CacheCPUCulledPipelineInfo(renderPipeline, newView, previousView, m_cpuCulledPipelinesPerView);
         }
 
         void DecalTextureArrayFeatureProcessor::RemoveMaterialFromDecal(const uint16_t decalIndex)
@@ -592,7 +592,7 @@ namespace AZ
         void DecalTextureArrayFeatureProcessor::CullDecals(const RPI::ViewPtr& view)
         {
             if (!AZ::RHI::CheckBitsAll(view->GetUsageFlags(), RPI::View::UsageFlags::UsageCamera) ||
-                Render::LightCommon::HasGPUCulling(GetParentScene(), view, m_hasGPUCulling))
+                !Render::LightCommon::NeedsCPUCulling(view, m_cpuCulledPipelinesPerView))
             {
                 return;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -167,7 +167,7 @@ namespace AZ
             // Number of buffers being used for visibility in the current frame.
             uint32_t m_visibleDecalBufferUsedCount = 0;
             // Views that have a GPU culling pass per render pipeline.
-            AZStd::unordered_set<AZStd::pair<const RPI::RenderPipeline*, const RPI::View*>> m_hasGPUCulling;
+            AZStd::unordered_map<const RPI::View*, AZStd::vector<const RPI::RenderPipeline*>> m_cpuCulledPipelinesPerView;
         };
     } // namespace Render
 } // namespace AZ


### PR DESCRIPTION
one of them needed CPU culling (i.e. didn't have a GPU culling pass), the view would not get CPU culling.

Before the changes, the code would register pairs of View A and RenderPipeline B if B had a GPU culling pass. Then to check if the view needed CPU culling, it would iterate over the pipelines in the scene, pair them with the view, and if any of these pipelines had a pair entry with the view (meaning the view has a pipeline which has a GPU culling pass), then the view would not get CPU culling.

This logic fails if a view has multiple pipelines and one of them needs CPU culling. I changed the logic so that now instead of remembering the views with GPU culling pipelines and ignoring those views, we remember the views with pipelines that don't have GPU culling passes and we run CPU culling on those views.

Testing: Found this because we have a setup where two pipelines use a same view, and one pipeline doesn't have GPU culling. The result was that spot lights weren't applied in the non-GPU culling pipeline. With this fix, spot lights are correctly applied.