### PR TITLE
DX12: Fixed setting the signalOnCPU feature

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -230,6 +230,7 @@ namespace AZ
             m_features.m_indirectDrawCountBufferSupported = true;
             m_features.m_indirectDispatchCountBufferSupported = true;
             m_features.m_indirectDrawStartInstanceLocationSupported = true;
+            m_features.m_signalFenceFromCPU = true;
 
             // DXGI_SCALING_ASPECT_RATIO_STRETCH is only compatible with CreateSwapChainForCoreWindow or CreateSwapChainForComposition,
             // not Win32 window handles and associated methods (cannot find an MSDN source for that)
@@ -299,8 +300,6 @@ namespace AZ
                     RHI::ShadingRateFlags::Rate4x2 |
                     RHI::ShadingRateFlags::Rate4x4;
             }
-
-            m_features.m_signalFenceFromCPU = true;
 
             m_limits.m_shadingRateTileSize = RHI::Size(options6.ShadingRateImageTileSize, options6.ShadingRateImageTileSize, 1);
 #endif


### PR DESCRIPTION
## What does this PR do?

The `signalOnCPU` device feature was set to true inside `#ifdef O3DE_DX12_VRS_SUPPORT`. It should always be set to true as all DX12 Fences can be signalled from the CPU.

## How was this PR tested?

Windows and DX12