### PR TITLE
Fixing Vulkan SparseBinding memoryBindings for 3D texture

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -193,7 +193,11 @@ namespace AZ
                     // find the offset base on bound blocks
                     VkOffset3D offset;
                     offset.x = (boundBlockCount % blockCountPerRow) * imageGranularity.width;
-                    offset.y = (boundBlockCount / blockCountPerRow) * imageGranularity.height;
+                    // the offset.y need to consider 3D texture case. Consider the example if we have 64x64x64(width,height,layer) 3d
+                    // texture and the block size is 16x16x16. When boundBlockCount is 20, without (% blockCountPerColumn), we would get
+                    // offset.y to (20/4 *16) = 80. The later extent.height = mipSize.m_height-offset.y = ((unsigned)64-80) will be a huge
+                    // positive number, thus led to error in sparse Binding.
+                    offset.y = ((boundBlockCount / blockCountPerRow) % blockCountPerColumn) * imageGranularity.height;
                     offset.z = (boundBlockCount / (blockCountPerRow * blockCountPerColumn)) * imageGranularity.depth;
 
                     // only update the width of the extent 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -192,11 +192,8 @@ namespace AZ
                 {
                     // find the offset base on bound blocks
                     VkOffset3D offset;
+                    // The offset need to modulo over the blockCountPerRow/PerColumn to ensure it stays in the boundary
                     offset.x = (boundBlockCount % blockCountPerRow) * imageGranularity.width;
-                    // the offset.y need to consider 3D texture case. Consider the example if we have 64x64x64(width,height,layer) 3d
-                    // texture and the block size is 16x16x16. When boundBlockCount is 20, without (% blockCountPerColumn), we would get
-                    // offset.y to (20/4 *16) = 80. The later extent.height = mipSize.m_height-offset.y = ((unsigned)64-80) will be a huge
-                    // positive number, thus led to error in sparse Binding.
                     offset.y = ((boundBlockCount / blockCountPerRow) % blockCountPerColumn) * imageGranularity.height;
                     offset.z = (boundBlockCount / (blockCountPerRow * blockCountPerColumn)) * imageGranularity.depth;
 


### PR DESCRIPTION
## What does this PR do?

The current `UpdateMipMemoryBindInfo(uint16_t mipLevel)` did not consider the 3D volume texture case.  

Consider the example if we have `64x64x64(width,height,layer` 3d texture and the block size is 16x16x16. When `boundBlockCount` is 20, without `(% blockCountPerColumn)`, we would get `offset.y` to `(20/4 *16) = 80`. The later `extent.height = mipSize.m_height-offset.y = ((unsigned)64-80)` will be a huge positive number because of integer overflow, thus led to error in Sparse binding.

### Results comparisons:

| Before | After Fix |
| :-------: | :----------: |
|   ![1721430474192](https://github.com/user-attachments/assets/3de3eb12-6527-49ad-8e11-eb6ba4ef2d32) | ![1721430496319](https://github.com/user-attachments/assets/08271e64-926a-4ff3-bcc7-33e051eb96e8)
|

## How was this PR tested?

Locally Tested.
