### PR TITLE
feat: migrate GetValue SetValue (GHI-1933)

### DIFF
--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -1996,13 +1996,13 @@ void CTrackViewDopeSheetBase::ChangeSequenceTrackSelection(CTrackViewSequence* s
 bool CTrackViewDopeSheetBase::CreateColorKey(CTrackViewTrack* pTrack, float keyTime)
 {
     bool keyCreated = false;
-    Vec3 vColor(0, 0, 0);
+    AZ::Vector3 vColor(0, 0, 0);
     pTrack->GetValue(keyTime, vColor);
 
     const AZ::Color defaultColor(
-        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.x)), 0, 255),
-        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.y)), 0, 255),
-        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.z)), 0, 255),
+        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.GetX())), 0, 255),
+        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.GetY())), 0, 255),
+        clamp_tpl<AZ::u8>(static_cast<AZ::u8>(FloatToIntRet(vColor.GetZ())), 0, 255),
         255);
     AzQtComponents::ColorPicker dlg(AzQtComponents::ColorPicker::Configuration::RGB, QString(), this);
     dlg.setWindowTitle(tr("Select Color"));
@@ -2114,13 +2114,13 @@ void CTrackViewDopeSheetBase::EditSelectedColorKey(CTrackViewTrack* pTrack)
             // init with the first selected key color
             m_colorUpdateKeyTime = selectedKeyBundle.GetKey(0).GetTime();
 
-            Vec3  color;
+            AZ::Vector3  color;
             pTrack->GetValue(m_colorUpdateKeyTime, color);
 
             const AZ::Color defaultColor(
-                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.x)), AZ::u8(0), AZ::u8(255)),
-                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.y)), AZ::u8(0), AZ::u8(255)),
-                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.z)), AZ::u8(0), AZ::u8(255)),
+                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.GetX())), AZ::u8(0), AZ::u8(255)),
+                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.GetY())), AZ::u8(0), AZ::u8(255)),
+                clamp_tpl(static_cast<AZ::u8>(FloatToIntRet(color.GetZ())), AZ::u8(0), AZ::u8(255)),
                 255);
 
             AzQtComponents::ColorPicker picker(AzQtComponents::ColorPicker::Configuration::RGB);
@@ -3584,10 +3584,10 @@ void CTrackViewDopeSheetBase::DrawColorGradient(QPainter* painter, const QRect& 
     for (int x = rc.left(); x < rc.right(); ++x)
     {
         // This is really slow. Is there a better way?
-        Vec3 vColor(0, 0, 0);
+        AZ::Vector3 vColor(0, 0, 0);
         pTrack->GetValue(TimeFromPointUnsnapped(QPoint(x, rc.top())), vColor);
 
-        painter->setPen(ColorLinearToGamma(vColor / 255.0f));
+        painter->setPen(ColorToQColor(AZ::Color(vColor).ToU32LinearToGamma()));
         painter->drawLine(x, rc.top(), x, rc.bottom());
     }
     painter->setPen(pOldPen);

--- a/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
+++ b/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
@@ -456,30 +456,30 @@ namespace
         break;
         case AnimValueType::Quat:
         {
-            Quat value;
+            AZ::Quaternion value;
             pTrack->GetValue(time, value);
-            Ang3 rotation(value);
-            return AZStd::make_any<AZ::Vector3>(rotation.x, rotation.y, rotation.z);
+            const AZ::Vector3 rotation = value.GetEulerDegrees();
+            return AZStd::make_any<AZ::Vector3>(rotation);
         }
         case AnimValueType::Vector:
         {
-            Vec3 value;
+            AZ::Vector3 value;
             pTrack->GetValue(time, value);
-            return AZStd::make_any<AZ::Vector3>(value.x, value.y, value.z);
+            return AZStd::make_any<AZ::Vector3>(value);
         }
         break;
         case AnimValueType::Vector4:
         {
-            Vec4 value;
+            AZ::Vector4 value;
             pTrack->GetValue(time, value);
-            return AZStd::make_any<AZ::Vector4>(value.x, value.y, value.z, value.w);
+            return AZStd::make_any<AZ::Vector4>(value);
         }
         break;
         case AnimValueType::RGB:
         {
-            Vec3 value;
+            AZ::Vector3 value;
             pTrack->GetValue(time, value);
-            return AZStd::make_any<AZ::Color>(value.x, value.y, value.z, 0.0f);
+            return AZStd::make_any<AZ::Color>(value.GetX(), value.GetY(), value.GetZ(), 0.0f);
         }
         break;
         default:

--- a/Code/Legacy/CryCommon/IMovieSystem.cpp
+++ b/Code/Legacy/CryCommon/IMovieSystem.cpp
@@ -135,42 +135,6 @@ void IAnimTrack::Reflect(AZ::ReflectContext* context)
     }
 }
 
-// support for AZ:: vector types - re-route to legacy types
-void IAnimTrack::GetValue(float time, AZ::Vector3& value, bool applyMultiplier)
-{
-    Vec3 vec3;
-    GetValue(time, vec3, applyMultiplier);
-    value.Set(vec3.x, vec3.y, vec3.z);
-}
-void IAnimTrack::GetValue(float time, AZ::Vector4& value, bool applyMultiplier)
-{
-    Vec4 vec4;
-    GetValue(time, vec4, applyMultiplier);
-    value.Set(vec4.x, vec4.y, vec4.z, vec4.w);
-}
-void IAnimTrack::GetValue(float time, AZ::Quaternion& value)
-{
-    Quat quat;
-    GetValue(time, quat);
-    value.Set(quat.v.x, quat.v.y, quat.v.z, quat.w);
-}
-
-// support for AZ:: vector types - re-route to legacy types
-void IAnimTrack::SetValue(float time, AZ::Vector4& value, bool bDefault, bool applyMultiplier)
-{
-    Vec4 vec4(value.GetX(), value.GetY(), value.GetZ(), value.GetW());
-    SetValue(time, vec4, bDefault, applyMultiplier);
-}
-void IAnimTrack::SetValue(float time, AZ::Vector3& value, bool bDefault, bool applyMultiplier)
-{
-    Vec3 vec3(value.GetX(), value.GetY(), value.GetZ());
-    SetValue(time, vec3, bDefault, applyMultiplier);
-}
-void IAnimTrack::SetValue(float time, AZ::Quaternion& value, bool bDefault)
-{
-    Quat quat(value.GetW(), value.GetX(), value.GetY(), value.GetZ());
-    SetValue(time, quat, bDefault);
-}
 
 int IAnimTrack::NextKeyByTime(int key) const
 {
@@ -209,50 +173,6 @@ IAnimNode::SParamInfo::SParamInfo(const char* _name, CAnimParamType _paramType, 
 
 //! Compute and return the offset which brings the current position to the given position
 Vec3 IAnimNode::GetOffsetPosition(const Vec3& position) { return position - GetPos(); }
-
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent SetParamValue that accepts AZ::Vector3
- **/
-bool IAnimNode::SetParamValue(float time, CAnimParamType param, const AZ::Vector3& value)
-{
-    Vec3 vec3(value.GetX(), value.GetY(), value.GetZ());
-    return SetParamValue(time, param, vec3);
-}
-
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent SetParamValue that accepts AZ::Vector4
- **/
-bool IAnimNode::SetParamValue(float time, CAnimParamType param, const AZ::Vector4& value)
-{
-    Vec4 vec4(value.GetX(), value.GetY(), value.GetZ(), value.GetW());
-    return SetParamValue(time, param, vec4);
-}
-
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent GetParamValue that accepts AZ::Vector4
- **/
-bool IAnimNode::GetParamValue(float time, CAnimParamType param, AZ::Vector3& value)
-{
-    Vec3 vec3;
-    const bool result = GetParamValue(time, param, vec3);
-    value.Set(vec3.x, vec3.y, vec3.z);
-    return result;
-}
-
-/**
- * O3DE_DEPRECATION_NOTICE(GHI-9326)
- * use equivalent GetParamValue that accepts AZ::Vector4
- **/
-bool IAnimNode::GetParamValue(float time, CAnimParamType param, AZ::Vector4& value)
-{
-    Vec4 vec4;
-    const bool result = GetParamValue(time, param, vec4);
-    value.Set(vec4.x, vec4.y, vec4.z, vec4.w);
-    return result;
-}
 
 // IAnimStringTable RTTI member definitions
 AZ_TYPE_INFO_WITH_NAME_IMPL(IAnimStringTable, "IAnimStringTable", "{35690309-9D22-41FF-80B7-8AF7C8419945}");

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -382,56 +382,22 @@ struct IAnimTrack
     // Applies a scale multiplier set in SetMultiplier(), if requested
     //////////////////////////////////////////////////////////////////////////
     virtual void GetValue(float time, float& value, bool applyMultiplier=false) = 0;
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent GetValue that accepts AZ::Vector3
-     **/
-    virtual void GetValue(float time, Vec3& value, bool applyMultiplier = false) = 0;
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent GetValue that accepts AZ::Vector4
-     **/
-    virtual void GetValue(float time, Vec4& value, bool applyMultiplier = false) = 0;
-        /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent GetValue that accepts AZ::Quaternion
-     **/
-    virtual void GetValue(float time, Quat& value) = 0;
+    virtual void GetValue(float time, AZ::Vector3& value, bool applyMultiplier = false) = 0;
+    virtual void GetValue(float time, AZ::Vector4& value, bool applyMultiplier = false) = 0;
+    virtual void GetValue(float time, AZ::Quaternion& value) = 0;
     virtual void GetValue(float time, bool& value) = 0;
     virtual void GetValue(float time, Maestro::AssetBlends<AZ::Data::AssetData>& value) = 0;
-
-    // support for AZ:: vector types - re-route to legacy types
-    void GetValue(float time, AZ::Vector3& value, bool applyMultiplier = false);
-    void GetValue(float time, AZ::Vector4& value, bool applyMultiplier = false);
-    void GetValue(float time, AZ::Quaternion& value);
 
     //////////////////////////////////////////////////////////////////////////
     // Set track value at specified time.
     // Adds new keys if required.
     //////////////////////////////////////////////////////////////////////////
     virtual void SetValue(float time, const float& value, bool bDefault = false, bool applyMultiplier = false) = 0;
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent SetValue that accepts AZ::Vector3
-     **/
-    virtual void SetValue(float time, const Vec3& value, bool bDefault = false, bool applyMultiplier = false) = 0;
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent SetValue that accepts AZ::Vector4
-     **/
-    virtual void SetValue(float time, const Vec4& value, bool bDefault = false, bool applyMultiplier = false) = 0;
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9133)
-     * use equivalent SetValue that accepts AZ::Quaternion
-     **/
-    virtual void SetValue(float time, const Quat& value, bool bDefault = false) = 0;
+    virtual void SetValue(float time, const AZ::Vector3& value, bool bDefault = false, bool applyMultiplier = false) = 0;
+    virtual void SetValue(float time, const AZ::Vector4& value, bool bDefault = false, bool applyMultiplier = false) = 0;
+    virtual void SetValue(float time, const AZ::Quaternion& value, bool bDefault = false) = 0;
     virtual void SetValue(float time, const bool& value, bool bDefault = false) = 0;
     virtual void SetValue(float time, const Maestro::AssetBlends<AZ::Data::AssetData>& value, bool bDefault = false) = 0;
-
-    // support for AZ:: vector types - re-route to legacy types
-    void SetValue(float time, AZ::Vector4& value, bool bDefault = false, bool applyMultiplier = false);
-    void SetValue(float time, AZ::Vector3& value, bool bDefault = false, bool applyMultiplier = false);
-    void SetValue(float time, AZ::Quaternion& value, bool bDefault = false);
 
     // Only for position tracks, offset all track keys by this amount.
     virtual void OffsetKeyPosition(const AZ::Vector3& value) = 0;
@@ -606,38 +572,14 @@ public:
     // Set float/vec3/vec4 parameter at given time.
     // @return true if parameter set, false if this parameter not exist in node.
     virtual bool SetParamValue(float time, CAnimParamType param, float value) = 0;
-    virtual bool SetParamValue(float time, CAnimParamType param, const Vec3& value) = 0;
-    virtual bool SetParamValue(float time, CAnimParamType param, const Vec4& value) = 0;
-
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent SetParamValue that accepts AZ::Vector3
-     **/
-    bool SetParamValue(float time, CAnimParamType param, const AZ::Vector3& value);
-
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent SetParamValue that accepts AZ::Vector4
-     **/
-    bool SetParamValue(float time, CAnimParamType param, const AZ::Vector4& value);
+    virtual bool SetParamValue(float time, CAnimParamType param, const AZ::Vector3& value) = 0;
+    virtual bool SetParamValue(float time, CAnimParamType param, const AZ::Vector4& value) = 0;
 
     // Get float/vec3/vec4 parameter at given time.
     // @return true if parameter exist, false if this parameter not exist in node.
     virtual bool GetParamValue(float time, CAnimParamType param, float& value) = 0;
-    virtual bool GetParamValue(float time, CAnimParamType param, Vec3& value) = 0;
-    virtual bool GetParamValue(float time, CAnimParamType param, Vec4& value) = 0;
-
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent GetParamValue that accepts AZ::Vector4
-     **/
-    bool GetParamValue(float time, CAnimParamType param, AZ::Vector3& value);
-
-    /**
-     * O3DE_DEPRECATION_NOTICE(GHI-9326)
-     * use equivalent GetParamValue that accepts AZ::Vector4
-     **/
-    bool GetParamValue(float time, CAnimParamType param, AZ::Vector4& value);
+    virtual bool GetParamValue(float time, CAnimParamType param, AZ::Vector3& value) = 0;
+    virtual bool GetParamValue(float time, CAnimParamType param, AZ::Vector4& value) = 0;
 
     //! Evaluate animation node while not playing animation.
     virtual void StillUpdate() = 0;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.cpp
@@ -766,7 +766,7 @@ void CAnimComponentNode::InitializeTrackDefaultValue(IAnimTrack* pTrack, const C
                     Maestro::SequenceComponentRequestBus::Event(m_pSequence->GetSequenceEntityId(), &Maestro::SequenceComponentRequestBus::Events::GetAnimatedPropertyValue, defaultValue, GetParentAzEntityId(), address);
                     defaultValue.GetValue(vector3Value);
 
-                    pTrack->SetValue(0, Vec3(vector3Value.GetX(), vector3Value.GetY(), vector3Value.GetZ()), true);
+                    pTrack->SetValue(0, vector3Value, true);
                     break;
                 }
                 case AnimValueType::Quat:

--- a/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.cpp
@@ -20,6 +20,7 @@
 #include <Maestro/Types/AssetBlends.h>
 
 #include "CharacterTrack.h"
+#include "MathConversion.h"
 
 CAnimComponentNode::CAnimComponentNode(int id)
     : CAnimNode(id, AnimNodeType::Component)
@@ -454,7 +455,9 @@ Quat CAnimComponentNode::GetRotate(float time)
     IAnimTrack* rotTrack = GetTrackForParameter(AnimParamType::Rotation);
     if (rotTrack != nullptr && rotTrack->GetNumKeys() > 0)
     {
-        rotTrack->GetValue(time, worldRot);
+        AZ::Quaternion value;
+        rotTrack->GetValue(time, value);
+        worldRot = AZQuaternionToLYQuaternion(value);
 
         // Track values are always stored as relative to the parent (local), so convert to world.
         ConvertBetweenWorldAndLocalRotation(worldRot, eTransformConverstionDirection_toWorldSpace);
@@ -770,7 +773,7 @@ void CAnimComponentNode::InitializeTrackDefaultValue(IAnimTrack* pTrack, const C
                 {
                     Maestro::SequenceComponentRequests::AnimatedQuaternionValue defaultValue(AZ::Quaternion::CreateIdentity());
                     Maestro::SequenceComponentRequestBus::Event(m_pSequence->GetSequenceEntityId(), &Maestro::SequenceComponentRequestBus::Events::GetAnimatedPropertyValue, defaultValue, GetParentAzEntityId(), address);
-                    pTrack->SetValue(0, Quat(defaultValue.GetQuaternionValue()), true);
+                    pTrack->SetValue(0, defaultValue.GetQuaternionValue(), true);
                     break;
                 }
                 case AnimValueType::RGB:
@@ -780,8 +783,9 @@ void CAnimComponentNode::InitializeTrackDefaultValue(IAnimTrack* pTrack, const C
 
                     Maestro::SequenceComponentRequestBus::Event(m_pSequence->GetSequenceEntityId(), &Maestro::SequenceComponentRequestBus::Events::GetAnimatedPropertyValue, defaultValue, GetParentAzEntityId(), address);
                     defaultValue.GetValue(vector3Value);
+                    vector3Value = vector3Value.GetClamp(AZ::Vector3::CreateZero(), AZ::Vector3::CreateOne());
 
-                    pTrack->SetValue(0, Vec3(clamp_tpl((float)vector3Value.GetX(), .0f, 1.0f), clamp_tpl((float)vector3Value.GetY(), .0f, 1.0f), clamp_tpl((float)vector3Value.GetZ(), .0f, 1.0f)), /*setDefault=*/ true, /*applyMultiplier=*/ true);
+                    pTrack->SetValue(0, vector3Value, /*setDefault=*/ true, /*applyMultiplier=*/ true);
                     break;
                 }
                 case AnimValueType::Bool:
@@ -898,32 +902,27 @@ void CAnimComponentNode::Animate(SAnimContext& ac)
                         case AnimValueType::RGB:
                         {
                             float tolerance = AZ::Constants::FloatEpsilon;
-                            Vec3 vec3Value(.0f, .0f, .0f);
-                            pTrack->GetValue(ac.time, vec3Value, /*applyMultiplier= */ true);
-                            AZ::Vector3 vector3Value(vec3Value.x, vec3Value.y, vec3Value.z);
+                            AZ::Vector3 vec;
+                            pTrack->GetValue(ac.time, vec, /*applyMultiplier= */ true);
 
                             if (pTrack->GetValueType() == AnimValueType::RGB)
                             {
-                                vec3Value.x = clamp_tpl(vec3Value.x, 0.0f, 1.0f);
-                                vec3Value.y = clamp_tpl(vec3Value.y, 0.0f, 1.0f);
-                                vec3Value.z = clamp_tpl(vec3Value.z, 0.0f, 1.0f);
-
+                                vec = vec.GetClamp(AZ::Vector3::CreateZero(), AZ::Vector3::CreateOne());
                                 // set tolerance to just under 1 unit in normalized RGB space
                                 tolerance = (1.0f - AZ::Constants::FloatEpsilon) / 255.0f;
                             }
 
-                            Maestro::SequenceComponentRequests::AnimatedVector3Value value(AZ::Vector3(vec3Value.x, vec3Value.y, vec3Value.z));
-
-                            Maestro::SequenceComponentRequests::AnimatedVector3Value prevValue(AZ::Vector3(vec3Value.x, vec3Value.y, vec3Value.z));
+                            Maestro::SequenceComponentRequests::AnimatedVector3Value value(vec);
+                            Maestro::SequenceComponentRequests::AnimatedVector3Value prevValue(vec);
                             Maestro::SequenceComponentRequestBus::Event(m_pSequence->GetSequenceEntityId(), &Maestro::SequenceComponentRequestBus::Events::GetAnimatedPropertyValue, prevValue, GetParentAzEntityId(), animatableAddress);
                             AZ::Vector3 vector3PrevValue;
                             prevValue.GetValue(vector3PrevValue);
 
                             // Check sub-tracks for keys. If there are none, use the prevValue for that track (essentially making a non-keyed track a no-op)
-                            vector3Value.Set(pTrack->GetSubTrack(0)->HasKeys() ? vector3Value.GetX() : vector3PrevValue.GetX(),
-                                pTrack->GetSubTrack(1)->HasKeys() ? vector3Value.GetY() : vector3PrevValue.GetY(),
-                                pTrack->GetSubTrack(2)->HasKeys() ? vector3Value.GetZ() : vector3PrevValue.GetZ());
-                            value.SetValue(vector3Value);
+                            vec.Set(pTrack->GetSubTrack(0)->HasKeys() ? vec.GetX() : vector3PrevValue.GetX(),
+                                pTrack->GetSubTrack(1)->HasKeys() ? vec.GetY() : vector3PrevValue.GetY(),
+                                pTrack->GetSubTrack(2)->HasKeys() ? vec.GetZ() : vector3PrevValue.GetZ());
+                            value.SetValue(vec);
 
                             if (!value.IsClose(prevValue, tolerance))
                             {

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -16,6 +16,7 @@
 #include "CharacterTrack.h"
 #include "AnimSplineTrack.h"
 #include "BoolTrack.h"
+#include "MathConversion.h"
 #include "SelectTrack.h"
 #include "EventTrack.h"
 #include "SoundTrack.h"
@@ -777,7 +778,7 @@ bool CAnimNode::SetParamValue(float time, CAnimParamType param, float value)
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CAnimNode::SetParamValue(float time, CAnimParamType param, const Vec3& value)
+bool CAnimNode::SetParamValue(float time, CAnimParamType param, const AZ::Vector3& value)
 {
     if (m_bIgnoreSetParam)
     {
@@ -789,14 +790,14 @@ bool CAnimNode::SetParamValue(float time, CAnimParamType param, const Vec3& valu
     {
         // Vec3 track.
         bool bDefault = !(gEnv->pMovieSystem->IsRecording() && (m_flags & eAnimNodeFlags_EntitySelected)); // Only selected nodes can be recorded
-        pTrack->SetValue(time, value, bDefault);
+        pTrack->SetValue(time, AZVec3ToLYVec3(value), bDefault);
         return true;
     }
     return false;
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CAnimNode::SetParamValue(float time, CAnimParamType param, const Vec4& value)
+bool CAnimNode::SetParamValue(float time, CAnimParamType param, const AZ::Vector4& value)
 {
     if (m_bIgnoreSetParam)
     {
@@ -828,7 +829,7 @@ bool CAnimNode::GetParamValue(float time, CAnimParamType param, float& value)
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CAnimNode::GetParamValue(float time, CAnimParamType param, Vec3& value)
+bool CAnimNode::GetParamValue(float time, CAnimParamType param, AZ::Vector3& value)
 {
     CCompoundSplineTrack* pTrack = static_cast<CCompoundSplineTrack*>(GetTrackForParameter(param));
     if (pTrack && pTrack->GetValueType() == AnimValueType::Vector && pTrack->GetNumKeys() > 0)
@@ -841,7 +842,7 @@ bool CAnimNode::GetParamValue(float time, CAnimParamType param, Vec3& value)
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CAnimNode::GetParamValue(float time, CAnimParamType param, Vec4& value)
+bool CAnimNode::GetParamValue(float time, CAnimParamType param, AZ::Vector4& value)
 {
     CCompoundSplineTrack* pTrack = static_cast<CCompoundSplineTrack*>(GetTrackForParameter(param));
     if (pTrack && pTrack->GetValueType() == AnimValueType::Vector4 && pTrack->GetNumKeys() > 0)

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -790,7 +790,7 @@ bool CAnimNode::SetParamValue(float time, CAnimParamType param, const AZ::Vector
     {
         // Vec3 track.
         bool bDefault = !(gEnv->pMovieSystem->IsRecording() && (m_flags & eAnimNodeFlags_EntitySelected)); // Only selected nodes can be recorded
-        pTrack->SetValue(time, AZVec3ToLYVec3(value), bDefault);
+        pTrack->SetValue(time, value, bDefault);
         return true;
     }
     return false;
@@ -1166,8 +1166,8 @@ void CAnimNode::AnimateSound(std::vector<SSoundInfo>& nodeSoundInfo, SAnimContex
 }
 
 void CAnimNode::SetParent(IAnimNode* parent)
-{ 
-    m_pParentNode = parent; 
+{
+    m_pParentNode = parent;
     if (parent)
     {
         m_parentNodeId = static_cast<CAnimNode*>(m_pParentNode)->GetId();
@@ -1206,7 +1206,7 @@ void CAnimNode::UpdateDynamicParams()
         // which could happen from multiple threads. Lock to avoid a crash iterating over the lua stack
         AZStd::lock_guard<AZStd::mutex> lock(m_updateDynamicParamsLock);
 
-        // run this on the main thread to prevent further threading issues downstream in 
+        // run this on the main thread to prevent further threading issues downstream in
         // AnimNodes that may use EBuses that are not thread safe
         if (gEnv && gEnv->mMainThreadId == CryGetCurrentThreadId())
         {

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
@@ -94,11 +94,11 @@ public:
     unsigned int GetParamCount() const override { return 0; };
 
     bool SetParamValue(float time, CAnimParamType param, float val) override;
-    bool SetParamValue(float time, CAnimParamType param, const Vec3& val) override;
-    bool SetParamValue(float time, CAnimParamType param, const Vec4& val) override;
+    bool SetParamValue(float time, CAnimParamType param, const AZ::Vector3& val) override;
+    bool SetParamValue(float time, CAnimParamType param, const AZ::Vector4& val) override;
     bool GetParamValue(float time, CAnimParamType param, float& val) override;
-    bool GetParamValue(float time, CAnimParamType param, Vec3& val) override;
-    bool GetParamValue(float time, CAnimParamType param, Vec4& val) override;
+    bool GetParamValue(float time, CAnimParamType param, AZ::Vector3& val) override;
+    bool GetParamValue(float time, CAnimParamType param, AZ::Vector4& val) override;
 
     void SetTarget([[maybe_unused]] IAnimNode* node) {};
     IAnimNode* GetTarget() const { return 0; };

--- a/Gems/Maestro/Code/Source/Cinematics/AnimPostFXNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimPostFXNode.cpp
@@ -16,6 +16,7 @@
 #include "Maestro/Types/AnimNodeType.h"
 #include "Maestro/Types/AnimParamType.h"
 #include "Maestro/Types/AnimValueType.h"
+#include "MathConversion.h"
 
 //////////////////////////////////////////////////////////////////////////
 //!
@@ -342,7 +343,7 @@ void CAnimPostFXNode::CreateDefaultTracks()
             CCompoundSplineTrack* pCompoundTrack = static_cast<CCompoundSplineTrack*>(pTrack);
             Vec4 val(0.0f, 0.0f, 0.0f, 0.0f);
             m_pDescription->m_controlParams[i]->GetDefault(val);
-            pCompoundTrack->SetValue(0.0f, val, true);
+            pCompoundTrack->SetValue(0.0f, LYVec4ToAZVec4(val), true);
         }
     }
 }
@@ -388,7 +389,7 @@ void CAnimPostFXNode::Animate(SAnimContext& ac)
         }
         else if (valueType == AnimValueType::Vector4)
         {
-            Vec4 val(0.0f, 0.0f, 0.0f, 0.0f);
+            AZ::Vector4 val(0.0f, 0.0f, 0.0f, 0.0f);
             static_cast<CCompoundSplineTrack*>(pTrack)->GetValue(ac.time, val);
         }
     }

--- a/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
@@ -186,16 +186,16 @@ public:
     AnimValueType GetValueType() override { assert(0); return static_cast<AnimValueType>(0xFFFFFFFF); }
 
     void GetValue(float time, float& value, bool applyMultiplier = false) override { assert(0); }
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Vec3& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Vec4& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Quat& value) override { assert(0); }
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Vector3& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Vector4& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Quaternion& value) override { assert(0); }
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] bool& value) override { assert(0); }
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] Maestro::AssetBlends<AZ::Data::AssetData>& value) override { assert(0); }
 
     void SetValue(float time, const float& value, bool bDefault = false, bool applyMultiplier = false) override { assert(0); }
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Vec3& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Vec4& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Quat& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector3& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector4& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); }
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Quaternion& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const bool& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Maestro::AssetBlends<AZ::Data::AssetData>& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -158,9 +158,9 @@ public:
     // Interpolates keys if needed.
     //////////////////////////////////////////////////////////////////////////
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] float& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Vec3& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Vec4& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void GetValue([[maybe_unused]] float time, [[maybe_unused]] Quat& value) override { assert(0); };
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Vector3& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Vector4& value, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
+    void GetValue([[maybe_unused]] float time, [[maybe_unused]] AZ::Quaternion& value) override { assert(0); };
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] bool& value) override { assert(0); };
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] Maestro::AssetBlends<AZ::Data::AssetData>& value) override { assert(0); }
 
@@ -169,9 +169,9 @@ public:
     // Adds new keys if required.
     //////////////////////////////////////////////////////////////////////////
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const float& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Vec3& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Vec4& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
-    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Quat& value, [[maybe_unused]] bool bDefault = false) override { assert(0); };
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector3& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Vector4& value, [[maybe_unused]] bool bDefault = false, [[maybe_unused]] bool applyMultiplier = false) override { assert(0); };
+    void SetValue([[maybe_unused]] float time, [[maybe_unused]] const AZ::Quaternion& value, [[maybe_unused]] bool bDefault = false) override { assert(0); };
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const bool& value, [[maybe_unused]] bool bDefault = false) override { assert(0); };
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Maestro::AssetBlends<AZ::Data::AssetData>& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
 

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.h
@@ -80,9 +80,9 @@ public:
     // Interpolates keys if needed.
     //////////////////////////////////////////////////////////////////////////
     void GetValue(float time, float& value, bool applyMultiplier = false) override;
-    void GetValue(float time, Vec3& value, bool applyMultiplier = false) override;
-    void GetValue(float time, Vec4& value, bool applyMultiplier = false) override;
-    void GetValue(float time, Quat& value) override;
+    void GetValue(float time, AZ::Vector3& value, bool applyMultiplier = false) override;
+    void GetValue(float time, AZ::Vector4& value, bool applyMultiplier = false) override;
+    void GetValue(float time, AZ::Quaternion& value) override;
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] bool& value) override { assert(0); };
     void GetValue([[maybe_unused]] float time, [[maybe_unused]] Maestro::AssetBlends<AZ::Data::AssetData>& value) override { assert(0); }
 
@@ -91,9 +91,9 @@ public:
     // Adds new keys if required.
     //////////////////////////////////////////////////////////////////////////
     void SetValue(float time, const float& value, bool bDefault = false, bool applyMultiplier = false) override;
-    void SetValue(float time, const Vec3& value, bool bDefault = false, bool applyMultiplier = false) override;
-    void SetValue(float time, const Vec4& value, bool bDefault = false, bool applyMultiplier = false) override;
-    void SetValue(float time, const Quat& value, bool bDefault = false) override;
+    void SetValue(float time, const AZ::Vector3& value, bool bDefault = false, bool applyMultiplier = false) override;
+    void SetValue(float time, const AZ::Vector4& value, bool bDefault = false, bool applyMultiplier = false) override;
+    void SetValue(float time, const AZ::Quaternion& value, bool bDefault = false) override;
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const bool& value, [[maybe_unused]] bool bDefault = false) override { assert(0); };
     void SetValue([[maybe_unused]] float time, [[maybe_unused]] const Maestro::AssetBlends<AZ::Data::AssetData>& value, [[maybe_unused]] bool bDefault = false) override { assert(0); }
 


### PR DESCRIPTION
## What does this PR do?

I migrated the rest of the Get and set values for the node. wonder if this abstraction could be simplified a bit. All these separate overloaded functions seem kind of cumbersome. some kind of container seems more appropriate though. I was thinking of maybe something with a variant? 

## How was this PR tested?

ref: https://github.com/o3de/o3de/issues/9133
