### PR TITLE
Fix for LyShine Atlas Support.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
@@ -96,6 +96,9 @@ namespace ImageProcessingAtom
 
         //! Return true if the preset name is valid
         virtual bool IsValidPreset(PresetName presetName) = 0;
+
+        //! Returns true if the specified extension is supported by the image processing gem
+        virtual bool IsExtensionSupported(const char* extension) = 0;
     };
 
     using ImageBuilderRequestBus = AZ::EBus<ImageBuilderRequests>;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -289,6 +289,11 @@ namespace ImageProcessingAtom
         return ImageProcessingAtom::BuilderSettingManager::Instance()->IsValidPreset(presetName);
     }
 
+    bool BuilderPluginComponent::IsExtensionSupported(const char* extension)
+    {
+        return ImageProcessingAtom::IsExtensionSupported(extension);
+    }
+
     void ImageBuilderWorker::ShutDown()
     {
         // it is important to note that this will be called on a different thread than your process job thread

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
@@ -97,6 +97,8 @@ namespace ImageProcessingAtom
         PresetName GetDefaultAlphaPreset() override;
         bool IsValidPreset(PresetName presetName) override;
 
+        bool IsExtensionSupported(const char* extension) override;
+
         ////////////////////////////////////////////////////////////////////////
 
     private:

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -51,6 +51,9 @@ namespace LyShine
     {
         m_textures[0].m_texture = texture;
         m_textures[0].m_isClampTextureMode = isClampTextureMode;
+
+        m_combinedVertices.reserve(1024);
+        m_combinedIndices.reserve(1024);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -70,12 +73,18 @@ namespace LyShine
         m_textures[0].m_isClampTextureMode = isClampTextureMode;
         m_textures[1].m_texture = maskTexture;
         m_textures[1].m_isClampTextureMode = isClampTextureMode;
+
+        m_combinedVertices.reserve(1024);
+        m_combinedIndices.reserve(1024);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     PrimitiveListRenderNode::~PrimitiveListRenderNode()
     {
         m_primitives.clear();
+
+        m_combinedVertices.clear();
+        m_combinedIndices.clear();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -148,16 +157,13 @@ namespace LyShine
         drawSrg->SetConstant(uiShaderData.m_viewProjInputIndex, modelViewProjMat);
 
         drawSrg->Compile();
-
+        
         // Add the indexed primitives to the dynamic draw context for drawing
         //
         // [LYSHINE_ATOM_TODO][ATOM-15073] Combine into a single DrawIndexed call to take advantage of the draw call
         // optimization done by this RenderGraph. This option will be added to DynamicDrawContext. For
-        // now we could combine the vertices ourselves
-        for (const LyShine::UiPrimitive& primitive : m_primitives)
-        {
-            dynamicDraw->DrawIndexed(primitive.m_vertices, primitive.m_numVertices, primitive.m_indices, primitive.m_numIndices, AZ::RHI::IndexFormat::Uint16, drawSrg);
-        }
+        // now we combine the vertices ourselves during AddPrimitive
+        dynamicDraw->DrawIndexed(&m_combinedVertices[0], (uint32_t)m_combinedVertices.size(), &m_combinedIndices[0],  (uint32_t)m_combinedIndices.size(), AZ::RHI::IndexFormat::Uint16, drawSrg);
 
         uiRenderer->SetBaseState(prevBaseState);
     }
@@ -168,6 +174,16 @@ namespace LyShine
         // always clear the next pointer before adding to list
         primitive->m_next = nullptr;
         m_primitives.push_back(*primitive);
+
+        uint16 vertex_index_start = (uint16)m_combinedVertices.size();
+
+        // Add the vertices at the
+        m_combinedVertices.insert(m_combinedVertices.end(), primitive->m_vertices, primitive->m_vertices + primitive->m_numVertices);
+
+        for (int i = 0; i < primitive->m_numIndices; i++)
+        {
+            m_combinedIndices.push_back(vertex_index_start + primitive->m_indices[i]);
+        }
 
         m_totalNumVertices += primitive->m_numVertices;
         m_totalNumIndices += primitive->m_numIndices;

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -132,6 +132,10 @@ namespace LyShine
         int             m_totalNumIndices;
 
         LyShine::UiPrimitiveList   m_primitives;
+
+        // Per-frame combined vertex and index buffers
+        AZStd::vector<UiPrimitiveVertex> m_combinedVertices;
+        AZStd::vector<uint16> m_combinedIndices;
     };
 
     // A mask render node handles using one set of render nodes to mask another set of render nodes


### PR DESCRIPTION
## What does this PR do?

- Fixes atlas generation: filtering out unsupported file types, and ensuring the generated atlas streamingimage is added as an output product.
- Combing vertex and index buffers in LyShine RenderGraph to reduce drawcalls.

## How was this PR tested?

On PC, verifying that the atlas is loaded and used to reduce drawcalls.
