### PR TITLE
Cherry pick mobile fixes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
@@ -128,8 +128,6 @@ namespace AzFramework
         WindowSize GetMaximumClientAreaSize() const override;
         void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options) override;
         bool SupportsClientAreaResize() const override;
-        void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() const override;
         WindowSize GetRenderResolution() const override;
         void SetRenderResolution(WindowSize resolution) override;
         bool GetFullScreenState() const override;
@@ -168,7 +166,8 @@ namespace AzFramework
             static Implementation* Create();
             virtual ~Implementation() = default;
 
-            virtual void InitWindow(const AZStd::string& title,
+            void InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks);
+            virtual void InitWindowInternal(const AZStd::string& title,
                                     const WindowGeometry& geometry,
                                     const WindowStyleMasks& styleMasks) = 0;
 
@@ -183,8 +182,6 @@ namespace AzFramework
             virtual WindowSize GetMaximumClientAreaSize() const;
             virtual void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options);
             virtual bool SupportsClientAreaResize() const;
-            virtual void SetEnableCustomizedResolution(bool enable);
-            virtual bool IsCustomizedResolutionEnabled() const;
             virtual WindowSize GetRenderResolution() const;
             virtual void SetRenderResolution(WindowSize resolution);
             virtual bool GetFullScreenState() const;
@@ -197,8 +194,7 @@ namespace AzFramework
             uint32_t m_width = 0;
             uint32_t m_height = 0;
             bool m_activated = false;
-            WindowSize m_customizedRenderResolution;
-            bool m_enableCustomizedResolution = false;
+            WindowSize m_renderResolution;
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -90,6 +90,15 @@ namespace AzFramework
         //! Generally desktop platforms support resizing, mobile platforms don't.
         virtual bool SupportsClientAreaResize() const = 0;
 
+        //! Enable custom render resolution which is different than client area size.
+        //! If custom render resolution is disabled, the render resolution is same as client area size
+        AZ_DEPRECATED_MESSAGE("Custom resolution is always enabled now. No need to use this function anymore.")
+        void SetEnableCustomizedResolution([[maybe_unused]] bool enable){}
+
+        //! If the custom render resolution is enabled.
+        AZ_DEPRECATED_MESSAGE("Custom resolution is always enabled now. No need to use this function anymore.")
+        bool IsCustomizedResolutionEnabled() const { return true; }
+
         //! Get the render resolution.
         //! If customized resolution is not enabled, it would return client area size
         virtual WindowSize GetRenderResolution() const = 0;

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -90,13 +90,6 @@ namespace AzFramework
         //! Generally desktop platforms support resizing, mobile platforms don't.
         virtual bool SupportsClientAreaResize() const = 0;
 
-        //! Enable custom render resolution which is different than client area size.
-        //! If custom render resolution is disabled, the render resolution is same as client area size
-        virtual void SetEnableCustomizedResolution(bool enable) = 0;
-        
-        //! If the custom render resolution is enabled.
-        virtual bool IsCustomizedResolutionEnabled() const = 0;
-
         //! Get the render resolution.
         //! If customized resolution is not enabled, it would return client area size
         virtual WindowSize GetRenderResolution() const = 0;

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Windowing/NativeWindow_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Windowing/NativeWindow_Android.cpp
@@ -22,7 +22,7 @@ namespace AzFramework
         ~NativeWindowImpl_Android() override = default;
 
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -34,9 +34,10 @@ namespace AzFramework
         ANativeWindow* m_nativeWindow = nullptr;
     };
 
-    void NativeWindowImpl_Android::InitWindow([[maybe_unused]]const AZStd::string& title,
-                                              const WindowGeometry& geometry,
-                                              [[maybe_unused]]const WindowStyleMasks& styleMasks)
+    void NativeWindowImpl_Android::InitWindowInternal(
+        [[maybe_unused]] const AZStd::string& title,
+        const WindowGeometry& geometry,
+        [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {
         m_nativeWindow = AZ::Android::Utils::GetWindow();
 
@@ -78,7 +79,7 @@ namespace AzFramework
     void NativeWindowImpl_Android::SetRenderResolution(WindowSize resolution)
     {
         WindowSize newResolution = resolution;
-        if (m_enableCustomizedResolution && m_nativeWindow)
+        if (m_nativeWindow)
         {
             // Fit the aspect ratio of the resolution so it matches the aspect ratio of the window
             // so when the window image is scaled by the OS compositor, it doesn't look stretched in any direction.

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -48,7 +48,7 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    void XcbNativeWindow::InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks)
+    void XcbNativeWindow::InitWindowInternal(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks)
     {
         // Get the parent window
         const xcb_setup_t* xcbSetup = xcb_get_setup(m_xcbConnection);
@@ -432,10 +432,6 @@ namespace AzFramework
             {
                 WindowNotificationBus::Event(
                     reinterpret_cast<NativeWindowHandle>(m_xcbWindow), &WindowNotificationBus::Events::OnWindowResized, width, height);
-                if (!m_enableCustomizedResolution)
-                {
-                    WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, width, height);
-                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
@@ -27,7 +27,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // NativeWindow::Implementation
-        void InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks) override;
+        void InitWindowInternal(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks) override;
         void Activate() override;
         void Deactivate() override;
         NativeWindowHandle GetWindowHandle() const override;

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Windowing/NativeWindow_Mac.mm
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Windowing/NativeWindow_Mac.mm
@@ -25,7 +25,7 @@ namespace AzFramework
         ~NativeWindowImpl_Darwin() override;
         
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -52,7 +52,7 @@ namespace AzFramework
         m_nativeWindow = nil;
     }
 
-    void NativeWindowImpl_Darwin::InitWindow(const AZStd::string& title,
+    void NativeWindowImpl_Darwin::InitWindowInternal(const AZStd::string& title,
                                              const WindowGeometry& geometry,
                                              const WindowStyleMasks& styleMasks)
     {

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -66,9 +66,10 @@ namespace AzFramework
         }
     }
 
-    void NativeWindowImpl_Win32::InitWindow(const AZStd::string& title,
-                                            const WindowGeometry& geometry,
-                                            const WindowStyleMasks& styleMasks)
+    void NativeWindowImpl_Win32::InitWindowInternal(
+        const AZStd::string& title,
+        const WindowGeometry& geometry,
+        const WindowStyleMasks& styleMasks)
     {
         const HINSTANCE hInstance = GetModuleHandle(0);
 
@@ -409,10 +410,6 @@ namespace AzFramework
             if (m_activated)
             {
                 WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnWindowResized, width, height);
-                if (!m_enableCustomizedResolution)
-                {
-                    WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnResolutionChanged, width, height);
-                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.h
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.h
@@ -26,7 +26,7 @@ namespace AzFramework
         ~NativeWindowImpl_Win32() override;
 
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         void Activate() override;

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -24,7 +24,7 @@ namespace AzFramework
         ~NativeWindowImpl_Ios() override;
         
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -44,7 +44,7 @@ namespace AzFramework
         }
     }
     
-    void NativeWindowImpl_Ios::InitWindow([[maybe_unused]]const AZStd::string& title,
+    void NativeWindowImpl_Ios::InitWindowInternal([[maybe_unused]]const AZStd::string& title,
                                           const WindowGeometry& geometry,
                                           [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -31,6 +31,8 @@ namespace AzFramework
         uint32_t GetDisplayRefreshRate() const override;
         
     private:
+        bool IsLandscape() const;
+
         UIWindow* m_nativeWindow;
         uint32_t m_mainDisplayRefreshRate = 0;
     };
@@ -51,9 +53,18 @@ namespace AzFramework
         CGRect screenBounds = [[UIScreen mainScreen] bounds];
         m_nativeWindow = [[UIWindow alloc] initWithFrame: screenBounds];
         [m_nativeWindow makeKeyAndVisible];
+        
+        // On iOS we don't set the window size, we use the OS window's' size
+        m_width = [[UIScreen mainScreen] nativeBounds].size.width;
+        m_height = [[UIScreen mainScreen] nativeBounds].size.height;
 
-        m_width = geometry.m_width;
-        m_height = geometry.m_height;
+        // The rectangle returned by nativeBounds is always in a portrait orientation.
+        // If the app is landscape, width and height must be swapped.
+        if (IsLandscape())
+        {
+            AZStd::swap(m_width, m_height);
+        }
+        
         m_mainDisplayRefreshRate = [[UIScreen mainScreen] maximumFramesPerSecond];
     }
     
@@ -65,6 +76,12 @@ namespace AzFramework
     uint32_t NativeWindowImpl_Ios::GetDisplayRefreshRate() const
     {
         return m_mainDisplayRefreshRate;
+    }
+
+    bool NativeWindowImpl_Ios::IsLandscape() const
+    {
+        UIInterfaceOrientation uiOrientation = m_nativeWindow.windowScene.interfaceOrientation;
+        return uiOrientation == UIInterfaceOrientationLandscapeLeft || uiOrientation == UIInterfaceOrientationLandscapeRight;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
+++ b/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
@@ -27,6 +27,7 @@ namespace AZ::Render::Bootstrap
         virtual void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) = 0;
         virtual void SwitchAntiAliasing(const AZStd::string& newAntiAliasing, AZ::RPI::ViewportContextPtr viewportContext) = 0;
         virtual void SwitchMultiSample(const uint16_t newSampleCount, AZ::RPI::ViewportContextPtr viewportContext) = 0;
+        virtual void RefreshWindowResolution() = 0;
 
     protected:
         ~Request() = default;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -113,26 +113,28 @@ void cvar_r_multiSample_Changed(const uint16_t& newSampleCount)
 }
 
 
-AZ_CVAR(AZ::CVarFixedString, r_renderPipelinePath, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_r_renderPipelinePath_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
-AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
-AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
-AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
-AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
+void cvar_r_resolution_Changed([[maybe_unused]] const uint32_t& newValue)
+{
+    AZ::Render::Bootstrap::RequestBus::Broadcast(&AZ::Render::Bootstrap::RequestBus::Events::RefreshWindowResolution);
+}
 
 void cvar_r_renderScale_Changed(const float& newRenderScale)
 {
     AZ_Error("AtomBootstrap", newRenderScale > 0, "RenderScale should be greater than 0");
     if (newRenderScale > 0)
     {
-        AzFramework::WindowSize newSize =
-            AzFramework::WindowSize(static_cast<uint32_t>(r_width * newRenderScale), static_cast<uint32_t>(r_height * newRenderScale));
-        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, true);
-        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetRenderResolution, newSize);
+        AZ::Render::Bootstrap::RequestBus::Broadcast(&AZ::Render::Bootstrap::RequestBus::Events::RefreshWindowResolution);
     }
 }
+
+AZ_CVAR(AZ::CVarFixedString, r_renderPipelinePath, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_r_renderPipelinePath_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
+AZ_CVAR(uint32_t, r_width, 1920, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
+AZ_CVAR(uint32_t, r_height, 1080, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
+AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
+AZ_CVAR(uint32_t, r_resolutionMode, 0, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
 AZ_CVAR(float, r_renderScale, 1.0f, cvar_r_renderScale_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Scale to apply to the window resolution.");
 AZ_CVAR(AZ::CVarFixedString, r_antiAliasing, "", cvar_r_antiAliasing_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The anti-aliasing to be used for the current render pipeline. Available options: MSAA, TAA, SMAA");
 AZ_CVAR(uint16_t, r_multiSampleCount, 0, cvar_r_multiSample_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The multi-sample count to be used for the current render pipeline."); // 0 stands for unchanged, load the default setting from the pipeline itself
@@ -337,8 +339,8 @@ namespace AZ
                     // command line arguments into cvars.
                     UpdateCVarsFromCommandLine();
 
-                    auto windowSize = GetWindowResolution();
-                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, windowSize.m_width, windowSize.m_height));
+                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(
+                        projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, r_width, r_height));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
 
                     m_nativeWindow->Activate();
@@ -458,8 +460,7 @@ namespace AZ
                 if (!m_nativeWindow)
                 {
                     auto projectTitle = AZ::Utils::GetProjectDisplayName();
-                    auto windowSize = GetWindowResolution();
-                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, windowSize.m_width, windowSize.m_height));
+                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, r_width, r_height));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
 
                     m_nativeWindow->Activate();
@@ -498,15 +499,20 @@ namespace AZ
                 if (m_nativeWindow)
                 {
                     // wait until swapchain has been created before setting fullscreen state
+                    AzFramework::WindowSize resolution;
+                    float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);
                     if (r_resolutionMode > 0u)
                     {
-                        m_nativeWindow->SetEnableCustomizedResolution(true);
-                        m_nativeWindow->SetRenderResolution(GetWindowResolution());
+                        resolution.m_width = static_cast<uint32_t>(r_width * scale);
+                        resolution.m_height = static_cast<uint32_t>(r_height * scale);
                     }
                     else
                     {
-                        m_nativeWindow->SetEnableCustomizedResolution(false);
+                        const auto& windowSize = m_nativeWindow->GetClientAreaSize();
+                        resolution.m_width = static_cast<uint32_t>(windowSize.m_width * scale);
+                        resolution.m_height = static_cast<uint32_t>(windowSize.m_height * scale);
                     }
+                    m_nativeWindow->SetRenderResolution(resolution);
                     m_nativeWindow->SetFullScreenState(r_fullscreen);
                 }
             }
@@ -710,6 +716,11 @@ namespace AZ
                 AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(multiSampleStete);
             }
 
+            void BootstrapSystemComponent::RefreshWindowResolution()
+            {
+                SetWindowResolution();
+            }
+
             RPI::RenderPipelinePtr BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,
                                                     AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, AZ::RHI::MultisampleState& multisampleState)
             {
@@ -755,12 +766,6 @@ namespace AZ
                     AZ_Error("AtomBootstrap", false, "Pipeline file failed to load from path: %s.", pipelineName.data());
                     return nullptr;
                 }
-            }
-
-            AzFramework::WindowSize BootstrapSystemComponent::GetWindowResolution() const
-            {
-                float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);
-                return AzFramework::WindowSize(static_cast<uint32_t>(r_width * scale), static_cast<uint32_t>(r_height * scale));
             }
 
             void BootstrapSystemComponent::CreateDefaultRenderPipeline()
@@ -831,6 +836,11 @@ namespace AZ
                 AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
 #endif
                 AzFramework::WindowNotificationBus::Handler::BusDisconnect();
+            }
+
+            void BootstrapSystemComponent::OnWindowResized([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
+            {
+                SetWindowResolution();
             }
 
             AzFramework::NativeWindowHandle BootstrapSystemComponent::GetDefaultWindowHandle()

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -72,7 +72,8 @@ namespace AZ
                 void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void SwitchAntiAliasing(const AZStd::string& newAntiAliasing, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void SwitchMultiSample(const uint16_t newSampleCount, AZ::RPI::ViewportContextPtr viewportContext) override;
-
+                void RefreshWindowResolution() override;
+				
             protected:
                 // Component overrides ...
                 void Activate() override;
@@ -80,6 +81,7 @@ namespace AZ
 
                 // WindowNotificationBus::Handler overrides ...
                 void OnWindowClosed() override;
+                void OnWindowResized(uint32_t width, uint32_t height) override;
 
                 // TickBus::Handler overrides ...
                 void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
@@ -110,8 +112,6 @@ namespace AZ
                     AZStd::string_view xrPipelineName,
                     AZ::RPI::ViewType viewType,
                     AZ::RHI::MultisampleState& multisampleState);
-
-                AzFramework::WindowSize GetWindowResolution() const;
 
                 AzFramework::Scene::RemovalEvent::Handler m_sceneRemovalHandler;
 

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -73,7 +73,7 @@ namespace AZ
                 void SwitchAntiAliasing(const AZStd::string& newAntiAliasing, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void SwitchMultiSample(const uint16_t newSampleCount, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void RefreshWindowResolution() override;
-				
+
             protected:
                 // Component overrides ...
                 void Activate() override;

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -35,6 +35,7 @@
 #define ENABLE_REFLECTIONPROBE_BLENDING 0
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
+#define ENABLE_MOBILEBRDF 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
@@ -33,6 +33,7 @@
 #define ENABLE_REFLECTIONPROBE_BLENDING 0
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
+#define ENABLE_MOBILEBRDF 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/DisplayMapper.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/DisplayMapper.pass
@@ -1,0 +1,43 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MobileDisplayMapperTemplate",
+            "PassClass": "DisplayMapperPass",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                // SwapChain here is only used to reference the frame height and format
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "Input",
+                    "Output" : "Output"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/DisplayMapper.shader"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
@@ -266,6 +266,7 @@
                 {
                     "Name": "CopyToSwapChain",
                     "TemplateName": "FullscreenCopyTemplate",
+                    "Enabled": false,
                     "Connections": [
                         {
                             "LocalSlot": "Input",

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/PostProcessParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/PostProcessParent.pass
@@ -74,7 +74,7 @@
                 },
                 {
                     "Name": "DisplayMapperPass",
-                    "TemplateName": "DisplayMapperTemplate",
+                    "TemplateName": "MobileDisplayMapperTemplate",
                     "Enabled": true,
                     "Connections": [
                         {
@@ -86,6 +86,13 @@
                         },
                         {
                             "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "PipelineOutput"

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -581,6 +581,10 @@
                 "Path": "Passes/Mobile/PostProcessParent.pass"
             },
             {
+                "Name": "MobileDisplayMapperTemplate",
+                "Path": "Passes/Mobile/DisplayMapper.pass"
+            },
+            {
                 "Name": "KawaseShadowBlurTemplate",
                 "Path": "Passes/KawaseShadowBlur.pass"
             },

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -49,7 +49,7 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, fl
             litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, real3(surface.position), surface.vertexNormal, screenUv);
         }
 #else 
-        litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, real3(surface.position), surface.vertexNormal, screenUv);
+        litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, surface.position, surface.vertexNormal, screenUv);
 #endif // ENABLE_TRANSMISSION
 
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
@@ -23,7 +23,7 @@
 //--------------------------------------------------------------------------------------------------
 
 // Margin to avoid counting samples past the shadows bounds as being in shadow.
-static const real DepthMargin = 1.0 - 1e-6;
+static const real DepthMargin = 1.0 - 1e-3;
 
 struct SampleShadowMapBicubicParameters
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -40,13 +40,13 @@ class DirectionalLightShadow
 
     //! Calculates visibility ratio of the surface from the light origin. Should be called from fragment shaders.
     //! Returns lit ratio from the light (1.0 is fully visible, 0.0 is fully shadowed).
-    static real GetVisibility(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv);
+    static real GetVisibility(uint lightIndex, float3 worldPos, real3 normalVector, float4 screenUv);
 
     static float2 GetVisibilityThickTransmission(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv);
 
     static float2 GetVisibilityThinTransmission(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv, real shrinkFactor);
 
-    static DirectionalShadowCalculator MakeShadowCalculator(uint lightIndex, real3 worldPos, real3 normalVector);
+    static DirectionalShadowCalculator MakeShadowCalculator(uint lightIndex, float3 worldPos, real3 normalVector);
 
     //! This alters the input color to visualize which cascade is being used
     //! and whether PCF is used as a fallback in ESM+PCF mode or not.
@@ -67,7 +67,7 @@ bool DirectionalLightShadow::UseFullscreenShadows()
 #endif
 }
 
-DirectionalShadowCalculator DirectionalLightShadow::MakeShadowCalculator(uint lightIndex, real3 worldPos, real3 normalVector)
+DirectionalShadowCalculator DirectionalLightShadow::MakeShadowCalculator(uint lightIndex, float3 worldPos, real3 normalVector)
 {
     DirectionalShadowCalculator calc;
     calc.SetBlendBetweenCascadesEnable(o_blend_between_cascades_enable);
@@ -127,7 +127,7 @@ float2 DirectionalLightShadow::GetVisibilityThinTransmission(uint lightIndex, re
     return float2(visibility, thickness);
 }
 
-real DirectionalLightShadow::GetVisibility(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv)
+real DirectionalLightShadow::GetVisibility(uint lightIndex, float3 worldPos, real3 normalVector, float4 screenUv)
 {
     if (UseFullscreenShadows())
     {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -46,7 +46,7 @@ class DirectionalShadowCalculator
         m_worldNormal = worldNormal;
     }
 
-    void SetWorldPos(const real3 worldPos)
+    void SetWorldPos(const float3 worldPos)
     {
         m_worldPos = worldPos;
     }
@@ -84,7 +84,7 @@ class DirectionalShadowCalculator
     float3 m_shadowPosDX[ViewSrg::MaxCascadeCount];
     float3 m_shadowPosDY[ViewSrg::MaxCascadeCount];
     real3 m_worldNormal;
-    real3 m_worldPos;
+    float3 m_worldPos;
 
     bool m_receiverShadowPlaneBiasEnable;
     bool m_blendBetweenCascadesEnable;
@@ -324,6 +324,7 @@ real DirectionalShadowCalculator::SamplePcfBicubic(const real3 shadowCoord, cons
 real DirectionalShadowCalculator::GetVisibilityFromLightPcf()
 {
     real lit = 1.0;
+    
     for (int indexOfCascade = m_minCascade; indexOfCascade <= m_maxCascade && lit > 0.01; ++indexOfCascade)
     {
         lit = min(lit, SamplePcfBicubic(real3(m_shadowCoords[indexOfCascade]), indexOfCascade));
@@ -410,3 +411,4 @@ real DirectionalShadowCalculator::CalculateCascadeBlendAmount(const real3 texCoo
     const real currentPixelsBlendBandLocation = min(min(texCoord.x, texCoord.y), distanceToOneMin);
     return currentPixelsBlendBandLocation / CascadeBlendArea;
 }
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ReceiverPlaneDepthBias.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ReceiverPlaneDepthBias.azsli
@@ -15,7 +15,12 @@
 // Another implementation example: https://github.com/TheRealMJP/Shadows
 float2 ComputeReceiverPlaneDepthBias(float3 projCoordsDDX, float3 projCoordsDDY)
 {
-    const float invDet = 1.0 / ((projCoordsDDX.x * projCoordsDDY.y) - (projCoordsDDX.y * projCoordsDDY.x));
+    float denom = ((projCoordsDDX.x * projCoordsDDY.y) - (projCoordsDDX.y * projCoordsDDY.x));
+    if(denom < EPSILON)
+    {
+        return float2(0.0,0.0);
+    }
+    const float invDet = 1.0 / denom ;
 
     float2 receiverPlaneDepthBias;
     

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
@@ -67,6 +67,9 @@ real3 GetSpecularLighting_EnhancedPBR(Surface surface, LightingData lightingData
     }
     else
     {
+#if ENABLE_MOBILEBRDF
+        specular = SpecularGGXMobile(lightingData.dirToCamera, dirToLight, surface.GetSpecularNormal(), surface.GetSpecularF0(), surface.roughnessA2, surface.roughnessA, surface.roughnessLinear);
+#else
         specular = SpecularGGX(lightingData.dirToCamera, dirToLight, surface.GetSpecularNormal(), surface.GetSpecularF0(), lightingData.GetSpecularNdotV(), surface.roughnessA2, lightingData.multiScatterCompensation);
     }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
@@ -53,7 +53,7 @@ real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, float4 uvDxDy
     sampledValue =  (sampledValue * 2) - 1;
 #endif
 
-    return sampledValue;
+    return sampledValue.xy;
 }
 
 //! Samples the normal map and returns the XY values of the normal. 

--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/iOS/RHI/Metal_RHI_iOS.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/iOS/RHI/Metal_RHI_iOS.cpp
@@ -79,8 +79,7 @@ namespace Platform
 
     void ResizeInternal(RHIMetalView* metalView, CGSize viewSize)
     {
-        AZ_UNUSED(metalView);
-        AZ_UNUSED(viewSize);
+        [metalView.metalLayer setDrawableSize: viewSize];
     }
 
     RHIMetalView* GetMetalView(NativeWindowType* nativeWindow)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
@@ -117,6 +117,7 @@ namespace AZ
         {
             bool resourceAdded = false;
 
+            
             for (const RHI::ShaderInputBufferDescriptor& shaderInputBuffer : m_srgLayout->GetShaderInputListForBuffers())
             {
                 MTLArgumentDescriptor* bufferArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
@@ -138,7 +139,7 @@ namespace AZ
                 MTLArgumentDescriptor* samplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 samplerArgDescriptor.dataType = MTLDataTypeSampler;
                 samplerArgDescriptor.index = shaderInputSampler.m_registerId;
-                samplerArgDescriptor.access = MTLArgumentAccessReadOnly;
+                samplerArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 samplerArgDescriptor.arrayLength = shaderInputSampler.m_count > 1 ? shaderInputSampler.m_count:0;
                 [argBufferDecriptors addObject:samplerArgDescriptor];
                 resourceAdded = true;
@@ -149,7 +150,7 @@ namespace AZ
                 MTLArgumentDescriptor* staticSamplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 staticSamplerArgDescriptor.dataType = MTLDataTypeSampler;
                 staticSamplerArgDescriptor.index = staticSamplerInput.m_registerId;
-                staticSamplerArgDescriptor.access = MTLArgumentAccessReadOnly;
+                staticSamplerArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 [argBufferDecriptors addObject:staticSamplerArgDescriptor];
                 resourceAdded = true;
             }
@@ -161,7 +162,7 @@ namespace AZ
                 MTLArgumentDescriptor* constBufferArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 constBufferArgDescriptor.dataType = MTLDataTypePointer;
                 constBufferArgDescriptor.index = shaderInputConstant.m_registerId;
-                constBufferArgDescriptor.access = MTLArgumentAccessReadOnly;
+                constBufferArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 [argBufferDecriptors addObject:constBufferArgDescriptor];
                 resourceAdded = true;
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
@@ -48,7 +48,7 @@ namespace AZ::Metal
             MTLArgumentDescriptor* argDescriptor = [[MTLArgumentDescriptor alloc]init];
             argDescriptor.dataType = MTLDataTypeTexture;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.textureType = MTLTextureType2D;
             argDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
             argBufferDescriptors.push_back(argDescriptor);
@@ -57,14 +57,14 @@ namespace AZ::Metal
             mtlArgBufferOffsets.push_back(m_bindlessTextureArgBuffer->GetOffset());
 
             //Unbounded read write textures
-            argDescriptor.access = MTLArgumentAccessReadWrite;
+            argDescriptor.access = MTLBindingAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWTextures");
             mtlArgBuffers.push_back(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessRWTextureArgBuffer->GetOffset());
             
             //Unbounded read cube textures
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.textureType = MTLTextureTypeCube;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessCubeTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessCubeROTextures");
@@ -73,14 +73,14 @@ namespace AZ::Metal
 
             //Unbounded read only buffers
             argDescriptor.dataType = MTLDataTypePointer;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessROBuffers");
             mtlArgBuffers.push_back(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessBufferArgBuffer->GetOffset());
 
             //Unbounded read write buffers
-            argDescriptor.access = MTLArgumentAccessReadWrite;
+            argDescriptor.access = MTLBindingAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWBuffers");
             mtlArgBuffers.push_back(m_bindlessRWBufferArgBuffer->GetArgEncoderBuffer());
@@ -89,7 +89,7 @@ namespace AZ::Metal
             //Container Argument buffer for all the unbounded arrays
             argDescriptor.dataType = MTLDataTypePointer;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.arrayLength = static_cast<uint32_t>(RHI::BindlessResourceType::Count) - 1;
             argBufferDescriptors[0] = argDescriptor;
             m_rootArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRoot");
@@ -111,7 +111,7 @@ namespace AZ::Metal
                 
                 resourceArgDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
                 resourceArgDescriptor.dataType = MTLDataTypeTexture;
-                resourceArgDescriptor.access = MTLArgumentAccessReadOnly;
+                resourceArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
 
                 if(i == m_bindlessSrgDesc.m_roTextureIndex)
                 {
@@ -122,7 +122,7 @@ namespace AZ::Metal
                 {
                     resourceArgDescriptor.index = RHI::Limits::Pipeline::UnboundedArraySize * m_bindlessSrgDesc.m_rwTextureIndex;
                     resourceArgDescriptor.textureType = MTLTextureType2D;
-                    resourceArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    resourceArgDescriptor.access = MTLBindingAccessReadWrite;
                 }
                 else if(i == m_bindlessSrgDesc.m_roTextureCubeIndex)
                 {
@@ -138,7 +138,7 @@ namespace AZ::Metal
                 {
                     resourceArgDescriptor.index = RHI::Limits::Pipeline::UnboundedArraySize * m_bindlessSrgDesc.m_rwBufferIndex;
                     resourceArgDescriptor.dataType = MTLDataTypePointer;
-                    resourceArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    resourceArgDescriptor.access = MTLBindingAccessReadWrite;
                 }
                 argBufferDescriptors.push_back(resourceArgDescriptor);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -365,6 +365,7 @@ namespace AZ
             mtlTextureDesc.hazardTrackingMode = resourceDescriptor.m_mtlHazardTrackingMode;
             
             mtlTextureDesc.sampleCount = resourceDescriptor.m_sampleCount;
+            //NSLog(@"ConvertImageDescriptor %p\n", mtlTextureDesc);
             return mtlTextureDesc;
         }
     
@@ -948,27 +949,50 @@ namespace AZ
             }
         }
 
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputImageAccess accessType)
+        {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            MTLBindingAccess mtlBindingAccess = MTLBindingAccessReadOnly;
+#else
+            MTLBindingAccess mtlBindingAccess = MTLArgumentAccessReadOnly;
+#endif
+            
+            if(accessType == RHI::ShaderInputImageAccess::ReadWrite)
+            {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            mtlBindingAccess = MTLBindingAccessReadWrite;
+#else
+            mtlBindingAccess = MTLArgumentAccessReadWrite;
+#endif
+            }
+            return mtlBindingAccess;
+        }
+    
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputBufferAccess accessType)
+        {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            MTLBindingAccess mtlBindingAccess = MTLBindingAccessReadOnly;
+#else
+            MTLBindingAccess mtlBindingAccess = MTLArgumentAccessReadOnly;
+#endif
+            
+            if(accessType == RHI::ShaderInputBufferAccess::ReadWrite)
+            {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            mtlBindingAccess = MTLBindingAccessReadWrite;
+#else
+            mtlBindingAccess = MTLArgumentAccessReadWrite;
+#endif
+            }
+            return mtlBindingAccess;
+        }
+    
         void ConvertImageArgumentDescriptor(MTLArgumentDescriptor* imgArgDescriptor, const RHI::ShaderInputImageDescriptor& shaderInputImage)
         {
             imgArgDescriptor.dataType = MTLDataTypeTexture;
             imgArgDescriptor.index = shaderInputImage.m_registerId;
-            switch(shaderInputImage.m_access)
-            {
-                case RHI::ShaderInputImageAccess::Read:
-                {
-                    imgArgDescriptor.access = MTLArgumentAccessReadOnly;
-                    break;
-                }
-                case RHI::ShaderInputImageAccess::ReadWrite:
-                {
-                    imgArgDescriptor.access = MTLArgumentAccessReadWrite;
-                    break;
-                }
-                default:
-                {
-                    AZ_Assert(false, "Invalid usage type.");
-                }
-            }
+            imgArgDescriptor.access = GetBindingAccess(shaderInputImage.m_access);
+
             switch(shaderInputImage.m_type)
             {
                 case RHI::ShaderInputImageType::Image1D:
@@ -1024,24 +1048,8 @@ namespace AZ
             AZ_Assert(bufferArgDescriptor, "bufferArgDescriptor is null");
             
             bufferArgDescriptor.index = shaderInputBuffer.m_registerId;
-            switch(shaderInputBuffer.m_access)
-            {
-                case RHI::ShaderInputBufferAccess::Constant:
-                case RHI::ShaderInputBufferAccess::Read:
-                {
-                    bufferArgDescriptor.access = MTLArgumentAccessReadOnly;
-                    break;
-                }
-                case RHI::ShaderInputBufferAccess::ReadWrite:
-                {
-                    bufferArgDescriptor.access = MTLArgumentAccessReadWrite;
-                    break;
-                }
-                default:
-                {
-                    AZ_Assert(false, "Invalid usage type.");
-                }
-            }
+            bufferArgDescriptor.access = GetBindingAccess(shaderInputBuffer.m_access);
+
             bufferArgDescriptor.arrayLength = shaderInputBuffer.m_count;
             
             if(shaderInputBuffer.m_type == RHI::ShaderInputBufferType::Typed)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -365,7 +365,6 @@ namespace AZ
             mtlTextureDesc.hazardTrackingMode = resourceDescriptor.m_mtlHazardTrackingMode;
             
             mtlTextureDesc.sampleCount = resourceDescriptor.m_sampleCount;
-            //NSLog(@"ConvertImageDescriptor %p\n", mtlTextureDesc);
             return mtlTextureDesc;
         }
     

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
@@ -79,6 +79,8 @@ namespace AZ
         MTLResourceOptions CovertCPUCahceMode(MTLCPUCacheMode cpuCahceMode);
         MTLResourceOptions CovertToResourceOptions(MTLStorageMode storageMode, MTLCPUCacheMode cpuCahceMode, MTLHazardTrackingMode hazardTrackingMode);
         MTLStorageMode GetCPUGPUMemoryMode();
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputImageAccess accessType);
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputBufferAccess accessType);
     
         void ConvertSamplerState(const RHI::SamplerState& state, MTLSamplerDescriptor* samplerDesc);
         void ConvertDepthStencilState(const RHI::DepthStencilState& depthStencil, MTLDepthStencilDescriptor* mtlDepthStencilDesc);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
@@ -398,6 +398,7 @@ namespace AZ
             m_limits.m_maxConstantBufferSize = m_metalDevice.maxBufferLength;
             m_limits.m_maxBufferSize = m_metalDevice.maxBufferLength;
  
+            m_features.m_swapchainScalingFlags = RHI::ScalingFlags::Stretch;
             AZ_Assert(m_metalDevice.argumentBuffersSupport >= MTLArgumentBuffersTier1, "Atom needs Argument buffer support to run");
         }
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -94,8 +94,11 @@ namespace AZ
             
             for (RHI::ImageScopeAttachment* scopeAttachment : GetImageAttachments())
             {
-                m_isWritingToSwapChainScope = scopeAttachment->IsSwapChainAttachment() && scopeAttachment->HasUsage(RHI::ScopeAttachmentUsage::RenderTarget);
-                if(m_isWritingToSwapChainScope)
+                bool isWritingToSwapChainScope = scopeAttachment->IsSwapChainAttachment() && scopeAttachment->HasUsage(RHI::ScopeAttachmentUsage::RenderTarget);
+                const RHI::SwapChainFrameAttachment* swapChainFrameAttachment = (azrtti_cast<const RHI::SwapChainFrameAttachment*>(&scopeAttachment->GetFrameAttachment()));
+                
+                //Check if this scope is writing to the swapchain texture and if the swapchain attachment is valid
+                if(isWritingToSwapChainScope && swapChainFrameAttachment)
                 {
                     //The way Metal works is that we ask the drivers for the swapchain texture right before we write to it.
                     //And if we have to read from the swapchain texture we need to tell the driver this information when requesting the
@@ -115,7 +118,8 @@ namespace AZ
                         }
                     }
                     
-                    //Cache this as we will use this to request the drawable from the driver in the Execute phase (i.e Scope::Begin)
+                    //Cache the result as we will use this to request the drawable from the driver in the Execute phase (i.e Scope::Begin)
+                    m_isWritingToSwapChainScope = true;
                     m_swapChainAttachment = scopeAttachment;
                 }
                 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
@@ -72,6 +72,11 @@ namespace AZ
             //! Wait on all the transient resource fences associated with this scope
             void WaitOnAllResourceFences(CommandList& commandList) const;
             void WaitOnAllResourceFences(id <MTLCommandBuffer> mtlCommandBuffer) const;
+            
+            //! Accesors for the information cached in Compile phase
+            bool IsWritingToSwapChain() const;
+            bool IsRequestingSwapChain() const;
+            
         private:
             
             struct QueryPoolAttachment
@@ -126,7 +131,10 @@ namespace AZ
 
             AZStd::vector<QueryPoolAttachment> m_queryPoolAttachments;
             
-            /// Used to check if the current scope is writing to a swapchain texture
+            /// Used to check if the current scope is requesting to a swapchain texture
+            bool m_isRequestingSwapChainDrawable = false;
+            
+            /// Used to check if the current scope is writing the swapchain texture
             bool m_isWritingToSwapChainScope = false;
             
             /// Used to check if the current scope is a swapchain scope and the next scope will be used to capture the current frame

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -16,6 +16,7 @@
 #include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Console/ILogger.h>
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
@@ -600,14 +601,13 @@ namespace AZ
                     m_dimensions.m_imageWidth,
                     m_surfaceCapabilities.minImageExtent.width,
                     m_surfaceCapabilities.maxImageExtent.width);
-                AZ_Printf(
-                    "Vulkan", "Resizing swapchain from (%u, %u) to (%u, %u).",
+                AZLOG_DEBUG("Resizing swapchain from (%u, %u) to (%u, %u).",
                     oldWidth, oldHeight, m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
             }
 
             RHI::ResultCode result = BuildNativeSwapChain(m_dimensions);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Vulkan", "Swapchain created. Width: %u, Height: %u.\n", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
+            AZLOG_DEBUG("Swapchain created. Width: %u, Height: %u.\n", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
 
             // Do not recycle the semaphore because they may not ever get signaled and since
             // we can't recycle Vulkan semaphores we just delete them.
@@ -634,13 +634,13 @@ namespace AZ
                 device.GetNativeDevice(), m_nativeSwapChain, &m_dimensions.m_imageCount, m_swapchainNativeImages.data());
             AssertSuccess(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
-            AZ_TracePrintf("Swapchain", "Obtained presentable images.\n");
+            AZLOG_DEBUG("Obtained presentable images.\n");
 
             // Acquire the first image
             uint32_t imageIndex = 0;
             result = AcquireNewImage(&imageIndex);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Swapchain", "Acquired the first image.\n");
+            AZLOG_DEBUG("Acquired the first image.\n");
 
             return RHI::ResultCode::Success;
         }

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
@@ -11,9 +11,15 @@
 // ---------- Tangent & World Space ----------
 
 //! Utility function to convert vector from tangent space to world space
-real3 TangentSpaceToWorld(real3 vectorTS, real3 normalWS, real3 tangentWS, real3 bitangentWS)
+half3 TangentSpaceToWorld(half3 vectorTS, half3 normalWS, half3 tangentWS, half3 bitangentWS)
 {
-    return real3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
+    return half3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
+}
+
+//! Utility function to convert vector from tangent space to world space
+float3 TangentSpaceToWorld(float3 vectorTS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
+{
+    return float3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
 }
 
 float3 TangentSpaceToWorldFp32(float3 vectorTS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
@@ -22,13 +28,22 @@ float3 TangentSpaceToWorldFp32(float3 vectorTS, float3 normalWS, float3 tangentW
 }
 
 //! Utility function to convert vector from world space to tangent space
-real3 WorldSpaceToTangent(real3 vectorWS, real3 normalWS, real3 tangentWS, real3 bitangentWS)
+half3 WorldSpaceToTangent(half3 vectorWS, half3 normalWS, half3 tangentWS, half3 bitangentWS)
 {
-    real a = dot(tangentWS, vectorWS);
-    real b = dot(bitangentWS, vectorWS);
-    real c = dot(normalWS, vectorWS);
+    half a = dot(tangentWS, vectorWS);
+    half b = dot(bitangentWS, vectorWS);
+    half c = dot(normalWS, vectorWS);
 
-    return real3(a, b, c);
+    return half3(a, b, c);
+}
+
+float3 WorldSpaceToTangent(float3 vectorWS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
+{
+    float a = dot(tangentWS, vectorWS);
+    float b = dot(bitangentWS, vectorWS);
+    float c = dot(normalWS, vectorWS);
+
+    return float3(a, b, c);
 }
 
 float3 WorldSpaceToTangentFp32(float3 vectorWS, float3 normalWS, float3 tangentWS, float3 bitangentWS)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -113,7 +113,7 @@ namespace AZ
             LodData m_lodData;
 
             using FlagType = uint32_t;
-            FlagType m_prevShaderOptionFlags = 0;
+            FlagType m_prevShaderOptionFlags = ~0u; // Init to something different than 0, so it updates on first usage.
             AZStd::atomic<FlagType> m_shaderOptionFlags = 0;
             FlagType m_flags;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -109,8 +109,7 @@ namespace AZ
                 m_pipelinOutputAttachment->m_descriptor = outputImageDesc;
                 m_pipelinOutputAttachment->m_name = "PipelineOutput";
                 m_pipelinOutputAttachment->ComputePathName(GetPathName());
-                // Note: do not add m_pipelinOutputAttachment to m_ownedAttachments so it won't be imported to frame graph's attachment database. 
-                // This is because this attachment is only used for pass reference, but not used for RHI frame graph
+                m_ownedAttachments.push_back(m_pipelinOutputAttachment);
 
                 // use the intermediate attachment as pipeline's output
                 pipelineOutput->SetAttachment(m_pipelinOutputAttachment);
@@ -143,6 +142,7 @@ namespace AZ
                 RPI::Ptr<RPI::Pass> copyPass = RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
                 if (copyPass)
                 {
+                    copyPass->SetEnabled(true);
                     auto outputBinding = copyPass->FindAttachmentBinding(Name("Output"));
                     outputBinding->SetAttachment(m_swapChainAttachment);
                     // set connected binding to nullptr so it won't use the output attachment specified in the pipeline's pass template

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -117,8 +117,6 @@ namespace AtomToolsFramework
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
-        void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() const override;
         AzFramework::WindowSize GetRenderResolution() const override;
         void SetRenderResolution(AzFramework::WindowSize resolution) override;
         float GetDpiScaleFactor() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -454,16 +454,6 @@ namespace AtomToolsFramework
         // The RenderViewportWidget does not currently support full screen.
     }
 
-    void RenderViewportWidget::SetEnableCustomizedResolution([[maybe_unused]]bool enable)
-    {
-        // The RenderViewportWidget does not currently support customized render resolution.
-    }
-
-    bool RenderViewportWidget::IsCustomizedResolutionEnabled() const
-    {
-        return false;
-    }
-
     AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
     {
         // We want render resolution matches the screen's resolution


### PR DESCRIPTION
## What does this PR do?

Cherry pick multiple fixes from Carbonated


- Disable CopyToSwapchain pass for Mobile pipeline 5b743e444a4f1f0e754ef2501f6da07cd7bd8e6b
- Fix precision issue with cascade shadowmaps 9089fdd91fc171fb0d9e472dd2b24bf721c97e5e
- Add support to apply r_renderScale when r_resolutionMode is 0 fd1d6d6db2889c7874f4f863cebcaf545c6d072b
- Fix NativeWindow size on iOS f70641b09df2c058a0a3c6ba10ed87b31bf3030c
- Fix per mesh shader options for instanced meshes 0c3e981b32b956763aa838f3fe585bab9ed72cb6
- Fix issues in case the pipeline wants to request and write to swapchain in the tonemapper pass 5fb8c5cb54058084b8aab6f9410777cf4eb6ea80
- Fix NANs showing up in DOF effect. 31dbf96c71585c55026ebb36120f7e09a86504b4
- Fix pixelated shadows 9f16d2c53e54d7685082f290287aa9997930b903
- Add Resize support for ios 25719de48ab567966943433b3d97bf0e77ccd17c
- Fix the issue whereby we had scopes from two different groups requesting swapchain drawable in parallel which is not allowed 08671ddcf0ab20ff874094966d19ce74251801b7
- Fixed the assert by ensuring that the scopes coming after the one requesting the swapchain drawable is not separated into a separate group based on commandlist cost a8dfade905b0a8b1b1594e94eb7b73031bacc5e5

## How was this PR tested?

Run PC and Android