### PR TITLE
Atom/print view draw list mask

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -76,5 +76,8 @@ namespace AZ::RHI
  
     //! Utility function to get the Name associated with a DrawListTag
     Name GetDrawListName(DrawListTag drawListTag);
+
+    AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask);
+
 }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
@@ -486,4 +486,26 @@ namespace AZ::RHI
         RHI::DrawListTagRegistry* drawListTagRegistry = GetDrawListTagRegistry();
         return drawListTagRegistry->GetName(drawListTag);
     }
+
+    AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask)
+    {
+        AZStd::string tagString;
+        u32 maxTags = RHI::Limits::Pipeline::DrawListTagCountMax;
+
+        u32 drawListTagCount = 0;
+
+        for (u32 i = 0; i < maxTags; ++i)
+        {
+            if (drawListMask[i])
+            {
+                DrawListTag tag(i);
+                tagString += AZStd::string::format("%s | ", GetDrawListName(tag).GetCStr());
+                ++drawListTagCount;
+            }
+        }
+
+        AZStd::string output = AZStd::string::format("DrawListMask has %d tags = %s", drawListTagCount, tagString.c_str());
+        return output;
+    }
+
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -66,6 +66,9 @@ namespace AZ
             RHI::DrawListMask GetDrawListMask() const { return m_drawListMask; }
             void Reset();
 
+            //! Prints the draw list mask for this view. Useful for printf debugging.
+            void PrintDrawListMask();
+
             RHI::ShaderResourceGroup* GetRHIShaderResourceGroup() const;
 
             Data::Instance<RPI::ShaderResourceGroup> GetShaderResourceGroup();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -14,6 +14,7 @@
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <AzCore/Casting/lossy_cast.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
@@ -50,7 +51,7 @@ namespace AZ
         {
             AZ_Assert(!name.IsEmpty(), "invalid name");
 
-            // Set default matrices 
+            // Set default matrices
             SetWorldToViewMatrix(AZ::Matrix4x4::CreateIdentity());
             AZ::Matrix4x4 viewToClipMatrix;
             AZ::MakePerspectiveFovMatrixRH(viewToClipMatrix, AZ::Constants::HalfPi, 1, 0.1f, 1000.f, true);
@@ -98,6 +99,11 @@ namespace AZ
             m_passesByDrawList = nullptr;
         }
 
+        void View::PrintDrawListMask()
+        {
+            AZ_Printf("View", RHI::DrawListMaskToString(m_drawListMask).c_str());
+        }
+
         RHI::ShaderResourceGroup* View::GetRHIShaderResourceGroup() const
         {
             return m_shaderResourceGroup->GetRHIShaderResourceGroup();
@@ -112,7 +118,7 @@ namespace AZ
         {
             // This function is thread safe since DrawListContent has storage per thread for draw item data.
             m_drawListContext.AddDrawPacket(drawPacket, depth);
-        }        
+        }
 
         void View::AddDrawPacket(const RHI::DrawPacket* drawPacket, const Vector3& worldPosition)
         {
@@ -217,7 +223,7 @@ namespace AZ
             yUpWorld.StoreToRowMajorFloat12(viewToWorldMatrixRaw);
             const AZ::Matrix4x4 prevViewToWorldMatrix = m_viewToWorldMatrix;
             UpdateViewToWorldMatrix(AZ::Matrix4x4::CreateFromRowMajorFloat16(viewToWorldMatrixRaw));
- 
+
             m_worldToViewMatrix = m_viewToWorldMatrix.GetInverseFast();
 
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
@@ -234,7 +240,7 @@ namespace AZ
                 m_onWorldToViewMatrixChange.Signal(m_worldToViewMatrix);
             }
             m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
-        }        
+        }
 
         void View::SetViewToClipMatrix(const AZ::Matrix4x4& viewToClip)
         {
@@ -297,13 +303,13 @@ namespace AZ
         {
             m_viewToClipMatrix = viewToClip;
             m_clipToViewMatrix = m_viewToClipMatrix.GetInverseFull();
-            
+
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
             m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
 
             // Update z depth constant simultaneously
             if(reverseDepth)
-            {       
+            {
                 // zNear -> n, zFar -> f
                 // A = 2n/(f-n), B = 2fn / (f - n)
                 // the formula of A and B should be the same as projection matrix's definition
@@ -328,7 +334,7 @@ namespace AZ
                 m_linearizeDepthConstants.SetY(float((-2 * B * A)/ ((A + 1.0) * (A - 1.0)))); //<--- -f-n
                 m_linearizeDepthConstants.SetZ(float((2 * B * B) / ((A - 1.0) * (A + 1.0)))); //<-----2fn
                 m_linearizeDepthConstants.SetW(float((-2 * B) / ((A - 1.0) * (A + 1.0)))); //<------f-n
-            }     
+            }
 
             // The constants below try to remap 0---1 to -1---+1 and multiply with inverse of projection.
             // Assuming that inverse of projection matrix only has value in the first column for first row
@@ -347,7 +353,7 @@ namespace AZ
 
             m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
         }
-        
+
         void View::SetClipSpaceOffset(float xOffset, float yOffset)
         {
             m_clipSpaceOffset.Set(xOffset, yOffset);
@@ -492,7 +498,7 @@ namespace AZ
         {
             // Note: it's possible that the m_passesByDrawList doesn't have a pass for the input tag.
             // This is because a View can be used for multiple render pipelines.
-            // So it may contains draw list tag which exists in one render pipeline but not others. 
+            // So it may contains draw list tag which exists in one render pipeline but not others.
             auto itr = m_passesByDrawList->find(tag);
             if (itr != m_passesByDrawList->end())
             {
@@ -510,7 +516,7 @@ namespace AZ
             handler.Connect(m_onWorldToClipMatrixChange);
         }
 
-        // [GFX TODO] This function needs unit tests and might need to be reworked 
+        // [GFX TODO] This function needs unit tests and might need to be reworked
         RHI::DrawItemSortKey View::GetSortKeyForPosition(const Vector3& positionInWorld) const
         {
             // We are using fixed-point depth representation for the u64 sort key
@@ -532,7 +538,7 @@ namespace AZ
 
         float View::CalculateSphereAreaInClipSpace(const AZ::Vector3& sphereWorldPosition, float sphereRadius) const
         {
-            // Projection of a sphere to clip space 
+            // Projection of a sphere to clip space
             // Derived from https://www.iquilezles.org/www/articles/sphereproj/sphereproj.htm
 
             if (sphereRadius <= 0.0f)


### PR DESCRIPTION
Adding utility function to get draw list mask as a string to help with debugging. 
Adding utility function to print a view's draw list mask in a human readable form.
I used this with AZ_Printf to track what views contain which draw list masks during debugging, thought it might come in handy for others who are debugging view and draw list mask related issues.

Note: in View.cpp all those lines that are seemingly unchanged are invisible whitespace deletions.