### PR TITLE
Added some guards that prevent crashes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -594,6 +594,12 @@ namespace AZ::Render
     {
         static uint32_t nameIndex = 0;
 
+        if (!m_primaryProjectedShadowmapsPass)
+        {
+            // If this pass doesn't exist, then do nothing.
+            return;
+        }
+
         // Create index table buffer.
         // [GFX TODO ATOM-14851] Should not be creating a new buffer here, just map the data or orphan with new data.
         const AZStd::string indexTableBufferName = AZStd::string::format("IndexTableBuffer(Projected) %d", nameIndex++);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -188,10 +188,7 @@ namespace AZ
             {
                 const ViewPtr& view = views.front();
 
-                // Assert the view has our draw list (the view's DrawlistTags are collected from passes using its viewTag)
-                AZ_Assert(view->HasDrawListTag(m_drawListTag), "View's DrawListTags out of sync with pass'. ");
-
-                // Draw List 
+                // Draw List. May return an empty list, and that's ok.
                 viewDrawList = view->GetDrawList(m_drawListTag);
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -496,6 +496,12 @@ namespace AZ
 
         void View::SortDrawList(RHI::DrawList& drawList, RHI::DrawListTag tag)
         {
+            if (!m_passesByDrawList)
+            {
+                // Nothing to sort.
+                return;
+            }
+
             // Note: it's possible that the m_passesByDrawList doesn't have a pass for the input tag.
             // This is because a View can be used for multiple render pipelines.
             // So it may contains draw list tag which exists in one render pipeline but not others.


### PR DESCRIPTION
## What does this PR do?

Added some guards that prevent crashes
that may occur under some custom render pipeline
configurations.

## How was this PR tested?

Custom pipelines don't crash anymore and the default main pipeline works well. Also tested ASV samples.
