### PR TITLE
Remove snap core 20 from the build scripts

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -387,19 +387,6 @@
       "CMAKE_TARGET": "install"
     }
   },
-  "install_mono_20_release": {
-    "TAGS": [],
-    "PIPELINE_ENV": {
-      "NODE_LABEL": "ubuntu-20-packaging"
-    },
-    "COMMAND": "build_linux.sh",
-    "PARAMETERS": {
-      "CONFIGURATION": "release",
-      "OUTPUT_DIRECTORY": "build/linux_mono",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_MONOLITHIC_GAME=TRUE -DLY_PARALLEL_LINK_JOBS=4 -DLY_DISABLE_TEST_MODULES=TRUE -DLY_STRIP_DEBUG_SYMBOLS=TRUE",
-      "CMAKE_TARGET": "install"
-    }
-  },
   "install_mono_22_release": {
     "TAGS": [],
     "PIPELINE_ENV": {
@@ -419,7 +406,6 @@
       "nightly-installer"
     ],
     "steps": [
-      "install_mono_20_release",
       "installer"
     ]
   },
@@ -464,34 +450,6 @@
       "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4 -DLY_DISABLE_TEST_MODULES=TRUE -DO3DE_INSTALL_ENGINE_NAME=o3de-sdk -DLY_STRIP_DEBUG_SYMBOLS=TRUE",
       "EXTRA_CMAKE_OPTIONS": "-DO3DE_INCLUDE_INSTALL_IN_PACKAGE=TRUE",
       "CPACK_OPTIONS": "-D CPACK_UPLOAD_URL=${CPACK_UPLOAD_URL}",
-      "CMAKE_TARGET": "all"
-    }
-  },
-  "snap_core20_pipe": {
-    "TAGS": [
-      "periodic-clean-weekly-internal",
-      "nightly-installer"
-    ],
-    "steps": [
-      "install_mono_20_release",
-      "snap_core20_package"
-    ]
-  },
-  "snap_core20_package": {
-    "TAGS": [
-      "periodic-clean-weekly-internal"
-    ],
-    "PIPELINE_ENV": {
-      "NODE_LABEL": "ubuntu-20-packaging"
-    },
-    "COMMAND": "build_installer_linux.sh",
-    "PARAMETERS": {
-      "CONFIGURATION": "profile",
-      "OUTPUT_DIRECTORY": "build/linux",
-      "O3DE_PACKAGE_TYPE": "SNAP",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4 -DLY_DISABLE_TEST_MODULES=TRUE -DO3DE_INSTALL_ENGINE_NAME=o3de-sdk -DLY_STRIP_DEBUG_SYMBOLS=TRUE",
-      "EXTRA_CMAKE_OPTIONS": "-DO3DE_INCLUDE_INSTALL_IN_PACKAGE=TRUE",
-      "CPACK_OPTIONS": "-D CPACK_UPLOAD_URL=${CPACK_UPLOAD_URL} -D CPACK_SNAP_DISTRO=core20",
       "CMAKE_TARGET": "all"
     }
   },


### PR DESCRIPTION
## What does this PR do?

Removes snap core 20 jobs from the installer pipeline.

Implements https://github.com/o3de/rfcs/issues/54

## How was this PR tested?
TBD
