### PR TITLE
feat: minor refactor trackview tracknodes icons

### DIFF
--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -49,37 +49,6 @@
 #include "TrackViewFBXImportPreviewDialog.h"
 #include "AnimationContext.h"
 
-static QString TrackIcon = QStringLiteral(":/nodes/tvnodes-13.png");
-static QString FovIcon = QStringLiteral(":/nodes/tvnodes-02.png");
-static QString PositionIcon = QStringLiteral(":/nodes/tvnodes-03.png");
-static QString RotationIcon = QStringLiteral(":/nodes/tvnodes-04.png");
-static QString ScaleIcon = QStringLiteral(":/nodes/tvnodes-05.png");
-static QString EventIcon = QStringLiteral(":/nodes/tvnodes-06.png");
-static QString VisibilityIcon = QStringLiteral(":/nodes/tvnodes-07.png");
-static QString CameraIcon = QStringLiteral(":/nodes/tvnodes-08.png");
-static QString SoundIcon = QStringLiteral(":/nodes/tvnodes-09.png");
-static QString AnimationIcon = QStringLiteral(":/nodes/tvnodes-10.png");
-static QString SequenceIcon = QStringLiteral(":/nodes/tvnodes-11.png");
-static QString CaptureIcon = QStringLiteral(":/nodes/tvnodes-25.png");
-static QString ConsoleIcon = QStringLiteral(":/nodes/tvnodes-15.png");
-static QString LookAtIcon = QStringLiteral(":/nodes/tvnodes-17.png");
-static QString TimeWarpIcon = QStringLiteral(":/nodes/tvnodes-22.png");
-static QString CommentTextIcon = QStringLiteral(":/nodes/tvnodes-23.png");
-static QString ShakeMultiplierIcon = QStringLiteral(":/nodes/tvnodes-28.png");
-
-static QString AzEntityNode = QStringLiteral(":/nodes/tvnodes-21.png");
-static QString DirectorIcon = QStringLiteral(":/nodes/tvnodes-27.png");
-static QString CvarIcon = QStringLiteral(":/nodes/tvnodes-15.png");
-static QString ScriptVarIcon = QStringLiteral(":/nodes/tvnodes-14.png");
-static QString GroupIcon = QStringLiteral(":/nodes/tvnodes-01.png");
-static QString LayerIcon = QStringLiteral(":/nodes/tvnodes-20.png");
-static QString CommentIcon = QStringLiteral(":/nodes/tvnodes-23.png");
-static QString LightIcon = QStringLiteral(":/nodes/tvnodes-18.png");
-static QString ShadowIcon = QStringLiteral(":/nodes/tvnodes-24.png");
-static QString EmptyIcon = QStringLiteral(":/nodes/tvnodes-21.png");
-static QString HdrIcon = QStringLiteral(":/nodes/tvnodes-26.png");
-static QString MaterialIcon = QStringLiteral(":/nodes/tvnodes-16.png");
-
 CTrackViewNodesCtrl::CRecord::CRecord(CTrackViewNode* pNode /*= nullptr*/)
     : m_pNode(pNode)
     , m_bVisible(false)
@@ -496,7 +465,6 @@ CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddAnimNodeRecord(CRecord* pP
 CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddTrackRecord(CRecord* pParentRecord, CTrackViewTrack* pTrack)
 {
     CRecord* pNewTrackRecord = new CRecord(pTrack);
-    //pNewTrackRecord->setSizeHint(0, QSize(50, 18));
     pNewTrackRecord->setText(0, QString::fromUtf8(pTrack->GetName().c_str()));
     UpdateTrackRecord(pNewTrackRecord, pTrack);
     pParentRecord->insertChild(GetInsertPosition(pParentRecord, pTrack), pNewTrackRecord);
@@ -2431,10 +2399,13 @@ void CTrackViewNodesCtrl::EndUndoTransaction()
     UpdateDopeSheet();
 }
 
-QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack) {
+QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack)
+{
+    const QIcon defaultIcon(QStringLiteral(":/nodes/tvnodes-13.png"));
+
     if (!pTrack)
     {
-        return QIcon(TrackIcon);
+        return defaultIcon;
     }
     const CAnimParamType paramType = pTrack->GetParameterType();
     const AnimValueType valueType = pTrack->GetValueType();
@@ -2443,59 +2414,59 @@ QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack) {
     if (nodeType == AnimNodeType::RadialBlur || nodeType == AnimNodeType::ColorCorrection || nodeType == AnimNodeType::DepthOfField ||
         nodeType == AnimNodeType::ShadowSetup)
     {
-        return QIcon(TrackIcon);
+        return defaultIcon;
     }
 
     switch (valueType)
     {
     case AnimValueType::CharacterAnim:
     case AnimValueType::AssetBlend:
-        return QIcon(AnimationIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-10.png"));
     }
 
     AnimParamType type = paramType.GetType();
     switch (type)
     {
     case AnimParamType::FOV:
-        return QIcon(FovIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-02.png"));
     case AnimParamType::Position:
-        return QIcon(PositionIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-03.png"));
     case AnimParamType::Rotation:
-        return QIcon(RotationIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-04.png"));
     case AnimParamType::Scale:
-        return QIcon(ScaleIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-05.png"));
     case AnimParamType::Event:
     case AnimParamType::TrackEvent:
-        return QIcon(EventIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-06.png"));
     case AnimParamType::Visibility:
-        return QIcon(VisibilityIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-07.png"));
     case AnimParamType::Camera:
-        return QIcon(CameraIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-08.png"));
     case AnimParamType::Sound:
-        return QIcon(CameraIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-09.png"));
     case AnimParamType::Animation:
     case AnimParamType::TimeRanges:
-        return QIcon(AnimationIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-10.png"));
     case AnimParamType::Sequence:
-        return QIcon(SequenceIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-11.png"));
     case AnimParamType::Capture:
-        return QIcon(CaptureIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-25.png"));
     case AnimParamType::Console:
-        return QIcon(ConsoleIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-15.png"));
     case AnimParamType::LookAt:
-        return QIcon(LookAtIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-17.png"));
     case AnimParamType::TimeWarp:
-        return QIcon(TimeWarpIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-22.png"));
     case AnimParamType::CommentText:
-        return QIcon(CommentTextIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-23.png"));
     case AnimParamType::ShakeMultiplier:
     case AnimParamType::TransformNoise:
-        return QIcon(ShakeMultiplierIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-28.png"));
     default:
     case AnimParamType::Float:
         break;
     }
-    return QIcon(TrackIcon);
+    return defaultIcon;
 }
 
 QIcon CTrackViewNodesCtrl::TrackViewNodeIcon(AnimNodeType type)
@@ -2503,31 +2474,31 @@ QIcon CTrackViewNodesCtrl::TrackViewNodeIcon(AnimNodeType type)
     switch (type)
     {
     case AnimNodeType::AzEntity:
-        return QIcon(AzEntityNode);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-21.png"));
     case AnimNodeType::Director:
-        return QIcon(DirectorIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-27.png"));
     case AnimNodeType::Camera:
-        return QIcon(CameraIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-08.png"));
     case AnimNodeType::CVar:
-        return QIcon(CvarIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-15.png"));
     case AnimNodeType::ScriptVar:
-        return QIcon(ScriptVarIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-14.png"));
     case AnimNodeType::Material:
-        return QIcon(MaterialIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-16.png"));
     case AnimNodeType::Event:
-        return QIcon(EventIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-06.png"));
     case AnimNodeType::Group:
-        return QIcon(GroupIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-01.png"));
     case AnimNodeType::Layer:
-        return QIcon(LayerIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-20.png"));
     case AnimNodeType::Comment:
-        return QIcon(CommentIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-23.png"));
     case AnimNodeType::Light:
-        return QIcon(LightIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-18.png"));
     case AnimNodeType::ShadowSetup:
-        return QIcon(ShadowIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-24.png"));
     }
-    return QIcon(EmptyIcon);
+    return QIcon(QStringLiteral(":/nodes/tvnodes-21.png"));
 }
 //////////////////////////////////////////////////////////////////////////
 QIcon CTrackViewNodesCtrl::GetIconForTrack(const CTrackViewTrack* pTrack)

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -2460,6 +2460,7 @@ QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack)
     case AnimParamType::CommentText:
         return QIcon(QStringLiteral(":/nodes/tvnodes-23.png"));
     case AnimParamType::ShakeMultiplier:
+        [[fallthrough]];
     case AnimParamType::TransformNoise:
         return QIcon(QStringLiteral(":/nodes/tvnodes-28.png"));
     default:
@@ -2474,7 +2475,7 @@ QIcon CTrackViewNodesCtrl::TrackViewNodeIcon(AnimNodeType type)
     switch (type)
     {
     case AnimNodeType::AzEntity:
-        return QIcon(QStringLiteral(":/nodes/tvnodes-21.png"));
+        return QIcon(QStringLiteral(":/nodes/tvnodes-29.png"));
     case AnimNodeType::Director:
         return QIcon(QStringLiteral(":/nodes/tvnodes-27.png"));
     case AnimNodeType::Camera:

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -49,6 +49,36 @@
 #include "TrackViewFBXImportPreviewDialog.h"
 #include "AnimationContext.h"
 
+static QString TrackIcon = QStringLiteral(":/nodes/tvnodes-13.png");
+static QString FovIcon = QStringLiteral(":/nodes/tvnodes-02.png");
+static QString PositionIcon = QStringLiteral(":/nodes/tvnodes-03.png");
+static QString RotationIcon = QStringLiteral(":/nodes/tvnodes-04.png");
+static QString ScaleIcon = QStringLiteral(":/nodes/tvnodes-05.png");
+static QString EventIcon = QStringLiteral(":/nodes/tvnodes-06.png");
+static QString VisibilityIcon = QStringLiteral(":/nodes/tvnodes-07.png");
+static QString CameraIcon = QStringLiteral(":/nodes/tvnodes-08.png");
+static QString SoundIcon = QStringLiteral(":/nodes/tvnodes-09.png");
+static QString AnimationIcon = QStringLiteral(":/nodes/tvnodes-10.png");
+static QString SequenceIcon = QStringLiteral(":/nodes/tvnodes-11.png");
+static QString CaptureIcon = QStringLiteral(":/nodes/tvnodes-25.png");
+static QString ConsoleIcon = QStringLiteral(":/nodes/tvnodes-15.png");
+static QString LookAtIcon = QStringLiteral(":/nodes/tvnodes-17.png");
+static QString TimeWarpIcon = QStringLiteral(":/nodes/tvnodes-22.png");
+static QString CommentTextIcon = QStringLiteral(":/nodes/tvnodes-23.png");
+static QString ShakeMultiplierIcon = QStringLiteral(":/nodes/tvnodes-28.png");
+
+static QString AzEntityNode = QStringLiteral(":/nodes/tvnodes-21.png");
+static QString DirectorIcon = QStringLiteral(":/nodes/tvnodes-27.png");
+static QString CvarIcon = QStringLiteral(":/nodes/tvnodes-15.png");
+static QString ScriptVarIcon = QStringLiteral(":/nodes/tvnodes-14.png");
+static QString GroupIcon = QStringLiteral(":/nodes/tvnodes-01.png");
+static QString LayerIcon = QStringLiteral(":/nodes/tvnodes-20.png");
+static QString CommentIcon = QStringLiteral(":/nodes/tvnodes-23.png");
+static QString LightIcon = QStringLiteral(":/nodes/tvnodes-18.png");
+static QString ShadowIcon = QStringLiteral(":/nodes/tvnodes-24.png");
+static QString EmptyIcon = QStringLiteral(":/nodes/tvnodes-21.png");
+static QString HdrIcon = QStringLiteral(":/nodes/tvnodes-26.png");
+static QString MaterialIcon = QStringLiteral(":/nodes/tvnodes-16.png");
 
 CTrackViewNodesCtrl::CRecord::CRecord(CTrackViewNode* pNode /*= nullptr*/)
     : m_pNode(pNode)
@@ -381,16 +411,6 @@ CTrackViewNodesCtrl::CTrackViewNodesCtrl(QWidget* hParentWnd, CTrackViewDialog* 
 
     connect(ui->searchField, &QLineEdit::textChanged, this, &CTrackViewNodesCtrl::OnFilterChange);
 
-    // legacy node icons are enumerated and stored as png files on disk
-    for (int i = 0; i <= 29; i++)
-    {
-        QIcon icon(QString(":/nodes/tvnodes-%1.png").arg(i, 2, 10, QLatin1Char('0')));
-        if (!icon.isNull())
-        {
-            m_imageList[i] = icon;
-        }
-    }
-
     m_bEditLock = false;
 
     m_arrowCursor = Qt::ArrowCursor;
@@ -460,148 +480,6 @@ void CTrackViewNodesCtrl::SetDopeSheet(CTrackViewDopeSheetBase* pDopeSheet)
 }
 
 //////////////////////////////////////////////////////////////////////////
-int CTrackViewNodesCtrl::GetIconIndexForTrack(const CTrackViewTrack* pTrack) const
-{
-    int nImage = 13; // Default
-
-    if (!pTrack)
-    {
-        return nImage;
-    }
-
-    CAnimParamType paramType = pTrack->GetParameterType();
-    AnimValueType valueType = pTrack->GetValueType();
-    AnimNodeType nodeType = pTrack->GetAnimNode()->GetType();
-
-    // If it's a track which belongs to the post-fx node,
-    // just use a default icon.
-    if (nodeType == AnimNodeType::RadialBlur
-        || nodeType == AnimNodeType::ColorCorrection
-        || nodeType == AnimNodeType::DepthOfField
-        || nodeType == AnimNodeType::ShadowSetup)
-    {
-        return nImage;
-    }
-
-    AnimParamType type = paramType.GetType();
-
-    if (type == AnimParamType::Position)
-    {
-        nImage = 3;
-    }
-    else if (type == AnimParamType::Rotation)
-    {
-        nImage = 4;
-    }
-    else if (type == AnimParamType::Scale)
-    {
-        nImage = 5;
-    }
-    else if (type == AnimParamType::Event || type == AnimParamType::TrackEvent)
-    {
-        nImage = 6;
-    }
-    else if (type == AnimParamType::Visibility)
-    {
-        nImage = 7;
-    }
-    else if (type == AnimParamType::Camera)
-    {
-        nImage = 8;
-    }
-    else if (type == AnimParamType::Sound)
-    {
-        nImage = 9;
-    }
-    else if (type == AnimParamType::Animation || type == AnimParamType::TimeRanges || valueType == AnimValueType::CharacterAnim || valueType == AnimValueType::AssetBlend)
-    {
-        nImage = 10;
-    }
-    else if (type == AnimParamType::Sequence)
-    {
-        nImage = 11;
-    }
-    else if (type == AnimParamType::Float)
-    {
-        nImage = 13;
-    }
-    else if (type == AnimParamType::Capture)
-    {
-        nImage = 25;
-    }
-    else if (type == AnimParamType::Console)
-    {
-        nImage = 15;
-    }
-    else if (type == AnimParamType::LookAt)
-    {
-        nImage = 17;
-    }
-    else if (type == AnimParamType::TimeWarp)
-    {
-        nImage = 22;
-    }
-    else if (type == AnimParamType::CommentText)
-    {
-        nImage = 23;
-    }
-    else if (type == AnimParamType::ShakeMultiplier || type == AnimParamType::TransformNoise)
-    {
-        nImage = 28;
-    }
-
-    return nImage;
-}
-
-//////////////////////////////////////////////////////////////////////////
-int CTrackViewNodesCtrl::GetIconIndexForNode(AnimNodeType type) const
-{
-    int nImage = 0;
-    if (type == AnimNodeType::AzEntity)
-    {
-        nImage = 29;
-    }
-    else if (type == AnimNodeType::Director)
-    {
-        nImage = 27;
-    }
-    else if (type == AnimNodeType::CVar)
-    {
-        nImage = 15;
-    }
-    else if (type == AnimNodeType::ScriptVar)
-    {
-        nImage = 14;
-    }
-    else if (type == AnimNodeType::Event)
-    {
-        nImage = 6;
-    }
-    else if (type == AnimNodeType::Group)
-    {
-        nImage = 1;
-    }
-    else if (type == AnimNodeType::Layer)
-    {
-        nImage = 20;
-    }
-    else if (type == AnimNodeType::Comment)
-    {
-        nImage = 23;
-    }
-    else if (type == AnimNodeType::Light)
-    {
-        nImage = 18;
-    }
-    else if (type == AnimNodeType::ShadowSetup)
-    {
-        nImage = 24;
-    }
-
-    return nImage;
-}
-
-//////////////////////////////////////////////////////////////////////////
 CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddAnimNodeRecord(CRecord* pParentRecord, CTrackViewAnimNode* animNode)
 {
     CRecord* pNewRecord = new CRecord(animNode);
@@ -618,7 +496,7 @@ CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddAnimNodeRecord(CRecord* pP
 CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddTrackRecord(CRecord* pParentRecord, CTrackViewTrack* pTrack)
 {
     CRecord* pNewTrackRecord = new CRecord(pTrack);
-    pNewTrackRecord->setSizeHint(0, QSize(30, 18));
+    //pNewTrackRecord->setSizeHint(0, QSize(50, 18));
     pNewTrackRecord->setText(0, QString::fromUtf8(pTrack->GetName().c_str()));
     UpdateTrackRecord(pNewTrackRecord, pTrack);
     pParentRecord->insertChild(GetInsertPosition(pParentRecord, pTrack), pNewTrackRecord);
@@ -737,10 +615,7 @@ void CTrackViewNodesCtrl::UpdateNodeRecord(CRecord* record)
 //////////////////////////////////////////////////////////////////////////
 void CTrackViewNodesCtrl::UpdateTrackRecord(CRecord* record, CTrackViewTrack* pTrack)
 {
-    int nImage = GetIconIndexForTrack(pTrack);
-    assert(m_imageList.contains(nImage));
-    record->setIcon(0, m_imageList[nImage]);
-
+    record->setIcon(0, GetIconForTrack(pTrack));
     // Check if parameter is valid for non sub tracks
     CTrackViewAnimNode* animNode = pTrack->GetAnimNode();
     const bool isParamValid = pTrack->IsSubTrack() || animNode->IsParamValid(pTrack->GetParameterType());
@@ -768,9 +643,9 @@ void CTrackViewNodesCtrl::UpdateAnimNodeRecord(CRecord* record, CTrackViewAnimNo
     if (nodeType == AnimNodeType::Component)
     {
         // get the component icon from cached component icons
-        
+
         AZ::Entity* azEntity = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(azEntity, &AZ::ComponentApplicationBus::Events::FindEntity, 
+        AZ::ComponentApplicationBus::BroadcastResult(azEntity, &AZ::ComponentApplicationBus::Events::FindEntity,
                                                         static_cast<CTrackViewAnimNode*>(animNode->GetParentNode())->GetAzEntityId());
         if (azEntity)
         {
@@ -782,18 +657,14 @@ void CTrackViewNodesCtrl::UpdateAnimNodeRecord(CRecord* record, CTrackViewAnimNo
                 {
                     record->setIcon(0, findIter->second);
                 }
-            }           
-        }     
+            }
+        }
     }
     else
     {
-        // legacy node icons
-        int nNodeImage = GetIconIndexForNode(nodeType);
-        assert(m_imageList.contains(nNodeImage));
-
-        record->setIcon(0, m_imageList[nNodeImage]);
+        record->setIcon(0, TrackViewNodeIcon(nodeType));
     }
-    
+
 
     const bool disabled = animNode->IsDisabled();
     record->setData(0, CRecord::EnableRole, !disabled);
@@ -1323,7 +1194,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
         if (animNode)
         {
             unsigned int menuId = cmd - eMI_AddTrackBase;
-            
+
             if (animNode->GetType() != AnimNodeType::AzEntity)
             {
                 // add track
@@ -1334,7 +1205,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                     animNode->CreateTrack(findIter->second);
                     undoBatch.MarkEntityDirty(animNode->GetSequence()->GetSequenceComponentEntityId());
                 }
-            }                   
+            }
         }
     }
     else if (cmd == eMI_RemoveTrack)
@@ -2560,11 +2431,108 @@ void CTrackViewNodesCtrl::EndUndoTransaction()
     UpdateDopeSheet();
 }
 
+QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack) {
+    if (!pTrack)
+    {
+        return QIcon(TrackIcon);
+    }
+    const CAnimParamType paramType = pTrack->GetParameterType();
+    const AnimValueType valueType = pTrack->GetValueType();
+    const AnimNodeType nodeType = pTrack->GetAnimNode()->GetType();
+
+    if (nodeType == AnimNodeType::RadialBlur || nodeType == AnimNodeType::ColorCorrection || nodeType == AnimNodeType::DepthOfField ||
+        nodeType == AnimNodeType::ShadowSetup)
+    {
+        return QIcon(TrackIcon);
+    }
+
+    switch (valueType)
+    {
+    case AnimValueType::CharacterAnim:
+    case AnimValueType::AssetBlend:
+        return QIcon(AnimationIcon);
+    }
+
+    AnimParamType type = paramType.GetType();
+    switch (type)
+    {
+    case AnimParamType::FOV:
+        return QIcon(FovIcon);
+    case AnimParamType::Position:
+        return QIcon(PositionIcon);
+    case AnimParamType::Rotation:
+        return QIcon(RotationIcon);
+    case AnimParamType::Scale:
+        return QIcon(ScaleIcon);
+    case AnimParamType::Event:
+    case AnimParamType::TrackEvent:
+        return QIcon(EventIcon);
+    case AnimParamType::Visibility:
+        return QIcon(VisibilityIcon);
+    case AnimParamType::Camera:
+        return QIcon(CameraIcon);
+    case AnimParamType::Sound:
+        return QIcon(CameraIcon);
+    case AnimParamType::Animation:
+    case AnimParamType::TimeRanges:
+        return QIcon(AnimationIcon);
+    case AnimParamType::Sequence:
+        return QIcon(SequenceIcon);
+    case AnimParamType::Capture:
+        return QIcon(CaptureIcon);
+    case AnimParamType::Console:
+        return QIcon(ConsoleIcon);
+    case AnimParamType::LookAt:
+        return QIcon(LookAtIcon);
+    case AnimParamType::TimeWarp:
+        return QIcon(TimeWarpIcon);
+    case AnimParamType::CommentText:
+        return QIcon(CommentTextIcon);
+    case AnimParamType::ShakeMultiplier:
+    case AnimParamType::TransformNoise:
+        return QIcon(ShakeMultiplierIcon);
+    default:
+    case AnimParamType::Float:
+        break;
+    }
+    return QIcon(TrackIcon);
+}
+
+QIcon CTrackViewNodesCtrl::TrackViewNodeIcon(AnimNodeType type)
+{
+    switch (type)
+    {
+    case AnimNodeType::AzEntity:
+        return QIcon(AzEntityNode);
+    case AnimNodeType::Director:
+        return QIcon(DirectorIcon);
+    case AnimNodeType::Camera:
+        return QIcon(CameraIcon);
+    case AnimNodeType::CVar:
+        return QIcon(CvarIcon);
+    case AnimNodeType::ScriptVar:
+        return QIcon(ScriptVarIcon);
+    case AnimNodeType::Material:
+        return QIcon(MaterialIcon);
+    case AnimNodeType::Event:
+        return QIcon(EventIcon);
+    case AnimNodeType::Group:
+        return QIcon(GroupIcon);
+    case AnimNodeType::Layer:
+        return QIcon(LayerIcon);
+    case AnimNodeType::Comment:
+        return QIcon(CommentIcon);
+    case AnimNodeType::Light:
+        return QIcon(LightIcon);
+    case AnimNodeType::ShadowSetup:
+        return QIcon(ShadowIcon);
+    }
+    return QIcon(EmptyIcon);
+}
 //////////////////////////////////////////////////////////////////////////
 QIcon CTrackViewNodesCtrl::GetIconForTrack(const CTrackViewTrack* pTrack)
 {
-    int r = GetIconIndexForTrack(pTrack);
-    return m_imageList.contains(r) ? m_imageList[r] : QIcon();
+    return TrackViewIcon(pTrack);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -2427,8 +2427,6 @@ QIcon CTrackViewNodesCtrl::TrackViewIcon(const CTrackViewTrack* pTrack)
     AnimParamType type = paramType.GetType();
     switch (type)
     {
-    case AnimParamType::FOV:
-        return QIcon(QStringLiteral(":/nodes/tvnodes-02.png"));
     case AnimParamType::Position:
         return QIcon(QStringLiteral(":/nodes/tvnodes-03.png"));
     case AnimParamType::Rotation:
@@ -2478,8 +2476,6 @@ QIcon CTrackViewNodesCtrl::TrackViewNodeIcon(AnimNodeType type)
         return QIcon(QStringLiteral(":/nodes/tvnodes-29.png"));
     case AnimNodeType::Director:
         return QIcon(QStringLiteral(":/nodes/tvnodes-27.png"));
-    case AnimNodeType::Camera:
-        return QIcon(QStringLiteral(":/nodes/tvnodes-08.png"));
     case AnimNodeType::CVar:
         return QIcon(QStringLiteral(":/nodes/tvnodes-15.png"));
     case AnimNodeType::ScriptVar:

--- a/Code/Editor/TrackView/TrackViewNodes.h
+++ b/Code/Editor/TrackView/TrackViewNodes.h
@@ -113,6 +113,9 @@ public:
 
     void Update();
 
+    static QIcon TrackViewIcon(const CTrackViewTrack* track);
+    static QIcon TrackViewNodeIcon(AnimNodeType type);
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
@@ -137,14 +140,11 @@ private:
     int ShowPopupMenu(QPoint point, const CRecord* pItemInfo);
 
     bool FillAddTrackMenu(struct STrackMenuTreeNode& menuAddTrack, const CTrackViewAnimNode* pAnimNode);
-    
+
     void CreateAddTrackMenuRec(QMenu& parent, const QString& name, CTrackViewAnimNode* animNode, struct STrackMenuTreeNode& node, unsigned int& currentId);
-    
+
     void SetPopupMenuLock(QMenu* menu);
     void CreateSetAnimationLayerPopupMenu(QMenu& menuSetLayer, CTrackViewTrack* pTrack) const;
-
-    int GetIconIndexForTrack(const CTrackViewTrack* pTrack) const;
-    int GetIconIndexForNode(AnimNodeType type) const;
 
     void AddNodeRecord(CRecord* pParentRecord, CTrackViewNode* pNode);
     CRecord* AddTrackRecord(CRecord* pParentRecord, CTrackViewTrack* pTrack);
@@ -202,7 +202,6 @@ private:
     std::unordered_map<unsigned int, CAnimParamType> m_menuParamTypeMap;
     std::unordered_map<const CTrackViewNode*, CRecord*> m_nodeToRecordMap;
 
-    QMap<int, QIcon> m_imageList;
     QScopedPointer<Ui::CTrackViewNodesCtrl> ui;
 
     //! Cached map of component icons.

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
@@ -42,22 +42,6 @@
 #include <AzQtComponents/Components/Widgets/ColorPicker.h>
 #include <AzQtComponents/Utilities/Conversions.h>
 
-static QString AzEntityNode = QStringLiteral(":/nodes/tvnodes-21.png");
-static QString DirectorIcon = QStringLiteral(":/nodes/tvnodes-27.png");
-static QString CvarIcon = QStringLiteral(":/nodes/tvnodes-15.png");
-static QString ScriptVarIcon = QStringLiteral(":/nodes/tvnodes-14.png");
-static QString GroupIcon = QStringLiteral(":/nodes/tvnodes-01.png");
-static QString LayerIcon = QStringLiteral(":/nodes/tvnodes-20.png");
-static QString CommentIcon = QStringLiteral(":/nodes/tvnodes-23.png");
-static QString LightIcon = QStringLiteral(":/nodes/tvnodes-18.png");
-static QString ShadowIcon = QStringLiteral(":/nodes/tvnodes-24.png");
-static QString EmptyIcon = QStringLiteral(":/nodes/tvnodes-21.png");
-static QString HdrIcon = QStringLiteral(":/nodes/tvnodes-26.png");
-static QString MaterialIcon = QStringLiteral(":/nodes/tvnodes-16.png");
-static QString CameraIcon = QStringLiteral(":/nodes/tvnodes-08.png");
-static QString EventIcon = QStringLiteral(":/nodes/tvnodes-06.png");
-static QString TrackIcon = QStringLiteral(":/nodes/tvnodes-13.png");
-
 CUiAnimViewNodesCtrl::CRecord::CRecord(CUiAnimViewNode* pNode /*= nullptr*/)
     : m_pNode(pNode)
     , m_bVisible(false)
@@ -480,7 +464,7 @@ void CUiAnimViewNodesCtrl::UpdateNodeRecord(CRecord* pRecord)
 //////////////////////////////////////////////////////////////////////////
 void CUiAnimViewNodesCtrl::UpdateTrackRecord(CRecord* pRecord, CUiAnimViewTrack* pTrack)
 {
-    pRecord->setIcon(0, QIcon(TrackIcon));
+    pRecord->setIcon(0, QIcon(QStringLiteral(":/nodes/tvnodes-13.png")));
 
     // Check if parameter is valid for non sub tracks
     CUiAnimViewAnimNode* pAnimNode = pTrack->GetAnimNode();
@@ -493,38 +477,38 @@ void CUiAnimViewNodesCtrl::UpdateTrackRecord(CRecord* pRecord, CUiAnimViewTrack*
     pRecord->setData(0, CRecord::EnableRole, !bDisabledOrMuted && isParamValid);
 }
 
-QIcon CUiAnimViewNodesCtrl::TrackViewNodeIcon(EUiAnimNodeType nodeType)
+QIcon CUiAnimViewNodesCtrl::NodeTypeToTrackViewIcon(EUiAnimNodeType nodeType)
 {
     switch (nodeType)
     {
     case eUiAnimNodeType_AzEntity:
-        return QIcon(AzEntityNode);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-21.png"));
     case eUiAnimNodeType_Director:
-        return QIcon(DirectorIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-27.png"));
     case eUiAnimNodeType_Camera:
-        return QIcon(CameraIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-08.png"));
     case eUiAnimNodeType_CVar:
-        return QIcon(CvarIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-15.png"));
     case eUiAnimNodeType_ScriptVar:
-        return QIcon(ScriptVarIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-14.png"));
     case eUiAnimNodeType_Material:
-        return QIcon(MaterialIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-16.png"));
     case eUiAnimNodeType_Event:
-        return QIcon(EventIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-06.png"));
     case eUiAnimNodeType_Group:
-        return QIcon(GroupIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-01.png"));
     case eUiAnimNodeType_Layer:
-        return QIcon(LayerIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-20.png"));
     case eUiAnimNodeType_Comment:
-        return QIcon(CommentIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-23.png"));
     case eUiAnimNodeType_Light:
-        return QIcon(LightIcon);
+        return QIcon( QStringLiteral(":/nodes/tvnodes-18.png"));
     case eUiAnimNodeType_HDRSetup:
-        return QIcon(HdrIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-26.png"));
     case eUiAnimNodeType_ShadowSetup:
-        return QIcon(ShadowIcon);
+        return QIcon(QStringLiteral(":/nodes/tvnodes-24.png"));
     }
-    return QIcon(EmptyIcon);
+    return QIcon(QStringLiteral(":/nodes/tvnodes-21.png"));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -543,7 +527,7 @@ void CUiAnimViewNodesCtrl::UpdateUiAnimNodeRecord(CRecord* pRecord, CUiAnimViewA
     EUiAnimNodeType nodeType = pAnimNode->GetType();
     QString nodeName = QString::fromUtf8(pAnimNode->GetName().c_str());
 
-    pRecord->setIcon(0, TrackViewNodeIcon(nodeType));
+    pRecord->setIcon(0, NodeTypeToTrackViewIcon(nodeType));
 
     const bool bDisabled = pAnimNode->IsDisabled();
     pRecord->setData(0, CRecord::EnableRole, !bDisabled);
@@ -1654,7 +1638,7 @@ void CUiAnimViewNodesCtrl::EndUndoTransaction()
 //////////////////////////////////////////////////////////////////////////
 QIcon CUiAnimViewNodesCtrl::GetIconForTrack(const CUiAnimViewTrack* pTrack)
 {
-    return QIcon(TrackIcon);
+    return QIcon(QStringLiteral(":/nodes/tvnodes-13.png"));
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
@@ -1636,7 +1636,7 @@ void CUiAnimViewNodesCtrl::EndUndoTransaction()
 }
 
 //////////////////////////////////////////////////////////////////////////
-QIcon CUiAnimViewNodesCtrl::GetIconForTrack(const CUiAnimViewTrack* pTrack)
+QIcon CUiAnimViewNodesCtrl::GetIconForTrack([[maybe_unused]] const CUiAnimViewTrack* pTrack)
 {
     return QIcon(QStringLiteral(":/nodes/tvnodes-13.png"));
 }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.cpp
@@ -42,6 +42,22 @@
 #include <AzQtComponents/Components/Widgets/ColorPicker.h>
 #include <AzQtComponents/Utilities/Conversions.h>
 
+static QString AzEntityNode = QStringLiteral(":/nodes/tvnodes-21.png");
+static QString DirectorIcon = QStringLiteral(":/nodes/tvnodes-27.png");
+static QString CvarIcon = QStringLiteral(":/nodes/tvnodes-15.png");
+static QString ScriptVarIcon = QStringLiteral(":/nodes/tvnodes-14.png");
+static QString GroupIcon = QStringLiteral(":/nodes/tvnodes-01.png");
+static QString LayerIcon = QStringLiteral(":/nodes/tvnodes-20.png");
+static QString CommentIcon = QStringLiteral(":/nodes/tvnodes-23.png");
+static QString LightIcon = QStringLiteral(":/nodes/tvnodes-18.png");
+static QString ShadowIcon = QStringLiteral(":/nodes/tvnodes-24.png");
+static QString EmptyIcon = QStringLiteral(":/nodes/tvnodes-21.png");
+static QString HdrIcon = QStringLiteral(":/nodes/tvnodes-26.png");
+static QString MaterialIcon = QStringLiteral(":/nodes/tvnodes-16.png");
+static QString CameraIcon = QStringLiteral(":/nodes/tvnodes-08.png");
+static QString EventIcon = QStringLiteral(":/nodes/tvnodes-06.png");
+static QString TrackIcon = QStringLiteral(":/nodes/tvnodes-13.png");
+
 CUiAnimViewNodesCtrl::CRecord::CRecord(CUiAnimViewNode* pNode /*= nullptr*/)
     : m_pNode(pNode)
     , m_bVisible(false)
@@ -255,15 +271,6 @@ CUiAnimViewNodesCtrl::CUiAnimViewNodesCtrl(QWidget* hParentWnd, CUiAnimViewDialo
 
     connect(ui->searchField, &QLineEdit::textChanged, this, &CUiAnimViewNodesCtrl::OnFilterChange);
 
-    for (int i = 0; i <= 28; i++)
-    {
-        QIcon icon(QString(":/nodes/tvnodes-%1.png").arg(i, 2, 10, QLatin1Char('0')));
-        if (!icon.isNull())
-        {
-            m_imageList[i] = icon;
-        }
-    }
-
     m_bEditLock = false;
 
     m_arrowCursor = Qt::ArrowCursor;
@@ -335,74 +342,6 @@ void CUiAnimViewNodesCtrl::OnSequenceChanged()
 void CUiAnimViewNodesCtrl::SetDopeSheet(CUiAnimViewDopeSheetBase* pDopeSheet)
 {
     m_pDopeSheet = pDopeSheet;
-}
-
-//////////////////////////////////////////////////////////////////////////
-int CUiAnimViewNodesCtrl::GetIconIndexForTrack([[maybe_unused]] const CUiAnimViewTrack* pTrack) const
-{
-    int nImage = 13; // Default
-    return nImage;
-}
-
-//////////////////////////////////////////////////////////////////////////
-int CUiAnimViewNodesCtrl::GetIconIndexForNode(EUiAnimNodeType type) const
-{
-    int nImage = 0;
-    if (type == eUiAnimNodeType_Entity)
-    {
-        // TODO: Get specific icons for lights, particles etc.
-        nImage = 21;
-    }
-    else if (type == eUiAnimNodeType_Director)
-    {
-        nImage = 27;
-    }
-    else if (type == eUiAnimNodeType_Camera)
-    {
-        nImage = 8;
-    }
-    else if (type == eUiAnimNodeType_CVar)
-    {
-        nImage = 15;
-    }
-    else if (type == eUiAnimNodeType_ScriptVar)
-    {
-        nImage = 14;
-    }
-    else if (type == eUiAnimNodeType_Material)
-    {
-        nImage = 16;
-    }
-    else if (type == eUiAnimNodeType_Event)
-    {
-        nImage = 6;
-    }
-    else if (type == eUiAnimNodeType_Group)
-    {
-        nImage = 1;
-    }
-    else if (type == eUiAnimNodeType_Layer)
-    {
-        nImage = 20;
-    }
-    else if (type == eUiAnimNodeType_Comment)
-    {
-        nImage = 23;
-    }
-    else if (type == eUiAnimNodeType_Light)
-    {
-        nImage = 18;
-    }
-    else if (type == eUiAnimNodeType_HDRSetup)
-    {
-        nImage = 26;
-    }
-    else if (type == eUiAnimNodeType_ShadowSetup)
-    {
-        nImage = 24;
-    }
-
-    return nImage;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -541,9 +480,7 @@ void CUiAnimViewNodesCtrl::UpdateNodeRecord(CRecord* pRecord)
 //////////////////////////////////////////////////////////////////////////
 void CUiAnimViewNodesCtrl::UpdateTrackRecord(CRecord* pRecord, CUiAnimViewTrack* pTrack)
 {
-    int nImage = GetIconIndexForTrack(pTrack);
-    assert(m_imageList.contains(nImage));
-    pRecord->setIcon(0, m_imageList[nImage]);
+    pRecord->setIcon(0, QIcon(TrackIcon));
 
     // Check if parameter is valid for non sub tracks
     CUiAnimViewAnimNode* pAnimNode = pTrack->GetAnimNode();
@@ -554,6 +491,40 @@ void CUiAnimViewNodesCtrl::UpdateTrackRecord(CRecord* pRecord, CUiAnimViewTrack*
 
     // If track is not valid and disabled/muted color node in grey
     pRecord->setData(0, CRecord::EnableRole, !bDisabledOrMuted && isParamValid);
+}
+
+QIcon CUiAnimViewNodesCtrl::TrackViewNodeIcon(EUiAnimNodeType nodeType)
+{
+    switch (nodeType)
+    {
+    case eUiAnimNodeType_AzEntity:
+        return QIcon(AzEntityNode);
+    case eUiAnimNodeType_Director:
+        return QIcon(DirectorIcon);
+    case eUiAnimNodeType_Camera:
+        return QIcon(CameraIcon);
+    case eUiAnimNodeType_CVar:
+        return QIcon(CvarIcon);
+    case eUiAnimNodeType_ScriptVar:
+        return QIcon(ScriptVarIcon);
+    case eUiAnimNodeType_Material:
+        return QIcon(MaterialIcon);
+    case eUiAnimNodeType_Event:
+        return QIcon(EventIcon);
+    case eUiAnimNodeType_Group:
+        return QIcon(GroupIcon);
+    case eUiAnimNodeType_Layer:
+        return QIcon(LayerIcon);
+    case eUiAnimNodeType_Comment:
+        return QIcon(CommentIcon);
+    case eUiAnimNodeType_Light:
+        return QIcon(LightIcon);
+    case eUiAnimNodeType_HDRSetup:
+        return QIcon(HdrIcon);
+    case eUiAnimNodeType_ShadowSetup:
+        return QIcon(ShadowIcon);
+    }
+    return QIcon(EmptyIcon);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -570,12 +541,9 @@ void CUiAnimViewNodesCtrl::UpdateUiAnimNodeRecord(CRecord* pRecord, CUiAnimViewA
     pRecord->setFont(0, f);
 
     EUiAnimNodeType nodeType = pAnimNode->GetType();
-    int nNodeImage = GetIconIndexForNode(nodeType);
-    assert(m_imageList.contains(nNodeImage));
-
     QString nodeName = QString::fromUtf8(pAnimNode->GetName().c_str());
 
-    pRecord->setIcon(0, m_imageList[nNodeImage]);
+    pRecord->setIcon(0, TrackViewNodeIcon(nodeType));
 
     const bool bDisabled = pAnimNode->IsDisabled();
     pRecord->setData(0, CRecord::EnableRole, !bDisabled);
@@ -1686,8 +1654,7 @@ void CUiAnimViewNodesCtrl::EndUndoTransaction()
 //////////////////////////////////////////////////////////////////////////
 QIcon CUiAnimViewNodesCtrl::GetIconForTrack(const CUiAnimViewTrack* pTrack)
 {
-    int r = GetIconIndexForTrack(pTrack);
-    return m_imageList.contains(r) ? m_imageList[r] : QIcon();
+    return QIcon(TrackIcon);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.h
@@ -104,6 +104,7 @@ public:
     QIcon GetIconForTrack(const CUiAnimViewTrack* pTrack);
     void ShowNextResult();
 
+    static QIcon TrackViewNodeIcon(EUiAnimNodeType type);
 protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
@@ -126,9 +127,6 @@ private:
 
     void SetPopupMenuLock(QMenu* menu);
     void CreateSetAnimationLayerPopupMenu(QMenu& menuSetLayer, CUiAnimViewTrack* pTrack) const;
-
-    int GetIconIndexForTrack(const CUiAnimViewTrack* pTrack) const;
-    int GetIconIndexForNode(EUiAnimNodeType type) const;
 
     void AddNodeRecord(CRecord* pParentRecord, CUiAnimViewNode* pNode);
     CRecord* AddTrackRecord(CRecord* pParentRecord, CUiAnimViewTrack* pTrack);
@@ -185,7 +183,6 @@ private:
 
     std::unordered_map<const CUiAnimViewNode*, CRecord*> m_nodeToRecordMap;
 
-    QMap<int, QIcon> m_imageList;
     QScopedPointer<Ui::CUiAnimViewNodesCtrl> ui;
 };
 

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewNodes.h
@@ -101,10 +101,10 @@ public:
     virtual void EndUndoTransaction() override;
 
     // Helper for dialog
-    QIcon GetIconForTrack(const CUiAnimViewTrack* pTrack);
     void ShowNextResult();
 
-    static QIcon TrackViewNodeIcon(EUiAnimNodeType type);
+    QIcon GetIconForTrack(const CUiAnimViewTrack* pTrack);
+    static QIcon NodeTypeToTrackViewIcon(EUiAnimNodeType type);
 protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;


### PR DESCRIPTION
## What does this PR do?

wanted to rework this code a bit and fix a couple problems with the track view tree view. I resolve the cut arrows in the treeview and simplified the logic for icons. I would like to revisit the icons in the treeview but this should be a good place to start.  It doesn't seem like its necessary to stash the QIcons in a table, not sure the overhead but it can't be worth having a qmap. 

![image](https://github.com/o3de/o3de/assets/854359/f313dfa4-9f01-42ee-9195-8b44b69ca480)

## How was this PR tested?

- open the trackview
- add an entity from the scene.

