### PR TITLE
Fix nounity-build on Windows

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <RHI/ShaderUtils.h>
+#include <RHI/DX12.h>
 #include <openssl/md5.h>
 #include <Atom/RHI.Reflect/DX12/ShaderStageFunction.h>
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following compile error when using a nounity build on Windows:
```
..\Gems\Atom\RHI\DX12\Code\Source\RHI\ShaderUtils.cpp:16:41: error: use of undeclared identifier 'MAKE_FOURCC'
   16 |     static const uint32_t FOURCC_DXBC = MAKE_FOURCC('D', 'X', 'B', 'C');
      |         
```

## How was this PR tested?

Compile with `-DLY_UNITY_BUILD=OFF` on Windows.
