### PR TITLE
feat: remove legacy cry camera from trackview

### DIFF
--- a/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
+++ b/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
@@ -47,7 +47,6 @@ namespace
 {
     const STrackEntry g_trackEntries[] = {
         // Color for tracks
-        { AnimParamType::FOV, "FOV", QColor(220, 220, 220) },
         { AnimParamType::Position, "Pos", QColor(90, 150, 90) },
         { AnimParamType::Rotation, "Rot", QColor(90, 150, 90) },
         { AnimParamType::Scale, "Scale", QColor(90, 150, 90) },
@@ -363,7 +362,7 @@ bool CTVCustomizeTrackColorsDlg::Import(const QString& fullPath)
         // Get the entry index for this param type.
         const STrackEntry* pEntry = std::find_if(g_trackEntries, g_trackEntries + arraysize(g_trackEntries),
                 [=](const STrackEntry& entry)
-        { 
+        {
             return entry.paramType == paramType;
         });
         int entryIndex = static_cast<int>(pEntry - g_trackEntries);

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -490,7 +490,7 @@ CTrackViewAnimNode* CTrackViewAnimNode::CreateSubNode(
     CTrackViewAnimNode* newNode = animNodeFactory.BuildAnimNode(m_animSequence, newAnimNode, this);
 
     // Make sure that camera and entity nodes get created with an owner
-    AZ_Assert((animNodeType != AnimNodeType::Camera && animNodeType != AnimNodeType::Entity), "Entity node should have valid owner.");
+    AZ_Assert((animNodeType != AnimNodeType::Entity), "Entity node should have valid owner.");
 
     newNode->SetNodeEntityId(owner);
     newAnimNode->SetNodeOwner(newNode);
@@ -1287,17 +1287,6 @@ void CTrackViewAnimNode::AddCurrentLayer()
     const QString name = "Main";
 
     CreateSubNode(name, AnimNodeType::Entity);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CTrackViewAnimNode::SetAsViewCamera()
-{
-    assert (GetType() == AnimNodeType::Camera);
-
-    if (GetType() == AnimNodeType::Camera)
-    {
-        AZ_Error("CTrackViewAnimNode", false, "Legacy cameras are no longer supported.  Unable to set view camera.");
-    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewAnimNode.h
+++ b/Code/Editor/TrackView/TrackViewAnimNode.h
@@ -119,9 +119,6 @@ public:
     // Checks if anim node is part of active sequence and of an active director
     virtual bool IsActive();
 
-    // Set as view camera
-    virtual void SetAsViewCamera();
-
     // Name setter/getter
     AZStd::string GetName() const override { return m_animNode->GetName(); }
     virtual bool SetName(const char* pName) override;
@@ -224,7 +221,7 @@ public:
     virtual bool IsValidReparentingTo(CTrackViewAnimNode* pNewParent);
 
     int GetDefaultKeyTangentFlags() const { return m_animNode ? m_animNode->GetDefaultKeyTangentFlags() : SPLINE_KEY_TANGENT_UNIFIED; }
-    
+
     void SetComponent(AZ::ComponentId componentId, const AZ::Uuid& componentTypeId);
 
     // returns the AZ::ComponentId of the component associated with this node if it is of type AnimNodeType::Component, InvalidComponentId otherwise
@@ -234,7 +231,7 @@ public:
     void MarkAsModified() override;
     // ~IAnimNodeOwner
 
-    // Compares all of the node's track values at the given time with the associated property value and 
+    // Compares all of the node's track values at the given time with the associated property value and
     //     sets a key at that time if they are different to match the latter
     // Returns the number of keys set
     int SetKeysForChangedTrackValues(float time) { return m_animNode->SetKeysForChangedTrackValues(time); }
@@ -252,7 +249,7 @@ public:
     // AZ::EntityBus
     void OnEntityActivated(const AZ::EntityId& entityId) override;
     void OnEntityDestruction(const AZ::EntityId& entityId) override;
-    //~AZ::EntityBus 
+    //~AZ::EntityBus
 
     //////////////////////////////////////////////////////////////////////////
     //! AZ::TransformNotificationBus::Handler

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -486,11 +486,7 @@ int CTrackViewNodesCtrl::GetIconIndexForTrack(const CTrackViewTrack* pTrack) con
 
     AnimParamType type = paramType.GetType();
 
-    if (type == AnimParamType::FOV)
-    {
-        nImage = 2;
-    }
-    else if (type == AnimParamType::Position)
+    if (type == AnimParamType::Position)
     {
         nImage = 3;
     }
@@ -1003,14 +999,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
 
     float scrollPos = SaveVerticalScrollPos();
 
-    if (cmd == eMI_SetAsViewCamera)
-    {
-        if (animNode && animNode->GetType() == AnimNodeType::Camera)
-        {
-            animNode->SetAsViewCamera();
-        }
-    }
-    else if (cmd == eMI_RemoveSelected)
+    if (cmd == eMI_RemoveSelected)
     {
         // If we are about to delete the sequence, cancel the notification
         // context, otherwise it will notify on a stale sequence pointer.
@@ -1220,18 +1209,6 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 groupNode->GetAnimNodesByType(AnimNodeType::AzEntity).CollapseAll();
                 undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
             }
-            else if (cmd == eMI_ExpandCameras)
-            {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Expand Track View cameras");
-                groupNode->GetAnimNodesByType(AnimNodeType::Camera).ExpandAll();
-                undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
-            }
-            else if (cmd == eMI_CollapseCameras)
-            {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Collapse Track View cameras");
-                groupNode->GetAnimNodesByType(AnimNodeType::Camera).CollapseAll();
-                undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
-            }
             else if (cmd == eMI_ExpandEvents)
             {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Expand Track View events");
@@ -1244,7 +1221,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 groupNode->GetAnimNodesByType(AnimNodeType::Event).CollapseAll();
                 undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
             }
-        }  
+        }
     }
 
     if (cmd == eMI_EditEvents)
@@ -1666,11 +1643,6 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
 
         contextMenu.main.addAction("Select In Viewport")->setData(eMI_SelectInViewport);
 
-        if (animNode->GetType() == AnimNodeType::Camera)
-        {
-            contextMenu.main.addAction("Set As View Camera")->setData(eMI_SetAsViewCamera);
-        }
-
         bAppended = true;
     }
 
@@ -1994,7 +1966,7 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
     int paramCount = 0;
     IAnimNode::AnimParamInfos animatableProperties;
     CTrackViewNode* parentNode = animNode->GetParentNode();
-   
+
     // all AZ::Entity entities are animated through components. Component nodes always have a parent - the containing AZ::Entity
     if (nodeType == AnimNodeType::Component && parentNode)
     {
@@ -2007,19 +1979,19 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
             const AZ::EntityId azEntityId = static_cast<CTrackViewAnimNode*>(parentNode)->GetAzEntityId();
 
             // query the animatable component properties from the Sequence Component
-            Maestro::EditorSequenceComponentRequestBus::Event(const_cast<CTrackViewAnimNode*>(animNode)->GetSequence()->GetSequenceComponentEntityId(), 
-                                                                    &Maestro::EditorSequenceComponentRequestBus::Events::GetAllAnimatablePropertiesForComponent, 
+            Maestro::EditorSequenceComponentRequestBus::Event(const_cast<CTrackViewAnimNode*>(animNode)->GetSequence()->GetSequenceComponentEntityId(),
+                                                                    &Maestro::EditorSequenceComponentRequestBus::Events::GetAllAnimatablePropertiesForComponent,
                                                                     animatableProperties, azEntityId, animNode->GetComponentId());
 
             paramCount = static_cast<int>(animatableProperties.size());
-        }       
+        }
     }
     else
     {
         // legacy Entity
-        paramCount = animNode->GetParamCount(); 
+        paramCount = animNode->GetParamCount();
     }
-    
+
     for (int i = 0; i < paramCount; ++i)
     {
         CAnimParamType paramType;
@@ -2081,9 +2053,9 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
             pParamNode->paramType = paramType;
 
             bTracksToAdd = true;
-        }  
+        }
     }
-    
+
     return bTracksToAdd;
 }
 
@@ -2422,7 +2394,7 @@ void CTrackViewNodesCtrl::ClearCustomTrackColor(CTrackViewTrack* pTrack)
     }
 
     AzToolsFramework::ScopedUndoBatch undoBatch("Clear Custom Track Color");
-    
+
     pTrack->ClearCustomColor();
     undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
 

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -1750,8 +1750,6 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
             contextMenu.collapseSub.addAction("Collapse Folders")->setData(eMI_CollapseFolders);
             contextMenu.expandSub.addAction("Expand Entities")->setData(eMI_ExpandEntities);
             contextMenu.collapseSub.addAction("Collapse Entities")->setData(eMI_CollapseEntities);
-            contextMenu.expandSub.addAction("Expand Cameras")->setData(eMI_ExpandCameras);
-            contextMenu.collapseSub.addAction("Collapse Cameras")->setData(eMI_CollapseCameras);
             contextMenu.expandSub.addAction("Expand Events")->setData(eMI_ExpandEvents);
             contextMenu.collapseSub.addAction("Collapse Events")->setData(eMI_CollapseEvents);
         }

--- a/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
@@ -22,7 +22,7 @@ enum class AnimNodeType
     Invalid                   = 0x00,
     Entity                    = 0x01,       // Legacy Cry Entities (CE is AzEntity)
     Director                  = 0x02,
-    Camera                    = 0x03,       // Legacy Cry Camera Object
+    //Camera                    = 0x03,       // Legacy Cry Camera Object
     CVar                      = 0x04,
     ScriptVar                 = 0x05,
     Material                  = 0x06,

--- a/Code/Legacy/CryCommon/Maestro/Types/AnimParamType.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AnimParamType.h
@@ -24,7 +24,7 @@ enum class AnimParamType
     // Parameter is specified by string. See CAnimParamType
     ByString                         = 8,
 
-    FOV                              = 0,
+    //FOV                              = 0,
     Position                         = 1,
     Rotation                         = 2,
     Scale                            = 3,

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -85,7 +85,6 @@ void CMovieSystem::RegisterNodeTypes()
 {
     REGISTER_NODE_TYPE(Entity)
     REGISTER_NODE_TYPE(Director)
-    REGISTER_NODE_TYPE(Camera)
     REGISTER_NODE_TYPE(CVar)
     REGISTER_NODE_TYPE(ScriptVar)
     REGISTER_NODE_TYPE(Material)
@@ -109,13 +108,11 @@ void CMovieSystem::RegisterNodeTypes()
 // If you get an assert in this function, it means two param types have the same enum value.
 void CMovieSystem::RegisterParamTypes()
 {
-    REGISTER_PARAM_TYPE(FOV)
     REGISTER_PARAM_TYPE(Position)
     REGISTER_PARAM_TYPE(Rotation)
     REGISTER_PARAM_TYPE(Scale)
     REGISTER_PARAM_TYPE(Event)
     REGISTER_PARAM_TYPE(Visibility)
-    REGISTER_PARAM_TYPE(Camera)
     REGISTER_PARAM_TYPE(Animation)
     REGISTER_PARAM_TYPE(Sound)
     REGISTER_PARAM_TYPE(Sequence)
@@ -552,27 +549,6 @@ int CMovieSystem::OnCameraRenamed(const char* before, const char* after)
                 }
             }
             break;
-        }
-    }
-
-    // For every sequence,
-    for (Sequences::iterator it = m_sequences.begin(); it != m_sequences.end(); ++it)
-    {
-        // Find camera nodes.
-        for (int k = 0; k < (*it)->GetNodeCount(); ++k)
-        {
-            IAnimNode* node = (*it)->GetNode(k);
-
-            if (node->GetType() != AnimNodeType::Camera)
-            {
-                continue;
-            }
-
-            // Update its name, if it's a corresponding one.
-            if (_stricmp(node->GetName(), before) == 0)
-            {
-                node->SetName(after);
-            }
         }
     }
 

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
@@ -867,11 +867,7 @@ void CAnimSceneNode::ApplyCameraKey(ISelectKey& key, SAnimContext& ec)
                 prevCameraAnimNode = m_pSequence->FindNodeByName(prevKey.szSelection.c_str(), nullptr);
             }
 
-            if (prevCameraAnimNode && prevCameraAnimNode->GetType() == AnimNodeType::Camera && prevCameraAnimNode->GetTrackForParameter(AnimParamType::FOV))
-            {
-                prevCameraAnimNode->SetParamValue(ec.time, AnimParamType::FOV, stashedData.m_FoV);
-            }
-            else if (prevSceneCamera)
+            if (prevSceneCamera)
             {
                 prevSceneCamera->SetNearZAndFOVIfChanged(DEG2RAD(stashedData.m_FoV), stashedData.m_nearZ);
             }


### PR DESCRIPTION
## What does this PR do?

removed the cry legacy camera. I can't see a way to create this type of node in the editor. I don't think there is currently a way to use this node. shouldn't hurt to remove all the code associated with the legacy camera. 
