### PR TITLE
Fix for floats that are strings.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpace.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpace.pass
@@ -78,8 +78,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -95,8 +95,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
@@ -132,8 +132,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -152,8 +152,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {
@@ -172,8 +172,8 @@
                             "Attachment": "DepthStencilInput"
                         },
                         "Multipliers": {
-                            "WidthMultiplier": "0.5",
-                            "HeightMultiplier": "0.5"
+                            "WidthMultiplier": 0.5,
+                            "HeightMultiplier": 0.5
                         }
                     },
                     "ImageDescriptor": {


### PR DESCRIPTION
## What does this PR do?

The JSON parser appears to be locale dependent, so for locales where the floating point is a comma instead of a period this leads to wrong parsing of the numbers.

## How was this PR tested?

ASV reflections sample.
