### PR TITLE
bugfix: resolve rotated entities when adding them to trackview (GHI-14978)

### DIFF
--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -1833,15 +1833,15 @@ void CTrackViewAnimNode::SetPos(const Vec3& position)
 
                 // Set the selected flag to enable record when unselected camera is moved through viewport
                 m_animNode->SetFlags(flags | eAnimNodeFlags_EntitySelected);
-                m_animNode->SetPos(sequence->GetTime(), position);
+                m_animNode->SetPos(sequence->GetTime(), LYVec3ToAZVec3(position));
                 m_animNode->SetFlags(flags);
-                    
+
                 // We don't want to use ScopedUndoBatch here because we don't want a separate Undo operation
                 // generate for every frame as the user moves an entity.
                 AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, 
+                    &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity,
                     sequence->GetSequenceComponentEntityId()
-                );                    
+                );
 
                 sequence->OnKeysChanged();
             }
@@ -1865,7 +1865,7 @@ void CTrackViewAnimNode::SetScale(const Vec3& scale)
             // undo a previous move delta as the entity is dragged.
             CUndo::Record(new CUndoComponentEntityTrackObject(track));
 
-            m_animNode->SetScale(sequence->GetTime(), scale);
+            m_animNode->SetScale(sequence->GetTime(), LYVec3ToAZVec3(scale));
 
             // We don't want to use ScopedUndoBatch here because we don't want a separate Undo operation
             // generate for every frame as the user scales an entity.
@@ -1897,7 +1897,7 @@ void CTrackViewAnimNode::SetRotation(const Quat& rotation)
 
             // Set the selected flag to enable record when unselected camera is moved through viewport
             m_animNode->SetFlags(flags | eAnimNodeFlags_EntitySelected);
-            m_animNode->SetRotate(sequence->GetTime(), rotation);
+            m_animNode->SetRotate(sequence->GetTime(), LYQuaternionToAZQuaternion(rotation));
             m_animNode->SetFlags(flags);
 
             // We don't want to use ScopedUndoBatch here because we don't want a separate Undo operation
@@ -2458,10 +2458,10 @@ void CTrackViewAnimNode::OnParentChanged(AZ::EntityId oldParent, AZ::EntityId ne
     }
 }
 
-void CTrackViewAnimNode::OnParentTransformWillChange(AZ::Transform oldTransform, AZ::Transform newTransform) 
-{ 
-    // Only used in circumstances where modified keys are required, but OnParentChanged 
-    // message will not be received for some reason, e.g. node being cloned in memory 
+void CTrackViewAnimNode::OnParentTransformWillChange(AZ::Transform oldTransform, AZ::Transform newTransform)
+{
+    // Only used in circumstances where modified keys are required, but OnParentChanged
+    // message will not be received for some reason, e.g. node being cloned in memory
     UpdateKeyDataAfterParentChanged(oldTransform, newTransform);
 
     CTrackViewSequence* sequence = GetSequence();

--- a/Code/Legacy/CryCommon/IMovieSystem.cpp
+++ b/Code/Legacy/CryCommon/IMovieSystem.cpp
@@ -207,34 +207,6 @@ IAnimNode::SParamInfo::SParamInfo(const char* _name, CAnimParamType _paramType, 
     , valueType(_valueType)
     , flags(_flags) {};
 
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent SetPos that accepts AZ::Vector3
- **/
-void IAnimNode::SetPos(float time, const AZ::Vector3& pos)
-{
-    Vec3 vec3(pos.GetX(), pos.GetY(), pos.GetZ());
-    SetPos(time, vec3);
-}
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent SetRotate that accepts AZ::Quaternion
- **/
-void IAnimNode::SetRotate(float time, const AZ::Quaternion& rot)
-{
-    Quat quat(rot.GetX(), rot.GetY(), rot.GetZ(), rot.GetW());
-    SetRotate(time, quat);
-}
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent SetScale that accepts AZ::Vector3
- **/
-void IAnimNode::SetScale(float time, const AZ::Vector3& scale)
-{
-    Vec3 vec3(scale.GetX(), scale.GetY(), scale.GetZ());
-    SetScale(time, vec3);
-}
-
 //! Compute and return the offset which brings the current position to the given position
 Vec3 IAnimNode::GetOffsetPosition(const Vec3& position) { return position - GetPos(); }
 

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -587,31 +587,9 @@ public:
     // Return movie system that created this node.
     virtual IMovieSystem*   GetMovieSystem() const = 0;
 
-    //////////////////////////////////////////////////////////////////////////
-    // Space position/orientation scale.
-    //////////////////////////////////////////////////////////////////////////
-    //! Translate entity node.
-    virtual void SetPos(float time, const Vec3& pos) = 0;
-    //! Rotate entity node.
-    virtual void SetRotate(float time, const Quat& quat) = 0;
-    //! Scale entity node.
-    virtual void SetScale(float time, const Vec3& scale) = 0;
-
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent SetPos that accepts AZ::Vector3
-     **/
-    void SetPos(float time, const AZ::Vector3& pos);
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent SetRotate that accepts AZ::Quaternion
-     **/
-    void SetRotate(float time, const AZ::Quaternion& rot);
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent SetScale that accepts AZ::Vector3
-     **/
-    void SetScale(float time, const AZ::Vector3& scale);
+    virtual void SetPos(float time, const AZ::Vector3& pos) = 0;
+    virtual void SetRotate(float time, const AZ::Quaternion& rot) = 0;
+    virtual void SetScale(float time, const AZ::Vector3& scale) = 0;
 
     //! Compute and return the offset which brings the current position to the given position
     virtual Vec3 GetOffsetPosition(const Vec3& position);

--- a/Gems/Maestro/Code/Source/Cinematics/AnimAZEntityNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimAZEntityNode.cpp
@@ -134,7 +134,7 @@ CAnimComponentNode* CAnimAzEntityNode::GetTransformComponentNode() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CAnimAzEntityNode::SetPos(float time, const Vec3& pos)
+void CAnimAzEntityNode::SetPos(float time, const AZ::Vector3& pos)
 {
     CAnimComponentNode* transformComponent = GetTransformComponentNode();
     if (transformComponent)
@@ -155,7 +155,7 @@ Vec3 CAnimAzEntityNode::GetPos()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CAnimAzEntityNode::SetRotate(float time, const Quat& rotation)
+void CAnimAzEntityNode::SetRotate(float time, const AZ::Quaternion& rotation)
 {
     CAnimComponentNode* transformComponent = GetTransformComponentNode();
     if (transformComponent)
@@ -185,7 +185,7 @@ Quat CAnimAzEntityNode::GetRotate(float time)
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CAnimAzEntityNode::SetScale(float time, const Vec3& scale)
+void CAnimAzEntityNode::SetScale(float time, const AZ::Vector3& scale)
 {
     CAnimComponentNode* transformComponent = GetTransformComponentNode();
     if (transformComponent)

--- a/Gems/Maestro/Code/Source/Cinematics/AnimAZEntityNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimAZEntityNode.h
@@ -51,9 +51,9 @@ public:
     // return AnimParamType::Invalid for this pure virtual for the legacy system
     CAnimParamType GetParamType(unsigned int nIndex) const override;
 
-    void SetPos(float time, const Vec3& pos) override;
-    void SetRotate(float time, const Quat& quat) override;
-    void SetScale(float time, const Vec3& scale) override;
+    void SetPos(float time, const AZ::Vector3& pos) override;
+    void SetRotate(float time, const AZ::Quaternion& quat) override;
+    void SetScale(float time, const AZ::Vector3& scale) override;
 
     Vec3 GetOffsetPosition(const Vec3& position) override;
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
@@ -65,9 +65,9 @@ public:
 
     void SetNodeOwner(IAnimNodeOwner* pOwner) override;
 
-    void SetPos(float time, const Vec3& pos) override;
-    void SetRotate(float time, const Quat& quat) override;
-    void SetScale(float time, const Vec3& scale) override;
+    void SetPos(float time, const AZ::Vector3& pos) override;
+    void SetRotate(float time, const AZ::Quaternion& quat) override;
+    void SetScale(float time, const AZ::Vector3& scale) override;
 
     Vec3 GetPos() override;
     Quat GetRotate() override;
@@ -125,6 +125,10 @@ private:
     void ConvertBetweenWorldAndLocalPosition(Vec3& position, ETransformSpaceConversionDirection conversionDirection) const;
     void ConvertBetweenWorldAndLocalRotation(Quat& rotation, ETransformSpaceConversionDirection conversionDirection) const;
     void ConvertBetweenWorldAndLocalScale(Vec3& scale, ETransformSpaceConversionDirection conversionDirection) const;
+
+    AZ::Vector3 TransformFromWorldToLocalPosition(const AZ::Vector3& position) const;
+    AZ::Quaternion TransformFromWorldToLocalRotation(const AZ::Quaternion& rotation) const;
+    AZ::Vector3 TransformFromWorldToLocalScale(const AZ::Vector3& scale) const;
 
     // Utility function to query the units for a track and set the track multiplier if needed. Returns true if track multiplier was set.
     bool SetTrackMultiplier(IAnimTrack* track) const;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
@@ -75,9 +75,9 @@ public:
     //////////////////////////////////////////////////////////////////////////
     // Space position/orientation scale.
     //////////////////////////////////////////////////////////////////////////
-    void SetPos([[maybe_unused]] float time, [[maybe_unused]] const Vec3& pos) override {};
-    void SetRotate([[maybe_unused]] float time, [[maybe_unused]] const Quat& quat) override {};
-    void SetScale([[maybe_unused]] float time, [[maybe_unused]] const Vec3& scale) override {};
+    void SetPos([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector3& pos) override {};
+    void SetRotate([[maybe_unused]] float time, [[maybe_unused]] const AZ::Quaternion& quat) override {};
+    void SetScale([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector3& scale) override {};
 
     Vec3 GetPos() override { return Vec3(0, 0, 0); };
     Quat GetRotate() override { return Quat(0, 0, 0, 0); };


### PR DESCRIPTION
## What does this PR do?

when adding entity to trackview they can appear rotated. looks like this was a regression that I introduced with https://github.com/o3de/o3de/issues/9326
## How was this PR tested?

look at the referenced ticket
ref: https://github.com/o3de/o3de/issues/14978
