### PR TITLE
DX12 RHI: Fix the check for wive operation

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -247,7 +247,7 @@ namespace AZ
             shaderModel.HighestShaderModel = D3D_HIGHEST_SHADER_MODEL;
             if (FAILED(GetDevice()->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModel, sizeof(shaderModel))))
             {
-                AZ_Trace("DX12", "Failed to check feature D3D12_FEATURE_SHADER_MODEL");
+                AZ_Warning("DX12",  false, "Failed to check feature D3D12_FEATURE_SHADER_MODEL");
                 m_features.m_waveOperation = false;
             }
             else

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -244,8 +244,16 @@ namespace AZ
 
             // Check support of wive operation
             D3D12_FEATURE_DATA_SHADER_MODEL shaderModel;
-            GetDevice()->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModel, sizeof(shaderModel));
-            m_features.m_waveOperation = shaderModel.HighestShaderModel >= D3D_SHADER_MODEL_6_0;
+            shaderModel.HighestShaderModel = D3D_HIGHEST_SHADER_MODEL;
+            if (FAILED(GetDevice()->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModel, sizeof(shaderModel))))
+            {
+                AZ_Trace("DX12", "Failed to check feature D3D12_FEATURE_SHADER_MODEL");
+                m_features.m_waveOperation = false;
+            }
+            else
+            {
+                m_features.m_waveOperation = shaderModel.HighestShaderModel >= D3D_SHADER_MODEL_6_0;
+            }
 
 #ifdef AZ_DX12_DXR_SUPPORT
             D3D12_FEATURE_DATA_D3D12_OPTIONS5 options5;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -244,7 +244,7 @@ namespace AZ
 
             // Check support of wive operation
             D3D12_FEATURE_DATA_SHADER_MODEL shaderModel;
-            shaderModel.HighestShaderModel = D3D_HIGHEST_SHADER_MODEL;
+            shaderModel.HighestShaderModel = D3D_SHADER_MODEL_6_0;
             if (FAILED(GetDevice()->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModel, sizeof(shaderModel))))
             {
                 AZ_Warning("DX12",  false, "Failed to check feature D3D12_FEATURE_SHADER_MODEL");


### PR DESCRIPTION
## What does this PR do?
Properly checks feature support for wive operation.

Before the CheckFeatureSupport would return E_INVALIDARG and silently fail at least on AMD and
with this fix it will properly get that feature support with logging if it fails.

## How was this PR tested?
Running the editor and game launcher in profile mode.