### PR TITLE
Fix all scope attachment clear actions except first being ignored in DX12

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -354,7 +354,6 @@ namespace AZ
                     m_clearBufferRequests.push_back(request);
 
                     isFullClear = bufferView->IsFullView();
-                    break;
                 }
 
                 CompileAttachmentInternal(isFullClear, *scopeAttachment, bufferView->GetMemory());


### PR DESCRIPTION
## What does this PR do?

This PR fixes all scope attachments with a clear action, except for the first one in a scope, being ignored on DX12. This error was introduced in #17972, when the [inner for loop in Scope.cpp](https://github.com/o3de/o3de/pull/17972/files#diff-27f74ae18c3f87683167a2034541add9b9d62a25c30b5035efc9441cde394601L294) was removed due to the usage/access refactoring, but the `break` instruction stayed there, which now exits the [outer loop](https://github.com/o3de/o3de/pull/17972/files#diff-27f74ae18c3f87683167a2034541add9b9d62a25c30b5035efc9441cde394601L284), leading to all remaining scope attachment clear requests being ignored.

## How was this PR tested?

Manually test with one of our internal gems on DX12; as far as I could tell this error does not lead to problems with the default project template.
