### PR TITLE
AssetProcessor Analysis Stats 

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -255,7 +255,7 @@ namespace AssetProcessor
         void PrepareForFileMove(AZ::IO::PathView oldPath, AZ::IO::PathView newPath) override;
 
     Q_SIGNALS:
-        void NumRemainingJobsChanged(int newNumJobs);
+        void NumRemainingJobsChanged(int newNumJobs, QString extraInfo = "");
 
         void AssetToProcess(JobDetails jobDetails);
 
@@ -530,6 +530,15 @@ namespace AssetProcessor
         typedef QHash<QString, FileEntry> FileExamineContainer;
         FileExamineContainer m_filesToExamine; // order does not actually matter in this (yet)
 
+        QString AnalysisExtraInfo() const;
+        int m_totalScannerFilesToAssess = 0;
+        int m_scannerFilesAssessed = 0;
+        int m_assetsNeedingProcessing_BuildersChanged = 0;
+        int m_assetsNeedingProcessing_NewFile = 0;
+        int m_assetsNeedingProcessing_TimeStampChanged = 0;
+        int m_assetsNeedingProcessing_DependenciesChanged = 0;
+
+
         // Set of files which are metadata-enabled but don't have a metadata file.
         // These files will be delayed for processing for a short time to wait for a metadata file to show up.
         AZStd::unordered_map<AZ::IO::Path, QDateTime> m_delayProcessMetadataFiles;
@@ -674,6 +683,7 @@ namespace AssetProcessor
         int m_numSourcesNeedingFullAnalysis = 0;
         int m_numSourcesNotHandledByAnyBuilder = 0;
         bool m_reportedAnalysisMetrics = false;
+        int m_numOverrides = 0;
 
         // cache these so we don't have to check them each time during analysis:
         QSet<QString> m_metaFilesWhichActuallyExistOnDisk;

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -1557,7 +1557,13 @@ void MainWindow::OnAssetProcessorStatusChanged(const AssetProcessor::AssetProces
 
         if (m_processJobsCount + m_createJobCount > 0)
         {
-            text = tr("Working, analyzing jobs remaining %1, processing jobs remaining %2...").arg(m_createJobCount).arg(m_processJobsCount);
+            text += tr("Working, analyzing jobs remaining %1, processing jobs remaining %2...").arg(m_createJobCount).arg(m_processJobsCount);
+
+            if (!entry.m_extraInfo.isEmpty())
+            {
+                text += tr("<p style='font-size:small;'>%1</p>").arg(entry.m_extraInfo);
+            }
+
             ui->timerContainerWidget->setVisible(false);
             ui->productAssetDetailsPanel->SetScanQueueEnabled(false);
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -831,7 +831,7 @@ void ApplicationManagerBase::InitAssetRequestHandler(AssetProcessor::AssetReques
     QObject::connect(GetRCController(), &RCController::CompileGroupCreated, m_assetRequestHandler, &AssetRequestHandler::OnCompileGroupCreated);
     QObject::connect(GetRCController(), &RCController::CompileGroupFinished, m_assetRequestHandler, &AssetRequestHandler::OnCompileGroupFinished);
 
-    QObject::connect(GetAssetProcessorManager(), &AssetProcessor::AssetProcessorManager::NumRemainingJobsChanged, this, [this](int newNum)
+    QObject::connect(GetAssetProcessorManager(), &AssetProcessor::AssetProcessorManager::NumRemainingJobsChanged, this, [this](int newNum, QString extraInfo)
         {
             if (!m_assetProcessorManagerIsReady)
             {
@@ -848,7 +848,7 @@ void ApplicationManagerBase::InitAssetRequestHandler(AssetProcessor::AssetReques
                 }
             }
 
-            AssetProcessor::AssetProcessorStatusEntry entry(AssetProcessor::AssetProcessorStatus::Analyzing_Jobs, newNum);
+            AssetProcessor::AssetProcessorStatusEntry entry(AssetProcessor::AssetProcessorStatus::Analyzing_Jobs, newNum, extraInfo);
             Q_EMIT AssetProcessorStatusChanged(entry);
         });
 }


### PR DESCRIPTION
Display information as AssetProcessor (AP) analyzes assets. How many assets are new files, are outdated, have altered dependencies, or have new builders

![image](https://github.com/o3de/o3de/assets/32776221/38279b1f-e7db-4b67-9601-4f141dbbad77)


## How was this PR tested?
1. a. Ran AP from scratch using no-cache folder: the normal "analyzing jobs remaining" shows countdown of all assets. Initial scanner pass is nearly instant... all assets are "Unregistered/new files".
    b. Restarted AP with Fast Scan enabled, and disabled. See that scanner file information is displayed during analysis mode, and is also printed to console after scan is complete.
2. Profiled analysis mode to ensure statistical tracking did not affect processing time.
