### PR TITLE
Cherrypick from stabilization to dev - Fix unparent prefab entities (#18073)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -196,8 +196,19 @@ namespace AZ
             //! For use with slice creation tools. See SliceCreationFlags below for details.
             const static AZ::Crc32 SliceFlags = AZ_CRC("SliceFlags", 0xa447e1fb);
 
-            //! Does the clear button in the LineEdit need to have a test for visibility.
-            const static AZ::Crc32 ShowClearButtonHandler = AZ_CRC_CE("ShowClearButtonHandler");
+            //! On controls with a clear button, this attribute specifies whether the clear button should be shown.
+            const static AZ::Crc32 ShowClearButtonHandler = AZ_CRC("ShowClearButtonHandler", 0x2ef414c9);
+
+            //! Specifies whether the picker button should be shown.
+            //! Authors - if you add this attribute to other handlers, list them here:
+            //!      EntityId handler
+            const static AZ::Crc32 ShowPickButton = AZ_CRC("ShowPickButton", 0xc40252dd);
+
+            //! Specifies whether drop onto this control should be allowed.
+            //! Used to turn off drag and drop for Transform Parents - you have to modify that via the outliner.
+            //! Authors - if you add this attribute to other handlers, list them here:
+            //!      EntityId handler
+            const static AZ::Crc32 AllowDrop = AZ_CRC("AllowDrop", 0x85424942);
 
             //! For optional use on Getter Events used for Virtual Properties
             const static AZ::Crc32 PropertyPosition = AZ_CRC("Position", 0x462ce4f5);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -918,93 +918,6 @@ namespace AzToolsFramework
             return false;
         }
 
-        AZ::Outcome<void, AZStd::string> TransformComponent::ValidatePotentialParent(void* newValue, const AZ::Uuid& valueType)
-        {
-            if (azrtti_typeid<AZ::EntityId>() != valueType)
-            {
-                AZ_Assert(false, "Unexpected value type");
-                return AZ::Failure(AZStd::string("Trying to set an entity ID to something that isn't an entity ID."));
-            }
-
-            AZ::EntityId newParentId = static_cast<AZ::EntityId>(*((AZ::EntityId*)newValue));
-
-            if (!newParentId.IsValid())
-            {
-                // Handled by the calling code.
-                return AZ::Success();
-            }
-
-            AZ::EntityId selectedEntityId = GetEntityId();
-
-            // Prevent setting the parent to the entity itself.
-            if (newParentId == selectedEntityId)
-            {
-                return AZ::Failure(AZStd::string("You cannot set an entity's parent to itself."));
-            }
-
-            if (!EntitiesBelongToSamePrefab(EntityIdList{ selectedEntityId }, newParentId))
-            {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of an entity owned by a different prefab."));
-            }
-
-            // Don't allow the change if it will result in a cycle hierarchy
-            auto potentialParentTransformComponent = GetTransformComponent(newParentId);
-            if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(selectedEntityId))
-            {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children."));
-            }
-
-            // Don't allow read-only entities to be re-parented at all.
-            // Also don't allow entities to be parented under read-only entities.
-            if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
-                readOnlyEntityPublicInterface->IsReadOnly(selectedEntityId) || readOnlyEntityPublicInterface->IsReadOnly(newParentId))
-            {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a read-only entity."));
-            }
-
-            // Don't allow entities to be parented under closed containers.
-            if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
-                !containerEntityInterface->IsContainerOpen(newParentId))
-            {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container."));
-            }
-
-            // Don't allow entities to be parented outside their container.
-            if (m_focusModeInterface && !m_focusModeInterface->IsInFocusSubTree(newParentId))
-            {
-                return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab."));
-            }
-
-            return AZ::Success();
-        }
-
-        AZ::u32 TransformComponent::ParentChangedInspector()
-        {
-            AZ::u32 refreshLevel = AZ::Edit::PropertyRefreshLevels::None;
-
-            if (!m_parentEntityId.IsValid())
-            {
-                // Reroute the invalid id to the focused prefab container entity id
-                auto prefabFocusPublicInterface = AZ::Interface<Prefab::PrefabFocusPublicInterface>::Get();
-
-                if (prefabFocusPublicInterface)
-                {
-                    auto editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-                    EditorEntityContextRequestBus::BroadcastResult(
-                        editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
-
-                    m_parentEntityId = prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
-                    refreshLevel = AZ::Edit::PropertyRefreshLevels::ValuesOnly;
-                }
-            }
-
-            auto parentId = m_parentEntityId;
-            m_parentEntityId = m_previousParentEntityId;
-            SetParent(parentId);
-
-            return refreshLevel;
-        }
-
         AZ::u32 TransformComponent::TransformChangedInspector()
         {
             if (TransformChanged())
@@ -1182,12 +1095,6 @@ namespace AzToolsFramework
             return AZ::Edit::PropertyRefreshLevels::EntireTree;
         }
 
-        bool TransformComponent::ShowClearButtonHandler()
-        {
-            // Hide the clear button if the current entity is the focus root, which is the default value.
-            return(!m_focusModeInterface->IsFocusRoot(GetParentId()));
-        }
-
         void TransformComponent::Reflect(AZ::ReflectContext* context)
         {
             // reflect data for script, serialization, editing..
@@ -1221,11 +1128,11 @@ namespace AzToolsFramework
                             Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Transform.svg")->
                             Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/transform/")->
                             Attribute(AZ::Edit::Attributes::AutoExpand, true)->
-                        DataElement(AZ::Edit::UIHandlers::Default, &TransformComponent::m_parentEntityId, "Parent entity", "")->
-                            Attribute(AZ::Edit::Attributes::ChangeValidate, &TransformComponent::ValidatePotentialParent)->
-                            Attribute(AZ::Edit::Attributes::ChangeNotify, &TransformComponent::ParentChangedInspector)->
+                        DataElement(AZ::Edit::UIHandlers::Default, &TransformComponent::m_parentEntityId, "Parent entity", "Modify this using the Entity Outliner")->
                             Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::DontGatherReference | AZ::Edit::SliceFlags::NotPushableOnSliceRoot)->
-                            Attribute(AZ::Edit::Attributes::ShowClearButtonHandler, &TransformComponent::ShowClearButtonHandler)->
+                            Attribute(AZ::Edit::Attributes::ShowClearButtonHandler, false)->
+                            Attribute(AZ::Edit::Attributes::ShowPickButton, false)->
+                            Attribute(AZ::Edit::Attributes::AllowDrop, false)->
                         DataElement(AZ::Edit::UIHandlers::Default, &TransformComponent::m_editorTransform, "Values", "")->
                             Attribute(AZ::Edit::Attributes::ChangeNotify, &TransformComponent::TransformChangedInspector)->
                             Attribute(AZ::Edit::Attributes::AutoExpand, true)->

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -161,8 +161,6 @@ namespace AzToolsFramework
             void UpdateCachedWorldTransform();
             void ClearCachedWorldTransform();
 
-            bool ShowClearButtonHandler();
-
             // SliceEntityHierarchyRequestBus
             AZ::EntityId GetSliceEntityParentId() override;
             AZStd::vector<AZ::EntityId> GetSliceEntityChildren() override;
@@ -182,10 +180,7 @@ namespace AzToolsFramework
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
             static void Reflect(AZ::ReflectContext* context);
 
-            AZ::Outcome<void, AZStd::string> ValidatePotentialParent(void* newValue, const AZ::Uuid& valueType);
-
             AZ::u32 TransformChangedInspector();
-            AZ::u32 ParentChangedInspector();
             AZ::u32 StaticChangedInspector();
 
             bool TransformChanged();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -200,6 +200,11 @@ namespace AzToolsFramework
             return;
         }
 
+        if (!AllowsDrop())
+        {
+            return;
+        }
+
         const bool isValidDropTarget = IsCorrectMimeData(event->mimeData()) &&
             EntityIdsFromMimeData(*event->mimeData());
 
@@ -214,6 +219,11 @@ namespace AzToolsFramework
     void PropertyEntityIdCtrl::dropEvent(QDropEvent* event)
     {
         AzQtComponents::LineEdit::removeDropTargetStyle(m_entityIdLineEdit);
+
+        if (!AllowsDrop())
+        {
+            return;
+        }
 
         if (event == nullptr)
         {
@@ -344,6 +354,15 @@ namespace AzToolsFramework
         m_entityIdLineEdit->setClearButtonEnabled(HasClearButton());
         m_entityIdLineEdit->SetEntityId(newEntityId, nameOverride);
         m_componentsSatisfyingServices.clear();
+
+        if (!HasPickButton())
+        {
+            m_pickButton->hide();
+        }
+        else
+        {
+            m_pickButton->show();
+        }
 
         if (!m_requiredServices.empty() || !m_incompatibleServices.empty())
         {
@@ -537,6 +556,22 @@ namespace AzToolsFramework
             if (attrValue->Read<bool>(value))
             {
                 GUI->SetHasClearButton(value);
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::ShowPickButton)
+        {
+            bool value;
+            if (attrValue->Read<bool>(value))
+            {
+                GUI->SetHasPickButton(value);
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::AllowDrop)
+        {
+            bool value;
+            if (attrValue->Read<bool>(value))
+            {
+                GUI->SetAllowsDrop(value);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
@@ -73,7 +73,12 @@ namespace AzToolsFramework
         void SetAcceptedEntityContext(AzFramework::EntityContextId contextId);
 
         void SetHasClearButton(bool value) { m_hasClearButton = value; }
+        void SetHasPickButton(bool value) { m_hasPickButton = value; }
+        void SetAllowsDrop(bool value) { m_allowsDrop = value; }
+
         bool HasClearButton() { return m_hasClearButton; }
+        bool HasPickButton() { return m_hasPickButton; }
+        bool AllowsDrop() { return m_allowsDrop; }
 
     signals:
         void OnEntityIdChanged(AZ::EntityId newEntityId);
@@ -103,6 +108,9 @@ namespace AzToolsFramework
         AZStd::list<AZStd::string> m_componentsSatisfyingServices;
 
         bool m_hasClearButton{ true };
+        bool m_hasPickButton{ true };
+        bool m_allowsDrop { true };
+
         QIcon m_pickerIcon;
     };
 


### PR DESCRIPTION
* Fixes issue where invalid parenting can be done via inspector

Fixes Issue #16541
Fixes Issue #18052

Makes it so that you MUST use the entity outliner to modify parenting of entities.  This prevents a whole series of issues related to parenting that already has a ton of code written in the outliner to prevent various side effects and issues.

See the original PR at https://github.com/o3de/o3de/pull/18073 for additional information.  This is just a cherrypick.