### PR TITLE
Add fallback implementation for the ProceduralGeometryIntersectionAttributes struct if float16 is not supported by the RHI

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingIntersectionAttributes.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingIntersectionAttributes.azsli
@@ -6,12 +6,79 @@
  *
  */
 
+#include <Atom/RPI/Math.azsli>
+
+
+#ifdef NO_FLOAT_16
+
+uint PackNormalToLower30BitsOfUint(float3 normal)
+{
+    float3 encodedNormal = EncodeNormalSignedOctahedron(normal);
+    return
+        ((uint)(encodedNormal.x * 1023.f) & 0x3FF) << 20 |
+        ((uint)(encodedNormal.y * 1023.f) & 0x3FF) << 10 |
+        ((uint)(encodedNormal.z * 1023.f) & 0x3FF) <<  0;
+}
+
+float3 UnpackNormalFromLower30BitsOfUint(uint packedNormal)
+{
+    float3 encodedNormal = float3(
+        (float)((packedNormal >> 20) & 0x3FF) / 1023.f,
+        (float)((packedNormal >> 10) & 0x3FF) / 1023.f,
+        (float)((packedNormal >>  0) & 0x3FF) / 1023.f
+    );
+    return DecodeNormalSignedOctahedron(encodedNormal);
+}
+
+uint PackTangentToLower31BitsOfUint(float4 tangent)
+{
+    return PackNormalToLower30BitsOfUint(tangent.xyz) | (tangent.w > 0 ? 1 : 0) << 30;
+}
+
+float4 UnpackTangentFromLower31BitsOfUint(uint packedTangent)
+{
+    float3 tangent = UnpackNormalFromLower30BitsOfUint(packedTangent);
+    return float4(tangent, (packedTangent >> 30) ? 1.f : -1.f);
+}
+
 // This structure must not be larger than 32 bytes (D3D12_RAYTRACING_MAX_ATTRIBUTE_SIZE_IN_BYTES)
-struct ProceduralGeometryIntersectionAttributes
+class ProceduralGeometryIntersectionAttributes
+{
+    float3 m_position;    // [12 bytes] Surface hit point in object space (BLAS space)
+    float2 m_uv;          // [ 8 bytes] Surface uv coordinates
+    uint m_packedNormal;  // [ 4 bytes] Surface normal in object space (BLAS space)
+    uint m_packedTangent; // [ 4 bytes] Surface tangent in object space (BLAS space)
+    //                   sum: 28 bytes
+
+    float3 GetPosition() { return m_position; }
+    float2 GetUv()       { return m_uv; }
+    float3 GetNormal()   { return UnpackNormalFromLower30BitsOfUint(m_packedNormal); }
+    float4 GetTangent()  { return UnpackTangentFromLower31BitsOfUint(m_packedTangent); }
+    void SetPosition(float3 position) { m_position = position; }
+    void SetUv      (float2 uv)       { m_uv = uv; }
+    void SetNormal  (float3 normal)   { m_packedNormal = PackNormalToLower30BitsOfUint(normal); }
+    void SetTangent (float4 tangent)  { m_packedTangent = PackTangentToLower31BitsOfUint(tangent); }
+};
+
+#else
+
+// This structure must not be larger than 32 bytes (D3D12_RAYTRACING_MAX_ATTRIBUTE_SIZE_IN_BYTES)
+class ProceduralGeometryIntersectionAttributes
 {
     float3 m_position; // [12 bytes] Surface hit point in object space (BLAS space)
     half3 m_normal;    // [ 6 bytes] Surface normal in object space (BLAS space)
     half2 m_uv;        // [ 4 bytes] Surface uv coordinates
     half4 m_tangent;   // [ 8 bytes] Surface tangent in object space (BLAS space)
     //                sum: 30 bytes
+
+    float3 GetPosition() { return m_position; }
+    float2 GetUv()       { return float2(m_uv); }
+    float3 GetNormal()   { return float3(m_normal); }
+    float4 GetTangent()  { return float4(m_tangent); }
+    void SetPosition(float3 position) { m_position = position; }
+    void SetUv      (float2 uv)       { m_uv = half2(uv); }
+    void SetNormal  (float3 normal)   { m_normal = half3(normal); }
+    void SetTangent (float4 tangent)  { m_tangent = half4(tangent); }
 };
+
+#endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHitProcedural.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHitProcedural.azsl
@@ -14,10 +14,10 @@
 void ClosestHitProcedural(inout PayloadData payload, ProceduralGeometryIntersectionAttributes attrib)
 {
     VertexData vertexData;
-    vertexData.m_position = attrib.m_position;
-    vertexData.m_normal = float3(attrib.m_normal);
-    vertexData.m_uv = float2(attrib.m_uv);
-    vertexData.m_tangent = float4(attrib.m_tangent);
+    vertexData.m_position = attrib.GetPosition();
+    vertexData.m_normal = attrib.GetNormal();
+    vertexData.m_uv = attrib.GetUv();
+    vertexData.m_tangent = attrib.GetTangent();
     vertexData.m_bitangent = cross(vertexData.m_normal, vertexData.m_tangent.xyz) * vertexData.m_tangent.w;
 
     ScreenSpaceClosestHitImpl(payload, vertexData, transpose(ObjectToWorld4x3()));

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHitProcedural.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingClosestHitProcedural.shader
@@ -31,8 +31,32 @@
         },
         {
             "Name": "NoMSAA",
-            "AddBuildArguments": {
+            "AddBuildArguments":
+            {
                 "azslc": ["--no-ms"]
+            },
+            "RemoveBuildArguments" :
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoFloat16",
+            "AddBuildArguments":
+            {
+                "preprocessor": ["-DNO_FLOAT_16=1"]
+            },
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoFloat16NoMSAA",
+            "AddBuildArguments":
+            {
+                "azslc": ["--no-ms"],
+                "preprocessor": ["-DNO_FLOAT_16=1"]
             },
             "RemoveBuildArguments" :
             {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/DispatchRaysItem.h>
 #include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/PipelineState.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 #include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
@@ -79,7 +80,7 @@ namespace AZ
             };
             AZStd::fixed_vector<RTShaderLib, 4> shaderLibs;
 
-            auto loadRayTracingShader = [&](auto& assetReference) -> RTShaderLib&
+            auto loadRayTracingShader = [&](auto& assetReference, const AZ::Name& supervariantName = AZ::Name("")) -> RTShaderLib&
             {
                 auto it = std::find_if(
                     shaderLibs.begin(),
@@ -94,7 +95,7 @@ namespace AZ
                 }
                 auto shaderAsset{ AZ::RPI::FindShaderAsset(assetReference.m_assetId, assetReference.m_filePath) };
                 AZ_Assert(shaderAsset.IsReady(), "Failed to load shader %s", assetReference.m_filePath.c_str());
-                auto shader{ AZ::RPI::Shader::FindOrCreate(shaderAsset) };
+                auto shader{ AZ::RPI::Shader::FindOrCreate(shaderAsset, supervariantName) };
                 auto shaderVariant{ shader->GetVariant(AZ::RPI::ShaderAsset::RootShaderVariantStableId) };
                 AZ::RHI::PipelineStateDescriptorForRayTracing pipelineStateDescriptor;
                 shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
@@ -115,7 +116,8 @@ namespace AZ
 
             if (!m_passData->m_closestHitProceduralShaderName.empty())
             {
-                auto& closestHitProceduralShaderLib{ loadRayTracingShader(m_passData->m_closestHitProceduralShaderAssetReference) };
+                auto& closestHitProceduralShaderLib{ loadRayTracingShader(
+                    m_passData->m_closestHitProceduralShaderAssetReference, AZ::RHI::GetDefaultSupervariantNameWithNoFloat16Fallback()) };
                 closestHitProceduralShaderLib.m_closestHitProceduralShaderName = m_passData->m_closestHitProceduralShaderName;
                 m_closestHitProceduralShader = closestHitProceduralShaderLib.m_shader;
             }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
@@ -100,6 +100,9 @@ namespace AZ::RHI
         //! If this is false, the Fence::SignalOnCpu inserts the signal command into a queue
         bool m_signalFenceFromCPU = false;
 
+        //! Whether float16 (half-precision floating-point format) support is available.
+        bool m_float16 = false;
+
         /// Additional features here.
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -51,6 +51,10 @@ namespace AZ::RHI
     //! Returns true if the Atom/GraphicsDevMode settings registry key is set
     bool IsGraphicsDevModeEnabled();
 
+    //! Returns the default supervariant name of an empty string if float16 is supported and the name of "NoFloat16" if float16 is not
+    //! supported. This is useful for loading the correct supervariant when a shader needs to have a version with and without float16.
+    const AZ::Name& GetDefaultSupervariantNameWithNoFloat16Fallback();
+
     //! Utility function to write captured pool data to a json document
     //! Ensure the passed pool won't be modified during the call to this function
     //! Available externally to the RHI through the RHIMemoryStatisticsInterface

--- a/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
@@ -162,6 +162,13 @@ namespace AZ::RHI
         return graphicsDevMode;
     }
 
+    const AZ::Name& GetDefaultSupervariantNameWithNoFloat16Fallback()
+    {
+        const static AZ::Name DefaultSupervariantName{ "" };
+        const static AZ::Name NoFloat16SupervariantName{ "NoFloat16" };
+        return GetRHIDevice()->GetFeatures().m_float16 ? DefaultSupervariantName : NoFloat16SupervariantName;
+    }
+
     // Pool attributes
     using JsonStringRef = rapidjson::Value::StringRefType;
     const char PoolNameAttribStr[] = "PoolName";

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -255,6 +255,8 @@ namespace AZ
             m_features.m_rayTracing = false;
 #endif
 
+            m_features.m_float16 = (options.MinPrecisionSupport & D3D12_SHADER_MIN_PRECISION_SUPPORT_16_BIT) != 0;
+
             m_features.m_unboundedArrays = true;
 
 #ifdef O3DE_DX12_VRS_SUPPORT

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1145,6 +1145,8 @@ namespace AZ
                 m_features.m_rayTracing = (itRayTracingExtension != deviceExtensions.end());
             }
 
+            m_features.m_float16 = physicalDevice.GetPhysicalDeviceFloat16Int8Features().shaderFloat16;
+
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))
             {
                 const auto& shadingRateFeatures = physicalDevice.GetPhysicalDeviceFragmentShadingRateFeatures();

--- a/Gems/DebugDraw/Assets/Shaders/ObbIntersection.azsl
+++ b/Gems/DebugDraw/Assets/Shaders/ObbIntersection.azsl
@@ -74,10 +74,10 @@ void ObbIntersection()
     if (IntersectRayAABB(ObjectRayOrigin(), ObjectRayDirection(), aabbMin, aabbMax, t, normal))
     {
         ProceduralGeometryIntersectionAttributes attrib;
-        attrib.m_position = ObjectRayOrigin() + ObjectRayDirection() * t;
-        attrib.m_normal = half3(normal);
-        attrib.m_uv = half2(0, 0);
-        attrib.m_tangent = half4(1, 0, 0, 1);
+        attrib.SetPosition(ObjectRayOrigin() + ObjectRayDirection() * t);
+        attrib.SetNormal(normal);
+        attrib.SetUv(float2(0, 0));
+        attrib.SetTangent(float4(1, 0, 0, 1));
         ReportHit(t, 0, attrib);
     }
 }

--- a/Gems/DebugDraw/Assets/Shaders/ObbIntersection.shader
+++ b/Gems/DebugDraw/Assets/Shaders/ObbIntersection.shader
@@ -28,6 +28,17 @@
             {
                 "azslc": ["--strip-unused-srgs"]
             }
+        },
+        {
+            "Name": "NoFloat16",
+            "AddBuildArguments":
+            {
+                "preprocessor": ["-DNO_FLOAT_16=1"]
+            },
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
         }
     ]
 }

--- a/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
+++ b/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
@@ -68,10 +68,10 @@ void SphereIntersection()
     if (IntersectRaySphere(WorldRayOrigin(), WorldRayDirection(), sphereCenterWS, sphereRadiusWS, t))
     {
         ProceduralGeometryIntersectionAttributes attrib;
-        attrib.m_position = ObjectRayOrigin() + ObjectRayDirection() * t;
-        attrib.m_normal = half3(normalize(attrib.m_position - sphereCenter));
-        attrib.m_uv = half2(0, 0);
-        attrib.m_tangent = half4(1, 0, 0, 1);
+        attrib.SetPosition(ObjectRayOrigin() + ObjectRayDirection() * t);
+        attrib.SetNormal(normalize(attrib.m_position - sphereCenter));
+        attrib.SetUv(float2(0, 0));
+        attrib.SetTangent(float4(1, 0, 0, 1));
         ReportHit(t, 0, attrib);
     }
 }

--- a/Gems/DebugDraw/Assets/Shaders/SphereIntersection.shader
+++ b/Gems/DebugDraw/Assets/Shaders/SphereIntersection.shader
@@ -28,6 +28,17 @@
             {
                 "azslc": ["--strip-unused-srgs"]
             }
+        },
+        {
+            "Name": "NoFloat16",
+            "AddBuildArguments":
+            {
+                "preprocessor": ["-DNO_FLOAT_16=1"]
+            },
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
         }
     ]
 }

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -27,6 +27,7 @@
 #include <AzToolsFramework/Entity/EditorEntityContextComponent.h>
 #endif // DEBUGDRAW_GEM_EDITOR
 
+#include <Atom/RHI/RHIUtils.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Scene.h>
@@ -1127,7 +1128,7 @@ namespace DebugDraw
                 AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::RayTracingFeatureProcessor>(element.m_targetEntityId);
 
             auto shaderAsset = AZ::RPI::FindShaderAsset("shaders/sphereintersection.azshader");
-            auto rayTracingShader = AZ::RPI::Shader::FindOrCreate(shaderAsset);
+            auto rayTracingShader = AZ::RPI::Shader::FindOrCreate(shaderAsset, AZ::RHI::GetDefaultSupervariantNameWithNoFloat16Fallback());
 
             AZ::RPI::CommonBufferDescriptor desc;
             desc.m_bufferName = "SpheresBuffer";
@@ -1191,7 +1192,7 @@ namespace DebugDraw
                 AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::RayTracingFeatureProcessor>(element.m_targetEntityId);
 
             auto shaderAsset = AZ::RPI::FindShaderAsset("shaders/obbintersection.azshader");
-            auto rayTracingShader = AZ::RPI::Shader::FindOrCreate(shaderAsset);
+            auto rayTracingShader = AZ::RPI::Shader::FindOrCreate(shaderAsset, AZ::RHI::GetDefaultSupervariantNameWithNoFloat16Fallback());
 
             m_obbRayTracingTypeHandle =
                 m_rayTracingFeatureProcessor->RegisterProceduralGeometryType("DebugDraw::Obb", rayTracingShader, "ObbIntersection");


### PR DESCRIPTION
## What does this PR do?

This PR fixes a problem with devices which support raytracing but do not support float16 by adding a fallback implementation for the `ProceduralGeometryIntersectionAttributes` struct with getters and setters which uses octahedron-encoding and quantization to store normals and tangents instead of half-precision floating point.

## How was this PR tested?

Test both version on Windows with DX12 and Vulkan by changing the return value of `GetDefaultSupervariantNameWithNoFloat16Fallback()`, while introducing some errors into the code in `RayTracingIntersectionAttributes.azsli` to visually verify that both code paths (with and without `NO_FLOAT_16` macro are taken) are taken. When using the correct code, both versions are visually indistinguishable, only a diff image shows some differences between the two "compression" methods (float16 in the left image, octahedron encoding + 10-bit quantization in the right image):
![compare](https://github.com/o3de/o3de/assets/113582781/65ce1b50-c6fc-4bd1-ac6e-934549e50f81)

@nick-l-o3de Could you please test this with the device where you got the error due to `NativeLowPrecision` not being supported? If it works, this should probably supersede PR #18035.