### PR TITLE
feat: remove usage of SendEvent for ObjectManager

### DIFF
--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -465,9 +465,6 @@ bool CGameEngine::LoadLevel(
     // directory is wrong
     QDir::setCurrent(GetIEditor()->GetPrimaryCDFolder());
 
-    // Audio: notify audio of level loading start?
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_REFRESH);
-
     m_bLevelLoaded = true;
 
     return true;
@@ -500,9 +497,6 @@ void CGameEngine::SwitchToInGame()
     m_pISystem->GetIMovieSystem()->EnablePhysicsEvents(true);
     m_bInGameMode = true;
 
-    //! Send event to switch into game.
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_INGAME);
-
     m_pISystem->GetIMovieSystem()->Reset(true, false);
 
     // Transition to runtime entity context.
@@ -534,10 +528,6 @@ void CGameEngine::SwitchToInEditor()
     CViewport* pGameViewport = GetIEditor()->GetViewManager()->GetGameViewport();
 
     m_pISystem->GetIMovieSystem()->EnablePhysicsEvents(m_bSimulationMode);
-
-    // [Anton] - order changed, see comments for CGameEngine::SetSimulationMode
-    //! Send event to switch out of game.
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_OUTOFGAME);
 
     m_bInGameMode = false;
 
@@ -620,8 +610,6 @@ void CGameEngine::SetGameMode(bool bInGame)
         SwitchToInEditor();
     }
 
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_PHYSICS_APPLYSTATE);
-
     // Enables engine to know about that.
     if (MainWindow::instance())
     {
@@ -658,19 +646,6 @@ void CGameEngine::SetSimulationMode(bool enabled, bool bOnlyPhysics)
 
     // Enables engine to know about simulation mode.
     gEnv->SetIsEditorSimulationMode(enabled);
-
-    if (m_bSimulationMode)
-    {
-        // [Anton] the order of the next 3 calls changed, since, EVENT_INGAME loads physics state (if any),
-        // and Reset should be called before it
-        GetIEditor()->GetObjectManager()->SendEvent(EVENT_INGAME);
-    }
-    else
-    {
-        GetIEditor()->GetObjectManager()->SendEvent(EVENT_OUTOFGAME);
-    }
-
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_PHYSICS_APPLYSTATE);
 
     // Execute all queued events before switching modes.
     ExecuteQueuedEvents();

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -1294,7 +1294,6 @@ void CEditorImpl::ReduceMemory()
 {
     GetIEditor()->GetUndoManager()->ClearRedoStack();
     GetIEditor()->GetUndoManager()->ClearUndoStack();
-    GetIEditor()->GetObjectManager()->SendEvent(EVENT_FREE_GAME_DATA);
 
 #if defined(AZ_PLATFORM_WINDOWS)
     HANDLE hHeap = GetProcessHeap();


### PR DESCRIPTION
## What does this PR do?

pretty simple to just start remove references to sendEvent for ObjectManager these events are only consumed by BaseObject but we don't spawn any BaseObjects in the engine.

