### PR TITLE
Bugfix for #18086: Assert trigger when reloading Sponza level

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -18,8 +18,6 @@ namespace AZ::RHI
     AZStd::shared_ptr<DeviceRayTracingShaderTableDescriptor> RayTracingShaderTableDescriptor::GetDeviceRayTracingShaderTableDescriptor(
         int deviceIndex)
     {
-        AZ_Assert(m_RayTracingPipelineState, "No RayTracingPipelineState available\n");
-
         AZStd::shared_ptr<DeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<DeviceRayTracingShaderTableDescriptor>();
 
         if (m_RayTracingPipelineState)


### PR DESCRIPTION
## What does this PR do?

Fix #18086. Empty RayTracingShaderTableDescriptors are allowed, so the assert can simply be removed.

## How was this PR tested?

As described in #18086.
