### PR TITLE
Allow collapsing all passes in pass tree view

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
@@ -37,6 +37,7 @@ namespace AZ
 
             bool m_shouldPreviewAttachment = false;
             bool m_showAttachments = false;
+            bool m_expandAllPasses = true;
 
             AZ::RPI::Pass* m_selectedPass = nullptr;
             AZ::RPI::Pass* m_lastSelectedPass = nullptr;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
@@ -86,6 +86,8 @@ namespace AZ::Render
                 }
             }
 
+            Scriptable_ImGui::Checkbox("Expand All Passes", &m_expandAllPasses);
+
             if (m_showAttachments)
             {
                 Scriptable_ImGui::SliderFloat2("Color Range", m_attachmentColorTranformRange, 0.0f, 1.0f);
@@ -272,7 +274,8 @@ namespace AZ::Render
             else
             {
                 // Draw the pass as a tree node which has attachments as its children
-                ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_DefaultOpen
+                ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick 
+                    | (m_expandAllPasses ? ImGuiTreeNodeFlags_DefaultOpen : 0)
                     | ((m_selectedPassPath == pass->GetPathName()) ? ImGuiTreeNodeFlags_Selected : 0);
 
                 bool nodeOpen = Scriptable_ImGui::TreeNodeEx(pass->GetName().GetCStr(), flags);
@@ -308,7 +311,8 @@ namespace AZ::Render
         else
         {
             // For a ParentPasse, draw it as a tree node 
-            ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_DefaultOpen
+            ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick
+                | (m_expandAllPasses ? ImGuiTreeNodeFlags_DefaultOpen : 0)
                 | ((m_selectedPassPath == pass->GetPathName()) ? ImGuiTreeNodeFlags_Selected : 0);
 
             bool nodeOpen = ImGui::TreeNodeEx(pass->GetName().GetCStr(), flags);


### PR DESCRIPTION
## What does this PR do?

Currently the passes in the ImGui pass tree are all expanded by default, if the pipeline has a lot of passes, seeking for a pass in a pipeline can be painful.

This PR adds an "Expand All Passes" check box to allow expanding/collapsing all passes, and the default behavior of it is to expand all by default, remaining the current behavior but allows users to collapse all passes and only expand his/her wanted pass, making the life easier to find a pass in a long pipeline.

![image](https://github.com/user-attachments/assets/7e5a654a-ceb0-4efc-b83a-bee404ee6e2b)


## How was this PR tested?

Tested in windows.
