### PR TITLE
Fix a validation warning due to overlapping attachments in DiffuseProbeGrid and an AZ_Assert for the AABB BLAS descriptor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
@@ -57,7 +57,7 @@ namespace AZ::Render
 
     void RayTracingDebugFeatureProcessor::Deactivate()
     {
-        EnableSceneNotification();
+        DisableSceneNotification();
         FeatureProcessor::Deactivate();
 
         m_sceneSrg = nullptr;

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingAccelerationStructure.cpp
@@ -53,7 +53,7 @@ namespace AZ::RHI
 
     DeviceRayTracingBlasDescriptor* DeviceRayTracingBlasDescriptor::BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
     {
-        AZ_Assert(m_buildContext, "BuildFlags property can only be added to a Geometry entry");
+        AZ_Assert(m_buildContext || m_aabb, "BuildFlags property can only be added to a Geometry or AABB entry");
         m_buildFlags = buildFlags;
         return this;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -26,12 +26,12 @@ namespace AZ::RHI
                 ->IndexBuffer(geometry.m_indexBuffer.GetDeviceIndexBufferView(deviceIndex));
         }
 
-        descriptor.BuildFlags(m_buildFlags);
-
         if(m_aabb.has_value())
         {
             descriptor.AABB(m_aabb.value());
         }
+
+        descriptor.BuildFlags(m_buildFlags);
 
         return descriptor;
     }
@@ -79,7 +79,7 @@ namespace AZ::RHI
 
     RayTracingBlasDescriptor* RayTracingBlasDescriptor::BuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
     {
-        AZ_Assert(m_buildContext, "BuildFlags property can only be added to a Geometry entry");
+        AZ_Assert(m_buildContext || m_aabb, "BuildFlags property can only be added to a Geometry or AABB entry");
         m_buildFlags = buildFlags;
         return this;
     }

--- a/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridQueryFullscreenWithAlbedo.pass
+++ b/Gems/DiffuseProbeGrid/Assets/Passes/DiffuseProbeGridQueryFullscreenWithAlbedo.pass
@@ -10,25 +10,25 @@
             "Slots": [
                 {
                     "Name": "AlbedoInput",
-                    "SlotType": "InputOutput",
+                    "SlotType": "Input",
                     "ShaderInputName": "m_albedo",
                     "ScopeAttachmentUsage": "Shader"
                 },
                 {
                     "Name": "NormalInput",
-                    "SlotType": "InputOutput",
+                    "SlotType": "Input",
                     "ShaderInputName": "m_normal",
                     "ScopeAttachmentUsage": "Shader"
                 },
                 {
                     "Name": "PositionInput",
-                    "SlotType": "InputOutput",
+                    "SlotType": "Input",
                     "ShaderInputName": "m_queryPositions",
                     "ScopeAttachmentUsage": "Shader"
                 },
                 {
                     "Name": "DirectionInput",
-                    "SlotType": "InputOutput",
+                    "SlotType": "Input",
                     "ShaderInputName": "m_queryDirections",
                     "ScopeAttachmentUsage": "Shader"
                 },


### PR DESCRIPTION
## What does this PR do?

This PR fixes two warnings and a typo in RayTracingDebugFeatureProcessor:

- Assert about setting the RT-Acceleration structure build flags before assigning a AABB when using procedurel geoemtry

- DX12 validation error due to the `FallbackNormal` attachment of `ReflectionScreenSpaceRayTracingPass` being used for both `NormalInput` and `DirectionInput` of `DiffuseProbeGridQueryFullscreenWithAlbedoPass`. I fixes this by changing the `SlotType` of the inputs in Diffuse-GI-Pass to `Input`
```
..\Gems\Atom\RHI\Code\Source\RHI\FrameGraph.cpp(130): (62068)
'void AZ::RHI::FrameGraph::ValidateOverlappingAttachment(
    AttachmentId, ScopeAttachmentUsage, ScopeAttachmentAccess, const ScopeAttachment &) const'
When adding two overlapping attachments in a scope, neither should have write
access, but a write access was detected when adding overlapping attachment
Root.MainPipeline_0.OpaquePass.ReflectionsPass.ReflectionScreenSpacePass.ReflectionScreenSpaceRayTracingPass.NormalImage.
```
- Call `DisableSceneNotification()` in `RayTracingDebugFeatureProcessor::Deactivate()` instead of Enable

## How was this PR tested?

Run Editor on Windows with DX12 with a small test scene which contains mesh and procedural geometry and uses RT-reflections.
