### PR TITLE
Moving the device mask to ResourcePoolDescriptor.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
@@ -352,7 +352,7 @@ namespace AZ::Render
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
         imagePoolDesc.m_budgetInBytes = ImagePoolBudget;
 
-        RHI::ResultCode resultCode = m_displayMapperImagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
+        RHI::ResultCode resultCode = m_displayMapperImagePool->Init(imagePoolDesc);
         if (resultCode != RHI::ResultCode::Success)
         {
             AZ_Error("AcesDisplayMapperFeatureProcessor", false, "Failed to initialize image pool.");

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -53,10 +53,11 @@ namespace AZ
             RHI::BufferPoolDescriptor desc;
             desc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             desc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
+            desc.m_deviceMask = deviceMask;
 
             m_bufferPool = aznew RHI::BufferPool;
             m_bufferPool->SetName(Name("AuxGeomFixedShapeBufferPool"));
-            RHI::ResultCode resultCode = m_bufferPool->Init(deviceMask, desc);
+            RHI::ResultCode resultCode = m_bufferPool->Init(desc);
 
             if (resultCode != RHI::ResultCode::Success)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -44,7 +44,7 @@ namespace AZ
 
             m_bufferPool = aznew RHI::BufferPool;
             m_bufferPool->SetName(Name("ReflectionProbeBoxBufferPool"));
-            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(RHI::MultiDevice::AllDevices, desc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(desc);
             AZ_Error("ReflectionProbeFeatureProcessor", resultCode == RHI::ResultCode::Success, "Failed to initialize buffer pool");
 
             // create box mesh vertices and indices

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResourcePoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResourcePoolDescriptor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI.Reflect/Limits.h>
 #include <Atom/RHI.Reflect/MemoryEnums.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
@@ -34,5 +35,8 @@ namespace AZ::RHI
         //! the platform itself may still report out of memory errors. Therefore, it is strongly recommended to assign
         //! a budget to Device pools where virtual memory is not present on most platforms.
         AZ::u64 m_budgetInBytes = 0;
+
+        /// The device mask used to create resources from this pool.
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -48,7 +48,7 @@ namespace AZ::RHI
         //!  @param descriptor The descriptor containing properties used to initialize the pool.
         //!  @return A result code denoting the status of the call. If successful, the pool is considered
         //!      initialized and is able to service buffer requests. If failure, the pool remains uninitialized.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor);
+        ResultCode Init(const BufferPoolDescriptor& descriptor);
 
         //! Initializes a buffer instance created from this pool. The buffer must be in an uninitialized
         //! state, or the call will fail. To re-use an existing buffer instance, first call Shutdown

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
@@ -32,7 +32,7 @@ namespace AZ::RHI
         virtual ~ImagePool() = default;
 
         //! Initializes the pool. The pool must be initialized before images can be registered with it.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor);
+        ResultCode Init(const ImagePoolDescriptor& descriptor);
 
         //! Initializes an image onto the pool. The pool provides backing GPU resources to the image.
         ResultCode InitImage(const ImageInitRequest& request);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPool.h
@@ -35,8 +35,9 @@ namespace AZ::RHI
         QueryPool() = default;
         virtual ~QueryPool() override = default;
 
-        //!  Initialize the QueryPool by initializing all device-specific QueryPools for each device mentioned in the deviceMask.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor);
+        //!  Initialize the QueryPool by initializing all device-specific QueryPools for each device mentioned in the descriptor's
+        //!  deviceMask.
+        ResultCode Init(const QueryPoolDescriptor& descriptor);
 
         //! Initialize a query from the pool (one device-specific query for each DeviceQueryPool).
         //! When initializing multiple queries use the other version of InitQuery

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupPool.h
@@ -34,7 +34,7 @@ namespace AZ::RHI
         virtual ~ShaderResourceGroupPool() override = default;
 
         //! Initializes the shader resource group pool for all devices noted in the deviceMask.
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupPoolDescriptor& descriptor);
+        ResultCode Init(const ShaderResourceGroupPoolDescriptor& descriptor);
 
         //! Initializes the resource group and associates it with the pool. The resource
         //! group must be updated on this pool.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -33,7 +33,7 @@ namespace AZ
             virtual ~StreamingImagePool() = default;
 
             //! Initializes the pool. The pool must be initialized before images can be registered with it.
-            ResultCode Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor);
+            ResultCode Init(const StreamingImagePoolDescriptor& descriptor);
 
             //! Initializes the backing resources of an image.
             ResultCode InitImage(const StreamingImageInitRequest& request);

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -100,10 +100,10 @@ namespace AZ::RHI
         return true;
     }
 
-    ResultCode BufferPool::Init(MultiDevice::DeviceMask deviceMask, const BufferPoolDescriptor& descriptor)
+    ResultCode BufferPool::Init(const BufferPoolDescriptor& descriptor)
     {
         return ResourcePool::Init(
-            deviceMask,
+            descriptor.m_deviceMask,
             [this, &descriptor]()
             {
                 if (!ValidatePoolDescriptor(descriptor))

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -64,7 +64,7 @@ namespace AZ::RHI
             return resultCode;
         }
 
-        RHI::MultiDevice::DeviceMask transientAttachmentPoolDeviceMask{0};
+        RHI::MultiDevice::DeviceMask transientAttachmentPoolDeviceMask{ 0 };
 
         for (auto& [deviceIndex, transientAttachmentPoolDescriptor] : descriptor.m_transientAttachmentPoolDescriptors)
         {
@@ -77,7 +77,8 @@ namespace AZ::RHI
         if (transientAttachmentPoolDeviceMask != static_cast<RHI::MultiDevice::DeviceMask>(0))
         {
             m_transientAttachmentPool = aznew TransientAttachmentPool();
-            resultCode = m_transientAttachmentPool->Init(transientAttachmentPoolDeviceMask, descriptor.m_transientAttachmentPoolDescriptors);
+            resultCode =
+                m_transientAttachmentPool->Init(transientAttachmentPoolDeviceMask, descriptor.m_transientAttachmentPoolDescriptors);
 
             if (resultCode != ResultCode::Success)
             {

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -12,10 +12,10 @@
 
 namespace AZ::RHI
 {
-    ResultCode ImagePool::Init(MultiDevice::DeviceMask deviceMask, const ImagePoolDescriptor& descriptor)
+    ResultCode ImagePool::Init(const ImagePoolDescriptor& descriptor)
     {
         return ResourcePool::Init(
-            deviceMask,
+            descriptor.m_deviceMask,
             [this, &descriptor]()
             {
                 // Assign the descriptor prior to initialization. Technically, the descriptor is undefined

--- a/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
@@ -15,7 +15,7 @@
 
 namespace AZ::RHI
 {
-    ResultCode QueryPool::Init(MultiDevice::DeviceMask deviceMask, const QueryPoolDescriptor& descriptor)
+    ResultCode QueryPool::Init(const QueryPoolDescriptor& descriptor)
     {
         if (Validation::IsEnabled())
         {
@@ -41,7 +41,7 @@ namespace AZ::RHI
         }
 
         auto resultCode = ResourcePool::Init(
-            deviceMask,
+            descriptor.m_deviceMask,
             [this, &descriptor]()
             {
                 // Assign the descriptor prior to initialization. Technically, the descriptor is undefined

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -14,8 +14,7 @@
 
 namespace AZ::RHI
 {
-    ResultCode ShaderResourceGroupPool::Init(
-        MultiDevice::DeviceMask deviceMask, const ShaderResourceGroupPoolDescriptor& descriptor)
+    ResultCode ShaderResourceGroupPool::Init(const ShaderResourceGroupPoolDescriptor& descriptor)
     {
         if (Validation::IsEnabled())
         {
@@ -27,7 +26,7 @@ namespace AZ::RHI
         }
 
         ResultCode resultCode = ResourcePool::Init(
-            deviceMask,
+            descriptor.m_deviceMask,
             [this, &descriptor]()
             {
                 IterateDevices(

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -62,12 +62,12 @@ namespace AZ::RHI
         return true;
     }
 
-    ResultCode StreamingImagePool::Init(MultiDevice::DeviceMask deviceMask, const StreamingImagePoolDescriptor& descriptor)
+    ResultCode StreamingImagePool::Init(const StreamingImagePoolDescriptor& descriptor)
     {
         AZ_PROFILE_FUNCTION(RHI);
 
         return ResourcePool::Init(
-            deviceMask,
+            descriptor.m_deviceMask,
             [this, &descriptor]()
             {
                 // Assign the descriptor prior to initialization. Technically, the descriptor is undefined

--- a/Gems/Atom/RHI/Code/Tests/FrameGraphTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameGraphTests.cpp
@@ -90,7 +90,8 @@ namespace UnitTest
 
                 RHI::BufferPoolDescriptor desc;
                 desc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
-                m_state->m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, desc);
+                desc.m_deviceMask = RHI::MultiDevice::DefaultDevice;
+                m_state->m_bufferPool->Init(desc);
             }
 
             for (uint32_t i = 0; i < BufferCount; ++i)
@@ -117,7 +118,8 @@ namespace UnitTest
 
                 RHI::ImagePoolDescriptor desc;
                 desc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
-                m_state->m_imagePool->Init(RHI::MultiDevice::DefaultDevice, desc);
+                desc.m_deviceMask = RHI::MultiDevice::DefaultDevice;
+                m_state->m_imagePool->Init(desc);
             }
 
             for (uint32_t i = 0; i < ImageCount; ++i)

--- a/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameSchedulerTests.cpp
@@ -171,7 +171,8 @@ namespace UnitTest
 
                 RHI::BufferPoolDescriptor desc;
                 desc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
-                m_state->m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, desc);
+                desc.m_deviceMask = RHI::MultiDevice::DefaultDevice;
+                m_state->m_bufferPool->Init(desc);
             }
 
             for (uint32_t i = 0; i < ImportedBufferCount; ++i)
@@ -197,7 +198,7 @@ namespace UnitTest
 
                 RHI::ImagePoolDescriptor desc;
                 desc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
-                m_state->m_imagePool->Init(RHI::MultiDevice::AllDevices, desc);
+                m_state->m_imagePool->Init(desc);
             }
 
             for (uint32_t i = 0; i < ImportedImageCount; ++i)

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
@@ -66,7 +66,7 @@ namespace UnitTest
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
-            bufferPool->Init(DeviceMask, bufferPoolDesc);
+            bufferPool->Init(bufferPoolDesc);
 
             AZStd::vector<uint8_t> testData(32);
             for (uint32_t i = 0; i < 32; ++i)
@@ -140,7 +140,7 @@ namespace UnitTest
 
             RHI::Ptr<AZ::RHI::BufferPool> bufferPoolB;
             bufferPoolB = aznew AZ::RHI::BufferPool;
-            bufferPoolB->Init(DeviceMask, bufferPoolDesc);
+            bufferPoolB->Init(bufferPoolDesc);
 
             initRequest.m_buffer = bufferB.get();
             initRequest.m_descriptor = RHI::BufferDescriptor(RHI::BufferBindFlags::Constant, 16);
@@ -170,7 +170,7 @@ namespace UnitTest
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
-            bufferPool->Init(DeviceMask, bufferPoolDesc);
+            bufferPool->Init(bufferPoolDesc);
 
             RHI::Ptr<RHI::Buffer> buffer;
             buffer = aznew RHI::Buffer;
@@ -253,7 +253,7 @@ namespace UnitTest
             m_bufferPool = aznew AZ::RHI::BufferPool;
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = GetParam().bufferBindFlags;
-            m_bufferPool->Init(DeviceMask, bufferPoolDesc);
+            m_bufferPool->Init(bufferPoolDesc);
 
             m_buffer = aznew RHI::Buffer;
             RHI::BufferInitRequest initRequest;
@@ -499,7 +499,7 @@ namespace UnitTest
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
-        bufferPool->Init(DeviceMask, bufferPoolDesc);
+        bufferPool->Init(bufferPoolDesc);
 
         RHI::Ptr<RHI::Buffer> buffer;
         buffer = aznew RHI::Buffer;

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceDrawPacketTests.cpp
@@ -63,9 +63,10 @@ namespace UnitTest
         MultiDeviceDrawPacketData(SimpleLcgRandom& random)
         {
             RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_deviceMask = LocalDeviceMask;
             m_bufferPool = aznew RHI::BufferPool;
             m_bufferEmpty = aznew RHI::Buffer;
-            m_bufferPool->Init(LocalDeviceMask, bufferPoolDesc);
+            m_bufferPool->Init(bufferPoolDesc);
             RHI::BufferInitRequest request;
             request.m_buffer = m_bufferEmpty.get();
             request.m_descriptor = RHI::BufferDescriptor{};

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
@@ -61,7 +61,7 @@ namespace UnitTest
 
             RHI::ImagePoolDescriptor imagePoolDesc;
             imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
-            imagePool->Init(DeviceMask, imagePoolDesc);
+            imagePool->Init(imagePoolDesc);
 
             ASSERT_TRUE(imageA->IsInitialized() == false);
             ASSERT_TRUE(imageB->IsInitialized() == false);
@@ -116,7 +116,7 @@ namespace UnitTest
 
             RHI::Ptr<RHI::ImagePool> imagePoolB;
             imagePoolB = aznew RHI::ImagePool;
-            imagePoolB->Init(DeviceMask, imagePoolDesc);
+            imagePoolB->Init(imagePoolDesc);
 
             initRequest.m_image = imageB.get();
             initRequest.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::Color, 8, 8, RHI::Format::R8G8B8A8_UNORM_SRGB);
@@ -145,7 +145,7 @@ namespace UnitTest
 
             RHI::ImagePoolDescriptor imagePoolDesc;
             imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color;
-            imagePool->Init(DeviceMask, imagePoolDesc);
+            imagePool->Init(imagePoolDesc);
 
             RHI::Ptr<RHI::Image> image;
             image = aznew RHI::Image;
@@ -249,7 +249,7 @@ namespace UnitTest
             m_imagePool = aznew RHI::ImagePool;
             RHI::ImagePoolDescriptor imagePoolDesc;
             imagePoolDesc.m_bindFlags = GetParam().imageBindFlags;
-            m_imagePool->Init(DeviceMask, imagePoolDesc);
+            m_imagePool->Init(imagePoolDesc);
 
             RHI::ImageDescriptor imageDescriptor;
             imageDescriptor.m_bindFlags = GetParam().imageBindFlags;

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceIndirectBufferTests.cpp
@@ -56,7 +56,7 @@ namespace UnitTest
             m_bufferPool = aznew AZ::RHI::BufferPool;
             RHI::BufferPoolDescriptor poolDesc;
             poolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
-            m_bufferPool->Init(DeviceMask, poolDesc);
+            m_bufferPool->Init(poolDesc);
 
             m_buffer = aznew AZ::RHI::Buffer;
             RHI::BufferInitRequest initRequest;

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
@@ -70,7 +70,7 @@ namespace UnitTest
             queryPoolDesc.m_queriesCount = 2;
             queryPoolDesc.m_type = RHI::QueryType::Occlusion;
             queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
-            queryPool->Init(DeviceMask, queryPoolDesc);
+            queryPool->Init(queryPoolDesc);
 
             EXPECT_FALSE(queryA->IsInitialized());
             EXPECT_FALSE(queryB->IsInitialized());
@@ -107,7 +107,7 @@ namespace UnitTest
 
             RHI::Ptr<RHI::QueryPool> queryPoolB;
             queryPoolB = aznew RHI::QueryPool;
-            queryPoolB->Init(DeviceMask, queryPoolDesc);
+            queryPoolB->Init(queryPoolDesc);
 
             queryPoolB->InitQuery(queryB.get());
             EXPECT_EQ(queryB->GetPool(), queryPoolB.get());
@@ -140,7 +140,7 @@ namespace UnitTest
         queryPoolDesc.m_queriesCount = numQueries;
         queryPoolDesc.m_type = RHI::QueryType::Occlusion;
         queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
-        queryPool->Init(DeviceMask, queryPoolDesc);
+        queryPool->Init(queryPoolDesc);
 
         AZStd::vector<RHI::Query*> queriesToInitialize(numQueries);
         for (size_t i = 0; i < queries.size(); ++i)
@@ -230,7 +230,7 @@ namespace UnitTest
         queryPoolDesc.m_queriesCount = numQueries;
         queryPoolDesc.m_type = RHI::QueryType::Occlusion;
         queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
-        queryPool->Init(DeviceMask, queryPoolDesc);
+        queryPool->Init(queryPoolDesc);
 
         AZStd::vector<RHI::Query*> queriesToInitialize(numQueries);
         for (size_t i = 0; i < queries.size(); ++i)
@@ -299,7 +299,7 @@ namespace UnitTest
             queryPoolDesc.m_pipelineStatisticsMask = queryPoolDesc.m_type == RHI::QueryType::PipelineStatistics
                 ? RHI::PipelineStatisticsFlags::CInvocations
                 : RHI::PipelineStatisticsFlags::None;
-            queryPool->Init(DeviceMask, queryPoolDesc);
+            queryPool->Init(queryPoolDesc);
         }
 
         auto& occlusionQueryPool = queryPools[static_cast<uint32_t>(RHI::QueryType::Occlusion)];
@@ -424,19 +424,19 @@ namespace UnitTest
         queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
         // Count of 0
         AZ_TEST_START_ASSERTTEST;
-        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        EXPECT_EQ(queryPool->Init(queryPoolDesc), RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(1);
 
         // valid m_pipelineStatisticsMask for Occlusion QueryType
         queryPoolDesc.m_queriesCount = 1;
         queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::CInvocations;
-        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+        EXPECT_EQ(queryPool->Init(queryPoolDesc), RHI::ResultCode::Success);
 
         // invalid m_pipelineStatisticsMask for PipelineStatistics QueryType
         queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
         queryPoolDesc.m_pipelineStatisticsMask = RHI::PipelineStatisticsFlags::None;
         AZ_TEST_START_ASSERTTEST;
-        EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::InvalidArgument);
+        EXPECT_EQ(queryPool->Init(queryPoolDesc), RHI::ResultCode::InvalidArgument);
         AZ_TEST_STOP_ASSERTTEST(1);
     }
 
@@ -452,7 +452,7 @@ namespace UnitTest
             queryPoolDesc.m_queriesCount = 2;
             queryPoolDesc.m_type = RHI::QueryType::PipelineStatistics;
             queryPoolDesc.m_pipelineStatisticsMask = mask;
-            EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+            EXPECT_EQ(queryPool->Init(queryPoolDesc), RHI::ResultCode::Success);
         }
 
         RHI::Ptr<RHI::Query> query = aznew RHI::Query;
@@ -505,7 +505,7 @@ namespace UnitTest
             RHI::QueryPoolDescriptor queryPoolDesc;
             queryPoolDesc.m_queriesCount = 5;
             queryPoolDesc.m_type = RHI::QueryType::Occlusion;
-            EXPECT_EQ(queryPool->Init(DeviceMask, queryPoolDesc), RHI::ResultCode::Success);
+            EXPECT_EQ(queryPool->Init(queryPoolDesc), RHI::ResultCode::Success);
 
             for (size_t i = 0; i < queries2.size(); ++i)
             {

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceShaderResourceGroupTests.cpp
@@ -202,11 +202,11 @@ namespace UnitTest
                     descriptor.m_layout = srgLayout.get();
 
                     ASSERT_FALSE(srgPool->IsInitialized());
-                    srgPool->Init(DeviceMask, descriptor);
+                    srgPool->Init(descriptor);
                     ASSERT_TRUE(srgPool->IsInitialized());
                     srgPool->Shutdown();
                     ASSERT_FALSE(srgPool->IsInitialized());
-                    srgPool->Init(DeviceMask, descriptor);
+                    srgPool->Init(descriptor);
                     ASSERT_TRUE(srgPool->IsInitialized());
                     ASSERT_TRUE(srgPool->use_count() == 1);
 
@@ -310,7 +310,7 @@ namespace UnitTest
             RHI::ShaderResourceGroupPoolDescriptor descriptor;
             descriptor.m_budgetInBytes = 16;
             descriptor.m_layout = srgLayout.get();
-            srgPool->Init(DeviceMask, descriptor);
+            srgPool->Init(descriptor);
 
             RHI::Ptr<RHI::ShaderResourceGroup> srg = aznew AZ::RHI::ShaderResourceGroup;
             srgPool->InitGroup(*srg);
@@ -495,7 +495,7 @@ namespace UnitTest
 
             RHI::ShaderResourceGroupPoolDescriptor descriptor;
             descriptor.m_layout = srgLayout.get();
-            srgPool->Init(DeviceMask, descriptor);
+            srgPool->Init(descriptor);
 
             RHI::Ptr<RHI::ShaderResourceGroup> srg = aznew AZ::RHI::ShaderResourceGroup;
             srgPool->InitGroup(*srg);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
@@ -45,8 +45,8 @@ namespace AZ
             BufferPool() = default;
 
             // Standard asset creation path.
-            static Data::Instance<BufferPool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
-            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
+            static Data::Instance<BufferPool> CreateInternal(ResourcePoolAsset& poolAsset);
+            RHI::ResultCode Init(ResourcePoolAsset& poolAsset);
 
             RHI::Ptr<RHI::BufferPool> m_pool;
         };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferSystem.h
@@ -33,7 +33,7 @@ namespace AZ
             Data::Instance<Buffer> CreateBufferFromCommonPool(const CommonBufferDescriptor& descriptor) override;
             Data::Instance<Buffer> FindCommonBuffer(AZStd::string_view uniqueBufferName) override;
 
-            void Init(RHI::MultiDevice::DeviceMask deviceMask);
+            void Init();
             void Shutdown();
 
         protected:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
@@ -46,8 +46,8 @@ namespace AZ
             AttachmentImagePool() = default;
 
             // Standard asset creation path.
-            static Data::Instance<AttachmentImagePool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
-            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset);
+            static Data::Instance<AttachmentImagePool> CreateInternal(ResourcePoolAsset& poolAsset);
+            RHI::ResultCode Init(ResourcePoolAsset& poolAsset);
 
             /// The RHI image pool instance.
             RHI::Ptr<RHI::ImagePool> m_pool;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageSystem.h
@@ -43,7 +43,7 @@ namespace AZ
             static void Reflect(AZ::ReflectContext* context);
             static void GetAssetHandlers(AssetHandlerPtrList& assetHandlers);
 
-            void Init(RHI::MultiDevice::DeviceMask deviceMask, const ImageSystemDescriptor& desc);
+            void Init(const ImageSystemDescriptor& desc);
             void Shutdown();
 
             //! Performs a streaming controller update tick, which will fetch / evict mips

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
@@ -81,8 +81,8 @@ namespace AZ
             StreamingImagePool() = default;
 
             // Standard init path from asset data.
-            static Data::Instance<StreamingImagePool> CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& streamingImagePoolAsset);
-            RHI::ResultCode Init(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& poolAsset);
+            static Data::Instance<StreamingImagePool> CreateInternal(StreamingImagePoolAsset& streamingImagePoolAsset);
+            RHI::ResultCode Init(StreamingImagePoolAsset& poolAsset);
 
             // Updates the streaming controller (ticked by the system component).
             void Update();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferPool.cpp
@@ -28,10 +28,10 @@ namespace AZ
                 resourcePoolAsset);
         }
 
-        Data::Instance<BufferPool> BufferPool::CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
+        Data::Instance<BufferPool> BufferPool::CreateInternal(ResourcePoolAsset& poolAsset)
         {
             Data::Instance<BufferPool> bufferPool = aznew BufferPool();
-            RHI::ResultCode resultCode = bufferPool->Init(deviceMask, poolAsset);
+            RHI::ResultCode resultCode = bufferPool->Init(poolAsset);
             if (resultCode == RHI::ResultCode::Success)
             {
                 return bufferPool;
@@ -40,7 +40,7 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode BufferPool::Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
+        RHI::ResultCode BufferPool::Init(ResourcePoolAsset& poolAsset)
         {
             RHI::Ptr<RHI::BufferPool> bufferPool = aznew RHI::BufferPool;
             if (!bufferPool)
@@ -57,7 +57,7 @@ namespace AZ
             }
 
             bufferPool->SetName(AZ::Name{ poolAsset.GetPoolName() });
-            RHI::ResultCode resultCode = bufferPool->Init(deviceMask, *desc);
+            RHI::ResultCode resultCode = bufferPool->Init(*desc);
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_pool = bufferPool;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
@@ -34,7 +34,7 @@ namespace AZ
             assetHandlers.emplace_back(MakeAssetHandler<BufferAssetHandler>());
         }
 
-        void BufferSystem::Init(RHI::MultiDevice::DeviceMask deviceMask)
+        void BufferSystem::Init()
         {
             {
                 Data::InstanceHandler<Buffer> handler;
@@ -47,9 +47,9 @@ namespace AZ
 
             {
                 Data::InstanceHandler<BufferPool> handler;
-                handler.m_createFunction = [deviceMask](Data::AssetData* poolAsset)
+                handler.m_createFunction = [](Data::AssetData* poolAsset)
                 {
-                    return BufferPool::CreateInternal(deviceMask, *(azrtti_cast<ResourcePoolAsset*>(poolAsset)));
+                    return BufferPool::CreateInternal(*(azrtti_cast<ResourcePoolAsset*>(poolAsset)));
                 };
                 Data::InstanceDatabase<BufferPool>::Create(azrtti_typeid<ResourcePoolAsset>(), handler);
             }
@@ -152,7 +152,7 @@ namespace AZ
             }
 
             bufferPool->SetName(Name(AZStd::string::format("RPI::CommonBufferPool_%i", static_cast<uint32_t>(poolType))));
-            RHI::ResultCode resultCode = bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
+            RHI::ResultCode resultCode = bufferPool->Init(bufferPoolDesc);
             if (resultCode != RHI::ResultCode::Success)
             {
                 AZ_Error("BufferSystem", false, "Failed to create buffer pool: %d", poolType);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/QueryPool.cpp
@@ -77,7 +77,7 @@ namespace AZ
                 m_rhiQueryPool = aznew RHI::QueryPool();
                 AZStd::string poolName = AZStd::string::format("%sQueryPool", GetQueryTypeString(queryType));
                 m_rhiQueryPool->SetName(AZ::Name(poolName));
-                [[maybe_unused]] auto result = m_rhiQueryPool->Init(RHI::MultiDevice::AllDevices, queryPoolDesc);
+                [[maybe_unused]] auto result = m_rhiQueryPool->Init(queryPoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to create the query pool");
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImagePool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImagePool.cpp
@@ -28,11 +28,10 @@ namespace AZ
                 resourcePoolAsset);
         }
 
-        Data::Instance<AttachmentImagePool> AttachmentImagePool::CreateInternal(
-            RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
+        Data::Instance<AttachmentImagePool> AttachmentImagePool::CreateInternal(ResourcePoolAsset& poolAsset)
         {
             Data::Instance<AttachmentImagePool> imagePool = aznew AttachmentImagePool();
-            RHI::ResultCode resultCode = imagePool->Init(deviceMask, poolAsset);
+            RHI::ResultCode resultCode = imagePool->Init(poolAsset);
 
             if (resultCode == RHI::ResultCode::Success)
             {
@@ -42,7 +41,7 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode AttachmentImagePool::Init(RHI::MultiDevice::DeviceMask deviceMask, ResourcePoolAsset& poolAsset)
+        RHI::ResultCode AttachmentImagePool::Init(ResourcePoolAsset& poolAsset)
         {
             RHI::Ptr<RHI::ImagePool> imagePool = aznew RHI::ImagePool;
             if (!imagePool)
@@ -59,7 +58,7 @@ namespace AZ
             }
 
             imagePool->SetName(AZ::Name(poolAsset.GetPoolName()));
-            RHI::ResultCode resultCode = imagePool->Init(deviceMask, *desc);
+            RHI::ResultCode resultCode = imagePool->Init(*desc);
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_pool = imagePool;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -131,7 +131,7 @@ namespace AZ
             assetHandlers.emplace_back(MakeAssetHandler<StreamingImagePoolAssetHandler>());
         }
 
-        void ImageSystem::Init(RHI::MultiDevice::DeviceMask deviceMask, const ImageSystemDescriptor& desc)
+        void ImageSystem::Init(const ImageSystemDescriptor& desc)
         {
             // Register attachment image instance database.
             {
@@ -145,9 +145,9 @@ namespace AZ
 
             {
                 Data::InstanceHandler<AttachmentImagePool> handler;
-                handler.m_createFunction = [deviceMask](Data::AssetData* poolAsset)
+                handler.m_createFunction = [](Data::AssetData* poolAsset)
                 {
-                    return AttachmentImagePool::CreateInternal(deviceMask, *(azrtti_cast<ResourcePoolAsset*>(poolAsset)));
+                    return AttachmentImagePool::CreateInternal(*(azrtti_cast<ResourcePoolAsset*>(poolAsset)));
                 };
                 Data::InstanceDatabase<AttachmentImagePool>::Create(azrtti_typeid<ResourcePoolAsset>(), handler);
             }
@@ -165,9 +165,10 @@ namespace AZ
 
             {
                 Data::InstanceHandler<StreamingImagePool> handler;
-                handler.m_createFunction = [this, deviceMask](Data::AssetData* poolAsset)
+                handler.m_createFunction = [this](Data::AssetData* poolAsset)
                 {
-                    Data::Instance<StreamingImagePool> instance = StreamingImagePool::CreateInternal(deviceMask, *(azrtti_cast<StreamingImagePoolAsset*>(poolAsset)));
+                    Data::Instance<StreamingImagePool> instance =
+                        StreamingImagePool::CreateInternal(*(azrtti_cast<StreamingImagePoolAsset*>(poolAsset)));
                     if (instance)
                     {
                         m_activeStreamingPoolMutex.lock();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImagePool.cpp
@@ -27,10 +27,10 @@ namespace AZ
                 streamingImagePoolAsset);
         }
 
-        Data::Instance<StreamingImagePool> StreamingImagePool::CreateInternal(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& streamingImagePoolAsset)
+        Data::Instance<StreamingImagePool> StreamingImagePool::CreateInternal(StreamingImagePoolAsset& streamingImagePoolAsset)
         {
             Data::Instance<StreamingImagePool> streamingImagePool = aznew StreamingImagePool();
-            const RHI::ResultCode resultCode = streamingImagePool->Init(deviceMask, streamingImagePoolAsset);
+            const RHI::ResultCode resultCode = streamingImagePool->Init(streamingImagePoolAsset);
 
             if (resultCode == RHI::ResultCode::Success)
             {
@@ -40,7 +40,7 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::ResultCode StreamingImagePool::Init(RHI::MultiDevice::DeviceMask deviceMask, StreamingImagePoolAsset& poolAsset)
+        RHI::ResultCode StreamingImagePool::Init(StreamingImagePoolAsset& poolAsset)
         {
             AZ_PROFILE_FUNCTION(RPI);
 
@@ -54,8 +54,7 @@ namespace AZ
             }
 
             RHI::Ptr<RHI::StreamingImagePool> pool = aznew RHI::StreamingImagePool;
-
-            const RHI::ResultCode resultCode = pool->Init(deviceMask, poolAsset.GetPoolDescriptor());
+            const RHI::ResultCode resultCode = pool->Init(poolAsset.GetPoolDescriptor());
 
             if (resultCode == RHI::ResultCode::Success)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -443,8 +443,8 @@ namespace AZ
             }
 
             m_rhiSystem.Init(bindlessSrgLayout);
-            m_imageSystem.Init(RHI::MultiDevice::AllDevices, m_descriptor.m_imageSystemDescriptor);
-            m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
+            m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
+            m_bufferSystem.Init();
             m_dynamicDraw.Init(m_descriptor.m_dynamicDrawSystemDescriptor);
 
             m_passSystem.InitPassTemplates();
@@ -477,8 +477,8 @@ namespace AZ
 
             //Init rhi/image/buffer systems to match InitializeSystemAssets
             m_rhiSystem.Init();
-            m_imageSystem.Init(RHI::MultiDevice::AllDevices, m_descriptor.m_imageSystemDescriptor);
-            m_bufferSystem.Init(RHI::MultiDevice::AllDevices);
+            m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
+            m_bufferSystem.Init();
 
             // Assets aren't actually available or needed for tests, but the m_systemAssetsInitialized flag still needs to be flipped.
             m_systemAssetsInitialized = true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroupPool.cpp
@@ -59,7 +59,7 @@ namespace AZ
 
             m_pool->SetName(AZ::Name(AZStd::string::format("%s_%s",shaderAsset.GetName().GetCStr(),srgName.GetCStr())));
 
-            const RHI::ResultCode resultCode = m_pool->Init(RHI::MultiDevice::AllDevices, poolDescriptor);
+            const RHI::ResultCode resultCode = m_pool->Init(poolDescriptor);
             return resultCode;
         }
 

--- a/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairCommon.cpp
@@ -132,7 +132,7 @@ namespace AZ
             Data::Instance<RHI::ImagePool> UtilityClass::CreateImagePool(RHI::ImagePoolDescriptor& imagePoolDesc)
             {
                 Data::Instance<RHI::ImagePool> imagePool = aznew RHI::ImagePool;
-                RHI::ResultCode result = imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
+                RHI::ResultCode result = imagePool->Init(imagePoolDesc);
                 if (result != RHI::ResultCode::Success)
                 {
                     AZ_Error("CreateImagePool", false, "Failed to create or initialize image pool");

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -59,7 +59,7 @@ namespace AZ
 
             m_bufferPool = aznew RHI::BufferPool;
             m_bufferPool->SetName(Name("DiffuseProbeGridBoxBufferPool"));
-            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(RHI::MultiDevice::AllDevices, desc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(desc);
             AZ_Error("DiffuseProbeGridFeatureProcessor", resultCode == RHI::ResultCode::Success, "Failed to initialize buffer pool");
 
             // create box mesh vertices and indices
@@ -72,7 +72,7 @@ namespace AZ
 
                 m_probeGridRenderData.m_imagePool = aznew RHI::ImagePool;
                 m_probeGridRenderData.m_imagePool->SetName(Name("DiffuseProbeGridRenderImageData"));
-                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
+                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_imagePool->Init(imagePoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
             }
 
@@ -83,7 +83,7 @@ namespace AZ
 
                 m_probeGridRenderData.m_bufferPool = aznew RHI::BufferPool;
                 m_probeGridRenderData.m_bufferPool->SetName(Name("DiffuseProbeGridRenderBufferData"));
-                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
+                [[maybe_unused]] RHI::ResultCode result = m_probeGridRenderData.m_bufferPool->Init(bufferPoolDesc);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output buffer pool");
             }
 

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
@@ -122,7 +122,7 @@ namespace UnitTest
 
         AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
         m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(AZ::RHI::MultiDevice::AllDevices, imageSystemDescriptor);
+        m_imageSystem->Init(imageSystemDescriptor);
     }
 
     void GradientSignalBaseFixture::TearDownCoreSystems()

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
@@ -421,7 +421,7 @@ namespace UnitTest
 
         AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
         m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(AZ::RHI::MultiDevice::AllDevices, imageSystemDescriptor);
+        m_imageSystem->Init(imageSystemDescriptor);
 
         // Now that the RPISystem is activated, activate the system entity.
         m_systemEntity->Init();


### PR DESCRIPTION
## What does this PR do?

Currently, it is not possible to create RPI::BufferPools/RPI::ImagePools with a device mask other than AllDevices, since the BufferSystem and ImageSystem are initialized with this mask. This PR moves the mask to the ResourcePoolDescriptor and resolves this issue. I also changed it for all the other pools to keep the API unified. It also simplifies their code. A disadvantage is that the mask within the descriptor is also part of the descriptor of the DeviceResources. This could be solved by creating a DeviceResourcePoolDescriptor and derivatives, but it feels like that's a worse solution than just ignoring it for device specific resource pools.

## How was this PR tested?

Compiled and ran ASV samples.
