### PR TITLE
Adding utility function to get draw list mask as a string to help with debugging

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -76,5 +76,8 @@ namespace AZ::RHI
  
     //! Utility function to get the Name associated with a DrawListTag
     Name GetDrawListName(DrawListTag drawListTag);
+
+    AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask);
+
 }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
@@ -486,4 +486,26 @@ namespace AZ::RHI
         RHI::DrawListTagRegistry* drawListTagRegistry = GetDrawListTagRegistry();
         return drawListTagRegistry->GetName(drawListTag);
     }
+
+    AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask)
+    {
+        AZStd::string tagString;
+        u32 maxTags = RHI::Limits::Pipeline::DrawListTagCountMax;
+
+        u32 drawListTagCount = 0;
+
+        for (u32 i = 0; i < maxTags; ++i)
+        {
+            if (drawListMask[i])
+            {
+                DrawListTag tag(i);
+                tagString += AZStd::string::format("%s | ", GetDrawListName(tag).GetCStr());
+                ++drawListTagCount;
+            }
+        }
+
+        AZStd::string output = AZStd::string::format("DrawListMask has %d tags = %s", drawListTagCount, tagString.c_str());
+        return output;
+    }
+
 }


### PR DESCRIPTION
Adding utility function to get draw list mask as a string to help with debugging. I used this with AZ_Printf to track what views contain which draw list masks during debugging.