### PR TITLE
libxcb-image0-dev  and xxd added to dependencies of build nodes

### DIFF
--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -20,6 +20,8 @@ libxkbcommon-x11-dev                    # For xcb keyboard input
 libxkbcommon-dev                        # For xcb keyboard input
 libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
+libxcb-image0-dev                       # For xcb image support
+xxd
 zlib1g-dev
 mesa-common-dev
 libunwind-dev

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -19,6 +19,8 @@ libxkbcommon-x11-dev                    # For xcb keyboard input
 libxkbcommon-dev                        # For xcb keyboard input
 libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
+libxcb-image0-dev                       # For xcb image support
+xxd
 zlib1g-dev
 mesa-common-dev
 ros-humble-ackermann-msgs 

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
@@ -19,6 +19,8 @@ libxkbcommon-x11-dev                    # For xcb keyboard input
 libxkbcommon-dev                        # For xcb keyboard input
 libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
+libxcb-image0-dev                       # For xcb image support
+xxd
 zlib1g-dev
 mesa-common-dev
 ros-humble-ackermann-msgs               # ROS2 development tools


### PR DESCRIPTION
## What does this PR do?

It modifies build nodes in preparation for another pr https://github.com/o3de/o3de/pull/17913

## How was this PR tested?

I checked correctness of package names
