### PR TITLE
Cherry-pick: Registry option to disable mouse capture (#18042)

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -185,6 +185,15 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputDeviceMouse::SetCaptureCursor(bool captureCursor)
+    {
+        if (m_pimpl)
+        {
+            m_pimpl->SetCaptureCursor(captureCursor);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
     InputDeviceMouse::Implementation::Implementation(InputDeviceMouse& inputDevice)
         : m_inputDevice(inputDevice)
         , m_rawMovementSampleRate()
@@ -296,5 +305,11 @@ namespace AzFramework
         {
             m_rawMovementSampleRate = static_cast<AZStd::sys_time_t>(1000000 / sampleRateHertz);
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputDeviceMouse::Implementation::SetCaptureCursor(bool captureCursor)
+    {
+        m_captureCursor = captureCursor;
     }
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -189,6 +189,11 @@ namespace AzFramework
         //! \param[in] sampleRateHertz The raw movement sample rate in Hertz (cycles per second)
         void SetRawMovementSampleRate(AZ::u32 sampleRateHertz);
 
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Set if the cursor should be visible or hidden
+        //! \param[in] captureCursor True if the cursor should be visible, false if it should be hidden
+        void SetCaptureCursor(bool captureCursor);
+
     protected:
         ////////////////////////////////////////////////////////////////////////////////////////////
         ///@{
@@ -273,6 +278,11 @@ namespace AzFramework
             //! \param[in] sampleRateHertz The raw movement sample rate in Hertz (cycles per second)
             void SetRawMovementSampleRate(AZ::u32 sampleRateHertz);
 
+            ////////////////////////////////////////////////////////////////////////////////////////////
+            //! Set if the cursor should be visible or hidden
+            //! \param[in] captureCursor True if the cursor should be visible, false if it should be hidden
+            void SetCaptureCursor(bool captureCursor);
+
         protected:
             ////////////////////////////////////////////////////////////////////////////////////////
             //! Queue raw button events to be processed in the next call to ProcessRawEventQueues.
@@ -314,6 +324,8 @@ namespace AzFramework
             RawButtonEventQueueByIdMap   m_rawButtonEventQueuesById;   //!< Raw button events by id
             RawMovementEventQueueByIdMap m_rawMovementEventQueuesById; //!< Raw movement events by id
             LastSampleTimeArray          m_timeOfLastRawMovementSample;  //!< Time of the last raw movement sample
+        protected:
+            bool                         m_captureCursor;              //!< Should the cursor be captured?
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
@@ -191,6 +191,7 @@ namespace AzFramework
         , m_virtualKeyboardEnabled(true)
         , m_currentlyUpdatingInputDevices(false)
         , m_recreateInputDevicesAfterUpdate(false)
+        , m_captureMouseCursor(true)
     {
     }
 
@@ -219,6 +220,7 @@ namespace AzFramework
             settingsRegistry->Get(m_mouseEnabled, "/O3DE/InputSystem/MouseEnabled");
             settingsRegistry->Get(m_touchEnabled, "/O3DE/InputSystem/TouchEnabled");
             settingsRegistry->Get(m_virtualKeyboardEnabled, "/O3DE/InputSystem/VirtualKeyboardEnabled");
+            settingsRegistry->Get(m_captureMouseCursor, "/O3DE/InputSystem/Mouse/CaptureMouseCursor");
         }
 
         // Create all enabled input devices
@@ -307,6 +309,7 @@ namespace AzFramework
         if (m_mouse)
         {
             m_mouse->SetRawMovementSampleRate(m_mouseMovementSampleRateHertz);
+            m_mouse->SetCaptureCursor(m_captureMouseCursor);
         }
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.h
@@ -130,5 +130,6 @@ namespace AzFramework
         // Other Variables
         bool m_currentlyUpdatingInputDevices;   //!< Are we currently updating input devices?
         bool m_recreateInputDevicesAfterUpdate; //!< Should we recreate devices after update?
+        bool m_captureMouseCursor;              //!< Should we capture the mouse cursor?
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -316,25 +316,30 @@ namespace AzFramework
 
     void XcbInputDeviceMouse::SetSystemCursorState(SystemCursorState systemCursorState)
     {
-        if (systemCursorState != m_systemCursorState)
-        {
-            m_systemCursorState = systemCursorState;
+        if (m_captureCursor) {
+            if (systemCursorState != m_systemCursorState) {
+                m_systemCursorState = systemCursorState;
 
-            m_focusWindow = GetSystemCursorFocusWindow(s_xcbConnection);
+                m_focusWindow = GetSystemCursorFocusWindow(s_xcbConnection);
 
-            HandleCursorState(m_focusWindow, systemCursorState);
+                HandleCursorState(m_focusWindow, systemCursorState);
+            }
+
         }
     }
 
     void XcbInputDeviceMouse::HandleCursorState(xcb_window_t window, SystemCursorState systemCursorState)
     {
-        const bool confined = (systemCursorState == SystemCursorState::ConstrainedAndHidden) ||
-            (systemCursorState == SystemCursorState::ConstrainedAndVisible);
-        const bool cursorShown = (systemCursorState == SystemCursorState::ConstrainedAndVisible) ||
-            (systemCursorState == SystemCursorState::UnconstrainedAndVisible);
+        if (m_captureCursor)
+        {
+            const bool confined = (systemCursorState == SystemCursorState::ConstrainedAndHidden) ||
+                (systemCursorState == SystemCursorState::ConstrainedAndVisible);
+            const bool cursorShown = (systemCursorState == SystemCursorState::ConstrainedAndVisible) ||
+                (systemCursorState == SystemCursorState::UnconstrainedAndVisible);
 
-        CreateBarriers(window, confined);
-        ShowCursor(window, cursorShown);
+            CreateBarriers(window, confined);
+            ShowCursor(window, cursorShown);
+        }
     }
 
     SystemCursorState XcbInputDeviceMouse::GetSystemCursorState() const

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Mouse/InputDeviceMouse_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Mouse/InputDeviceMouse_Windows.cpp
@@ -131,7 +131,7 @@ namespace AzFramework
     ////////////////////////////////////////////////////////////////////////////////////////////////
     void InputDeviceMouseWindows::SetSystemCursorState(SystemCursorState systemCursorState)
     {
-        if (systemCursorState != m_systemCursorState)
+        if (m_captureCursor && systemCursorState != m_systemCursorState)
         {
             m_systemCursorState = systemCursorState;
             RefreshSystemCursorClippingConstraint();


### PR DESCRIPTION
## What does this PR do?

This is a cherry-pick of the PR https://github.com/o3de/o3de/pull/18042 that was merged into `development`.

The change in the codebase is small, so the chance of introducing a bug to the stabilization branch is also small. The feature is quite important for simulation.

Copy from #18042 :

> This PR allows setting a registry key "O3DE/InputSystem/Mouse/CaptureMouseCursor" to disable mouse capture.
> It is useful in two scenarios:
> - during a debugging session, where you can be left with the system without a cursor and active breakpoint
> - simulation use case, where switching context and focus does not always work, and the user is left without a mouse cursor with the GameLauncher window minimized

## How was this PR tested?

#18042 was tested on Linux and Windows, I tested it again after cherry-picking on Linux.
