### PR TITLE
CopyPass fixes

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -107,7 +107,8 @@ namespace AZ
                     AZStd::bind(&CopyPass::SetupFrameGraphDependenciesSameDevice, this, AZStd::placeholders::_1),
                     AZStd::bind(&CopyPass::CompileResourcesSameDevice, this, AZStd::placeholders::_1),
                     AZStd::bind(&CopyPass::BuildCommandListInternalSameDevice, this, AZStd::placeholders::_1),
-                    m_hardwareQueueClass);
+                    m_hardwareQueueClass,
+                    m_data.m_sourceDeviceIndex);
             }
             else if (m_copyMode == CopyMode::DifferentDevicesIntermediateHost)
             {
@@ -392,6 +393,7 @@ namespace AZ
                         desc.m_byteCount = m_deviceHostBufferByteCount[m_currentBufferIndex];
 
                         m_device1HostBuffer[m_currentBufferIndex] = BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+                        desc.m_poolType = RPI::CommonBufferPoolType::Staging;
                         desc.m_bufferName = AZStd::string(GetPathName().GetStringView()) + "_hostbuffer2";
                         m_device2HostBuffer[m_currentBufferIndex] = BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
                     }
@@ -599,6 +601,7 @@ namespace AZ
             copyDesc.m_destinationOffset = m_data.m_bufferDestinationOffset;
             copyDesc.m_destinationBytesPerRow = m_data.m_bufferDestinationBytesPerRow;
             copyDesc.m_destinationBytesPerImage = m_data.m_bufferDestinationBytesPerImage;
+            copyDesc.m_destinationFormat = sourceImage->GetDescriptor().m_format;
 
             m_copyItemSameDevice = copyDesc;
         }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a few things in the CopyPass:
- Copying on the same device was always performed on the default device
- The host buffer for the host-to-device copy was wrongly allocated in the Readback Buffer Pool, instead of the Staging Buffer Pool
- The destination format was missing when copying a image to a buffer on the same device

## How was this PR tested?

AtomSampleViewer on Windows with DX12/Vulkan
