### PR TITLE
OcclusionBus improved support for culling by entity ID

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OcclusionBus.cpp
@@ -6,6 +6,9 @@
  *
  */
 
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Preprocessor/Enum.h>
+#include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Visibility/OcclusionBus.h>
@@ -14,10 +17,19 @@ DECLARE_EBUS_INSTANTIATION(AzFramework::OcclusionRequests);
 
 namespace AzFramework
 {
+    AZ_ENUM_DEFINE_REFLECT_UTILITIES(OcclusionState);
+
     void OcclusionRequests::Reflect(AZ::ReflectContext* context)
     {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            OcclusionStateReflect(*serializeContext);
+        }
+
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
+            OcclusionStateReflect(*behaviorContext);
+
             behaviorContext->EBus<OcclusionRequestBus>("OcclusionRequestBus")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Visibility")

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -114,6 +114,7 @@ namespace AZ
             {
             }
 
+            AZ::EntityId m_entityId{ AZ::EntityId::InvalidEntityId };
             Data::Asset<RPI::ModelAsset> m_modelAsset;
             bool m_isRayTracingEnabled = true;
             bool m_useForwardPassIblSpecular = false;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2850,6 +2850,7 @@ namespace AZ
             m_cullable.m_cullData.m_boundingObb = localAabb.GetTransformedObb(localToWorld);
             m_cullable.m_cullData.m_visibilityEntry.m_boundingVolume = localAabb.GetTransformedAabb(localToWorld);
             m_cullable.m_cullData.m_visibilityEntry.m_userData = &m_cullable;
+            m_cullable.m_cullData.m_entityId = m_descriptor.m_entityId;
             if (!r_meshInstancingEnabled)
             {
                 m_cullable.m_cullData.m_visibilityEntry.m_typeFlags = AzFramework::VisibilityEntry::TYPE_RPI_Cullable;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -68,6 +68,9 @@ namespace AZ
                 //! Set to all 0's if you don't want to hide the object from any Views.
                 RPI::View::UsageFlags m_hideFlags = RPI::View::UsageNone;
 
+                //! ID of the entity owning this cullable (optional)
+                AZ::EntityId m_entityId{ AZ::EntityId::InvalidEntityId };
+
                 //! UUID and type of the component that owns this cullable (optional)
                 AZ::Uuid m_componentUuid = AZ::Uuid::CreateNull();
                 uint32_t m_componentType = 0;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -490,6 +490,10 @@ namespace AZ
                     worklistData->m_sceneEntityContextId,
                     [&](AzFramework::OcclusionRequestBus::Events* handler)
                     {
+                        // An occlusion culling system might precompute visibility data for static objects or entities in a scene. If the
+                        // system that implements OcclusionRequestBus supports that behavior then we want to perform an initial visibility
+                        // test using the entity ID. This can avoid potentially more expensive dynamic tests, like those against an
+                        // occlusion buffer.
                         if (visibleEntry->m_typeFlags & AzFramework::VisibilityEntry::TYPE_RPI_Cullable)
                         {
                             auto cullable = static_cast<RPI::Cullable*>(visibleEntry->m_userData);
@@ -499,6 +503,9 @@ namespace AZ
                             }
                         }
 
+                        // Entries that don't meet the above criteria or return an inconclusive or partially visible state will perform a
+                        // dynamic, bounding box visibility test. One entity can have multiple visibility entries that may need to be tested
+                        // individually. If the entire entity is hidden, no further testing is required.
                         if (state != AzFramework::OcclusionState::Hidden)
                         {
                             state = handler->GetOcclusionViewAabbVisibility(viewName, visibleEntry->m_boundingVolume);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -483,16 +483,30 @@ namespace AZ
             // Perform occlusion tests using OcclusionRequestBus if it is connected to the entity context ID for this scene.
             if (!worklistData->m_sceneEntityContextId.IsNull())
             {
-                bool result = true;
-                AzFramework::OcclusionRequestBus::EventResult(
-                    result,
+                AzFramework::OcclusionState state = AzFramework::OcclusionState::Unknown;
+                const auto& viewName = worklistData->m_view->GetName();
+
+                AzFramework::OcclusionRequestBus::Event(
                     worklistData->m_sceneEntityContextId,
-                    &AzFramework::OcclusionRequestBus::Events::GetOcclusionViewAabbVisibility,
-                    worklistData->m_view->GetName(),
-                    visibleEntry->m_boundingVolume);
+                    [&](AzFramework::OcclusionRequestBus::Events* handler)
+                    {
+                        if (visibleEntry->m_typeFlags & AzFramework::VisibilityEntry::TYPE_RPI_Cullable)
+                        {
+                            auto cullable = static_cast<RPI::Cullable*>(visibleEntry->m_userData);
+                            if (cullable && cullable->m_cullData.m_entityId.IsValid())
+                            {
+                                state = handler->GetOcclusionViewEntityVisibility(viewName, cullable->m_cullData.m_entityId);
+                            }
+                        }
+
+                        if (state != AzFramework::OcclusionState::Hidden)
+                        {
+                            state = handler->GetOcclusionViewAabbVisibility(viewName, visibleEntry->m_boundingVolume);
+                        }
+                    });
 
                 // Return immediately to bypass MaskedOcclusionCulling
-                return result;
+                return state != AzFramework::OcclusionState::Hidden;
             }
 
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -441,6 +441,7 @@ namespace AZ
 
                 m_meshFeatureProcessor->ReleaseMesh(m_meshHandle);
                 MeshHandleDescriptor meshDescriptor;
+                meshDescriptor.m_entityId = m_entityComponentIdPair.GetEntityId();
                 meshDescriptor.m_modelAsset = m_configuration.m_modelAsset;
                 meshDescriptor.m_customMaterials = ConvertToCustomMaterialMap(materials);
                 meshDescriptor.m_useForwardPassIblSpecular = m_configuration.m_useForwardPassIblSpecular;
@@ -800,6 +801,7 @@ namespace AZ
                 // Copy the index and position data into the visible geometry structure.
                 AzFramework::VisibleGeometry visibleGeometry;
                 visibleGeometry.m_transform = AZ::Matrix4x4::CreateFromTransform(m_transformInterface->GetWorldTM());
+                visibleGeometry.m_transform *= AZ::Matrix4x4::CreateScale(m_cachedNonUniformScale);
 
                 // Reserve space for indices and copy data, assuming stride between elements is 0.
                 visibleGeometry.m_indices.resize_no_construct(indexBufferViewDesc.m_elementCount);


### PR DESCRIPTION
## What does this PR do?

Added occlusion state enum, with invalid state, to replace bool return values Updated occlusion bus functions to return occlusion state enum and invalid state as needed Added an optional entity id member to rhi culling structure to pass through to culling system Updated calls in multiplayer sample and culling system Added support for non uniform transform when recording visible geometry transforms

## How was this PR tested?

Compiled code without errors.
Tested in editor and came launcher.
Confirmed behavior with other local changes.