### PR TITLE
Implicitly multi-device RayTracingAccelerationStructurePass

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -12,6 +12,7 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/ScopeProducerFunction.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Buffer/BufferSystemInterface.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -41,20 +42,104 @@ namespace AZ
 
         void RayTracingAccelerationStructurePass::BuildInternal()
         {
-            InitScope(RHI::ScopeId(GetPathName()), AZ::RHI::HardwareQueueClass::Compute);
+            const auto deviceMask{ RHI::RHISystemInterface::Get()->GetRayTracingSupport() };
+            const auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                {
+                    m_scopeProducers[deviceIndex] = AZStd::make_shared<RHI::ScopeProducerFunctionNoData>(
+                        RHI::ScopeId{ AZStd::string(GetPathName().GetCStr() + AZStd::to_string(deviceIndex)) },
+                        AZStd::bind(&RayTracingAccelerationStructurePass::SetupFrameGraphDependencies, this, AZStd::placeholders::_1),
+                        [](const RHI::FrameGraphCompileContext&)
+                        {
+                        },
+                        AZStd::bind(&RayTracingAccelerationStructurePass::BuildCommandList, this, AZStd::placeholders::_1),
+                        RHI::HardwareQueueClass::Compute,
+                        deviceIndex);
+                }
+            }
         }
 
         void RayTracingAccelerationStructurePass::FrameBeginInternal(FramePrepareParams params)
         {
-            m_timestampResult = RPI::TimestampResult();
-            if(GetScopeId().IsEmpty())
+            const auto deviceMask{ RHI::RHISystemInterface::Get()->GetRayTracingSupport() };
+            const auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
             {
-                InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Compute);
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+                {
+                    params.m_frameGraphBuilder->ImportScopeProducer(*m_scopeProducers[deviceIndex]);
+                }
             }
 
-            params.m_frameGraphBuilder->ImportScopeProducer(*this);
-
             ReadbackScopeQueryResults();
+
+            RPI::Scene* scene = m_pipeline->GetScene();
+            RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
+
+            if (rayTracingFeatureProcessor)
+            {
+                m_rayTracingRevisionOutDated = rayTracingFeatureProcessor->GetRevision() != m_rayTracingRevision;
+                if (m_rayTracingRevisionOutDated)
+                {
+                    m_rayTracingRevision = rayTracingFeatureProcessor->GetRevision();
+
+                    RHI::RayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
+                    RayTracingFeatureProcessor::SubMeshVector& subMeshes = rayTracingFeatureProcessor->GetSubMeshes();
+
+                    // create the TLAS descriptor
+                    RHI::RayTracingTlasDescriptor tlasDescriptor;
+                    RHI::RayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
+
+                    uint32_t instanceIndex = 0;
+                    for (auto& subMesh : subMeshes)
+                    {
+                        tlasDescriptorBuild->Instance()
+                            ->InstanceID(instanceIndex)
+                            ->InstanceMask(subMesh.m_mesh->m_instanceMask)
+                            ->HitGroupIndex(0)
+                            ->Blas(subMesh.m_blas)
+                            ->Transform(subMesh.m_mesh->m_transform)
+                            ->NonUniformScale(subMesh.m_mesh->m_nonUniformScale)
+                            ->Transparent(subMesh.m_material.m_irradianceColor.GetA() < 1.0f);
+
+                        instanceIndex++;
+                    }
+
+                    unsigned proceduralHitGroupIndex = 1; // Hit group 0 is used for normal meshes
+                    const auto& proceduralGeometryTypes = rayTracingFeatureProcessor->GetProceduralGeometryTypes();
+                    AZStd::unordered_map<Name, unsigned> geometryTypeMap;
+                    geometryTypeMap.reserve(proceduralGeometryTypes.size());
+                    for (auto it = proceduralGeometryTypes.cbegin(); it != proceduralGeometryTypes.cend(); ++it)
+                    {
+                        geometryTypeMap[it->m_name] = proceduralHitGroupIndex++;
+                    }
+
+                    for (const auto& proceduralGeometry : rayTracingFeatureProcessor->GetProceduralGeometries())
+                    {
+                        tlasDescriptorBuild->Instance()
+                            ->InstanceID(instanceIndex)
+                            ->InstanceMask(proceduralGeometry.m_instanceMask)
+                            ->HitGroupIndex(geometryTypeMap[proceduralGeometry.m_typeHandle->m_name])
+                            ->Blas(proceduralGeometry.m_blas)
+                            ->Transform(proceduralGeometry.m_transform)
+                            ->NonUniformScale(proceduralGeometry.m_nonUniformScale);
+                        instanceIndex++;
+                    }
+
+                    // create the TLAS buffers based on the descriptor
+                    RHI::Ptr<RHI::RayTracingTlas>& rayTracingTlas = rayTracingFeatureProcessor->GetTlas();
+                    rayTracingTlas->CreateBuffers(
+                        RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &tlasDescriptor, rayTracingBufferPools);
+                }
+
+                // update and compile the RayTracingSceneSrg and RayTracingMaterialSrg
+                // Note: the timing of this update is very important, it needs to be updated after the TLAS is allocated so it can
+                // be set on the RayTracingSceneSrg for this frame, and the ray tracing mesh data in the RayTracingSceneSrg must
+                // exactly match the TLAS.  Any mismatch in this data may result in a TDR.
+                rayTracingFeatureProcessor->UpdateRayTracingSrgs();
+            }
         }
 
         RHI::Ptr<RPI::Query> RayTracingAccelerationStructurePass::GetQuery(RPI::ScopeQueryType queryType)
@@ -110,12 +195,12 @@ namespace AZ
 
         RPI::TimestampResult RayTracingAccelerationStructurePass::GetTimestampResultInternal() const
         {
-            return m_timestampResult;
+            return m_timestampResults.at(RHI::MultiDevice::DefaultDeviceIndex);
         }
 
         RPI::PipelineStatisticsResult RayTracingAccelerationStructurePass::GetPipelineStatisticsResultInternal() const
         {
-            return m_statisticsResult;
+            return m_statisticsResults.at(RHI::MultiDevice::DefaultDeviceIndex);
         }
 
         void RayTracingAccelerationStructurePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
@@ -125,56 +210,10 @@ namespace AZ
 
             if (rayTracingFeatureProcessor)
             {
-                if (rayTracingFeatureProcessor->GetRevision() != m_rayTracingRevision)
+                if (m_rayTracingRevisionOutDated)
                 {
-                    RHI::RayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
-                    RayTracingFeatureProcessor::SubMeshVector& subMeshes = rayTracingFeatureProcessor->GetSubMeshes();
-
-                    // create the TLAS descriptor
-                    RHI::RayTracingTlasDescriptor tlasDescriptor;
-                    RHI::RayTracingTlasDescriptor* tlasDescriptorBuild = tlasDescriptor.Build();
-
-                    uint32_t instanceIndex = 0;
-                    for (auto& subMesh : subMeshes)
-                    {
-                        tlasDescriptorBuild->Instance()
-                            ->InstanceID(instanceIndex)
-                            ->InstanceMask(subMesh.m_mesh->m_instanceMask)
-                            ->HitGroupIndex(0)
-                            ->Blas(subMesh.m_blas)
-                            ->Transform(subMesh.m_mesh->m_transform)
-                            ->NonUniformScale(subMesh.m_mesh->m_nonUniformScale)
-                            ->Transparent(subMesh.m_material.m_irradianceColor.GetA() < 1.0f)
-                            ;
-
-                        instanceIndex++;
-                    }
-
-                    unsigned proceduralHitGroupIndex = 1; // Hit group 0 is used for normal meshes
-                    const auto& proceduralGeometryTypes = rayTracingFeatureProcessor->GetProceduralGeometryTypes();
-                    AZStd::unordered_map<Name, unsigned> geometryTypeMap;
-                    geometryTypeMap.reserve(proceduralGeometryTypes.size());
-                    for (auto it = proceduralGeometryTypes.cbegin(); it != proceduralGeometryTypes.cend(); ++it)
-                    {
-                        geometryTypeMap[it->m_name] = proceduralHitGroupIndex++;
-                    }
-
-                    for (const auto& proceduralGeometry : rayTracingFeatureProcessor->GetProceduralGeometries())
-                    {
-                        tlasDescriptorBuild->Instance()
-                            ->InstanceID(instanceIndex)
-                            ->InstanceMask(proceduralGeometry.m_instanceMask)
-                            ->HitGroupIndex(geometryTypeMap[proceduralGeometry.m_typeHandle->m_name])
-                            ->Blas(proceduralGeometry.m_blas)
-                            ->Transform(proceduralGeometry.m_transform)
-                            ->NonUniformScale(proceduralGeometry.m_nonUniformScale)
-                            ;
-                        instanceIndex++;
-                    }
-
                     // create the TLAS buffers based on the descriptor
                     RHI::Ptr<RHI::RayTracingTlas>& rayTracingTlas = rayTracingFeatureProcessor->GetTlas();
-                    rayTracingTlas->CreateBuffers(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &tlasDescriptor, rayTracingBufferPools);
 
                     // import and attach the TLAS buffer
                     const RHI::Ptr<RHI::Buffer>& rayTracingTlasBuffer = rayTracingTlas->GetTlasBuffer();
@@ -209,12 +248,6 @@ namespace AZ
                     AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to attach SkinnedMeshOutputStream buffer with error %d", result);
                 }
 
-                // update and compile the RayTracingSceneSrg and RayTracingMaterialSrg
-                // Note: the timing of this update is very important, it needs to be updated after the TLAS is allocated so it can
-                // be set on the RayTracingSceneSrg for this frame, and the ray tracing mesh data in the RayTracingSceneSrg must
-                // exactly match the TLAS.  Any mismatch in this data may result in a TDR.
-                rayTracingFeatureProcessor->UpdateRayTracingSrgs();
-
                 AddScopeQueryToFrameGraph(frameGraph);
             }
         }
@@ -234,14 +267,11 @@ namespace AZ
                 return;
             }
 
-            if (rayTracingFeatureProcessor->GetRevision() == m_rayTracingRevision && rayTracingFeatureProcessor->GetSkinnedMeshCount() == 0)
+            if (!m_rayTracingRevisionOutDated && rayTracingFeatureProcessor->GetSkinnedMeshCount() == 0)
             {
                 // TLAS is up to date
                 return;
             }
-
-            // update the stored revision, even if we don't have any meshes to process
-            m_rayTracingRevision = rayTracingFeatureProcessor->GetRevision();
 
             if (!rayTracingFeatureProcessor->HasGeometry())
             {
@@ -257,13 +287,15 @@ namespace AZ
             for (auto& blasInstance : blasInstances)
             {
                 const bool isSkinnedMesh = blasInstance.second.m_isSkinnedMesh;
-                if (blasInstance.second.m_blasBuilt == false || isSkinnedMesh)
+                const bool buildBlas = (blasInstance.second.m_blasBuilt & RHI::MultiDevice::DeviceMask(1 << context.GetDeviceIndex())) ==
+                    RHI::MultiDevice::NoDevices;
+                if (buildBlas || isSkinnedMesh)
                 {
                     for (auto submeshIndex = 0; submeshIndex < blasInstance.second.m_subMeshes.size(); ++submeshIndex)
                     {
                         auto& submeshBlasInstance = blasInstance.second.m_subMeshes[submeshIndex];
                         changedBlasList.push_back(submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()).get());
-                        if (blasInstance.second.m_blasBuilt == false)
+                        if (buildBlas)
                         {
                             // Always build the BLAS, if it has not previously been built
                             context.GetCommandList()->BuildBottomLevelAccelerationStructure(*submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()));
@@ -289,7 +321,8 @@ namespace AZ
                         }
                     }
 
-                    blasInstance.second.m_blasBuilt = true;
+                    AZStd::lock_guard lock(rayTracingFeatureProcessor->GetBlasBuiltMutex());
+                    blasInstance.second.m_blasBuilt |= RHI::MultiDevice::DeviceMask(1 << context.GetDeviceIndex());
                 }
             }
 
@@ -342,26 +375,33 @@ namespace AZ
             // [GHI-16945] Feature Request - Add GPU timestamp and pipeline statistic support for scopes
             ExecuteOnTimestampQuery(endQuery);
             ExecuteOnPipelineStatisticsQuery(endQuery);
-
-            m_lastDeviceIndex = context.GetDeviceIndex();
         }
 
         void RayTracingAccelerationStructurePass::ReadbackScopeQueryResults()
         {
-            ExecuteOnTimestampQuery(
-                [this](const RHI::Ptr<RPI::Query>& query)
+            const auto deviceMask{ RHI::RHISystemInterface::Get()->GetRayTracingSupport() };
+            const auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
+            for (auto deviceIndex{ 0 }; deviceIndex < deviceCount; ++deviceIndex)
+            {
+                if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
                 {
-                  const uint32_t TimestampResultQueryCount{ 2u };
-                  uint64_t timestampResult[TimestampResultQueryCount] = { 0 };
-                  query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount, m_lastDeviceIndex);
-                  m_timestampResult = RPI::TimestampResult(timestampResult[0], timestampResult[1], RHI::HardwareQueueClass::Graphics);
-                });
+                    ExecuteOnTimestampQuery(
+                        [this, deviceIndex](const RHI::Ptr<RPI::Query>& query)
+                        {
+                            const uint32_t TimestampResultQueryCount{ 2u };
+                            uint64_t timestampResult[TimestampResultQueryCount] = { 0 };
+                            query->GetLatestResult(&timestampResult, sizeof(uint64_t) * TimestampResultQueryCount, deviceIndex);
+                            m_timestampResults[deviceIndex] =
+                                RPI::TimestampResult(timestampResult[0], timestampResult[1], RHI::HardwareQueueClass::Compute);
+                        });
 
-            ExecuteOnPipelineStatisticsQuery(
-                [this](const RHI::Ptr<RPI::Query>& query)
-                {
-                  query->GetLatestResult(&m_statisticsResult, sizeof(RPI::PipelineStatisticsResult), m_lastDeviceIndex);
-                });
+                    ExecuteOnPipelineStatisticsQuery(
+                        [this, deviceIndex](const RHI::Ptr<RPI::Query>& query)
+                        {
+                            query->GetLatestResult(&m_statisticsResults[deviceIndex], sizeof(RPI::PipelineStatisticsResult), deviceIndex);
+                        });
+                }
+            }
         }
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
@@ -17,9 +17,7 @@ namespace AZ
     namespace Render
     {
         //! This pass builds the RayTracing acceleration structures for a scene
-        class RayTracingAccelerationStructurePass final
-            : public RPI::Pass
-            , public RHI::ScopeProducer
+        class RayTracingAccelerationStructurePass final : public RPI::Pass
         {
         public:
             AZ_RPI_PASS(RayTracingAccelerationStructurePass);
@@ -40,8 +38,8 @@ namespace AZ
             explicit RayTracingAccelerationStructurePass(const RPI::PassDescriptor& descriptor);
 
             // Scope producer functions
-            void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
-            void BuildCommandList(const RHI::FrameGraphExecuteContext& context) override;
+            void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph);
+            void BuildCommandList(const RHI::FrameGraphExecuteContext& context);
 
             // Pass overrides
             void BuildInternal() override;
@@ -71,11 +69,17 @@ namespace AZ
             // Used to set some build options for the TLASes
             static AZ::RHI::RayTracingAccelerationStructureBuildFlags CreateRayTracingAccelerationStructureBuildFlags(bool isSkinnedMesh);
 
+            // Scope producers for each device
+            AZStd::unordered_map<int, AZStd::shared_ptr<AZ::RHI::ScopeProducer>> m_scopeProducers;
+
             // buffer view descriptor for the TLAS
             RHI::BufferViewDescriptor m_tlasBufferViewDescriptor;
 
             // revision number of the ray tracing data when the TLAS was built
             uint32_t m_rayTracingRevision = 0;
+
+            // revision out of date
+            bool m_rayTracingRevisionOutDated{ false };
 
             // keeps track of the current frame to determine updates or rebuilds of the skinned BLASes
             uint64_t m_frameCount = 0;
@@ -84,13 +88,10 @@ namespace AZ
             static constexpr uint32_t SKINNED_BLAS_REBUILD_FRAME_INTERVAL = 8;
 
             // Readback results from the Timestamp queries
-            AZ::RPI::TimestampResult m_timestampResult;
+            AZStd::unordered_map<int, AZ::RPI::TimestampResult> m_timestampResults;
 
             // Readback results from the PipelineStatistics queries
-            AZ::RPI::PipelineStatisticsResult m_statisticsResult;
-
-            // The device index the pass ran on during the last frame, necessary to read the queries.
-            int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
+            AZStd::unordered_map<int, AZ::RPI::PipelineStatisticsResult> m_statisticsResults;
 
             // For each ScopeProducer an instance of the ScopeQuery is created, which consists
             // of a Timestamp and PipelineStatistic query.

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -340,6 +340,12 @@ namespace AZ
             //! This is used to determine if the RayTracingPipelineState needs to be recreated.
             uint32_t GetProceduralGeometryTypeRevision() const { return m_proceduralGeometryTypeRevision; }
 
+            //! Provide access to the mutex protecting the blasBuilt flag
+            AZStd::mutex& GetBlasBuiltMutex()
+            {
+                return m_blasBuiltMutex;
+            }
+
             uint32_t GetSkinnedMeshCount() const
             {
                 return m_skinnedMeshCount;
@@ -382,8 +388,8 @@ namespace AZ
                 uint32_t m_count = 0;
                 AZStd::vector<SubMeshBlasInstance> m_subMeshes;
 
-                // flag indicating if the Blas objects in the sub-mesh list are built
-                bool m_blasBuilt = false;
+                // Flags indicating if the Blas objects in the sub-mesh list are already built
+                RHI::MultiDevice::DeviceMask m_blasBuilt = RHI::MultiDevice::NoDevices;
                 bool m_isSkinnedMesh = false;
             };
 
@@ -442,6 +448,9 @@ namespace AZ
 
             // mutex for the mesh and BLAS lists
             AZStd::mutex m_mutex;
+
+            // mutex for the m_blasBuilt flag manipulation
+            AZStd::mutex m_blasBuiltMutex;
 
             // structure for data in the m_meshInfoBuffer, shaders that use the buffer must match this type
             struct MeshInfo


### PR DESCRIPTION
## What does this PR do?

To be able to utilize the raytracing acceleration structures in a multi-GPU context, the `RayTracingAccelerationStructurePass` needs to run on all devices and build the TLAS and BLAS instances on these devices.
Simply duplicating the pass on all devices does not suffice, as the current design uses a boolean to see if the acceleration structures need to be built, which would not work with multiple passes on different devices in a multi-threaded context.

Our solution changes the following aspects:
1. The `RayTracingAccelerationStructurePass` now implicitly runs on all devices that support ray tracing
    - This is done by explicitly creating `ScopeProducer`s for each device with ray tracing support
2. The revision check is done once during `FrameBeginInternal` as well as all code that should be executed only once for all `ScopeProducer`s (like creating the multi-device TLASBuffers)
3. `m_blasBuilt` changes from a `bool` to a `MultiDevice::DeviceMask`, tracking the build status for each device (as this is manipulated concurrently, it is protected by a `mutex`)
4. The `Query`s are retrieved for all devices, the `Get*Result` calls currently return the default (from GPU 0) result (would require changing the API or somehow combining the results)

## How was this PR tested?

Tested the ASV samples using raytracing with `dx12` and `vulkan`.
