### PR TITLE
feat: remove ScriptTable entires in AnimNode

### DIFF
--- a/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
+++ b/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
@@ -22,8 +22,6 @@
 //////////////////////////////////////////////////////////////////////////
 namespace
 {
-    const char* kScriptTablePrefix = "ScriptTable:";
-
     AZStd::array<CUiAnimNode::SParamInfo, 1> s_nodeParams{ { {
         /*.name =*/"Component Field float",
         /*.paramType =*/eUiAnimParamType_AzComponentField,
@@ -336,12 +334,6 @@ AZStd::string CUiAnimAzEntityNode::GetParamName(const CUiAnimParamType& param) c
         return info.name;
     }
 
-    const char* pName = param.GetName();
-    if (param.GetType() == eUiAnimParamType_ByString && pName && strncmp(pName, kScriptTablePrefix, strlen(kScriptTablePrefix)) == 0)
-    {
-        return pName + strlen(kScriptTablePrefix);
-    }
-
     return "Unknown Entity Parameter";
 }
 
@@ -360,12 +352,6 @@ AZStd::string CUiAnimAzEntityNode::GetParamNameForTrack(const CUiAnimParamType& 
     if (GetParamInfoFromType(param, info))
     {
         return info.name;
-    }
-
-    const char* pName = param.GetName();
-    if (param.GetType() == eUiAnimParamType_ByString && pName && strncmp(pName, kScriptTablePrefix, strlen(kScriptTablePrefix)) == 0)
-    {
-        return pName + strlen(kScriptTablePrefix);
     }
 
     return "Unknown Entity Parameter";

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -56,11 +56,6 @@ static const EAnimCurveType DEFAULT_TRACK_TYPE = eAnimCurveType_BezierFloat;
 // Old serialization values that are no longer
 // defined in IMovieSystem.h, but needed for conversion:
 static const int OLD_ACURVE_GOTO = 21;
-static const int OLD_APARAM_PARTICLE_COUNT_SCALE = 95;
-static const int OLD_APARAM_PARTICLE_PULSE_PERIOD = 96;
-static const int OLD_APARAM_PARTICLE_SCALE = 97;
-static const int OLD_APARAM_PARTICLE_SPEED_SCALE = 98;
-static const int OLD_APARAM_PARTICLE_STRENGTH = 99;
 
 //////////////////////////////////////////////////////////////////////////
 // CAnimNode.
@@ -537,57 +532,6 @@ void CAnimNode::SerializeAnims(XmlNodeRef& xmlNode, bool bLoading, bool bLoadEmp
             {
                 // APARAM_USER 100 => 100000
                 paramType = static_cast<AnimParamType>(static_cast<int>(paramType.GetType()) + static_cast<int>(AnimParamType::User) - OLD_APARAM_USER);
-            }
-
-            if (paramTypeVersion <= 4)
-            {
-                // In old versions there was special code for particles
-                // that is now handles by generic entity node code
-                switch (paramType.GetType())
-                {
-                case static_cast<AnimParamType>(OLD_APARAM_PARTICLE_COUNT_SCALE) :
-                    paramType = CAnimParamType("ScriptTable:Properties/CountScale");
-                    break;
-                case static_cast<AnimParamType>(OLD_APARAM_PARTICLE_PULSE_PERIOD) :
-                    paramType = CAnimParamType("ScriptTable:Properties/PulsePeriod");
-                    break;
-                case static_cast<AnimParamType>(OLD_APARAM_PARTICLE_SCALE) :
-                    paramType = CAnimParamType("ScriptTable:Properties/Scale");
-                    break;
-                case static_cast<AnimParamType>(OLD_APARAM_PARTICLE_SPEED_SCALE) :
-                    paramType = CAnimParamType("ScriptTable:Properties/SpeedScale");
-                    break;
-                case static_cast<AnimParamType>(OLD_APARAM_PARTICLE_STRENGTH):
-                    paramType = CAnimParamType("ScriptTable:Properties/Strength");
-                    break;
-                }
-            }
-
-            if (paramTypeVersion <= 5 && !(GetSequence()->GetFlags() & IAnimSequence::eSeqFlags_LightAnimationSet))
-            {
-                // In old versions there was special code for lights that is now handled
-                // by generic entity node code if this is not a light animation set sequence
-                switch (paramType.GetType())
-                {
-                case AnimParamType::LightDiffuse:
-                    paramType = CAnimParamType("ScriptTable:Properties/Color/clrDiffuse");
-                    break;
-                case AnimParamType::LightRadius:
-                    paramType = CAnimParamType("ScriptTable:Properties/Radius");
-                    break;
-                case AnimParamType::LightDiffuseMult:
-                    paramType = CAnimParamType("ScriptTable:Properties/Color/fDiffuseMultiplier");
-                    break;
-                case AnimParamType::LightHDRDynamic:
-                    paramType = CAnimParamType("ScriptTable:Properties/Color/fHDRDynamic");
-                    break;
-                case AnimParamType::LightSpecularMult:
-                    paramType = CAnimParamType("ScriptTable:Properties/Color/fSpecularMultiplier");
-                    break;
-                case AnimParamType::LightSpecPercentage:
-                    paramType = CAnimParamType("ScriptTable:Properties/Color/fSpecularPercentage");
-                    break;
-                }
             }
 
             if (paramTypeVersion <= 7 && paramType.GetType() == AnimParamType::Physics)
@@ -1165,8 +1109,8 @@ void CAnimNode::AnimateSound(std::vector<SSoundInfo>& nodeSoundInfo, SAnimContex
 }
 
 void CAnimNode::SetParent(IAnimNode* parent)
-{ 
-    m_pParentNode = parent; 
+{
+    m_pParentNode = parent;
     if (parent)
     {
         m_parentNodeId = static_cast<CAnimNode*>(m_pParentNode)->GetId();
@@ -1205,7 +1149,7 @@ void CAnimNode::UpdateDynamicParams()
         // which could happen from multiple threads. Lock to avoid a crash iterating over the lua stack
         AZStd::lock_guard<AZStd::mutex> lock(m_updateDynamicParamsLock);
 
-        // run this on the main thread to prevent further threading issues downstream in 
+        // run this on the main thread to prevent further threading issues downstream in
         // AnimNodes that may use EBuses that are not thread safe
         if (gEnv && gEnv->mMainThreadId == CryGetCurrentThreadId())
         {


### PR DESCRIPTION
## What does this PR do?

Remove ScriptTable entries in from AnimNode. Looks like these properties refer to variables for EntityObject. I don't see an upgrade path from here.  umm, do these fields ever map  correctly?
