### PR TITLE
bugfix: partial fix crash when renaming a deleted node (GHI-15048)

### DIFF
--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -1320,7 +1320,13 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 }
             } while (retryRename);
 
-            if (!newName.isEmpty())
+            if(!GetNodeRecord(animNode2)) {
+                QMessageBox::warning(
+                    this,
+                    tr("Entity does not exists"),
+                    tr("Entity has been deleted.\n\nUnable to rename entity"));
+            }
+            else if (!newName.isEmpty())
             {
                 const CTrackViewSequenceManager* sequenceManager = GetIEditor()->GetSequenceManager();
                 sequenceManager->RenameNode(animNode2, newName.toUtf8().data());

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -1323,7 +1323,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
             if(!GetNodeRecord(animNode2)) {
                 QMessageBox::warning(
                     this,
-                    tr("Entity does not exists"),
+                    tr("Entity does not exist"),
                     tr("Entity has been deleted.\n\nUnable to rename entity"));
             }
             else if (!newName.isEmpty())

--- a/Code/Editor/TrackView/TrackViewSequence.cpp
+++ b/Code/Editor/TrackView/TrackViewSequence.cpp
@@ -611,7 +611,7 @@ void CTrackViewSequence::SubmitPendingNotifcations(bool force)
         m_selectionRecursionLevel = 1;
     }
 
-    assert(m_selectionRecursionLevel > 0);
+    AZ_Assert(m_selectionRecursionLevel > 0, "Dangling SubmitPendingNotifcations()");
     if (m_selectionRecursionLevel > 0)
     {
         --m_selectionRecursionLevel;


### PR DESCRIPTION

## What does this PR do?

this ends up resolving the initial crash but, I can occasional get this into a state where SubmitPendingNotifcations end up in a state where this assert is hit in CTrackViewSequence. seems like the force call when you delete a node will set m_selectionRecursionLevel = 1 so when this is called the assert will get hit.  

## How was this PR tested?

follow the steps in the listed PR: 
ref: https://github.com/o3de/o3de/issues/15048