### PR TITLE
Bugfix for wrong iteration.

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -336,11 +336,11 @@ namespace AZ::RHI
                 {
                     m_tlasInstancesBuffer->m_deviceObjects.clear();
                     m_tlasInstancesBuffer = nullptr;
-                    return false;
+                    return ResultCode::Fail;
                 }
 
                 m_tlasInstancesBuffer->SetDescriptor(m_tlasInstancesBuffer->GetDeviceBuffer(deviceIndex)->GetDescriptor());
-                return true;
+                return ResultCode::Success;
             });
         return m_tlasInstancesBuffer;
     }


### PR DESCRIPTION
## What does this PR do?

`MultiDeviceObject::IterateObjects` has no implementation that supports a callback returning a boolean, it needs to be a `ResultCode`.

## How was this PR tested?

Compiled an ran a code sample where this is used (so far it's not used anywhere else, that's why the bug didn't appear).
