### PR TITLE
Further fixes for the ScriptCanvas debugging facilities

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Script/ScriptSystemBus.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <Builder/ScriptCanvasBuilder.h>
@@ -97,8 +98,20 @@ namespace ScriptCanvasBuilder
         using namespace ScriptCanvasBuilder;
 
         BuilderSourceStorage result;
-        
-        auto assetTreeOutcome = LoadEditorAssetTree(sourceHandle);
+
+        AZ::ApplicationTypeQuery appType;
+        AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+        ScriptCanvas::MakeInternalGraphEntitiesUnique makeUnique = ScriptCanvas::MakeInternalGraphEntitiesUnique::Yes;
+        const bool isAssetProcessor = appType.IsValid() && (appType.IsTool() && !appType.IsEditor());
+        if (isAssetProcessor)
+        {
+            // Allow to keep the same entity UIDs between the editable scriptCanvas and the compiled scriptCanvas files,
+            // This is needed to support debug features such as breakpoints.
+            // In editor we force the UIDs to be re-generated to prevent UIDs collision as entities are not unregistered on file reload.
+            makeUnique = ScriptCanvas::MakeInternalGraphEntitiesUnique::No;
+        }
+
+        auto assetTreeOutcome = LoadEditorAssetTree(sourceHandle, makeUnique);
         if (!assetTreeOutcome.IsSuccess())
         {
             AZ_Warning("ScriptCanvas", false

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
@@ -54,7 +54,7 @@ namespace ScriptCanvasBuilder
         // By default, entity IDs are made unique, so that multiple instances of the script canvas file can be loaded at the same time.
         // However, in this case the file is not loaded multiple times at once, and the entity IDs need to be stable so that
         // the logic used to generate the fingerprint for this file remains stable.
-        auto result = LoadFromFile(fullPath, MakeInternalGraphEntitiesUnique::No, LoadReferencedAssets::No);
+        const auto result = LoadFromFile(fullPath, MakeInternalGraphEntitiesUnique::No, LoadReferencedAssets::No);
         if (result)
         {
             sourceHandle = result.m_handle;
@@ -255,7 +255,7 @@ namespace ScriptCanvasBuilder
             return;
         }
 
-        auto result = LoadFromFile(request.m_fullPath);
+        const auto result = LoadFromFile(request.m_fullPath, MakeInternalGraphEntitiesUnique::No);
         if (!result)
         {
             AZ_Error(s_scriptCanvasBuilder, false, R"(Loading of ScriptCanvas asset for source file "%s" has failed)", fullPath.data());

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -3381,6 +3381,47 @@ namespace ScriptCanvasEditor
         return graphCanvasEndpoint;
     }
 
+    void EditorGraph::SetOriginalToNewIdsMap(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIds)
+    {
+        m_originalIdToNewIds = originalIdToNewIds;
+    }
+
+    void EditorGraph::GetOriginalToNewIdsMap(AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIdsOut) const
+    {
+        originalIdToNewIdsOut = m_originalIdToNewIds;
+    }
+
+    AZ::EntityId EditorGraph::FindNewIdFromOriginal(const AZ::EntityId& originalId) const
+    {
+        if (m_originalIdToNewIds.empty())
+        {
+            return originalId;
+        }
+
+        if (!m_originalIdToNewIds.contains(originalId))
+        {
+            return AZ::EntityId();
+        }
+
+        return m_originalIdToNewIds.at(originalId);
+    }
+
+    AZ::EntityId EditorGraph::FindOriginalIdFromNew(const AZ::EntityId& newId) const
+    {
+        if (m_originalIdToNewIds.empty())
+        {
+            return newId;
+        }
+
+        const auto it = m_originalIdToNewIds.find(newId);
+        if (it == m_originalIdToNewIds.end())
+        {
+            return AZ::EntityId();
+        }
+
+        return it->first;
+    }
+
     void EditorGraph::OnSaveDataDirtied(const AZ::EntityId& savedElement)
     {
         // The EbusHandlerEvent's are a visual only representation of alternative data, and should not be saved.

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Assets/ScriptCanvasFileHandling.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Assets/ScriptCanvasFileHandling.h
@@ -25,7 +25,8 @@ namespace ScriptCanvas
 {
     class ScriptCanvasData;
 
-    AZ::Outcome<SourceTree, AZStd::string> LoadEditorAssetTree(SourceHandle handle);
+    AZ::Outcome<SourceTree, AZStd::string> LoadEditorAssetTree(
+        SourceHandle handle, MakeInternalGraphEntitiesUnique makeUniqueEntities);
     
     struct FileLoadResult
     {

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Bus/EditorScriptCanvasBus.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Bus/EditorScriptCanvasBus.h
@@ -34,37 +34,6 @@ namespace GraphCanvas
 
 namespace ScriptCanvasEditor
 {
-    //=========================================================================
-    // EditorGraphBus
-    //=========================================================================
-    class EditorScriptCanvasRequests : public AZ::EBusTraits
-    {
-    public:
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
-        using BusIdType = ScriptCanvas::ScriptCanvasId;
-
-
-        //! Sets the name of the ScriptCanvas Graph.
-        //! \param name value to set
-        virtual void SetName(const AZStd::string& name) = 0;
-
-        //! Gets the name of the ScriptCanvas Graph.
-        //! \return reference to Graph name
-        virtual const AZStd::string& GetName() const = 0;
-
-        //! Will open the graph in the editor.
-        virtual void OpenEditor() = 0;
-
-        //! Used to close a graph that is currently opened in the editor.
-        virtual void CloseGraph() = 0;
-
-        //! Returns the Entity ID of the Editor Entity that owns this graph.
-        virtual AZ::EntityId GetEditorEntityId() const = 0;
-        virtual AZ::NamedEntityId GetNamedEditorEntityId() const = 0;
-    };
-
-    using EditorScriptCanvasRequestBus = AZ::EBus<EditorScriptCanvasRequests>;
-
     class EditorScriptCanvasComponentRequests : public AZ::EBusTraits
     {
     public:
@@ -76,7 +45,7 @@ namespace ScriptCanvasEditor
     };
 
     using EditorScriptCanvasComponentRequestBus = AZ::EBus<EditorScriptCanvasComponentRequests>;
-            
+
     class EditorGraphRequests : public AZ::EBusTraits
     {
     public:
@@ -119,8 +88,13 @@ namespace ScriptCanvasEditor
 
         virtual ScriptCanvas::Endpoint ConvertToScriptCanvasEndpoint(const GraphCanvas::Endpoint& endpoinnt) const = 0;
         virtual GraphCanvas::Endpoint ConvertToGraphCanvasEndpoint(const ScriptCanvas::Endpoint& endpoint) const = 0;
+
+        virtual void SetOriginalToNewIdsMap(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIds) = 0;
+        virtual void GetOriginalToNewIdsMap(AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIds) const = 0;
+        virtual AZ::EntityId FindNewIdFromOriginal(const AZ::EntityId& originalId) const = 0;
+        virtual AZ::EntityId FindOriginalIdFromNew(const AZ::EntityId& newId) const = 0;
     };
-    
+
     using EditorGraphRequestBus = AZ::EBus<EditorGraphRequests>;
 
     class EditorGraphNotifications

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
@@ -238,14 +238,12 @@ namespace ScriptCanvasEditor
         void DisplayGraphCanvasScene() override;
 
         /////
-        EditorGraphUpgradeMachine m_upgradeSM;
-
         enum UpgradeRequest
         {
             IfOutOfDate,
             Forced
         };
-bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const UpgradeGraphConfig& upgradeConfig);
+        bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const UpgradeGraphConfig& upgradeConfig);
         void ConnectGraphCanvasBuses();
         void DisconnectGraphCanvasBuses();
         ///////
@@ -254,6 +252,7 @@ bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const Upgr
         void OnSystemTick() override;
         ////
 
+        // EditorGraphRequestBus
         void OnGraphCanvasSceneVisible() override;
 
         GraphCanvas::GraphId GetGraphCanvasGraphId() const override;
@@ -287,6 +286,11 @@ bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const Upgr
 
         ScriptCanvas::Endpoint ConvertToScriptCanvasEndpoint(const GraphCanvas::Endpoint& endpoint) const override;
         GraphCanvas::Endpoint ConvertToGraphCanvasEndpoint(const ScriptCanvas::Endpoint& endpoint) const override;
+
+        void SetOriginalToNewIdsMap(const AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIds) override;
+        void GetOriginalToNewIdsMap(AZStd::unordered_map<AZ::EntityId, AZ::EntityId>& originalIdToNewIdsOut) const override;
+        AZ::EntityId FindNewIdFromOriginal(const AZ::EntityId& originalId) const override;
+        AZ::EntityId FindOriginalIdFromNew(const AZ::EntityId& newId) const override;
         ////
 
         bool OnVersionConversionBegin(ScriptCanvas::Node& node);
@@ -342,8 +346,6 @@ bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const Upgr
         void HandleQueuedUpdates();
         bool IsNodeVersionConverting(const AZ::EntityId& graphCanvasNodeId) const;
 
-        AZStd::unordered_map< AzToolsFramework::ToastId, AZ::EntityId > m_toastNodeIds;
-
         // Function Definition Node Extension
         void HandleFunctionDefinitionExtension(ScriptCanvas::Node* node, GraphCanvas::SlotId graphCanvasSlotId, const GraphCanvas::NodeId& nodeId);
 
@@ -395,6 +397,10 @@ bool UpgradeGraph(SourceHandle source, UpgradeRequest upgradeRequest, const Upgr
 
         void RefreshVariableReferences(const ScriptCanvas::VariableId& variableId) override;
 
+    private:
+        AZStd::unordered_map<AZ::EntityId, AZ::EntityId> m_originalIdToNewIds;
+        EditorGraphUpgradeMachine m_upgradeSM;
+        AZStd::unordered_map<AzToolsFramework::ToastId, AZ::EntityId> m_toastNodeIds;
         bool m_allowVersionUpdate = false;
         AZStd::unordered_set< AZ::EntityId > m_queuedConvertingNodes;
         AZStd::unordered_set< AZ::EntityId > m_convertingNodes;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
@@ -9,8 +9,9 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <EditorCoreAPI.h>
-#include <ScriptCanvas/Asset/RuntimeAsset.h>
 #include <IEditor.h>
+#include <QtWidgets/QLabel>
+#include <ScriptCanvas/Asset/RuntimeAsset.h>
 
 #include <Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.h>
 
@@ -223,6 +224,15 @@ namespace ScriptCanvasEditor
 
         m_ui->autoCaptureToggle->setChecked(m_userSettings->IsAutoCaptureEnabled());
         QObject::connect(m_ui->autoCaptureToggle, &QToolButton::toggled, this, &LiveLoggingWindowSession::OnAutoCaptureToggled);
+
+        if (!AzFramework::RemoteToolsInterface::Get())
+        {
+            m_ui->logTree->setHidden(true);
+            m_ui->verticalLayout->setAlignment(Qt::AlignTop);
+            QLabel* warnMessage = new QLabel("Please enable the **Remote Tools Connection** gem to use graph debugging features");
+            warnMessage->setTextFormat(Qt::MarkdownText);
+            m_ui->verticalLayout->addWidget(warnMessage);
+        }
     }
 
     LiveLoggingWindowSession::~LiveLoggingWindowSession()

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -10,6 +10,8 @@
 #include <QGraphicsItem>
 #include <QScopedValueRollback>
 
+#include <AzCore/Asset/AssetManagerBus.h>
+
 #include <GraphCanvas/Components/Nodes/NodeTitleBus.h>
 #include <GraphCanvas/Components/SceneBus.h>
 #include <GraphCanvas/Components/Slots/SlotBus.h>
@@ -247,52 +249,35 @@ namespace ScriptCanvasEditor
     {
         if (modelIndex.column() == DebugLogTreeItem::Column::ScriptName)
         {
-            QModelIndex sourceIndex = m_filterModel->mapToSource(modelIndex);
-            DebugLogTreeItem* treeItem = static_cast<DebugLogTreeItem*>(sourceIndex.internalPointer());
-
-            if (ExecutionLogTreeItem* executionItem = azrtti_cast<ExecutionLogTreeItem*>(treeItem))
-            {
-                QScopedValueRollback<bool> valueRollback(m_clearSelectionOnSceneSelectionChange, false);
-
-                const AZ::Data::AssetId& assetId = executionItem->GetAssetId();
-                
-                GeneralRequestBus::Broadcast(&GeneralRequests::OpenScriptCanvasAssetId
-                    , SourceHandle(nullptr, assetId.m_guid), Tracker::ScriptCanvasFileState::UNMODIFIED);
-            }
+            OnLogDoubleClicked(modelIndex);
         }
     }
 
     void LoggingWindowSession::OnLogDoubleClicked(const QModelIndex& modelIndex)
     {
         ExecutionLogTreeItem* executionItem = ResolveExecutionItem(modelIndex);
-
-        if (executionItem)
+        if (!executionItem)
         {
-            const AZ::Data::AssetId& assetId = executionItem->GetAssetId();
-
-            bool isAssetOpen = false;
-            GeneralRequestBus::BroadcastResult(isAssetOpen, &GeneralRequests::IsScriptCanvasAssetOpen, SourceHandle(nullptr, assetId.m_guid));
-
-            GeneralRequestBus::Broadcast(&GeneralRequests::OpenScriptCanvasAssetId
-                , SourceHandle(nullptr, assetId.m_guid), Tracker::ScriptCanvasFileState::UNMODIFIED);
-
-            AZ::EntityId graphCanvasGraphId;
-            GeneralRequestBus::BroadcastResult(graphCanvasGraphId, &GeneralRequests::FindGraphCanvasGraphIdByAssetId
-                , SourceHandle(nullptr, assetId.m_guid));
-            
-            if (isAssetOpen)
-            {
-                FocusOnElement(assetId, executionItem->GetScriptCanvasAssetNodeId());
-            }
-            else
-            {
-                m_assetId = assetId;
-                m_assetNodeId = executionItem->GetScriptCanvasAssetNodeId();
-
-                m_focusDelayTimer.stop();
-                m_focusDelayTimer.start();
-            }
+            return;
         }
+
+        const AZ::Data::AssetId& assetId = executionItem->GetAssetId();
+
+        bool isAssetOpen = false;
+        GeneralRequestBus::BroadcastResult(isAssetOpen, &GeneralRequests::IsScriptCanvasAssetOpen, SourceHandle(nullptr, assetId.m_guid));
+        if (isAssetOpen)
+        {
+            FocusOnElement(assetId, executionItem->GetScriptCanvasAssetNodeId());
+            return;
+        }
+
+        // TODO https://github.com/o3de/o3de/issues/9192 need to get the source graph path from the relative fn_compiled_scriptcanvas and open it
+
+        m_assetId = assetId;
+        m_assetNodeId = executionItem->GetScriptCanvasAssetNodeId();
+
+        m_focusDelayTimer.stop();
+        m_focusDelayTimer.start();
     }
 
     void LoggingWindowSession::OnLogSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
@@ -350,13 +335,14 @@ namespace ScriptCanvasEditor
         AZ::EntityId activeGraphCanvasGraphId;
         GeneralRequestBus::BroadcastResult(activeGraphCanvasGraphId, &GeneralRequests::GetActiveGraphCanvasGraphId);
 
+        // TODO https://github.com/o3de/o3de/issues/9192 will never be valid because the source handle does not have the editor graph ptr (broken by #6394)
         AZ::EntityId graphCanvasGraphId;
         GeneralRequestBus::BroadcastResult(graphCanvasGraphId, &GeneralRequests::FindGraphCanvasGraphIdByAssetId, SourceHandle(nullptr, m_assetId.m_guid));
 
         if (activeGraphCanvasGraphId == graphCanvasGraphId)
         {
             FocusOnElement(m_assetId, m_assetNodeId);
-            
+
             m_focusDelayTimer.stop();
 
             m_assetId.SetInvalid();
@@ -368,7 +354,6 @@ namespace ScriptCanvasEditor
     {
         GraphCanvas::FocusConfig focusConfig;
 
-        // TODO https://github.com/o3de/o3de/issues/9192 focus broken because both scriptCanvasNodeId and graphCanvasNodeId are invalid (broken by #6394)
         AZ::EntityId scriptCanvasNodeId;
         AssetGraphSceneBus::BroadcastResult(scriptCanvasNodeId, &AssetGraphScene::FindEditorNodeIdByAssetNodeId, SourceHandle(nullptr, assetId.m_guid), assetNodeId);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -10,8 +10,6 @@
 #include <QGraphicsItem>
 #include <QScopedValueRollback>
 
-#include <AzCore/Asset/AssetManagerBus.h>
-
 #include <GraphCanvas/Components/Nodes/NodeTitleBus.h>
 #include <GraphCanvas/Components/SceneBus.h>
 #include <GraphCanvas/Components/Slots/SlotBus.h>
@@ -271,7 +269,8 @@ namespace ScriptCanvasEditor
             return;
         }
 
-        // TODO https://github.com/o3de/o3de/issues/9192 need to get the source graph path from the relative fn_compiled_scriptcanvas and open it
+        // TODO https://github.com/o3de/o3de/issues/9192 need to get the source graph path from the relative fn_compiled_scriptcanvas and open it via a bus which leads to MainWindow::OpenFile
+        // See QuerySourceByProductID, maybe should be made available in AssetManagerBus
 
         m_assetId = assetId;
         m_assetNodeId = executionItem->GetScriptCanvasAssetNodeId();

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3555,27 +3555,17 @@ namespace ScriptCanvasEditor
         return findChild<QObject*>(elementName);
     }
 
-    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId(const SourceHandle& assetId, AZ::EntityId assetNodeId) const
+    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId([[maybe_unused]] const SourceHandle& assetId, AZ::EntityId assetNodeId) const
     {
-        ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
-        if (assetId.Id() != assetId.Id())
-        {
-            return AZ::EntityId();
-        }
-
+        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
         AZ::EntityId newNodeId;
         EditorGraphRequestBus::EventResult(newNodeId, scriptId, &EditorGraphRequests::FindNewIdFromOriginal, assetNodeId);
         return newNodeId;
     }
 
-    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId(const SourceHandle& assetId, AZ::EntityId editorNodeId) const
+    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId([[maybe_unused]] const SourceHandle& assetId, AZ::EntityId editorNodeId) const
     {
-        ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
-        if (assetId.Id() != assetId.Id())
-        {
-            return AZ::EntityId();
-        }
-
+        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
         AZ::EntityId originalNodeId;
         EditorGraphRequestBus::EventResult(originalNodeId, scriptId, &EditorGraphRequests::FindOriginalIdFromNew, editorNodeId);
         return originalNodeId;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3555,24 +3555,30 @@ namespace ScriptCanvasEditor
         return findChild<QObject*>(elementName);
     }
 
-    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId([[maybe_unused]] const SourceHandle& assetId
-        , [[maybe_unused]] AZ::EntityId assetNodeId) const
+    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId(const SourceHandle& assetId, AZ::EntityId assetNodeId) const
     {
-        AZ::EntityId editorEntityId{};
-//         AssetTrackerRequestBus::BroadcastResult
-//             ( editorEntityId, &AssetTrackerRequests::GetEditorEntityIdFromSceneEntityId, assetId.Id(), assetNodeId);
-        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
-        return editorEntityId;
+        ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
+        if (assetId.Id() != assetId.Id())
+        {
+            return AZ::EntityId();
+        }
+
+        AZ::EntityId newNodeId;
+        EditorGraphRequestBus::EventResult(newNodeId, scriptId, &EditorGraphRequests::FindNewIdFromOriginal, assetNodeId);
+        return newNodeId;
     }
 
-    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId([[maybe_unused]] const SourceHandle& assetId
-        , [[maybe_unused]] AZ::EntityId editorNodeId) const
+    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId(const SourceHandle& assetId, AZ::EntityId editorNodeId) const
     {
-        AZ::EntityId sceneEntityId{};
-        // AssetTrackerRequestBus::BroadcastResult
-        // ( sceneEntityId, &AssetTrackerRequests::GetSceneEntityIdFromEditorEntityId, assetId.Id(), editorNodeId);
-        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
-        return sceneEntityId;
+        ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
+        if (assetId.Id() != assetId.Id())
+        {
+            return AZ::EntityId();
+        }
+
+        AZ::EntityId originalNodeId;
+        EditorGraphRequestBus::EventResult(originalNodeId, scriptId, &EditorGraphRequests::FindOriginalIdFromNew, editorNodeId);
+        return originalNodeId;
     }
 
     GraphCanvas::Endpoint MainWindow::CreateNodeForProposalWithGroup(const AZ::EntityId& connectionId

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/GraphSerialization.h
@@ -53,6 +53,7 @@ namespace ScriptCanvas
         AZStd::string m_jsonResults;
         AZStd::string m_errors;
         DataPtr m_graphDataPtr;
+        AZStd::unordered_map<AZ::EntityId, AZ::EntityId> m_originalIdsToNewIds; // If empty ids same as file
 
         inline operator bool() const
         {


### PR DESCRIPTION
## What does this PR do?

Follow-up to https://github.com/o3de/o3de/pull/17912. And work for https://github.com/o3de/o3de/issues/9192.

**As a user**:
- When a graph is open and has entries in the live trace window, double click on an entry to jump to the right node (see video below)
- Be notified when the remote debugging gem is not enabled (see image below)

**As a developer**:
- This PR allows to match node UIDs from runtime graphs to editor graph. This is the basis needed to make a scriptCanvas breakpoint debugging system.
- The node UIDs in the **.scriptcanvas** json are now the same in the **.scriptcanvas_compiled** runtime binary files, allowing easier debug when you break in the lua VM (possible to use g_saveRuntimeAssetsAsPlainTextForDebug to check the binary file content).

https://github.com/user-attachments/assets/56ece460-7d8f-4783-8441-dd865f9400cf

When remote gem is not enabled

![message](https://github.com/user-attachments/assets/f63f778d-7d70-4e58-af01-c3ce59504ae6)

## What remains ?

As shown in the code TODOs, still need to open the scriptcanvas if not already opened on double click. Also need to fill the "Entity" tabs as it used to be. After this point, the regressions will be fixed and start on new features such as a breakpoint and watch system can begin.

## Implications of this change

The reason for which the UIDs of the graphs are regenerated on load is to prevent UIDs collisions when there are multiple instances of the same graph. There is nothing which makes me think that having different UIDs between the compiled and the json scriptcanvas file is justified : editor graph load is always updating all uids, and runtime graphs as well via the runtime overrides system (see `Context::CreateActivateInputRange`). The alternative to save the remap hashmap in the compiled graph seems overkill.

While I haven't seen issues, this change does modify a bit the underlying working of the scriptgraph compilation, so it should be taken into scrutiny and tested thoroughly (which I'm doing my best to do on my own)

## How was this PR tested?

In the NewsPaperSample project, deleted and regenerated the asset cache. Then :
- Launched the game in editor multiple times in a row
- Modified and resave multiple graphs
- Created a new graph
- Ran levels with multiple instances of the same graph
