### PR TITLE
Revert "Fix permission issues in docker container for the installed o3de (#18047)"

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -46,14 +46,9 @@ then
     echo 'Mapping of the user id was not provided on docker run. You need to provide the following arguments: -v "$HOME/.o3de:/home/o3de/.o3de" -v "$HOME/O3DE:/home/o3de/O3DE"'
     exit 1
 else
-    echo "Updating O3DE permissions"
-
     # Make sure ownership is correct for the mapped O3DE folders
     sudo chown $O3DE_USER:$O3DE_USER -R /home/$O3DE_USER/.o3de
     sudo chown $O3DE_USER:$O3DE_USER -R /home/$O3DE_USER/O3DE
-
-    # Make sure the ownership of the installed O3DE is updated to the correct permissions
-    sudo chown $O3DE_USER:$O3DE_USER -R /opt/O3DE
 
     # Prepare and set the XDG_RUNTIME_DIR value for Qt in order to launch mime applications from Project Manager
     sudo mkdir -p /run/user/$UID


### PR DESCRIPTION
## What does this PR do?

This reverts commit d7a5ab5513069b34eaf48c1969797499d2b48b02. The ownership changes for O3DE introduced a 2+ minute delay on docker startup, and was unnecessary
