### PR TITLE
Fix unparent prefab entities

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -104,14 +104,6 @@ namespace AZ
             const static AZ::Crc32 ChangeNotify = AZ_CRC("ChangeNotify", 0xf793bc19);
             const static AZ::Crc32 ClearNotify = AZ_CRC("ClearNotify", 0x88914c8c);
 
-            //! Used on supported handlers to replace the "Clear" function with your own callback.
-            //! Note that ClearNotify and ClearCallback are different.  Notify is used to tell you that it has been cleared.
-            //! Callback (currently only supported on EntityId handlers), if present, will replace the default behavior and leave
-            //! it up to the callback to make any modifications.  If you do this, you must handle any entity dirtying yourself.
-            //! The function will be invoked on the owning instance of the variable being cleared as the 'this' pointer
-            //! and must have the signature void SomeClass::somefunction();
-            const static AZ::Crc32 ClearCallback = AZ_CRC("ClearCallback", 0x3b3af425);
-
             //! Specifies a function to accept or reject a value changed in the Open 3D Engine Editor.
             //! For example, a component could reject AZ::EntityId values that reference its own entity.
             //!

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -104,6 +104,14 @@ namespace AZ
             const static AZ::Crc32 ChangeNotify = AZ_CRC("ChangeNotify", 0xf793bc19);
             const static AZ::Crc32 ClearNotify = AZ_CRC("ClearNotify", 0x88914c8c);
 
+            //! Used on supported handlers to replace the "Clear" function with your own callback.
+            //! Note that ClearNotify and ClearCallback are different.  Notify is used to tell you that it has been cleared.
+            //! Callback (currently only supported on EntityId handlers), if present, will replace the default behavior and leave
+            //! it up to the callback to make any modifications.  If you do this, you must handle any entity dirtying yourself.
+            //! The function will be invoked on the owning instance of the variable being cleared as the 'this' pointer
+            //! and must have the signature void SomeClass::somefunction();
+            const static AZ::Crc32 ClearCallback = AZ_CRC("ClearCallback", 0x3b3af425);
+
             //! Specifies a function to accept or reject a value changed in the Open 3D Engine Editor.
             //! For example, a component could reject AZ::EntityId values that reference its own entity.
             //!
@@ -196,8 +204,19 @@ namespace AZ
             //! For use with slice creation tools. See SliceCreationFlags below for details.
             const static AZ::Crc32 SliceFlags = AZ_CRC("SliceFlags", 0xa447e1fb);
 
-            //! Does the clear button in the LineEdit need to have a test for visibility.
-            const static AZ::Crc32 ShowClearButtonHandler = AZ_CRC_CE("ShowClearButtonHandler");
+            //! On controls with a clear button, this attribute specifies whether the clear button should be shown.
+            const static AZ::Crc32 ShowClearButtonHandler = AZ_CRC("ShowClearButtonHandler", 0x2ef414c9);
+
+            //! Specifies whether the picker button should be shown.
+            //! Authors - if you add this attribute to other handlers, list them here:
+            //!      EntityId handler
+            const static AZ::Crc32 ShowPickButton = AZ_CRC("ShowPickButton", 0xc40252dd);
+
+            //! Specifies whether drop onto this control should be allowed.
+            //! Used to turn off drag and drop for Transform Parents - you have to modify that via the outliner.
+            //! Authors - if you add this attribute to other handlers, list them here:
+            //!      EntityId handler
+            const static AZ::Crc32 AllowDrop = AZ_CRC("AllowDrop", 0x85424942);
 
             //! For optional use on Getter Events used for Virtual Properties
             const static AZ::Crc32 PropertyPosition = AZ_CRC("Position", 0x462ce4f5);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -1129,7 +1129,6 @@ namespace AzToolsFramework
                             Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/transform/")->
                             Attribute(AZ::Edit::Attributes::AutoExpand, true)->
                         DataElement(AZ::Edit::UIHandlers::Default, &TransformComponent::m_parentEntityId, "Parent entity", "Modify this using the Entity Outliner")->
-                            //Attribute(AZ::Edit::Attributes::ReadOnly, true)->
                             Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::DontGatherReference | AZ::Edit::SliceFlags::NotPushableOnSliceRoot)->
                             Attribute(AZ::Edit::Attributes::ShowClearButtonHandler, false)->
                             Attribute(AZ::Edit::Attributes::ShowPickButton, false)->

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -161,8 +161,6 @@ namespace AzToolsFramework
             void UpdateCachedWorldTransform();
             void ClearCachedWorldTransform();
 
-            bool ShowClearButtonHandler();
-
             // SliceEntityHierarchyRequestBus
             AZ::EntityId GetSliceEntityParentId() override;
             AZStd::vector<AZ::EntityId> GetSliceEntityChildren() override;
@@ -182,10 +180,7 @@ namespace AzToolsFramework
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
             static void Reflect(AZ::ReflectContext* context);
 
-            AZ::Outcome<void, AZStd::string> ValidatePotentialParent(void* newValue, const AZ::Uuid& valueType);
-
             AZ::u32 TransformChangedInspector();
-            AZ::u32 ParentChangedInspector();
             AZ::u32 StaticChangedInspector();
 
             bool TransformChanged();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -200,6 +200,11 @@ namespace AzToolsFramework
             return;
         }
 
+        if (!AllowsDrop())
+        {
+            return;
+        }
+
         const bool isValidDropTarget = IsCorrectMimeData(event->mimeData()) &&
             EntityIdsFromMimeData(*event->mimeData());
 
@@ -214,6 +219,11 @@ namespace AzToolsFramework
     void PropertyEntityIdCtrl::dropEvent(QDropEvent* event)
     {
         AzQtComponents::LineEdit::removeDropTargetStyle(m_entityIdLineEdit);
+
+        if (!AllowsDrop())
+        {
+            return;
+        }
 
         if (event == nullptr)
         {
@@ -344,6 +354,15 @@ namespace AzToolsFramework
         m_entityIdLineEdit->setClearButtonEnabled(HasClearButton());
         m_entityIdLineEdit->SetEntityId(newEntityId, nameOverride);
         m_componentsSatisfyingServices.clear();
+
+        if (!HasPickButton())
+        {
+            m_pickButton->hide();
+        }
+        else
+        {
+            m_pickButton->show();
+        }
 
         if (!m_requiredServices.empty() || !m_incompatibleServices.empty())
         {
@@ -537,6 +556,22 @@ namespace AzToolsFramework
             if (attrValue->Read<bool>(value))
             {
                 GUI->SetHasClearButton(value);
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::ShowPickButton)
+        {
+            bool value;
+            if (attrValue->Read<bool>(value))
+            {
+                GUI->SetHasPickButton(value);
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::AllowDrop)
+        {
+            bool value;
+            if (attrValue->Read<bool>(value))
+            {
+                GUI->SetAllowsDrop(value);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
@@ -73,7 +73,12 @@ namespace AzToolsFramework
         void SetAcceptedEntityContext(AzFramework::EntityContextId contextId);
 
         void SetHasClearButton(bool value) { m_hasClearButton = value; }
+        void SetHasPickButton(bool value) { m_hasPickButton = value; }
+        void SetAllowsDrop(bool value) { m_allowsDrop = value; }
+
         bool HasClearButton() { return m_hasClearButton; }
+        bool HasPickButton() { return m_hasPickButton; }
+        bool AllowsDrop() { return m_allowsDrop; }
 
     signals:
         void OnEntityIdChanged(AZ::EntityId newEntityId);
@@ -103,6 +108,9 @@ namespace AzToolsFramework
         AZStd::list<AZStd::string> m_componentsSatisfyingServices;
 
         bool m_hasClearButton{ true };
+        bool m_hasPickButton{ true };
+        bool m_allowsDrop { true };
+
         QIcon m_pickerIcon;
     };
 


### PR DESCRIPTION
## What does this PR do?

Fixes Issue #16541
Fixes Issue #18052

Makes it so that you MUST use the entity outliner to modify parenting of entities.  This prevents a whole series of issues related to parenting that already has a ton of code written in the outliner to prevent various side effects and issues.

## How was this PR tested?

Manual testing - making sure you can still copy the entity name and click on it and see the tooltip and that you can still "copy component" / "paste component" and undo and redo and all that but that all other transform parent manipulations must go thru the outliner.
