### PR TITLE
Fixing some members with wrong names.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -201,7 +201,7 @@ namespace AZ
                 if (startIndex == 0)
                 {
                     RHI::CommandList* commandList = context.GetCommandList();
-                    commandList->Submit(m_clearShadowDrawPacket->GetDrawItemProperties(0).m_Item->GetDeviceDrawItem(context.GetDeviceIndex()), 0);
+                    commandList->Submit(m_clearShadowDrawPacket->GetDrawItemProperties(0).m_item->GetDeviceDrawItem(context.GetDeviceIndex()), 0);
                 }
                 else
                 {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
@@ -142,10 +142,10 @@ namespace AZ::RHI
         //! Returns the device-specific DeviceCopyQueryToBufferDescriptor for the given index
         DeviceCopyQueryToBufferDescriptor GetDeviceCopyQueryToBufferDescriptor(int deviceIndex) const
         {
-            AZ_Assert(m_SourceQueryPool, "Not initialized with source QueryPool\n");
+            AZ_Assert(m_sourceQueryPool, "Not initialized with source QueryPool\n");
             AZ_Assert(m_destinationBuffer, "Not initialized with destination Buffer\n");
 
-            return DeviceCopyQueryToBufferDescriptor{ m_SourceQueryPool ? m_SourceQueryPool->GetDeviceQueryPool(deviceIndex).get() : nullptr,
+            return DeviceCopyQueryToBufferDescriptor{ m_sourceQueryPool ? m_sourceQueryPool->GetDeviceQueryPool(deviceIndex).get() : nullptr,
                                                 m_firstQuery,
                                                 m_queryCount,
                                                 m_destinationBuffer ? m_destinationBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
@@ -153,7 +153,7 @@ namespace AZ::RHI
                                                 m_destinationStride };
         }
 
-        const QueryPool* m_SourceQueryPool = nullptr;
+        const QueryPool* m_sourceQueryPool = nullptr;
         QueryHandle m_firstQuery = QueryHandle(0);
         uint32_t m_queryCount = 0;
         const Buffer* m_destinationBuffer = nullptr;
@@ -165,14 +165,14 @@ namespace AZ::RHI
     {
         CopyItem()
             : m_type{ CopyItemType::Buffer }
-            , m_Buffer{}
+            , m_buffer{}
         {
         }
 
         CopyItem(
             const CopyBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
             : m_type{ CopyItemType::Buffer }
-            , m_Buffer{ descriptor }
+            , m_buffer{ descriptor }
             , m_deviceMask{ mask }
         {
         }
@@ -180,7 +180,7 @@ namespace AZ::RHI
         CopyItem(
             const CopyImageDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
             : m_type{ CopyItemType::Image }
-            , m_Image{ descriptor }
+            , m_image{ descriptor }
             , m_deviceMask{ mask }
         {
         }
@@ -188,7 +188,7 @@ namespace AZ::RHI
         CopyItem(
             const CopyBufferToImageDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
             : m_type{ CopyItemType::BufferToImage }
-            , m_BufferToImage{ descriptor }
+            , m_bufferToImage{ descriptor }
             , m_deviceMask{ mask }
         {
         }
@@ -196,7 +196,7 @@ namespace AZ::RHI
         CopyItem(
             const CopyImageToBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
             : m_type{ CopyItemType::ImageToBuffer }
-            , m_ImageToBuffer{ descriptor }
+            , m_imageToBuffer{ descriptor }
             , m_deviceMask{ mask }
         {
         }
@@ -204,7 +204,7 @@ namespace AZ::RHI
         CopyItem(
             const CopyQueryToBufferDescriptor& descriptor, RHI::MultiDevice::DeviceMask mask = RHI::MultiDevice::AllDevices)
             : m_type{ CopyItemType::QueryToBuffer }
-            , m_QueryToBuffer{ descriptor }
+            , m_queryToBuffer{ descriptor }
             , m_deviceMask{ mask }
         {
         }
@@ -215,15 +215,15 @@ namespace AZ::RHI
             switch (m_type)
             {
             case CopyItemType::Buffer:
-                return DeviceCopyItem(m_Buffer.GetDeviceCopyBufferDescriptor(deviceIndex));
+                return DeviceCopyItem(m_buffer.GetDeviceCopyBufferDescriptor(deviceIndex));
             case CopyItemType::Image:
-                return DeviceCopyItem(m_Image.GetDeviceCopyImageDescriptor(deviceIndex));
+                return DeviceCopyItem(m_image.GetDeviceCopyImageDescriptor(deviceIndex));
             case CopyItemType::BufferToImage:
-                return DeviceCopyItem(m_BufferToImage.GetDeviceCopyBufferToImageDescriptor(deviceIndex));
+                return DeviceCopyItem(m_bufferToImage.GetDeviceCopyBufferToImageDescriptor(deviceIndex));
             case CopyItemType::ImageToBuffer:
-                return DeviceCopyItem(m_ImageToBuffer.GetDeviceCopyImageToBufferDescriptor(deviceIndex));
+                return DeviceCopyItem(m_imageToBuffer.GetDeviceCopyImageToBufferDescriptor(deviceIndex));
             case CopyItemType::QueryToBuffer:
-                return DeviceCopyItem(m_QueryToBuffer.GetDeviceCopyQueryToBufferDescriptor(deviceIndex));
+                return DeviceCopyItem(m_queryToBuffer.GetDeviceCopyQueryToBufferDescriptor(deviceIndex));
             default:
                 return DeviceCopyItem();
             }
@@ -232,11 +232,11 @@ namespace AZ::RHI
         CopyItemType m_type;
         union
         {
-            CopyBufferDescriptor m_Buffer;
-            CopyImageDescriptor m_Image;
-            CopyBufferToImageDescriptor m_BufferToImage;
-            CopyImageToBufferDescriptor m_ImageToBuffer;
-            CopyQueryToBufferDescriptor m_QueryToBuffer;
+            CopyBufferDescriptor m_buffer;
+            CopyImageDescriptor m_image;
+            CopyBufferToImageDescriptor m_bufferToImage;
+            CopyImageToBufferDescriptor m_imageToBuffer;
+            CopyQueryToBufferDescriptor m_queryToBuffer;
         };
         //! A DeviceMask to denote on which devices an operation should take place
         RHI::MultiDevice::DeviceMask m_deviceMask;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
@@ -41,7 +41,7 @@ namespace AZ::RHI
 
         DispatchArguments(const DispatchIndirect& indirect)
             : m_type{ DispatchType::Indirect }
-            , m_Indirect{ indirect }
+            , m_indirect{ indirect }
         {
         }
 
@@ -53,7 +53,7 @@ namespace AZ::RHI
             case DispatchType::Direct:
                 return DeviceDispatchArguments(m_direct);
             case DispatchType::Indirect:
-                return DeviceDispatchArguments(DeviceDispatchIndirect{m_Indirect.m_maxSequenceCount, m_Indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_Indirect.m_indirectBufferByteOffset, m_Indirect.m_countBuffer ? m_Indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr, m_Indirect.m_countBufferByteOffset});
+                return DeviceDispatchArguments(DeviceDispatchIndirect{m_indirect.m_maxSequenceCount, m_indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_indirect.m_indirectBufferByteOffset, m_indirect.m_countBuffer ? m_indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr, m_indirect.m_countBufferByteOffset});
             default:
                 return DeviceDispatchArguments();
             }
@@ -64,7 +64,7 @@ namespace AZ::RHI
             //! Arguments for a direct dispatch.
             DispatchDirect m_direct;
             //! Arguments for an indirect dispatch.
-            DispatchIndirect m_Indirect;
+            DispatchIndirect m_indirect;
         };
     };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -73,7 +73,7 @@ namespace AZ::RHI
 
         DispatchRaysArguments(const DispatchRaysIndirect& indirect)
             : m_type{ DispatchRaysType::Indirect }
-            , m_Indirect{ indirect }
+            , m_indirect{ indirect }
         {
         }
 
@@ -86,14 +86,14 @@ namespace AZ::RHI
                 return DeviceDispatchRaysArguments(m_direct);
             case DispatchRaysType::Indirect:
                 return DeviceDispatchRaysArguments(DeviceDispatchRaysIndirect{
-                    m_Indirect.m_maxSequenceCount,
-                    m_Indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex),
-                    m_Indirect.m_indirectBufferByteOffset,
-                    m_Indirect.m_dispatchRaysIndirectBuffer
-                        ? m_Indirect.m_dispatchRaysIndirectBuffer->GetDeviceDispatchRaysIndirectBuffer(deviceIndex).get()
+                    m_indirect.m_maxSequenceCount,
+                    m_indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex),
+                    m_indirect.m_indirectBufferByteOffset,
+                    m_indirect.m_dispatchRaysIndirectBuffer
+                        ? m_indirect.m_dispatchRaysIndirectBuffer->GetDeviceDispatchRaysIndirectBuffer(deviceIndex).get()
                         : nullptr,
-                    m_Indirect.m_countBuffer ? m_Indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
-                    m_Indirect.m_countBufferByteOffset });
+                    m_indirect.m_countBuffer ? m_indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
+                    m_indirect.m_countBufferByteOffset });
             default:
                 return DeviceDispatchRaysArguments();
             }
@@ -104,7 +104,7 @@ namespace AZ::RHI
             //! Arguments for a direct dispatch.
             DispatchRaysDirect m_direct;
             //! Arguments for an indirect dispatch.
-            DispatchRaysIndirect m_Indirect;
+            DispatchRaysIndirect m_indirect;
         };
     };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -53,7 +53,7 @@ namespace AZ::RHI
 
         DrawArguments(const DrawIndirect& indirect)
             : m_type{ DrawType::Indirect }
-            , m_Indirect{ indirect }
+            , m_indirect{ indirect }
         {
         }
 
@@ -67,7 +67,7 @@ namespace AZ::RHI
             case DrawType::Linear:
                 return DeviceDrawArguments(m_linear);
             case DrawType::Indirect:
-                return DeviceDrawArguments(DeviceDrawIndirect{m_Indirect.m_maxSequenceCount, m_Indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_Indirect.m_indirectBufferByteOffset, m_Indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get(), m_Indirect.m_countBufferByteOffset});
+                return DeviceDrawArguments(DeviceDrawIndirect{m_indirect.m_maxSequenceCount, m_indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_indirect.m_indirectBufferByteOffset, m_indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get(), m_indirect.m_countBufferByteOffset});
             default:
                 return DeviceDrawArguments();
             }
@@ -77,7 +77,7 @@ namespace AZ::RHI
         union {
             DrawIndexed m_indexed;
             DrawLinear m_linear;
-            DrawIndirect m_Indirect;
+            DrawIndirect m_indirect;
         };
     };
 
@@ -280,7 +280,7 @@ namespace AZ::RHI
     {
         bool operator==(const DrawItemProperties& rhs) const
         {
-            return m_Item == rhs.m_Item && m_sortKey == rhs.m_sortKey && m_depth == rhs.m_depth &&
+            return m_item == rhs.m_item && m_sortKey == rhs.m_sortKey && m_depth == rhs.m_depth &&
                 m_drawFilterMask == rhs.m_drawFilterMask;
         }
 
@@ -297,15 +297,15 @@ namespace AZ::RHI
         //! Returns the device-specific DeviceDrawItemProperties for the given index
         DeviceDrawItemProperties GetDeviceDrawItemProperties(int deviceIndex) const
         {
-            AZ_Assert(m_Item, "Not initialized with DrawItem\n");
+            AZ_Assert(m_item, "Not initialized with DrawItem\n");
 
-            DeviceDrawItemProperties result{ &m_Item->GetDeviceDrawItem(deviceIndex), m_sortKey, m_drawFilterMask, m_depth };
+            DeviceDrawItemProperties result{ &m_item->GetDeviceDrawItem(deviceIndex), m_sortKey, m_drawFilterMask, m_depth };
 
             return result;
         }
 
         //! A pointer to the draw item
-        const DrawItem* m_Item = nullptr;
+        const DrawItem* m_item = nullptr;
         //! A sorting key of this draw item which is used for sorting draw items in DrawList
         //! Check RHI::SortDrawList() function for detail
         DrawItemSortKey m_sortKey = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
@@ -47,7 +47,7 @@ namespace AZ::RHI
 
     private:
         HashValue64 m_hash = HashValue64{ 0 };
-        const Buffer* m_Buffer = nullptr;
+        const Buffer* m_buffer = nullptr;
         uint32_t m_byteOffset = 0;
         uint32_t m_byteCount = 0;
         IndexFormat m_format = IndexFormat::Uint32;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
@@ -69,7 +69,7 @@ namespace AZ::RHI
         void Shutdown() final;
 
     private:
-        IndirectBufferSignatureDescriptor m_Descriptor;
+        IndirectBufferSignatureDescriptor m_descriptor;
         static constexpr uint32_t UNINITIALIZED_VALUE{ std::numeric_limits<uint32_t>::max() };
         uint32_t m_byteStride{ UNINITIALIZED_VALUE };
     };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferView.h
@@ -35,8 +35,8 @@ namespace AZ::RHI
         //! The mutex stops the default generation
         IndirectBufferView(const IndirectBufferView& other)
             : m_hash{ other.m_hash }
-            , m_Buffer{ other.m_Buffer }
-            , m_Signature{ other.m_Signature }
+            , m_buffer{ other.m_buffer }
+            , m_signature{ other.m_signature }
             , m_byteOffset{ other.m_byteOffset }
             , m_byteCount{ other.m_byteCount }
             , m_byteStride{ other.m_byteStride }
@@ -46,8 +46,8 @@ namespace AZ::RHI
         IndirectBufferView& operator=(const IndirectBufferView& other)
         {
             this->m_hash = other.m_hash;
-            this->m_Buffer = other.m_Buffer;
-            this->m_Signature = other.m_Signature;
+            this->m_buffer = other.m_buffer;
+            this->m_signature = other.m_signature;
             this->m_byteOffset = other.m_byteOffset;
             this->m_byteCount = other.m_byteCount;
             this->m_byteStride = other.m_byteStride;
@@ -60,8 +60,8 @@ namespace AZ::RHI
         //! Returns the device-specific DeviceIndirectBufferView for the given index
         const DeviceIndirectBufferView& GetDeviceIndirectBufferView(int deviceIndex) const
         {
-            AZ_Error("IndirectBufferView", m_Signature, "No IndirectBufferSignature available\n");
-            AZ_Error("IndirectBufferView", m_Buffer, "No Buffer available\n");
+            AZ_Error("IndirectBufferView", m_signature, "No IndirectBufferSignature available\n");
+            AZ_Error("IndirectBufferView", m_buffer, "No Buffer available\n");
 
             AZStd::lock_guard lock(m_bufferViewMutex);
             auto iterator{ m_cache.find(deviceIndex) };
@@ -71,8 +71,8 @@ namespace AZ::RHI
                 auto [new_iterator, inserted]{ m_cache.insert(AZStd::make_pair(
                     deviceIndex,
                     DeviceIndirectBufferView(
-                        *m_Buffer->GetDeviceBuffer(deviceIndex),
-                        *m_Signature->GetDeviceIndirectBufferSignature(deviceIndex),
+                        *m_buffer->GetDeviceBuffer(deviceIndex),
+                        *m_signature->GetDeviceIndirectBufferSignature(deviceIndex),
                         m_byteOffset,
                         m_byteCount,
                         m_byteStride))) };
@@ -106,8 +106,8 @@ namespace AZ::RHI
 
     private:
         HashValue64 m_hash = HashValue64{ 0 };
-        const IndirectBufferSignature* m_Signature = nullptr;
-        const Buffer* m_Buffer = nullptr;
+        const IndirectBufferSignature* m_signature = nullptr;
+        const Buffer* m_buffer = nullptr;
         uint32_t m_byteOffset = 0;
         uint32_t m_byteCount = 0;
         uint32_t m_byteStride = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
@@ -29,8 +29,8 @@ namespace AZ::RHI
     struct RayTracingGeometry
     {
         RHI::Format m_vertexFormat = RHI::Format::Unknown;
-        RHI::StreamBufferView m_VertexBuffer;
-        RHI::IndexBufferView m_IndexBuffer;
+        RHI::StreamBufferView m_vertexBuffer;
+        RHI::IndexBufferView m_indexBuffer;
     };
     using RayTracingGeometryVector = AZStd::vector<RayTracingGeometry>;
 
@@ -58,16 +58,16 @@ namespace AZ::RHI
         //! Accessors
         const RayTracingGeometryVector& GetGeometries() const
         {
-            return m_Geometries;
+            return m_geometries;
         }
         RayTracingGeometryVector& GetGeometries()
         {
-            return m_Geometries;
+            return m_geometries;
         }
 
         [[nodiscard]] const RayTracingAccelerationStructureBuildFlags& GetBuildFlags() const
         {
-            return m_BuildFlags;
+            return m_buildFlags;
         }
 
         //! Build operations
@@ -80,10 +80,10 @@ namespace AZ::RHI
         RayTracingBlasDescriptor* BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags& buildFlags);
 
     private:
-        RayTracingGeometryVector m_Geometries;
+        RayTracingGeometryVector m_geometries;
         AZStd::optional<AZ::Aabb> m_aabb;
-        RayTracingGeometry* m_BuildContext = nullptr;
-        RayTracingAccelerationStructureBuildFlags m_BuildFlags = AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE;
+        RayTracingGeometry* m_buildContext = nullptr;
+        RayTracingAccelerationStructureBuildFlags m_buildFlags = AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE;
     };
 
     //! RayTracingBlas
@@ -108,7 +108,7 @@ namespace AZ::RHI
         bool IsValid() const;
 
     private:
-        RayTracingBlasDescriptor m_Descriptor;
+        RayTracingBlasDescriptor m_descriptor;
     };
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -128,7 +128,7 @@ namespace AZ::RHI
         AZ::Transform m_transform = AZ::Transform::CreateIdentity();
         AZ::Vector3 m_nonUniformScale = AZ::Vector3::CreateOne();
         bool m_transparent = false;
-        RHI::Ptr<RHI::RayTracingBlas> m_Blas;
+        RHI::Ptr<RHI::RayTracingBlas> m_blas;
     };
     using MultiDeviceRayTracingTlasInstanceVector = AZStd::vector<RayTracingTlasInstance>;
 
@@ -162,20 +162,20 @@ namespace AZ::RHI
         //! Accessors
         const MultiDeviceRayTracingTlasInstanceVector& GetInstances() const
         {
-            return m_Instances;
+            return m_instances;
         }
         MultiDeviceRayTracingTlasInstanceVector& GetInstances()
         {
-            return m_Instances;
+            return m_instances;
         }
 
         const RHI::Ptr<RHI::Buffer>& GetInstancesBuffer() const
         {
-            return m_InstancesBuffer;
+            return m_instancesBuffer;
         }
         RHI::Ptr<RHI::Buffer>& GetInstancesBuffer()
         {
-            return m_InstancesBuffer;
+            return m_instancesBuffer;
         }
 
         uint32_t GetNumInstancesInBuffer() const
@@ -197,11 +197,11 @@ namespace AZ::RHI
         RayTracingTlasDescriptor* NumInstances(uint32_t numInstancesInBuffer);
 
     private:
-        MultiDeviceRayTracingTlasInstanceVector m_Instances;
-        RayTracingTlasInstance* m_BuildContext = nullptr;
+        MultiDeviceRayTracingTlasInstanceVector m_instances;
+        RayTracingTlasInstance* m_buildContext = nullptr;
 
         //! externally created Instances buffer, cannot be combined with other Instances
-        RHI::Ptr<RHI::Buffer> m_InstancesBuffer;
+        RHI::Ptr<RHI::Buffer> m_instancesBuffer;
         uint32_t m_numInstancesInBuffer = 0;
     };
 
@@ -231,7 +231,7 @@ namespace AZ::RHI
         //! Safe-guard access to creation of buffers cache during parallel access
         mutable AZStd::mutex m_tlasBufferMutex;
         mutable AZStd::mutex m_tlasInstancesBufferMutex;
-        RayTracingTlasDescriptor m_Descriptor;
+        RayTracingTlasDescriptor m_descriptor;
         mutable RHI::Ptr<RHI::Buffer> m_tlasBuffer;
         mutable RHI::Ptr<RHI::Buffer> m_tlasInstancesBuffer;
     };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
@@ -58,7 +58,7 @@ namespace AZ::RHI
 
         const RHI::PipelineState* GetPipelineState() const
         {
-            return m_PipelineState;
+            return m_pipelineState;
         }
 
         const RayTracingShaderLibraryVector& GetShaderLibraries() const
@@ -96,7 +96,7 @@ namespace AZ::RHI
         RayTracingPipelineStateDescriptor* HitGroup(const AZ::Name& name);
 
     private:
-        const RHI::PipelineState* m_PipelineState = nullptr;
+        const RHI::PipelineState* m_pipelineState = nullptr;
         DeviceRayTracingPipelineStateDescriptor m_descriptor;
     };
 
@@ -113,7 +113,7 @@ namespace AZ::RHI
 
         const RayTracingPipelineStateDescriptor& GetDescriptor() const
         {
-            return m_Descriptor;
+            return m_descriptor;
         }
 
         //! Initialize all device-specific RayTracingPipelineStates
@@ -123,6 +123,6 @@ namespace AZ::RHI
         //! explicit shutdown is not allowed for this type
         void Shutdown() override final;
 
-        RayTracingPipelineStateDescriptor m_Descriptor;
+        RayTracingPipelineStateDescriptor m_descriptor;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
         AZ::Name m_shaderExportName;
 
         //! shader resource group for this shader record
-        const RHI::ShaderResourceGroup* m_ShaderResourceGroup;
+        const RHI::ShaderResourceGroup* m_shaderResourceGroup;
 
         static const uint32_t InvalidKey = static_cast<uint32_t>(-1);
 
@@ -41,7 +41,7 @@ namespace AZ::RHI
     //! using the following pattern:
     //!
     //! RHI::RayTracingShaderTableDescriptor descriptor;
-    //! descriptor.Build(AZ::Name("RayTracingExampleShaderTable"), m_RayTracingPipelineState)
+    //! descriptor.Build(AZ::Name("RayTracingExampleShaderTable"), m_rayTracingPipelineState)
     //!     ->RayGenerationRecord(AZ::Name("RayGenerationShader"))
     //!     ->MissRecord(AZ::Name("MissShader"))
     //!         ->ShaderResourceGroup(missSrg)
@@ -63,34 +63,34 @@ namespace AZ::RHI
         //! Accessors
         const RHI::Ptr<RayTracingPipelineState>& GetPipelineState() const
         {
-            return m_RayTracingPipelineState;
+            return m_rayTracingPipelineState;
         }
 
         const RayTracingShaderTableRecordList& GetRayGenerationRecord() const
         {
-            return m_RayGenerationRecord;
+            return m_rayGenerationRecord;
         }
         RayTracingShaderTableRecordList& GetRayGenerationRecord()
         {
-            return m_RayGenerationRecord;
+            return m_rayGenerationRecord;
         }
 
         const RayTracingShaderTableRecordList& GetMissRecords() const
         {
-            return m_MissRecords;
+            return m_missRecords;
         }
         RayTracingShaderTableRecordList& GetMissRecords()
         {
-            return m_MissRecords;
+            return m_missRecords;
         }
 
         const RayTracingShaderTableRecordList& GetHitGroupRecords() const
         {
-            return m_HitGroupRecords;
+            return m_hitGroupRecords;
         }
         RayTracingShaderTableRecordList& GetHitGroupRecords()
         {
-            return m_HitGroupRecords;
+            return m_hitGroupRecords;
         }
 
         void RemoveHitGroupRecords(uint32_t key);
@@ -106,13 +106,13 @@ namespace AZ::RHI
 
     private:
         AZ::Name m_name;
-        RHI::Ptr<RayTracingPipelineState> m_RayTracingPipelineState;
+        RHI::Ptr<RayTracingPipelineState> m_rayTracingPipelineState;
         //! limited to one record, but stored as a list to simplify processing
-        RayTracingShaderTableRecordList m_RayGenerationRecord;
-        RayTracingShaderTableRecordList m_MissRecords;
-        RayTracingShaderTableRecordList m_HitGroupRecords;
+        RayTracingShaderTableRecordList m_rayGenerationRecord;
+        RayTracingShaderTableRecordList m_missRecords;
+        RayTracingShaderTableRecordList m_hitGroupRecords;
 
-        RayTracingShaderTableRecord* m_BuildContext = nullptr;
+        RayTracingShaderTableRecord* m_buildContext = nullptr;
     };
 
     //! Shader Table

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
@@ -76,7 +76,7 @@ namespace AZ::RHI
         void SetFrameAttachment(FrameAttachment* frameAttachment);
 
         //! The parent pool this resource is registered with.
-        ResourcePool* m_Pool = nullptr;
+        ResourcePool* m_pool = nullptr;
 
         //! The current frame attachment registered on this resource.
         FrameAttachment* m_frameAttachment = nullptr;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePool.h
@@ -95,14 +95,14 @@ namespace AZ::RHI
 
         //! The registry of resources initialized on the pool, guarded by a shared_mutex.
         mutable AZStd::shared_mutex m_registryMutex;
-        AZStd::unordered_set<Resource*> m_Registry;
+        AZStd::unordered_set<Resource*> m_registry;
     };
 
     template<typename ResourceType>
     void ResourcePool::ForEach(AZStd::function<void(ResourceType&)> callback)
     {
         AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
-        for (Resource* resourceBase : m_Registry)
+        for (Resource* resourceBase : m_registry)
         {
             ResourceType* resourceType = azrtti_cast<ResourceType*>(resourceBase);
             if (resourceType)
@@ -116,7 +116,7 @@ namespace AZ::RHI
     void ResourcePool::ForEach(AZStd::function<void(const ResourceType&)> callback) const
     {
         AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
-        for (const Resource* resourceBase : m_Registry)
+        for (const Resource* resourceBase : m_registry)
         {
             const ResourceType* resourceType = azrtti_cast<const ResourceType*>(resourceBase);
             if (resourceType)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroup.h
@@ -50,7 +50,7 @@ namespace AZ::RHI
         void Shutdown() override final;
 
     private:
-        ShaderResourceGroupData m_Data;
+        ShaderResourceGroupData m_data;
 
         //! The binding slot cached from the layout.
         uint32_t m_bindingSlot = aznumeric_cast<uint32_t>(-1);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamBufferView.h
@@ -29,9 +29,9 @@ namespace AZ::RHI
         //! Returns the device-specific DeviceStreamBufferView for the given index
         DeviceStreamBufferView GetDeviceStreamBufferView(int deviceIndex) const
         {
-            AZ_Assert(m_Buffer, "No Buffer available\n");
+            AZ_Assert(m_buffer, "No Buffer available\n");
 
-            return DeviceStreamBufferView(*m_Buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_byteStride);
+            return DeviceStreamBufferView(*m_buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_byteStride);
         }
 
         //! Returns the hash of the view. This hash is precomputed at creation time.
@@ -52,7 +52,7 @@ namespace AZ::RHI
 
     private:
         HashValue64 m_hash = HashValue64{ 0 };
-        const Buffer* m_Buffer = nullptr;
+        const Buffer* m_buffer = nullptr;
         uint32_t m_byteOffset = 0;
         uint32_t m_byteCount = 0;
         uint32_t m_byteStride = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -93,7 +93,7 @@ namespace AZ::RHI
         struct InitImageRequest
         {
             //! Pointer to the image to initialize.
-            Image* m_Image = nullptr;
+            Image* m_image = nullptr;
 
             //! Index of the image in the swap chain.
             uint32_t m_imageIndex = 0;
@@ -120,7 +120,7 @@ namespace AZ::RHI
         SwapChainDescriptor m_descriptor;
 
         //! Images corresponding to each image in the swap chain.
-        AZStd::vector<Ptr<Image>> m_Images;
+        AZStd::vector<Ptr<Image>> m_images;
 
         //! Cache the XR system at initialization time
         RHI::XRRenderingInterface* m_xrSystem = nullptr;

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawList.cpp
@@ -39,7 +39,7 @@ namespace AZ::RHI
                     {
                         return a.m_depth < b.m_depth;
                     }
-                    return a.m_Item < b.m_Item;
+                    return a.m_item < b.m_item;
                 }
             );
             break;
@@ -55,7 +55,7 @@ namespace AZ::RHI
                     {
                         return a.m_depth > b.m_depth;
                     }
-                    return a.m_Item < b.m_Item;
+                    return a.m_item < b.m_item;
                 }
             );
             break;
@@ -71,7 +71,7 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_Item < b.m_Item;
+                    return a.m_item < b.m_item;
                 }
             );
             break;
@@ -87,7 +87,7 @@ namespace AZ::RHI
                     {
                         return a.m_sortKey < b.m_sortKey;
                     }
-                    return a.m_Item < b.m_Item;
+                    return a.m_item < b.m_item;
                 }
             );
             break;

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawListContext.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawListContext.cpp
@@ -52,7 +52,7 @@ namespace AZ::RHI
                 if (m_drawListMask[drawListTag.GetIndex()])
                 {
                     DrawItemProperties drawItem = drawPacket->GetDrawItemProperties(i);
-                    if (drawItem.m_Item->GetEnabled())
+                    if (drawItem.m_item->GetEnabled())
                     {
                         drawItem.m_depth = depth;
                         threadListsByTag[drawListTag.GetIndex()].push_back(drawItem);
@@ -71,7 +71,7 @@ namespace AZ::RHI
 
     void DrawListContext::AddDrawItem(DrawListTag drawListTag, DrawItemProperties drawItemProperties)
     {
-        if (!drawItemProperties.m_Item->GetEnabled())
+        if (!drawItemProperties.m_item->GetEnabled())
         {
             return;
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/IndexBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/IndexBufferView.cpp
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     IndexBufferView::IndexBufferView(
         const Buffer& buffer, uint32_t byteOffset, uint32_t byteCount, IndexFormat format)
-        : m_Buffer{ &buffer }
+        : m_buffer{ &buffer }
         , m_byteOffset{ byteOffset }
         , m_byteCount{ byteCount }
         , m_format{ format }
@@ -24,9 +24,9 @@ namespace AZ::RHI
 
     DeviceIndexBufferView IndexBufferView::GetDeviceIndexBufferView(int deviceIndex) const
     {
-        AZ_Assert(m_Buffer, "No Buffer available\n");
+        AZ_Assert(m_buffer, "No Buffer available\n");
 
-        return DeviceIndexBufferView(*m_Buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_format);
+        return DeviceIndexBufferView(*m_buffer->GetDeviceBuffer(deviceIndex), m_byteOffset, m_byteCount, m_format);
     }
 
     AZ::HashValue64 IndexBufferView::GetHash() const
@@ -36,7 +36,7 @@ namespace AZ::RHI
 
     const Buffer* IndexBufferView::GetBuffer() const
     {
-        return m_Buffer;
+        return m_buffer;
     }
 
     uint32_t IndexBufferView::GetByteOffset() const

--- a/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -51,7 +51,7 @@ namespace AZ::RHI
                 return resultCode == ResultCode::Success;
             });
 
-        m_Descriptor = descriptor;
+        m_descriptor = descriptor;
 
         return resultCode;
     }
@@ -73,7 +73,7 @@ namespace AZ::RHI
                 return 0;
             }
 
-            if (index.GetIndex() >= m_Descriptor.m_layout.GetCommands().size())
+            if (index.GetIndex() >= m_descriptor.m_layout.GetCommands().size())
             {
                 AZ_Assert(false, "Index %d is greater than the number of commands on the layout", index.GetIndex());
                 return 0;
@@ -99,12 +99,12 @@ namespace AZ::RHI
 
     const IndirectBufferSignatureDescriptor& IndirectBufferSignature::GetDescriptor() const
     {
-        return m_Descriptor;
+        return m_descriptor;
     }
 
     const AZ::RHI::IndirectBufferLayout& IndirectBufferSignature::GetLayout() const
     {
-        return m_Descriptor.m_layout;
+        return m_descriptor.m_layout;
     }
 
     void IndirectBufferSignature::Shutdown()

--- a/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferView.cpp
@@ -18,18 +18,18 @@ namespace AZ::RHI
         uint32_t byteOffset,
         uint32_t byteCount,
         uint32_t byteStride)
-        : m_Buffer(&buffer)
+        : m_buffer(&buffer)
         , m_byteOffset(byteOffset)
         , m_byteCount(byteCount)
         , m_byteStride(byteStride)
-        , m_Signature(&signature)
+        , m_signature(&signature)
     {
         size_t seed = 0;
-        AZStd::hash_combine(seed, m_Buffer);
+        AZStd::hash_combine(seed, m_buffer);
         AZStd::hash_combine(seed, m_byteOffset);
         AZStd::hash_combine(seed, m_byteCount);
         AZStd::hash_combine(seed, m_byteStride);
-        AZStd::hash_combine(seed, m_Signature);
+        AZStd::hash_combine(seed, m_signature);
         m_hash = static_cast<HashValue64>(seed);
     }
 
@@ -40,7 +40,7 @@ namespace AZ::RHI
 
     const Buffer* IndirectBufferView::GetBuffer() const
     {
-        return m_Buffer;
+        return m_buffer;
     }
 
     uint32_t IndirectBufferView::GetByteOffset() const
@@ -60,6 +60,6 @@ namespace AZ::RHI
 
     const IndirectBufferSignature* IndirectBufferView::GetSignature() const
     {
-        return m_Signature;
+        return m_signature;
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -18,12 +18,12 @@ namespace AZ::RHI
     {
         DeviceRayTracingBlasDescriptor descriptor;
 
-        for (const auto& geometry : m_Geometries)
+        for (const auto& geometry : m_geometries)
         {
             descriptor.Geometry()
                 ->VertexFormat(geometry.m_vertexFormat)
-                ->VertexBuffer(geometry.m_VertexBuffer.GetDeviceStreamBufferView(deviceIndex))
-                ->IndexBuffer(geometry.m_IndexBuffer.GetDeviceIndexBufferView(deviceIndex));
+                ->VertexBuffer(geometry.m_vertexBuffer.GetDeviceStreamBufferView(deviceIndex))
+                ->IndexBuffer(geometry.m_indexBuffer.GetDeviceIndexBufferView(deviceIndex));
         }
 
         if(m_aabb.has_value())
@@ -41,8 +41,8 @@ namespace AZ::RHI
 
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::Geometry()
     {
-        m_Geometries.emplace_back();
-        m_BuildContext = &m_Geometries.back();
+        m_geometries.emplace_back();
+        m_buildContext = &m_geometries.back();
         return this;
     }
 
@@ -55,30 +55,30 @@ namespace AZ::RHI
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::VertexBuffer(
         const RHI::StreamBufferView& vertexBuffer)
     {
-        AZ_Assert(m_BuildContext, "VertexBuffer property can only be added to a Geometry entry");
-        m_BuildContext->m_VertexBuffer = vertexBuffer;
+        AZ_Assert(m_buildContext, "VertexBuffer property can only be added to a Geometry entry");
+        m_buildContext->m_vertexBuffer = vertexBuffer;
         return this;
     }
 
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::VertexFormat(RHI::Format vertexFormat)
     {
-        AZ_Assert(m_BuildContext, "VertexFormat property can only be added to a Geometry entry");
-        m_BuildContext->m_vertexFormat = vertexFormat;
+        AZ_Assert(m_buildContext, "VertexFormat property can only be added to a Geometry entry");
+        m_buildContext->m_vertexFormat = vertexFormat;
         return this;
     }
 
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::IndexBuffer(
         const RHI::IndexBufferView& indexBuffer)
     {
-        AZ_Assert(m_BuildContext, "IndexBuffer property can only be added to a Geometry entry");
-        m_BuildContext->m_IndexBuffer = indexBuffer;
+        AZ_Assert(m_buildContext, "IndexBuffer property can only be added to a Geometry entry");
+        m_buildContext->m_indexBuffer = indexBuffer;
         return this;
     }
 
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
     {
-        AZ_Assert(m_BuildContext, "BuildFlags property can only be added to a Geometry entry");
-        m_BuildFlags = buildFlags;
+        AZ_Assert(m_buildContext, "BuildFlags property can only be added to a Geometry entry");
+        m_buildFlags = buildFlags;
         return this;
     }
 
@@ -86,7 +86,7 @@ namespace AZ::RHI
     {
         DeviceRayTracingTlasDescriptor descriptor;
 
-        for (const auto& instance : m_Instances)
+        for (const auto& instance : m_instances)
         {
             descriptor.Instance()
                 ->InstanceID(instance.m_instanceID)
@@ -94,12 +94,12 @@ namespace AZ::RHI
                 ->Transform(instance.m_transform)
                 ->NonUniformScale(instance.m_nonUniformScale)
                 ->Transparent(instance.m_transparent)
-                ->Blas(instance.m_Blas->GetDeviceRayTracingBlas(deviceIndex));
+                ->Blas(instance.m_blas->GetDeviceRayTracingBlas(deviceIndex));
         }
 
-        if (m_InstancesBuffer)
+        if (m_instancesBuffer)
         {
-            descriptor.InstancesBuffer(m_InstancesBuffer->GetDeviceBuffer(deviceIndex))->NumInstances(m_numInstancesInBuffer);
+            descriptor.InstancesBuffer(m_instancesBuffer->GetDeviceBuffer(deviceIndex))->NumInstances(m_numInstancesInBuffer);
         }
 
         return descriptor;
@@ -112,73 +112,73 @@ namespace AZ::RHI
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::Instance()
     {
-        AZ_Assert(m_InstancesBuffer == nullptr, "Instance cannot be combined with an instances buffer");
-        m_Instances.emplace_back();
-        m_BuildContext = &m_Instances.back();
+        AZ_Assert(m_instancesBuffer == nullptr, "Instance cannot be combined with an instances buffer");
+        m_instances.emplace_back();
+        m_buildContext = &m_instances.back();
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::InstanceID(uint32_t instanceID)
     {
-        AZ_Assert(m_BuildContext, "InstanceID property can only be added to an Instance entry");
-        m_BuildContext->m_instanceID = instanceID;
+        AZ_Assert(m_buildContext, "InstanceID property can only be added to an Instance entry");
+        m_buildContext->m_instanceID = instanceID;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::InstanceMask(uint32_t instanceMask)
     {
-        AZ_Assert(m_BuildContext, "InstanceMask property can only be added to an Instance entry");
-        m_BuildContext->m_instanceMask = instanceMask;
+        AZ_Assert(m_buildContext, "InstanceMask property can only be added to an Instance entry");
+        m_buildContext->m_instanceMask = instanceMask;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::HitGroupIndex(uint32_t hitGroupIndex)
     {
-        AZ_Assert(m_BuildContext, "HitGroupIndex property can only be added to an Instance entry");
-        m_BuildContext->m_hitGroupIndex = hitGroupIndex;
+        AZ_Assert(m_buildContext, "HitGroupIndex property can only be added to an Instance entry");
+        m_buildContext->m_hitGroupIndex = hitGroupIndex;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::Transform(const AZ::Transform& transform)
     {
-        AZ_Assert(m_BuildContext, "Transform property can only be added to an Instance entry");
-        m_BuildContext->m_transform = transform;
+        AZ_Assert(m_buildContext, "Transform property can only be added to an Instance entry");
+        m_buildContext->m_transform = transform;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::NonUniformScale(const AZ::Vector3& nonUniformScale)
     {
-        AZ_Assert(m_BuildContext, "NonUniformSCale property can only be added to an Instance entry");
-        m_BuildContext->m_nonUniformScale = nonUniformScale;
+        AZ_Assert(m_buildContext, "NonUniformSCale property can only be added to an Instance entry");
+        m_buildContext->m_nonUniformScale = nonUniformScale;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::Transparent(bool transparent)
     {
-        AZ_Assert(m_BuildContext, "Transparent property can only be added to a Geometry entry");
-        m_BuildContext->m_transparent = transparent;
+        AZ_Assert(m_buildContext, "Transparent property can only be added to a Geometry entry");
+        m_buildContext->m_transparent = transparent;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::Blas(const RHI::Ptr<RHI::RayTracingBlas>& blas)
     {
-        AZ_Assert(m_BuildContext, "Blas property can only be added to an Instance entry");
-        m_BuildContext->m_Blas = blas;
+        AZ_Assert(m_buildContext, "Blas property can only be added to an Instance entry");
+        m_buildContext->m_blas = blas;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::InstancesBuffer(
         RHI::Ptr<RHI::Buffer>& instancesBuffer)
     {
-        AZ_Assert(!m_BuildContext, "InstancesBuffer property can only be added to the top level");
-        AZ_Assert(m_Instances.size() == 0, "InstancesBuffer cannot exist with instance entries");
-        m_InstancesBuffer = instancesBuffer;
+        AZ_Assert(!m_buildContext, "InstancesBuffer property can only be added to the top level");
+        AZ_Assert(m_instances.size() == 0, "InstancesBuffer cannot exist with instance entries");
+        m_instancesBuffer = instancesBuffer;
         return this;
     }
 
     RayTracingTlasDescriptor* RayTracingTlasDescriptor::NumInstances(uint32_t numInstancesInBuffer)
     {
-        AZ_Assert(m_InstancesBuffer.get(), "NumInstances property can only be added to the InstancesBuffer entry");
+        AZ_Assert(m_instancesBuffer.get(), "NumInstances property can only be added to the InstancesBuffer entry");
         m_numInstancesInBuffer = numInstancesInBuffer;
         return this;
     }
@@ -188,7 +188,7 @@ namespace AZ::RHI
         const RayTracingBlasDescriptor* descriptor,
         const RayTracingBufferPools& rayTracingBufferPools)
     {
-        m_Descriptor = *descriptor;
+        m_descriptor = *descriptor;
         ResultCode resultCode{ ResultCode::Success };
 
         MultiDeviceObject::Init(deviceMask);
@@ -242,7 +242,7 @@ namespace AZ::RHI
         const RayTracingTlasDescriptor* descriptor,
         const RayTracingBufferPools& rayTracingBufferPools)
     {
-        m_Descriptor = *descriptor;
+        m_descriptor = *descriptor;
 
         MultiDeviceObject::Init(deviceMask);
 

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -15,13 +15,13 @@ namespace AZ::RHI
     DeviceRayTracingPipelineStateDescriptor RayTracingPipelineStateDescriptor::GetDeviceRayTracingPipelineStateDescriptor(
         int deviceIndex) const
     {
-        AZ_Assert(m_PipelineState, "No PipelineState available\n");
+        AZ_Assert(m_pipelineState, "No PipelineState available\n");
 
         DeviceRayTracingPipelineStateDescriptor descriptor{ m_descriptor };
 
-        if (m_PipelineState)
+        if (m_pipelineState)
         {
-            descriptor.m_pipelineState = m_PipelineState->GetDevicePipelineState(deviceIndex).get();
+            descriptor.m_pipelineState = m_pipelineState->GetDevicePipelineState(deviceIndex).get();
         }
 
         return descriptor;
@@ -54,7 +54,7 @@ namespace AZ::RHI
     RayTracingPipelineStateDescriptor* RayTracingPipelineStateDescriptor::PipelineState(
         const RHI::PipelineState* pipelineState)
     {
-        m_PipelineState = pipelineState;
+        m_pipelineState = pipelineState;
         return this;
     }
 
@@ -108,7 +108,7 @@ namespace AZ::RHI
     ResultCode RayTracingPipelineState::Init(
         MultiDevice::DeviceMask deviceMask, const RayTracingPipelineStateDescriptor& descriptor)
     {
-        m_Descriptor = descriptor;
+        m_descriptor = descriptor;
 
         MultiDeviceObject::Init(deviceMask);
 
@@ -120,7 +120,7 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingPipelineState();
 
-                auto descriptor{ m_Descriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
+                auto descriptor{ m_descriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
                 resultCode = GetDeviceRayTracingPipelineState(deviceIndex)->Init(*device, &descriptor);
                 return resultCode == ResultCode::Success;
             });

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -20,36 +20,36 @@ namespace AZ::RHI
     {
         AZStd::shared_ptr<DeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<DeviceRayTracingShaderTableDescriptor>();
 
-        if (m_RayTracingPipelineState)
+        if (m_rayTracingPipelineState)
         {
-            descriptor->Build(m_name, m_RayTracingPipelineState->GetDeviceRayTracingPipelineState(deviceIndex));
+            descriptor->Build(m_name, m_rayTracingPipelineState->GetDeviceRayTracingPipelineState(deviceIndex));
         }
 
-        for (const auto& rayGenerationRecord : m_RayGenerationRecord)
+        for (const auto& rayGenerationRecord : m_rayGenerationRecord)
         {
             descriptor->RayGenerationRecord(rayGenerationRecord.m_shaderExportName);
-            if (rayGenerationRecord.m_ShaderResourceGroup)
+            if (rayGenerationRecord.m_shaderResourceGroup)
             {
                 descriptor->ShaderResourceGroup(
-                    rayGenerationRecord.m_ShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+                    rayGenerationRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
             }
         }
 
-        for (const auto& missRecord : m_MissRecords)
+        for (const auto& missRecord : m_missRecords)
         {
             descriptor->MissRecord(missRecord.m_shaderExportName);
-            if (missRecord.m_ShaderResourceGroup)
+            if (missRecord.m_shaderResourceGroup)
             {
-                descriptor->ShaderResourceGroup(missRecord.m_ShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+                descriptor->ShaderResourceGroup(missRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
             }
         }
 
-        for (const auto& hitGroupRecord : m_HitGroupRecords)
+        for (const auto& hitGroupRecord : m_hitGroupRecords)
         {
             descriptor->HitGroupRecord(hitGroupRecord.m_shaderExportName, hitGroupRecord.m_key);
-            if (hitGroupRecord.m_ShaderResourceGroup)
+            if (hitGroupRecord.m_shaderResourceGroup)
             {
-                descriptor->ShaderResourceGroup(hitGroupRecord.m_ShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
+                descriptor->ShaderResourceGroup(hitGroupRecord.m_shaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get());
             }
         }
 
@@ -58,14 +58,14 @@ namespace AZ::RHI
 
     void RayTracingShaderTableDescriptor::RemoveHitGroupRecords(uint32_t key)
     {
-        for (RayTracingShaderTableRecordList::iterator itHitGroup = m_HitGroupRecords.begin();
-             itHitGroup != m_HitGroupRecords.end();
+        for (RayTracingShaderTableRecordList::iterator itHitGroup = m_hitGroupRecords.begin();
+             itHitGroup != m_hitGroupRecords.end();
              ++itHitGroup)
         {
             RayTracingShaderTableRecord& record = *itHitGroup;
             if (record.m_key == key)
             {
-                m_HitGroupRecords.erase(itHitGroup);
+                m_hitGroupRecords.erase(itHitGroup);
             }
         }
     }
@@ -74,39 +74,39 @@ namespace AZ::RHI
         const AZ::Name& name, RHI::Ptr<RayTracingPipelineState>& rayTracingPipelineState)
     {
         m_name = name;
-        m_RayTracingPipelineState = rayTracingPipelineState;
+        m_rayTracingPipelineState = rayTracingPipelineState;
         return this;
     }
 
     RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::RayGenerationRecord(const AZ::Name& name)
     {
-        AZ_Assert(m_RayGenerationRecord.empty(), "Ray generation record already added");
-        m_RayGenerationRecord.emplace_back(RayTracingShaderTableRecord{ name });
-        m_BuildContext = &m_RayGenerationRecord.back();
+        AZ_Assert(m_rayGenerationRecord.empty(), "Ray generation record already added");
+        m_rayGenerationRecord.emplace_back(RayTracingShaderTableRecord{ name });
+        m_buildContext = &m_rayGenerationRecord.back();
         return this;
     }
 
     RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::MissRecord(const AZ::Name& name)
     {
-        m_MissRecords.emplace_back(RayTracingShaderTableRecord{ name });
-        m_BuildContext = &m_MissRecords.back();
+        m_missRecords.emplace_back(RayTracingShaderTableRecord{ name });
+        m_buildContext = &m_missRecords.back();
         return this;
     }
 
     RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::HitGroupRecord(
         const AZ::Name& name, uint32_t key /* = RayTracingShaderTableRecord::InvalidKey */)
     {
-        m_HitGroupRecords.emplace_back(RayTracingShaderTableRecord{ name, nullptr, key });
-        m_BuildContext = &m_HitGroupRecords.back();
+        m_hitGroupRecords.emplace_back(RayTracingShaderTableRecord{ name, nullptr, key });
+        m_buildContext = &m_hitGroupRecords.back();
         return this;
     }
 
     RayTracingShaderTableDescriptor* RayTracingShaderTableDescriptor::ShaderResourceGroup(
         const RHI::ShaderResourceGroup* shaderResourceGroup)
     {
-        AZ_Assert(m_BuildContext, "ShaderResourceGroup can only be added to a shader table record");
-        AZ_Assert(m_BuildContext->m_ShaderResourceGroup == nullptr, "Records can only have one ShaderResourceGroup");
-        m_BuildContext->m_ShaderResourceGroup = shaderResourceGroup;
+        AZ_Assert(m_buildContext, "ShaderResourceGroup can only be added to a shader table record");
+        AZ_Assert(m_buildContext->m_shaderResourceGroup == nullptr, "Records can only have one ShaderResourceGroup");
+        m_buildContext->m_shaderResourceGroup = shaderResourceGroup;
         return this;
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Resource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Resource.cpp
@@ -53,7 +53,7 @@ namespace AZ::RHI
 
     void Resource::SetPool(ResourcePool* bufferPool)
     {
-        m_Pool = bufferPool;
+        m_pool = bufferPool;
 
         const bool isValidPool = bufferPool != nullptr;
         if (isValidPool)
@@ -71,12 +71,12 @@ namespace AZ::RHI
 
     const ResourcePool* Resource::GetPool() const
     {
-        return m_Pool;
+        return m_pool;
     }
 
     ResourcePool* Resource::GetPool()
     {
-        return m_Pool;
+        return m_pool;
     }
 
     void Resource::SetFrameAttachment(FrameAttachment* frameAttachment)
@@ -105,7 +105,7 @@ namespace AZ::RHI
     void Resource::Shutdown()
     {
         // Shutdown is delegated to the parent pool if this resource is registered on one.
-        if (m_Pool)
+        if (m_pool)
         {
             AZ_Error(
                 "Resource",
@@ -114,7 +114,7 @@ namespace AZ::RHI
                 "to shutdown a resource while it is being used as an Attachment. The "
                 "behavior is undefined.");
 
-            m_Pool->ShutdownResource(this);
+            m_pool->ShutdownResource(this);
         }
         MultiDeviceObject::Shutdown();
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
@@ -13,13 +13,13 @@ namespace AZ::RHI
 {
     ResourcePool::~ResourcePool()
     {
-        AZ_Assert(m_Registry.empty(), "ResourceType pool was not properly shutdown.");
+        AZ_Assert(m_registry.empty(), "ResourceType pool was not properly shutdown.");
     }
 
     uint32_t ResourcePool::GetResourceCount() const
     {
         AZStd::shared_lock<AZStd::shared_mutex> lock(m_registryMutex);
-        return static_cast<uint32_t>(m_Registry.size());
+        return static_cast<uint32_t>(m_registry.size());
     }
 
     bool ResourcePool::ValidateIsRegistered(const Resource* resource) const
@@ -74,7 +74,7 @@ namespace AZ::RHI
         resource.SetPool(this);
 
         AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
-        m_Registry.emplace(&resource);
+        m_registry.emplace(&resource);
     }
 
     void ResourcePool::Unregister(Resource& resource)
@@ -82,7 +82,7 @@ namespace AZ::RHI
         resource.SetPool(nullptr);
 
         AZStd::unique_lock<AZStd::shared_mutex> lock(m_registryMutex);
-        m_Registry.erase(&resource);
+        m_registry.erase(&resource);
     }
 
     ResultCode ResourcePool::Init(MultiDevice::DeviceMask deviceMask, const PlatformMethod& platformInitMethod)
@@ -108,12 +108,12 @@ namespace AZ::RHI
         // Multiple shutdown is allowed for pools.
         if (IsInitialized())
         {
-            for (Resource* resource : m_Registry)
+            for (Resource* resource : m_registry)
             {
                 resource->SetPool(nullptr);
                 resource->Shutdown();
             }
-            m_Registry.clear();
+            m_registry.clear();
             MultiDeviceObject::Shutdown();
         }
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroup.cpp
@@ -15,7 +15,7 @@ namespace AZ::RHI
     void ShaderResourceGroup::Compile(
         const ShaderResourceGroupData& groupData, CompileMode compileMode /*= CompileMode::Async*/)
     {
-        m_Data = groupData;
+        m_data = groupData;
 
         IterateObjects<DeviceShaderResourceGroup>([&groupData, compileMode](auto deviceIndex, auto deviceShaderResourceGroup)
         {
@@ -53,7 +53,7 @@ namespace AZ::RHI
 
     const ShaderResourceGroupData& ShaderResourceGroup::GetData() const
     {
-        return m_Data;
+        return m_data;
     }
 
     void ShaderResourceGroup::Shutdown()

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -78,7 +78,7 @@ namespace AZ::RHI
             const ShaderResourceGroupLayout* layout = GetLayout();
 
             // Pre-initialize the data so that we can build view diffs later.
-            group.m_Data = ShaderResourceGroupData(GetDeviceMask(), layout);
+            group.m_data = ShaderResourceGroupData(GetDeviceMask(), layout);
 
             // Cache off the binding slot for one less indirection.
             group.m_bindingSlot = layout->GetBindingSlot();

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamBufferView.cpp
@@ -14,13 +14,13 @@ namespace AZ::RHI
 {
     StreamBufferView::StreamBufferView(
         const Buffer& buffer, uint32_t byteOffset, uint32_t byteCount, uint32_t byteStride)
-        : m_Buffer{ &buffer }
+        : m_buffer{ &buffer }
         , m_byteOffset{ byteOffset }
         , m_byteCount{ byteCount }
         , m_byteStride{ byteStride }
     {
         size_t seed = 0;
-        AZStd::hash_combine(seed, m_Buffer);
+        AZStd::hash_combine(seed, m_buffer);
         AZStd::hash_combine(seed, m_byteOffset);
         AZStd::hash_combine(seed, m_byteCount);
         AZStd::hash_combine(seed, m_byteStride);
@@ -34,7 +34,7 @@ namespace AZ::RHI
 
     const Buffer* StreamBufferView::GetBuffer() const
     {
-        return m_Buffer;
+        return m_buffer;
     }
 
     uint32_t StreamBufferView::GetByteOffset() const

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -94,25 +94,25 @@ namespace AZ::RHI
     void SwapChain::ShutdownImages()
     {
         // Shutdown existing set of images.
-        uint32_t imageSize = aznumeric_cast<uint32_t>(m_Images.size());
+        uint32_t imageSize = aznumeric_cast<uint32_t>(m_images.size());
         for (uint32_t imageIdx = 0; imageIdx < imageSize; ++imageIdx)
         {
-            m_Images[imageIdx]->Shutdown();
+            m_images[imageIdx]->Shutdown();
         }
 
-        m_Images.clear();
+        m_images.clear();
     }
 
     ResultCode SwapChain::InitImages()
     {
         ResultCode resultCode = ResultCode::Success;
 
-        m_Images.reserve(m_descriptor.m_dimensions.m_imageCount);
+        m_images.reserve(m_descriptor.m_dimensions.m_imageCount);
 
         // If the new display mode has more buffers, add them.
         for (uint32_t i = 0; i < m_descriptor.m_dimensions.m_imageCount; ++i)
         {
-            m_Images.emplace_back(aznew Image());
+            m_images.emplace_back(aznew Image());
         }
 
         InitImageRequest request;
@@ -126,11 +126,11 @@ namespace AZ::RHI
 
         for (uint32_t imageIdx = 0; imageIdx < m_descriptor.m_dimensions.m_imageCount; ++imageIdx)
         {
-            request.m_Image = m_Images[imageIdx].get();
+            request.m_image = m_images[imageIdx].get();
             request.m_imageIndex = imageIdx;
 
             resultCode = ImagePoolBase::InitImage(
-                request.m_Image,
+                request.m_image,
                 imageDescriptor,
                 [this, imageIdx]()
                 {
@@ -138,7 +138,7 @@ namespace AZ::RHI
 
                     IterateObjects<DeviceSwapChain>([this, imageIdx](auto deviceIndex, auto deviceSwapChain)
                     {
-                        m_Images[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
+                        m_images[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
                     });
 
                     return result;
@@ -254,24 +254,24 @@ namespace AZ::RHI
 
     uint32_t SwapChain::GetImageCount() const
     {
-        return aznumeric_cast<uint32_t>(m_Images.size());
+        return aznumeric_cast<uint32_t>(m_images.size());
     }
 
     Image* SwapChain::GetCurrentImage() const
     {
         if (m_descriptor.m_isXrSwapChain)
         {
-            return m_Images[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
+            return m_images[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
         }
         AZ_Error("Swapchain", !m_deviceObjects.empty(), "No device swapchain image available.");
         // Note: Taking the current swapchain image index from the first device swap chain if there are multiple
         auto currentImageIndex{ AZStd::static_pointer_cast<DeviceSwapChain>(m_deviceObjects.begin()->second)->GetCurrentImageIndex() };
-        return m_Images[currentImageIndex].get();
+        return m_images[currentImageIndex].get();
     }
 
     Image* SwapChain::GetImage(uint32_t index) const
     {
-        return m_Images[index].get();
+        return m_images[index].get();
     }
 
     void SwapChain::Present()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -723,7 +723,7 @@ namespace AZ
 
                 RHI::DrawItemProperties drawItemProperties;
                 drawItemProperties.m_sortKey = drawItemInfo.m_sortKey;
-                drawItemProperties.m_Item = &drawItemInfo.m_drawItem;
+                drawItemProperties.m_item = &drawItemInfo.m_drawItem;
                 drawItemProperties.m_drawFilterMask = m_drawFilter;
                 m_cachedDrawList.emplace_back(drawItemProperties);
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -311,7 +311,7 @@ namespace AZ
                 if (m_attachmentType == RHI::AttachmentType::Image)
                 {
                     // copy image to read back buffer since only buffer can be accessed by host
-                    const auto image = readbackItem.m_copyItem.m_Image.m_sourceImage;
+                    const auto image = readbackItem.m_copyItem.m_image.m_sourceImage;
                     if (!image)
                     {
                         AZ_Warning(
@@ -553,7 +553,7 @@ namespace AZ
                         uint8_t* const destBegin = readbackItem.m_dataBuffer->data();
                         // The source image WAS the destination when the copy item transferred data from GPU to CPU
                         // this explains why the name srcBytesPerRow for these memcpy operations.
-                        const auto srcBytesPerRow = readbackItem.m_copyItem.m_ImageToBuffer.m_destinationBytesPerRow;
+                        const auto srcBytesPerRow = readbackItem.m_copyItem.m_imageToBuffer.m_destinationBytesPerRow;
                         for (uint32_t row = 0; row < rowCount; ++row)
                         {
                             void* dest = destBegin + row * imageLayout.m_bytesPerRow;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -264,7 +264,7 @@ namespace AZ
                 const RHI::DrawItemProperties& drawItemProperties = m_drawListView[index];
                 if (drawItemProperties.m_drawFilterMask & m_pipeline->GetDrawFilterMask())
                 {
-                    commandList->Submit(drawItemProperties.m_Item->GetDeviceDrawItem(context.GetDeviceIndex()), index + indexOffset);
+                    commandList->Submit(drawItemProperties.m_item->GetDeviceDrawItem(context.GetDeviceIndex()), index + indexOffset);
                 }
             }
         }


### PR DESCRIPTION
Names started with m_[A-Z] instead of m_[a-z].

## What does this PR do?

Renamed some wrongly named variables.

## How was this PR tested?

Compiled with o3de-extras and atom-sampleviewer.
