### PR TITLE
DO NOT MERGE TO DEV - Makes o3de.git/stabilization/2409 use o3de-extras.git/stabilization/2409

### DIFF
--- a/.automatedtesting.json
+++ b/.automatedtesting.json
@@ -15,7 +15,7 @@
         {
             "NAME": "o3de-extras",
             "URL": "https://github.com/o3de/o3de-extras.git",
-            "BRANCH": "development"
+            "BRANCH": "stabilization/2409"
         }
     ]
 }


### PR DESCRIPTION
## What does this PR do?

Makes it so that when the AR system builds branches based on stabilization/2409, it uses the stabilization/2409 version of o3de-extras as well, instead of o3de-extras:development branch

! DO NOT MERGE THIS CHANGE BACK TO DEVELOPMENT !

## How was this PR tested?

I'll be triggering an AR to test it.

example of the problem: https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/detail/PR-18056/2/pipeline/129
Lots of Atom-related API change errors, its checking development of extras out instead of the stabilization branch during AR.
