### PR TITLE
Adds a check for half16, required for ray tracing.

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/DX12.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/DX12.cpp
@@ -265,20 +265,22 @@ namespace AZ
 
             if (FAILED(hr))
             {
-                char* msgBuf = nullptr;
+                wchar_t* msgBuf = nullptr;
 
-                if (FormatMessage(
+                if (FormatMessageW(
                         FORMAT_MESSAGE_ALLOCATE_BUFFER |
                         FORMAT_MESSAGE_FROM_SYSTEM |
                         FORMAT_MESSAGE_IGNORE_INSERTS,
                         NULL,
                         hr,
                         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-                        (LPTSTR) &msgBuf,
+                        (LPWSTR)&msgBuf,
                         0,
                         NULL))
                 {
-                    AZ_Assert(false, "HRESULT not a success %x, error msg = %s", hr, msgBuf);
+                    AZStd::string utf8EncodedString;
+                    AZStd::to_string(utf8EncodedString, msgBuf);
+                    AZ_Assert(false, "HRESULT not a success %x, error msg = %s", hr, utf8EncodedString.c_str());
                     LocalFree(msgBuf);
                 }
                 else

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1143,6 +1143,28 @@ namespace AZ
             {
                 // Ray tracing needs raytracing extensions and unbounded arrays to work
                 m_features.m_rayTracing = (itRayTracingExtension != deviceExtensions.end());
+
+                // RAYTRACE_REQUIRE_HALF16 (search for this tag to find other instances of this check for other platforms)
+                // Raytracing support currently requires support of half16 (low precision float) values in shaders.
+                // Not all raytracing-capable hardware actually supports this.
+                // When shaders are created that can instead use full precision floats we can remove this check and switch over.
+                if (m_features.m_rayTracing)
+                {
+                    m_features.m_rayTracing = physicalDevice.GetPhysicalDeviceFloat16Int8Features().shaderFloat16;
+                    if (m_features.m_rayTracing)
+                    {
+                        AZ_Info("Vulkan", "Device has " VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME " and shaderFloat16 support - raytracing feature enabled.")
+
+                    }
+                    else
+                    {
+                        AZ_Info("Vulkan", "Device has " VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME " but not shaderFloat16 - raytracing feature disabled.")
+                    }
+                }
+            }
+            else
+            {
+                AZ_Info("Vulkan", "Device does not have " VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME " - raytracing feature disabled.")
             }
 
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))


### PR DESCRIPTION

## What does this PR do?

This adds a check to both DX12 and Vulkan to ensure that the hardware supports half16.  If it does not, the engine will turn off ray tracing and log the reason why.

If it finds the necessary support, it will turn on ray tracing and also log that it has done so.

This change also fixes the print out of errors from the DX12 "ensure success" function.  Previously, this function was printing out just the first letter of the error message because it was feeding a wchar string into a printf that expects utf8 input.  This change explicitly calls the wstring version of the error function and explicitly converts it to utf8 before feeding it to the utf8 AZ_xxxx function.

Doing so means that localized error messages will print correctly in environments that support them.  While doing so, I've also eliminated the use of the macroized functions that change their types based on whether the UNICODE define is set or not.  This code will function no matter what the defines are and the types will not change.

## How was this PR tested?

On windows, initializing a device that had raytrace support, but not half16 support.
I also ran it with `--rhi=vulkan`.

Before this PR, you'd get a bunch of asserts and raytrace would fail to actually create the necessary objects to function.
Then it would continue to assert during runtime.

After this PR, it seems to operate okay, without asserts (and without raytrace).

