### PR TITLE
Ensure Project Manager properly deletes restricted project folder when needed

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectInfo.h
+++ b/Code/Tools/ProjectManager/Source/ProjectInfo.h
@@ -55,6 +55,7 @@ namespace O3DE::ProjectManager
         QString m_iconPath;
         QString m_requirements;
         QString m_license;
+        QString m_restricted;
         QStringList m_userTags;
 
         QStringList m_requiredGemDependencies;

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -469,11 +469,10 @@ namespace O3DE::ProjectManager
                     if (!pInfo.GetValue().m_restricted.isEmpty())
                     {
                         QDir restrictedDirectory(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
-                        restrictedDirectory.cd("O3DE");
-                        restrictedDirectory.cd("Restricted");
-                        restrictedDirectory.cd("Projects");
-                        restrictedDirectory.cd(pInfo.GetValue().m_restricted);
-                        if (!restrictedDirectory.isEmpty())
+                        
+                        if (restrictedDirectory.cd("O3DE/Restricted/Projects") &&
+                            restrictedDirectory.cd(pInfo.GetValue().m_restricted) &&
+                            !restrictedDirectory.isEmpty())
                         {
                             restrictedDirectory.removeRecursively();
                         }

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -23,6 +23,7 @@
 #include <QGuiApplication>
 #include <QProgressDialog>
 #include <QSpacerItem>
+#include <QStandardPaths>
 #include <QGridLayout>
 #include <QTextEdit>
 #include <QByteArray>
@@ -461,8 +462,22 @@ namespace O3DE::ProjectManager
             if (projectDirectory.exists())
             {
                 // Check if there is an actual project here or just force it
-                if (force || PythonBindingsInterface::Get()->GetProject(path).IsSuccess())
+                AZ::Outcome<ProjectInfo> pInfo = PythonBindingsInterface::Get()->GetProject(path);
+                if (force || pInfo.IsSuccess())
                 {
+                    //determine if we have a restricted directory to worry about
+                    if (!pInfo.GetValue().m_restricted.isEmpty())
+                    {
+                        QDir restrictedDirectory(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+                        restrictedDirectory.cd("O3DE");
+                        restrictedDirectory.cd("Restricted");
+                        restrictedDirectory.cd("Projects");
+                        restrictedDirectory.cd(pInfo.GetValue().m_restricted);
+                        if (!restrictedDirectory.isEmpty())
+                        {
+                            restrictedDirectory.removeRecursively();
+                        }
+                    }
                     return projectDirectory.removeRecursively();
                 }
             }

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1109,6 +1109,7 @@ namespace O3DE::ProjectManager
         projectInfo.m_license = Py_To_String_Optional(projectData, "license", projectInfo.m_license);
         projectInfo.m_iconPath = Py_To_String_Optional(projectData, "icon", ProjectPreviewImagePath);
         projectInfo.m_engineName = Py_To_String_Optional(projectData, "engine", projectInfo.m_engineName);
+        projectInfo.m_restricted = Py_To_String_Optional(projectData, "restricted", projectInfo.m_restricted);
         if (projectData.contains("user_tags"))
         {
             for (auto tag : projectData["user_tags"])


### PR DESCRIPTION
## What does this PR do?
This PR is a bugfix for https://github.com/o3de/o3de/issues/17988.
Changes ensure that if the project being deleted also contains a folder of matching project name in the O3DE/Restricted folder, the contents of that folder are also properly deleted.

## How was this PR tested?
Testing was performed manually using the ProjectManager in the Visual Studio debugger. I confirmed that upon project deletion, the project info correctly indicates the restricted folder, and checks for that folder's existence, and deletes the folder accordingly.