### PR TITLE
Working splash screen in Linux GameLauncher

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,6 +1,6 @@
 [lfs]
 # Default LFS endpoint for this repository
-url=https://d3df09qsjufr6g.cloudfront.net/api/v1
+url=https://d3df09qsjufr6g.cloudfront.net/api/v1/fork/robotecai
 
 # To use the endpoint with your fork, run the following git command
 # in your local repository (without the '#'), replacing 'owner' with 
@@ -9,7 +9,7 @@ url=https://d3df09qsjufr6g.cloudfront.net/api/v1
 # git config lfs.url "https://d3df09qsjufr6g.cloudfront.net/api/v1/fork/owner"
 #
 # For example, if your fork is https://github.com/octocat/o3de use
-# git config lfs.url "https://d3df09qsjufr6g.cloudfront.net/api/v1/fork/octocat"
+# git config lfs.url "https://d3df09qsjufr6g.cloudfront.net/api/v1/fork/robotecai"
 #
 # IMPORTANT: authenticate with your GitHub username and personal access token
 # not your GitHub password

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
@@ -54,10 +54,13 @@ namespace AzFramework
         // Initialize all used atoms.
         void InitializeAtoms();
         void GetWMStates();
+        
+        void DrawSplash();
 
         xcb_connection_t* m_xcbConnection = nullptr;
         xcb_screen_t* m_xcbRootScreen = nullptr;
         xcb_window_t m_xcbWindow = 0;
+        xcb_gcontext_t m_xcbGraphicContext = 0;
         int32_t m_posX;
         int32_t m_posY;
         bool m_fullscreenState = false;

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/generate_splash_screen_header.cmake
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/generate_splash_screen_header.cmake
@@ -1,0 +1,50 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# If not set explicitly, look for a splash image in the project directory
+if(NOT DEFINED SPLASH_FILE)
+    # start by looking for file in the project directory
+    if(EXISTS ${PROJECT_SOURCE_DIR}/Resources/Splash.png)
+        set(SPLASH_FILE ${PROJECT_SOURCE_DIR}/Resources/Splash.png)
+    endif()
+    # if not found, assume it's engine centric build
+    if(DEFINED LY_PROJECTS)
+        if(EXISTS ${LY_PROJECTS}/Resources/Splash.png)
+            set(SPLASH_FILE ${LY_PROJECTS}/Resources/Splash.png)
+        endif()
+    endif ()
+endif()
+# If value is set, check if it exists and generate the header file
+if(DEFINED SPLASH_FILE)
+    # check if xdd is available
+    find_program(XXD xxd)
+    if(NOT XXD)
+        message(WARNING "xxd not found, no splash screen will be displayed"
+                " (install xxd to create splash screen header file)")
+        unset(SPLASH_FILE)
+    else()
+        file(TO_CMAKE_PATH ${SPLASH_FILE} SPLASH_FILE_RESOLVED_PATH)
+        # check if it's a png file
+        if(NOT ${SPLASH_FILE_RESOLVED_PATH} MATCHES ".*\\.png")
+            message(WARNING "Splash file must be a PNG image, omitting splash screen generation.")
+        else()
+            if(EXISTS ${SPLASH_FILE_RESOLVED_PATH})
+                execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${SPLASH_FILE_RESOLVED_PATH} ${CMAKE_BINARY_DIR}/Splash.png)
+                file(REMOVE ${CMAKE_BINARY_DIR}/Splash.h)
+                add_definitions(-DSPLASH_IMAGE_EXISTS)
+                execute_process(COMMAND xxd -i Splash.png Splash.h
+                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                )
+                include_directories(${CMAKE_BINARY_DIR})
+            else ()
+                message(WARNING "${SPLASH_FILE} not found, no splash screen will be displayed"
+                        " (set SPLASH_FILE to a valid path to a splash image to display it)")
+            endif()
+        endif()
+    endif()
+endif()

--- a/Code/Framework/AzFramework/Platform/Linux/platform_nativeui_linux.cmake
+++ b/Code/Framework/AzFramework/Platform/Linux/platform_nativeui_linux.cmake
@@ -18,6 +18,7 @@ if (${PAL_TRAIT_LINUX_WINDOW_MANAGER} STREQUAL "xcb")
     set(LY_FILES_CMAKE
         Platform/Common/Xcb/azframework_xcb_files.cmake
     )
+    include(Platform/Common/Xcb/generate_splash_screen_header.cmake)
     set(LY_BUILD_DEPENDENCIES
         PRIVATE
             3rdParty::X11::xcb
@@ -25,6 +26,8 @@ if (${PAL_TRAIT_LINUX_WINDOW_MANAGER} STREQUAL "xcb")
             3rdParty::X11::xcb_xfixes
             3rdParty::X11::xkbcommon
             3rdParty::X11::xkbcommon_X11
+            xcb-image
+            3rdParty::PNG
             xcb-xinput
     )
 

--- a/Templates/DefaultProject/Template/Resources/Splash.png
+++ b/Templates/DefaultProject/Template/Resources/Splash.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210ccc8dfbc7718f3a10a5c323108fb0dd29ec4911cc4e2bd3fa03d2cdc1bcb7
+size 44828

--- a/Templates/MinimalProject/Template/Resources/Splash.png
+++ b/Templates/MinimalProject/Template/Resources/Splash.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210ccc8dfbc7718f3a10a5c323108fb0dd29ec4911cc4e2bd3fa03d2cdc1bcb7
+size 44828

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -48,6 +48,7 @@ elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
         libxkbcommon-dev                        # For xcb keyboard input
         libxcb-xfixes0-dev                      # For mouse input
         libxcb-xinput-dev                       # For mouse input
+        libxcb-image0-dev                       # For xcb image support
         libpcre2-16-0
         zlib1g-dev
         mesa-common-dev


### PR DESCRIPTION
## What does this PR do?

This PR allows for setting of splash screen that is rendered using xcb, therefore it removes black screen while renderer is working.

Splash screen image is passed via xxd generated .h file during compilation, from png file named logo.png

The use of generic malloc for data vector and not AZ vectors is due to the fact that functions like xcb_destroy_image, expect ability to deallocate vector with data.

It adds dependency on libxcb-image0-dev


## How was this PR tested?

It was tested in debug builds, of project.
