### PR TITLE
[Impactful Changes] Specialization constants enabled by default

### DIFF
--- a/Gems/Atom/Asset/Shader/Assets/Config/Shader/shader_build_options.settings
+++ b/Gems/Atom/Asset/Shader/Assets/Config/Shader/shader_build_options.settings
@@ -9,6 +9,7 @@
                 , "--W1" // Warning Level 1
                 , "--strip-unused-srgs" // Remove unreferenced SRGs.
                 , "--root-const=128"
+                , "--sc-options" // Use specialization constants for shader options.
         ],
         "dxc": ["-Zpr" // Row major matrices.
         ],


### PR DESCRIPTION
## What does this PR do?

This PR enables specialization constants for shader options for all platforms and all RHIs by default. The specialization constants implementation is already submitted, but it was not being used by default. Please refer to the RFC for the details about the implementation https://github.com/o3de/sig-graphics-audio/blob/main/rfcs/SpecializationConstants/SpecializationConstants.md

## How was this PR tested?

Run Windows on DX12 and Vulkan.
Run Android on Vulkan.
Run MacOS on Metal.
Run iOS on Metal.
Run Linux on Vulkan.
Run Quest2 on Vulkan.