### PR TITLE
Stabilization: MiniAudio: Set the default playback volume to 100%

### DIFF
--- a/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.h
+++ b/Gems/MiniAudio/Code/Source/Clients/MiniAudioPlaybackComponentConfig.h
@@ -40,7 +40,8 @@ namespace MiniAudio
         //! environment audio.
         bool m_autoplayOnActivate = false;
 
-        float m_volume = 1.f;
+        //! Playback volume represented as a percentage
+        float m_volume = 100.f;
 
         //! If true, follow the position of the entity.
         bool m_autoFollowEntity = false;


### PR DESCRIPTION
Since the volume is represented as a percentage now, the default value should be set to 100%.

Note: same as #18006 just targeting `stabilization/2409` instead of `development` (cherry-picked PR's commit).