### PR TITLE
Fix multi-threaded creation of PipelineStates in PipelineStateCache

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineState.h
@@ -44,6 +44,9 @@ namespace AZ::RHI
             const PipelineStateDescriptor& descriptor,
             PipelineLibrary* pipelineLibrary = nullptr);
 
+        //! Preinitializes a pipeline state to allow for safe usage with multi-threaded DrawPacket creation
+        void PreInitialize(MultiDevice::DeviceMask deviceMask);
+
         PipelineStateType GetType() const;
 
     private:

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -29,6 +29,19 @@ namespace AZ::RHI
         return true;
     }
 
+    void PipelineState::PreInitialize(MultiDevice::DeviceMask deviceMask)
+    {
+        int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+        for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
+        {
+            if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+            {
+                m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
+            }
+        }
+    }
+
     ResultCode PipelineState::Init(
         MultiDevice::DeviceMask deviceMask, const PipelineStateDescriptor& descriptor, PipelineLibrary* pipelineLibrary)
     {
@@ -50,8 +63,10 @@ namespace AZ::RHI
             [this, &descriptor, &pipelineLibrary, &resultCode](int deviceIndex)
             {
                 auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
-
-                m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
+                if(!m_deviceObjects.contains(deviceIndex))
+                {
+                    m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
+                }
                 switch (descriptor.GetType())
                 {
                 case PipelineStateType::Draw:
@@ -106,8 +121,8 @@ namespace AZ::RHI
 
         if (resultCode != ResultCode::Success)
         {
-            // Reset already initialized device-specific PipelineStates and set deviceMask to 0
-            m_deviceObjects.clear();
+            // Only reset the device mask but the the device-specific PipelineStates, as other
+            // threads might be using them already
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
         }
 
@@ -116,9 +131,9 @@ namespace AZ::RHI
 
     void PipelineState::Shutdown()
     {
+        m_deviceObjects.clear();
         if (IsInitialized())
         {
-            m_deviceObjects.clear();
             MultiDeviceObject::Shutdown();
         }
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -31,7 +31,7 @@ namespace AZ::RHI
 
     void PipelineState::PreInitialize(MultiDevice::DeviceMask deviceMask)
     {
-        int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
+        const int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
 
         for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
         {
@@ -63,10 +63,12 @@ namespace AZ::RHI
             [this, &descriptor, &pipelineLibrary, &resultCode](int deviceIndex)
             {
                 auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+
                 if(!m_deviceObjects.contains(deviceIndex))
                 {
                     m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
                 }
+
                 switch (descriptor.GetType())
                 {
                 case PipelineStateType::Draw:

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -376,6 +376,8 @@ namespace AZ::RHI
             // but don't initialize it yet. We can safely allocate the 'empty' instance and cache it.
             pipelineState = aznew PipelineState;
 
+            pipelineState->PreInitialize(m_deviceMask);
+
             [[maybe_unused]] bool success =
                 InsertPipelineState(pendingCache, PipelineStateEntry(pipelineStateHash, pipelineState, descriptor));
             AZ_Assert(success, "PipelineStateEntry already exists in the pending cache.");


### PR DESCRIPTION
## What does this PR do?

We encountered an issue that happens mainly when loading very large levels with loads of meshes. 
The issue originates in the `PipelineStateCache` and how `PipelineState`s are created there and how that interplays with multi-threaded `MeshDrawPacket` creation.

During `appendShader` in `MeshDrawPacket::DoUpdate()`, it calls 
```cpp
const RHI::PipelineState* pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);

```
which in turn calls
```cpp
m_pipelineStateCache->AcquirePipelineState(m_pipelineLibraryHandle, descriptor, m_asset->GetName());
```
This then checks the read-only cache, the thread-local cache, and if neither provides something in return, it calls 

```cpp
ConstPtr<PipelineState> pipelineState = CompilePipelineState(globalLibraryEntry, threadLibraryEntry, descriptor, pipelineStateHash, name);
```

which itself either creates a new `PipelineState` or, if someone else already started doing that, it can take an "in-flight" `PipelineState` from the `m_pendingCache`.
The insertion and query to the `m_pendingCache` is protected by a mutex, but the initialization happens after the lock is released, as is stated in the code 
```cpp
// We no longer have the lock, but we own compilation of the pipeline state. Use the
// thread-local library to perform compilation without blocking other threads.
resultCode = pipelineState->Init(m_deviceMask, descriptor, pipelineLibrary);
```

Now it might happen that a thread now gets such a `PipelineState` that is currently being initialized, and puts that into the `DrawRequest`, but since these are just pointers, everything is fine and the initialization of the `PipelineState` is guaranteed to be finished before the `DrawPacket` is actually used.

But now, the same situation might lead to a crash, since when we place the `PipelineState` into the `DrawRequest` and this is added to the `DrawPacketBuilder` via 
```cpp
drawPacketBuilder.AddDrawItem(drawRequest);
```
this internally also adds the `DeviceDrawRequest`s to the `DeviceDrawItem`s, which in turn needs to call 
```cpp
m_pipelineState->GetDevicePipelineState(deviceIndex) // and this may fail if the initialization is currently on-going, as it might happen that the objects are not yet initialized
```

Since we do not want to extend the blocked code to include the initialization, we rather propose to "pre-initialize" the `PipelineState` within the mutex-locked region (i.e. just create the uninitialized objects, same behavior as before), which then works for the `DeviceDrawItem`s and solves this problem.
