### PR TITLE
Make the Debug Raytracing Pass more portable

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
@@ -33,8 +33,8 @@
                 {
                     "LocalSlot": "ColorInputOutput",
                     "AttachmentRef": {
-                        "Pass": "PostProcessPass",
-                        "Attachment": "Output"
+                        "Pass": "AuxGeomPass",
+                        "Attachment": "ColorInputOutput"
                     }
                 }
             ],


### PR DESCRIPTION
## What does this PR do?

The `DebugRaytracingPass` is injected behind the `AuxGeomPass`, but is connected to the output slot of the `PostProcessPass`.
This is a problem if the Debug Pass is used in a custom render pipeline that uses the `AuxGeomPass`, but not the `PostProcessPass`.

This PR changes this connection to the output slot of the `AuxGeomPass`, so the Debug Pass can function in any render pipeline that contains at least the `AuxGeomPass`.

## How was this PR tested?

On Vulkan / Windows with a custom render pipeline. 
