### PR TITLE
Fix nounity-build on Windows

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include <RHI/FrameGraphExecuteGroupMerged.h>
+#include <RHI/Device.h>
 #include <RHI/SwapChain.h>
 
 namespace AZ


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following compile error when using a nounity build on Windows:
```
.../Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp:70:43: error: member access into incomplete type 'Device'
   70 |             request.m_deviceIndex = device.GetDeviceIndex();
      |                                           ^
.../Gems/Atom/RHI/DX12/Code/Source\RHI/CommandListBase.h:24:15: note: forward declaration of 'AZ::DX12::Device'
   24 |         class Device;
      |               ^
```

## How was this PR tested?

Compile with `-DLY_UNITY_BUILD=OFF` on Windows.
