### PR TITLE
Fix material processing failure

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -116,12 +116,12 @@ namespace AZ
             {
                 // We usually won't load file during CreateJob since we want to keep the function fast. But here we have to load the
                 // material type data to find the exact material type format so we could create an accurate source dependency.
-                const auto materialresolvedPath = AssetUtils::ResolvePathReference(materialSourcePath, materialSourceData.m_materialType);
-                const auto resolvedMaterialTypePath = MaterialUtils::PredictOriginalMaterialTypeSourcePath(materialresolvedPath);
+                const auto materialResolvedPath = AssetUtils::ResolvePathReference(materialSourcePath, materialSourceData.m_materialType);
+                const auto resolvedMaterialTypePath = MaterialUtils::PredictOriginalMaterialTypeSourcePath(materialResolvedPath);
 
                 AZ_Warning(
                     MaterialBuilderName,
-                    AZ::StringFunc::Equal(materialresolvedPath, resolvedMaterialTypePath),
+                    AZ::StringFunc::Equal(materialResolvedPath, resolvedMaterialTypePath),
                     "Material type is referencing an asset in the intermediate or cache folder. Please update it with the proper path %s",
                     resolvedMaterialTypePath.c_str());
 


### PR DESCRIPTION
## What does this PR do?

Fix asset processor failures on the first try for some materials. Some materials are pointing to the intermediate asset folder for the material type. Add support to transform from the intermediate path to the original path before reading the material type during the CreateJobs function of Material Builder.

Fixes https://github.com/o3de/o3de/issues/17968 

## How was this PR tested?

Deleted the cache folder and built materials with a material type in the intermediate asset folder.