### PR TITLE
Fix for Audio Thread Taking 90% Frame Time

### DIFF
--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -240,7 +240,7 @@ namespace Audio
         if (!handleBlockingRequest)
         {
             auto endUpdateTime = AZStd::chrono::steady_clock::now();      // stamp the end time
-            auto elapsedUpdateTime = AZStd::chrono::duration_cast<duration_ms>(endUpdateTime - startUpdateTime);
+            auto elapsedUpdateTime = AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(endUpdateTime - startUpdateTime);
             if (elapsedUpdateTime < m_targetUpdatePeriod)
             {
                 AZ_PROFILE_SCOPE(Audio, "Wait Remaining Time in Update Period");

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.h
@@ -107,8 +107,9 @@ namespace Audio
 
         bool m_bSystemInitialized;
 
-        using duration_ms = AZStd::chrono::duration<float, AZStd::milli>;
-        const duration_ms m_targetUpdatePeriod = AZStd::chrono::milliseconds(4);
+        // Using microseconds to allow sub-millisecond sleeping. 4000us is 4ms.
+        // chrono::microseconds is stored in 64-bit so can safely be added to epoch time (now) to produce absolute time.
+        const AZStd::chrono::microseconds m_targetUpdatePeriod = AZStd::chrono::microseconds(4000);
 
         CAudioTranslationLayer m_oATL;
         CAudioThread m_audioSystemThread;


### PR DESCRIPTION
Fix for audio system stealing CPU time. 
Updating audiosystem update to use microseconds to allow for sub-millisecond sleeping.
_try_acquire_for_ converts relative time (4ms) to absolute time (now+4ms). Instead of using a custom duration type use the built-in AZStd::chrono::microseconds which stores 64-bit integers so can safely be added to epoch time (now) to produce absolute time.

Tested by running on iOS and seeing that AudioSystem::InteralUpdate no longer instantly returns after calling _try_aquire_for_ 