### PR TITLE
Fix False Reports of Using Legacy Assets 

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -189,18 +189,7 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
-            const AZStd::string legacyAssetPath = GetAssetPathByIdInternal(legacyMapping);
-            AZ_Warning(
-                "O3DE_DEPRECATION_NOTICE(GHI-17861)",
-                legacyAssetPath.empty(),
-                "Deprecated asset id warning! GetAssetPathByIdInternal could not find the modern asset id for \"%s\" and so fell back to using "
-                "the legacy asset id \"%s\"."
-                "Please recreate the asset and update any other assets referencing this asset in order to generate a modern asset id.",
-                legacyAssetPath.c_str(),
-                legacyMapping.ToFixedString().c_str()
-            );
-
-            return legacyAssetPath;
+            return GetAssetPathByIdInternal(legacyMapping);
         }
 
         return AZStd::string();
@@ -236,18 +225,7 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
-            const AZ::Data::AssetInfo legacyAssetInfo = GetAssetInfoByIdInternal(legacyMapping);
-            AZ_Warning(
-                "O3DE_DEPRECATION_NOTICE(GHI-17861)",
-                legacyAssetInfo.m_assetType == AZ::Data::s_invalidAssetType,
-                "Deprecated asset id warning! GetAssetInfoByIdInternal could not the modern asset id for \"%s\" and so fell back to using "
-                "the legacy asset id \"%s\"."
-                "Please recreate the asset and update any other assets referencing this asset in order to generate a modern asset id.",
-                legacyAssetInfo.m_relativePath.c_str(),
-                legacyMapping.ToFixedString().c_str()
-            );
-
-            return legacyAssetInfo;
+            return GetAssetInfoByIdInternal(legacyMapping);
         }
 
         return AZ::Data::AssetInfo();


### PR DESCRIPTION
Removing 2 of 3 legacy asset id warnings.  When an asset is reprocessed, asset processor triggers a OnCatalogAssetChanged event. [It triggers the event for both the normal asset id, and the legacy asset id equivalent](https://github.com/o3de/o3de/blob/8e66aced697f18e82afeb2cadb7974537202f73e/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp#L891-L911) even if the legacy asset id isn't ultimately used.

The legacy asset warning still exists, but only inside the [AssetProcessor's GetProductAssetInfo()](https://github.com/o3de/o3de/blob/development/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp#L1715-L1728
); this appears to only be called when a legacy asset is actually being processed.


## How was this PR tested?
1. Build assets from scratch and see no false warnings about legacy asset ids
2. Leave editor open and reprocess a prefab and see no false warnings about legacy asset ids


Fixes #17933