### PR TITLE
Support inheriting device index from parent pass

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -411,6 +411,9 @@ namespace AZ
                 RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite,
                 RHI::ImageAspectFlags aspectFlags = RHI::ImageAspectFlags::Color);
 
+            // Recursively get device index ignoring the cached parent device index
+            int RecursiveGetDeviceIndex() const;
+
             // --- Protected Members ---
 
             const Name PassNameThis{"This"};
@@ -495,6 +498,9 @@ namespace AZ
 
                         // Whether this pass contains a binding that is referenced globally through the pipeline
                         uint64_t m_containsGlobalReference : 1;
+                        
+                        // Whether this pass already cached parent pass's device index
+                        uint64_t m_parentDeviceIndexCached : 1;
 
                         // If this is a parent pass, indicates whether the child passes should be merged as subpasses.
                         // If this is a child pass, indicates whether it is a subpass.
@@ -651,6 +657,9 @@ namespace AZ
 
             // Used to track what phases of build/initialization the pass is queued for
             PassQueueState m_queueState = PassQueueState::NoQueue;
+
+            // Cache the parent pass's device index to prevent recursively fetching it every time
+            int m_parentDeviceIndex = AZ::RHI::MultiDevice::InvalidDeviceIndex;
         };
 
         //! Struct used to return results from Pass hierarchy validation

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -411,9 +411,6 @@ namespace AZ
                 RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite,
                 RHI::ImageAspectFlags aspectFlags = RHI::ImageAspectFlags::Color);
 
-            // Recursively get device index ignoring the cached parent device index
-            int RecursiveGetDeviceIndex() const;
-
             // --- Protected Members ---
 
             const Name PassNameThis{"This"};
@@ -539,7 +536,7 @@ namespace AZ
             RHI::ScopeAttachmentStage m_defaultShaderAttachmentStage = RHI::ScopeAttachmentStage::AnyGraphics;
 
             // The device index the pass should run on. Can be invalid if it doesn't matter.
-            int m_deviceIndex{ AZ::RHI::MultiDevice::InvalidDeviceIndex };
+            int m_deviceIndex = AZ::RHI::MultiDevice::InvalidDeviceIndex;
 
         private:
             // Return the Timestamp result of this pass

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -532,6 +532,9 @@ namespace AZ
             //! Default RHI::ScopeAttachmentStage value for all pass attachments of usage RHI::ScopeAttachmentUsage::Shader
             RHI::ScopeAttachmentStage m_defaultShaderAttachmentStage = RHI::ScopeAttachmentStage::AnyGraphics;
 
+            // The device index the pass should run on. Can be invalid if it doesn't matter.
+            int m_deviceIndex{ AZ::RHI::MultiDevice::InvalidDeviceIndex };
+
         private:
             // Return the Timestamp result of this pass
             virtual TimestampResult GetTimestampResultInternal() const { return TimestampResult(); }
@@ -648,9 +651,6 @@ namespace AZ
 
             // Used to track what phases of build/initialization the pass is queued for
             PassQueueState m_queueState = PassQueueState::NoQueue;
-
-            // The device index the pass should run on. Can be invalid if it doesn't matter.
-            int m_deviceIndex{ AZ::RHI::MultiDevice::InvalidDeviceIndex };
         };
 
         //! Struct used to return results from Pass hierarchy validation

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -150,6 +150,9 @@ namespace AZ
             //! Get the device index of this pass
             int GetDeviceIndex() const;
 
+            //! Set the device index of this pass (and potentially affects its child's)
+            bool SetDeviceIndex(int deviceIndex);
+
             //! Enable/disable this pass
             //! If the pass is disabled, it (and any children if it's a ParentPass) won't be rendered.  
             void SetEnabled(bool enabled);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -147,6 +147,9 @@ namespace AZ
             //! It may return nullptr if the pass wasn't create from a template
             const PassTemplate* GetPassTemplate() const { return m_template.get(); }
 
+            //! Get the device index of this pass
+            int GetDeviceIndex() const;
+
             //! Enable/disable this pass
             //! If the pass is disabled, it (and any children if it's a ParentPass) won't be rendered.  
             void SetEnabled(bool enabled);
@@ -645,6 +648,9 @@ namespace AZ
 
             // Used to track what phases of build/initialization the pass is queued for
             PassQueueState m_queueState = PassQueueState::NoQueue;
+
+            // The device index the pass should run on. Can be invalid if it doesn't matter.
+            int m_deviceIndex{ AZ::RHI::MultiDevice::InvalidDeviceIndex };
         };
 
         //! Struct used to return results from Pass hierarchy validation

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -153,6 +153,8 @@ namespace AZ
             PipelineStatisticsResult m_statisticsResult;
 
             // The device index the pass should run on. Can be invalid if it doesn't matter.
+            // Please note that the m_deviceIndex might not be the actual running device index if it is invalid
+            // because the actually running device index is specified in RenderPass::FrameBeginInternal if m_deviceIndex is invalid.
             int m_deviceIndex{RHI::MultiDevice::InvalidDeviceIndex};
             // The device index the pass ran on during the last frame, necessary to read the queries.
             int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -152,10 +152,6 @@ namespace AZ
             // Readback results from the PipelineStatistics queries
             PipelineStatisticsResult m_statisticsResult;
 
-            // The device index the pass should run on. Can be invalid if it doesn't matter.
-            // Please note that the m_deviceIndex might not be the actual running device index if it is invalid
-            // because the actually running device index is specified in RenderPass::FrameBeginInternal if m_deviceIndex is invalid.
-            int m_deviceIndex{RHI::MultiDevice::InvalidDeviceIndex};
             // The device index the pass ran on during the last frame, necessary to read the queries.
             int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
@@ -52,6 +52,9 @@ namespace AZ
 
             Name m_pipelineViewTag;
 
+            int m_deviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
+
+
             //! Only applicable for ParentPass.
             //! If set to "true" then:
             //! 0- You may get performance benefits if the GPU is a Tiled Based Rasterizer and the RHI supports TBR (like Vulkan).

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/RenderPassData.h
@@ -32,8 +32,6 @@ namespace AZ
             RHI::ShaderDataMappings m_mappings;
 
             bool m_bindViewSrg = false;
-
-            int m_deviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -129,6 +129,20 @@ namespace AZ
             return m_deviceIndex;
         }
 
+        bool Pass::SetDeviceIndex(int deviceIndex)
+        {
+            const int deviceCount = AZ::RHI::RHISystemInterface::Get()->GetDeviceCount();
+            if (deviceIndex < AZ::RHI::MultiDevice::InvalidDeviceIndex || deviceIndex >= deviceCount)
+            {
+                AZ_Error("Pass", false, "Device index should be at least -1(RHI::MultiDevice::InvalidDeviceIndex) and less than current device count %d.", deviceCount);
+                return false;
+            }
+
+            m_deviceIndex = deviceIndex;
+            OnHierarchyChange();
+            return true;
+        }
+
         void Pass::SetEnabled(bool enabled)
         {
             m_flags.m_enabled = enabled;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -119,6 +119,8 @@ namespace AZ
 
         int Pass::GetDeviceIndex() const
         {
+            AZ_Assert(m_state != PassState::Uninitialized && m_state != PassState::Reset,
+                "Getting device index before building might return a wrong result since its parent pass is not yet ready.");
             if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
             {
                 return m_flags.m_parentDeviceIndexCached ? m_parentDeviceIndex : m_parent->GetDeviceIndex();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -120,8 +120,6 @@ namespace AZ
 
         int Pass::GetDeviceIndex() const
         {
-            AZ_Assert(m_state != PassState::Uninitialized && m_state != PassState::Reset,
-                "Getting device index before building might return a wrong result since its parent pass is not yet ready.");
             if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
             {
                 return m_flags.m_parentDeviceIndexCached ? m_parentDeviceIndex : m_parent->GetDeviceIndex();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -56,6 +56,7 @@ namespace AZ
             {
                 PassUtils::ExtractPipelineGlobalConnections(m_passData, m_pipelineGlobalConnections);
                 m_viewTag = m_passData->m_pipelineViewTag;
+                m_deviceIndex = m_passData->m_deviceIndex;
             }
 
             m_flags.m_enabled = true;
@@ -111,6 +112,15 @@ namespace AZ
             
             desc.m_passData = m_passData;
             return desc;
+        }
+
+        const int Pass::GetDeviceIndex() const
+        {
+            if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
+            {
+                return m_parent->GetDeviceIndex();
+            }
+            return AZStd::max(m_deviceIndex, 0);
         }
 
         void Pass::SetEnabled(bool enabled)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -65,6 +65,7 @@ namespace AZ
             m_flags.m_enabled = true;
             m_flags.m_timestampQueryEnabled = false;
             m_flags.m_pipelineStatisticsQueryEnabled = false;
+            m_flags.m_parentDeviceIndexCached = false;
 
             m_template = descriptor.m_passTemplate;
             if (m_template)
@@ -128,15 +129,6 @@ namespace AZ
             return m_deviceIndex;
         }
 
-        int Pass::RecursiveGetDeviceIndex() const
-        {
-            if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
-            {
-                return m_parent->RecursiveGetDeviceIndex();
-            }
-            return m_deviceIndex;
-        }
-
         void Pass::SetEnabled(bool enabled)
         {
             m_flags.m_enabled = enabled;
@@ -185,7 +177,7 @@ namespace AZ
                 m_path = ConcatPassName(m_parent->m_path, m_name);
                 m_flags.m_partOfHierarchy = m_parent->m_flags.m_partOfHierarchy;
 
-                m_parentDeviceIndex = m_parent->RecursiveGetDeviceIndex();
+                m_parentDeviceIndex = m_parent->GetDeviceIndex();
                 m_flags.m_parentDeviceIndexCached = true;
 
                 if (m_state == PassState::Orphaned)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -56,7 +56,10 @@ namespace AZ
             {
                 PassUtils::ExtractPipelineGlobalConnections(m_passData, m_pipelineGlobalConnections);
                 m_viewTag = m_passData->m_pipelineViewTag;
-                m_deviceIndex = m_passData->m_deviceIndex;
+                if (m_passData->m_deviceIndex >= 0 && m_passData->m_deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount())
+                {
+                    m_deviceIndex = m_passData->m_deviceIndex;
+                }
             }
 
             m_flags.m_enabled = true;
@@ -114,13 +117,13 @@ namespace AZ
             return desc;
         }
 
-        const int Pass::GetDeviceIndex() const
+        int Pass::GetDeviceIndex() const
         {
             if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
             {
                 return m_parent->GetDeviceIndex();
             }
-            return AZStd::max(m_deviceIndex, 0);
+            return m_deviceIndex;
         }
 
         void Pass::SetEnabled(bool enabled)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -121,7 +121,16 @@ namespace AZ
         {
             if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
             {
-                return m_parent->GetDeviceIndex();
+                return m_flags.m_parentDeviceIndexCached ? m_parentDeviceIndex : m_parent->GetDeviceIndex();
+            }
+            return m_deviceIndex;
+        }
+
+        int Pass::RecursiveGetDeviceIndex() const
+        {
+            if (m_deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
+            {
+                return m_parent->RecursiveGetDeviceIndex();
             }
             return m_deviceIndex;
         }
@@ -173,6 +182,9 @@ namespace AZ
                 m_treeDepth = m_parent->m_treeDepth + 1;
                 m_path = ConcatPassName(m_parent->m_path, m_name);
                 m_flags.m_partOfHierarchy = m_parent->m_flags.m_partOfHierarchy;
+
+                m_parentDeviceIndex = m_parent->RecursiveGetDeviceIndex();
+                m_flags.m_parentDeviceIndexCached = true;
 
                 if (m_state == PassState::Orphaned)
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -273,7 +273,7 @@ namespace AZ
         {
             m_timestampResult = AZ::RPI::TimestampResult();
 
-            // the pass is potentially re-allocated amount devices dynamically in runtime so deviceIndex is updated everyframe.
+            // the pass may potentially migrate between devices dynamically at runtime so the deviceIndex is updated every frame.
             if (GetScopeId().IsEmpty())
             {
                 InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, Pass::GetDeviceIndex());

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -43,10 +43,6 @@ namespace AZ
             {
                 m_flags.m_bindViewSrg = true;
             }
-            if (passData && passData->m_deviceIndex >= 0 && passData->m_deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount())
-            {
-                m_deviceIndex = passData->m_deviceIndex;
-            }
         }
 
         RenderPass::~RenderPass()
@@ -278,15 +274,9 @@ namespace AZ
             m_timestampResult = AZ::RPI::TimestampResult();
 
             // the pass is potentially re-allocated amount devices dynamically in runtime so deviceIndex is updated everyframe.
-            int deviceIndex = m_deviceIndex;
-            if (deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
-            {
-                deviceIndex = azrtti_cast<AZ::RPI::ParentPass*>(m_parent)->GetDeviceIndex();
-            }
-
             if (GetScopeId().IsEmpty())
             {
-                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, deviceIndex);
+                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, Pass::GetDeviceIndex());
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -276,9 +276,17 @@ namespace AZ
         void RenderPass::FrameBeginInternal(FramePrepareParams params)
         {
             m_timestampResult = AZ::RPI::TimestampResult();
+
+            // the pass is potentially re-allocated amount devices dynamically in runtime so deviceIndex is updated everyframe.
+            int deviceIndex = m_deviceIndex;
+            if (deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex && m_parent)
+            {
+                deviceIndex = azrtti_cast<AZ::RPI::ParentPass*>(m_parent)->GetDeviceIndex();
+            }
+
             if (GetScopeId().IsEmpty())
             {
-                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, m_deviceIndex);
+                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, deviceIndex);
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -51,8 +51,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<RenderPassData, PassData>()
-                    ->Version(1)
-                    ->Field("DeviceIndex", &RenderPassData::m_deviceIndex)
+                    ->Version(2)
                     ->Field("BindViewSrg", &RenderPassData::m_bindViewSrg)
                     ->Field("ShaderDataMappings", &RenderPassData::m_mappings);
             }
@@ -93,7 +92,9 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<PassData>()
-                    ->Version(2) // Added "MergeChildrenAsSubpasses"
+                    ->Version(3)
+
+                    ->Field("DeviceIndex", &PassData::m_deviceIndex)
                     ->Field("PipelineViewTag", &PassData::m_pipelineViewTag)
                     ->Field("PipelineGlobalConnections", &PassData::m_pipelineGlobalConnections)
                     ->Field("MergeChildrenAsSubpasses", &PassData::m_mergeChildrenAsSubpasses);


### PR DESCRIPTION
## What does this PR do?

This is almost the same with #17906 before multi-device-resources branch get merged, as we discussed there, I re-create this PR here to development branch.

In the current code, we would have to set the device index for each render pass, in real render pipeline, there are quite a lot parent passes, the render passes are hidden behind the parent pass, being not able to set the device index for them easily.

This PR supports inheriting device index from parent pass, so that user/developer can batch set the device index for multiple child passes, to easily create multi-device pipeline.


## How was this PR tested?

Self tested on Windows with one/two devices.
