### PR TITLE
Fix debug symbol error.

### DIFF
--- a/cmake/Platform/Linux/ProcessDebugSymbols.cmake
+++ b/cmake/Platform/Linux/ProcessDebugSymbols.cmake
@@ -71,6 +71,8 @@ execute_process(COMMAND
 # Step 3: Re-link the debug information file from stemp 1 (For 'DETACH' actions)
 if (${DEBUG_SYMBOL_OPTION} STREQUAL "DETACH")
 
+    execute_process(COMMAND ${GNU_OBJCOPY} --remove-section=.gnu_debuglink ${STRIP_TARGET})
+
     execute_process(COMMAND 
                         ${GNU_OBJCOPY} --add-gnu-debuglink=${filename_only}.${DEBUG_SYMBOL_EXT} ${STRIP_TARGET}
                     WORKING_DIRECTORY 


### PR DESCRIPTION
## What does this PR do?

objcpy reports "debuglink section already exists" as there seems to be such a section already present. The following issue helped here: https://github.com/softprops/lambda-rust/issues/41

## How was this PR tested?

Compiled with this and got rid of the error.
