### PR TITLE
[LUA Editor] Fix for 'function' keyword being interpreted as function name when syntax highlighting

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -589,7 +589,7 @@ namespace LUAEditor
         // Match methods and definitions. Any word which ends with '('
         {
             HighlightingRule rule;
-            rule.pattern = QRegularExpression(R"(\b[A-Za-z0-9_]+(?=\())");
+            rule.pattern = QRegularExpression(R"(\b(?!function\b)[A-Za-z0-9_]+(?=\())");
             rule.colorCB = [colors]()
             {
                 return colors->GetMethodColor();


### PR DESCRIPTION
## What does this PR do?

In the current regex pattern to detect functions, causes also the LUA keyword 'function' being interpreted as a function name. I assume this is not the intention.  This PR will introduce an exclude pattern for the 'function' keyword.

## How was this PR tested?

Tested on my local Ubuntu 22.04 LTS computer.

This is how it is now:

![image](https://github.com/o3de/o3de/assets/7720708/72613f9c-a4ef-44a8-b58e-a6ed670a0622)

apply this PR will make it:

![image](https://github.com/o3de/o3de/assets/7720708/9cf1579b-e3e0-43f1-ad7a-dbb973d7758e)


Best regards

Yaakuro