### PR TITLE
Support PGM image format in ImageProcessingAtom.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingDefines.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingDefines.h
@@ -59,7 +59,8 @@ namespace ImageProcessingAtom
         "*.tga",
         "*.gif",
         "*.dds",
-        "*.exr"
+        "*.exr",
+        "*.pgm"
     };
     static constexpr int s_TotalSupportedImageExtensions = AZ_ARRAY_SIZE(s_SupportedImageExtensions);
 


### PR DESCRIPTION
## What does this PR do?

It enables PGM in Atom Image Builder. PGM is very simple grayscale format, that is useful with integration with some other software.

## How was this PR tested?

By loading the ocuppancy grid map created by [Navigation2](https://github.com/ros-navigation/navigation2) .
