### PR TITLE
Fix waitSemaphore dynamic cast

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -125,7 +125,7 @@ namespace AZ
 
                     for (auto& fence : fencesToWaitFor)
                     {
-                        auto timelineSemaphoreFence = azrtti_cast<TimelineSemaphoreFence*>(fence);
+                        auto timelineSemaphoreFence = azrtti_cast<TimelineSemaphoreFence*>(&fence->GetFenceBase());
                         AZ_Assert(timelineSemaphoreFence, "Queue: Only fences of type timeline semaphores can be waited for");
                         vkWaitSemaphoreValues.push_back(timelineSemaphoreFence->GetPendingValue());
                         vkWaitSemaphoreVector.push_back(timelineSemaphoreFence->GetNativeSemaphore());


### PR DESCRIPTION
## What does this PR do?

During the last re-write of PR #17761, this change in the class hierarchy was not correctly reflected in this line of code, this currently returns now a `nullptr` instead of a pointer to the `TimelineSemaphore`.
