### PR TITLE
Revert using the multi-device-resources branch for o3de-extras.

### DIFF
--- a/.automatedtesting.json
+++ b/.automatedtesting.json
@@ -15,7 +15,7 @@
         {
             "NAME": "o3de-extras",
             "URL": "https://github.com/o3de/o3de-extras.git",
-            "BRANCH": "multi-device-resources"
+            "BRANCH": "development"
         }
     ]
 }


### PR DESCRIPTION
## What does this PR do?

Reverts switching the o3de-extras branch to multi-device-resources introduced in #17974 which was necessary to make the CI happy. This depends on https://github.com/o3de/o3de-extras/pull/716 being merged first.
