### PR TITLE
Enabling get_python.sh to work on windows git bash.

### DIFF
--- a/python/get_python.sh
+++ b/python/get_python.sh
@@ -67,6 +67,10 @@ if [[ "$OSTYPE" = *"darwin"* ]];
 then
     PAL=Mac
     CMAKE_FOLDER_RELATIVE_TO_ROOT=CMake.app/Contents/bin
+elif [[ "$OSTYPE" == "msys" ]]; then #git bash
+    PAL=Windows
+    CMAKE_FOLDER_RELATIVE_TO_ROOT=bin
+    LINUX_HOST_ARCHITECTURE=""
 else
     PAL=Linux
     CMAKE_FOLDER_RELATIVE_TO_ROOT=bin

--- a/python/python.sh
+++ b/python/python.sh
@@ -22,6 +22,10 @@ if [[ "$OSTYPE" = *"darwin"* ]];
 then
     PAL=Mac
     ARCH=
+elif [[ "$OSTYPE" = "msys" ]];
+then
+    PAL=Windows
+    ARCH=
 else
     PAL=Linux
     ARCH=$( uname -m )
@@ -55,11 +59,18 @@ fi
 # Set the expected location of the python venv for this engine and the locations of the critical scripts/executables 
 # needed to run python within the venv properly
 PYTHON_VENV=$HOME/.o3de/Python/venv/$ENGINE_ID
-PYTHON_VENV_ACTIVATE=$PYTHON_VENV/bin/activate
-PYTHON_VENV_PYTHON=$PYTHON_VENV/bin/python
+if [[ "$OSTYPE" == "msys" ]];  #git bash on windows
+then
+    PYTHON_VENV_ACTIVATE=$PYTHON_VENV/Scripts/activate
+    PYTHON_VENV_PYTHON=$PYTHON_VENV/Scripts/python
+else
+    PYTHON_VENV_ACTIVATE=$PYTHON_VENV/bin/activate
+    PYTHON_VENV_PYTHON=$PYTHON_VENV/bin/python
+fi
+
 if [ ! -f $PYTHON_VENV_PYTHON ]
 then
-    echo "Python has not been downloaded/configured yet."    
+    echo "Python has not been downloaded/configured yet."
     echo "Try running $DIR/get_python.sh first."
     exit 1
 fi


### PR DESCRIPTION
## What does this PR do?

Enabling configuring and building o3de on windows with git bash. Previously we cannot configuring o3de on windows under git bash since immediately `python.sh` will assume we are under Unix environment. This causes failing of setup an python virtual environment. This is important to me because I use git bash on windows as daily drive. The fix to this is also fairly simple.

## How was this PR tested?

Locally tested.