### PR TITLE
[LUA Editor] Allow none anti-aliased fonts.

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.cpp
@@ -18,6 +18,7 @@ namespace LUAEditor
         m_font.setFixedPitch(true);
         m_font.setStyleHint(QFont::Monospace);
         m_font.setPointSize(m_fontSize);
+        m_font.setStyleStrategy(GetNoAntiAliasing() ? QFont::NoAntialias : QFont::PreferDefault);
     }
 
     void SyntaxStyleSettings::SetZoomPercent(float zoom)
@@ -32,9 +33,11 @@ namespace LUAEditor
         if (serializeContext)
         {
             serializeContext->Class<SyntaxStyleSettings, AZ::UserSettings >()
-                ->Version(6)
+                ->Version(7)
+                ->EventHandler<SerializationEvents>()
                 ->Field("m_fontFamily", &SyntaxStyleSettings::m_fontFamily)
                 ->Field("m_fontSize", &SyntaxStyleSettings::m_fontSize)
+                ->Field("m_noAntialiasing", &SyntaxStyleSettings::m_noAntialiasing)
                 ->Field("m_tabSize", &SyntaxStyleSettings::m_tabSize)
                 ->Field("m_useSpacesInsteadOfTabs", &SyntaxStyleSettings::m_useSpacesInsteadOfTabs)
 
@@ -92,6 +95,9 @@ namespace LUAEditor
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnFontChange)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_fontSize, "Size", "")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnFontChange)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_noAntialiasing, "No Antialiasing", "")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SyntaxStyleSettings::OnFontChange)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SyntaxStyleSettings::m_tabSize, "Tab Size", "")
@@ -198,6 +204,8 @@ namespace LUAEditor
     {
         m_font.setFamily(m_fontFamily.c_str());
         m_font.setPointSize(m_fontSize);
+        m_font.setStyleStrategy(GetNoAntiAliasing() ? QFont::NoAntialias : QFont::PreferDefault);
+
         LUAEditorMainWindowMessages::Bus::Broadcast(&LUAEditorMainWindowMessages::Bus::Events::Repaint);
     }
 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorStyleMessages.h
@@ -12,6 +12,7 @@
 #include <AzCore/UserSettings/UserSettings.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 #include <QColor>
 #include <QFont>
@@ -70,6 +71,7 @@ namespace LUAEditor
         QColor GetFindResultsMatchColor() const { return ToQColor(m_findResultsMatchColor); }
         QColor GetFindResultsLineHighlightColor() const { return ToQColor(m_findResultsLineHighlightColor); }
         const QFont& GetFont() const { return m_font; }
+        bool GetNoAntiAliasing() const { return m_noAntialiasing; }
         int GetTabSize() const { return m_tabSize; }
         bool UseSpacesInsteadOfTabs() const { return m_useSpacesInsteadOfTabs; }
 
@@ -182,6 +184,9 @@ namespace LUAEditor
         int m_fontSize {
             14
         };
+        bool m_noAntialiasing {
+            false
+        };
         // Number of spaces to make a tab
         int m_tabSize {
             4
@@ -192,6 +197,18 @@ namespace LUAEditor
 
         void OnColorChange();
         void OnFontChange();
+
+        // We use this class to ensure that the font is updated when the instance of it got de-serialized.
+        class SerializationEvents : public AZ::SerializeContext::IEventHandler
+        {
+            void OnReadEnd(void* classPtr) override
+            {
+                if(auto* settings = static_cast<SyntaxStyleSettings*>(classPtr))
+                {
+                    settings->OnFontChange();
+                }
+            }
+        };
     };
 
     class HighlightedWords


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new property to the LUA Editor's settings dialog, allowing users to toggle anti-aliased font rendering on or off. This feature enables the use of non-anti-aliased fonts, which can produce better results for certain font types.

## How was this PR tested?

Tested on my local computer Ubuntu 22.04 LTS.

## Showcase

Here some pictures. Here is anti-aliasing enabled:

![image](https://github.com/o3de/o3de/assets/7720708/785eac53-72ea-4ebc-aeb0-56da891f824d)

Here is anti-aliasing disabled:

![image](https://github.com/o3de/o3de/assets/7720708/31031dcb-c76e-4e1c-b8a8-6587ad7e6f0d)

## Fix
With the PR https://github.com/o3de/o3de/pull/17894 a new issue was introduced. The issue is that when the Editor opens a LUA script file the font retrieved by the changed method GetFont() wasn't correctly initialized. To make the m_font update directly after de-serialization the AZ::SerializeContext::IEventHandler was used.

Best regards

Yaakuro
