### PR TITLE
Fix permission issues in docker container for the installed o3de

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -46,9 +46,14 @@ then
     echo 'Mapping of the user id was not provided on docker run. You need to provide the following arguments: -v "$HOME/.o3de:/home/o3de/.o3de" -v "$HOME/O3DE:/home/o3de/O3DE"'
     exit 1
 else
+    echo "Updating O3DE permissions"
+
     # Make sure ownership is correct for the mapped O3DE folders
     sudo chown $O3DE_USER:$O3DE_USER -R /home/$O3DE_USER/.o3de
     sudo chown $O3DE_USER:$O3DE_USER -R /home/$O3DE_USER/O3DE
+
+    # Make sure the ownership of the installed O3DE is updated to the correct permissions
+    sudo chown $O3DE_USER:$O3DE_USER -R /opt/O3DE
 
     # Prepare and set the XDG_RUNTIME_DIR value for Qt in order to launch mime applications from Project Manager
     sudo mkdir -p /run/user/$UID


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with permissions in the docker container for the installed O3DE under `/opt/O3DE`

Even though a default o3de user is created with the following
```
RUN addgroup --gid 1000 "$O3DE_USER" \
    && adduser --gid 1000 --gecos "" --disabled-password "$O3DE_USER" \
    && usermod -a -G sudo $O3DE_USER \
    && echo "$O3DE_USER ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/$O3DE_USER
```
When the entry script maps the `o3de` user to the input `$GID`:
```
usermod -u "$UID" "$O3DE_USER" 2>/dev/null && {
    groupmod -g "$GID" "$O3DE_USER" 2>/dev/null ||
    usermod -a -G "$GID" "$O3DE_USER"
}
```
The permissions originally set for `/opt/O3DE` does not get properly matched, resulting in file permission issues when `entrypoint/sh` is bootstrapped.


