### PR TITLE
Fixes crash bugs and improves performance when editing entity properties

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -60,15 +60,14 @@ namespace AzToolsFramework
     //! Return true to accept this type of component.
     using ComponentFilter = AZStd::function<bool(const AZ::SerializeContext::ClassData&)>;
 
-    // when a property is modified, we attempt to retrieve the value that comes out in response to the Property Modification function that you may supply
-    // if you return anything other than Refresh_None, the tree may be queued for update:
+    //! Controls how much to rebuild the property display when a change is made
     enum PropertyModificationRefreshLevel : int
     {
-        Refresh_None,
-        Refresh_Values,
-        Refresh_AttributesAndValues,
-        Refresh_EntireTree,
-        Refresh_EntireTree_NewContent,
+        Refresh_None,                   //! No refresh is required
+        Refresh_Values,                 //! Repopulate the values from components into the UI
+        Refresh_AttributesAndValues,    //! In addition to the above, also check if attributes such as visibility have changed
+        Refresh_EntireTree,             //! Discard the entire UI and rebuild it from scratch
+        Refresh_EntireTree_NewContent,  //! In addition to the above, scroll to the bottom of the view.
     };
 
     /**
@@ -155,9 +154,18 @@ namespace AzToolsFramework
         virtual void OnEndUndo(const char* /*label*/, bool /*changed*/) {}
 
         /*!
-         * Notify property UI to refresh the property tree.
+         * Notify property UI to refresh the property tree.  Note that this will go out to every
+         * property UI control in every window in the entire application, and using the below function if you can
+         * will yield faster results.
          */
         virtual void InvalidatePropertyDisplay(PropertyModificationRefreshLevel /*level*/) {}
+
+        /*!
+         * Notify property UI to refresh the properties displayed for a specific component.
+         * You should prefer to use this call over the above one, except in circumstances where
+         * you need to refresh every UI element in every property tree in every window in the entire application.
+         */
+        virtual void InvalidatePropertyDisplayForComponent(AZ::EntityComponentIdPair /*entityComponentIdPair*/, PropertyModificationRefreshLevel /*level*/) {}
 
         /*!
          * Process source control status for the specified file.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -155,8 +155,8 @@ namespace AzToolsFramework
 
         /*!
          * Notify property UI to refresh the property tree.  Note that this will go out to every
-         * property UI control in every window in the entire application, and using the below function if you can
-         * will yield faster results.
+         * property UI control in every window in the entire application.
+         * Use InvalidatePropertyDisplayForComponent() instead when possible for faster results.
          */
         virtual void InvalidatePropertyDisplay(PropertyModificationRefreshLevel /*level*/) {}
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -366,13 +366,17 @@ namespace AzToolsFramework
         void ComponentModeDelegate::OnEntityVisibilityChanged(bool /*visibility*/)
         {
             ToolsApplicationNotificationBus::Broadcast(
-                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_AttributesAndValues);
+                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                m_entityComponentIdPair,
+                Refresh_AttributesAndValues);
         }
 
         void ComponentModeDelegate::OnEntityLockChanged(bool /*locked*/)
         {
             ToolsApplicationNotificationBus::Broadcast(
-                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_AttributesAndValues);
+                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                m_entityComponentIdPair,
+                Refresh_AttributesAndValues);
         }
     } // namespace ComponentModeFramework
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
@@ -46,12 +46,13 @@ namespace AzToolsFramework
             {
                 ToolsApplicationRequests::Bus::Broadcast(
                     &ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityComponentId.GetEntityId());
+                ToolsApplicationNotificationBus::Broadcast(
+                    &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                    entityComponentId,
+                    Refresh_Values);
             }
 
             (*this.*m_onLeftMouseDownImpl)(interaction, rayIntersectionDistance);
-
-            ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
-
             return true;
         }
 
@@ -72,12 +73,13 @@ namespace AzToolsFramework
             {
                 ToolsApplicationRequests::Bus::Broadcast(
                     &ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityComponentId.GetEntityId());
+                ToolsApplicationNotificationBus::Broadcast(
+                    &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                    entityComponentId,
+                    Refresh_Values);
+
             }
-
             (*this.*m_onRightMouseDownImpl)(interaction, rayIntersectionDistance);
-
-            ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
-
             return true;
         }
 
@@ -121,7 +123,13 @@ namespace AzToolsFramework
     {
         OnMouseWheelImpl(interaction);
 
-        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
+        for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
+        {
+            ToolsApplicationNotificationBus::Broadcast(
+                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                entityComponentId,
+                Refresh_Values);
+        }
     }
 
     void BaseManipulator::OnMouseMove(const ViewportInteraction::MouseInteraction& interaction)
@@ -136,7 +144,13 @@ namespace AzToolsFramework
         }
 
         // ensure property grid (entity inspector) values are refreshed
-        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
+        for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
+        {
+            ToolsApplicationNotificationBus::Broadcast(
+                &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                entityComponentId,
+                Refresh_Values);
+        }
 
         OnMouseMoveImpl(interaction);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -275,7 +275,9 @@ namespace AzToolsFramework
         OnEntityComponentPropertyChanged(entityComponentIdPair);
 
         // ensure property grid values are refreshed
-        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
+        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+            entityComponentIdPair,
+            Refresh_EntireTree);
     }
 
     template<typename Vertex>
@@ -336,7 +338,10 @@ namespace AzToolsFramework
         OnEntityComponentPropertyChanged(GetEntityComponentIdPair());
 
         // ensure property grid values are refreshed
-        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
+        ToolsApplicationNotificationBus::Broadcast(
+            &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent, 
+            GetEntityComponentIdPair(),
+            Refresh_Values);
     }
 
     // iterate over all vertices currently associated with the translation manipulator and update their

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.cpp
@@ -176,6 +176,14 @@ namespace AzToolsFramework
             return AzToolsFramework::IsSelected(GetEntityId());
         }
 
+        void EditorComponentBase::InvalidatePropertyDisplay(PropertyModificationRefreshLevel refreshFlags)
+        {
+            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplayForComponent,
+                AZ::EntityComponentIdPair(GetEntityId(), GetId()), 
+                static_cast<PropertyModificationRefreshLevel>(refreshFlags));
+        }
+
         void EditorComponentBase::SetSerializedIdentifier(AZStd::string alias)
         {
             m_alias = alias;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
@@ -19,9 +19,6 @@
 #pragma once
 
 #include <AzCore/base.h>
-#include <AzCore/Asset/AssetCommon.h>
-#include <AzCore/Math/Crc.h>
-#include <AzCore/Math/Transform.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/Entity.h>
@@ -31,10 +28,19 @@ class QMenu;
 namespace AZ
 {
     class Vector2;
+    class TransformInterface;
+    class Transform;
+
+    namespace Data
+    {
+        struct AssetId;
+    }
 }
 
 namespace AzToolsFramework
 {
+    enum PropertyModificationRefreshLevel : int;
+
     namespace Components
     {        
         /**
@@ -163,6 +169,18 @@ namespace AzToolsFramework
              * Otherwise, false.
              */
             bool IsSelected() const;
+
+            /** 
+             * Invoke this to refresh the property display for the component.
+             * Only refreshes the ui for this component, not adjacent ones, which is faster than
+             * asking for complete full tree refresh of every entity in every inspector on every
+             * component.
+             * See @ref AzToolsFramework::RefreshType for the different types of refreshes.
+             * @ref Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+             * @param refreshFlags The type of refresh to perform.
+             *   (Most common is either Refresh_EntireTree or Refresh_Values).
+             */
+            void InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel refreshFlags);
 
             /**
              * Override this function to create one or more game components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h> // for Entity::ComponentArrayType
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h> // for Entity::ComponentArrayType
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -782,7 +782,7 @@ namespace AzToolsFramework
                 m_scriptComponent.m_context->GetDebugContext()->ConnectHook();
             }
 
-            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
+            InvalidatePropertyDisplay(Refresh_EntireTree);
             ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
         }
 
@@ -842,7 +842,7 @@ namespace AzToolsFramework
 
             SortProperties(m_scriptComponent.m_properties);
 
-            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, Refresh_EntireTree);
+            InvalidatePropertyDisplay(Refresh_EntireTree);
         }
 
         void ScriptEditorComponent::ClearDataElements()
@@ -862,9 +862,7 @@ namespace AzToolsFramework
             // edited, so a refresh is at best superfluous, and at worst could cause a feedback loop of infinite refreshes.
             if (GetEntity())
             {
-                AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                    &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, 
-                    AzToolsFramework::Refresh_EntireTree);
+                InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -303,21 +303,12 @@ namespace AzToolsFramework
                 {
                     boundsUnion->OnTransformUpdated(GetEntity());
                 }
-                // Fire a property changed notification for this component
+                // Fire a property changed notification for this component.  This will cascade to updating the UI.  It is not
+                // necessary to notify the UI directly.
                 if (const AZ::Component* component = entity->FindComponent<Components::TransformComponent>())
                 {
                     PropertyEditorEntityChangeNotificationBus::Event(
                         GetEntityId(), &PropertyEditorEntityChangeNotifications::OnEntityComponentPropertyChanged, component->GetId());
-                }
-
-                // Refresh the property editor if we're selected
-                bool selected = false;
-                ToolsApplicationRequestBus::BroadcastResult(
-                    selected, &AzToolsFramework::ToolsApplicationRequests::IsSelected, GetEntityId());
-                if (selected)
-                {
-                    ToolsApplicationEvents::Bus::Broadcast(
-                        &ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
                 }
             }
         }
@@ -1048,9 +1039,7 @@ namespace AzToolsFramework
         // This is called when our transform changes static state.
         AZ::u32 TransformComponent::StaticChangedInspector()
         {
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay,
-                AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
            
             if (GetEntity())
             {
@@ -1320,7 +1309,7 @@ namespace AzToolsFramework
                         SetDirty();
                     }
 
-                    AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+                    InvalidatePropertyDisplay(AzToolsFramework::Refresh_Values);
                 });
                 resetAction->setEnabled(!m_editorTransform.m_locked && !parentEntityIsReadOnly);
 
@@ -1332,7 +1321,7 @@ namespace AzToolsFramework
                         m_editorTransform.m_locked = !m_editorTransform.m_locked;
                         SetDirty();
                     }
-                    AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+                    InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
                 });
                 lockAction->setEnabled(!parentEntityIsReadOnly);
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -47,6 +47,14 @@ namespace AZ::DocumentPropertyEditor
         RequestRefresh(level);
     }
 
+    void ComponentAdapter::InvalidatePropertyDisplayForComponent(AZ::EntityComponentIdPair entityComponentIdPair, AzToolsFramework::PropertyModificationRefreshLevel level)
+    {
+        if ((entityComponentIdPair.GetEntityId() == m_entityId) && (entityComponentIdPair.GetComponentId() == m_componentId))
+        {
+            RequestRefresh(level);
+        }
+    }
+
     void ComponentAdapter::RequestRefresh(AzToolsFramework::PropertyModificationRefreshLevel level)
     {
         if (level > m_queuedRefreshLevel)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -40,6 +40,9 @@ namespace AZ::DocumentPropertyEditor
         // AzToolsFramework::ToolsApplicationEvents::Bus overrides
         void InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel level) override;
 
+        // AzToolsFramework::ToolsApplicationEvents::Bus overrides
+        void InvalidatePropertyDisplayForComponent(AZ::EntityComponentIdPair entityComponentIdPair, AzToolsFramework::PropertyModificationRefreshLevel level) override;
+
         // AzToolsFramework::PropertyEditorGUIMessages::Bus overrides
         void RequestRefresh(AzToolsFramework::PropertyModificationRefreshLevel level) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -875,10 +875,12 @@ namespace AzToolsFramework
 
     void EntityOutlinerWidget::OnSelectEntity(const AZ::EntityId& entityId, bool selected)
     {
+        bool selectionChanged = false;
         if (selected)
         {
             if (m_entitiesSelectedByOutliner.find(entityId) == m_entitiesSelectedByOutliner.end())
             {
+                selectionChanged = true;
                 m_entitiesToSelect.insert(entityId);
                 m_entitiesToDeselect.erase(entityId);
             }
@@ -887,11 +889,15 @@ namespace AzToolsFramework
         {
             if (m_entitiesDeselectedByOutliner.find(entityId) == m_entitiesDeselectedByOutliner.end())
             {
+                selectionChanged = true;
                 m_entitiesToSelect.erase(entityId);
                 m_entitiesToDeselect.insert(entityId);
             }
         }
-        QueueUpdateSelection();
+        if (selectionChanged)
+        {
+            QueueUpdateSelection();
+        }
     }
 
     void EntityOutlinerWidget::OnEnableSelectionUpdates(bool enable)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -605,7 +605,7 @@ namespace AzToolsFramework
 
     void ComponentEditor::QueuePropertyEditorInvalidationForComponent(AZ::EntityComponentIdPair entityComponentIdPair, PropertyModificationRefreshLevel refreshLevel)
     {
-        for (auto component : m_components)
+        for (const auto component : m_components)
         {
             if ((component->GetId() == entityComponentIdPair.GetComponentId()) 
              && (component->GetEntityId() == entityComponentIdPair.GetEntityId()))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -603,6 +603,19 @@ namespace AzToolsFramework
         GetPropertyEditor()->QueueInvalidation(refreshLevel);
     }
 
+    void ComponentEditor::QueuePropertyEditorInvalidationForComponent(AZ::EntityComponentIdPair entityComponentIdPair, PropertyModificationRefreshLevel refreshLevel)
+    {
+        for (auto component : m_components)
+        {
+            if ((component->GetId() == entityComponentIdPair.GetComponentId()) 
+             && (component->GetEntityId() == entityComponentIdPair.GetEntityId()))
+            {
+                GetPropertyEditor()->QueueInvalidation(refreshLevel);
+                break;
+            }
+        }
+    }
+
     void ComponentEditor::CancelQueuedRefresh()
     {
         GetPropertyEditor()->CancelQueuedRefresh();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -83,6 +83,8 @@ namespace AzToolsFramework
         void SetFilterString(AZStd::string filterString);
         void InvalidateAll(const char* filter = nullptr);
         void QueuePropertyEditorInvalidation(PropertyModificationRefreshLevel refreshLevel);
+        void QueuePropertyEditorInvalidationForComponent(AZ::EntityComponentIdPair entityComponentIdPair, PropertyModificationRefreshLevel refreshLevel);
+        
         void CancelQueuedRefresh();
         void PreventRefresh(bool shouldPrevent);
         void contextMenuEvent(QContextMenuEvent *event) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -227,6 +227,7 @@ namespace AzToolsFramework
             const AzToolsFramework::EntityIdList& newlySelectedEntities,
             const AzToolsFramework::EntityIdList& newlyDeselectedEntities) override;
         void InvalidatePropertyDisplay(PropertyModificationRefreshLevel level) override;
+        void InvalidatePropertyDisplayForComponent(AZ::EntityComponentIdPair componentId, PropertyModificationRefreshLevel level) override;
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////
@@ -621,6 +622,9 @@ namespace AzToolsFramework
         bool m_isAlreadyQueuedRefresh;
         bool m_shouldScrollToNewComponents;
         bool m_shouldScrollToNewComponentsQueued;
+
+        int m_savedVerticalScroll = -1;
+        int m_savedHorizontalScroll = -1;
 
         AZStd::string m_filterString;
 

--- a/Code/Framework/AzToolsFramework/Tests/ManipulatorCoreTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ManipulatorCoreTests.cpp
@@ -155,8 +155,9 @@ namespace UnitTest
             m_editorEntityComponentChangeDetector->m_componentIds,
             UnorderedElementsAre(m_transformComponentId, m_lockComponentId, m_visibiltyComponentId));
 
-        EXPECT_TRUE(m_editorEntityComponentChangeDetector->PropertyDisplayInvalidated());
-        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // note that manipulators talk to property editor components directly via the above call, which causes
+        // an automatic invalidation of the property editor UI for that entity/component pair in all windows where
+        // it is present.  It is not necessary to broadcast a message to invalidate anything else.
     }
 
     using ManipulatorCoreInteractionFixture = DirectCallManipulatorViewportInteractionFixtureMixin<ManipulatorCoreFixture>;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -277,8 +277,7 @@ namespace AZ
 
             MaterialComponentNotificationBus::Event(GetEntityId(), &MaterialComponentNotifications::OnMaterialsEdited);
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
         }
 
         void EditorMaterialComponent::OnMaterialsCreated(const MaterialAssignmentMap& materials)
@@ -361,8 +360,7 @@ namespace AZ
 
             MaterialComponentNotificationBus::Event(GetEntityId(), &MaterialComponentNotifications::OnMaterialsEdited);
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
 
         AZ::u32 EditorMaterialComponent::OpenMaterialExporterFromRPE()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -258,9 +258,7 @@ namespace AZ
             }
 
             // Refresh the tree when the model loads to update UI based on the model.
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
-                AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
 
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
@@ -323,9 +323,7 @@ namespace AZ
             m_controller.OnConfigChanged();
 
             m_generatedLutAbsolutePath = resolvedOutputFilePath + AZStd::string(".azasset");
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-                AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
 
             EditorHDRColorGradingNotificationBus::Event(GetEntityId(), &EditorHDRColorGradingNotificationBus::Handler::OnGenerateLutCompleted, m_generatedLutAbsolutePath);
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/EditorReflectionProbeComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/EditorReflectionProbeComponent.cpp
@@ -162,11 +162,13 @@ namespace AZ
 
             AZ::u64 entityId = (AZ::u64)GetEntityId();
             configuration.m_entityId = entityId;
+            AZ::EntityComponentIdPair entityComponentId = AZ::EntityComponentIdPair(GetEntityId(), GetId());
 
-            m_innerExtentsChangedHandler = AZ::Event<bool>::Handler([]([[maybe_unused]] bool value)
+            m_innerExtentsChangedHandler = AZ::Event<bool>::Handler([entityComponentId]([[maybe_unused]] bool value)
                 {
                     AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                        &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
+                        &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplayForComponent,
+                        entityComponentId,
                         AzToolsFramework::Refresh_Values);
                 });
             m_controller.RegisterInnerExtentsChangedHandler(m_innerExtentsChangedHandler);

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -196,11 +196,9 @@ namespace AZ
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
             AZ::TickBus::Handler::BusConnect();
             AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusConnect();
-            m_boxChangedByGridHandler = AZ::Event<bool>::Handler([]([[maybe_unused]] bool value)
+            m_boxChangedByGridHandler = AZ::Event<bool>::Handler([this]([[maybe_unused]] bool value)
                 {
-                    AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                        &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
-                        AzToolsFramework::Refresh_EntireTree);
+                    this->InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
                 });
             m_controller.RegisterBoxChangedByGridHandler(m_boxChangedByGridHandler);
 

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -846,7 +846,6 @@ namespace GradientSignal
 
     void ImageGradientComponent::ClearImageModificationBuffer()
     {
-        AZ_Assert(!ModificationBufferIsActive(), "Clearing modified image data while it's still in use as the active asset!");
         AZ_Assert(m_configuration.m_numImageModificationsActive == 0, "Clearing modified image data while in modification mode!")
         m_modifiedImageData.resize(0);
         m_imageIsModified = false;
@@ -856,7 +855,7 @@ namespace GradientSignal
     {
         // The modification buffer is considered active if the modification buffer has data in it and
         // our cached imageData pointer is pointing into the modification buffer instead of into an image asset.
-        return (m_modifiedImageData.data() != nullptr) &&
+        return (m_modifiedImageData.data() != nullptr) && (!m_modifiedImageData.empty()) && 
             (reinterpret_cast<const void*>(m_imageData.data()) == reinterpret_cast<const void*>(m_modifiedImageData.data()));
     }
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientBakerComponent.cpp
@@ -438,8 +438,7 @@ namespace GradientSignal
         m_previewer.SetPreviewEntity(m_configuration.m_inputBounds);
         m_previewer.RefreshPreview();
 
-        AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
     }
 
     void EditorGradientBakerComponent::SetupDependencyMonitor()
@@ -483,8 +482,7 @@ namespace GradientSignal
         m_bakeImageJob->Start();
 
         // Force a refresh now so the bake button gets disabled
-        AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
     }
 
     bool EditorGradientBakerComponent::IsBakeDisabled() const
@@ -516,8 +514,7 @@ namespace GradientSignal
             }
 
             // Refresh once the job has completed so the Bake button can be re-enabled
-            AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
         }
         else if (!m_bakeImageJob)
         {

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientTransformComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientTransformComponent.cpp
@@ -50,7 +50,7 @@ namespace GradientSignal
     void EditorGradientTransformComponent::OnCompositionChanged()
     {
         UpdateFromShape();
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
     }
 
     void EditorGradientTransformComponent::UpdateFromShape()

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
@@ -41,6 +41,7 @@ namespace GradientSignal
         StreamingImagePropertyAssetCtrl(QWidget* parent = nullptr);
 
         void PickAssetSelectionFromDialog(AssetSelectionModel& selection, QWidget* parent) override;
+        bool CanAcceptAsset(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType) const override;
 
     public Q_SLOTS:
         void OnAutocomplete(const QModelIndex& index) override;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorSurfaceAltitudeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorSurfaceAltitudeGradientComponent.cpp
@@ -39,7 +39,7 @@ namespace GradientSignal
     void EditorSurfaceAltitudeGradientComponent::OnCompositionChanged()
     {
         UpdateFromShape();
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
     }
 
     void EditorSurfaceAltitudeGradientComponent::UpdateFromShape()

--- a/Gems/GradientSignal/Code/Source/Editor/PaintableImageAssetHelper.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/PaintableImageAssetHelper.cpp
@@ -602,8 +602,10 @@ namespace GradientSignal::ImageCreatorUtils
         // Resync the configurations and refresh the display to hide the "Create" button
         // We need to use "Refresh_EntireTree" because "Refresh_AttributesAndValues" isn't enough to refresh the visibility
         // settings.
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+        AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
+                &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                m_ownerEntityComponentIdPair,
+                AzToolsFramework::Refresh_EntireTree);
 
         return createdAsset;
     }

--- a/Gems/LmbrCentral/Code/Source/Audio/EditorAudioListenerComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Audio/EditorAudioListenerComponent.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
-
+#include <AzCore/Math/Vector3.h>
 
 namespace LmbrCentral
 {

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
@@ -98,8 +98,7 @@ namespace LmbrCentral
     void EditorBaseShapeComponent::SetShapeColor(const AZ::Color& shapeColor)
     {
         m_shapeColor = shapeColor;
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_Values);
     }
 
     void EditorBaseShapeComponent::SetShapeWireframeColor(const AZ::Color& wireColor)
@@ -125,8 +124,7 @@ namespace LmbrCentral
             }
 
             // This changes the visibility of a property so a request to refresh the entire tree must be sent.
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
     }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponent.cpp
@@ -156,6 +156,9 @@ namespace LmbrCentral
         ShapeComponentNotificationsBus::Event(
             GetEntityId(), &ShapeComponentNotificationsBus::Events::OnShapeChanged,
             ShapeComponentNotifications::ShapeChangeReasons::ShapeChanged);
+
+        // refresh the UI for this component, too
+        InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel::Refresh_Values);
     }
 
     void EditorTubeShapeComponent::OnSplineChanged()
@@ -165,30 +168,22 @@ namespace LmbrCentral
 
     void EditorTubeShapeComponent::OnAttributeAdded([[maybe_unused]] size_t index)
     {
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-            &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-            AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+       InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorTubeShapeComponent::OnAttributeRemoved([[maybe_unused]] size_t index)
     {
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-            &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-            AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorTubeShapeComponent::OnAttributesSet([[maybe_unused]] size_t size)
     {
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-            &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-            AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorTubeShapeComponent::OnAttributesCleared()
     {
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-            &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-            AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorTubeShapeComponent::BuildGameEntity(AZ::Entity* gameEntity)

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponentMode.cpp
@@ -349,7 +349,9 @@ namespace LmbrCentral
 
         // ensure property grid values are refreshed
         AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-            &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+            &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent, 
+            GetEntityComponentIdPair(),
+            AzToolsFramework::Refresh_Values);
     }
 
     void EditorTubeShapeComponentMode::OnOpenCloseChanged(const bool /*closed*/)

--- a/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/TubeShape.cpp
@@ -603,27 +603,16 @@ namespace LmbrCentral
         }
     }
 
-    static void RefreshUI()
-    {
-#if LMBR_CENTRAL_EDITOR
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-            &AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-            AzToolsFramework::PropertyModificationRefreshLevel::Refresh_Values);
-#endif
-    }
-
     void TubeShape::BaseRadiusChanged()
     {
         // ensure all variable radii stay in bounds should the base radius
         // change and cause the resulting total radius to be negative
         ValidateAllVariableRadii();
-        RefreshUI();
     }
 
     void TubeShape::VariableRadiusChanged(size_t vertIndex)
     {
         ValidateVariableRadius(vertIndex);
-        RefreshUI();
     }
 
     void TubeShape::ValidateVariableRadius(const size_t vertIndex)

--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -318,7 +318,9 @@ namespace Maestro
         {
             s_lastPropertyRefreshTime = time;
 
-            // refresh
+            // refresh.  We have to refresh the entire property tree system since sequences can modify
+            // multiple different shapes in multiple different components.
+            
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
 
             // disconnect from tick bus now that we've refreshed

--- a/Gems/NvCloth/Code/Source/Components/EditorClothComponent.cpp
+++ b/Gems/NvCloth/Code/Source/Components/EditorClothComponent.cpp
@@ -507,9 +507,7 @@ namespace NvCloth
         UpdateConfigMeshNodeData();
 
         // Refresh UI
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
-            AzToolsFramework::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorClothComponent::OnModelPreDestroy()
@@ -531,9 +529,7 @@ namespace NvCloth
         UpdateConfigMeshNodeData();
 
         // Refresh UI
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
-            AzToolsFramework::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     bool EditorClothComponent::IsSimulatedInEditor() const

--- a/Gems/PhysX/Core/Code/Editor/ColliderComponentMode.cpp
+++ b/Gems/PhysX/Core/Code/Editor/ColliderComponentMode.cpp
@@ -377,7 +377,7 @@ namespace PhysX
         return azrtti_typeid<ColliderComponentMode>();
     }
 
-    void RefreshUI()
+    void RefreshUI(const AZ::EntityComponentIdPair& entityComponentIdPair)
     {
         /// The reason this is in a free function is because ColliderComponentMode
         /// privately inherits from ToolsApplicationNotificationBus. Trying to invoke
@@ -386,14 +386,16 @@ namespace PhysX
         /// Using the global namespace operator :: should have fixed that, except there
         /// is a bug in the microsoft compiler meaning it doesn't work. So this is a work around.
         AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-            &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+            &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent, 
+            entityComponentIdPair,
+            AzToolsFramework::Refresh_Values);
     }
 
     void ColliderComponentMode::ResetCurrentMode()
     {
         m_subModes[m_subMode]->ResetValues(GetEntityComponentIdPair());
         m_subModes[m_subMode]->Refresh(GetEntityComponentIdPair());
-        RefreshUI();
+        RefreshUI(GetEntityComponentIdPair());
     }
 
     AZStd::vector<AzToolsFramework::ViewportUi::ClusterId> ColliderComponentMode::PopulateViewportUiImpl()

--- a/Gems/PhysX/Core/Code/Editor/Source/ComponentModes/Joints/JointsComponentMode.cpp
+++ b/Gems/PhysX/Core/Code/Editor/Source/ComponentModes/Joints/JointsComponentMode.cpp
@@ -134,7 +134,7 @@ namespace PhysX
             return buttonId;
         }
 
-        void RefreshUI()
+        void RefreshUI(const AZ::EntityComponentIdPair& entityComponentIdPair)
         {
             // The reason this is in a free function is because JointsComponentMode
             // privately inherits from ToolsApplicationNotificationBus. Trying to invoke
@@ -143,7 +143,8 @@ namespace PhysX
             // Using the global namespace operator :: should have fixed that, except there
             // is a bug in the Microsoft compiler meaning it doesn't work. So this is a work around.
             AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-                &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+                &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
+                entityComponentIdPair, AzToolsFramework::Refresh_Values);
         }
     } // namespace Internal
 
@@ -997,7 +998,7 @@ namespace PhysX
         m_subModes[m_subMode]->ResetValues(entityComponentIdPair);
         m_subModes[m_subMode]->Refresh(entityComponentIdPair);
 
-        Internal::RefreshUI();
+        Internal::RefreshUI(entityComponentIdPair);
     }
 
     void JointsComponentMode::TeardownSubModes()

--- a/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
@@ -318,8 +318,7 @@ namespace PhysX
             m_config.m_localPosition = newLocalJoint.GetTranslation();
             m_config.m_localRotation = newLocalJoint.GetEulerDegrees();
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_Values);
         }
         m_cachedWorldTM = worldTM;
     }

--- a/Gems/PhysX/Core/Code/Source/EditorBallJointComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorBallJointComponent.cpp
@@ -203,9 +203,7 @@ namespace PhysX
             m_swingLimit.m_standardLimitConfig.m_inComponentMode = value;
             m_config.m_inComponentMode = value;
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-                , AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
     }
 

--- a/Gems/PhysX/Core/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorHingeJointComponent.cpp
@@ -174,9 +174,7 @@ namespace PhysX
             m_angularLimit.m_standardLimitConfig.m_inComponentMode = value;
             m_config.m_inComponentMode = value;
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-                , AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
         else if (parameterName == PhysX::JointsComponentModeCommon::ParameterNames::EnableLimits)
         {

--- a/Gems/PhysX/Core/Code/Source/EditorJointComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorJointComponent.cpp
@@ -88,8 +88,7 @@ namespace PhysX
             m_config.m_localPosition = newLocalJoint.GetTranslation();
             m_config.m_localRotation = newLocalJoint.GetEulerDegrees();
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_Values);
         }
         m_cachedWorldTM = worldTM;
     }
@@ -274,9 +273,7 @@ namespace PhysX
         {
             m_config.m_inComponentMode = value;
 
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-                , AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
     }
 

--- a/Gems/PhysX/Core/Code/Source/EditorMeshColliderComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorMeshColliderComponent.cpp
@@ -559,7 +559,7 @@ namespace PhysX
 
         m_configuration.m_materialSlots.SetSlotsReadOnly(m_proxyShapeConfiguration.m_physicsAsset.m_configuration.m_useMaterialsFromAsset);
 
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
 
         // By refreshing the entire tree the component's properties reflected on edit context
         // will get updated correctly and show the right material slots list.
@@ -623,8 +623,7 @@ namespace PhysX
         else
         {
             m_componentWarnings.clear();
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
     }
 
@@ -645,8 +644,7 @@ namespace PhysX
             {
                 m_componentWarnings.clear();
 
-                AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                    &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+                InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
                 return;
             }
 
@@ -699,8 +697,7 @@ namespace PhysX
             m_componentWarnings.clear();
         }
 
-        AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
+        InvalidatePropertyDisplay(
             m_componentWarnings.empty() ? AzToolsFramework::Refresh_EntireTree : AzToolsFramework::Refresh_EntireTree_NewContent);
     }
 

--- a/Gems/PhysX/Core/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorRigidBodyComponent.cpp
@@ -355,11 +355,9 @@ namespace PhysX
         }
 
         m_sceneConfigChangedHandler = AzPhysics::SystemEvents::OnDefaultSceneConfigurationChangedEvent::Handler(
-            []([[maybe_unused]] const AzPhysics::SceneConfiguration* config)
+            [this]([[maybe_unused]] const AzPhysics::SceneConfiguration* config)
             {
-                AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-                    &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay,
-                    AzToolsFramework::Refresh_EntireTree);
+                this->InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
             });
 
         if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())

--- a/Gems/PhysX/Core/Code/Source/EditorShapeColliderComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorShapeColliderComponent.cpp
@@ -663,9 +663,7 @@ namespace PhysX
         // m_shapeConfigs vector is reflected in the component and resizing it without invalidating property tree leads to dangling pointers
         // in the hierarchy comparison system.
 
-        AzToolsFramework::ToolsApplicationNotificationBus::Broadcast(
-            &AzToolsFramework::ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay,
-            AzToolsFramework::Refresh_EntireTree);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     // AZ::Component

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorScriptCanvasComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorScriptCanvasComponent.cpp
@@ -56,21 +56,18 @@ namespace ScriptCanvasEditor
 
         EditorComponentBase::Activate();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
-        m_handlerSourceCompiled = m_configuration.ConnectToSourceCompiled([](const Configuration&)
+        m_handlerSourceCompiled = m_configuration.ConnectToSourceCompiled([this](const Configuration&)
             {
-                AzToolsFramework::ToolsApplicationNotificationBus::Broadcast
-                    ( &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-                    , AzToolsFramework::Refresh_EntireTree_NewContent);
+                this->InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
             });
 
         m_configuration.Refresh();
-        AzToolsFramework::ToolsApplicationNotificationBus::Broadcast
-            ( &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay
-            , AzToolsFramework::Refresh_EntireTree_NewContent);
+        InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
     }
 
     void EditorScriptCanvasComponent::Deactivate()
     {
+        m_handlerSourceCompiled.Disconnect();
         EditorComponentBase::Deactivate();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/InterpreterWidget/InterpreterWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/InterpreterWidget/InterpreterWidget.cpp
@@ -74,7 +74,7 @@ namespace ScriptCanvasEditor
         m_handlerSourceCompiled = m_interpreter.GetConfiguration().ConnectToSourceCompiled
             ([propertyEditor](const Configuration&)
             {
-                propertyEditor->QueueInvalidation(AzToolsFramework::Refresh_EntireTree_NewContent);
+                propertyEditor->QueueInvalidation(AzToolsFramework::Refresh_EntireTree);
             });
 
         // initialized status window and enabled setting for buttons

--- a/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponent.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponent.cpp
@@ -265,13 +265,11 @@ namespace Terrain
 
             // If the asset status changed and the image asset property is visible, refresh the entire tree so
             // that the label change is picked up.
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_EntireTree);
         }
         else
         {
-            AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
+            InvalidatePropertyDisplay(AzToolsFramework::Refresh_AttributesAndValues);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

* Adds a new API to AzToolsFramework::ToolsApplicationAPI to allow to notify the application that a specific property of a specific entity has been changed.
* This is different from the previous API which simply broadcast to everyone to refresh every component in every property tree in every GUI in every window in the entire editor.
* Added a base call in the Base Editor Entity class which calls this API to clean up and de-duplicate code.
* Found a crash that causes the image gradient editor to crash and/or not be able to modify an image more than once / not be able to change image properties after the first time. Not sure if I caused it with these other changes, but this fixes it anyway.

Ultimately, this results in a performance improvement when editing entity properties, including when using manipulators in the viewport to do so.  In my testing, scrubbing an entity around in the viewport previously tanked my framerate down to 10fps from 60.

After this change, I can scrub an entity around in the viewport and my framerate stays at 60fps no matter what I do.  This also affects manipulators and other property editors.

In addition, changing individual properties on components in the inspector happens quickly and doesn't cause the entire editor to freeze up for seconds nor does it cause it to scroll around wildly and lose your place.

This potentially fixes issue #17504 as well as several other issues related to property editing, namely #17880 and any other bugs related to DPE refresh and scrolling

## How was this PR tested?

Lots of manual testing, and then CI builds locally.

See comment below on implementation worries.
