### PR TITLE
Add search bar to ImGui PassTree view

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
@@ -29,11 +29,13 @@ namespace AZ
             void Reset();
 
         private:
-            void DrawTreeView(AZ::RPI::Pass* rootPass);
+            void DrawTreeView(AZ::RPI::Pass* rootPass, const AZStd::unordered_set<Name>& filteredPassNames);
 
             void ReadbackCallback(const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult);
 
             void DrawPassAttachments(AZ::RPI::Pass* pass);
+
+            bool GetFilteredPassNames(AZ::RPI::Pass* pass, AZStd::unordered_set<Name>& filteredPassNames) const;
 
             bool m_shouldPreviewAttachment = false;
             bool m_showAttachments = false;
@@ -54,6 +56,8 @@ namespace AZ
             AZStd::string m_engineRoot;
             
             AZStd::string m_attachmentReadbackInfo;
+
+            ImGuiTextFilter m_passFilter;
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds a search bar to the PassTree view of the ImGui debug gui, such that finding a specific pass is faster than manually searching through the list. The same option already exists for the "Timestamp view" window.
Each pass which matches the search term, and all of their parents up to the root pass are shown, which matches the behavior of the Timestamp view.

<img src="https://github.com/user-attachments/assets/599688e6-8c82-40fe-9c8c-66400a5a53a1" width="350">


## How was this PR tested?

Run the Editor on Windows, use a few search terms to make sure the correct passes show up.
