### PR TITLE
Expose GetIntensityMode/SetIntensityMode  in DirectionalLightBus.h

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
@@ -34,6 +34,14 @@ namespace AZ
             //! @param color directional light's color
             virtual void SetColor(const Color& color) = 0;
 
+            //! Gets the intensity mode of a directional light
+            //! @return directional light's intensity mode
+            virtual PhotometricUnit GetIntensityMode() const = 0;
+
+            //! Sets the intensity mode of a directional light
+            //! @param directional light's intensity mode
+            virtual void SetIntensityMode(PhotometricUnit intensityMode) = 0;
+
             //! Gets a directional light's intensity. This value is independent from its color.
             //! @return directional light's intensity
             virtual float GetIntensity() const = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
@@ -56,6 +56,8 @@ namespace AZ
                     ->Event("SetColor", &DirectionalLightRequestBus::Events::SetColor)
                     ->Event("GetIntensity", &DirectionalLightRequestBus::Events::GetIntensity)
                     ->Event("SetIntensity", static_cast<void(DirectionalLightRequestBus::Events::*)(float)>(&DirectionalLightRequestBus::Events::SetIntensity))
+                    ->Event("GetIntensityMode", &DirectionalLightRequestBus::Events::GetIntensityMode)
+                    ->Event("SetIntensityMode", &DirectionalLightRequestBus::Events::SetIntensityMode)
                     ->Event("GetAngularDiameter", &DirectionalLightRequestBus::Events::GetAngularDiameter)
                     ->Event("SetAngularDiameter", &DirectionalLightRequestBus::Events::SetAngularDiameter)
                     ->Event("GetShadowmapSize", &DirectionalLightRequestBus::Events::GetShadowmapSize)
@@ -98,6 +100,7 @@ namespace AZ
                     ->Event("SetLightingChannelMask", &DirectionalLightRequestBus::Events::SetLightingChannelMask)
                     ->VirtualProperty("Color", "GetColor", "SetColor")
                     ->VirtualProperty("Intensity", "GetIntensity", "SetIntensity")
+                    ->VirtualProperty("IntensityMode", "GetIntensityMode", "SetIntensityMode")
                     ->VirtualProperty("AngularDiameter", "GetAngularDiameter", "SetAngularDiameter")
                     ->VirtualProperty("ShadowmapSize", "GetShadowmapSize", "SetShadowmapSize")
                     ->VirtualProperty("CascadeCount", "GetCascadeCount", "SetCascadeCount")
@@ -199,6 +202,19 @@ namespace AZ
         float DirectionalLightComponentController::GetIntensity() const
         {
             return m_configuration.m_intensity;
+        }
+
+        PhotometricUnit DirectionalLightComponentController::GetIntensityMode() const
+        {
+            return m_configuration.m_intensityMode;
+        }
+
+        void DirectionalLightComponentController::SetIntensityMode(PhotometricUnit unit)
+        {
+            m_photometricValue.ConvertToPhotometricUnit(unit);
+            m_configuration.m_intensityMode = unit;
+            m_configuration.m_intensity = m_photometricValue.GetIntensity();
+            ColorIntensityChanged();
         }
 
         void DirectionalLightComponentController::SetIntensity(float intensity, PhotometricUnit unit)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
@@ -50,6 +50,8 @@ namespace AZ
             const Color& GetColor() const override;
             void SetColor(const Color& color) override;
             float GetIntensity() const override;
+            PhotometricUnit GetIntensityMode() const override;
+            void SetIntensityMode(PhotometricUnit unit) override;
             void SetIntensity(float intensity, PhotometricUnit unit) override;
             void SetIntensity(float intensity) override;
             float GetAngularDiameter() const override;


### PR DESCRIPTION
## What does this PR do?

Since we are already exposing Get/SetIntensity in DirectionalLightBus.h, it makes a lot of sense to also expose Get/SetIntensityMode there. It is useful for implementing gems that receives directional lights, like implementing participant media rendering that reacts directional lights.

## How was this PR tested?

Tested on Windows with both RHI. Exposing it should not cast any effect on existing things.
