### PR TITLE
Compile fix for when AZ_FORCE_CPU_GPU_INSYNC is defined.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -68,9 +68,9 @@ namespace AZ
             // we can be sure about the work gpu was working on before the crash.
             for (auto it = scopes.begin(); it != scopes.end(); ++it)
             {
-                const Scope& scope = *static_cast<const Scope*>(*it);
+                Scope& scope = *static_cast<Scope*>(*it);
                 auto nextIter = it + 1;
-                scopeNext = nextIter != scopes.end() ? static_cast<const Scope*>(*nextIter) : nullptr;
+                scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
                 const bool subpassGroup = (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
                                           (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
                 


### PR DESCRIPTION
## What does this PR do?

Fixes a compile error w.r.t. wrongly const declared data types.

## How was this PR tested?

Defined `AZ_FORCE_CPU_GPU_INSYNC` in `Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h` and compiled.
