### PR TITLE
Fix a crash during level reload when resource allocation fails

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -319,9 +319,12 @@ namespace AZ::RHI
                 return ResultCode::Success;
             });
 
-        if (const auto& name = m_tlasBuffer->GetName(); !name.IsEmpty())
+        if (m_tlasBuffer)
         {
-            m_tlasBuffer->SetName(name);
+            if (const auto& name = m_tlasBuffer->GetName(); !name.IsEmpty())
+            {
+                m_tlasBuffer->SetName(name);
+            }
         }
 
         return m_tlasBuffer;
@@ -360,10 +363,14 @@ namespace AZ::RHI
                 return ResultCode::Success;
             });
 
-        if (const auto& name = m_tlasInstancesBuffer->GetName(); !name.IsEmpty())
+        if (m_tlasInstancesBuffer)
         {
-            m_tlasInstancesBuffer->SetName(name);
+            if (const auto& name = m_tlasInstancesBuffer->GetName(); !name.IsEmpty())
+            {
+                m_tlasInstancesBuffer->SetName(name);
+            }
         }
+
         return m_tlasInstancesBuffer;
     }
 } // namespace AZ::RHI


### PR DESCRIPTION
## What does this PR do?

Introduced by https://github.com/o3de/o3de/pull/18126, the weird handling of the `GetTLAS*Buffer` methods can lead to this method returning a `nullptr`, which was not accounted for when calling `SetName` on it, which leads to a crash when switching levels.

## How was this PR tested?

Tested by reloading or switching between levels.
