### PR TITLE
Cherry picking occlusion bus changes to stabilization 2409

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
@@ -26,8 +26,11 @@ namespace AzFramework
                 ->Event("CreateOcclusionView", &OcclusionRequestBus::Events::CreateOcclusionView)
                 ->Event("DestroyOcclusionView", &OcclusionRequestBus::Events::DestroyOcclusionView)
                 ->Event("UpdateOcclusionView", &OcclusionRequestBus::Events::UpdateOcclusionView)
-                ->Event("IsEntityVisibleInOcclusionView", &OcclusionRequestBus::Events::IsEntityVisibleInOcclusionView)
-                ->Event("IsAabbVisibleInOcclusionView", &OcclusionRequestBus::Events::IsAabbVisibleInOcclusionView)
+                ->Event("GetOcclusionViewEntityVisibility", &OcclusionRequestBus::Events::GetOcclusionViewEntityVisibility)
+                ->Event("GetOcclusionViewAabbVisibility", &OcclusionRequestBus::Events::GetOcclusionViewAabbVisibility)
+                ->Event("GetOcclusionViewAabbToAabbVisibility", &OcclusionRequestBus::Events::GetOcclusionViewAabbToAabbVisibility)
+                ->Event("GetOcclusionViewSphereToSphereVisibility", &OcclusionRequestBus::Events::GetOcclusionViewSphereToSphereVisibility)
+                ->Event("GetOcclusionViewEntityToEntityVisibility", &OcclusionRequestBus::Events::GetOcclusionViewEntityToEntityVisibility)
                 ;
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.h
@@ -25,8 +25,12 @@ namespace AZ
 
 namespace AzFramework
 {
-    //! OcclusionRequests is an interface for creating occlusion views and queries. The bus must be connected to an entity context ID for an
-    //! entity context containing objects that contribute to or interact with the occlusion scene.
+    //! @brief OcclusionRequests provides an interface for integrating with occlusion culling systems. Use the interface to create
+    //! occlusion views that configure the camera state and context for making occlusion queries. Creating multiple occlusion views
+    //! also allows queries to be made across multiple threads.
+    //!
+    //! The bus must be connected to an entity context ID for an entity context containing objects that contribute to or interacting
+    //! with the occlusion scene.
     class OcclusionRequests : public AZ::EBusTraits
     {
     public:
@@ -37,50 +41,69 @@ namespace AzFramework
 
         static void Reflect(AZ::ReflectContext* context);
 
-        //! Clear previously collected debug rendering lines and statistics
+        //! @brief Clear previously collected debug rendering lines and statistics
         virtual void ClearOcclusionViewDebugInfo() = 0;
 
-        //! Return true if the occlusion view exists.
-        virtual bool IsOcclusionView(const AZ::Name& viewName) const = 0;
+        //! @brief Check if an occlusion view exists with the specified name
+        //! @param viewName Unique name of the view to check
+        //! @return true if a view with the given name exists, otherwise false.
+        virtual bool IsOcclusionViewValid(const AZ::Name& viewName) const = 0;
 
-        //! Create an occlusion view using the specified viewName. After the view is created, the name can be used to look up the view and
-        //! make updates or queries against it. More than one occlusion view can be created at a time and used across threads.
+        //! @brief Create an occlusion view using the specified name. After the view is created, the name can be used to look up the
+        //! view and make updates or queries against it. More than one occlusion view can be created at a time and used across threads.
+        //! @param viewName Unique name of the view to create
+        //! @return true if a view with the given name was created and registered with the system, otherwise false.
         virtual bool CreateOcclusionView(const AZ::Name& viewName) = 0;
 
-        //! Destroy a previously created occlusion view.
+        //! @brief Destroy a previously created occlusion view.
+        //! @param viewName Unique name of the view to destroy
+        //! @return true if a view with the given name was destroyed and removed from the system, otherwise false.
         virtual bool DestroyOcclusionView(const AZ::Name& viewName) = 0;
 
-        //! Updating the occlusion view to capture occlusion data from the specified camera perspective.
+        //! @brief Update the occlusion view from the given camera perspective.
+        //! @param viewName Unique name of the view to update
+        //! @param cameraWorldPos World position of the camera view
+        //! @param cameraWorldToClip Matrix transforming vertices from world space to clip space for occlusion tests
+        //! @return true if a view with the given name was updated, otherwise false.
         virtual bool UpdateOcclusionView(
             const AZ::Name& viewName, const AZ::Vector3& cameraWorldPos, const AZ::Matrix4x4& cameraWorldToClip) = 0;
 
-        //! Returns true if the entity is not occluded in the occlusion view. Otherwise, returns false.
+        //! @brief Determine if an entity is visible within the specified occlusion view.
+        //! @param viewName Unique name of the view to query for entity visibility
+        //! @param entityId ID of the entity to test for visibility
+        //! @return true if the given entity is visible within the specified view, otherwise false. 
         virtual bool GetOcclusionViewEntityVisibility(const AZ::Name& viewName, const AZ::EntityId& entityId) const = 0;
 
-        //! Returns true if the AABB is not occluded in the occlusion view. Otherwise, returns false.
+        //! @brief Determine if an AABB is visible within the specified occlusion view.
+        //! @param viewName Unique name of the view to query for AABB visibility
+        //! @param bounds World AABB to test for visibility
+        //! @return true if the given AABB is visible within the specified view, otherwise false. 
         virtual bool GetOcclusionViewAabbVisibility(const AZ::Name& viewName, const AZ::Aabb& bounds) const = 0;
 
-        //! @brief Test if target shapes are visible from the perspective of a source shape, within a volume extruded between them.
-        //! @param sourceAabb Bounding volume for the source shape defining the frame of reference for visibility tests.
-        //! @param targetAabbs Vector of bounding volumes for target shapes that will be tested for visibility.
-        //! @return A vector of flags containing the visibility state for corresponding target shapes. The size of the returned container
-        //! should match the size of the input target container unless an ever occurred.
+        //! @brief Test if target bounding volumes are visible from the perspective of a source bounding volume, within a volume extruded between them.
+        //! @param viewName Unique name of the view to query
+        //! @param sourceAabb Source bounding volume defining the frame of reference for visibility tests.
+        //! @param targetAabbs Vector of target bounding volumes that will be tested for visibility.
+        //! @return A vector of flags containing the visibility state for corresponding target bounding volumes. The size of the returned container
+        //! should match the size of the input target container unless an error occurred, in which case an empty vector is returned.
         virtual AZStd::vector<bool> GetOcclusionViewAabbToAabbVisibility(
             const AZ::Name& viewName, const AZ::Aabb& sourceAabb, const AZStd::vector<AZ::Aabb>& targetAabbs) const = 0;
 
-        //! @brief Test if target shapes are visible from the perspective of a source shape, within a volume extruded between them.
-        //! @param sourceSphere Bounding volume for the source shape defining the frame of reference for visibility tests.
-        //! @param targetSpheres Vector of bounding volumes for target shapes that will be tested for visibility.
-        //! @return A vector of flags containing the visibility state for corresponding target shapes. The size of the returned container
-        //! should match the size of the input target container unless an ever occurred.
+        //! @brief Test if target bounding volumes are visible from the perspective of a source bounding volume, within a volume extruded between them.
+        //! @param viewName Unique name of the view to query
+        //! @param sourceSphere Source bounding volume for the frame of reference for visibility tests.
+        //! @param targetSpheres Vector of target bounding volumes that will be tested for visibility.
+        //! @return A vector of flags containing the visibility state for corresponding target bounding volumes. The size of the returned container
+        //! should match the size of the input target container unless an error occurred, in which case an empty vector is returned.
         virtual AZStd::vector<bool> GetOcclusionViewSphereToSphereVisibility(
             const AZ::Name& viewName, const AZ::Sphere& sourceSphere, const AZStd::vector<AZ::Sphere>& targetSpheres) const = 0;
 
-        //! @brief Test if target entities are visible from the perspective of a source entity, within a volume extruded between them.
+        //! @brief Test if target entity AABBs are visible from the perspective of a source entity AABB, within a volume extruded between them.
+        //! @param viewName Unique name of the view to query
         //! @param sourceEntityId Id for the source entity defining the frame of reference for visibility tests.
-        //! @param targetEntityIds Vector of Ids for target entities that will be tested for visibility.
+        //! @param targetEntityIds Vector of target entity Ids that will be tested for visibility.
         //! @return A vector of flags containing the visibility state for corresponding target entities. The size of the returned container
-        //! should match the size of the input target container unless an ever occurred.
+        //! should match the size of the input target container unless an error occurred, in which case an empty vector is returned.
         virtual AZStd::vector<bool> GetOcclusionViewEntityToEntityVisibility(
             const AZ::Name& viewName, const AZ::EntityId& sourceEntityId, const AZStd::vector<AZ::EntityId>& targetEntityIds) const = 0;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -487,7 +487,7 @@ namespace AZ
                 AzFramework::OcclusionRequestBus::EventResult(
                     result,
                     worklistData->m_sceneEntityContextId,
-                    &AzFramework::OcclusionRequestBus::Events::IsAabbVisibleInOcclusionView,
+                    &AzFramework::OcclusionRequestBus::Events::GetOcclusionViewAabbVisibility,
                     worklistData->m_view->GetName(),
                     visibleEntry->m_boundingVolume);
 


### PR DESCRIPTION
## What does this PR do?

This PR cherry picks occlusion bus functions, comments, and changes from development branch to stabilization. There are no functional changes, just updates to the interface being used in other projects.

## How was this PR tested?

Compiled stabilization branch and automated testing project.
Launch editor and material canvas.
While testing, discovered that current stabilization branch is not compatible with atom sample viewer, extras, or multiplayer sample, which will need stabilization branches created.