### PR TITLE
Add missing "SetProceduralGeometryMaterial" method to RayTracingFeatureProcessor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -207,6 +207,24 @@ namespace AZ
             m_proceduralGeometryInfoBufferNeedsUpdate = true;
         }
 
+        void RayTracingFeatureProcessor::SetProceduralGeometryMaterial(
+            const Uuid& uuid, const RayTracingFeatureProcessor::SubMeshMaterial& material)
+        {
+            if (!m_rayTracingEnabled)
+            {
+                return;
+            }
+
+            AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
+
+            if (auto it = m_proceduralGeometryLookup.find(uuid); it != m_proceduralGeometryLookup.end())
+            {
+                ConvertMaterial(m_proceduralGeometryMaterialInfos[it->second], material);
+            }
+
+            m_materialInfoBufferNeedsUpdate = true;
+        }
+
         void RayTracingFeatureProcessor::RemoveProceduralGeometry(const Uuid& uuid)
         {
             if (!m_rayTracingEnabled)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -282,6 +282,11 @@ namespace AZ
             //! used together with `GetBindlessBufferIndex()` to access per-instance geometry data.
             void SetProceduralGeometryLocalInstanceIndex(const Uuid& uuid, uint32_t localInstanceIndex);
 
+            //! Sets the material of a procedural geometry instance.
+            //! \param uuid The Uuid of the procedural geometry which must have been added with `AddProceduralGeometry` before.
+            //! \param material The material of the procedural geometry instance.
+            void SetProceduralGeometryMaterial(const Uuid& uuid, const SubMeshMaterial& material);
+
             //! Removes a procedural geometry instance from the ray tracing scene.
             //! \param uuid The Uuid of the procedrual geometry which must have been added with `AddProceduralGeometry` before.
             void RemoveProceduralGeometry(const Uuid& uuid);


### PR DESCRIPTION
## What does this PR do?

This PR adds a function, which set the ray tracing material of  a procedural geometry instance, to `RayTracingFeatureProcessor`, which was omitted when the other procedural geometry functions were introduced in #17734. The same function for triangle geometry already exists and is called `SetMeshMaterials`.

## How was this PR tested?

Manual test with one of our internal Gems (the DebugDraw gem does not use this function since the debug shapes are always re-created when the color changes).