### PR TITLE
feat: remove unused logic that references VertexFormat

### DIFF
--- a/Code/Legacy/CryCommon/IRenderer.h
+++ b/Code/Legacy/CryCommon/IRenderer.h
@@ -148,47 +148,4 @@ enum EDrawTextFlags
     eDrawText_UseTransform = BIT(11),  // use a transform for the text
 };
 
-//////////////////////////////////////////////////////////////////////////
-// Description:
-//   This structure used in DrawText method of renderer.
-//   It provide all necessary information of how to render text on screen.
-// See also:
-//   IRenderer::Draw2dText
-struct SDrawTextInfo
-{
-    // Summary:
-    //  One of EDrawTextFlags flags.
-    // See also:
-    //  EDrawTextFlags
-    int     flags;
-    // Summary:
-    //  Text color, (r,g,b,a) all members must be specified.
-    float   color[4];
-    float xscale;
-    float yscale;
 
-    SDrawTextInfo()
-    {
-        flags = 0;
-        color[0] = color[1] = color[2] = color[3] = 1;
-        xscale = 1.0f;
-        yscale = 1.0f;
-    }
-};
-
-//////////////////////////////////////////////////////////////////////
-struct IRenderDebugListener
-{
-    virtual ~IRenderDebugListener() {}
-
-    virtual void OnDebugDraw() = 0;
-};
-
-struct DynUiPrimitive : public AZStd::intrusive_slist_node<DynUiPrimitive>
-{
-    SVF_P2F_C4B_T2F_F4B* m_vertices = nullptr;
-    uint16* m_indices = nullptr;
-    int m_numVertices = 0;
-    int m_numIndices = 0;
-};
-using DynUiPrimitiveList = AZStd::intrusive_slist<DynUiPrimitive, AZStd::slist_base_hook<DynUiPrimitive>>;

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -17,7 +17,6 @@
 #include <ISystem.h>
 #include <imgui/imgui.h>
 #include <ImGuiBus.h>
-#include <VertexFormats.h>
 
 #if defined(LOAD_IMGUI_LIB_DYNAMICALLY)  && !defined(AZ_MONOLITHIC_BUILD)
 #   include <AzCore/Module/DynamicModuleHandle.h>
@@ -98,10 +97,6 @@ namespace ImGui
         ImVec2 m_lastRenderResolution;
         AzFramework::WindowSize m_windowSize = AzFramework::WindowSize(1920, 1080);
         bool m_overridingWindowSize = false;
-
-        // Rendering buffers
-        std::vector<SVF_P3F_C4B_T2F> m_vertBuffer;
-        std::vector<uint16> m_idxBuffer;
 
         //Controller navigation
         bool m_button1Pressed, m_button2Pressed, m_menuBarStatusChanged;


### PR DESCRIPTION
## What does this PR do?

removed a couple references to VertexFormat