### PR TITLE
Fix vulkan fence synchronization

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -463,7 +463,9 @@ namespace AZ
                     // The fence wait might not be on the framegraph (wait on CPU)
                     // In this case we want wait for the current scopes dependencies (i.e. for signalling of the fence itself)
                     // If the Fence is waited-for on the framegraph at a later scope, we overwrite the dependencies later
-                    fence->SetSignalEventDependencies(currentDependencies);
+                    SignalEvent::BitSet fenceDependencies = currentDependencies;
+                    fenceDependencies.set(currentBitToSignal);
+                    fence->SetSignalEventDependencies(fenceDependencies);
                     hasSemaphoreSignal = true;
                 }
                 for (auto& semaphore : scope->GetSignalSemaphores())


### PR DESCRIPTION
## What does this PR do?

This fixes issues related to synchronization of VkFence and binary semaphores introduced by https://github.com/o3de/o3de/pull/17761 , when a device without timeline semaphore support is used:
1. Re-added synchronization to fences used in the Vulkan async upload queue. The SignalEvent class of the Fence was formerly owned by the Fence itself. Now it must be supplied from outside the class.
2. In the case of waiting for a fence that is signaled from the framegraph, we did not wait for the fence itself to be signaled. Only the fences/semaphores it dependent upon. We now also wait for the fence itself to be signaled.

This PR should fix https://github.com/o3de/o3de/issues/17890. I cannot test this directly as I don't have access to a Quest. We however managed to fix multiple Vulkan validation warnings related to VkFence and multi threading.

## How was this PR tested?

Tested with various atom sample viewer samples, and some custom levels.
I couldn't get the OpenXRTest project to run, as mentioned in https://github.com/o3de/o3de/issues/17890. There are many passes/shaders that won't compile in the AssetProcessor. We managed to create Vulkan validation errors in some of the atom sample viewer samples however.
