### PR TITLE
Add backwards compatibility functions for materials after adding vertex color

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#ifndef ENABLE_VERTEX_COLOR
+#define ENABLE_VERTEX_COLOR 0
+#endif
+
 // This #define magic lets you use the EvaluateSurface function in this file without making it the final EvaluateSurface
 // used in your shader. Simply #define EvaluateSurface to your custom definition before including this file
 //
@@ -16,6 +20,18 @@
 #endif
 
 #include <Atom/Features/MatrixUtility.azsli>
+
+real3 BlendVertexColor(real3 baseColor, real3 vertexColor)
+{
+#if ENABLE_VERTEX_COLOR
+    // Check to ensure the material is using vertex colors (i.e o_useVertexColor) and that the mesh supports color vertex stream (i.e o_color0_isBound)
+    if(o_useVertexColor && o_color0_isBound)
+    {
+        baseColor = BlendBaseColor(vertexColor, baseColor, real(MaterialSrg::m_vertexColorFactor), o_vertexColorBlendMode, true);
+    }
+#endif
+    return baseColor;
+}
 
 Surface EvaluateSurface_BasePBR(
     float3 positionWS,
@@ -53,11 +69,7 @@ Surface EvaluateSurface_BasePBR(
     float2 baseColorUv = uvs[MaterialSrg::m_baseColorMapUvIndex];
     real3 sampledColor = GetBaseColorInput(MaterialSrg::m_baseColorMap, MaterialSrg::m_sampler, baseColorUv, real3(MaterialSrg::m_baseColor.rgb), o_baseColor_useTexture, uvDxDy, customDerivatives);
     real3 baseColor = BlendBaseColor(sampledColor, real3(MaterialSrg::m_baseColor.rgb), real(MaterialSrg::m_baseColorFactor), o_baseColorTextureBlendMode, o_baseColor_useTexture);
-    // Check to ensure the material is using vertex colors (i.e o_useVertexColor) and that the mesh supports color vertex stream (i.e o_color0_isBound)
-    if(o_useVertexColor && o_color0_isBound)
-    {
-        baseColor = BlendBaseColor(real3(vertexColor.rgb), baseColor, real(MaterialSrg::m_vertexColorFactor), o_vertexColorBlendMode, true);
-    }
+    baseColor = BlendVertexColor(baseColor, real3(vertexColor.rgb));
     
     // ------- Metallic -------
 
@@ -81,8 +93,39 @@ Surface EvaluateSurface_BasePBR(
     return surface;
 }
 
+float4 GetVertexColor(VsOutput IN)
+{
+#if ENABLE_VERTEX_COLOR
+    return IN.color0;
+#else
+    return float4(1.0f, 1.0f, 1.0f, 1.0f);
+#endif
+}
+
 // helper function to keep compatible with the previous version
 // because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_BasePBR(
+    float3 positionWS,
+    real3 vertexNormal,
+    float3 tangents[UvSetCount],
+    float3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace,
+    float4 uvDxDy,
+    bool customDerivatives)
+{
+    return EvaluateSurface_BasePBR(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        uvDxDy,
+        customDerivatives,
+        float4(1.0f, 1.0f, 1.0f, 1.0f));
+}
+
 Surface EvaluateSurface_BasePBR(
     float3 positionWS,
     real3 vertexNormal,
@@ -99,8 +142,7 @@ Surface EvaluateSurface_BasePBR(
         uvs,
         isFrontFace,
         float4(0.0f, 0.0f, 0.0f, 0.0f),
-        false,
-        float4(1.0f, 1.0f, 1.0f, 1.0f));
+        false);
 }
 
 Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
@@ -114,7 +156,7 @@ Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData, float4 u
         geoData.isFrontFace,
         uvDxDy,
         customDerivatives,
-        IN.color0);
+        GetVertexColor(IN));
 }
 
 Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData)
@@ -128,5 +170,5 @@ Surface EvaluateSurface_BasePBR(VsOutput IN, PixelGeometryData geoData)
         geoData.isFrontFace,
         float4(0.0f, 0.0f, 0.0f, 0.0f),
         false,
-        IN.color0);
+        GetVertexColor(IN));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexData.azsli
@@ -27,7 +27,6 @@
 #define ENABLE_VERTEX_COLOR 0
 #endif
 
-
 #if ENABLE_VERTEX_COLOR
 option bool o_color0_isBound = false;
 #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#ifndef ENABLE_VERTEX_COLOR
+#define ENABLE_VERTEX_COLOR 0
+#endif
+
 // This #define magic allows you to use the EvaluateVertexGeometry function in this file without making it the final
 // EvaluateVertexGeometry used in your shader. Simply #define EvaluateVertexGeometry before including this file
 //
@@ -25,9 +29,9 @@ VsOutput EvaluateVertexGeometry_BasePBR(
     float4 tangent,
     float2 uv0,
     float2 uv1,
-    float4 color0,
     uint instanceId,
-    bool useVertexColor0)
+    bool useVertexColor0,
+    float4 color0)
 {
     VsOutput output;
 
@@ -61,22 +65,49 @@ VsOutput EvaluateVertexGeometry_BasePBR(
     return output;
 }
 
-VsOutput EvaluateVertexGeometry_BasePBR(VsInput IN, VsSystemValues SV)
+void GetVertexColor(VsInput IN, out float4 color, out bool useVertexColor)
 {
 #if ENABLE_VERTEX_COLOR
-    float4 color0 = IN.m_optional_color0;
-    bool useVertexColor0 = o_color0_isBound;
+    color = IN.m_optional_color0;
+    useVertexColor = o_color0_isBound;
 #else
-    float4 color0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
-    bool useVertexColor0 = false;
+    color = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    useVertexColor = false;
 #endif
+}
+
+VsOutput EvaluateVertexGeometry_BasePBR(VsInput IN, VsSystemValues SV)
+{
+    float4 color0;
+    bool useVertexColor0;
+    GetVertexColor(IN, color0, useVertexColor0);
+
     return EvaluateVertexGeometry_BasePBR(
         IN.position,
         IN.normal,
         IN.tangent,
         IN.uv0,
         IN.uv1,
-        color0,
         SV.m_instanceId,
-        useVertexColor0);
+        useVertexColor0,
+        color0);
+}
+
+VsOutput EvaluateVertexGeometry_BasePBR(
+    float3 position,
+    float3 normal,
+    float4 tangent,
+    float2 uv0,
+    float2 uv1,
+    uint instanceId)
+{
+    return EvaluateVertexGeometry_BasePBR(
+        position,
+        normal,
+        tangent,
+        uv0,
+        uv1,
+        instanceId,
+        float4(1.0f, 1.0f, 1.0f, 1.0f),
+        false);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -28,7 +28,8 @@ Surface EvaluateSurface_EnhancedPBR(
     bool isFrontFace,
     bool isDisplacementClipped,
     float4 uvDxDy,
-    bool customDerivatives)
+    bool customDerivatives,
+    float4 vertexColor)
 {
     Surface surface;
     surface.position = positionWS;
@@ -73,6 +74,7 @@ Surface EvaluateSurface_EnhancedPBR(
     real3 baseColor = GetDetailedBaseColorInput(
         MaterialSrg::m_baseColorMap,             MaterialSrg::m_sampler, baseColorUv, o_baseColor_useTexture,        real3(MaterialSrg::m_baseColor),  real(MaterialSrg::m_baseColorFactor), o_baseColorTextureBlendMode,
         MaterialSrg::m_detail_baseColor_texture, MaterialSrg::m_sampler, detailUv,    o_detail_baseColor_useTexture, detailLayerBaseColorFactor, uvDxDy, customDerivatives);
+    baseColor = BlendVertexColor(baseColor, real3(vertexColor.rgb));
     
     // ------- Parallax Clipping -------
 
@@ -175,8 +177,34 @@ Surface EvaluateSurface_EnhancedPBR(
     return surface;
 }
 
-// helper function to keep compatible with the previous version
+// Helper functions to keep compatible with the previous version
 // because dxc compiler doesn't allow default parameters on functions with overloads
+Surface EvaluateSurface_EnhancedPBR(
+    float3 positionWS,
+    real3 normalWS,
+    float3 tangents[UvSetCount],
+    float3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    float2 detailUvs[UvSetCount],
+    bool isFrontFace,
+    bool isDisplacementClipped,
+    float4 uvDxDy,
+    bool customDerivatives)
+{
+    return EvaluateSurface_EnhancedPBR(
+            positionWS,
+            normalWS,
+            tangents,
+            bitangents,
+            uvs,
+            detailUvs,
+            isFrontFace,
+            isDisplacementClipped,
+            uvDxDy,
+            customDerivatives,
+            float4(1.0f, 1.0f, 1.0f, 1.0f));
+}
+
 Surface EvaluateSurface_EnhancedPBR(
     float3 positionWS,
     real3 normalWS,
@@ -212,7 +240,8 @@ Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData, floa
         geoData.isFrontFace,
         geoData.isDisplacementClipped,
         uvDxDy,
-        customDerivatives);
+        customDerivatives,
+        GetVertexColor(IN));
 }
 
 Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData)
@@ -227,5 +256,6 @@ Surface EvaluateSurface_EnhancedPBR(VsOutput IN, PixelGeometryData geoData)
         geoData.isFrontFace,
         geoData.isDisplacementClipped,
         float4(0.0f, 0.0f, 0.0f, 0.0f),
-        false);
+        false,
+        GetVertexColor(IN));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexData.azsli
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#ifndef ENABLE_VERTEX_COLOR
+#define ENABLE_VERTEX_COLOR 0
+#endif
+
 #ifndef VsOutput
 #define VsOutput        VsOutput_EnhancedPBR
 #endif
@@ -39,8 +43,10 @@
         float2 uvs[UvSetCount] : UV1;
         float2 detailUvs[UvSetCount] : UV3;
 
+#if ENABLE_VERTEX_COLOR
         // Optional
         float4 color0 : UV7; // Using UV7 just to leave some room for non optional attributes
+#endif
     };
 
 #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_VertexEval.azsli
@@ -25,10 +25,11 @@ VsOutput EvaluateVertexGeometry_EnhancedPBR(
     float2 uv0,
     float2 uv1,
     uint instanceId,
+    bool useVertexColor,
     float4 color0)
 {
     // BasePBRP
-    VsOutput output = EvaluateVertexGeometry_BasePBR(position, normal, tangent, uv0, uv1, color0, instanceId, o_color0_isBound);
+    VsOutput output = EvaluateVertexGeometry_BasePBR(position, normal, tangent, uv0, uv1, instanceId, useVertexColor, color0);
 
     // Detail UVs
     float2 detailUvs[UvSetCount] = { uv0, uv1 };
@@ -37,8 +38,14 @@ VsOutput EvaluateVertexGeometry_EnhancedPBR(
     return output;
 }
 
+// Helper functions to keep compatible with the previous version
+// because dxc compiler doesn't allow default parameters on functions with overloads
 VsOutput EvaluateVertexGeometry_EnhancedPBR(VsInput IN, VsSystemValues SV)
 {
+    float4 color0;
+    bool useVertexColor0;
+    GetVertexColor(IN, color0, useVertexColor0);
+
     return EvaluateVertexGeometry_EnhancedPBR(
         IN.position,
         IN.normal,
@@ -46,5 +53,25 @@ VsOutput EvaluateVertexGeometry_EnhancedPBR(VsInput IN, VsSystemValues SV)
         IN.uv0,
         IN.uv1,
         SV.m_instanceId,
-        IN.m_optional_color0);
+        useVertexColor0,
+        color0);
+}
+
+VsOutput EvaluateVertexGeometry_EnhancedPBR(
+    float3 position,
+    float3 normal,
+    float4 tangent,
+    float2 uv0,
+    float2 uv1,
+    uint instanceId)
+{
+    return EvaluateVertexGeometry_EnhancedPBR(
+        position,
+        normal,
+        tangent,
+        uv0,
+        uv1,
+        instanceId,
+        false,
+        float4(1.0f, 1.0f, 1.0f, 1.0f));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -91,6 +91,30 @@ Surface EvaluateSurface_StandardPBR(
     float3 bitangents[UvSetCount],
     float2 uvs[UvSetCount],
     bool isFrontFace,
+    bool isDisplacementClipped,
+    float4 uvDxDy,
+    bool customDerivatives)
+{
+    return EvaluateSurface_StandardPBR(
+        positionWS,
+        vertexNormal,
+        tangents,
+        bitangents,
+        uvs,
+        isFrontFace,
+        isDisplacementClipped,
+        uvDxDy,
+        customDerivatives,
+        float4(1.0f, 1.0f, 1.0f, 1.0f));
+}
+
+Surface EvaluateSurface_StandardPBR(
+    float3 positionWS,
+    real3 vertexNormal,
+    float3 tangents[UvSetCount],
+    float3 bitangents[UvSetCount],
+    float2 uvs[UvSetCount],
+    bool isFrontFace,
     bool isDisplacementClipped)
 {
     return EvaluateSurface_StandardPBR(
@@ -102,8 +126,7 @@ Surface EvaluateSurface_StandardPBR(
         isFrontFace,
         isDisplacementClipped,
         float4(0.0f, 0.0f, 0.0f, 0.0f),
-        false,
-        float4(1.0f, 1.0f, 1.0f, 1.0f));
+        false);
 }
 
 Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData, float4 uvDxDy, bool customDerivatives)
@@ -118,7 +141,7 @@ Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData, floa
         geoData.isDisplacementClipped,
         uvDxDy,
         customDerivatives,
-        IN.color0);
+        GetVertexColor(IN));
 }
 
 Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData)
@@ -133,5 +156,5 @@ Surface EvaluateSurface_StandardPBR(VsOutput IN, PixelGeometryData geoData)
         geoData.isDisplacementClipped,
         float4(0.0f, 0.0f, 0.0f, 0.0f),
         false,
-        IN.color0);
+        GetVertexColor(IN));
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -38,7 +38,11 @@ Surface EvaluateSurface_MaterialGraphName(
     const float3 O3DE_MC_NORMAL_WS = normalWS;
     const float3 O3DE_MC_TANGENT_WS = tangents[0];
     const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
+#if ENABLE_VERTEX_COLOR
     const float4 O3DE_MC_COLOR = IN.color0;
+#else
+    const float4 O3DE_MC_COLOR = float4(1.0f, 1.0f, 1.0f, 1.0f);
+#endif
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
 
     // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_VertexEval.azsli
@@ -24,9 +24,9 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     real4 tangent,
     float2 uv0,
     float2 uv1,
-    float4 color0,
     uint instanceId,
-    bool useVertexColor0)
+    bool useVertexColor0,
+    float4 color0)
 {
     const float4x4 objectToWorld = GetObjectToWorldMatrix(instanceId);
     const float3x3 objectToWorldIT = GetObjectToWorldMatrixInverseTranspose(instanceId);
@@ -64,6 +64,7 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     output.normal = normal;
     output.tangent = tangent;
     output.m_instanceId = instanceId;
+#if ENABLE_VERTEX_COLOR
     if(useVertexColor0)
     {
         output.color0 =  color0;
@@ -72,18 +73,26 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     {
         output.color0 = float4(1,1,1,1);
     }
+#endif
     return output;
 }
 
 VsOutput EvaluateVertexGeometry_MaterialGraphName(VsInput IN, VsSystemValues SV)
 {
+#if ENABLE_VERTEX_COLOR
+    float4 color0 = IN.m_optional_color0;
+    bool useVertexColor = o_color0_isBound;
+#else
+    float4 color0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    bool useVertexColor = false;
+#endif
     return EvaluateVertexGeometry_MaterialGraphName(
         IN.position,
         real3(IN.normal),
         real4(IN.tangent),
         IN.uv0,
         IN.uv1,
-        IN.m_optional_color0,
         SV.m_instanceId,
-        o_color0_isBound);
+        useVertexColor,
+        color0);
 }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -40,7 +40,11 @@ Surface EvaluateSurface_MaterialGraphName(
     const float3 O3DE_MC_NORMAL_WS = normalWS;
     const float3 O3DE_MC_TANGENT_WS = tangents[0];
     const float3 O3DE_MC_BITANGENT_WS = bitangents[0];
+#if ENABLE_VERTEX_COLOR
     const float4 O3DE_MC_COLOR = IN.color0;
+#else
+    const float4 O3DE_MC_COLOR = float4(1.0f, 1.0f, 1.0f, 1.0f);
+#endif
     #define O3DE_MC_UV(index) uvs[clamp(index, 0, UvSetCount-1)];
 
     // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_VertexEval.azsli
@@ -24,9 +24,9 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     real4 tangent,
     float2 uv0,
     float2 uv1,
-    float4 color0,
     uint instanceId,
-    bool useVertexColor0)
+    bool useVertexColor0,
+    float4 color0)
 {
     const float4x4 objectToWorld = GetObjectToWorldMatrix(instanceId);
     const float3x3 objectToWorldIT = GetObjectToWorldMatrixInverseTranspose(instanceId);
@@ -64,6 +64,7 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     output.normal = normal;
     output.tangent = tangent;
     output.m_instanceId = instanceId;
+#if ENABLE_VERTEX_COLOR
     if(useVertexColor0)
     {
         output.color0 =  color0;
@@ -72,19 +73,46 @@ VsOutput EvaluateVertexGeometry_MaterialGraphName(
     {
         output.color0 = float4(1,1,1,1);
     }
+#endif
 
     return output;
 }
 
 VsOutput EvaluateVertexGeometry_MaterialGraphName(VsInput IN, VsSystemValues SV)
 {
+#if ENABLE_VERTEX_COLOR
+    float4 color0 = IN.m_optional_color0;
+    bool useVertexColor = o_color0_isBound;
+#else
+    float4 color0 = float4(1.0f, 1.0f, 1.0f, 1.0f);
+    bool useVertexColor = false;
+#endif
     return EvaluateVertexGeometry_MaterialGraphName(
         IN.position,
         real3(IN.normal),
         real4(IN.tangent),
         IN.uv0,
         IN.uv1,
-        IN.m_optional_color0,        
         SV.m_instanceId,
-        o_color0_isBound);
+        useVertexColor,
+        color0);
+}
+
+VsOutput EvaluateVertexGeometry_MaterialGraphName(
+    float3 position,
+    real3 normal,
+    real4 tangent,
+    float2 uv0,
+    float2 uv1,
+    uint instanceId)
+{
+    return EvaluateVertexGeometry_MaterialGraphName(
+        position,
+        normal,
+        tangent,
+        uv0,
+        uv1,
+        instanceId,
+        false,
+        float4(1.0f, 1.0f, 1.0f, 1.0f));
 }


### PR DESCRIPTION
## What does this PR do?

After adding vertex color support some of the BasePBR, StandardPBR and EnhancedBR functions change their signature. This could break any external shader that is using any of those functions, so I added new interfaces to be able to handle the old interface (the one without vertex color). 

## How was this PR tested?

Run PC Editor, Material Canvas and Material Editor.