### PR TITLE
Update engine.json for 24.09

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "4.2.0",
+    "version": "2.3.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",


### PR DESCRIPTION
## What does this PR do?

Bumps the engine version to `2.3.0` for stabilization/2409

## How was this PR tested?

Tested on Jenkins