### PR TITLE
Pass on `Name` to DeviceObjects

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -38,6 +38,9 @@ namespace AZ::RHI
         //! Returns whether the device object is initialized.
         bool IsInitialized() const;
 
+        //! Pass on name to DeviceObjects
+        virtual void SetName(const Name& name);
+
         //! Returns the device this object is associated with. It is only permitted to call
         //! this method when the object is initialized.
         MultiDevice::DeviceMask GetDeviceMask() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -38,9 +38,6 @@ namespace AZ::RHI
         //! Returns whether the device object is initialized.
         bool IsInitialized() const;
 
-        //! Pass on name to DeviceObjects
-        virtual void SetName(const Name& name);
-
         //! Returns the device this object is associated with. It is only permitted to call
         //! this method when the object is initialized.
         MultiDevice::DeviceMask GetDeviceMask() const;
@@ -161,6 +158,9 @@ namespace AZ::RHI
     private:
         //! Returns the number of initialized devices
         int GetDeviceCount() const;
+
+        //! Pass on name to DeviceObjects
+        virtual void SetNameInternal(const AZStd::string_view& name) override;
 
         //! A bitmask denoting on which devices an object is present/valid/allocated
         MultiDevice::DeviceMask m_deviceMask{ 0u };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
         virtual ~Object() = default;
 
         //! Sets the name of the object.
-        virtual void SetName(const Name& name);
+        void SetName(const Name& name);
 
         //! Returns the name set on the object by SetName
         const Name& GetName() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
         virtual ~Object() = default;
 
         //! Sets the name of the object.
-        void SetName(const Name& name);
+        virtual void SetName(const Name& name);
 
         //! Returns the name set on the object by SetName
         const Name& GetName() const;

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -124,6 +124,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateBufferPool();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         result = GetDeviceBufferPool(deviceIndex)->Init(*device, descriptor);
 
                         return result == ResultCode::Success;
@@ -159,6 +165,11 @@ namespace AZ::RHI
                     if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
                     {
                         initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
+                    }
+
+                    if (const auto& name = initRequest.m_buffer->GetName(); !name.IsEmpty())
+                    {
+                        initRequest.m_buffer->m_deviceObjects[deviceIndex]->SetName(name);
                     }
 
                     DeviceBufferInitRequest bufferInitRequest(

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -125,11 +125,6 @@ namespace AZ::RHI
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateBufferPool();
 
-                        if (const auto& name = GetName(); !name.IsEmpty())
-                        {
-                            m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         result = GetDeviceBufferPool(deviceIndex)->Init(*device, descriptor);
 
                         return result == ResultCode::Success;
@@ -165,11 +160,6 @@ namespace AZ::RHI
                     if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
                     {
                         initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
-                    }
-
-                    if (const auto& name = initRequest.m_buffer->GetName(); !name.IsEmpty())
-                    {
-                        initRequest.m_buffer->m_deviceObjects[deviceIndex]->SetName(name);
                     }
 
                     DeviceBufferInitRequest bufferInitRequest(

--- a/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
@@ -50,6 +50,12 @@ namespace AZ::RHI
                 auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateFence();
+
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 resultCode = GetDeviceFence(deviceIndex)->Init(*device, initialState);
 
                 return resultCode == ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
@@ -51,11 +51,6 @@ namespace AZ::RHI
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateFence();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 resultCode = GetDeviceFence(deviceIndex)->Init(*device, initialState);
 
                 return resultCode == ResultCode::Success;
@@ -66,6 +61,11 @@ namespace AZ::RHI
             // Reset already initialized device-specific Fences and set deviceMask to 0
             m_deviceObjects.clear();
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -30,11 +30,6 @@ namespace AZ::RHI
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateImagePool();
 
-                        if (const auto& name = GetName(); !name.IsEmpty())
-                        {
-                            m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         GetDeviceImagePool(deviceIndex)->Init(*device, descriptor);
 
                         return true;
@@ -80,11 +75,6 @@ namespace AZ::RHI
                     if (!initRequest.m_image->m_deviceObjects.contains(deviceIndex))
                     {
                         initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
-                    }
-
-                    if (const auto& name = initRequest.m_image->GetName(); !name.IsEmpty())
-                    {
-                        initRequest.m_image->m_deviceObjects[deviceIndex]->SetName(name);
                     }
 
                     DeviceImageInitRequest imageInitRequest(

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -29,6 +29,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateImagePool();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         GetDeviceImagePool(deviceIndex)->Init(*device, descriptor);
 
                         return true;
@@ -74,6 +80,11 @@ namespace AZ::RHI
                     if (!initRequest.m_image->m_deviceObjects.contains(deviceIndex))
                     {
                         initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
+                    }
+
+                    if (const auto& name = initRequest.m_image->GetName(); !name.IsEmpty())
+                    {
+                        initRequest.m_image->m_deviceObjects[deviceIndex]->SetName(name);
                     }
 
                     DeviceImageInitRequest imageInitRequest(

--- a/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -40,11 +40,6 @@ namespace AZ::RHI
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateIndirectBufferSignature();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-                
                 resultCode = GetDeviceIndirectBufferSignature(deviceIndex)->Init(
                     *device, descriptor.GetDeviceIndirectBufferSignatureDescriptor(deviceIndex));
 
@@ -56,6 +51,11 @@ namespace AZ::RHI
 
                 return resultCode == ResultCode::Success;
             });
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
 
         m_descriptor = descriptor;
 

--- a/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -39,6 +39,12 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateIndirectBufferSignature();
+
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+                
                 resultCode = GetDeviceIndirectBufferSignature(deviceIndex)->Init(
                     *device, descriptor.GetDeviceIndirectBufferSignatureDescriptor(deviceIndex));
 

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -26,6 +26,17 @@ namespace AZ::RHI
         m_deviceMask = deviceMask;
     }
 
+    void MultiDeviceObject::SetName(const Name& name)
+    {
+        IterateObjects<DeviceObject>(
+            [&name]([[maybe_unused]] auto deviceIndex, auto deviceObject)
+            {
+                deviceObject->SetName(name);
+            });
+
+        Object::SetName(name);
+    }
+
     void MultiDeviceObject::Shutdown()
     {
         m_deviceMask = static_cast<MultiDevice::DeviceMask>(0u);

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -26,15 +26,14 @@ namespace AZ::RHI
         m_deviceMask = deviceMask;
     }
 
-    void MultiDeviceObject::SetName(const Name& name)
+    void MultiDeviceObject::SetNameInternal(const AZStd::string_view& name)
     {
         IterateObjects<DeviceObject>(
             [&name]([[maybe_unused]] auto deviceIndex, auto deviceObject)
             {
-                deviceObject->SetName(name);
+                AZStd::string deviceName{ AZStd::string{ name } + AZStd::to_string(deviceIndex) };
+                deviceObject->SetName(Name(deviceName));
             });
-
-        Object::SetName(name);
     }
 
     void MultiDeviceObject::Shutdown()

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
@@ -54,6 +54,12 @@ namespace AZ::RHI
                 auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineLibrary();
+
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 resultCode = GetDevicePipelineLibrary(deviceIndex)->Init(*device, descriptor.GetDevicePipelineLibraryDescriptor(deviceIndex));
 
                 return resultCode == ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
@@ -55,11 +55,6 @@ namespace AZ::RHI
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineLibrary();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 resultCode = GetDevicePipelineLibrary(deviceIndex)->Init(*device, descriptor.GetDevicePipelineLibraryDescriptor(deviceIndex));
 
                 return resultCode == ResultCode::Success;
@@ -72,6 +67,10 @@ namespace AZ::RHI
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
         }
 
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
 
         return resultCode;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -69,6 +69,12 @@ namespace AZ::RHI
                     m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
                 }
 
+
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 switch (descriptor.GetType())
                 {
                 case PipelineStateType::Draw:

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -69,12 +69,6 @@ namespace AZ::RHI
                     m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
                 }
 
-
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 switch (descriptor.GetType())
                 {
                 case PipelineStateType::Draw:
@@ -132,6 +126,11 @@ namespace AZ::RHI
             // Only reset the device mask but the the device-specific PipelineStates, as other
             // threads might be using them already
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
@@ -57,6 +57,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateQueryPool();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         resultCode = GetDeviceQueryPool(deviceIndex)->Init(*device, descriptor);
                         return resultCode == ResultCode::Success;
                     });
@@ -102,6 +108,11 @@ namespace AZ::RHI
             for (auto index{ 0u }; index < queryCount; ++index)
             {
                 queries[index]->m_deviceObjects[deviceIndex] = deviceQueries[index];
+
+                if (const auto& name = queries[index]->GetName(); !name.IsEmpty())
+                {
+                    queries[index]->m_deviceObjects[deviceIndex]->SetName(name);
+                }
             }
 
             return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -201,6 +201,11 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBlas();
 
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingBlasDescriptor(deviceIndex) };
 
                 resultCode = GetDeviceRayTracingBlas(deviceIndex)
@@ -256,6 +261,11 @@ namespace AZ::RHI
                 auto deviceRayTracingTlas{Factory::Get().CreateRayTracingTlas()};
                 this->m_deviceObjects[deviceIndex] = deviceRayTracingTlas;
 
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
 
                 resultCode = deviceRayTracingTlas->CreateBuffers(
@@ -298,6 +308,11 @@ namespace AZ::RHI
             {
                 m_tlasBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
 
+                if (const auto& name = m_tlasBuffer->GetName(); !name.IsEmpty())
+                {
+                    m_tlasBuffer->m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 if (!m_tlasBuffer->m_deviceObjects[deviceIndex])
                 {
                     m_tlasBuffer->m_deviceObjects.clear();
@@ -333,6 +348,11 @@ namespace AZ::RHI
             [this](int deviceIndex, auto deviceRayTracingTlas)
             {
                 m_tlasInstancesBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
+
+                if (const auto& name = m_tlasInstancesBuffer->GetName(); !name.IsEmpty())
+                {
+                    m_tlasInstancesBuffer->m_deviceObjects[deviceIndex]->SetName(name);
+                }
 
                 if (!m_tlasInstancesBuffer->m_deviceObjects[deviceIndex])
                 {

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -201,11 +201,6 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBlas();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingBlasDescriptor(deviceIndex) };
 
                 resultCode = GetDeviceRayTracingBlas(deviceIndex)
@@ -220,6 +215,11 @@ namespace AZ::RHI
             // Reset already initialized device-specific DeviceRayTracingBlas and set deviceMask to 0
             m_deviceObjects.clear();
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         return resultCode;
@@ -261,11 +261,6 @@ namespace AZ::RHI
                 auto deviceRayTracingTlas{Factory::Get().CreateRayTracingTlas()};
                 this->m_deviceObjects[deviceIndex] = deviceRayTracingTlas;
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
 
                 resultCode = deviceRayTracingTlas->CreateBuffers(
@@ -278,6 +273,11 @@ namespace AZ::RHI
             // Reset already initialized device-specific DeviceRayTracingTlas and set deviceMask to 0
             m_deviceObjects.clear();
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         // Each call to CreateBuffers advances m_currentBufferIndex internally, reset buffers to always receive currently active
@@ -308,11 +308,6 @@ namespace AZ::RHI
             {
                 m_tlasBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
 
-                if (const auto& name = m_tlasBuffer->GetName(); !name.IsEmpty())
-                {
-                    m_tlasBuffer->m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 if (!m_tlasBuffer->m_deviceObjects[deviceIndex])
                 {
                     m_tlasBuffer->m_deviceObjects.clear();
@@ -323,6 +318,11 @@ namespace AZ::RHI
                 m_tlasBuffer->SetDescriptor(m_tlasBuffer->GetDeviceBuffer(deviceIndex)->GetDescriptor());
                 return ResultCode::Success;
             });
+
+        if (const auto& name = m_tlasBuffer->GetName(); !name.IsEmpty())
+        {
+            m_tlasBuffer->SetName(name);
+        }
 
         return m_tlasBuffer;
     }
@@ -349,11 +349,6 @@ namespace AZ::RHI
             {
                 m_tlasInstancesBuffer->m_deviceObjects[deviceIndex] = deviceRayTracingTlas->GetTlasBuffer();
 
-                if (const auto& name = m_tlasInstancesBuffer->GetName(); !name.IsEmpty())
-                {
-                    m_tlasInstancesBuffer->m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 if (!m_tlasInstancesBuffer->m_deviceObjects[deviceIndex])
                 {
                     m_tlasInstancesBuffer->m_deviceObjects.clear();
@@ -364,6 +359,11 @@ namespace AZ::RHI
                 m_tlasInstancesBuffer->SetDescriptor(m_tlasInstancesBuffer->GetDeviceBuffer(deviceIndex)->GetDescriptor());
                 return ResultCode::Success;
             });
+
+        if (const auto& name = m_tlasInstancesBuffer->GetName(); !name.IsEmpty())
+        {
+            m_tlasInstancesBuffer->SetName(name);
+        }
         return m_tlasInstancesBuffer;
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingBufferPools.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingBufferPools.cpp
@@ -65,14 +65,14 @@ namespace AZ::RHI
                 RHI::Ptr<RHI::Device> device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBufferPools();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 GetDeviceRayTracingBufferPools(deviceIndex)->Init(device);
                 return true;
             });
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
 
         m_shaderTableBufferPool = aznew RHI::BufferPool();
         m_shaderTableBufferPool->Init(

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingBufferPools.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingBufferPools.cpp
@@ -64,6 +64,12 @@ namespace AZ::RHI
             {
                 RHI::Ptr<RHI::Device> device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBufferPools();
+
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 GetDeviceRayTracingBufferPools(deviceIndex)->Init(device);
                 return true;
             });

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -120,11 +120,6 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingPipelineState();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 auto descriptor{ m_descriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
                 resultCode = GetDeviceRayTracingPipelineState(deviceIndex)->Init(*device, &descriptor);
                 return resultCode == ResultCode::Success;
@@ -135,6 +130,11 @@ namespace AZ::RHI
             // Reset already initialized device-specific DeviceRayTracingPipelineState and set deviceMask to 0
             m_deviceObjects.clear();
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -120,6 +120,11 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingPipelineState();
 
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 auto descriptor{ m_descriptor.GetDeviceRayTracingPipelineStateDescriptor(deviceIndex) };
                 resultCode = GetDeviceRayTracingPipelineState(deviceIndex)->Init(*device, &descriptor);
                 return resultCode == ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -120,17 +120,17 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingShaderTable();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 auto deviceBufferPool{ bufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get() };
 
                 GetDeviceRayTracingShaderTable(deviceIndex)->Init(*device, *deviceBufferPool);
 
                 return true;
             });
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
     }
 
     void RayTracingShaderTable::Build(const AZStd::shared_ptr<RayTracingShaderTableDescriptor> descriptor)

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -120,6 +120,11 @@ namespace AZ::RHI
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingShaderTable();
 
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 auto deviceBufferPool{ bufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get() };
 
                 GetDeviceRayTracingShaderTable(deviceIndex)->Init(*device, *deviceBufferPool);

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
@@ -100,6 +100,11 @@ namespace AZ::RHI
 
         ResultCode resultCode = platformInitMethod();
 
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
+
         return resultCode;
     }
 
@@ -135,6 +140,11 @@ namespace AZ::RHI
         {
             resource->Init(GetDeviceMask());
             Register(*resource);
+
+            if (const auto& name = resource->GetName(); !name.IsEmpty())
+            {
+                resource->SetName(name);
+            }
         }
         return resultCode;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -37,11 +37,6 @@ namespace AZ::RHI
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateShaderResourceGroupPool();
 
-                        if (const auto& name = GetName(); !name.IsEmpty())
-                        {
-                            m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         GetDeviceShaderResourceGroupPool(deviceIndex)->Init(*device, descriptor);
 
                         return true;
@@ -75,11 +70,6 @@ namespace AZ::RHI
                 return IterateObjects<DeviceShaderResourceGroupPool>([this, &group](auto deviceIndex, [[maybe_unused]] auto deviceShaderResourceGroupPool)
                 {
                     group.m_deviceObjects[deviceIndex] = Factory::Get().CreateShaderResourceGroup();
-
-                    if (const auto& name = group.GetName(); !name.IsEmpty())
-                    {
-                        group.m_deviceObjects[deviceIndex]->SetName(name);
-                    }
 
                     return GetDeviceShaderResourceGroupPool(deviceIndex)->InitGroup(*group.GetDeviceShaderResourceGroup(deviceIndex));
                 });

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -36,6 +36,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateShaderResourceGroupPool();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         GetDeviceShaderResourceGroupPool(deviceIndex)->Init(*device, descriptor);
 
                         return true;
@@ -69,6 +75,12 @@ namespace AZ::RHI
                 return IterateObjects<DeviceShaderResourceGroupPool>([this, &group](auto deviceIndex, [[maybe_unused]] auto deviceShaderResourceGroupPool)
                 {
                     group.m_deviceObjects[deviceIndex] = Factory::Get().CreateShaderResourceGroup();
+
+                    if (const auto& name = group.GetName(); !name.IsEmpty())
+                    {
+                        group.m_deviceObjects[deviceIndex]->SetName(name);
+                    }
+
                     return GetDeviceShaderResourceGroupPool(deviceIndex)->InitGroup(*group.GetDeviceShaderResourceGroup(deviceIndex));
                 });
             });

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -83,6 +83,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateStreamingImagePool();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         result = GetDeviceStreamingImagePool(deviceIndex)->Init(*device, descriptor);
 
                         return result == ResultCode::Success;
@@ -121,6 +127,12 @@ namespace AZ::RHI
                 return IterateObjects<DeviceStreamingImagePool>([&initRequest](auto deviceIndex, auto deviceStreamingImagePool)
                 {
                     initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
+
+                    if (const auto& name = initRequest.m_image->GetName(); !name.IsEmpty())
+                    {
+                        initRequest.m_image->m_deviceObjects[deviceIndex]->SetName(name);
+                    }
+
                     DeviceStreamingImageInitRequest streamingImageInitRequest(
                         *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);
                     return deviceStreamingImagePool->InitImage(streamingImageInitRequest);

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -84,11 +84,6 @@ namespace AZ::RHI
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateStreamingImagePool();
 
-                        if (const auto& name = GetName(); !name.IsEmpty())
-                        {
-                            m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         result = GetDeviceStreamingImagePool(deviceIndex)->Init(*device, descriptor);
 
                         return result == ResultCode::Success;
@@ -127,11 +122,6 @@ namespace AZ::RHI
                 return IterateObjects<DeviceStreamingImagePool>([&initRequest](auto deviceIndex, auto deviceStreamingImagePool)
                 {
                     initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
-
-                    if (const auto& name = initRequest.m_image->GetName(); !name.IsEmpty())
-                    {
-                        initRequest.m_image->m_deviceObjects[deviceIndex]->SetName(name);
-                    }
 
                     DeviceStreamingImageInitRequest streamingImageInitRequest(
                         *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -58,11 +58,6 @@ namespace AZ::RHI
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateSwapChain();
 
-                        if (const auto& name = GetName(); !name.IsEmpty())
-                        {
-                            m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         result = GetDeviceSwapChain(deviceIndex)->Init(*device, descriptor);
                         nativeDimensions = GetDeviceSwapChain(deviceIndex)->GetDescriptor().m_dimensions;
 
@@ -80,6 +75,11 @@ namespace AZ::RHI
             m_descriptor.m_dimensions = nativeDimensions;
 
             resultCode = InitImages();
+
+            if (const auto& name = GetName(); !name.IsEmpty())
+            {
+                SetName(name);
+            }
         }
         else
         {
@@ -142,15 +142,11 @@ namespace AZ::RHI
                 {
                     ResultCode result = ResultCode::Success;
 
-                    IterateObjects<DeviceSwapChain>([this, imageIdx](auto deviceIndex, auto deviceSwapChain)
-                    {
-                        m_images[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
-
-                        if (const auto& name = m_Images[imageIdx]->GetName(); !name.IsEmpty())
+                    IterateObjects<DeviceSwapChain>(
+                        [this, imageIdx](auto deviceIndex, auto deviceSwapChain)
                         {
-                            m_Images[imageIdx]->m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-                    });
+                            m_images[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
+                        });
 
                     return result;
                 });

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -57,6 +57,12 @@ namespace AZ::RHI
                         auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
 
                         m_deviceObjects[deviceIndex] = Factory::Get().CreateSwapChain();
+
+                        if (const auto& name = GetName(); !name.IsEmpty())
+                        {
+                            m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         result = GetDeviceSwapChain(deviceIndex)->Init(*device, descriptor);
                         nativeDimensions = GetDeviceSwapChain(deviceIndex)->GetDescriptor().m_dimensions;
 
@@ -139,6 +145,11 @@ namespace AZ::RHI
                     IterateObjects<DeviceSwapChain>([this, imageIdx](auto deviceIndex, auto deviceSwapChain)
                     {
                         m_images[imageIdx]->m_deviceObjects[deviceIndex] = deviceSwapChain->GetImage(imageIdx);
+
+                        if (const auto& name = m_Images[imageIdx]->GetName(); !name.IsEmpty())
+                        {
+                            m_Images[imageIdx]->m_deviceObjects[deviceIndex]->SetName(name);
+                        }
                     });
 
                     return result;

--- a/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -42,11 +42,6 @@ namespace AZ::RHI
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateTransientAttachmentPool();
 
-                if (const auto& name = GetName(); !name.IsEmpty())
-                {
-                    m_deviceObjects[deviceIndex]->SetName(name);
-                }
-
                 resultCode = GetDeviceTransientAttachmentPool(deviceIndex)->Init(*device, m_descriptors[deviceIndex]);
 
                 return resultCode == ResultCode::Success;
@@ -57,6 +52,11 @@ namespace AZ::RHI
             // Reset already initialized device-specific TransientAttachmentPools and set deviceMask to 0
             m_deviceObjects.clear();
             MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
         }
 
         return resultCode;

--- a/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -42,6 +42,11 @@ namespace AZ::RHI
 
                 m_deviceObjects[deviceIndex] = Factory::Get().CreateTransientAttachmentPool();
 
+                if (const auto& name = GetName(); !name.IsEmpty())
+                {
+                    m_deviceObjects[deviceIndex]->SetName(name);
+                }
+
                 resultCode = GetDeviceTransientAttachmentPool(deviceIndex)->Init(*device, m_descriptors[deviceIndex]);
 
                 return resultCode == ResultCode::Success;
@@ -153,6 +158,11 @@ namespace AZ::RHI
                 {
                     image->m_deviceObjects[deviceIndex] = deviceImage;
                     image->SetDescriptor(deviceImage->GetDescriptor());
+
+                    if (const auto& name = image->GetName(); !name.IsEmpty())
+                    {
+                        image->m_deviceObjects[deviceIndex]->SetName(name);
+                    }
                 }
                 else
                 {
@@ -213,6 +223,11 @@ namespace AZ::RHI
                 {
                     buffer->m_deviceObjects[deviceIndex] = deviceBuffer;
                     buffer->SetDescriptor(deviceBuffer->GetDescriptor());
+
+                    if (const auto& name = buffer->GetName(); !name.IsEmpty())
+                    {
+                        buffer->m_deviceObjects[deviceIndex]->SetName(name);
+                    }
                 }
                 else
                 {

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
@@ -77,13 +77,13 @@ namespace UnitTest
                 {
                     this->m_psoEmpty->m_deviceObjects[deviceIndex] = RHI::Factory::Get().CreatePipelineState();
 
-                    if (const auto& name = this->m_psoEmpty->GetName(); !name.IsEmpty())
-                    {
-                        this->m_psoEmpty->m_deviceObjects[deviceIndex]->SetName(name);
-                    }
-
                     return true;
                 });
+
+            if (const auto& name = this->m_psoEmpty->GetName(); !name.IsEmpty())
+            {
+                this->m_psoEmpty->SetName(name);
+            }
 
             for (auto& srg : m_srgs)
             {
@@ -94,13 +94,13 @@ namespace UnitTest
                     {
                         srg->m_deviceObjects[deviceIndex] = RHI::Factory::Get().CreateShaderResourceGroup();
 
-                        if (const auto& name = srg->GetName(); !name.IsEmpty())
-                        {
-                            srg->m_deviceObjects[deviceIndex]->SetName(name);
-                        }
-
                         return true;
                     });
+
+                if (const auto& name = srg->GetName(); !name.IsEmpty())
+                {
+                    srg->SetName(name);
+                }
             }
 
             unsigned int* data = reinterpret_cast<unsigned int*>(m_rootConstants.data());

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
@@ -76,6 +76,12 @@ namespace UnitTest
                 [this](int deviceIndex)
                 {
                     this->m_psoEmpty->m_deviceObjects[deviceIndex] = RHI::Factory::Get().CreatePipelineState();
+
+                    if (const auto& name = this->m_psoEmpty->GetName(); !name.IsEmpty())
+                    {
+                        this->m_psoEmpty->m_deviceObjects[deviceIndex]->SetName(name);
+                    }
+
                     return true;
                 });
 
@@ -87,6 +93,12 @@ namespace UnitTest
                     [&srg](int deviceIndex)
                     {
                         srg->m_deviceObjects[deviceIndex] = RHI::Factory::Get().CreateShaderResourceGroup();
+
+                        if (const auto& name = srg->GetName(); !name.IsEmpty())
+                        {
+                            srg->m_deviceObjects[deviceIndex]->SetName(name);
+                        }
+
                         return true;
                     });
             }


### PR DESCRIPTION
## What does this PR do?

We recently found that calls to `SetName()` are not passed on to the `DeviceObject`s, which leads to incomplete log output, e.g.
```
<12:23:00> [Error] (DeviceBufferPoolBase) - Failed to map buffer ''.
<12:23:00> [Error] (BufferPool) - Unable to map buffer 'EsmParameterBuffer(Directional)(MainPipeline_0)7'.
<12:23:00> [Error] (BufferPool) - Failed to map buffer 'EsmParameterBuffer(Directional)(MainPipeline_0)7'.
<12:23:00> [Error] (RPI::Buffer) - Failed to update RHI buffer. Error code: 2
```
Since `SetName()` is not set consistently before or after the call to `Init()`, it is either directly passed on in the call to `MultiDeviceObject::SetName()` or after creating the `DeviceObject`s in the respective calls to `Init()`.