### PR TITLE
Fix ESM Shadow and LinearDepth for Projected light shadow.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthExponentiation.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthExponentiation.pass
@@ -54,7 +54,7 @@
                         "Attachment": "Depth"
                     },
                     "ImageDescriptor": {
-                        "Format": "R16_FLOAT"
+                        "Format": "R32_FLOAT"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/EsmShadowmaps.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EsmShadowmaps.pass
@@ -59,7 +59,7 @@
                                 "Attachment": "Input"
                             },
                             "ImageDescriptor": {
-                                "Format": "R16_FLOAT"
+                                "Format": "R32_FLOAT"
                             }
                         }
                     ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ShadowParent.pass
@@ -147,7 +147,7 @@
                                 "Attachment": "Shadowmap"
                             },
                             "ImageDescriptor": {
-                                "Format": "R16_FLOAT"
+                                "Format": "R32_FLOAT"
                             }
                         }
                     ],

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ESM.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ESM.azsli
@@ -8,13 +8,16 @@
  
 #pragma once
  
-
+// The calculation of ESM is given by formula exp((occluder - zReceiver) * esmComponent). Which can be spitted into 2 parts.
+// exp(occluer*esmComponent) * exp(-zReceiver * esmComponent).  Here is the calculation of Receiver part, combined with
+// occluder part to give the final soft shadow.
+// see DepthExponentiation.azsl for the calcuation of occluder part.
 float SampleESM(const Texture2DArray<float> shadowMap, const SamplerState samp, const float3 uv, const float zReceiver, const float esmExponent)
 {
-	const float mipmaplevel = 0;
-	const float occluder = shadowMap.SampleLevel(samp,uv, mipmaplevel).r;
-	const float lit = exp((occluder - zReceiver) * esmExponent);
-	return lit;
+    const float mipmaplevel = 0;
+    const float occluder = shadowMap.SampleLevel(samp, uv, mipmaplevel).r;
+    const float lit = exp(-zReceiver * esmExponent) * occluder;
+    return lit;
 }
 
 float PCFFallbackForESM(const Texture2DArray<float> shadowMap, const float3 uv, const float zReceiver, const float esmExponent)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
@@ -186,10 +186,10 @@ float ProjectedShadow::GetVisibilityEsm()
         m_shadowPosition.y >= 0 && m_shadowPosition.y * size < size - PixelMargin)
     {
         const float3 coefficients = float3(
-            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_n_f_n,
-            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_n_f,
+            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_nf,
+            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_f_n,
             ViewSrg::m_projectedFilterParams[m_shadowIndex].m_f);
-        if (coefficients.x == 0.) 
+        if (coefficients.x == 0.)
         {
             return 1.;
         }
@@ -226,8 +226,8 @@ float ProjectedShadow::GetVisibilityEsmPcf()
         m_shadowPosition.y >= 0 && m_shadowPosition.y * size < size - PixelMargin)
     {
         const float3 coefficients = float3(
-            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_n_f_n,
-            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_n_f,
+            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_nf,
+            ViewSrg::m_projectedFilterParams[m_shadowIndex].m_f_n,
             ViewSrg::m_projectedFilterParams[m_shadowIndex].m_f);
         if (coefficients.x == 0.)
         {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
@@ -202,8 +202,7 @@ float ProjectedShadow::GetVisibilityEsm()
         const float esmExponent = ViewSrg::m_projectedShadows[m_shadowIndex].m_esmExponent;
         const float ratio = SampleESM(shadowmap, PassSrg::LinearSampler, uv, depth, esmExponent);
 
-        // pow() mitigates light bleeding to shadows from near shadow casters.
-        return saturate( pow(ratio, 8) );
+        return saturate(ratio);
     }
 
     return 1.;
@@ -245,12 +244,7 @@ float ProjectedShadow::GetVisibilityEsmPcf()
         static const float pcfFallbackThreshold = 1.04;
         if (ratio > pcfFallbackThreshold)
         {
-            ratio = PCFFallbackForESM(shadowmap, uv, depth, esmExponent);
-        }
-        else
-        {
-            // pow() mitigates light bleeding to shadows from near shadow casters.
-            ratio = pow(ratio, 8);
+            ratio = GetVisibilityPcf();
         }
         return saturate(ratio);
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/Shadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/Shadow.azsli
@@ -19,8 +19,8 @@ struct FilterParameter
     uint2 m_shadowmapOriginInSlice;
     uint m_shadowmapSize;
     float m_lightDistanceOfCameraViewFrustum;
-    float m_n_f_n; // n / (f - n)
-    float m_n_f;   // n - f
+    float m_nf;    // nf
+    float m_f_n;   // f - n
     float m_f;     // f
                    // where n: nearDepth, f: farDepth.
 };

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -28,10 +28,10 @@ partial ShaderResourceGroup ViewSrg
         uint2 m_shadowmapOriginInSlice;
         uint m_shadowmapSize;
         float m_lightDistanceOfCameraViewFrustum;
-        float m_n_f_n; // n / (f - n)
-        float m_n_f;   // n - f
-        float m_f;     // f
-                       // where n: nearDepth, f: farDepth.
+        float m_nf;  // n*f
+        float m_f_n; // f - n
+        float m_f;   // f
+                     // where n: nearDepth, f: farDepth.
     };
 
     // Simple Point Lights 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
@@ -70,8 +70,8 @@ void MainCS(uint3 dispatchId: SV_DispatchThreadID)
         case ShadowmapLightType::Spot:
         {
             const float3 coefficients = float3(
-                filterParameter.m_n_f_n,
-                filterParameter.m_n_f,
+                filterParameter.m_nf,
+                filterParameter.m_f_n,
                 filterParameter.m_f);
             
             // With a spot light shadowmap, "depthInClip" is calculated

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
@@ -27,6 +27,16 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     RWTexture2DArray<float> m_outputShadowmap;
     Buffer<uint2> m_shadowmapIndexTable;
     StructuredBuffer<FilterParameter> m_filterParameters;
+    float m_esmExponent;
+}
+
+// The calculation of ESM is given by formula exp((occluder - zReceiver) * esmComponent). Which can be spitted into 2 parts.
+// exp(occluer*esmComponent) * exp(-zReceiver * esmComponent).  Here is the calculation of occluder part.
+float CalculateESMShadowMapExponent(float linearDepth, float esmExponent)
+{
+    // note that ESMShadowMapComponent is really a huge number. if esmExponent is a large number, exp(esmExponent*linearDistance)
+    // will quickly overflow  r16_float on the 5 exponent bit. We need r32 which uses 8 bit for exponent part.
+    return exp(linearDepth * esmExponent);
 }
 
 [numthreads(16,16,1)]
@@ -80,7 +90,8 @@ void MainCS(uint3 dispatchId: SV_DispatchThreadID)
             // and it often causes light bleeding with ESM.
             // So this converts it to a linear depth to emphasize the 
             // difference like a orthogonal depth.
-            PassSrg::m_outputShadowmap[dispatchId].r = PerspectiveDepthToLinear(depthInClip, coefficients);
+            PassSrg::m_outputShadowmap[dispatchId].r =
+                CalculateESMShadowMapExponent(PerspectiveDepthToLinear(depthInClip, coefficients), PassSrg::m_esmExponent);
             break;
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/KawaseShadowBlur.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/KawaseShadowBlur.azsl
@@ -30,7 +30,9 @@ ShaderResourceGroup FilterPassSrg : SRG_PerPass
 
     // This contains parameters related to filtering.
     StructuredBuffer<FilterParameter> m_filterParameters;
-       
+
+    float m_esmExponent;
+
     // x and y contain the inverse of the texture map resolution, z contains the kawase iteration
     // i.e. a two pass kawase blur passes in 0 for the 1st pass and 1 for the second pass
     float4 m_rcpResolutionAndIteration;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.cpp
@@ -71,6 +71,11 @@ namespace AZ
             m_filterParameterBuffer = dataBuffer;
         }
 
+        void EsmShadowmapsPass::SetEsmExponent(float exponent)
+        {
+            m_esmExponent = exponent;
+        }
+
         void EsmShadowmapsPass::SetBlurParameters(Data::Instance<RPI::ShaderResourceGroup> srg, const uint32_t childPassIndex)
         {
             if (m_shadowmapIndexTableBufferIndices[childPassIndex].IsNull())
@@ -84,6 +89,8 @@ namespace AZ
                 m_filterParameterBufferIndices[childPassIndex] = srg->FindShaderInputBufferIndex(Name("m_filterParameters"));
             }
             srg->SetBuffer(m_filterParameterBufferIndices[childPassIndex], m_filterParameterBuffer);
+
+            srg->SetConstant(srg->FindShaderInputConstantIndex(Name("m_esmExponent")), m_esmExponent);
         }
 
         void EsmShadowmapsPass::SetKawaseBlurSpecificParameters(Data::Instance<RPI::ShaderResourceGroup> srg, uint32_t kawaseBlurIndex)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.h
@@ -51,10 +51,10 @@ namespace AZ
                 AZStd::array<uint32_t, 2> m_shadowmapOriginInSlice = { {0, 0 } }; // shadowmap origin in the slice of the atlas.
                 uint32_t m_shadowmapSize = static_cast<uint32_t>(ShadowmapSize::None); // width and height of shadowmap.
                 float m_lightDistanceOfCameraViewFrustum = 0.f;
-                float m_n_f_n = 0.f; // n / (f - n)
-                float m_n_f = 0.f;   // n - f
-                float m_f = 0.f;     // f
-                                     // where n: nearDepth, f: farDepth.
+                float m_nf = 0.f;  // nf
+                float m_f_n = 0.f; // f - n
+                float m_f = 0.f;   // f
+                                   // where n: nearDepth, f: farDepth.
             };
 
             virtual ~EsmShadowmapsPass() = default;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.h
@@ -78,6 +78,8 @@ namespace AZ
             //! Sets the image to use as the output for all esm passes. This is needed so multiple pipelines in a scene can share the same resource.
             void SetAtlasAttachmentImage(Data::Instance<RPI::AttachmentImage> atlasAttachmentIamge);
 
+            void SetEsmExponent(float esmExponent);
+
         private:
             EsmShadowmapsPass() = delete;
             explicit EsmShadowmapsPass(const RPI::PassDescriptor& descriptor);
@@ -104,6 +106,7 @@ namespace AZ
             Name m_lightTypeName;
             RHI::Size m_shadowmapImageSize;
             uint16_t m_shadowmapArraySize;
+            float m_esmExponent = 5.0;
 
             Data::Instance<RPI::AttachmentImage> m_atlasAttachmentImage;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -220,6 +220,7 @@ namespace AZ::Render
         ShadowData& shadowData = m_shadowData.GetElement<ShadowDataIndex>(id.GetIndex());
         shadowData.m_esmExponent = exponent;
         m_deviceBufferNeedsUpdate = true;
+        m_filterParameterNeedsUpdate = true;
     }
 
     void ProjectedShadowFeatureProcessor::SetShadowFilterMethod(ShadowId id, ShadowFilterMethod method)
@@ -580,11 +581,14 @@ namespace AZ::Render
         for (const auto& shadowProperty : m_shadowProperties.GetDataVector())
         {
             FilterParameter& esmData = m_shadowData.GetElement<FilterParamIndex>(shadowProperty.m_shadowId.GetIndex());
+            ShadowData& shadowData = m_shadowData.GetElement<ShadowDataIndex>(shadowProperty.m_shadowId.GetIndex());
             if (esmData.m_isEnabled)
             {
                 anyShadowsUseEsm = true;
                 break;
             }
+            // TODO: why do we set it multiple times?
+            m_primaryEsmShadowmapsPass->SetEsmExponent(shadowData.m_esmExponent);
         }
 
         m_primaryEsmShadowmapsPass->SetEnabledComputation(anyShadowsUseEsm);

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -836,7 +836,8 @@ namespace AZ::Render
 
         if (needsEsm)
         {
-            m_esmAtlasImage = createAtlas(RHI::Format::R16_FLOAT, RHI::ImageBindFlags::ShaderReadWrite, RHI::ImageAspectFlags::Color, "ProjectedShadowAtlasESM");
+            m_esmAtlasImage = createAtlas(
+                RHI::Format::R32_FLOAT, RHI::ImageBindFlags::ShaderReadWrite, RHI::ImageAspectFlags::Color, "ProjectedShadowAtlasESM");
             for (auto& [key, esmShadowmapsPass] : m_esmShadowmapsPasses)
             {
                 esmShadowmapsPass->SetAtlasAttachmentImage(m_esmAtlasImage);

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -307,10 +307,10 @@ namespace AZ::Render
         shadowData.m_bias = nearDist * shadowProperty.m_bias * 0.01f;
         
         FilterParameter& esmData = m_shadowData.GetElement<FilterParamIndex>(shadowProperty.m_shadowId.GetIndex());
-        
+
         // Set parameters to calculate linear depth if ESM is used.
-        esmData.m_n_f_n = nearDist / (farDist - nearDist);
-        esmData.m_n_f = nearDist - farDist;
+        esmData.m_nf = nearDist * farDist;
+        esmData.m_f_n = farDist - nearDist;
         esmData.m_f = farDist;
         esmData.m_isEnabled = FilterMethodIsEsm(shadowData);
         m_filterParameterNeedsUpdate = m_filterParameterNeedsUpdate || esmData.m_isEnabled;

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
@@ -324,24 +324,22 @@ float3 RotateVectorByQuaternion(float3 v, float4 q)
 
 // This converts depth in clip space of perspective projection to linear depth in [0, 1].
 // coefficients:
-//   x : n / f - n
-//   y : n - f
+//   x : n * f
+//   y : f - n
 //   z : f
 //   where n : nearDepth and f : farDepth.
 // By the definition of the perspective projection,
 //   (z_, w_)^T = P (z, w)^T
 // where P = /  f/(n-f)    nf/(n-f)   \
 //           \    -1          0       /.
-// Then inverse(P) (d, 1)^T =
-//       /         -1          \
-//       \   ((n-f)d + f) / nf /.
+// Then the inverse: z = n*f / ((f-n) * z_ - f). See DepthToLinearDepth.azsl. abs() here to keep positive value.
 float PerspectiveDepthToLinear(float clipDepth, float3 coefficients)
 {
-    return coefficients.x * (coefficients.z / (coefficients.y * clipDepth + coefficients.z) - 1.);
+    return abs(coefficients.x / (coefficients.y * clipDepth - coefficients.z));
 }
 half PerspectiveDepthToLinear(half clipDepth, half3 coefficients)
 {
-    return coefficients.x * (coefficients.z / (coefficients.y * clipDepth + coefficients.z) - 1.);
+    return abs(coefficients.x / (coefficients.y * clipDepth - coefficients.z));
 }
 
 // ---------- Random number generators -----------

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Math.azsli
@@ -333,6 +333,7 @@ float3 RotateVectorByQuaternion(float3 v, float4 q)
 // where P = /  f/(n-f)    nf/(n-f)   \
 //           \    -1          0       /.
 // Then the inverse: z = n*f / ((f-n) * z_ - f). See DepthToLinearDepth.azsl. abs() here to keep positive value.
+// Here is a link showing the relationship between clip depth and linear depth: https://www.desmos.com/calculator/tx9mz0qwzb
 float PerspectiveDepthToLinear(float clipDepth, float3 coefficients)
 {
     return abs(coefficients.x / (coefficients.y * clipDepth - coefficients.z));

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -169,8 +169,8 @@ namespace AZ
                             Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_esmExponent, "ESM exponent",
                             "Exponent used by ESM shadows. "
                             "Larger values increase the sharpness of the border between lit and unlit areas.")
-                            ->Attribute(Edit::Attributes::Min, 50.0f)
-                            ->Attribute(Edit::Attributes::Max, 5000.0f)
+                            ->Attribute(Edit::Attributes::Min, 1.0f)
+                            ->Attribute(Edit::Attributes::Max, 20.0f)
                             ->Attribute(AZ::Edit::Attributes::Decimals, 0)
                             ->Attribute(AZ::Edit::Attributes::SliderCurveMidpoint, 0.05f)
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)


### PR DESCRIPTION
## What does this PR do?

1. Corrects the `PerspectiveDepthToLinear()` formula and it related parameters. [Ref plot](https://www.desmos.com/calculator/tx9mz0qwzb)
2. This MR corrects the implementation of the **Exponential Shadow Map** for projected light. Based on the formula proposed in the [orignal paper](https://jankautz.com/publications/esm_gi08.pdf).
3. Convert the ESM attachment images to`R32_FlOAT` because `R16_FLOAT` will easily overflow. 

### Notes
The current  `PerspectiveDepthToLinear()` formula in o3de is wrong, as it plots the curve of `z_1` in https://www.desmos.com/calculator/tx9mz0qwzb. After the correction I also found the ESM implementation in the Atom is also incorrect as it is storing the `linearDepth` as opposed to `exponentiation` in the `DepthExponentiation.pass`. 

With the correction of `PerspectiveDepthToLinear()` it will not produce soft shadow because fast decay of `exp((occluder - zReceiver) * esmExponent)`

![loss-of-soft-shadow](https://github.com/o3de/o3de/assets/5506916/2ff73543-63dc-498c-83bb-a4578b4b33f3)

With correct formula. We can see the soft shadow is regained.

![fixed-ESM](https://github.com/o3de/o3de/assets/5506916/706e0187-b04b-4c02-98fd-bcbd97f02138)


## How was this PR tested?
Locally Tested.

## TODO
This MR fixes the ESM for projected light. The Directional Light fixes will come later.