### PR TITLE
Fix a physx cloth sim crash on linux

### DIFF
--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Math/PackedVector3.h>
+#include <AzCore/Math/PackedVector4.h>
 
 #include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
 #include <AtomLyIntegration/CommonFeatures/SkinnedMesh/SkinnedMeshOverrideBus.h>
@@ -552,7 +553,7 @@ namespace NvCloth
 
             MappedBuffer<AZ::PackedVector3f> destVertices(subMesh.GetSemanticBufferAssetView(positionSemantic), numVertices, AZ::RHI::Format::R32G32B32_FLOAT);
             MappedBuffer<AZ::PackedVector3f> destNormals(subMesh.GetSemanticBufferAssetView(normalSemantic), numVertices, AZ::RHI::Format::R32G32B32_FLOAT);
-            MappedBuffer<AZ::Vector4> destTangents(subMesh.GetSemanticBufferAssetView(tangentSemantic), numVertices, AZ::RHI::Format::R32G32B32A32_FLOAT);
+            MappedBuffer<AZ::PackedVector4f> destTangents(subMesh.GetSemanticBufferAssetView(tangentSemantic), numVertices, AZ::RHI::Format::R32G32B32A32_FLOAT);
             MappedBuffer<AZ::PackedVector3f> destBitangents(subMesh.GetSemanticBufferAssetView(bitangentSemantic), numVertices, AZ::RHI::Format::R32G32B32_FLOAT);
 
             auto* destVerticesBuffer = destVertices.GetBuffer();
@@ -590,7 +591,9 @@ namespace NvCloth
                 {
                     const AZ::Vector3& renderTangent = renderTangents[renderVertexIndex];
                     destTangentsBuffer[index].Set(
-                        renderTangent,
+                        renderTangent.GetX(),
+                        renderTangent.GetY(),
+                        renderTangent.GetZ(),
                         -1.0f); // Shader function ConstructTBN inverts w to change bitangent sign, but the bitangents passed are already corrected, so passing -1.0 to counteract.
                 }
 


### PR DESCRIPTION
## What does this PR do?

Fix issue https://github.com/o3de/o3de/issues/16937

Cloth would crash on linux whenever simulated.  I got a 100% repro rate just by choosing the plane asset and having it "simulate in editor".

Changing the code in the manner in the PR causes it to have a 0% repro rate for me and the cloth simulates smoothly in the editor.

I don't fully understand why though, since I am not familiar with Atom Packed vectors v AZ:: Vectors.   Its my intuition that since the buffer being written to IS an atom buffer, it should be treated as an atom packed vector4 rather than an AZ::Vector4.

## How was this PR tested?

Just reproing the error 100% before the change, and 0% after.
