### PR TITLE
Fix several selection and focus related issues for the Asset Browser.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -1038,8 +1038,11 @@ void AzAssetBrowserRequestHandler::DoDropItemView(bool& accepted, AzQtComponents
     }
 }
 
-// There are two paths for generating entities by dragging and dropping from the asset browser.
-// This logic handles dropping them into the viewport. Dropping them in the outliner is handled by OutlinerListModel::DropMimeDataAssets.
+// There are multiple paths for generating entities by dragging and dropping from the asset browser.
+// This logic handles dropping them into the viewport.
+// Dropping them in the outliner is handled by OutlinerListModel::DropMimeDataAssets.
+// There's also a higher priority listener for dropping things containing prefabs, by instantiating the prefab.
+// This is used just when there's no higher priority listener to handle basic drops.
 void AzAssetBrowserRequestHandler::Drop(QDropEvent* event, AzQtComponents::DragAndDropContextBase& context)
 {
     using namespace AzToolsFramework;

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -1057,10 +1057,23 @@ void AzAssetBrowserWindow::SetFavoritesWindowHeight(int height)
     m_ui->m_leftsplitter->setSizes(sizes);
 }
 
-void AzAssetBrowserWindow::SelectionChanged([[maybe_unused]] const QItemSelection& selected, [[maybe_unused]] const QItemSelection& deselected)
+void AzAssetBrowserWindow::SelectionChanged(const QItemSelection& selected, [[maybe_unused]] const QItemSelection& deselected)
 {
     OnFilterCriteriaChanged();
-}
 
+    // if we select 1 thing, give the previewer a chance to view it.
+    if (selected.size() == 1)
+    {
+        auto* entry = selected.indexes()[0].data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+        if (entry)
+        {
+            AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::PreviewAsset, entry);
+            return;
+        }
+    }
+    // if we get here, we have no selection or multiple selection, clear preview.
+    // Note the above code SHOULD early return if more cases appear.
+    AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::ClearPreview);
+}
 
 #include <AzAssetBrowser/moc_AzAssetBrowserWindow.cpp>

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -1069,22 +1069,7 @@ void AzAssetBrowserWindow::SelectionChanged(const QItemSelection& selected, [[ma
     // we also don't care to actually count how many rows there are that are unique, we just need to know if there is exactly
     // one row, so we can stop after finding more than one.
 
-    int numberOfuniqueRows = 0;
-    int lastSeenRow = -1;
-    for (const auto& element : selectedIndices)
-    {
-        if (element.row() != lastSeenRow)
-        {
-            lastSeenRow = element.row();
-            numberOfuniqueRows++;
-            if (numberOfuniqueRows > 1)
-            {
-                break;
-            }
-        }
-    }
-    
-    if (numberOfuniqueRows == 1)
+    if (QtUtil::ModelIndexListHasExactlyOneRow(selectedIndices))
     {
         QModelIndex selectedIndex = selectedIndices[0];
         if (selectedIndex.isValid())

--- a/Code/Editor/QtUtil.h
+++ b/Code/Editor/QtUtil.h
@@ -15,6 +15,7 @@
 #include <QApplication>
 #include <QDropEvent>
 #include <QWidget>
+#include <QModelIndexList>
 
 #ifdef LoadCursor
 #undef LoadCursor
@@ -39,6 +40,31 @@ namespace QtUtil
     {
         // We prepend a char, so that the left doesn't get trimmed, then we remove it after trimming
         return QString(QStringLiteral("A") + str).trimmed().remove(0, 1);
+    }
+
+    //! ModelIndexListHasExactlyOneRow returns true only if the given list of indices has exactly one row represented.
+    //! It will return false in all other cases, including when it is empty, or it has multiple different rows represented.
+    //! A list of model indexes from for example a selection model can contain different indices representing the same row,
+    //! but different columns.  Often, such controls will select an entire row (all columns) when the user clicks on an item,
+    //! resulting in for example, 5 modelindexes selected (but they are all referring to the same row, which is the same logical item),
+    //! and we need to differentiate this from the case where the user has selected multiple different rows in a multi-select.
+    inline bool ModelIndexListHasExactlyOneRow(const QModelIndexList& indexes)
+    {
+        int numberOfUniqueRows = 0;
+        int lastSeenRow = -1;
+        for (const auto& element : indexes)
+        {
+            if (element.row() != lastSeenRow)
+            {
+                lastSeenRow = element.row();
+                numberOfUniqueRows++;
+                if (numberOfUniqueRows > 1) // we only care if its exactly 1 row so can early out
+                {
+                    return false;
+                }
+            }
+        }
+        return (numberOfUniqueRows == 1);
     }
 
     template<typename ... Args>

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -117,6 +117,15 @@ void QtViewport::dropEvent(QDropEvent* event)
         ViewportDragContext context;
         BuildDragDropContext(context, GetViewportId(), event->pos());
         DragAndDropEventsBus::Event(DragAndDropContexts::EditorViewport, &DragAndDropEvents::Drop, event, context);
+        if (event->isAccepted())
+        {
+            // send focus to whatever window accepted it.  Its not necessarily this window, as it might be a child embedded in it.
+            QWidget* widget = qApp->widgetAt(event->pos());
+            if (widget)
+            {
+                widget->setFocus(Qt::MouseFocusReason);
+            }
+        }
     }
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
@@ -26,6 +26,8 @@ namespace AzQtComponents
         setSortingEnabled(true);
         setContextMenuPolicy(Qt::CustomContextMenu);
         setSelectionMode(ExtendedSelection);
+
+        connect(this, &QAbstractItemView::clicked, this, &AssetFolderTableView::onClickedView);
     }
 
     void AssetFolderTableView::setRootIndex(const QModelIndex& index)
@@ -69,8 +71,23 @@ namespace AzQtComponents
 
     void AssetFolderTableView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
     {
+        m_selectionChangedSinceClick = true;
         TableView::selectionChanged(selected, deselected);
         Q_EMIT selectionChangedSignal(selected, deselected);
+
+    }
+
+    void AssetFolderTableView::onClickedView([[maybe_unused]] const QModelIndex& index)
+    {
+        // if we click on an item and selection wasn't changed, then reselect the current item so that it shows up in
+        // any related previewers.
+        bool didSelectionChange = m_selectionChangedSinceClick;
+        m_selectionChangedSinceClick = false;
+        if (!didSelectionChange)
+        {
+            // just refresh the UI and make sure it shows what is already selected.
+            Q_EMIT selectionChangedSignal(selectionModel()->selection(), {});
+        }
     }
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.cpp
@@ -71,21 +71,17 @@ namespace AzQtComponents
 
     void AssetFolderTableView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
     {
-        m_selectionChangedSinceClick = true;
         TableView::selectionChanged(selected, deselected);
         Q_EMIT selectionChangedSignal(selected, deselected);
 
     }
 
-    void AssetFolderTableView::onClickedView([[maybe_unused]] const QModelIndex& index)
+    void AssetFolderTableView::onClickedView(const QModelIndex& index)
     {
         // if we click on an item and selection wasn't changed, then reselect the current item so that it shows up in
         // any related previewers.
-        bool didSelectionChange = m_selectionChangedSinceClick;
-        m_selectionChangedSinceClick = false;
-        if (!didSelectionChange)
+        if (selectionModel()->isSelected(index))
         {
-            // just refresh the UI and make sure it shows what is already selected.
             Q_EMIT selectionChangedSignal(selectionModel()->selection(), {});
         }
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.h
@@ -31,18 +31,20 @@ namespace AzQtComponents
 
     protected Q_SLOTS:
         void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
+        void onClickedView(const QModelIndex& idx);
 
     signals:
         void tableRootIndexChanged(const QModelIndex& idx);
         void showInTableFolderTriggered(const QModelIndex& idx);
         void rowDeselected();
         void selectionChangedSignal(const QItemSelection& selected, const QItemSelection& deselected);
-
+        
     protected:
         void mousePressEvent(QMouseEvent* event) override;
         void mouseDoubleClickEvent(QMouseEvent* event) override;
 
     private:
         bool m_showSearchResultsMode = false;
+        bool m_selectionChangedSinceClick = false;
     };
 }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderTableView.h
@@ -45,6 +45,5 @@ namespace AzQtComponents
 
     private:
         bool m_showSearchResultsMode = false;
-        bool m_selectionChangedSinceClick = false;
     };
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -312,8 +312,11 @@ namespace AzToolsFramework
             // however, in an effort to make it forward compatible, I assume we will get more than this and extend in the future
             // for example, if someone wants to implement a "folder" or "root" or "gem folder" previewer, at least we call this function
             // and give it the option to return and clear.
-            if (selectedEntry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Source &&
-                selectedEntry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Product)
+            const auto entryType = selectedEntry->GetEntryType();
+            bool canBePreviewed = (entryType == AssetBrowserEntry::AssetEntryType::Source) ||
+                                  (entryType == AssetBrowserEntry::AssetEntryType::Product);
+
+            if (!canBePreviewed)
             {
                 ClearPreview();
                 return;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -308,6 +308,17 @@ namespace AzToolsFramework
                 return;
             }
 
+            // currently, we only preview sources or products.
+            // however, in an effort to make it forward compatible, I assume we will get more than this and extend in the future
+            // for example, if someone wants to implement a "folder" or "root" or "gem folder" previewer, at least we call this function
+            // and give it the option to return and clear.
+            if (selectedEntry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Source &&
+                selectedEntry->GetEntryType() != AssetBrowserEntry::AssetEntryType::Product)
+            {
+                ClearPreview();
+                return;
+            }
+
             if (m_layoutSwitcher->currentWidget() != m_populatedLayoutWidget)
             {
                 m_layoutSwitcher->setCurrentWidget(m_populatedLayoutWidget);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.cpp
@@ -237,7 +237,6 @@ namespace AzToolsFramework
         
         void AssetBrowserFavoritesView::SelectionChanged(const QItemSelection& selected, [[maybe_unused]] const QItemSelection& deselected)
         {
-            m_selectionChangedSinceLastClick = true;
             NotifySelection(selected);
         }
 
@@ -262,16 +261,15 @@ namespace AzToolsFramework
                 }
             }
 
+            // note that if we don't early return above, we must clear the preview, as we have selected multiple items, or 0 items.
             AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::ClearPreview);
         }
 
-        void AssetBrowserFavoritesView::ItemClicked([[maybe_unused]] const QModelIndex& index)
+        void AssetBrowserFavoritesView::ItemClicked(const QModelIndex& index)
         {
-            // if we click on an item and selection wasn't changed, then reselect the current item so that it shows up in
-            // any related previewers.
-            bool didSelectionChange = m_selectionChangedSinceLastClick;
-            m_selectionChangedSinceLastClick = false;
-            if (!didSelectionChange)
+            // if we click on an item that was already selected, notify anyway, as we want the behavior to be that
+            // it refreshes the gui when you do that.
+            if (selectionModel()->isSelected(index))
             {
                 NotifySelection(selectionModel()->selection());
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
@@ -60,13 +60,17 @@ namespace AzToolsFramework
 
         protected Q_SLOTS:
             void SelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+            void ItemClicked(const QModelIndex& index);
 
         private:
             QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserFavoritesModel> m_favoritesModel;
             QScopedPointer<FavoritesEntryDelegate> m_delegate;
             int m_currentHeight = 0;
+            bool m_selectionChangedSinceLastClick = false;
 
             void OnContextMenu(const QPoint& point);
+
+            void NotifySelection(const QItemSelection& selected);
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
@@ -58,6 +58,9 @@ namespace AzToolsFramework
 
             void drawBranches(QPainter* painter, const QRect& rect, const QModelIndex& index) const override;
 
+        protected Q_SLOTS:
+            void SelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+
         private:
             QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserFavoritesModel> m_favoritesModel;
             QScopedPointer<FavoritesEntryDelegate> m_delegate;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesView.h
@@ -66,7 +66,6 @@ namespace AzToolsFramework
             QScopedPointer<AzToolsFramework::AssetBrowser::AssetBrowserFavoritesModel> m_favoritesModel;
             QScopedPointer<FavoritesEntryDelegate> m_delegate;
             int m_currentHeight = 0;
-            bool m_selectionChangedSinceLastClick = false;
 
             void OnContextMenu(const QPoint& point);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -58,7 +58,6 @@ namespace AzToolsFramework
                     const QItemSelection& selected,
                     const QItemSelection& deselected)
                 {
-                    m_selectionChangedSinceLastClick = true;
                     Q_EMIT selectionChangedSignal(selected, deselected);
                 });
 
@@ -68,12 +67,10 @@ namespace AzToolsFramework
                 this,
                 [this](const QModelIndex& index)
                 {
-                    bool wasSelectionChangedSinceLastClick = m_selectionChangedSinceLastClick;
-                    m_selectionChangedSinceLastClick = false;
-
                     auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
                     emit entryClicked(indexData);
-                    if (!wasSelectionChangedSinceLastClick)
+                    // if we click on an index that is already selected, refresh the selection so that other views update.
+                    if (m_thumbnailViewWidget->selectionModel()->isSelected(index))
                     {
                         // user clicked on the same entry as before, so make sure that the associated item is previewed
                         // in case they clicked on something else on the GUI and it was lost.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -58,19 +58,7 @@ namespace AzToolsFramework
                     const QItemSelection& selected,
                     const QItemSelection& deselected)
                 {
-                    auto selectedIndexes = m_thumbnailViewWidget->selectionModel()->selectedIndexes();
-                    if (selectedIndexes.size() == 1)
-                    {
-                        auto indexData = selectedIndexes.at(0).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
-                        if (indexData->GetEntryType() != AssetBrowserEntry::AssetEntryType::Folder)
-                        {
-                            AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::PreviewAsset, indexData);
-                        }
-                    }
-                    else
-                    {
-                        AssetBrowserPreviewRequestBus::Broadcast(&AssetBrowserPreviewRequest::ClearPreview);
-                    }
+                    m_selectionChangedSinceLastClick = true;
                     Q_EMIT selectionChangedSignal(selected, deselected);
                 });
 
@@ -80,8 +68,17 @@ namespace AzToolsFramework
                 this,
                 [this](const QModelIndex& index)
                 {
+                    bool wasSelectionChangedSinceLastClick = m_selectionChangedSinceLastClick;
+                    m_selectionChangedSinceLastClick = false;
+
                     auto indexData = index.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
                     emit entryClicked(indexData);
+                    if (!wasSelectionChangedSinceLastClick)
+                    {
+                        // user clicked on the same entry as before, so make sure that the associated item is previewed
+                        // in case they clicked on something else on the GUI and it was lost.
+                        Q_EMIT selectionChangedSignal(m_thumbnailViewWidget->selectionModel()->selection(), {});
+                    }
                 });
 
             connect(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -91,7 +91,6 @@ namespace AzToolsFramework
             void HandleTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
             void UpdateFilterInLocalFilterModel();
             QString m_name;
-            bool m_selectionChangedSinceLastClick = false;
             bool m_isActiveView = false;
         };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h
@@ -91,6 +91,7 @@ namespace AzToolsFramework
             void HandleTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
             void UpdateFilterInLocalFilterModel();
             QString m_name;
+            bool m_selectionChangedSinceLastClick = false;
             bool m_isActiveView = false;
         };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -594,25 +594,16 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
         {
-            AZ_TracePrintf("ITEM", "selectionChanged (entry)");
-            m_selectionChangedSinceClick = true;
-
             QTreeView::selectionChanged(selected, deselected);
             Q_EMIT selectionChangedSignal(selected, deselected);
-
-            AZ_TracePrintf("ITEM", "selectionChanged (exit)");
-
         }
 
-        void AssetBrowserTreeView::itemClicked([[maybe_unused]] const QModelIndex& index)
+        void AssetBrowserTreeView::itemClicked(const QModelIndex& index)
         {
             // if we click on an item and selection wasn't changed, then reselect the current item so that it shows up in
-            // any related previewers.
-            bool didSelectionChange = m_selectionChangedSinceClick;
-            m_selectionChangedSinceClick = false;
-            if (!didSelectionChange)
+            // any related previewers.  If its not currently selected, then the above selectionChanged will take care of it.
+            if (selectionModel()->isSelected(index))
             {
-                // just refresh the UI and make sure it shows what is already selected.
                 Q_EMIT selectionChangedSignal(selectionModel()->selection(), {});
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -123,6 +123,8 @@ namespace AzToolsFramework
                     DuplicateEntries();
                 });
             addAction(duplicateAction);
+
+            connect(this, &QAbstractItemView::clicked, this, &AssetBrowserTreeView::itemClicked);
         }
 
         AssetBrowserTreeView::~AssetBrowserTreeView()
@@ -592,8 +594,27 @@ namespace AzToolsFramework
 
         void AssetBrowserTreeView::selectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
         {
+            AZ_TracePrintf("ITEM", "selectionChanged (entry)");
+            m_selectionChangedSinceClick = true;
+
             QTreeView::selectionChanged(selected, deselected);
             Q_EMIT selectionChangedSignal(selected, deselected);
+
+            AZ_TracePrintf("ITEM", "selectionChanged (exit)");
+
+        }
+
+        void AssetBrowserTreeView::itemClicked([[maybe_unused]] const QModelIndex& index)
+        {
+            // if we click on an item and selection wasn't changed, then reselect the current item so that it shows up in
+            // any related previewers.
+            bool didSelectionChange = m_selectionChangedSinceClick;
+            m_selectionChangedSinceClick = false;
+            if (!didSelectionChange)
+            {
+                // just refresh the UI and make sure it shows what is already selected.
+                Q_EMIT selectionChangedSignal(selectionModel()->selection(), {});
+            }
         }
 
         void AssetBrowserTreeView::setModel(QAbstractItemModel* model)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -140,6 +140,7 @@ namespace AzToolsFramework
         protected Q_SLOTS:
             void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
             void rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end) override;
+            void itemClicked(const QModelIndex& index);
 
         private:
             QPointer<AssetBrowserModel> m_assetBrowserModel;
@@ -161,6 +162,8 @@ namespace AzToolsFramework
 
             QModelIndex m_indexToSelectAfterUpdate;
             AZStd::string m_fileToSelectAfterUpdate;
+
+            bool m_selectionChangedSinceClick = false;
 
             bool SelectProduct(const QModelIndex& idxParent, AZ::Data::AssetId assetID);
             bool SelectEntry(const QModelIndex& idxParent, const AZStd::vector<AZStd::string>& entryPathTokens, const uint32_t lastFolderIndex = 0, const uint32_t entryPathIndex = 0, bool useDisplayName = false);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -163,8 +163,6 @@ namespace AzToolsFramework
             QModelIndex m_indexToSelectAfterUpdate;
             AZStd::string m_fileToSelectAfterUpdate;
 
-            bool m_selectionChangedSinceClick = false;
-
             bool SelectProduct(const QModelIndex& idxParent, AZ::Data::AssetId assetID);
             bool SelectEntry(const QModelIndex& idxParent, const AZStd::vector<AZStd::string>& entryPathTokens, const uint32_t lastFolderIndex = 0, const uint32_t entryPathIndex = 0, bool useDisplayName = false);
 


### PR DESCRIPTION
Fixes issue https://github.com/o3de/o3de/issues/18067

Fixes an issue where if you click on an item in the Asset Browser window when it was already selected, it would not previously update the inspector to show the selected item details (it would only respond to selection change).  I tried updating on focus, but focus happens for many other reasons too like rolling the mouse wheel or scroll bar.  So I kept it "on click" on an item without changing focus.

Old behavior: 
1. Click on an asset in the Asset Browser.  Inspector shows that asset details and selects the asset
2. Click on anything else in any other part of gui.  Inspector shows that detail of what you clicked on
3. Click again on asset in Asset Browser (same one as before).  Because it was already selected the inspector does not update.
New behavior
Step 3:  Inspector shows the details for the thing you clicked on.

It also makes it so that when you drop something into the viewport, the viewport gets focus, letting you hit viewport hotkeys (WASD, etc) as well as the DELETE key, and the key you press goes to the viewport you dropped into, instead of attempting to, for example, delete the asset from the asset browser window that the drag started on.

Old behavior:
1. drag a file from the asset browser into the viewport.  Editor instantiates the item in the 3d world and selects it
2. Press delete to delete the item you just spawned in the 3d world
3. The asset browser gets the delete and tries to delete the actual asset off your disk instead of the new one out of the 3d viewport where your mouse is

new behavior
Step 3: the viewport gets the delete key and deletes the thing under your mouse.   This also means you can move the cam around with wasd after dropping (and otehr viewport hotkeys work).


Signed-off-by: Nicholas Lawson <70027408+nick-l-o3de@users.noreply.github.com>

Tested by actually interacting with the viewport and asset browser in every condition I can think of, for example, selecting an item in the asset browser, then selecting an entity in the outliner (which causes the inspector to show the details for the entity selected in the outliner) and then clicking back on the item in the Asset Browser.
[x] Click in Tree Mode
[x] Click in Favorites View
[x] Click in List View
[x] Click in Thumbnail View
[x] Drag to viewport and WASD/DELETE

Previous (incorrect) behavior was, if you clicked on an item that was already selected, it would never update the inspector view, which forces you to click off the item, then on it again to show the inspector.

