### PR TITLE
Bugfix for generating Buffer Barriers in Vulkan for Transient Attachments

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
@@ -113,10 +113,10 @@ namespace AZ
 
             BufferMemoryView memoryView = BufferMemoryView(bufferMemory);
 
+            buffer->SetDescriptor(bufferDescriptor);
             result = buffer->Init(GetVulkanRHIDevice(), bufferDescriptor, memoryView);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
-            buffer->SetDescriptor(bufferDescriptor);
             return RHI::ResultCode::Success;
         }
 


### PR DESCRIPTION
## What does this PR do?

Working on a sample where multiple consecutive compute shaders access a single transient buffer attachment, I found that no barriers were inserted into Vulkan's command buffer. The cause is that the buffers initialized in the AliasedHeap have their descriptor set too late which causes the initial setting of the queue owner to fail.

## How was this PR tested?

An own small sample in the ASV.
