### PR TITLE
Script canvas logger can now identify graph and entity names

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasReporter.h
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasReporter.h
@@ -173,11 +173,12 @@ namespace ScriptCanvasEditor
         // ExecutionNotificationsBus
         // IsGraphObserved is needed for unit testing code support only, no other event is
         void GraphActivated(const GraphActivation&) override {}
-        void GraphDeactivated(const GraphActivation&) override {}
-        bool IsGraphObserved(const ExecutionState& executionState) override;
+        void GraphDeactivated(const GraphDeactivation&) override {}
+        bool IsGraphObserved(const AZ::EntityId& entityId, const GraphIdentifier& identifier) override;
         bool IsVariableObserved(const VariableId&) override { return false; }
         void NodeSignaledOutput(const OutputSignal&) override {}
         void NodeSignaledInput(const InputSignal&) override {}
+        void GraphSignaledReturn(const ReturnSignal&) override {};
         void NodeStateUpdated(const NodeStateChange&) override {}
         void RuntimeError(const ExecutionState& executionState, const AZStd::string_view& description) override;
         void VariableChanged(const VariableChange&) override {}

--- a/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasReporter.inl
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasReporter.inl
@@ -172,9 +172,9 @@ namespace ScriptCanvasEditor
         return m_isGraphLoaded;
     }
 
-    AZ_INLINE bool Reporter::IsGraphObserved(const ExecutionState& executionState)
+    AZ_INLINE bool Reporter::IsGraphObserved([[maybe_unused]] const AZ::EntityId& entityId, const GraphIdentifier& identifier)
     {
-        return m_configuration == ExecutionConfiguration::Traced && executionState.GetAssetId() == m_graph;
+        return m_configuration == ExecutionConfiguration::Traced && identifier.m_assetId == m_graph;
     }
 
     AZ_INLINE void Reporter::RuntimeError([[maybe_unused]] const ExecutionState& executionState, const AZStd::string_view& description)

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -108,7 +108,10 @@ namespace ScriptCanvasEditor
     void SystemComponent::Init()
     {
         AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+    }
 
+    void SystemComponent::Activate()
+    {
 #if defined(ENABLE_REMOTE_TOOLS)
         if (auto* remoteToolsInterface = AzFramework::RemoteToolsInterface::Get())
         {
@@ -116,10 +119,7 @@ namespace ScriptCanvasEditor
                 ScriptCanvas::RemoteToolsKey, ScriptCanvas::RemoteToolsName, ScriptCanvas::RemoteToolsPort);
         }
 #endif
-    }
 
-    void SystemComponent::Activate()
-    {
         AZ::JobManagerDesc jobDesc;
         for (size_t i = 0; i < cs_jobThreads; ++i)
         {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.cpp
@@ -123,47 +123,18 @@ namespace ScriptCanvasEditor
         SetupExternalEntities();
     }
 
-    void LiveLoggingDataAggregator::GraphActivated([[maybe_unused]] const ScriptCanvas::GraphActivation& activationSignal)
+    void LiveLoggingDataAggregator::GraphActivated(const ScriptCanvas::GraphActivation& activationSignal)
     {
-        // Execution state sent by remote tool is not serialized
-        // This needs to be fixed so that the code below can be enabled (no identified side effect for the code below not working, but there might be some)
-        /*
-        const auto userData =
-            AZStd::any_cast<const ScriptCanvas::RuntimeComponentUserData>(&activationSignal.m_executionState->GetUserData());
-        if (!userData)
-        {
-            AZ_Error("LiveLoggingDataAggregator", false, "Failed to get user data from graph");
-            return;
-        }
-
-        const ScriptCanvas::GraphIdentifier graphIdentifier(activationSignal.m_executionState->GetAssetId(), userData->component.GetId());
-
         AZStd::lock(m_notificationMutex);
-        RegisterScriptCanvas(userData->entity, graphIdentifier);
-        RegisterEntityName(userData->entity, userData->entity.ToString());
-        LoggingDataNotificationBus::Event(
-            GetDataId(),
-            &LoggingDataNotifications::OnEnabledStateChanged,
-            activationSignal.m_entityIsObserved,
-            userData->entity,
-            graphIdentifier);
-        */
+        RegisterScriptCanvas(activationSignal.m_runtimeEntity, activationSignal.m_graphIdentifier);
+        RegisterEntityName(activationSignal.m_runtimeEntity, activationSignal.m_runtimeEntity.GetName());
+        LoggingDataNotificationBus::Event(GetDataId(), &LoggingDataNotifications::OnEnabledStateChanged, activationSignal.m_entityIsObserved, activationSignal.m_runtimeEntity, activationSignal.m_graphIdentifier);
     }
 
     void LiveLoggingDataAggregator::GraphDeactivated(const ScriptCanvas::GraphDeactivation& deactivationSignal)
     {
-        const auto userData =
-            AZStd::any_cast<const ScriptCanvas::RuntimeComponentUserData>(&deactivationSignal.m_executionState->GetUserData());
-        if (!userData)
-        {
-            AZ_Error("LiveLoggingDataAggregator", false, "Failed to get user data from graph");
-            return;
-        }
-
-        const ScriptCanvas::GraphIdentifier graphIdentifier(deactivationSignal.m_executionState->GetAssetId(), userData->component.GetId());
-
         AZStd::lock(m_notificationMutex);
-        UnregisterScriptCanvas(userData->entity, graphIdentifier);
+        UnregisterScriptCanvas(deactivationSignal.m_runtimeEntity, deactivationSignal.m_graphIdentifier);
     }
 
     void LiveLoggingDataAggregator::NodeStateChanged(const ScriptCanvas::NodeStateChange& nodeStateChangeSignal)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -368,6 +368,7 @@ namespace ScriptCanvasEditor
     {
         GraphCanvas::FocusConfig focusConfig;
 
+        // TODO https://github.com/o3de/o3de/issues/9192 focus broken because both scriptCanvasNodeId and graphCanvasNodeId are invalid (broken by #6394)
         AZ::EntityId scriptCanvasNodeId;
         AssetGraphSceneBus::BroadcastResult(scriptCanvasNodeId, &AssetGraphScene::FindEditorNodeIdByAssetNodeId, SourceHandle(nullptr, assetId.m_guid), assetNodeId);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.cpp
@@ -208,6 +208,7 @@ namespace ScriptCanvasEditor
         m_paletteConfiguration.SetColorPalette("MethodNodeTitlePalette");
 
         AZ::NamedEntityId entityName;
+        LoggingDataRequestBus::EventResult(entityName, m_loggingDataId, &LoggingDataRequests::FindNamedEntityId, m_graphInfo.m_runtimeEntity);
 
         m_sourceEntityName = entityName.ToString().c_str();
         m_displayName = nodeId.m_name.c_str();
@@ -217,16 +218,6 @@ namespace ScriptCanvasEditor
 
         m_inputName = "---";
         m_outputName = "---";
-
-        // Payload sent from remote tool does not serialize the execution state
-        // Without m_graphIdentifier the graph name on the log will be marked as "Unknown" this needs to be fixed
-        /*
-        if (m_graphInfo.m_executionState)
-        {
-            const auto userData = AZStd::any_cast<const ScriptCanvas::RuntimeComponentUserData>(&graphInfo.m_executionState->GetUserData());
-            m_graphIdentifier = ScriptCanvas::GraphIdentifier(m_graphInfo.m_executionState->GetAssetId(), userData->component.GetId());
-        }
-        */
 
         // GeneralAssetNotificationBus::Handler::BusConnect(GetAssetId());
     }
@@ -523,12 +514,12 @@ namespace ScriptCanvasEditor
 
     const ScriptCanvas::GraphIdentifier& ExecutionLogTreeItem::GetGraphIdentifier() const
     {
-        return m_graphIdentifier;
+        return m_graphInfo.m_graphIdentifier;
     }
 
     AZ::Data::AssetId ExecutionLogTreeItem::GetAssetId() const
     {
-        return m_graphIdentifier.m_assetId;
+        return m_graphInfo.m_graphIdentifier.m_assetId;
     }
 
     AZ::EntityId ExecutionLogTreeItem::GetScriptCanvasAssetNodeId() const

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.h
@@ -192,7 +192,6 @@ namespace ScriptCanvasEditor
         LoggingDataId                       m_loggingDataId;
         ScriptCanvas::NodeTypeIdentifier    m_nodeType;
         ScriptCanvas::GraphInfo             m_graphInfo;
-        ScriptCanvas::GraphIdentifier       m_graphIdentifier;
         QString                             m_sourceEntityName;
         QString                             m_graphName;
         QString                             m_relativeGraphPath;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3561,7 +3561,7 @@ namespace ScriptCanvasEditor
         AZ::EntityId editorEntityId{};
 //         AssetTrackerRequestBus::BroadcastResult
 //             ( editorEntityId, &AssetTrackerRequests::GetEditorEntityIdFromSceneEntityId, assetId.Id(), assetNodeId);
-        // #sc_editor_asset_redux fix logger
+        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
         return editorEntityId;
     }
 
@@ -3571,7 +3571,7 @@ namespace ScriptCanvasEditor
         AZ::EntityId sceneEntityId{};
         // AssetTrackerRequestBus::BroadcastResult
         // ( sceneEntityId, &AssetTrackerRequests::GetSceneEntityIdFromEditorEntityId, assetId.Id(), editorNodeId);
-        // #sc_editor_asset_redux fix logger
+        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
         return sceneEntityId;
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
@@ -10,6 +10,7 @@
 #include "ExecutionNotificationsBus.h"
 
 #include <ScriptCanvas/Execution/ExecutionState.h>
+#include <ScriptCanvas/Execution/RuntimeComponent.h>
 
 namespace ScriptCanvas
 {
@@ -22,10 +23,15 @@ namespace ScriptCanvas
             NamedSlotId::Reflect(context);
 
             serializeContext->Class<GraphIdentifier>()
-
                 ->Version(0)
                 ->Field("uniqueIdentifier", &GraphIdentifier::m_componentId)
                 ->Field("assetId", &GraphIdentifier::m_assetId)
+                ;
+
+            serializeContext->Class<GraphInfo>()
+                ->Version(0)
+                ->Field("graphIdentifier", &GraphInfo::m_graphIdentifier)
+                ->Field("runtimeEntity", &GraphInfo::m_runtimeEntity)
                 ;
 
             serializeContext->Class<ActiveGraphStatus>()
@@ -37,10 +43,6 @@ namespace ScriptCanvas
                 ->Version(0)
                 ->Field("NamedEntityId", &ActiveEntityStatus::m_namedEntityId)
                 ->Field("ActiveGraphs", &ActiveEntityStatus::m_activeGraphs)
-                ;
-
-            serializeContext->Class<GraphInfo>()
-                ->Version(0)
                 ;
 
             serializeContext->Class<DatumValue>()
@@ -96,6 +98,7 @@ namespace ScriptCanvas
                 ;
 
             OutputSignal::Reflect(context);
+            ReturnSignal::Reflect(context);
             VariableChange::Reflect(context);
         }
     }
@@ -185,14 +188,34 @@ namespace ScriptCanvas
         return AZStd::string::format("Asset: %s, ComponentId: %llu", m_assetId.ToString<AZStd::string>().data(), m_componentId);
     }
 
+    GraphInfo::GraphInfo(ExecutionStateWeakConstPtr executionState)
+    {
+        const auto userData = AZStd::any_cast<const RuntimeComponentUserData>(&executionState->GetUserData());
+        if (!userData)
+        {
+            AZ_Error("GraphInfo", false, "Failed to get user data from graph. Constructed with invalid values");
+            return;
+        }
+
+        const GraphIdentifier graphIdentifier(executionState->GetAssetId(), userData->component.GetId());
+        m_graphIdentifier = graphIdentifier;
+        m_runtimeEntity = userData->entity;
+    }
+
+    GraphInfo::GraphInfo(const NamedActiveEntityId& runtimeEntity, const GraphIdentifier& graphIdentifier)
+        : m_runtimeEntity(runtimeEntity)
+        , m_graphIdentifier(graphIdentifier)
+    {
+    }
+
     bool GraphInfo::operator==(const GraphInfo& other) const
     {
-        return m_executionState == other.m_executionState;
+        return m_graphIdentifier == other.m_graphIdentifier;
     }
 
     AZStd::string GraphInfo::ToString() const
     {
-        return m_executionState->ToString();
+        return AZStd::string::format("GraphIdentifier: %s", m_graphIdentifier.ToString().data());
     }
 
     NodeStateChange::NodeStateChange()
@@ -283,7 +306,8 @@ namespace ScriptCanvas
 
     bool Signal::operator==(const Signal& other) const
     {
-        return m_executionState == other.m_executionState
+        return m_runtimeEntity == other.m_runtimeEntity
+            && m_graphIdentifier == other.m_graphIdentifier
             && m_endpoint == other.m_endpoint;
     }    
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.h
@@ -70,11 +70,12 @@ namespace ScriptCanvas
             //////////////////////////////////////////////////////////////////////////
             // ExecutionNotifications
             void GraphActivated(const GraphActivation&) override;
-            void GraphDeactivated(const GraphActivation&) override;
-            bool IsGraphObserved(const ExecutionState& executionState) override;
+            void GraphDeactivated(const GraphDeactivation&) override;
+            bool IsGraphObserved(const AZ::EntityId& entityId, const GraphIdentifier& identifier) override;
             bool IsVariableObserved(const VariableId& variableId) override;
             void NodeSignaledOutput(const OutputSignal&) override;
             void NodeSignaledInput(const InputSignal&) override;
+            void GraphSignaledReturn(const ReturnSignal&) override;
             void NodeStateUpdated(const NodeStateChange&) override;
             void RuntimeError(const ExecutionState& executionState, const AZStd::string_view& description) override;
             void VariableChanged(const VariableChange&) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionBus.h
@@ -37,7 +37,6 @@
 
 namespace ScriptCanvas
 {
-    GraphInfo CreateGraphInfo(ScriptCanvasId executionId, const GraphIdentifier& graphIdentifier);
     class ExecutionState;
 
     namespace Execution

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -27,11 +27,6 @@ namespace ScriptCanvas
         }
     }
 
-    ActivationInfo ExecutionStateHandler::CreateActivationInfo() const
-    {
-        return ActivationInfo(GraphInfo(m_executionState));
-    }
-
     void ExecutionStateHandler::Execute()
     {
 #if defined(SC_RUNTIME_CHECKS_ENABLED)
@@ -45,7 +40,8 @@ namespace ScriptCanvas
 #endif // defined(SC_RUNTIME_CHECKS_ENABLED)
         AZ_PROFILE_SCOPE(ScriptCanvas, "ExecutionStateHandler::Execute (%s)"
             , m_executionState->GetRuntimeDataOverrides().m_runtimeAsset.GetId().ToString<AZStd::string>().c_str());
-        SC_EXECUTION_TRACE_GRAPH_ACTIVATED(CreateActivationInfo());
+        ScriptCanvas::ExecutionNotificationsBus::Broadcast(
+            &ScriptCanvas::ExecutionNotifications::GraphActivated, ActivationInfo(GraphInfo(m_executionState)));
         SCRIPT_CANVAS_PERFORMANCE_SCOPE_EXECUTION(m_executionState);
         m_executionState->Execute();
     }
@@ -132,7 +128,8 @@ namespace ScriptCanvas
             m_executionState->StopExecution();
             Execution::Destruct(m_executionStateStorage);
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
-            SC_EXECUTION_TRACE_GRAPH_DEACTIVATED(CreateActivationInfo());
+            ScriptCanvas::ExecutionNotificationsBus::Broadcast(
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphActivation(GraphInfo(m_executionState)));
             m_executionState = nullptr;
         }
     }
@@ -142,7 +139,8 @@ namespace ScriptCanvas
         {
             m_executionState->StopExecution();
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
-            SC_EXECUTION_TRACE_GRAPH_DEACTIVATED(CreateActivationInfo());
+            ScriptCanvas::ExecutionNotificationsBus::Broadcast(
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(GraphInfo(m_executionState)));
         }
     }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.h
@@ -43,8 +43,6 @@ namespace ScriptCanvas
         /// Clears the Executable on destruction if required.
         ~ExecutionStateHandler();
 
-        ActivationInfo CreateActivationInfo() const;
-
         /** Executes if possible, fails an SC_RUNTIME_CHECK if not. */
         void Execute();
 


### PR DESCRIPTION
## What does this PR do?

Work on #9192, #2583, #17643, #10795. Script canvas logger can now show graph names and entity names. Code has been mostly restored to the Lumberyard's state.

GraphInfo class has been moved back to its old state so that it can be serialized (only used by the debugger to send remote messages, make no sense to hold a ptr to execution state there)

There are two things which still needs to be done to have all of the functionnalities back:
- Fix the focus on double click in log entry (broken by #6394 and for now I'm unsure if there is an alternative already in the engine to get a NodeId from its assetNodeId)
- Fill the entities tab with entities spawned and placed in the scene

https://github.com/o3de/o3de/assets/19243508/88626984-d114-49bc-883f-871cc0de1057

## How was this PR tested?

Locally against the newspaper sample project, with multiple graphs