### PR TITLE
Fix missing build flags passed to DeviceRayTracingBlasDescriptor

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -26,6 +26,8 @@ namespace AZ::RHI
                 ->IndexBuffer(geometry.m_IndexBuffer.GetDeviceIndexBufferView(deviceIndex));
         }
 
+        descriptor.BuildFlags(m_BuildFlags);
+
         if(m_aabb.has_value())
         {
             descriptor.AABB(m_aabb.value());


### PR DESCRIPTION
## What does this PR do?

This fixes https://github.com/o3de/o3de/issues/18099.
The issue was that the `GetDeviceRayTracingBlasDescriptor()` did not correctly pass the `m_BuildFlags` to the `DeviceRayTracingBlasDescriptor`, which left them in the default state (`AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE`) and did not pass `AZ::RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_UPDATE | AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_BUILD` correctly on.

