### PR TITLE
Fix a crash if a RPI::Buffer is destroyed during upload

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -107,9 +107,12 @@ namespace AZ
             // Only held until the streaming upload is complete.
             Data::Asset<BufferAsset> m_bufferAsset;
 
+            // Note: The order of these members is important: The streamFence-destructor potentially uses m_pendingUploadMutex,
+            // so we need to make sure the mutex isn't destroyed before the fence
+
             // Tracks the streaming upload of the buffer.
-            RHI::Ptr<RHI::Fence> m_streamFence;
             AZStd::mutex m_pendingUploadMutex;
+            RHI::Ptr<RHI::Fence> m_streamFence;
             AZStd::atomic_int m_initialUploadCount{0};
 
             RHI::BufferViewDescriptor m_bufferViewDescriptor;


### PR DESCRIPTION
## What does this PR do?

This fixes a spurious crash that happens when the destructor of an RPI::Buffer is finished before the thread waiting for the GPU upload fence is executed. 

Fixes a crash with the following sequence:
- `RPI::Buffer::Init()`
   - Create wait thread with lambda in line 175 with `WaitOnCpuAsync()`
- `RPI::Buffer::~Buffer()`
   - Calls `WaitForUpload()` to block until GPU upload is finished
     - current thread happens to be called before the async waiting thread
   - class destructor finishes, data members are destroyed  
   - destructor for `m_pendingUploadMutex`
   - destructor for `m_streamFence`
     - lambda is executed and tries to lock already destroyed `m_pendingUploadMutex`

The fix reorders the data members and ensures that `m_pendingUploadMutex` still exists during the destructor of `m_streamFence`

## How was this PR tested?

Tested on Windows using Vulkan. 
