### PR TITLE
Cherrypick bugfix from stab to dev - Fixes a refresh issue with sliders in the DPE (#18003)

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SliderCombo.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SliderCombo.cpp
@@ -385,6 +385,17 @@ void SliderDoubleCombo::setSoftRange(double min, double max)
 
 }
 
+void SliderDoubleCombo::resetLimits()
+{
+    m_useSoftMinimum = false;
+    m_useSoftMaximum = false;
+    m_minimum = 0.0;
+    m_minimum = 100.0;
+    m_softMinimum = m_minimum;
+    m_softMaximum = m_minimum;
+    refreshUi();
+}
+
 int SliderDoubleCombo::numSteps() const
 {
     return m_slider->numSteps();

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SliderCombo.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SliderCombo.h
@@ -149,6 +149,8 @@ namespace AzQtComponents
         explicit SliderDoubleCombo(QWidget *parent = nullptr);
         ~SliderDoubleCombo();
 
+        void resetLimits();
+
         //! Sets the current value.
         void setValue(double value);
         //! Sets the current value.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1635,6 +1635,13 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::HandleDomChange(const AZ::Dom::Patch& patch)
     {
+        if (m_isBeingCleared)
+        {
+            AZ_Assert(false, "DocumentPropertyEditor::HandleDomChange called while being cleared.  check the callstack.  Suppress your signals during cleanup and destruction of widgets!");
+            AZ_TracePrintf("Document Property Editor", "DocumentPropertyEditor::HandleDomChange leaving early");
+            return;
+        }
+
         if (m_rootNode)
         {
             bool needsReset = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -306,6 +306,8 @@ namespace AzToolsFramework
 
         DPERowWidget* m_rootNode = nullptr;
 
+        bool m_isBeingCleared = false;
+
         // keep pools of frequently used widgets that can be recycled for efficiency without
         // incurring the cost of creating and destroying them
         AZStd::shared_ptr<AZ::InstancePool<DPERowWidget>> m_rowPool;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -72,36 +72,43 @@ namespace AzToolsFramework
 
     void PropertyDoubleSliderCtrl::setSoftMinimum(double val)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->setSoftMinimum(val);
     }
 
     void PropertyDoubleSliderCtrl::setSoftMaximum(double val)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->setSoftMaximum(val);
     }
 
     void PropertyDoubleSliderCtrl::setPrefix(QString val)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->spinbox()->setPrefix(val);
     }
 
     void PropertyDoubleSliderCtrl::setSuffix(QString val)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->spinbox()->setSuffix(val);
     }
 
     void PropertyDoubleSliderCtrl::setDecimals(int decimals)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->setDecimals(decimals);
     }
 
     void PropertyDoubleSliderCtrl::setDisplayDecimals(int displayDecimals)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->spinbox()->setDisplayDecimals(displayDecimals);
     }
 
     void PropertyDoubleSliderCtrl::setCurveMidpoint(double midpoint)
     {
+        QSignalBlocker block(m_sliderCombo);
         m_sliderCombo->setCurveMidpoint(midpoint);
     }
 
@@ -147,6 +154,11 @@ namespace AzToolsFramework
     void PropertyDoubleSliderCtrl::UpdateTabOrder()
     {
         setTabOrder(GetFirstInTabOrder(), GetLastInTabOrder());
+    }
+
+    void PropertyDoubleSliderCtrl::ClearSavedState()
+    {
+        m_sliderCombo->resetLimits();
     }
 
     // a common function to eat attribs, for all int handlers:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.hxx
@@ -56,6 +56,8 @@ namespace AzToolsFramework
         QWidget* GetLastInTabOrder();
         void UpdateTabOrder();
 
+        void ClearSavedState();
+
         void onValueChange();
     signals:
         void valueChanged(double val);
@@ -75,9 +77,12 @@ namespace AzToolsFramework
         QWidget* GetFirstInTabOrder(PropertyDoubleSliderCtrl* widget) override { return widget->GetFirstInTabOrder(); }
         QWidget* GetLastInTabOrder(PropertyDoubleSliderCtrl* widget) override { return widget->GetLastInTabOrder(); }
         void UpdateWidgetInternalTabbing(PropertyDoubleSliderCtrl* widget) override { widget->UpdateTabOrder(); }
+
+        void BeforeConsumeAttributes(PropertyDoubleSliderCtrl* widget, InstanceDataNode* /*attrValue*/) override
+        {
+            widget->ClearSavedState();
+        }
     };
-
-
 
     class doublePropertySliderHandler
         : QObject

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -651,22 +651,23 @@ namespace AzToolsFramework
         typedef WidgetType widget_t;
 
         // Resets widget attributes for reuse; returns true if widget was reset
+        // if you return false, the widget will be destroyed and recreated on each reuse, so implementing this
+        // can improve response speed and reduce flicker.  On the other hand, actually resetting a really complicated
+        // widget can involve cleaning out unexpected amounts of hidden state in a tree of child widgets, which themselves
+        // may have complicated hidden state, so implement it with care and test it extensively.
         virtual bool ResetGUIToDefaults([[maybe_unused]] WidgetType* widget)
         {
             return false;
         }
 
+        // see documentation in PropertyEditorAPI.h in @ref class PropertyHandler
+        virtual void BeforeConsumeAttributes(WidgetType* widget, InstanceDataNode* attrValue) = 0;
+
         // this will be called in order to initialize your gui.  Your class will be fed one attribute at a time
         // you can interpret the attributes as you wish - use attrValue->Read<int>() for example, to interpret it as an int.
         // all attributes can either be a flat value, or a function which returns that same type.  In the case of the function
         // it will be called on the first instance.
-        virtual void ConsumeAttribute(WidgetType* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
-        {
-            (void)widget;
-            (void)attrib;
-            (void)attrValue;
-            (void)debugName;
-        }
+        virtual void ConsumeAttribute(WidgetType* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) = 0;
 
         // provides an option to specify reading parent element attributes.
         // This allows parent elements to override attributes of their children if needed.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals_Impl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals_Impl.h
@@ -25,6 +25,8 @@ namespace AzToolsFramework
         WidgetType* wid = static_cast<WidgetType*>(widget);
         AZ_Assert(wid, "Invalid class cast - this is not the right kind of widget!");
 
+        BeforeConsumeAttributes(wid, dataNode);
+
         InstanceDataNode* parent = dataNode->GetParent();
 
         // Function callbacks require the instance pointer to be the first non-container ancestor.


### PR DESCRIPTION
This cherrypicks https://github.com/o3de/o3de/pull/18003 to dev from stab.

* Fixes a refresh issue with sliders in the DPE

Also adds a new function to the DPE to allow for handlers to clean up any internal state they have before new attributes are set.  Sliders are the only ones using this new function, but if we find controls that have internal state that causes problems like this we can update them to function correctly.

Also adds an assert to check for the case where the widgets being used by the DPE are sending signals while being recycled and cleared.

The slider was the only one I found that caused that assert, but the assert is also handled and continues without a crash if it hits, so it should be safer and less crashy even when compiled in profile mode.

The root cause of this problem is documented in the issue it fixes, which is https://github.com/o3de/o3de/issues/16947 (Issue #16947)

I did try several other approaches, such as resetting the DPE when given a reset of "EntireTree or "AttributesAndValues" but too many other control send an "AttributesAndValues" reset when they are updated, so clearing the entire tree and recycling all controls caused odd behavior like sliders not being draggable (since it happens while being dragged).


