### PR TITLE
Add entity focus for Depth Of Field component

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/DepthOfField/DepthOfFieldParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/DepthOfField/DepthOfFieldParams.inl
@@ -30,6 +30,9 @@ AZ_GFX_FLOAT_PARAM_FLOAT_OVERRIDE(float, FocusDistance, m_focusDistance)
 AZ_GFX_BOOL_PARAM(EnableAutoFocus, m_enableAutoFocus, true)
 AZ_GFX_ANY_PARAM_BOOL_OVERRIDE(bool, EnableAutoFocus, m_enableAutoFocus)
 
+AZ_GFX_COMMON_PARAM(EntityId, FocusedEntityId, m_focusedEntityId, EntityId())
+AZ_GFX_ANY_PARAM_BOOL_OVERRIDE(EntityId, FocusedEntityId, m_focusedEntityId)
+
 AZ_GFX_VEC2_PARAM(AutoFocusScreenPosition, m_autoFocusScreenPosition, AZ::Vector2(0.5f, 0.5f))
 AZ_GFX_FLOAT_PARAM_FLOAT_OVERRIDE(AZ::Vector2, AutoFocusScreenPosition, m_autoFocusScreenPosition)
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/PostProcess/DepthOfField/DepthOfFieldComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/PostProcess/DepthOfField/DepthOfFieldComponentConfig.h
@@ -39,7 +39,8 @@ namespace AZ
 
             bool IsCameraEntityInvalid() const { return !m_cameraEntityId.IsValid(); }
             bool ArePropertiesReadOnly() const { return !m_enabled || IsCameraEntityInvalid(); }
-            bool IsAutoFocusReadOnly() const { return !m_enableAutoFocus || ArePropertiesReadOnly(); }
+            bool IsAutoFocusReadOnly() const { return !m_enableAutoFocus || m_focusedEntityId.IsValid() || ArePropertiesReadOnly(); }
+            bool IsFocusedEntityReadonly() const { return !m_enableAutoFocus || ArePropertiesReadOnly(); }
             bool IsFocusDistanceReadOnly() const { return m_enableAutoFocus || ArePropertiesReadOnly(); }
         };
     }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DepthOfField/EditorDepthOfFieldComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DepthOfField/EditorDepthOfFieldComponent.cpp
@@ -102,6 +102,14 @@ namespace AZ
                         ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::AttributesAndValues)
                         ->Attribute(Edit::Attributes::ReadOnly, &DepthOfFieldComponentConfig::ArePropertiesReadOnly)
 
+                        ->DataElement(Edit::UIHandlers::Default,
+                            &DepthOfFieldComponentConfig::m_focusedEntityId,
+                            "Focused Entity",
+                            "Entity to focus on.\n"
+                            "If unset, the screen position is used.")
+                        ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::AttributesAndValues)
+                        ->Attribute(Edit::Attributes::ReadOnly, &DepthOfFieldComponentConfig::IsFocusedEntityReadonly)
+
                         ->DataElement(Edit::UIHandlers::Default, &DepthOfFieldComponentConfig::m_autoFocusScreenPosition,
                             "Focus Screen Position",
                             "Values of the focus position on screen.")


### PR DESCRIPTION
## What does this PR do?

Implements #5660. Auto focus can now be set to focus on a specific entity.

[Screencast from 05-27-2024 02:35:40 PM.webm](https://github.com/o3de/o3de/assets/32801410/864ecf51-f2dd-4a60-8f17-ae1e02974f44)

## How was this PR tested?

Tested manually.
