### PR TITLE
Implement "Debug Ray Tracing" component

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
@@ -1,0 +1,58 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "DebugRayTracingPassTemplate",
+            "PassClass": "RayTracingPass",
+            "Slots": [
+                {
+                    "Name": "ColorInputOutput",
+                    "ShaderInputName": "m_fallbackColor",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "Shader"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "ColorInputOutput",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "Parent",
+                            "Attachment": "PipelineOutput"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "Parent",
+                        "Attachment": "PipelineOutput"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "ColorInputOutput",
+                    "AttachmentRef": {
+                        "Pass": "PostProcessPass",
+                        "Attachment": "Output"
+                    }
+                }
+            ],
+            "PassData":  {
+                "$type": "RayTracingPassData",
+                "RayGenerationShaderAsset": { "FilePath": "Shaders/Debug/RayTracingDebugRayGeneration.shader" },
+                "RayGenerationShaderName": "RayGeneration",
+                "ClosestHitShaderAsset": { "FilePath": "Shaders/Debug/RayTracingDebugClosestHit.shader" },
+                "ClosestHitShaderName": "ClosestHit",
+                "ClosestHitProceduralShaderAsset": { "FilePath": "Shaders/Debug/RayTracingDebugClosestHitProcedural.shader" },
+                "ClosestHitProceduralShaderName": "ClosestHitProcedural",
+                "MissShaderAsset": { "FilePath": "Shaders/Debug/RayTracingDebugMiss.shader" },
+                "MissShaderName": "Miss",
+                "MaxPayloadSize": 16,
+                "MaxRecursionDepth": 1,
+                "Make Fullscreen Pass": true,
+                "BindViewSrg": true
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -513,6 +513,10 @@
                 "Path": "Passes/DebugOverlayParent.pass"
             },
             {
+                "Name": "DebugRayTracingPassTemplate",
+                "Path": "Passes/DebugRayTracingPass.pass"
+            },
+            {
                 "Name": "UIParentTemplate",
                 "Path": "Passes/UIParent.pass"
             },

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -206,6 +206,9 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
     #define MESH_BUFFER_FLAG_BITANGENT      (1 << 1)
     #define MESH_BUFFER_FLAG_UV             (1 << 2)
 
+    // Specifies which debug visualization to use (value must be from RayTracingDebugViewMode enum)
+    uint m_debugViewMode;
+
 #if !USE_BINDLESS_SRG
     // Unbounded array of mesh stream buffers:
     // Note 1: Index, Position, and Normal stream buffers are guaranteed to be valid for each mesh

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSrgs.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSrgs.azsli
@@ -17,3 +17,4 @@
 #include <Atom/Features/RayTracing/RayTracingSceneSrg.azsli>
 #include <Atom/Features/RayTracing/RayTracingMaterialSrg.azsli>
 #include <Atom/Features/RayTracing/RayTracingGlobalSrg.azsli>
+#include <Atom/Features/Bindless.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
@@ -38,12 +38,12 @@ void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes
 {
     switch (GetRayTracingDebugViewMode())
     {
-    case RayTracingDebugViewMode::InstanceID:     payload.SetColor(GetRandomColor(InstanceID()));             break;
-    case RayTracingDebugViewMode::InstanceIndex:  payload.SetColor(GetRandomColor(InstanceIndex()));          break;
-    case RayTracingDebugViewMode::PrimitiveIndex: payload.SetColor(GetRandomColor(PrimitiveIndex()));         break;
-    case RayTracingDebugViewMode::Barycentrics:   payload.SetColor(GetBarycentricColor(attrib.barycentrics)); break;
-    case RayTracingDebugViewMode::Normals:        payload.SetColor(GetNormalColor(attrib.barycentrics));      break;
-    case RayTracingDebugViewMode::UVs:            payload.SetColor(GetUVColor(attrib.barycentrics));          break;
-    default: break;
+    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());             break;
+    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());          break;
+    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());         break;
+    case RayTracingDebugViewMode::Barycentrics:   payload.m_color = GetBarycentricColor(attrib.barycentrics); break;
+    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.barycentrics);      break;
+    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.barycentrics);          break;
+    default:                                      payload.m_noData = true;                                    break;
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
@@ -38,12 +38,12 @@ void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes
 {
     switch (GetRayTracingDebugViewMode())
     {
-    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());             break;
-    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());          break;
-    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());         break;
-    case RayTracingDebugViewMode::Barycentrics:   payload.m_color = GetBarycentricColor(attrib.barycentrics); break;
-    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.barycentrics);      break;
-    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.barycentrics);          break;
-    default: payload.m_color = float3(1, 1, 1);
+    case RayTracingDebugViewMode::InstanceID:     payload.SetColor(GetRandomColor(InstanceID()));             break;
+    case RayTracingDebugViewMode::InstanceIndex:  payload.SetColor(GetRandomColor(InstanceIndex()));          break;
+    case RayTracingDebugViewMode::PrimitiveIndex: payload.SetColor(GetRandomColor(PrimitiveIndex()));         break;
+    case RayTracingDebugViewMode::Barycentrics:   payload.SetColor(GetBarycentricColor(attrib.barycentrics)); break;
+    case RayTracingDebugViewMode::Normals:        payload.SetColor(GetNormalColor(attrib.barycentrics));      break;
+    case RayTracingDebugViewMode::UVs:            payload.SetColor(GetUVColor(attrib.barycentrics));          break;
+    default: break;
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
+#include <RayTracingDebugCommon.azsli>
+
+[shader("closesthit")]
+void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes attrib)
+{
+    payload.m_color = GetRandomColor(InstanceIndex());
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
@@ -7,10 +7,43 @@
  */
 
 #include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
+#include <Atom/Features/RayTracing/RayTracingSceneUtils.azsli>
 #include <RayTracingDebugCommon.azsli>
+
+VertexData GetVertexData(float2 barycentrics)
+{
+    RayTracingSceneSrg::MeshInfo meshInfo = RayTracingSceneSrg::m_meshInfo[NonUniformResourceIndex(InstanceIndex())];
+    return GetHitInterpolatedVertexData(meshInfo, barycentrics);
+}
+
+float3 GetBarycentricColor(float2 barycentrics)
+{
+    return float3(barycentrics, 1.f - barycentrics.x - barycentrics.y);
+}
+
+float3 GetNormalColor(float2 barycentrics)
+{
+    VertexData vertexData = GetVertexData(barycentrics);
+    return vertexData.m_normal * 0.5f + 0.5f;
+}
+
+float3 GetUVColor(float2 barycentrics)
+{
+    VertexData vertexData = GetVertexData(barycentrics);
+    return float3(vertexData.m_uv, 0.f);
+}
 
 [shader("closesthit")]
 void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes attrib)
 {
-    payload.m_color = GetRandomColor(InstanceIndex());
+    switch (GetRayTracingDebugViewMode())
+    {
+    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());             break;
+    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());          break;
+    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());         break;
+    case RayTracingDebugViewMode::Barycentrics:   payload.m_color = GetBarycentricColor(attrib.barycentrics); break;
+    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.barycentrics);      break;
+    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.barycentrics);          break;
+    default: payload.m_color = float3(1, 1, 1);
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.shader
@@ -1,0 +1,44 @@
+{
+    "Source" : "RayTracingDebugClosestHit.azsl",
+    "DrawList" : "RayTracing",
+
+    "AddBuildArguments":
+    {
+        "dxc": ["-fspv-target-env=vulkan1.2"]
+    },
+
+    "ProgramSettings":
+    {
+        "EntryPoints":
+        [
+            {
+                "type": "RayTracing",
+                "name": "ClosestHit"
+            }
+        ]
+    },
+
+    "DisabledRHIBackends": ["metal"],
+
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments":
+            {
+                "azslc": ["--no-ms"]
+            },
+            "RemoveBuildArguments" :
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/RayTracing/RayTracingIntersectionAttributes.azsli>
+#include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
+#include <RayTracingDebugCommon.azsli>
+
+[shader("closesthit")]
+void ClosestHitProcedural(inout PayloadData payload, ProceduralGeometryIntersectionAttributes attrib)
+{
+    payload.m_color = GetRandomColor(InstanceIndex());
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
@@ -25,11 +25,11 @@ void ClosestHitProcedural(inout PayloadData payload, ProceduralGeometryIntersect
 {
     switch (GetRayTracingDebugViewMode())
     {
-    case RayTracingDebugViewMode::InstanceID:     payload.SetColor(GetRandomColor(InstanceID()));       break;
-    case RayTracingDebugViewMode::InstanceIndex:  payload.SetColor(GetRandomColor(InstanceIndex()));    break;
-    case RayTracingDebugViewMode::PrimitiveIndex: payload.SetColor(GetRandomColor(PrimitiveIndex()));   break;
-    case RayTracingDebugViewMode::Normals:        payload.SetColor(GetNormalColor(attrib.GetNormal())); break;
-    case RayTracingDebugViewMode::UVs:            payload.SetColor(GetUVColor(attrib.GetUv()));         break;
-    default: break;
+    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());       break;
+    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());    break;
+    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());   break;
+    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.GetNormal()); break;
+    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.GetUv());         break;
+    default:                                      payload.m_noData = true;                              break;
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
@@ -10,8 +10,26 @@
 #include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
 #include <RayTracingDebugCommon.azsli>
 
+float3 GetNormalColor(float3 normal)
+{
+    return normal * 0.5f + 0.5f;
+}
+
+float3 GetUVColor(float2 uv)
+{
+    return float3(uv, 0.f);
+}
+
 [shader("closesthit")]
 void ClosestHitProcedural(inout PayloadData payload, ProceduralGeometryIntersectionAttributes attrib)
 {
-    payload.m_color = GetRandomColor(InstanceIndex());
+    switch (GetRayTracingDebugViewMode())
+    {
+    case RayTracingDebugViewMode::InstanceID:     payload.SetColor(GetRandomColor(InstanceID()));       break;
+    case RayTracingDebugViewMode::InstanceIndex:  payload.SetColor(GetRandomColor(InstanceIndex()));    break;
+    case RayTracingDebugViewMode::PrimitiveIndex: payload.SetColor(GetRandomColor(PrimitiveIndex()));   break;
+    case RayTracingDebugViewMode::Normals:        payload.SetColor(GetNormalColor(attrib.GetNormal())); break;
+    case RayTracingDebugViewMode::UVs:            payload.SetColor(GetUVColor(attrib.GetUv()));         break;
+    default: break;
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.shader
@@ -1,0 +1,44 @@
+{
+    "Source" : "RayTracingDebugClosestHitProcedural.azsl",
+    "DrawList" : "RayTracing",
+
+    "AddBuildArguments":
+    {
+        "dxc": ["-fspv-target-env=vulkan1.2"]
+    },
+
+    "ProgramSettings":
+    {
+        "EntryPoints":
+        [
+            {
+                "type": "RayTracing",
+                "name": "ClosestHitProcedural"
+            }
+        ]
+    },
+
+    "DisabledRHIBackends": ["metal"],
+
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments":
+            {
+                "azslc": ["--no-ms"]
+            },
+            "RemoveBuildArguments" :
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
@@ -14,6 +14,22 @@ struct PayloadData
     float3 m_color;
 };
 
+// This enum must be the same as in RayTracingDebugConstants.h
+enum class RayTracingDebugViewMode
+{
+    InstanceIndex,
+    InstanceID,
+    PrimitiveIndex,
+    Barycentrics,
+    Normals,
+    UVs,
+};
+
+RayTracingDebugViewMode GetRayTracingDebugViewMode()
+{
+    return (RayTracingDebugViewMode)RayTracingSceneSrg::m_debugViewMode;
+}
+
 float3 Float3FromRGB(uint r, uint g, uint b)
 {
     return float3(r / 255.f, g / 255.f, b / 255.f);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
@@ -8,10 +8,16 @@
 
 #pragma once
 
-struct PayloadData
+class PayloadData
 {
-    float m_hitT;
+    bool m_colorSet;
     float3 m_color;
+
+    void SetColor(float3 color)
+    {
+        m_color = color;
+        m_colorSet = true;
+    }
 };
 
 // This enum must be the same as in RayTracingDebugConstants.h

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+struct PayloadData
+{
+    float m_hitT;
+    float3 m_color;
+};
+
+float3 Float3FromRGB(uint r, uint g, uint b)
+{
+    return float3(r / 255.f, g / 255.f, b / 255.f);
+}
+
+float3 GetRandomColor(uint index)
+{
+    // Color values from: "Polychrome: Creating and Assessing Qualitative Palettes with Many Colors" by Kevin R. Coombes et al.
+    // (https://doi.org/10.18637/jss.v090.c01), Figure 10: A 24-color palette of well-separated lighter colors.
+
+    switch (index % 24)
+    {
+    case  0: return Float3FromRGB(253,  50,  20);
+    case  1: return Float3FromRGB(  0, 254,  53);
+    case  2: return Float3FromRGB(106, 118, 252);
+    case  3: return Float3FromRGB(254, 212, 196);
+    case  4: return Float3FromRGB(254,   0, 206);
+    case  5: return Float3FromRGB( 13, 249, 255);
+    case  6: return Float3FromRGB(246, 249,  38);
+    case  7: return Float3FromRGB(255, 150,  22);
+    case  8: return Float3FromRGB( 71, 155,  85);
+    case  9: return Float3FromRGB(238, 166, 251);
+    case 10: return Float3FromRGB(220,  88, 125);
+    case 11: return Float3FromRGB(214,  38, 255);
+    case 12: return Float3FromRGB(110, 137, 156);
+    case 13: return Float3FromRGB(  0, 181, 247);
+    case 14: return Float3FromRGB(182, 142,   0);
+    case 15: return Float3FromRGB(201, 251, 229);
+    case 16: return Float3FromRGB(255,   0, 146);
+    case 17: return Float3FromRGB( 34, 255, 167);
+    case 18: return Float3FromRGB(227, 238, 158);
+    case 19: return Float3FromRGB(134, 206,   0);
+    case 20: return Float3FromRGB(188, 113, 150);
+    case 21: return Float3FromRGB(126, 125, 205);
+    case 22: return Float3FromRGB(252, 105,  85);
+    case 23: return Float3FromRGB(228, 143, 114);
+    }
+
+    return float3(1, 0, 0);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
@@ -8,16 +8,10 @@
 
 #pragma once
 
-class PayloadData
+struct PayloadData
 {
-    bool m_colorSet;
+    bool m_noData;
     float3 m_color;
-
-    void SetColor(float3 color)
-    {
-        m_color = color;
-        m_colorSet = true;
-    }
 };
 
 // This enum must be the same as in RayTracingDebugConstants.h

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
+#include <RayTracingDebugCommon.azsli>
+
+[shader("miss")]
+void Miss(inout PayloadData payload)
+{
+    payload.m_color = float3(0, 0, 0);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
@@ -12,5 +12,5 @@
 [shader("miss")]
 void Miss(inout PayloadData payload)
 {
-    payload.m_color = float3(0, 0, 0);
+    payload.SetColor(float3(0, 0, 0));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.azsl
@@ -12,5 +12,5 @@
 [shader("miss")]
 void Miss(inout PayloadData payload)
 {
-    payload.SetColor(float3(0, 0, 0));
+    payload.m_color = float3(0, 0, 0);
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugMiss.shader
@@ -1,0 +1,44 @@
+{
+    "Source" : "RayTracingDebugMiss.azsl",
+    "DrawList" : "RayTracing",
+
+    "AddBuildArguments":
+    {
+        "dxc": ["-fspv-target-env=vulkan1.2"]
+    },
+
+    "ProgramSettings":
+    {
+        "EntryPoints":
+        [
+            {
+                "type": "RayTracing",
+                "name": "Miss"
+            }
+        ]
+    },
+
+    "DisabledRHIBackends": ["metal"],
+
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments":
+            {
+                "azslc": ["--no-ms"]
+            },
+            "RemoveBuildArguments" :
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
@@ -22,10 +22,18 @@ void RayGeneration()
     RayDesc ray;
     ray.Origin = ViewSrg::m_worldPosition;
     ray.Direction = rayDir;
-    ray.TMin = 0.01f;
-    ray.TMax = 10000;
-    PayloadData payload;
+    ray.TMin = 0.f;
+    ray.TMax = RayTracingGlobalSrg::m_maxRayLength;
+    PayloadData payload = (PayloadData)0;
     TraceRay(RayTracingSceneSrg::m_scene, RAY_FLAG_NONE, 0xFF, 0, 1, 0, ray, payload);
 
-    RayTracingGlobalSrg::m_fallbackColor[pixelCoords] = float4(payload.m_color, 1);
+    if (payload.m_colorSet)
+    {
+        RayTracingGlobalSrg::m_fallbackColor[pixelCoords] = float4(payload.m_color, 1);
+    }
+    else
+    {
+        float grayscale = (pixelCoords.x / 8 % 2) ^ (pixelCoords.y / 8 % 2) ? 0.75f : 1.f;
+        RayTracingGlobalSrg::m_fallbackColor[pixelCoords] = float4(grayscale, grayscale, grayscale, 1.f);
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
+#include <RayTracingDebugCommon.azsli>
+
+[shader("raygeneration")]
+void RayGeneration()
+{
+    uint2 pixelCoords = DispatchRaysIndex().xy;
+    uint2 dimensions = DispatchRaysDimensions().xy;
+    float2 coordsNDC = ((float2)pixelCoords / dimensions * 2.f - 1.f) * float2(1.f, -1.f);
+
+    float4 rayTarget = mul(ViewSrg::m_viewProjectionInverseMatrix, float4(coordsNDC, 1.f, 1.f));
+    float3 rayDir = normalize(rayTarget.xyz / rayTarget.w - ViewSrg::m_worldPosition);
+
+    RayDesc ray;
+    ray.Origin = ViewSrg::m_worldPosition;
+    ray.Direction = rayDir;
+    ray.TMin = 0.01f;
+    ray.TMax = 10000;
+    PayloadData payload;
+    TraceRay(RayTracingSceneSrg::m_scene, RAY_FLAG_NONE, 0xFF, 0, 1, 0, ray, payload);
+
+    RayTracingGlobalSrg::m_fallbackColor[pixelCoords] = float4(payload.m_color, 1);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.azsl
@@ -27,7 +27,7 @@ void RayGeneration()
     PayloadData payload = (PayloadData)0;
     TraceRay(RayTracingSceneSrg::m_scene, RAY_FLAG_NONE, 0xFF, 0, 1, 0, ray, payload);
 
-    if (payload.m_colorSet)
+    if (!payload.m_noData)
     {
         RayTracingGlobalSrg::m_fallbackColor[pixelCoords] = float4(payload.m_color, 1);
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugRayGeneration.shader
@@ -1,0 +1,44 @@
+{
+    "Source" : "RayTracingDebugRayGeneration.azsl",
+    "DrawList" : "RayTracing",
+
+    "AddBuildArguments":
+    {
+        "dxc": ["-fspv-target-env=vulkan1.2"]
+    },
+
+    "ProgramSettings":
+    {
+        "EntryPoints":
+        [
+            {
+                "type": "RayTracing",
+                "name": "RayGeneration"
+            }
+        ]
+    },
+
+    "DisabledRHIBackends": ["metal"],
+
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "RemoveBuildArguments":
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        },
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments":
+            {
+                "azslc": ["--no-ms"]
+            },
+            "RemoveBuildArguments" :
+            {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -92,6 +92,7 @@ set(FILES
     Passes/ContrastAdaptiveSharpening.pass
     Passes/ConvertToAcescg.pass
     Passes/DebugOverlayParent.pass
+    Passes/DebugRayTracingPass.pass
     Passes/DeferredFog.pass
     Passes/Depth.pass
     Passes/DepthCheckerboard.pass

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -358,6 +358,15 @@ set(FILES
     Shaders/Checkerboard/CheckerboardColorResolveCS.shader
     Shaders/ColorGrading/LutGeneration.azsl
     Shaders/ColorGrading/LutGeneration.shader
+    Shaders/Debug/RayTracingDebugClosestHit.azsl
+    Shaders/Debug/RayTracingDebugClosestHit.shader
+    Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
+    Shaders/Debug/RayTracingDebugClosestHitProcedural.shader
+    Shaders/Debug/RayTracingDebugCommon.azsli
+    Shaders/Debug/RayTracingDebugMiss.azsl
+    Shaders/Debug/RayTracingDebugMiss.shader
+    Shaders/Debug/RayTracingDebugRayGeneration.azsl
+    Shaders/Debug/RayTracingDebugRayGeneration.shader
     Shaders/Depth/DepthPass.azsl
     Shaders/Depth/DepthPass.shader
     Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.azsl

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/base.h>
+
+namespace AZ::Render
+{
+    // This enum must be the same as in RayTracingDebugCommon.azsli
+    enum class RayTracingDebugViewMode : u32
+    {
+        InstanceIndex,
+        InstanceID,
+        PrimitiveIndex,
+        Barycentrics,
+        Normals,
+        UVs,
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
@@ -12,6 +12,7 @@
 
 namespace AZ::Render
 {
+    // The view modes of the ray tracing debug view
     // This enum must be the same as in RayTracingDebugCommon.azsli
     enum class RayTracingDebugViewMode : u32
     {

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
@@ -13,13 +13,20 @@
 
 namespace AZ::Render
 {
+    //! Interface for the RayTracingDebugFeatureProcessor, which handles debug ray tracing settings for the scene, such as displaying only
+    //! InstanceID, PrimitiveIndex, barycentric coordinates, normals, etc.
     class RayTracingDebugFeatureProcessorInterface : public RPI::FeatureProcessor
     {
     public:
         AZ_RTTI(RayTracingDebugFeatureProcessorInterface, "{873F5D8A-5A0D-41F3-BADF-57394F8542D8}", RPI::FeatureProcessor);
 
+        //! Retrieves existing settings. If none found, returns nullptr.
         virtual RayTracingDebugSettingsInterface* GetSettingsInterface() = 0;
+
+        //! Called when a ray tracing debug level component is added.
         virtual void OnRayTracingDebugComponentAdded() = 0;
+
+        //! Called when a ray tracing debug level component is removed.
         virtual void OnRayTracingDebugComponentRemoved() = 0;
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Debug/RayTracingDebugSettingsInterface.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugFeatureProcessorInterface : public RPI::FeatureProcessor
+    {
+    public:
+        AZ_RTTI(RayTracingDebugFeatureProcessorInterface, "{873F5D8A-5A0D-41F3-BADF-57394F8542D8}", RPI::FeatureProcessor);
+
+        virtual RayTracingDebugSettingsInterface* GetSettingsInterface() = 0;
+        virtual void OnRayTracingDebugComponentAdded() = 0;
+        virtual void OnRayTracingDebugComponentRemoved() = 0;
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+
+// Whether to turn on ray tracing debugging
+AZ_GFX_BOOL_PARAM(Enabled, m_enabled, true)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
@@ -11,3 +11,5 @@
 
 // Whether to turn on ray tracing debugging
 AZ_GFX_BOOL_PARAM(Enabled, m_enabled, true)
+
+AZ_GFX_COMMON_PARAM(RayTracingDebugViewMode, DebugViewMode, m_debugViewMode, RayTracingDebugViewMode::InstanceIndex)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugParams.inl
@@ -12,4 +12,5 @@
 // Whether to turn on ray tracing debugging
 AZ_GFX_BOOL_PARAM(Enabled, m_enabled, true)
 
+// Which property to display for the hit surface (InstanceIndex, PrimitiveIndex, barycentrics, ...)
 AZ_GFX_COMMON_PARAM(RayTracingDebugViewMode, DebugViewMode, m_debugViewMode, RayTracingDebugViewMode::InstanceIndex)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
@@ -17,7 +17,11 @@ namespace AZ::Render
     public:
         AZ_RTTI(RayTracingDebugSettingsInterface, "{E1C76937-7F82-4553-87AA-D6DC8885DC56}");
 
-        virtual bool GetEnabled() const = 0;
-        virtual void SetEnabled(bool enabled) = 0;
+        // clang-format off
+        // Generate virtual getter and setter functions
+        #include <Atom/Feature/ParamMacros/StartParamFunctionsVirtual.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugSettingsInterface
+    {
+    public:
+        AZ_RTTI(RayTracingDebugSettingsInterface, "{E1C76937-7F82-4553-87AA-D6DC8885DC56}");
+
+        virtual bool GetEnabled() const = 0;
+        virtual void SetEnabled(bool enabled) = 0;
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugSettingsInterface.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Debug/RayTracingDebugConstants.h>
 #include <AzCore/RTTI/RTTI.h>
 
 namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -40,7 +40,8 @@
 #include <Atom/Feature/Utils/LightingPreset.h>
 #include <Atom/Feature/Utils/ModelPreset.h>
 #include <ColorGrading/LutGenerationPass.h>
-#include <Debug/RenderDebugFeatureProcessor.h> 
+#include <Debug/RayTracingDebugFeatureProcessor.h>
+#include <Debug/RenderDebugFeatureProcessor.h>
 #include <Silhouette/SilhouetteFeatureProcessor.h>
 #include <PostProcess/PostProcessFeatureProcessor.h>
 #include <PostProcessing/BlendColorGradingLutsPass.h>
@@ -145,6 +146,7 @@ namespace AZ
             ImGuiPassData::Reflect(context);
             RayTracingPassData::Reflect(context);
             TaaPassData::Reflect(context);
+            RayTracingDebugFeatureProcessor::Reflect(context);
             RenderDebugFeatureProcessor::Reflect(context);
             SplashScreenFeatureProcessor::Reflect(context);
             SplashScreenSettings::Reflect(context);
@@ -207,6 +209,7 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<PostProcessFeatureProcessor, PostProcessFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<AcesDisplayMapperFeatureProcessor, DisplayMapperFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<ProjectedShadowFeatureProcessor, ProjectedShadowFeatureProcessorInterface>();
+                AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<RayTracingDebugFeatureProcessor, RayTracingDebugFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<RenderDebugFeatureProcessor, RenderDebugFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<ReflectionProbeFeatureProcessor, ReflectionProbeFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<SpecularReflectionsFeatureProcessor, SpecularReflectionsFeatureProcessorInterface>();
@@ -358,6 +361,7 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SkyBoxFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SkyAtmosphereFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<OcclusionCullingPlaneFeatureProcessor>();
+                AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<RayTracingDebugFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<RenderDebugFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SplashScreenFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SilhouetteFeatureProcessor>();

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Debug/RayTracingDebugFeatureProcessor.h>
+
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+
+namespace AZ::Render
+{
+    void RayTracingDebugFeatureProcessor::Reflect(ReflectContext* context)
+    {
+        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        {
+            // clang-format off
+            serializeContext->Class<RayTracingDebugFeatureProcessor, RPI::FeatureProcessor>()
+                ->Version(0)
+            ;
+            // clang-format on
+        }
+    }
+
+    RayTracingDebugSettingsInterface* RayTracingDebugFeatureProcessor::GetSettingsInterface()
+    {
+        return m_settings.get();
+    }
+
+    void RayTracingDebugFeatureProcessor::OnRayTracingDebugComponentAdded()
+    {
+        m_debugComponentCount++;
+        AddOrRemoveDebugPass();
+    }
+
+    void RayTracingDebugFeatureProcessor::OnRayTracingDebugComponentRemoved()
+    {
+        m_debugComponentCount--;
+        AddOrRemoveDebugPass();
+    }
+
+    void RayTracingDebugFeatureProcessor::Activate()
+    {
+        m_settings = AZStd::make_unique<RayTracingDebugSettings>();
+
+        FeatureProcessor::Activate();
+        EnableSceneNotification();
+    }
+
+    void RayTracingDebugFeatureProcessor::Deactivate()
+    {
+        EnableSceneNotification();
+        FeatureProcessor::Deactivate();
+
+        m_settings.reset();
+    }
+
+    void RayTracingDebugFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* pipeline)
+    {
+        m_pipeline = pipeline;
+        FeatureProcessor::AddRenderPasses(pipeline);
+    }
+
+    void RayTracingDebugFeatureProcessor::AddOrRemoveDebugPass()
+    {
+        bool shouldAddPass{ !m_rayTracingPass && m_debugComponentCount > 0 };
+        bool shouldRemovePass{ m_rayTracingPass && m_debugComponentCount == 0 };
+
+        if (shouldAddPass)
+        {
+            m_rayTracingPass = RPI::PassSystemInterface::Get()->CreatePassFromTemplate(
+                Name{ "DebugRayTracingPassTemplate" }, Name{ "DebugRayTracingPass" });
+            if (!m_rayTracingPass)
+            {
+                AZ_Assert(false, "Failed to create DebugRayTracingPass");
+                return;
+            }
+            // m_pipeline->AddPassBefore(m_rayTracingPass, Name{ "AuxGeomPass" });
+            m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "PostProcessPass" });
+        }
+
+        if (shouldRemovePass)
+        {
+            m_rayTracingPass->QueueForRemoval();
+            m_rayTracingPass.reset();
+        }
+    }
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
@@ -110,8 +110,6 @@ namespace AZ::Render
                 AZ_Assert(false, "Failed to create DebugRayTracingPass");
                 return;
             }
-            // m_pipeline->AddPassBefore(m_rayTracingPass, Name{ "AuxGeomPass" });
-            // m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "PostProcessPass" });
             m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "AuxGeomPass" });
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
@@ -111,7 +111,8 @@ namespace AZ::Render
                 return;
             }
             // m_pipeline->AddPassBefore(m_rayTracingPass, Name{ "AuxGeomPass" });
-            m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "PostProcessPass" });
+            // m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "PostProcessPass" });
+            m_pipeline->AddPassAfter(m_rayTracingPass, Name{ "AuxGeomPass" });
         }
 
         if (shouldRemovePass)

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Debug/RayTracingDebugSettings.h>
 
 namespace AZ::Render
@@ -30,13 +31,16 @@ namespace AZ::Render
         void Activate() override;
         void Deactivate() override;
         void AddRenderPasses(RPI::RenderPipeline* pipeline) override;
+        void Render(const RenderPacket& packet) override;
 
     private:
         void AddOrRemoveDebugPass();
 
         AZStd::unique_ptr<RayTracingDebugSettings> m_settings;
+        Data::Instance<RPI::ShaderResourceGroup> m_sceneSrg;
         RPI::RenderPipeline* m_pipeline{ nullptr };
         RPI::Ptr<RPI::Pass> m_rayTracingPass;
         int m_debugComponentCount{ 0 };
+        RHI::ShaderInputNameIndex m_debugOptionsIndex{ "m_debugViewMode" };
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
@@ -14,6 +14,8 @@
 
 namespace AZ::Render
 {
+    //! FeatureProcessor for handling debug ray tracing information, such as adding/removing the ray tracing debug pass to the render
+    //! pipeline and uploading the debug configuration data to the GPU
     class RayTracingDebugFeatureProcessor : public RayTracingDebugFeatureProcessorInterface
     {
     public:
@@ -34,10 +36,15 @@ namespace AZ::Render
         void Render(const RenderPacket& packet) override;
 
     private:
-        void AddOrRemoveDebugPass();
+        // Adds the debug ray tracing pass to the pipeline (The debug ray tracing pass is not part of the main pipeline and is only added if
+        // a "Debug Ray Tracing" level component is added to the scene).
+        void AddDebugPass();
+
+        // Removes the debug ray tracing pass from the pipeline.
+        void RemoveDebugPass();
 
         AZStd::unique_ptr<RayTracingDebugSettings> m_settings;
-        Data::Instance<RPI::ShaderResourceGroup> m_sceneSrg;
+        Data::Instance<RPI::ShaderResourceGroup> m_sceneSrg; // The ray tracing scene SRG (RayTracingSceneSrg)
         RPI::RenderPipeline* m_pipeline{ nullptr };
         RPI::Ptr<RPI::Pass> m_rayTracingPass;
         int m_debugComponentCount{ 0 };

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
+#include <Debug/RayTracingDebugSettings.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugFeatureProcessor : public RayTracingDebugFeatureProcessorInterface
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(RayTracingDebugFeatureProcessor, SystemAllocator)
+        AZ_RTTI(RayTracingDebugFeatureProcessor, "{283382D4-536D-4770-931D-84F033E18636}", RayTracingDebugFeatureProcessorInterface);
+
+        static void Reflect(ReflectContext* context);
+
+        // RayTracingDebugFeatureProcessorInterface overrides
+        RayTracingDebugSettingsInterface* GetSettingsInterface() override;
+        void OnRayTracingDebugComponentAdded() override;
+        void OnRayTracingDebugComponentRemoved() override;
+
+        // FeatureProcessor overrides
+        void Activate() override;
+        void Deactivate() override;
+        void AddRenderPasses(RPI::RenderPipeline* pipeline) override;
+
+    private:
+        void AddOrRemoveDebugPass();
+
+        AZStd::unique_ptr<RayTracingDebugSettings> m_settings;
+        RPI::RenderPipeline* m_pipeline{ nullptr };
+        RPI::Ptr<RPI::Pass> m_rayTracingPass;
+        int m_debugComponentCount{ 0 };
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
@@ -18,16 +18,19 @@ namespace AZ::Render
         AZ_CLASS_ALLOCATOR(RayTracingDebugSettings, SystemAllocator);
         AZ_RTTI(RayTracingDebugSettings, "{5EED94CE-79FF-4F78-9ADC-A6D186F346E0}");
 
-        bool GetEnabled() const override
-        {
-            return m_enabled;
-        }
+        // clang-format off
+        // Generate getters and setters
+        #include <Atom/Feature/ParamMacros/StartParamFunctionsOverrideImpl.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
 
-        void SetEnabled(bool enabled) override
-        {
-            m_enabled = enabled;
-        }
-
-        bool m_enabled{ true };
+    private:
+        // clang-format off
+        // Generate members
+        #include <Atom/Feature/ParamMacros/StartParamMembers.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Debug/RayTracingDebugSettingsInterface.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugSettings final : public RayTracingDebugSettingsInterface
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(RayTracingDebugSettings, SystemAllocator);
+        AZ_RTTI(RayTracingDebugSettings, "{5EED94CE-79FF-4F78-9ADC-A6D186F346E0}");
+
+        bool GetEnabled() const override
+        {
+            return m_enabled;
+        }
+
+        void SetEnabled(bool enabled) override
+        {
+            m_enabled = enabled;
+        }
+
+        bool m_enabled{ true };
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugSettings.h
@@ -12,6 +12,7 @@
 
 namespace AZ::Render
 {
+    // The settings class for the ray tracing debug view
     class RayTracingDebugSettings final : public RayTracingDebugSettingsInterface
     {
     public:

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -125,6 +125,9 @@ set(FILES
     Source/CubeMapCapture/CubeMapCapture.cpp
     Source/CubeMapCapture/CubeMapRenderer.h
     Source/CubeMapCapture/CubeMapRenderer.cpp
+    Source/Debug/RayTracingDebugFeatureProcessor.h
+    Source/Debug/RayTracingDebugFeatureProcessor.cpp
+    Source/Debug/RayTracingDebugSettings.h
     Source/Debug/RenderDebugFeatureProcessor.h
     Source/Debug/RenderDebugFeatureProcessor.cpp
     Source/Debug/RenderDebugSettings.h

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -19,6 +19,7 @@ set(FILES
     Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
     Include/Atom/Feature/CoreLights/ShadowConstants.h
     Include/Atom/Feature/CubeMapCapture/CubeMapCaptureFeatureProcessorInterface.h
+    Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
     Include/Atom/Feature/Debug/RenderDebugConstants.h
     Include/Atom/Feature/Debug/RenderDebugFeatureProcessorInterface.h
     Include/Atom/Feature/Debug/RenderDebugParams.inl

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -19,6 +19,7 @@ set(FILES
     Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
     Include/Atom/Feature/CoreLights/ShadowConstants.h
     Include/Atom/Feature/CubeMapCapture/CubeMapCaptureFeatureProcessorInterface.h
+    Include/Atom/Feature/Debug/RayTracingDebugConstants.h
     Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
     Include/Atom/Feature/Debug/RayTracingDebugParams.inl
     Include/Atom/Feature/Debug/RenderDebugConstants.h

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -20,6 +20,7 @@ set(FILES
     Include/Atom/Feature/CoreLights/ShadowConstants.h
     Include/Atom/Feature/CubeMapCapture/CubeMapCaptureFeatureProcessorInterface.h
     Include/Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h
+    Include/Atom/Feature/Debug/RayTracingDebugParams.inl
     Include/Atom/Feature/Debug/RenderDebugConstants.h
     Include/Atom/Feature/Debug/RenderDebugFeatureProcessorInterface.h
     Include/Atom/Feature/Debug/RenderDebugParams.inl

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugRequests : public ComponentBus
+    {
+    public:
+        AZ_RTTI(RayTracingDebugRequests, "{86A36D89-6799-440C-AEFE-0E42CE4C0A20}");
+
+        static const EBusHandlerPolicy HandlerPolicy{ EBusHandlerPolicy::Single };
+
+        virtual ~RayTracingDebugRequests()
+        {
+        }
+    };
+
+    using RayTracingDebugRequestBus = AZ::EBus<RayTracingDebugRequests>;
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h
@@ -22,6 +22,13 @@ namespace AZ::Render
         virtual ~RayTracingDebugRequests()
         {
         }
+
+        // clang-format off
+        // Generate virtual getters and setters
+        #include <Atom/Feature/ParamMacros/StartParamFunctionsVirtual.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
     };
 
     using RayTracingDebugRequestBus = AZ::EBus<RayTracingDebugRequests>;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Debug/RayTracingDebugSettingsInterface.h>
+#include <AzCore/Component/ComponentBus.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugComponentConfig final : public ComponentConfig
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(RayTracingDebugComponentConfig, SystemAllocator)
+        AZ_RTTI(RayTracingDebugComponentConfig, "{856B64FB-A019-47B8-A9D4-F74E18BE847A}", ComponentConfig);
+
+        static void Reflect(ReflectContext* context);
+
+        void CopySettingsFrom(RayTracingDebugSettingsInterface* settings);
+        void CopySettingsTo(RayTracingDebugSettingsInterface* settings);
+
+        bool m_enabled{ true };
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h
@@ -21,9 +21,19 @@ namespace AZ::Render
 
         static void Reflect(ReflectContext* context);
 
+        // clang-format off
+        // Generate members
+        #include <Atom/Feature/ParamMacros/StartParamMembers.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+
+        // Generate Getters/Setters
+        #include <Atom/Feature/ParamMacros/StartParamFunctions.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
+
         void CopySettingsFrom(RayTracingDebugSettingsInterface* settings);
         void CopySettingsTo(RayTracingDebugSettingsInterface* settings);
-
-        bool m_enabled{ true };
     };
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Debug/RayTracingDebugComponent.h>
+
+namespace AZ::Render
+{
+    RayTracingDebugComponent::RayTracingDebugComponent(const RayTracingDebugComponentConfig& config)
+        : BaseClass{ config }
+    {
+    }
+
+    void RayTracingDebugComponent::Reflect(ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        {
+            // clang-format off
+            serializeContext->Class<RayTracingDebugComponent, BaseClass>()
+                ->Version(0)
+            ;
+            // clang-format on
+        }
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.cpp
@@ -19,7 +19,7 @@ namespace AZ::Render
     {
         BaseClass::Reflect(context);
 
-        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        if (auto* serializeContext{ azrtti_cast<SerializeContext*>(context) })
         {
             // clang-format off
             serializeContext->Class<RayTracingDebugComponent, BaseClass>()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponent.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h>
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <Debug/RayTracingDebugComponentController.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugComponent final
+        : public AzFramework::Components::ComponentAdapter<RayTracingDebugComponentController, RayTracingDebugComponentConfig>
+    {
+    public:
+        using BaseClass = AzFramework::Components::ComponentAdapter<RayTracingDebugComponentController, RayTracingDebugComponentConfig>;
+        AZ_COMPONENT(RayTracingDebugComponent, "{143A2F13-8BE7-4F7F-BD23-4B5B8DCD83CA}", BaseClass);
+
+        RayTracingDebugComponent() = default;
+        RayTracingDebugComponent(const RayTracingDebugComponentConfig& config);
+
+        static void Reflect(ReflectContext* context);
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AZ::Render
+{
+    void RayTracingDebugComponentConfig::Reflect(ReflectContext* context)
+    {
+        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        {
+            // clang-format off
+            serializeContext->Class<RayTracingDebugComponentConfig, ComponentConfig>()
+                ->Version(0)
+                ->Field("Enabled", &RayTracingDebugComponentConfig::m_enabled)
+            ;
+            // clang-format on
+        }
+    }
+
+    void RayTracingDebugComponentConfig::CopySettingsFrom(RayTracingDebugSettingsInterface* settings)
+    {
+        m_enabled = settings->GetEnabled();
+    }
+
+    void RayTracingDebugComponentConfig::CopySettingsTo(RayTracingDebugSettingsInterface* settings)
+    {
+        settings->SetEnabled(m_enabled);
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
@@ -13,7 +13,7 @@ namespace AZ::Render
 {
     void RayTracingDebugComponentConfig::Reflect(ReflectContext* context)
     {
-        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        if (auto* serializeContext{ azrtti_cast<SerializeContext*>(context) })
         {
             // clang-format off
             serializeContext->Class<RayTracingDebugComponentConfig, ComponentConfig>()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentConfig.cpp
@@ -18,7 +18,12 @@ namespace AZ::Render
             // clang-format off
             serializeContext->Class<RayTracingDebugComponentConfig, ComponentConfig>()
                 ->Version(0)
-                ->Field("Enabled", &RayTracingDebugComponentConfig::m_enabled)
+                // Auto-gen serialize context code
+                #define SERIALIZE_CLASS RayTracingDebugComponentConfig
+                #include <Atom/Feature/ParamMacros/StartParamSerializeContext.inl>
+                #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+                #include <Atom/Feature/ParamMacros/EndParams.inl>
+                #undef SERIALIZE_CLASS
             ;
             // clang-format on
         }
@@ -26,11 +31,33 @@ namespace AZ::Render
 
     void RayTracingDebugComponentConfig::CopySettingsFrom(RayTracingDebugSettingsInterface* settings)
     {
-        m_enabled = settings->GetEnabled();
+        if (!settings)
+        {
+            return;
+        }
+
+        // clang-format off
+        #define COPY_SOURCE settings
+        #include <Atom/Feature/ParamMacros/StartParamCopySettingsFrom.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        #undef COPY_SOURCE
+        // clang-format on
     }
 
     void RayTracingDebugComponentConfig::CopySettingsTo(RayTracingDebugSettingsInterface* settings)
     {
-        settings->SetEnabled(m_enabled);
+        if (!settings)
+        {
+            return;
+        }
+
+        // clang-format off
+        #define COPY_TARGET settings
+        #include <Atom/Feature/ParamMacros/StartParamCopySettingsTo.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        #undef COPY_TARGET
+        // clang-format on
     }
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
@@ -25,6 +25,20 @@ namespace AZ::Render
             ;
             // clang-format on
         }
+
+        if (auto behaviorContext{ azrtti_cast<BehaviorContext*>(context) })
+        {
+            // clang-format off
+            behaviorContext->EBus<RayTracingDebugRequestBus>("RayTracingDebugRequestBus")
+                // Generate behavior context
+                #define PARAM_EVENT_BUS RayTracingDebugRequestBus::Events
+                #include <Atom/Feature/ParamMacros/StartParamBehaviorContext.inl>
+                #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+                #include <Atom/Feature/ParamMacros/EndParams.inl>
+                #undef PARAM_EVENT_BUS
+            ;
+            // clang-format on
+        }
     }
 
     RayTracingDebugComponentController::RayTracingDebugComponentController(const RayTracingDebugComponentConfig& config)
@@ -77,4 +91,47 @@ namespace AZ::Render
     {
         m_configuration.CopySettingsTo(m_rayTracingDebugSettingsInterface);
     }
+
+    // clang-format off
+    // Generate getter/setter function definitions.
+    // The setter functions will set the values on the Atom settings class, then get the value back
+    // from the settings class to set the local configuration. This is in case the settings class
+    // applies some custom logic that results in the set value being different from the input
+    #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)              \
+    ValueType RayTracingDebugComponentController::Get##Name() const                     \
+    {                                                                                   \
+        return m_configuration.MemberName;                                              \
+    }                                                                                   \
+    void RayTracingDebugComponentController::Set##Name(ValueType val)                   \
+    {                                                                                   \
+        if (m_rayTracingDebugSettingsInterface)                                         \
+        {                                                                               \
+            m_rayTracingDebugSettingsInterface->Set##Name(val);                         \
+            m_configuration.CopySettingsFrom(m_rayTracingDebugSettingsInterface);       \
+        }                                                                               \
+        else                                                                            \
+        {                                                                               \
+            m_configuration.MemberName = val;                                           \
+        }                                                                               \
+    }                                                                                   \
+
+    #define AZ_GFX_COMMON_OVERRIDE(ValueType, Name, MemberName, OverrideValueType)      \
+    OverrideValueType RayTracingDebugComponentController::Get##Name##Override() const   \
+    {                                                                                   \
+        return m_configuration.MemberName##Override;                                    \
+    }                                                                                   \
+    void RayTracingDebugComponentController::Set##Name##Override(OverrideValueType val) \
+    {                                                                                   \
+        m_configuration.MemberName##Override = val;                                     \
+        if (m_RayTracingDebugSettingsInterface)                                         \
+        {                                                                               \
+            m_rayTracingDebugSettingsInterface->Set##Name##Override(val);               \
+            m_configuration.CopySettingsFrom(m_rayTracingDebugSettingsInterface);       \
+        }                                                                               \
+    }                                                                                   \
+
+    #include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+    #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+    #include <Atom/Feature/ParamMacros/EndParams.inl>
+    // clang-format on
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Debug/RayTracingDebugComponentController.h>
+
+namespace AZ::Render
+{
+    void RayTracingDebugComponentController::Reflect(ReflectContext* context)
+    {
+        RayTracingDebugComponentConfig::Reflect(context);
+
+        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        {
+            // clang-format off
+            serializeContext->Class<RayTracingDebugComponentController>()
+                ->Version(0)
+                ->Field("Configuration", &RayTracingDebugComponentController::m_configuration)
+            ;
+            // clang-format on
+        }
+    }
+
+    RayTracingDebugComponentController::RayTracingDebugComponentController(const RayTracingDebugComponentConfig& config)
+        : m_configuration{ config }
+    {
+    }
+
+    void RayTracingDebugComponentController::Activate(EntityId entityId)
+    {
+        m_entityId = entityId;
+
+        auto fp{ RPI::Scene::GetFeatureProcessorForEntity<RayTracingDebugFeatureProcessorInterface>(m_entityId) };
+        if (fp)
+        {
+            m_rayTracingDebugSettingsInterface = fp->GetSettingsInterface();
+            if (m_rayTracingDebugSettingsInterface)
+            {
+                OnConfigurationChanged();
+            }
+            fp->OnRayTracingDebugComponentAdded();
+        }
+        RayTracingDebugRequestBus::Handler::BusConnect(m_entityId);
+    }
+
+    void RayTracingDebugComponentController::Deactivate()
+    {
+        auto fp{ RPI::Scene::GetFeatureProcessorForEntity<RayTracingDebugFeatureProcessorInterface>(m_entityId) };
+        if (fp)
+        {
+            fp->OnRayTracingDebugComponentRemoved();
+        }
+
+        RayTracingDebugRequestBus::Handler::BusDisconnect(m_entityId);
+        m_rayTracingDebugSettingsInterface = nullptr;
+        m_entityId.SetInvalid();
+    }
+
+    void RayTracingDebugComponentController::SetConfiguration(const RayTracingDebugComponentConfig& config)
+    {
+        m_configuration = config;
+        OnConfigurationChanged();
+    }
+
+    const RayTracingDebugComponentConfig& RayTracingDebugComponentController::GetConfiguration() const
+    {
+        return m_configuration;
+    }
+
+    void RayTracingDebugComponentController::OnConfigurationChanged()
+    {
+        m_configuration.CopySettingsTo(m_rayTracingDebugSettingsInterface);
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
@@ -16,7 +16,7 @@ namespace AZ::Render
     {
         RayTracingDebugComponentConfig::Reflect(context);
 
-        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        if (auto* serializeContext{ azrtti_cast<SerializeContext*>(context) })
         {
             // clang-format off
             serializeContext->Class<RayTracingDebugComponentController>()
@@ -26,7 +26,7 @@ namespace AZ::Render
             // clang-format on
         }
 
-        if (auto behaviorContext{ azrtti_cast<BehaviorContext*>(context) })
+        if (auto* behaviorContext{ azrtti_cast<BehaviorContext*>(context) })
         {
             // clang-format off
             behaviorContext->EBus<RayTracingDebugRequestBus>("RayTracingDebugRequestBus")

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
@@ -29,6 +29,13 @@ namespace AZ::Render
         void SetConfiguration(const RayTracingDebugComponentConfig& config);
         const RayTracingDebugComponentConfig& GetConfiguration() const;
 
+        // clang-format off
+        // Generate function override declarations (functions definitions in .cpp)
+        #include <Atom/Feature/ParamMacros/StartParamFunctionsOverride.inl>
+        #include <Atom/Feature/Debug/RayTracingDebugParams.inl>
+        #include <Atom/Feature/ParamMacros/EndParams.inl>
+        // clang-format on
+
     private:
         void OnConfigurationChanged();
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h>
+#include <AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugComponentController final : public RayTracingDebugRequestBus::Handler
+    {
+        friend class RayTracingDebugEditorComponent;
+
+    public:
+        AZ_TYPE_INFO(RayTracingDebugComponentController, "{7B1CAB96-6B9E-46C4-BBDE-B140E8082CEB}");
+        static void Reflect(ReflectContext* context);
+
+        RayTracingDebugComponentController() = default;
+        RayTracingDebugComponentController(const RayTracingDebugComponentConfig& config);
+
+        void Activate(EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const RayTracingDebugComponentConfig& config);
+        const RayTracingDebugComponentConfig& GetConfiguration() const;
+
+    private:
+        void OnConfigurationChanged();
+
+        RayTracingDebugSettingsInterface* m_rayTracingDebugSettingsInterface{ nullptr };
+        EntityId m_entityId{ EntityId::InvalidEntityId };
+        RayTracingDebugComponentConfig m_configuration;
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
@@ -45,6 +45,15 @@ namespace AZ::Render
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->DataElement(Edit::UIHandlers::CheckBox, &RayTracingDebugComponentConfig::m_enabled, "Enable Ray Tracing Debugging", "Enable Ray Tracing Debugging.")
                         ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(Edit::UIHandlers::ComboBox, &RayTracingDebugComponentConfig::m_debugViewMode, "View mode", "What property to output to the view")
+                        ->EnumAttribute(RayTracingDebugViewMode::InstanceIndex, "Instance Index")
+                        ->EnumAttribute(RayTracingDebugViewMode::InstanceID, "Instance ID")
+                        ->EnumAttribute(RayTracingDebugViewMode::PrimitiveIndex, "Primitive Index")
+                        ->EnumAttribute(RayTracingDebugViewMode::Barycentrics, "Barycentric Coordinates")
+                        ->EnumAttribute(RayTracingDebugViewMode::Normals, "Normals")
+                        ->EnumAttribute(RayTracingDebugViewMode::UVs, "UV Coordinates")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+                        ->Attribute(Edit::Attributes::Visibility, &RayTracingDebugComponentConfig::GetEnabled)
                 ;
                 // clang-format on
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Debug/RayTracingDebugEditorComponent.h>
+
+namespace AZ::Render
+{
+    void RayTracingDebugEditorComponent::Reflect(ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        {
+            // clang-format off
+            serializeContext->Class<RayTracingDebugEditorComponent, BaseClass>()
+                ->Version(0)
+            ;
+            // clang-format on
+
+            if (auto editContext{ serializeContext->GetEditContext() })
+            {
+                // clang-format off
+                editContext->Class<RayTracingDebugEditorComponent>("Debug Ray Tracing", "Controls for debugging ray tracing.")
+                    ->ClassElement(Edit::ClassElements::EditorData, "")
+                        ->Attribute(Edit::Attributes::Category, "Graphics/Debugging")
+                        ->Attribute(Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
+                        ->Attribute(Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Component_Placeholder.svg")
+                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Level"))
+                        ->Attribute(Edit::Attributes::AutoExpand, true)
+                ;
+
+                editContext->Class<RayTracingDebugComponentController>("RayTracingDebugComponentController", "")
+                    ->ClassElement(Edit::ClassElements::EditorData, "")
+                        ->Attribute(Edit::Attributes::AutoExpand, true)
+                    ->DataElement(Edit::UIHandlers::Default, &RayTracingDebugComponentController::m_configuration, "Configuration", "")
+                        ->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly)
+                ;
+
+                editContext->Class<RayTracingDebugComponentConfig>("RayTracingDebugComponentConfig", "")
+                    ->ClassElement(Edit::ClassElements::EditorData, "")
+                    ->DataElement(Edit::UIHandlers::CheckBox, &RayTracingDebugComponentConfig::m_enabled, "Enable Ray Tracing Debugging", "Enable Ray Tracing Debugging.")
+                        ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::EntireTree)
+                ;
+                // clang-format on
+            }
+        }
+    }
+
+    u32 RayTracingDebugEditorComponent::OnConfigurationChanged()
+    {
+        m_controller.OnConfigurationChanged();
+        return Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
@@ -14,7 +14,7 @@ namespace AZ::Render
     {
         BaseClass::Reflect(context);
 
-        if (auto serializeContext{ azrtti_cast<SerializeContext*>(context) })
+        if (auto* serializeContext{ azrtti_cast<SerializeContext*>(context) })
         {
             // clang-format off
             serializeContext->Class<RayTracingDebugEditorComponent, BaseClass>()
@@ -22,7 +22,7 @@ namespace AZ::Render
             ;
             // clang-format on
 
-            if (auto editContext{ serializeContext->GetEditContext() })
+            if (auto* editContext{ serializeContext->GetEditContext() })
             {
                 // clang-format off
                 editContext->Class<RayTracingDebugEditorComponent>("Debug Ray Tracing", "Controls for debugging ray tracing.")

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
+#include <Debug/RayTracingDebugComponent.h>
+#include <Debug/RayTracingDebugComponentController.h>
+
+namespace AZ::Render
+{
+    class RayTracingDebugEditorComponent final
+        : public AzToolsFramework::Components::
+              EditorComponentAdapter<RayTracingDebugComponentController, RayTracingDebugComponent, RayTracingDebugComponentConfig>
+    {
+    public:
+        using BaseClass = AzToolsFramework::Components::
+            EditorComponentAdapter<RayTracingDebugComponentController, RayTracingDebugComponent, RayTracingDebugComponentConfig>;
+        AZ_EDITOR_COMPONENT(RayTracingDebugEditorComponent, "{352A6033-4127-4A8D-BE8A-3FA1267B02EB}", BaseClass);
+
+        static void Reflect(ReflectContext* context);
+
+        // EditorComponentAdapter overrides
+        u32 OnConfigurationChanged() override;
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
@@ -14,6 +14,7 @@
 #include <CoreLights/AreaLightComponent.h>
 #include <CoreLights/DirectionalLightComponent.h>
 #include <CubeMapCapture/CubeMapCaptureComponent.h>
+#include <Debug/RayTracingDebugComponent.h>
 #include <Debug/RenderDebugComponent.h>
 #include <Decals/DecalComponent.h>
 #include <Grid/GridComponent.h>
@@ -53,6 +54,7 @@
 #include <CoreLights/EditorAreaLightComponent.h>
 #include <CoreLights/EditorDirectionalLightComponent.h>
 #include <CubeMapCapture/EditorCubeMapCaptureComponent.h>
+#include <Debug/RayTracingDebugEditorComponent.h>
 #include <Debug/RenderDebugEditorComponent.h>
 #include <Decals/EditorDecalComponent.h>
 #include <Grid/EditorGridComponent.h>
@@ -125,6 +127,7 @@ namespace AZ
                         PostFxLayerComponent::CreateDescriptor(),
                         ReflectionProbeComponent::CreateDescriptor(),
                         SpecularReflectionsComponent::CreateDescriptor(),
+                        RayTracingDebugComponent::CreateDescriptor(),
                         RenderDebugComponent::CreateDescriptor(),
                         RadiusWeightModifierComponent::CreateDescriptor(),
                         ShapeWeightModifierComponent::CreateDescriptor(),
@@ -166,6 +169,7 @@ namespace AZ
                         EditorPostFxLayerComponent::CreateDescriptor(),
                         EditorReflectionProbeComponent::CreateDescriptor(),
                         EditorSpecularReflectionsComponent::CreateDescriptor(),
+                        RayTracingDebugEditorComponent::CreateDescriptor(),
                         RenderDebugEditorComponent::CreateDescriptor(),
                         EditorRadiusWeightModifierComponent::CreateDescriptor(),
                         EditorShapeWeightModifierComponent::CreateDescriptor(),

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
@@ -22,6 +22,8 @@ set(FILES
     Source/CubeMapCapture/EditorCubeMapRenderer.cpp
     Source/CubeMapCapture/EditorCubeMapCaptureComponent.h
     Source/CubeMapCapture/EditorCubeMapCaptureComponent.cpp
+    Source/Debug/RayTracingDebugEditorComponent.cpp
+    Source/Debug/RayTracingDebugEditorComponent.h
     Source/Debug/RenderDebugEditorComponent.cpp
     Source/Debug/RenderDebugEditorComponent.h
     Source/Decals/EditorDecalComponent.h

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
@@ -40,6 +40,11 @@ set(FILES
     Source/CubeMapCapture/CubeMapCaptureComponent.cpp
     Source/CubeMapCapture/CubeMapCaptureComponentController.h
     Source/CubeMapCapture/CubeMapCaptureComponentController.cpp
+    Source/Debug/RayTracingDebugComponent.h
+    Source/Debug/RayTracingDebugComponent.cpp
+    Source/Debug/RayTracingDebugComponentConfig.cpp
+    Source/Debug/RayTracingDebugComponentController.h
+    Source/Debug/RayTracingDebugComponentController.cpp
     Source/Debug/RenderDebugComponent.cpp
     Source/Debug/RenderDebugComponent.h
     Source/Debug/RenderDebugComponentConfig.cpp

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
@@ -12,6 +12,8 @@ set(FILES
     Include/AtomLyIntegration/CommonFeatures/CoreLights/CoreLightsConstants.h
     Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
     Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
+    Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugBus.h
+    Include/AtomLyIntegration/CommonFeatures/Debug/RayTracingDebugComponentConfig.h
     Include/AtomLyIntegration/CommonFeatures/Debug/RenderDebugBus.h
     Include/AtomLyIntegration/CommonFeatures/Debug/RenderDebugComponentConfig.h
     Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h

--- a/Gems/DebugDraw/Assets/Shaders/ObbIntersection.azsl
+++ b/Gems/DebugDraw/Assets/Shaders/ObbIntersection.azsl
@@ -10,7 +10,7 @@
 #include <Atom/Features/SrgSemantics.azsli>
 
 // https://github.com/erich666/GraphicsGems/blob/master/gems/RayBox.c
-bool IntersectRayAABB(float3 rayOrigin, float3 rayDirection, float3 aabbMin, float3 aabbMax, out float t, out float3 normal)
+bool IntersectRayAABB(float3 rayOrigin, float3 rayDirection, float3 aabbMin, float3 aabbMax, out float t, out float3 normal, out float2 uv)
 {
     t = 0.f;
     normal = float3(1, 0, 0);
@@ -45,6 +45,7 @@ bool IntersectRayAABB(float3 rayOrigin, float3 rayDirection, float3 aabbMin, flo
         return false;
     }
 
+    int uvAxis = 0;
     for (int i = 0; i < 3; i++)
     {
         if (whichPlane != i)
@@ -54,6 +55,8 @@ bool IntersectRayAABB(float3 rayOrigin, float3 rayDirection, float3 aabbMin, flo
             {
                 return false;
             }
+
+            uv[uvAxis++] = (coord - aabbMin[i]) / (aabbMax[i] - aabbMin[i]);
         }
     }
 
@@ -71,12 +74,13 @@ void ObbIntersection()
 
     float t;
     float3 normal;
-    if (IntersectRayAABB(ObjectRayOrigin(), ObjectRayDirection(), aabbMin, aabbMax, t, normal))
+    float2 uv;
+    if (IntersectRayAABB(ObjectRayOrigin(), ObjectRayDirection(), aabbMin, aabbMax, t, normal, uv))
     {
         ProceduralGeometryIntersectionAttributes attrib;
         attrib.SetPosition(ObjectRayOrigin() + ObjectRayDirection() * t);
         attrib.SetNormal(normal);
-        attrib.SetUv(float2(0, 0));
+        attrib.SetUv(uv);
         attrib.SetTangent(float4(1, 0, 0, 1));
         ReportHit(t, 0, attrib);
     }

--- a/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
+++ b/Gems/DebugDraw/Assets/Shaders/SphereIntersection.azsl
@@ -9,7 +9,7 @@
 #include <Atom/Features/RayTracing/RayTracingIntersectionAttributes.azsli>
 #include <Atom/Features/RayTracing/RayTracingSrgs.azsli>
 #include <Atom/Features/RayTracing/RayTracingSceneUtils.azsli>
-#include <Atom/Features/Bindless.azsli>
+#include <Atom/RPI/Math.azsli>
 
 // https://gamedev.stackexchange.com/a/96487
 bool IntersectRaySphere(float3 p, float3 d, float3 center, float radius, out float t)
@@ -47,6 +47,13 @@ float3 ExtractScale(float3x4 m)
     return float3(sx, sy, sz);
 }
 
+float2 NormalToAzimuthElevation(float3 normal)
+{
+    float azimuth = atan2(normal.y, normal.x); // Azimuth in range [-PI, PI]
+    float elevation = asin(normal.z); // Elevation in range [-PI/2, PI/2]
+    return float2(azimuth / TWO_PI + 0.5f, elevation / PI + 0.5f);
+}
+
 [shader("intersection")]
 void SphereIntersection()
 {
@@ -67,10 +74,13 @@ void SphereIntersection()
     float t;
     if (IntersectRaySphere(WorldRayOrigin(), WorldRayDirection(), sphereCenterWS, sphereRadiusWS, t))
     {
+        float3 position = ObjectRayOrigin() + ObjectRayDirection() * t;
+        float3 normal = normalize(position - sphereCenter);
+
         ProceduralGeometryIntersectionAttributes attrib;
-        attrib.SetPosition(ObjectRayOrigin() + ObjectRayDirection() * t);
-        attrib.SetNormal(normalize(attrib.m_position - sphereCenter));
-        attrib.SetUv(float2(0, 0));
+        attrib.SetPosition(position);
+        attrib.SetNormal(normal);
+        attrib.SetUv(NormalToAzimuthElevation(normal));
         attrib.SetTangent(float4(1, 0, 0, 1));
         ReportHit(t, 0, attrib);
     }


### PR DESCRIPTION
## What does this PR do?

This PR adds the level component "Debug Ray Tracing" which can be used to debug various properties of the ray tracing scene. The currently implemented properties are:
- Instance Index
- Instance ID
- Primitive Index
- Barycentric Coordinates
- Normals
- UV Coordinates

The Editor component looks like this:
<img src="https://github.com/o3de/o3de/assets/113582781/152e41b4-553f-46e6-8f80-79ab5acaae96" width="350">

While the usefulness of this debug view might not be all that useful for normal meshes, it is very useful for debugging ray-traced procedural geometry, since it is otherwise not possible to visualize these properties without relying on other usages of ray tracing, such as ray-traced reflections, or by using an external GPU debugger.

I inject the debug ray tracing pass after the `AuxGeomPass`, because otherwise the debug shapes (sphere, cube) would be drawn after the debug values and overwrite them. This leads to other aux geometry, such as selection bounding boxes and gizmos, not being visible as well.

The following image shows the various debug options with a small test scene (first image without debug component or with first checkbox disabled); if a specific property is not available, such as barycentric coordinates for procedural geometry, a white-gray checkerboard is displayed instead:
<img src="https://github.com/o3de/o3de/assets/113582781/b3623040-ef4f-4e2c-a25a-70dd49df093f" width="600">

## How was this PR tested?

Create a small test level, add meshes and debug shapes. Add the debug ray tracing component to the level and switch between the view modes, enable/disable the debug view (first checkbox), add/remove the component
