### PR TITLE
Setting wildcard paths in engine dependencies xml files to SourceFiles

### DIFF
--- a/Assets/Engine/Schema/enginedependency.xmlschema
+++ b/Assets/Engine/Schema/enginedependency.xmlschema
@@ -1,34 +1,29 @@
 <ObjectStream version="3">
-	<Class name="XmlSchemaAsset" version="3" type="{2DF35909-AF12-40A8-BED2-A033478D864D}">
+	<Class name="XmlSchemaAsset" version="2" type="{2DF35909-AF12-40A8-BED2-A033478D864D}">
 		<Class name="VersionSearchRule" field="VersionSearchRule" version="1" type="{0AC0D453-7F3E-4BA2-9D28-B39052361B0F}">
 			<Class name="AZStd::string" field="RootNodeAttributeName" value="versionnumber" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
-		<Class name="AZStd::vector&lt;MatchingRule, allocator&gt;" field="MatchingRules" type="{990D25B4-F7F3-5899-AE45-22D7FA443F28}">
+		<Class name="AZStd::vector" field="MatchingRules" type="{990D25B4-F7F3-5899-AE45-22D7FA443F28}">
 			<Class name="MatchingRule" field="element" version="1" type="{0052598D-594B-44C7-8B0F-F268FBBA6E4F}">
 				<Class name="AZStd::string" field="FilePathPattern" value="*_Dependencies.xml" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="ExcludedFilePathPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::vector&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, allocator&gt;" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
+				<Class name="AZStd::vector" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
 			</Class>
 		</Class>
-		<Class name="AZStd::vector&lt;DependencySearchRule, allocator&gt;" field="DependencySearchRules" type="{240BAD02-4EC4-5815-B982-03BDD6639174}">
+		<Class name="AZStd::vector" field="DependencySearchRules" type="{240BAD02-4EC4-5815-B982-03BDD6639174}">
 			<Class name="DependencySearchRule" field="element" version="2" type="{5A6EB7DE-A2EC-47F3-A2AB-91F0560C2E66}">
-				<Class name="AZStd::vector&lt;SearchRuleDefinition, allocator&gt;" field="SearchRuleDefinitions" type="{2710FA0D-F33C-5CDD-AFC3-BBD98801ADAB}">
+				<Class name="AZStd::vector" field="SearchRuleDefinitions" type="{2710FA0D-F33C-5CDD-AFC3-BBD98801ADAB}">
 					<Class name="SearchRuleDefinition" field="element" version="1" type="{DA29525E-3032-4919-97B2-3FECCDFF06A6}">
 						<Class name="XmlSchemaElement" field="SearchRuleStructure" version="2" type="{DB03558D-9533-4426-B50F-3DB16F7AA686}">
 							<Class name="AZStd::string" field="Name" value="Dependency" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::vector&lt;XmlSchemaElement, allocator&gt;" field="ChildElements" type="{B6F737EE-7169-5296-B1D3-DB4734CC164E}"/>
-							<Class name="AZStd::vector&lt;XmlSchemaAttribute, allocator&gt;" field="Attributes" type="{9A92ACD0-EDDE-5A87-92B6-C7AD719907A7}">
-								<Class name="XmlSchemaAttribute" field="element" version="6" type="{EE322552-0565-4D54-B022-9A9F134BF447}">
+							<Class name="AZStd::vector" field="ChildElements" type="{B6F737EE-7169-5296-B1D3-DB4734CC164E}"/>
+							<Class name="AZStd::vector" field="Attributes" type="{9A92ACD0-EDDE-5A87-92B6-C7AD719907A7}">
+								<Class name="XmlSchemaAttribute" field="element" version="2" type="{EE322552-0565-4D54-B022-9A9F134BF447}">
 									<Class name="AZStd::string" field="Name" value="path" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 									<Class name="AZStd::string" field="ExpectedExtension" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-									<Class name="AZStd::string" field="MatchPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-									<Class name="AZStd::string" field="FindPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-									<Class name="AZStd::string" field="ReplacePattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 									<Class name="unsigned int" field="Type" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="unsigned int" field="PathDependencyType" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="bool" field="RelativeToSourceAssetFolder" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+									<Class name="unsigned int" field="PathDependencyType" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 									<Class name="bool" field="Optional" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-									<Class name="bool" field="CacheRelativePath" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 								</Class>
 							</Class>
 							<Class name="bool" field="Optional" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
@@ -36,10 +31,8 @@
 						<Class name="bool" field="RelativeToXmlRoot" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 					</Class>
 				</Class>
-				<Class name="AZStd::vector&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, allocator&gt;" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
+				<Class name="AZStd::vector" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
 			</Class>
 		</Class>
-		<Class name="bool" field="useAZSerialization" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 	</Class>
 </ObjectStream>
-

--- a/Assets/Engine/Schema/enginedependency.xmlschema
+++ b/Assets/Engine/Schema/enginedependency.xmlschema
@@ -1,29 +1,34 @@
 <ObjectStream version="3">
-	<Class name="XmlSchemaAsset" version="2" type="{2DF35909-AF12-40A8-BED2-A033478D864D}">
+	<Class name="XmlSchemaAsset" version="3" type="{2DF35909-AF12-40A8-BED2-A033478D864D}">
 		<Class name="VersionSearchRule" field="VersionSearchRule" version="1" type="{0AC0D453-7F3E-4BA2-9D28-B39052361B0F}">
 			<Class name="AZStd::string" field="RootNodeAttributeName" value="versionnumber" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
-		<Class name="AZStd::vector" field="MatchingRules" type="{990D25B4-F7F3-5899-AE45-22D7FA443F28}">
+		<Class name="AZStd::vector&lt;MatchingRule, allocator&gt;" field="MatchingRules" type="{990D25B4-F7F3-5899-AE45-22D7FA443F28}">
 			<Class name="MatchingRule" field="element" version="1" type="{0052598D-594B-44C7-8B0F-F268FBBA6E4F}">
 				<Class name="AZStd::string" field="FilePathPattern" value="*_Dependencies.xml" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 				<Class name="AZStd::string" field="ExcludedFilePathPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-				<Class name="AZStd::vector" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
+				<Class name="AZStd::vector&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, allocator&gt;" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
 			</Class>
 		</Class>
-		<Class name="AZStd::vector" field="DependencySearchRules" type="{240BAD02-4EC4-5815-B982-03BDD6639174}">
+		<Class name="AZStd::vector&lt;DependencySearchRule, allocator&gt;" field="DependencySearchRules" type="{240BAD02-4EC4-5815-B982-03BDD6639174}">
 			<Class name="DependencySearchRule" field="element" version="2" type="{5A6EB7DE-A2EC-47F3-A2AB-91F0560C2E66}">
-				<Class name="AZStd::vector" field="SearchRuleDefinitions" type="{2710FA0D-F33C-5CDD-AFC3-BBD98801ADAB}">
+				<Class name="AZStd::vector&lt;SearchRuleDefinition, allocator&gt;" field="SearchRuleDefinitions" type="{2710FA0D-F33C-5CDD-AFC3-BBD98801ADAB}">
 					<Class name="SearchRuleDefinition" field="element" version="1" type="{DA29525E-3032-4919-97B2-3FECCDFF06A6}">
 						<Class name="XmlSchemaElement" field="SearchRuleStructure" version="2" type="{DB03558D-9533-4426-B50F-3DB16F7AA686}">
 							<Class name="AZStd::string" field="Name" value="Dependency" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::vector" field="ChildElements" type="{B6F737EE-7169-5296-B1D3-DB4734CC164E}"/>
-							<Class name="AZStd::vector" field="Attributes" type="{9A92ACD0-EDDE-5A87-92B6-C7AD719907A7}">
-								<Class name="XmlSchemaAttribute" field="element" version="2" type="{EE322552-0565-4D54-B022-9A9F134BF447}">
+							<Class name="AZStd::vector&lt;XmlSchemaElement, allocator&gt;" field="ChildElements" type="{B6F737EE-7169-5296-B1D3-DB4734CC164E}"/>
+							<Class name="AZStd::vector&lt;XmlSchemaAttribute, allocator&gt;" field="Attributes" type="{9A92ACD0-EDDE-5A87-92B6-C7AD719907A7}">
+								<Class name="XmlSchemaAttribute" field="element" version="6" type="{EE322552-0565-4D54-B022-9A9F134BF447}">
 									<Class name="AZStd::string" field="Name" value="path" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 									<Class name="AZStd::string" field="ExpectedExtension" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+									<Class name="AZStd::string" field="MatchPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+									<Class name="AZStd::string" field="FindPattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+									<Class name="AZStd::string" field="ReplacePattern" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 									<Class name="unsigned int" field="Type" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="unsigned int" field="PathDependencyType" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+									<Class name="unsigned int" field="PathDependencyType" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+									<Class name="bool" field="RelativeToSourceAssetFolder" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 									<Class name="bool" field="Optional" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+									<Class name="bool" field="CacheRelativePath" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 								</Class>
 							</Class>
 							<Class name="bool" field="Optional" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
@@ -31,8 +36,10 @@
 						<Class name="bool" field="RelativeToXmlRoot" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 					</Class>
 				</Class>
-				<Class name="AZStd::vector" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
+				<Class name="AZStd::vector&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, allocator&gt;" field="VersionConstraints" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
 			</Class>
 		</Class>
+		<Class name="bool" field="useAZSerialization" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 	</Class>
 </ObjectStream>
+

--- a/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
@@ -440,13 +440,10 @@ namespace CopyDependencyBuilder
             AssetBuilderSDK::ProductPathDependencySet pathDependencies;
             if (MatchExistingSchema(request.m_sourceFile, matchedSchemas, productDependencies, pathDependencies, request.m_watchFolder) != SchemaMatchResult::Error)
             {
-                // Only add source path dependendencies if the path:
-                // a) .. is of type SourceFile
-                // b) .. contains a wildcard character
+                // Product dependencies with wildcards are treated as source dependencies
                 for (const auto& pathDependency : pathDependencies)
                 {
-                    if (pathDependency.m_dependencyType != AssetBuilderSDK::ProductPathDependencyType::SourceFile ||
-                        !(pathDependency.m_dependencyPath.contains('*') || pathDependency.m_dependencyPath.contains('?')))
+                    if (!pathDependency.m_dependencyPath.contains('*') && !pathDependency.m_dependencyPath.contains('?'))
                         continue;
 
                     AssetBuilderSDK::SourceFileDependency sourceFileDependency;

--- a/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
@@ -355,7 +355,7 @@ namespace CopyDependencyBuilder
         xmlSchemaBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("(?!.*libs\\/gameaudio\\/).*\\.xml", AssetBuilderSDK::AssetBuilderPattern::PatternType::Regex));
         xmlSchemaBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.vegdescriptorlist", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
         xmlSchemaBuilderDescriptor.m_busId = azrtti_typeid<XmlBuilderWorker>();
-        xmlSchemaBuilderDescriptor.m_version = 9;
+        xmlSchemaBuilderDescriptor.m_version = 10;
         xmlSchemaBuilderDescriptor.m_createJobFunction =
             AZStd::bind(&XmlBuilderWorker::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);
         xmlSchemaBuilderDescriptor.m_processJobFunction =
@@ -397,6 +397,7 @@ namespace CopyDependencyBuilder
         const AssetBuilderSDK::CreateJobsRequest& request) const
     {
         AZStd::vector<AssetBuilderSDK::SourceFileDependency> sourceDependencies;
+        AZStd::vector<AZStd::string> matchedSchemas;
 
         // Iterate through each schema file and check whether the source XML matches its file path pattern
         for (const AZStd::string& schemaFileDirectory : m_schemaFileDirectories)
@@ -420,8 +421,38 @@ namespace CopyDependencyBuilder
                 AzFramework::StringFunc::AssetDatabasePath::Join(request.m_watchFolder.c_str(), request.m_sourceFile.c_str(), fullPath);
                 if (SourceFileDependsOnSchema(schemaAsset, fullPath.c_str()))
                 {
+                    matchedSchemas.emplace_back(schemaPath);
+                }
+            }
+        }
+
+        // If we have matched any schemas, then add both the schemas as well as the path dependencies as source dependencies.
+        if (matchedSchemas.size() > 0)
+        {
+            for (const AZStd::string& schemaPath : matchedSchemas)
+            {
+                AssetBuilderSDK::SourceFileDependency sourceFileDependency;
+                sourceFileDependency.m_sourceFileDependencyPath = schemaPath;
+                sourceDependencies.emplace_back(sourceFileDependency);
+            }
+
+            AZStd::vector<AssetBuilderSDK::ProductDependency> productDependencies;
+            AssetBuilderSDK::ProductPathDependencySet pathDependencies;
+            if (MatchExistingSchema(request.m_sourceFile, matchedSchemas, productDependencies, pathDependencies, request.m_watchFolder) != SchemaMatchResult::Error)
+            {
+                // Only add source path dependendencies if the path:
+                // a) .. is of type SourceFile
+                // b) .. contains a wildcard character
+                for (const auto& pathDependency : pathDependencies)
+                {
+                    if (pathDependency.m_dependencyType != AssetBuilderSDK::ProductPathDependencyType::SourceFile ||
+                        !(pathDependency.m_dependencyPath.contains('*') || pathDependency.m_dependencyPath.contains('?')))
+                        continue;
+
                     AssetBuilderSDK::SourceFileDependency sourceFileDependency;
-                    sourceFileDependency.m_sourceFileDependencyPath = schemaPath;
+                    sourceFileDependency.m_sourceFileDependencyPath = pathDependency.m_dependencyPath;
+                    sourceFileDependency.m_sourceDependencyType = AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards;
+
                     sourceDependencies.emplace_back(sourceFileDependency);
                 }
             }

--- a/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/CopyDependencyBuilder/XmlBuilderWorker/XmlBuilderWorker.cpp
@@ -399,6 +399,9 @@ namespace CopyDependencyBuilder
         AZStd::vector<AssetBuilderSDK::SourceFileDependency> sourceDependencies;
         AZStd::vector<AZStd::string> matchedSchemas;
 
+        AZStd::string fullPath;
+        AzFramework::StringFunc::AssetDatabasePath::Join(request.m_watchFolder.c_str(), request.m_sourceFile.c_str(), fullPath);
+
         // Iterate through each schema file and check whether the source XML matches its file path pattern
         for (const AZStd::string& schemaFileDirectory : m_schemaFileDirectories)
         {
@@ -416,9 +419,6 @@ namespace CopyDependencyBuilder
                 {
                     return AZ::Failure(AZStd::string::format("Failed to load schema file: %s.", schemaPath.c_str()));
                 }
-
-                AZStd::string fullPath;
-                AzFramework::StringFunc::AssetDatabasePath::Join(request.m_watchFolder.c_str(), request.m_sourceFile.c_str(), fullPath);
                 if (SourceFileDependsOnSchema(schemaAsset, fullPath.c_str()))
                 {
                     matchedSchemas.emplace_back(schemaPath);
@@ -438,7 +438,7 @@ namespace CopyDependencyBuilder
 
             AZStd::vector<AssetBuilderSDK::ProductDependency> productDependencies;
             AssetBuilderSDK::ProductPathDependencySet pathDependencies;
-            if (MatchExistingSchema(request.m_sourceFile, matchedSchemas, productDependencies, pathDependencies, request.m_watchFolder) != SchemaMatchResult::Error)
+            if (MatchExistingSchema(fullPath, matchedSchemas, productDependencies, pathDependencies, request.m_watchFolder) != SchemaMatchResult::Error)
             {
                 // Product dependencies with wildcards are treated as source dependencies
                 for (const auto& pathDependency : pathDependencies)


### PR DESCRIPTION
## What does this PR do?

Fixes the issue detailed here:
https://github.com/o3de/o3de/issues/17876

1) Updates the enginedependency.xmlschema to treat "path" as a Source instead of a Product
2) During XmlBuilderWorker, pulls out the path dependencies - and only if they are (a) SourceFiles and (b) have wildcards, does it add them as source dependencies.

## How was this PR tested?

By adding / removing files under a wildcard capture and checking to see the dependencies are indeed updated.
