### PR TITLE
Vulkan validation layer message enhancement

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
@@ -45,11 +45,18 @@ namespace AZ::RHI
         //! The pipeline layout describing the shader resource bindings.
         ConstPtr<PipelineLayoutDescriptor> m_pipelineLayoutDescriptor = nullptr;
 
+        //! Sets the name of the object.
+        void SetName(const Name& name);
+
+        //! Returns the name set on the object by SetName
+        const Name& GetName() const;
+
     protected:
         PipelineStateDescriptor(PipelineStateType pipelineStateType);
 
     private:
         PipelineStateType m_type = PipelineStateType::Count;
+        Name m_name;
     };
 
     //! Describes state necessary to build a compute pipeline state object. The compute pipe

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateDescriptor.cpp
@@ -27,6 +27,16 @@ namespace AZ::RHI
         return m_type == rhs.m_type;
     }
 
+    void PipelineStateDescriptor::SetName(const Name& name)
+    {
+        m_name = name;
+    }
+
+    const Name& PipelineStateDescriptor::GetName() const
+    {
+        return m_name;
+    }
+
     PipelineStateDescriptorForDraw::PipelineStateDescriptorForDraw()
         : PipelineStateDescriptor(PipelineStateType::Draw)
     {}
@@ -107,4 +117,4 @@ namespace AZ::RHI
         return m_pipelineLayoutDescriptor == rhs.m_pipelineLayoutDescriptor &&
             m_rayTracingFunction == rhs.m_rayTracingFunction;
     }
-}
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.h
@@ -42,7 +42,7 @@ namespace AZ
             {
                 Device* m_device = nullptr;
                 RHI::ConstPtr<RHI::ShaderResourceGroupLayout> m_shaderResouceGroupLayout;
-
+                Name m_name;
                 HashValue64 GetHash() const;
             };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
@@ -21,6 +21,7 @@ namespace AZ
             AZ_Assert(descriptor.m_pipelineDescritor->m_pipelineLayoutDescriptor, "Pipeline layout descriptor is null.");
 
             PipelineLayout::Descriptor layoutDescriptor;
+            layoutDescriptor.m_name = descriptor.m_name;
             layoutDescriptor.m_device = descriptor.m_device;
             layoutDescriptor.m_pipelineLayoutDescriptor = descriptor.m_pipelineDescritor->m_pipelineLayoutDescriptor;
             RHI::Ptr<PipelineLayout> layout = descriptor.m_device->AcquirePipelineLayout(layoutDescriptor);
@@ -37,8 +38,8 @@ namespace AZ
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
             m_pipelineLayout = layout;
             m_pipelineLibrary = descriptor.m_pipelineLibrary;
-
-            SetName(GetName());
+            if (m_nativePipeline)
+                SetName(descriptor.m_name);
             return result;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.cpp
@@ -39,7 +39,9 @@ namespace AZ
             m_pipelineLayout = layout;
             m_pipelineLibrary = descriptor.m_pipelineLibrary;
             if (m_nativePipeline)
+            {
                 SetName(descriptor.m_name);
+            }
             return result;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Pipeline.h
@@ -38,6 +38,7 @@ namespace AZ
                 const RHI::PipelineStateDescriptor* m_pipelineDescritor = nullptr;
                 Device* m_device = nullptr;
                 PipelineLibrary* m_pipelineLibrary = nullptr;
+                Name m_name;
             };
 
             RHI::ResultCode Init(const Descriptor& descriptor);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.cpp
@@ -176,8 +176,8 @@ namespace AZ
             // Merged SRGs are part of the Pipeline Layout.
             result = BuildMergedShaderResourceGroupPools();
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-
-            SetName(GetName());
+            if (m_nativePipelineLayout)
+                SetName(descriptor.m_name);
             return result;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.cpp
@@ -177,7 +177,9 @@ namespace AZ
             result = BuildMergedShaderResourceGroupPools();
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
             if (m_nativePipelineLayout)
+            {
                 SetName(descriptor.m_name);
+            }
             return result;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineLayout.h
@@ -42,6 +42,7 @@ namespace AZ
 
                 Device* m_device = nullptr;
                 RHI::ConstPtr<RHI::PipelineLayoutDescriptor> m_pipelineLayoutDescriptor;
+                AZ::Name m_name;
             };
 
             using ShaderResourceGroupBitset = AZStd::bitset<RHI::Limits::Pipeline::ShaderResourceGroupCountMax>;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PipelineState.cpp
@@ -52,6 +52,7 @@ namespace AZ
         {
             Pipeline::Descriptor pipelineDescriptor;
             pipelineDescriptor.m_pipelineDescritor = &descriptor;
+            pipelineDescriptor.m_name = descriptor.GetName();
             pipelineDescriptor.m_device = static_cast<Device*>(&device);
             pipelineDescriptor.m_pipelineLibrary = static_cast<PipelineLibrary*>(pipelineLibrary);
             RHI::Ptr<GraphicsPipeline> pipeline = GraphicsPipeline::Create();
@@ -66,6 +67,7 @@ namespace AZ
         {
             Pipeline::Descriptor pipelineDescriptor;
             pipelineDescriptor.m_pipelineDescritor = &descriptor;
+            pipelineDescriptor.m_name = descriptor.GetName();
             pipelineDescriptor.m_device = static_cast<Device*>(&device);
             pipelineDescriptor.m_pipelineLibrary = static_cast<PipelineLibrary*>(pipelineLibrary);
             RHI::Ptr<ComputePipeline> pipeline = ComputePipeline::Create();
@@ -80,6 +82,7 @@ namespace AZ
         {
             Pipeline::Descriptor pipelineDescriptor;
             pipelineDescriptor.m_pipelineDescritor = &descriptor;
+            pipelineDescriptor.m_name = descriptor.GetName();
             pipelineDescriptor.m_device = static_cast<Device*>(&device);
             pipelineDescriptor.m_pipelineLibrary = static_cast<PipelineLibrary*>(pipelineLibrary);
             RHI::Ptr<RayTracingPipeline> pipeline = RayTracingPipeline::Create();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -38,6 +38,7 @@ namespace AZ
 
             DescriptorSetLayout::Descriptor layoutDescriptor;
             layoutDescriptor.m_device = &device;
+            layoutDescriptor.m_name = descriptor.m_layout->GetName();
             layoutDescriptor.m_shaderResouceGroupLayout = &layout;
             m_descriptorSetLayout = device.AcquireDescriptorSetLayout(layoutDescriptor);
             if (!m_descriptorSetLayout)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
@@ -120,9 +120,9 @@ namespace AZ
 
             //! Returns the ShaderOutputContract which describes which outputs the shader requires
             const ShaderOutputContract& GetOutputContract() const;
-            
+
             //! Acquires a pipeline state directly from a descriptor.
-            const RHI::PipelineState* AcquirePipelineState(const RHI::PipelineStateDescriptor& descriptor) const;
+            const RHI::PipelineState* AcquirePipelineState(RHI::PipelineStateDescriptor& descriptor) const;
 
             //! Finds and returns the shader resource group asset with the requested name. Returns an empty handle if no matching group was found.
             const RHI::Ptr<RHI::ShaderResourceGroupLayout>& FindShaderResourceGroupLayout(const Name& shaderResourceGroupName) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -440,8 +440,17 @@ namespace AZ
             return m_asset->GetOutputContract(m_supervariantIndex);
         }
 
-        const RHI::PipelineState* Shader::AcquirePipelineState(const RHI::PipelineStateDescriptor& descriptor) const
+        const RHI::PipelineState* Shader::AcquirePipelineState(RHI::PipelineStateDescriptor& descriptor) const
         {
+            // setup the descriptor's name using shader asset
+            if (descriptor.GetName().IsEmpty())
+            {
+                // this may not be the best way to set it, other option would be using m_asset->m_assetData.m_name
+                if (!m_asset->GetName().IsEmpty())
+                    descriptor.SetName(m_asset->GetName());
+                else if (!m_asset.GetHint().empty())
+                    descriptor.SetName(AZ::Name{ m_asset.GetHint() });
+            }
             return m_pipelineStateCache->AcquirePipelineState(m_pipelineLibraryHandle, descriptor, m_asset->GetName());
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -447,9 +447,13 @@ namespace AZ
             {
                 // this may not be the best way to set it, other option would be using m_asset->m_assetData.m_name
                 if (!m_asset->GetName().IsEmpty())
+                {
                     descriptor.SetName(m_asset->GetName());
+                }
                 else if (!m_asset.GetHint().empty())
+                {
                     descriptor.SetName(AZ::Name{ m_asset.GetHint() });
+                }
             }
             return m_pipelineStateCache->AcquirePipelineState(m_pipelineLibraryHandle, descriptor, m_asset->GetName());
         }


### PR DESCRIPTION
* patching the vulkan object with name for much easier debugging at crash.

## What does this PR do?

This PR aim to enhance the debug ability of Vulkan validation layers in Atom RHI. It injects the proper name into the RHI for Vulkan object to use.

So instead of:

<17:10:31> [Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-vkCmdDraw-None-02699 ] Object 0: handle = 0x91ef700000001718, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x1608dec0 | Descriptor set **VkDescriptorSet 0x91ef700000001718[]** encountered the following validation error at vkCmdDraw time: Descriptor in binding #8 index 0 requires FLOAT component type, but bound descriptor format is VK_FORMAT_R32_UINT. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid if they are statically used by the VkPipeline bound to the pipeline bind point used by this command


We would have proper pass name after the MR:
<17:10:31> [Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-vkCmdDraw-None-02699 ] Object 0: handle = 0x91ef700000001718, name = HairRenderingResolvePPLL_PassSrg, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x1608dec0 | Descriptor set **VkDescriptorSet 0x91ef700000001718 [FullscreenShadow_PassSrg]** encountered the following validation error at vkCmdDraw time: Descriptor in binding #8 index 0 requires FLOAT component type, but bound descriptor format is VK_FORMAT_R32_UINT. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid if they are statically used by the VkPipeline bound to the pipeline bind point used by this command (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-vkCmdDraw-None-02699)

Please be aware that the validation error message above does not indicate the same error message available in upstream o3de.

## How was this PR tested?

I ran the pytest TestSuite_Sandbox.py