### PR TITLE
Improve lua editor syntax highlighting and update style

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
@@ -95,7 +95,7 @@ namespace LUAEditor
                 drawRect.setLeft(c_borderSize);
                 drawRect.setRight(c_borderSize + m_numDigits * avgCharWidth);
 
-                p.setPen(QColor::fromRgb(200, 200, 200));
+                p.setPen(colors->GetLineNumberColor());
                 p.drawText(drawRect.toRect(), Qt::AlignRight | Qt::AlignBottom, lineNumStr.c_str());
 
                 {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.cpp
@@ -95,7 +95,7 @@ namespace LUAEditor
                 drawRect.setLeft(c_borderSize);
                 drawRect.setRight(c_borderSize + m_numDigits * avgCharWidth);
 
-                p.setPen(colors->GetTextColor());
+                p.setPen(QColor::fromRgb(200, 200, 200));
                 p.drawText(drawRect.toRect(), Qt::AlignRight | Qt::AlignBottom, lineNumStr.c_str());
 
                 {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -222,7 +222,14 @@ namespace LUAEditor
             newState->m_bAutoReloadUnmodifiedFiles = newValue;
         });
 
-        connect(this, &LUAEditorMainWindow::OnReferenceDataChanged, this, [this]() { luaClassFilterTextChanged(m_ClassReferenceFilter->GetFilter()); });
+        connect(this, &LUAEditorMainWindow::OnReferenceDataChanged, this, [this]() {
+            luaClassFilterTextChanged(m_ClassReferenceFilter->GetFilter());
+            if (auto* view = GetCurrentView())
+            {
+                // Update syntax highlighting now that the project libraries are loaded
+                view->UpdateFont();
+            }
+         });
 
         // preset our running state based on outside conditions when we are created
         if (connectedState)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
@@ -39,6 +39,7 @@ namespace LUAEditor
                 ->Field("m_useSpacesInsteadOfTabs", &SyntaxStyleSettings::m_useSpacesInsteadOfTabs)
 
                 ->Field("m_textColor", &SyntaxStyleSettings::m_textColor)
+                ->Field("m_lineNumberColor", &SyntaxStyleSettings::m_lineNumberColor)
                 ->Field("m_textSelectedColor", &SyntaxStyleSettings::m_textSelectedColor)
                 ->Field("m_textSelectedBackgroundColor", &SyntaxStyleSettings::m_textSelectedBackgroundColor)
 
@@ -105,6 +106,8 @@ namespace LUAEditor
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Text")
 
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textColor, "Default", "Default text color")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_lineNumberColor, "Line Number", "")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
 
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textSelectedColor, "Selected Text", "")

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
@@ -12,15 +12,18 @@
 
 namespace LUAEditor
 {
-    QFont SyntaxStyleSettings::GetFont() const
+    SyntaxStyleSettings::SyntaxStyleSettings()
     {
-        QFont result;
-        result.setFamily(m_font.c_str());
-        result.setFixedPitch(true);
-        result.setStyleHint(QFont::Monospace);
-        result.setPointSize(m_fontSize);
+        m_font.setFamily(m_fontFamily.c_str());
+        m_font.setFixedPitch(true);
+        m_font.setStyleHint(QFont::Monospace);
+        m_font.setPointSize(m_fontSize);
+    }
 
-        return result;
+    void SyntaxStyleSettings::SetZoomPercent(float zoom)
+    {
+        m_zoomPercent = zoom;
+        m_font.setPointSize(m_fontSize * (m_zoomPercent / 100.0f));
     }
 
     void SyntaxStyleSettings::Reflect(AZ::ReflectContext* reflection)
@@ -30,7 +33,7 @@ namespace LUAEditor
         {
             serializeContext->Class<SyntaxStyleSettings, AZ::UserSettings >()
                 ->Version(6)
-                ->Field("m_font", &SyntaxStyleSettings::m_font)
+                ->Field("m_fontFamily", &SyntaxStyleSettings::m_fontFamily)
                 ->Field("m_fontSize", &SyntaxStyleSettings::m_fontSize)
                 ->Field("m_tabSize", &SyntaxStyleSettings::m_tabSize)
                 ->Field("m_useSpacesInsteadOfTabs", &SyntaxStyleSettings::m_useSpacesInsteadOfTabs)
@@ -54,12 +57,16 @@ namespace LUAEditor
 
                 ->Field("m_currentIdentifierColor", &SyntaxStyleSettings::m_currentIdentifierColor)
                 ->Field("m_currentLineOutlineColor", &SyntaxStyleSettings::m_currentLineOutlineColor)
+                ->Field("m_specialCharacterColor", &SyntaxStyleSettings::m_specialCharacterColor)
                 ->Field("m_keywordColor", &SyntaxStyleSettings::m_keywordColor)
+                ->Field("m_specialKeywordColor", &SyntaxStyleSettings::m_specialKeywordColor)
                 ->Field("m_commentColor", &SyntaxStyleSettings::m_commentColor)
                 ->Field("m_stringLiteralColor", &SyntaxStyleSettings::m_stringLiteralColor)
                 ->Field("m_numberColor", &SyntaxStyleSettings::m_numberColor)
                 ->Field("m_libraryColor", &SyntaxStyleSettings::m_libraryColor)
+                ->Field("m_methodColor", &SyntaxStyleSettings::m_methodColor)
                 ->Field("m_bracketColor", &SyntaxStyleSettings::m_bracketColor)
+                ->Field("m_selectedBracketColor", &SyntaxStyleSettings::m_selectedBracketColor)
                 ->Field("m_unmatchedBracketColor", &SyntaxStyleSettings::m_unmatchedBracketColor)
 
                 ->Field("m_foldingColor", &SyntaxStyleSettings::m_foldingColor)
@@ -80,7 +87,7 @@ namespace LUAEditor
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Font")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
 
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_font, "Font", "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_fontFamily, "Font", "")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnFontChange)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_fontSize, "Size", "")
@@ -105,20 +112,40 @@ namespace LUAEditor
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textSelectedBackgroundColor, "Selected Text Background", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
 
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textFocusedBackgroundColor, "Focused Background Color", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textUnfocusedBackgroundColor, "Unfocused Background Color", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textReadOnlyFocusedBackgroundColor, "Read Only Focused Background", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textReadOnlyUnfocusedBackgroundColor, "Read Only Background", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textWhitespaceColor, "Whitespace Color", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
 
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "Interface")
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "LUA Syntax")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_currentIdentifierColor, "Current Identifier", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_specialCharacterColor, "Special character", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_keywordColor, "Keyword", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_specialKeywordColor, "Special Keyword", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_commentColor, "Comment", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_stringLiteralColor, "String", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_numberColor, "Number", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_libraryColor, "Library", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_methodColor, "Method", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_bracketColor, "Bracket", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_selectedBracketColor, "Selected Bracket", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_unmatchedBracketColor, "Unmatched Bracket", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Interface")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
 
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_breakpointFocusedBackgroundColor, "Focused Breakpoint Background", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
@@ -130,32 +157,19 @@ namespace LUAEditor
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_currentLineOutlineColor, "Line Outline", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "LUA Syntax")
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_currentIdentifierColor, "Current Identifier", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_keywordColor, "Keyword", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_commentColor, "Comment", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_stringLiteralColor, "String Literal", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_numberColor, "Number", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_libraryColor, "Library", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_bracketColor, "Bracket", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
-                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_unmatchedBracketColor, "Unmatched Bracket", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_foldingColor, "Folding", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_foldingCurrentColor, "Folding Current", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
                     ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_foldingLineColor, "Folding Line", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textFocusedBackgroundColor, "Focused Background Color", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textUnfocusedBackgroundColor, "Unfocused Background Color", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textReadOnlyFocusedBackgroundColor, "Read Only Focused Background", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &SyntaxStyleSettings::m_textReadOnlyUnfocusedBackgroundColor, "Read Only Background", "")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnColorChange)
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Find Results")
@@ -179,6 +193,8 @@ namespace LUAEditor
 
     void SyntaxStyleSettings::OnFontChange()
     {
+        m_font.setFamily(m_fontFamily.c_str());
+        m_font.setPointSize(m_fontSize);
         LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
     }
 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
@@ -37,6 +37,7 @@ namespace LUAEditor
         }
 
         QColor GetTextColor() const { return ToQColor(m_textColor); }
+        QColor GetLineNumberColor() const { return ToQColor(m_lineNumberColor); }
         QColor GetTextFocusedBackgroundColor() const { return ToQColor(m_textFocusedBackgroundColor); }
         QColor GetTextUnfocusedBackgroundColor() const { return ToQColor(m_textUnfocusedBackgroundColor); }
         QColor GetTextReadOnlyFocusedBackgroundColor() const { return ToQColor(m_textReadOnlyFocusedBackgroundColor); }
@@ -79,6 +80,9 @@ namespace LUAEditor
     private:
         AZ::Vector3 m_textColor {
             156.0f / 255.0f, 220.0f / 255.0f, 254.0f / 255.0f
+        };
+        AZ::Vector3 m_lineNumberColor {
+            200.0f / 255.0f, 200.0f / 255.0f, 200.0f / 255.0f
         };
         AZ::Vector3 m_textFocusedBackgroundColor {
             31.0f / 255.0f, 31.0f / 255.0f, 31.0f / 255.0f

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
@@ -29,6 +29,8 @@ namespace LUAEditor
         AZ_RTTI(SyntaxStyleSettings, "{9C5A2A16-1855-4074-AA06-FC58A6A789D7}", AZ::UserSettings);
         AZ_CLASS_ALLOCATOR(SyntaxStyleSettings, AZ::SystemAllocator);
 
+        SyntaxStyleSettings();
+
         QColor ToQColor(const AZ::Vector3& color) const
         {
             return QColor::fromRgbF(color.GetX(), color.GetY(), color.GetZ());
@@ -48,12 +50,16 @@ namespace LUAEditor
         QColor GetFoldingUnfocusedBackgroundColor() const { return ToQColor(m_foldingUnfocusedBackgroundColor); }
         QColor GetCurrentIdentifierColor() const { return ToQColor(m_currentIdentifierColor); }
         QColor GetCurrentLineOutlineColor() const { return ToQColor(m_currentLineOutlineColor); }
+        QColor GetSpecialCharacterColor() const { return ToQColor(m_specialCharacterColor); }
         QColor GetKeywordColor() const { return ToQColor(m_keywordColor); }
+        QColor GetSpecialKeywordColor() const { return ToQColor(m_specialKeywordColor); }
         QColor GetCommentColor() const { return ToQColor(m_commentColor); }
         QColor GetStringLiteralColor() const { return ToQColor(m_stringLiteralColor); }
         QColor GetNumberColor() const { return ToQColor(m_numberColor); }
         QColor GetLibraryColor() const { return ToQColor(m_libraryColor); }
+        QColor GetMethodColor() const { return ToQColor(m_methodColor); }
         QColor GetBracketColor() const { return ToQColor(m_bracketColor); }
+        QColor GetSelectedBracketColor() const { return ToQColor(m_selectedBracketColor); }
         QColor GetUnmatchedBracketColor() const { return ToQColor(m_unmatchedBracketColor); }
         QColor GetFoldingColor() const { return ToQColor(m_foldingColor); }
         QColor GetFoldingSelectedColor() const { return ToQColor(m_foldingCurrentColor); }
@@ -62,21 +68,23 @@ namespace LUAEditor
         QColor GetFindResultsFileColor() const { return ToQColor(m_findResultsFileColor); }
         QColor GetFindResultsMatchColor() const { return ToQColor(m_findResultsMatchColor); }
         QColor GetFindResultsLineHighlightColor() const { return ToQColor(m_findResultsLineHighlightColor); }
-        QFont GetFont() const;
+        const QFont& GetFont() const { return m_font; }
         int GetTabSize() const { return m_tabSize; }
         bool UseSpacesInsteadOfTabs() const { return m_useSpacesInsteadOfTabs; }
+
+        void SetZoomPercent(float zoom);
 
         static void Reflect(AZ::ReflectContext* reflection);
 
     private:
         AZ::Vector3 m_textColor {
-            220.0f / 255.0f, 220.0f / 255.0f, 220.0f / 255.0f
+            156.0f / 255.0f, 220.0f / 255.0f, 254.0f / 255.0f
         };
         AZ::Vector3 m_textFocusedBackgroundColor {
-            60.0f / 255.0f, 60.0f / 255.0f, 60.0f / 255.0f
+            31.0f / 255.0f, 31.0f / 255.0f, 31.0f / 255.0f
         };
         AZ::Vector3 m_textUnfocusedBackgroundColor {
-            60.0f / 255.0f, 60.0f / 255.0f, 60.0f / 255.0f
+            31.0f / 255.0f, 31.0f / 255.0f, 31.0f / 255.0f
         };
         AZ::Vector3 m_textReadOnlyFocusedBackgroundColor {
             60.0f / 255.0f, 60.0f / 255.0f, 60.0f / 255.0f
@@ -85,10 +93,10 @@ namespace LUAEditor
             60.0f / 255.0f, 60.0f / 255.0f, 60.0f / 255.0f
         };
         AZ::Vector3 m_textSelectedColor {
-            60.0f / 255.0f, 60.0f / 255.0f, 60.0f / 255.0f
+            225.0f / 255.0f, 225.0f / 255.0f, 225.0f / 255.0f
         };
         AZ::Vector3 m_textSelectedBackgroundColor {
-            220.0f / 255.0f, 220.0f / 255.0f, 220.0f / 255.0f
+            55.0f / 255.0f, 90.0f / 255.0f, 125.0f / 255.0f
         };
         AZ::Vector3 m_textWhitespaceColor{
             100.0f / 255.0f, 100.0f / 255.0f, 100.0f / 255.0f
@@ -106,63 +114,75 @@ namespace LUAEditor
             70.0f / 255.0f, 70.0f / 255.0f, 70.0f / 255.0f
         };
         AZ::Vector3 m_currentIdentifierColor {
-            25.0f / 255.0f, 25.0f / 255.0f, 25.0f / 255.0f
+            68.0f / 255.0f, 68.0f / 255.0f, 68.0f / 255.0f
         };
         AZ::Vector3 m_currentLineOutlineColor {
-            128.0f / 255.0f, 128.0f / 255.0f, 128.0f / 255.0f
+            61.0f / 255.0f, 61.0f / 255.0f, 61.0f / 255.0f
+        };
+        AZ::Vector3 m_specialCharacterColor {
+            204.0f / 255.0f, 204.0f / 255.0f, 204.0f / 255.0f
         };
         AZ::Vector3 m_keywordColor {
-            160.0f / 255.0f, 160.0f / 255.0f, 255.0f / 255.0f
+            213.0f / 255.0f, 134.0f / 255.0f, 192.0f / 255.0f
+        };
+        AZ::Vector3 m_specialKeywordColor {
+            63.0f / 255.0f, 156.0f / 255.0f, 214.0f / 255.0f
         };
         AZ::Vector3 m_commentColor {
-            130.0f / 255.0f, 160.0f / 255.0f, 130.0f / 255.0f
+            106.0f / 255.0f, 153.0f / 255.0f, 85.0f / 255.0f
         };
         AZ::Vector3 m_stringLiteralColor {
-            220.0f / 255.0f, 120.0f / 255.0f, 120.0f / 255.0f
+            206.0f / 255.0f, 145.0f / 255.0f, 117.0f / 255.0f
         };
         AZ::Vector3 m_numberColor {
-            200.0f / 255.0f, 200.0f / 255.0f, 100.0f / 255.0f
+            181.0f / 255.0f, 203.0f / 255.0f, 164.0f / 255.0f
         };
         AZ::Vector3 m_libraryColor {
-            220.0f / 255.0f, 150.0f / 255.0f, 220.0f / 255.0f
+            78.0f / 255.0f, 201.0f / 255.0f, 176.0f / 255.0f
+        };
+        AZ::Vector3 m_methodColor {
+            220.0f / 255.0f, 220.0f / 255.0f, 170.0f / 255.0f
         };
         AZ::Vector3 m_bracketColor {
-            80.0f / 255.0f, 190.0f / 255.0f, 190.0f / 255.0f
+            255.0f / 255.0f, 215.0f / 255.0f, 0.0f / 255.0f
+        };
+        AZ::Vector3 m_selectedBracketColor {
+            219.0f / 255.0f, 29.0f / 255.0f, 133.0f / 255.0f
         };
         AZ::Vector3 m_unmatchedBracketColor {
-            80.0f / 255.0f, 130.0f / 255.0f, 130.0f / 255.0f
+            219.0f / 255.0f, 29.0f / 255.0f, 133.0f / 255.0f
         };
         AZ::Vector3 m_foldingColor {
             150.0f / 255.0f, 150.0f / 255.0f, 150.0f / 255.0f
         };
         AZ::Vector3 m_foldingCurrentColor {
-            255.0f / 255.0f, 50.0f / 255.0f, 50.0f / 255.0f
+            240.0f / 255.0f, 240.0f / 255.0f, 240.0f / 255.0f
         };
         AZ::Vector3 m_foldingLineColor {
-            0.0f / 255.0f, 0.0f / 255.0f, 0.0f / 255.0f
+            150.0f / 255.0f, 150.0f / 255.0f, 150.0f / 255.0f
         };
         AZ::Vector3 m_findResultsHeaderColor {
-            255.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f
+            255.0f / 255.0f, 220.0f / 255.0f, 20.0f / 255.0f
         };
         AZ::Vector3 m_findResultsFileColor {
-            0.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f
+            105.0f / 255.0f, 220.0f / 255.0f, 53.0f / 255.0f
         };
         AZ::Vector3 m_findResultsMatchColor {
-            0.0f / 255.0f, 255.0f / 255.0f, 255.0f / 255.0f
+            255.0f / 255.0f, 220.0f / 255.0f, 20.0f / 255.0f
         };
         AZ::Vector3 m_findResultsLineHighlightColor {
             160.0f / 255.0f, 160.0f / 255.0f, 164.0f / 255.0f
         };
-        AZStd::string m_font {
-            "OpenSans"
-        };
+        QFont m_font;
+        AZStd::string m_fontFamily { "Consolas" };
         int m_fontSize {
-            10
+            14
         };
         // Number of spaces to make a tab
         int m_tabSize {
             4
         };
+        float m_zoomPercent = 100.f;
 
         bool m_useSpacesInsteadOfTabs = false;
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.hxx
@@ -8,10 +8,14 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
-#include <QSyntaxHighlighter>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/function/function_template.h>
+#include <AzCore/std/string/string.h>
+#include <QColor>
+#include <QRegularExpression>
+#include <QSyntaxHighlighter>
 #include <QTextEdit>
 #endif
 
@@ -34,7 +38,6 @@ namespace LUAEditor
         void highlightBlock(const QString& text) override;
         //set to -1 to disable bracket highlighting
         void SetBracketHighlighting(int openBracketPos, int closeBracketPos);
-        void SetFont(QFont font) { m_font = font; }
 
         //this is done using QT extraSelections not regular highlighting
         QList<QTextEdit::ExtraSelection> HighlightMatchingNames(const QTextCursor& cursor, const QString& text) const;
@@ -46,14 +49,22 @@ namespace LUAEditor
         void LUANamesInScopeChanged(const QStringList& luaNames) const;
 
     private:
+        void BuildRegExes();
         void AddBlockKeywords();
 
         StateMachine* m_machine;
         AZStd::unordered_set<AZStd::string> m_LUAStartBlockKeywords;
         AZStd::unordered_set<AZStd::string> m_LUAEndBlockKeywords;
+
+        struct HighlightingRule
+        {
+            QRegularExpression pattern;
+            AZStd::function<QColor()> colorCB;
+        };
+        AZStd::vector<HighlightingRule> m_highlightingRules;
+
         int m_openBracketPos{-1};
         int m_closeBracketPos{-1};
-        QFont m_font{"OpenSans", 10};
         mutable int m_currentScopeBlock{-1};
     };
 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -141,8 +141,6 @@ namespace LUAEditor
         option.setFlags(option.flags() | QTextOption::ShowTabsAndSpaces);
         doc->setDefaultTextOption(option);
 
-        UpdateFont();
-
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::modificationChanged, this, &LUAViewWidget::modificationChanged);
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::cursorPositionChanged, this, &LUAViewWidget::UpdateBraceHighlight);
         connect(m_gui->m_luaTextEdit, &LUAEditorPlainTextEdit::Scrolled, m_gui->m_folding, static_cast<void(FoldingWidget::*)()>(&FoldingWidget::update));
@@ -173,6 +171,8 @@ namespace LUAEditor
         SetReadonly(true);
 
         m_gui->m_luaTextEdit->SetGetLuaName([&](const QTextCursor& cursor) {return m_Highlighter->GetLUAName(cursor); });
+
+        UpdateFont();
 
         LUABreakpointTrackerMessages::Handler::BusConnect();
     }
@@ -289,6 +289,7 @@ namespace LUAEditor
             {
                 delete m_pLoadingProgressShield;
                 m_pLoadingProgressShield = NULL;
+                UpdateFont(); // Loading over, inner document need the latest font settings
             }
 
             // scan the breakpoint store from our context and pre-set the markers to get in sync
@@ -1239,15 +1240,14 @@ namespace LUAEditor
     void LUAViewWidget::UpdateFont()
     {
         auto syntaxSettings = AZ::UserSettings::CreateFind<SyntaxStyleSettings>(AZ_CRC("LUA Editor Text Settings", 0xb6e15565), AZ::UserSettings::CT_GLOBAL);
-        auto font = syntaxSettings->GetFont();
-        font.setPointSize(static_cast<int>(font.pointSize() * (m_zoomPercent / 100.0f)));
+        syntaxSettings->SetZoomPercent(m_zoomPercent);
+        const auto& font = syntaxSettings->GetFont();
 
         m_gui->m_luaTextEdit->SetTabSize(syntaxSettings->GetTabSize());
         m_gui->m_luaTextEdit->SetUseSpaces(syntaxSettings->UseSpacesInsteadOfTabs());
 
         m_gui->m_luaTextEdit->UpdateFont(font, syntaxSettings->GetTabSize());
         m_gui->m_breakpoints->SetFont(font);
-        m_Highlighter->SetFont(font);
         m_gui->m_folding->SetFont(font);
 
         m_gui->m_luaTextEdit->update();


### PR DESCRIPTION
## What does this PR do?

Match VSCode "DarkModern" theme in the Lua Editor. Fix some UI update logic and add simple regex on top of existing system to perform needed checks. The new highlight options are exposed as user setting.

Before:
![before](https://github.com/o3de/o3de/assets/19243508/b6d3090c-fdb4-495d-9262-61c29dfbcd5d)

After:
![new](https://github.com/o3de/o3de/assets/19243508/80f3e2b0-677e-46dd-9ad8-1cd272ae7ebb)

## How was this PR tested?

On a local build against multiple lua scripts found online
