### PR TITLE
hotfix: Remote tool send remote message fix and add proper unit test

### DIFF
--- a/Gems/RemoteTools/Code/CMakeLists.txt
+++ b/Gems/RemoteTools/Code/CMakeLists.txt
@@ -101,6 +101,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     Source
             BUILD_DEPENDENCIES
                 PRIVATE
+                    AZ::AzCoreTestCommon
                     AZ::AzTest
                     AZ::AzFramework
                     Gem::${gem_name}.Private.Static

--- a/Gems/RemoteTools/Code/Tests/RemoteToolsTest.cpp
+++ b/Gems/RemoteTools/Code/Tests/RemoteToolsTest.cpp
@@ -11,10 +11,13 @@
 #include <AzCore/Console/LoggerSystemComponent.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Name/NameDictionary.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Time/TimeSystem.h>
+#include <AzCore/UnitTest/MockComponentApplication.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/UnitTest/UnitTest.h>
 #include <AzFramework/Network/IRemoteTools.h>
+#include <AzFramework/Script/ScriptDebugMsgReflection.h>
 #include <AzNetworking/Framework/NetworkingSystemComponent.h>
 
 #include <RemoteToolsSystemComponent.h>
@@ -36,12 +39,25 @@ namespace UnitTest
             m_timeSystem = AZStd::make_unique<AZ::TimeSystem>();
             m_networkingSystemComponent = AZStd::make_unique<AzNetworking::NetworkingSystemComponent>();
             m_remoteToolsSystemComponent = AZStd::make_unique<RemoteToolsSystemComponent>();
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
             m_remoteTools = m_remoteToolsSystemComponent.get();
+            m_applicationMock = AZStd::make_unique<testing::NiceMock<UnitTest::MockComponentApplication>>();
+
+            ON_CALL(*m_applicationMock, GetSerializeContext())
+                .WillByDefault(
+                    [this]()
+                    {
+                        return m_serializeContext.get();
+                    });
+
+            AzFramework::ReflectScriptDebugClasses(m_serializeContext.get());
         }
 
         void TearDown() override
         {
+            m_applicationMock.reset();
             m_remoteTools = nullptr;
+            m_serializeContext.reset();
             m_remoteToolsSystemComponent.reset();
             m_networkingSystemComponent.reset();
             m_timeSystem.reset();
@@ -50,10 +66,12 @@ namespace UnitTest
             LeakDetectionFixture::SetUp();
         }
 
+        AZStd::unique_ptr<AZ::TimeSystem> m_timeSystem;
         AZStd::unique_ptr<AzNetworking::NetworkingSystemComponent> m_networkingSystemComponent;
         AZStd::unique_ptr<RemoteToolsSystemComponent> m_remoteToolsSystemComponent;
-        AZStd::unique_ptr<AZ::TimeSystem> m_timeSystem;
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AzFramework::IRemoteTools* m_remoteTools = nullptr;
+        AZStd::unique_ptr<testing::NiceMock<UnitTest::MockComponentApplication>> m_applicationMock;
     };
 
     TEST_F(RemoteToolsTests, TEST_RemoteToolsEmptyRegistry)
@@ -91,13 +109,21 @@ namespace UnitTest
         EXPECT_FALSE(m_remoteTools->IsEndpointOnline(TestToolsKey, TestToolsKey));
 
         {
-            AzFramework::RemoteToolsMessage msg;
+            AzFramework::ScriptDebugBreakpointRequest msg(1, "test", 2);
             msg.SetSenderTargetId(TestToolsKey);
             m_remoteTools->SendRemoteToolsMessage(endpointInfo, msg);
         }
+
         const AzFramework::ReceivedRemoteToolsMessages* receiveMsgs = m_remoteTools->GetReceivedMessages(TestToolsKey);
         EXPECT_NE(receiveMsgs, nullptr);
         EXPECT_EQ(receiveMsgs->size(), 1);
+
+        auto msg = azrtti_cast<AzFramework::ScriptDebugBreakpointRequest*>(receiveMsgs->at(0));
+        EXPECT_TRUE(msg != nullptr);
+        EXPECT_EQ(msg->m_request, 1);
+        EXPECT_STREQ(msg->m_context.c_str(), "test");
+        EXPECT_EQ(msg->m_line, 2);
+
         m_remoteTools->ClearReceivedMessages(TestToolsKey);
     }
 


### PR DESCRIPTION
## What does this PR do?

Fix remote tool message broken by the last commit on my PR #17879. 

The change at the origin of the defect was made to allow the unit test to go through, but I did not re-test it after and it was merged as is. This fixes the remote tool message, add proper unit test for message serialization, and I also removed changes made on "last target" as it is used internally to track the desired target (changing it can make the lua editor need to double click to connect on said target).

## How was this PR tested?

Local build against attached script canvas debug and lua script debug
