### PR TITLE
Fixed eye shader to work natively on Quest 3

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryData.azsli
@@ -21,10 +21,10 @@ class PixelGeometryData_Eye
 {
     // BasePBR
     float3 positionWS;
-    real3 vertexNormal;
     float2 uvs[UvSetCount];
     float3 tangents[UvSetCount];
     float3 bitangents[UvSetCount];
+    real3 vertexNormal;
     bool isFrontFace;
 
     // Eye

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_PixelGeometryEval.azsli
@@ -77,11 +77,11 @@ PixelGeometryData EvaluatePixelGeometry_Eye(
 
 PixelGeometryData EvaluatePixelGeometry_Eye(VsOutput IN, bool isFrontFace)
 {
-    float4x4 objectToWorld = float4x4(GetObjectToWorldMatrix(IN.m_instanceId));
-    float3x3 objectToWorldIT = float3x3(GetObjectToWorldMatrixInverseTranspose(IN.m_instanceId));
+    real4x4 objectToWorld = real4x4(GetObjectToWorldMatrix(IN.m_instanceId));
+    real3x3 objectToWorldIT = real3x3(GetObjectToWorldMatrixInverseTranspose(IN.m_instanceId));
 
     real3 normalWS, tangentWS, bitangentWS;
-    ConstructTBN(IN.normal, IN.tangent, objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
+    ConstructTBN(real3(IN.normal), real4(IN.tangent), objectToWorld, objectToWorldIT, normalWS, tangentWS, bitangentWS);
 
     // Bitangent is temporarily added back to fix the eye material screenshot test.
     bitangentWS = real3(normalize(mul(objectToWorld, float4(IN.bitangent, 0.0)).xyz));


### PR DESCRIPTION
Eyes didn't render at all on Quest 3. Now they do (might be something wrong with specular on Quest 3/Android though, will investigate that in a follow up PR)