### PR TITLE
DX12: Remove name from FenceEvent windows event

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
@@ -18,7 +18,7 @@ namespace AZ
         {
             AZStd::wstring nameW;
             AZStd::to_wstring(nameW, name);
-            m_EventHandle = CreateEvent(nullptr, false, false, nameW.c_str());
+            m_EventHandle = CreateEvent(nullptr, false, false, nullptr);
         }
 
         FenceEvent::~FenceEvent()

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
@@ -16,8 +16,6 @@ namespace AZ
             : m_EventHandle(nullptr)
             , m_name(name)
         {
-            AZStd::wstring nameW;
-            AZStd::to_wstring(nameW, name);
             m_EventHandle = CreateEvent(nullptr, false, false, nullptr);
         }
 


### PR DESCRIPTION
## What does this PR do?

This fixes a problem when we wait for more than one fence at the same time.

According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa), there cannot be two different events with the same name. Creating the second event returns the first one again:

```
If the named event object existed before the function call, the function returns a handle to the existing object and [GetLastError](https://learn.microsoft.com/en-us/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror) returns ERROR_ALREADY_EXISTS.
```

We therefor had only one event for two fences, sometimes leading to the problem that the wrong thread continued.

## How was this PR tested?

AtomSampleViewer on Windows+DX12. The Multi GPU RPI sample with the Copy Test Pipeline led to a deadlock with DX12. This PR fixes that problem.