### PR TITLE
Multi-device masks for Images and Buffers

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Bits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Bits.h
@@ -143,6 +143,13 @@ namespace AZ::RHI
         return v & (~bits);
     }
 
+    //! Sets the bit at bitIndex in v to 0.
+    template<typename T, typename U>
+    inline T ResetBit(T v, U bitIndex)
+    {
+        return v & static_cast<T>(~AZ_BIT(bitIndex));
+    }
+
     //! Reset any zero bits in bits in v to 0.
     template <typename T>
     inline T FilterBits(T v, T bits)
@@ -158,17 +165,17 @@ namespace AZ::RHI
     }
 
     //! Sets the bit at bitIndex in v to 1.
-    template <typename T>
-    inline T SetBit(T v, u8 bitIndex)
+    template<typename T, typename U>
+    inline T SetBit(T v, U bitIndex)
     {
-        return v | AZ_BIT(bitIndex);
+        return v | static_cast<T>(AZ_BIT(bitIndex));
     }
 
-    //! Returns the value of the bit at bitIndex (1 if the bit is 1, 0 if 0)
-    template <typename T>
-    inline T CheckBit(T v, u8 bitIndex)
+    //! Returns whether the bit at bitIndex is set.
+    template<typename T, typename U>
+    inline bool CheckBit(T v, U bitIndex)
     {
-        return (v >> bitIndex) & 1;
+        return (v & static_cast<T>(AZ_BIT(bitIndex))) != static_cast<T>(0);
     }
 
     //! Returns whether all the set bits in bits are set in v.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -72,9 +72,10 @@ namespace AZ::RHI
         AZ_RTTI(BufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
         virtual ~BufferView() = default;
 
-        BufferView(const RHI::Buffer* buffer, BufferViewDescriptor descriptor)
+        BufferView(const RHI::Buffer* buffer, BufferViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
             : m_buffer{ buffer }
             , m_descriptor{ descriptor }
+            , m_deviceMask{ deviceMask }
         {
         }
 
@@ -112,6 +113,8 @@ namespace AZ::RHI
         ConstPtr<RHI::Buffer> m_buffer;
         //! The corresponding BufferViewDescriptor for this view.
         BufferViewDescriptor m_descriptor;
+        //! The device mask of the buffer stored for comparison to figure out when cache entries need to be freed.
+        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
         //! DeviceBufferView cache
         //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
         //! which now, with multi-device objects in use, need to be held in memory as long as

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -23,36 +23,7 @@ namespace AZ::RHI
         AZStd::unordered_map<int, void*> m_data;
     };
 
-    struct BufferInitRequest
-    {
-        BufferInitRequest() = default;
-
-        BufferInitRequest(
-            Buffer& buffer,
-            const BufferDescriptor& descriptor,
-            const void* initialData = nullptr,
-            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
-            : m_buffer{ &buffer }
-            , m_descriptor{ descriptor }
-            , m_initialData{ initialData }
-            , m_deviceMask{ deviceMask }
-        {
-        }
-
-        /// The buffer to initialize. The buffer must be in an uninitialized state.
-        Buffer* m_buffer = nullptr;
-
-        /// The descriptor used to initialize the buffer.
-        BufferDescriptor m_descriptor;
-
-        /// [Optional] Initial data used to initialize the buffer.
-        const void* m_initialData = nullptr;
-
-        /// The device mask used for the buffer.
-        /// Note: Only devices in the mask of the buffer pool will be considered.
-        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
-    };
-
+    //! A structure used as an argument to BufferPool::UpdateBufferDeviceMask.
     struct BufferDeviceMaskRequest
     {
         BufferDeviceMaskRequest() = default;
@@ -74,6 +45,25 @@ namespace AZ::RHI
 
         /// [Optional] Initial data used to initialize new device buffers with.
         const void* m_initialData = nullptr;
+    };
+
+    //! A structure used as an argument to BufferPool::InitBuffer.
+    struct BufferInitRequest : public BufferDeviceMaskRequest
+    {
+        BufferInitRequest() = default;
+
+        BufferInitRequest(
+            Buffer& buffer,
+            const BufferDescriptor& descriptor,
+            const void* initialData = nullptr,
+            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+            : BufferDeviceMaskRequest{ buffer, deviceMask, initialData }
+            , m_descriptor{ descriptor }
+        {
+        }
+
+        /// The descriptor used to initialize the buffer.
+        BufferDescriptor m_descriptor;
     };
 
     using BufferMapRequest = BufferMapRequestTemplate<Buffer>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -23,7 +23,59 @@ namespace AZ::RHI
         AZStd::unordered_map<int, void*> m_data;
     };
 
-    using BufferInitRequest = BufferInitRequestTemplate<Buffer>;
+    struct BufferInitRequest
+    {
+        BufferInitRequest() = default;
+
+        BufferInitRequest(
+            Buffer& buffer,
+            const BufferDescriptor& descriptor,
+            const void* initialData = nullptr,
+            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+            : m_buffer{ &buffer }
+            , m_descriptor{ descriptor }
+            , m_initialData{ initialData }
+            , m_deviceMask{ deviceMask }
+        {
+        }
+
+        /// The buffer to initialize. The buffer must be in an uninitialized state.
+        Buffer* m_buffer = nullptr;
+
+        /// The descriptor used to initialize the buffer.
+        BufferDescriptor m_descriptor;
+
+        /// [Optional] Initial data used to initialize the buffer.
+        const void* m_initialData = nullptr;
+
+        /// The device mask used for the buffer.
+        /// Note: Only devices in the mask of the buffer pool will be considered.
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+    };
+
+    struct BufferDeviceMaskRequest
+    {
+        BufferDeviceMaskRequest() = default;
+
+        BufferDeviceMaskRequest(
+            Buffer& buffer, MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices, const void* initialData = nullptr)
+            : m_buffer{ &buffer }
+            , m_deviceMask{ deviceMask }
+            , m_initialData{ initialData }
+        {
+        }
+
+        /// The buffer to update the device mask of and (de)allocate device buffers.
+        Buffer* m_buffer = nullptr;
+
+        /// The new device mask used for the buffer.
+        /// Note: Only devices in the mask of the buffer pool will be considered.
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+
+        /// [Optional] Initial data used to initialize new device buffers with.
+        const void* m_initialData = nullptr;
+    };
+
     using BufferMapRequest = BufferMapRequestTemplate<Buffer>;
     using BufferStreamRequest = BufferStreamRequestTemplate<Buffer, Fence>;
 
@@ -61,6 +113,17 @@ namespace AZ::RHI
         //!      initialized, but will remain empty and the call will return ResultCode::OutOfMemory. Checking
         //!      this amounts to seeing if buffer.IsInitialized() is true.
         ResultCode InitBuffer(const BufferInitRequest& request);
+
+        //! Updates the device mask of a buffer instance created from this pool. The buffer must be in an
+        //! initialized state, or the call will fail, i.e., first call InitBuffer on the pool.
+        //!
+        //!  @param request The request used to update a buffer instance's device mask and device buffer
+        //!      allocations.
+        //!  @return A result code denoting the status of the call. If successful, the buffer device mask is
+        //!      considered updated. If the pool fails to secure an allocation for the device buffers, it's
+        //!      device mask may only partially change. If the initial data upload fails, the buffer will be
+        //!      initialized, but will remain empty and the call will return ResultCode::OutOfMemory.
+        ResultCode UpdateBufferDeviceMask(const BufferDeviceMaskRequest& request);
 
         //! NOTE: Only applicable to 'Host' pools. Device pools will fail with ResultCode::InvalidOperation.
         //!

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPool.h
@@ -15,22 +15,18 @@ namespace AZ::RHI
     class DeviceFence;
 
     //! A structure used as an argument to DeviceBufferPool::InitBuffer.
-    template <typename BufferClass>
-    struct BufferInitRequestTemplate
+    struct DeviceBufferInitRequest
     {
-        BufferInitRequestTemplate() = default;
+        DeviceBufferInitRequest() = default;
 
-        BufferInitRequestTemplate(
-            BufferClass& buffer,
-            const BufferDescriptor& descriptor,
-            const void* initialData = nullptr)
-            : m_buffer{&buffer}
-            , m_descriptor{descriptor}
-            , m_initialData{initialData}
-            {}
+        DeviceBufferInitRequest(DeviceBuffer& buffer, const BufferDescriptor& descriptor, const void* initialData = nullptr)
+            : m_buffer{ &buffer }
+            , m_descriptor{ descriptor }
+            , m_initialData{ initialData }
+        {}
 
         /// The buffer to initialize. The buffer must be in an uninitialized state.
-        BufferClass* m_buffer = nullptr;
+        DeviceBuffer* m_buffer = nullptr;
 
         /// The descriptor used to initialize the buffer.
         BufferDescriptor m_descriptor;
@@ -89,7 +85,6 @@ namespace AZ::RHI
         const void* m_sourceData = nullptr;
     };
 
-    using DeviceBufferInitRequest = BufferInitRequestTemplate<DeviceBuffer>;
     using DeviceBufferMapRequest = BufferMapRequestTemplate<DeviceBuffer>;
     using DeviceBufferStreamRequest = BufferStreamRequestTemplate<DeviceBuffer, DeviceFence>;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePool.h
@@ -15,22 +15,18 @@
 namespace AZ::RHI
 {
     //! @brief The data structure used to initialize an RHI::DeviceImage on an RHI::DeviceImagePool.
-    template <typename ImageClass>
-    struct ImageInitRequestTemplate
+    struct DeviceImageInitRequest
     {
-        ImageInitRequestTemplate() = default;
+        DeviceImageInitRequest() = default;
 
-        ImageInitRequestTemplate(
-            ImageClass& image,
-            const ImageDescriptor& descriptor,
-            const ClearValue* optimizedClearValue = nullptr)
-            : m_image{&image}
-            , m_descriptor{descriptor}
-            , m_optimizedClearValue{optimizedClearValue}
+        DeviceImageInitRequest(DeviceImage& image, const ImageDescriptor& descriptor, const ClearValue* optimizedClearValue = nullptr)
+            : m_image{ &image }
+            , m_descriptor{ descriptor }
+            , m_optimizedClearValue{ optimizedClearValue }
         {}
 
         /// The image to initialize.
-        ImageClass* m_image = nullptr;
+        DeviceImage* m_image = nullptr;
 
         /// The descriptor used to initialize the image.
         ImageDescriptor m_descriptor;
@@ -63,7 +59,6 @@ namespace AZ::RHI
         ImageSubresourceLayoutClass m_sourceSubresourceLayout;
     };
 
-    using DeviceImageInitRequest = ImageInitRequestTemplate<DeviceImage>;
     using DeviceImageUpdateRequest = ImageUpdateRequestTemplate<DeviceImage, DeviceImageSubresourceLayout>;
 
     //! DeviceImagePool is a pool of images that will be bound as attachments to the frame scheduler.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
@@ -37,22 +37,19 @@ namespace AZ::RHI
     using CompleteCallback = AZStd::function<void()>;
 
     //! A structure used as an argument to DeviceStreamingImagePool::InitImage.
-    template <typename ImageClass>
-    struct StreamingImageInitRequestTemplate
+    struct DeviceStreamingImageInitRequest
     {
-        StreamingImageInitRequestTemplate() = default;
+        DeviceStreamingImageInitRequest() = default;
 
-        StreamingImageInitRequestTemplate(
-            ImageClass& image,
-            const ImageDescriptor& descriptor,
-            AZStd::span<const StreamingImageMipSlice> tailMipSlices)
-            : m_image{&image}
-            , m_descriptor{descriptor}
-            , m_tailMipSlices{tailMipSlices}
+        DeviceStreamingImageInitRequest(
+            DeviceImage& image, const ImageDescriptor& descriptor, AZStd::span<const StreamingImageMipSlice> tailMipSlices)
+            : m_image{ &image }
+            , m_descriptor{ descriptor }
+            , m_tailMipSlices{ tailMipSlices }
         {}
 
         /// The image to initialize.
-        ImageClass* m_image = nullptr;
+        DeviceImage* m_image = nullptr;
 
         /// The descriptor used to to initialize the image.
         ImageDescriptor m_descriptor;
@@ -84,7 +81,6 @@ namespace AZ::RHI
         CompleteCallback m_completeCallback;
     };
 
-    using DeviceStreamingImageInitRequest = StreamingImageInitRequestTemplate<DeviceImage>;
     using DeviceStreamingImageExpandRequest = StreamingImageExpandRequestTemplate<DeviceImage>;
 
     class DeviceStreamingImagePool

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -119,9 +119,10 @@ namespace AZ::RHI
         AZ_RTTI(ImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
         virtual ~ImageView() = default;
 
-        ImageView(const RHI::Image* image, ImageViewDescriptor descriptor)
+        ImageView(const RHI::Image* image, ImageViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
             : m_image{ image }
             , m_descriptor{ descriptor }
+            , m_deviceMask{ deviceMask }
         {
         }
 
@@ -157,6 +158,8 @@ namespace AZ::RHI
         ConstPtr<RHI::Image> m_image;
         //! The corresponding ImageViewDescriptor for this view.
         ImageViewDescriptor m_descriptor;
+        //! The device mask of the image stored for comparison to figure out when cache entries need to be freed.
+        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
         //! DeviceImageView cache
         //! This cache is necessary as the caller receives raw pointers from the ResourceCache,
         //! which now, with multi-device objects in use, need to be held in memory as long as

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
@@ -15,38 +15,7 @@
 
 namespace AZ::RHI
 {
-    struct ImageInitRequest
-    {
-        ImageInitRequest() = default;
-
-        ImageInitRequest(
-            Image& image,
-            const ImageDescriptor& descriptor,
-            const ClearValue* optimizedClearValue = nullptr,
-            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
-            : m_image{ &image }
-            , m_descriptor{ descriptor }
-            , m_optimizedClearValue{ optimizedClearValue }
-            , m_deviceMask{ deviceMask }
-        {
-        }
-
-        /// The image to initialize.
-        Image* m_image = nullptr;
-
-        /// The descriptor used to initialize the image.
-        ImageDescriptor m_descriptor;
-
-        /// An optional, optimized clear value for the image. Certain
-        /// platforms may use this value to perform fast clears when this
-        /// clear value is used.
-        const ClearValue* m_optimizedClearValue = nullptr;
-
-        /// The device mask used for the image.
-        /// Note: Only devices in the mask of the image pool will be considered.
-        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
-    };
-
+    //! @brief The data structure used to update the device mask of an RHI::Image.
     struct ImageDeviceMaskRequest
     {
         ImageDeviceMaskRequest() = default;
@@ -70,6 +39,25 @@ namespace AZ::RHI
         /// platforms may use this value to perform fast clears when this
         /// clear value is used.
         const ClearValue* m_optimizedClearValue = nullptr;
+    };
+
+    //! @brief The data structure used to initialize an RHI::Image on an RHI::ImagePool.
+    struct ImageInitRequest : public ImageDeviceMaskRequest
+    {
+        ImageInitRequest() = default;
+
+        ImageInitRequest(
+            Image& image,
+            const ImageDescriptor& descriptor,
+            const ClearValue* optimizedClearValue = nullptr,
+            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+            : ImageDeviceMaskRequest{ image, deviceMask, optimizedClearValue }
+            , m_descriptor{ descriptor }
+        {
+        }
+
+        /// The descriptor used to initialize the image.
+        ImageDescriptor m_descriptor;
     };
 
     using ImageUpdateRequest = ImageUpdateRequestTemplate<Image, ImageSubresourceLayout>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
@@ -15,7 +15,63 @@
 
 namespace AZ::RHI
 {
-    using ImageInitRequest = ImageInitRequestTemplate<Image>;
+    struct ImageInitRequest
+    {
+        ImageInitRequest() = default;
+
+        ImageInitRequest(
+            Image& image,
+            const ImageDescriptor& descriptor,
+            const ClearValue* optimizedClearValue = nullptr,
+            MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+            : m_image{ &image }
+            , m_descriptor{ descriptor }
+            , m_optimizedClearValue{ optimizedClearValue }
+            , m_deviceMask{ deviceMask }
+        {
+        }
+
+        /// The image to initialize.
+        Image* m_image = nullptr;
+
+        /// The descriptor used to initialize the image.
+        ImageDescriptor m_descriptor;
+
+        /// An optional, optimized clear value for the image. Certain
+        /// platforms may use this value to perform fast clears when this
+        /// clear value is used.
+        const ClearValue* m_optimizedClearValue = nullptr;
+
+        /// The device mask used for the image.
+        /// Note: Only devices in the mask of the image pool will be considered.
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+    };
+
+    struct ImageDeviceMaskRequest
+    {
+        ImageDeviceMaskRequest() = default;
+
+        ImageDeviceMaskRequest(
+            Image& image, MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices, const ClearValue* optimizedClearValue = nullptr)
+            : m_image{ &image }
+            , m_deviceMask{ deviceMask }
+            , m_optimizedClearValue{ optimizedClearValue }
+        {
+        }
+
+        /// The image to initialize.
+        Image* m_image = nullptr;
+
+        /// The device mask used for the image.
+        /// Note: Only devices in the mask of the image pool will be considered.
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+
+        /// An optional, optimized clear value for the image. Certain
+        /// platforms may use this value to perform fast clears when this
+        /// clear value is used.
+        const ClearValue* m_optimizedClearValue = nullptr;
+    };
+
     using ImageUpdateRequest = ImageUpdateRequestTemplate<Image, ImageSubresourceLayout>;
 
     //! ImagePool is a pool of images that will be bound as attachments to the frame scheduler.
@@ -36,6 +92,9 @@ namespace AZ::RHI
 
         //! Initializes an image onto the pool. The pool provides backing GPU resources to the image.
         ResultCode InitImage(const ImageInitRequest& request);
+
+        //! Updates the device mask of an image instance created from this pool.
+        ResultCode UpdateImageDeviceMask(const ImageDeviceMaskRequest& request);
 
         //! Updates image content from the CPU.
         ResultCode UpdateImageContents(const ImageUpdateRequest& request);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -41,17 +41,9 @@ namespace AZ::RHI
         //! Helper method to check if a device index is set in the device mask.
         //! Note: A bit may be set but a device object may not actually exist,
         //! e.g. if the device index is bigger than the device count.
-        static AZ_FORCE_INLINE bool IsDeviceSet(MultiDevice::DeviceMask deviceMask, int deviceIndex)
-        {
-            return (AZStd::to_underlying(deviceMask) >> deviceIndex) & 1u;
-        }
-
-        //! Helper method to check if a device index is set in the device mask.
-        //! Note: A bit may be set but a device object may not actually exist,
-        //! e.g. if the device index is bigger than the device count.
         AZ_FORCE_INLINE bool IsDeviceSet(int deviceIndex) const
         {
-            return IsDeviceSet(m_deviceMask, deviceIndex);
+            return CheckBit(m_deviceMask, deviceIndex);
         }
 
         //! Helper method that will iterate over all available devices in a device mask and call the provided callback
@@ -69,7 +61,7 @@ namespace AZ::RHI
 
             for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if (IsDeviceSet(deviceMask, deviceIndex))
+                if (CheckBit(deviceMask, deviceIndex))
                 {
                     if (!callback(deviceIndex))
                     {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
@@ -32,7 +32,7 @@ namespace AZ::RHI
 
             for (auto deviceIndex { 0 }; deviceIndex < deviceCount; ++deviceIndex)
             {
-                if (CheckBit(AZStd::to_underlying(deviceMask), static_cast<u8>(deviceIndex)))
+                if (CheckBit(deviceMask, deviceIndex))
                 {
                     m_devicePipelineLibraryDescriptors[deviceIndex] = {
                         serializedData.contains(deviceIndex) ? serializedData.at(deviceIndex) : nullptr,

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -20,39 +20,7 @@ namespace AZ
     {
         using CompleteCallback = AZStd::function<void()>;
 
-        //! A structure used as an argument to StreamingImagePool::InitImage.
-        struct StreamingImageInitRequest
-        {
-            StreamingImageInitRequest() = default;
-
-            StreamingImageInitRequest(
-                Image& image,
-                const ImageDescriptor& descriptor,
-                AZStd::span<const StreamingImageMipSlice> tailMipSlices,
-                MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
-                : m_image{ &image }
-                , m_descriptor{ descriptor }
-                , m_tailMipSlices{ tailMipSlices }
-                , m_deviceMask{ deviceMask }
-            {
-            }
-
-            /// The image to initialize.
-            Image* m_image = nullptr;
-
-            /// The descriptor used to to initialize the image.
-            ImageDescriptor m_descriptor;
-
-            //! An array of tail mip slices to upload. This must not be empty or the call will fail.
-            //! This should only include the baseline set of mips necessary to render the image at
-            //! its lowest resolution. The uploads is performed synchronously.
-            AZStd::span<const StreamingImageMipSlice> m_tailMipSlices;
-
-            /// The device mask used for the image.
-            /// Note: Only devices in the mask of the image pool will be considered.
-            MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
-        };
-
+        //! A structure used as an argument to StreamingImagePool::UpdateImageDeviceMask.
         struct StreamingImageDeviceMaskRequest
         {
             StreamingImageDeviceMaskRequest() = default;
@@ -78,6 +46,25 @@ namespace AZ
             /// The device mask used for the image.
             /// Note: Only devices in the mask of the image pool will be considered.
             MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+        };
+
+        //! A structure used as an argument to StreamingImagePool::InitImage.
+        struct StreamingImageInitRequest : public StreamingImageDeviceMaskRequest
+        {
+            StreamingImageInitRequest() = default;
+
+            StreamingImageInitRequest(
+                Image& image,
+                const ImageDescriptor& descriptor,
+                AZStd::span<const StreamingImageMipSlice> tailMipSlices,
+                MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+                : StreamingImageDeviceMaskRequest{ image, tailMipSlices, deviceMask }
+                , m_descriptor{ descriptor }
+            {
+            }
+
+            /// The descriptor used to to initialize the image.
+            ImageDescriptor m_descriptor;
         };
 
         using StreamingImageExpandRequest = StreamingImageExpandRequestTemplate<Image>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -20,7 +20,66 @@ namespace AZ
     {
         using CompleteCallback = AZStd::function<void()>;
 
-        using StreamingImageInitRequest = StreamingImageInitRequestTemplate<Image>;
+        //! A structure used as an argument to StreamingImagePool::InitImage.
+        struct StreamingImageInitRequest
+        {
+            StreamingImageInitRequest() = default;
+
+            StreamingImageInitRequest(
+                Image& image,
+                const ImageDescriptor& descriptor,
+                AZStd::span<const StreamingImageMipSlice> tailMipSlices,
+                MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+                : m_image{ &image }
+                , m_descriptor{ descriptor }
+                , m_tailMipSlices{ tailMipSlices }
+                , m_deviceMask{ deviceMask }
+            {
+            }
+
+            /// The image to initialize.
+            Image* m_image = nullptr;
+
+            /// The descriptor used to to initialize the image.
+            ImageDescriptor m_descriptor;
+
+            //! An array of tail mip slices to upload. This must not be empty or the call will fail.
+            //! This should only include the baseline set of mips necessary to render the image at
+            //! its lowest resolution. The uploads is performed synchronously.
+            AZStd::span<const StreamingImageMipSlice> m_tailMipSlices;
+
+            /// The device mask used for the image.
+            /// Note: Only devices in the mask of the image pool will be considered.
+            MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+        };
+
+        struct StreamingImageDeviceMaskRequest
+        {
+            StreamingImageDeviceMaskRequest() = default;
+
+            StreamingImageDeviceMaskRequest(
+                Image& image,
+                AZStd::span<const StreamingImageMipSlice> tailMipSlices,
+                MultiDevice::DeviceMask deviceMask = MultiDevice::AllDevices)
+                : m_image{ &image }
+                , m_tailMipSlices{ tailMipSlices }
+                , m_deviceMask{ deviceMask }
+            {
+            }
+
+            /// The image to initialize.
+            Image* m_image = nullptr;
+
+            //! An array of tail mip slices to upload. This must not be empty or the call will fail.
+            //! This should only include the baseline set of mips necessary to render the image at
+            //! its lowest resolution. The uploads is performed synchronously.
+            AZStd::span<const StreamingImageMipSlice> m_tailMipSlices;
+
+            /// The device mask used for the image.
+            /// Note: Only devices in the mask of the image pool will be considered.
+            MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+        };
+
         using StreamingImageExpandRequest = StreamingImageExpandRequestTemplate<Image>;
 
         class StreamingImagePool : public ImagePoolBase
@@ -37,6 +96,9 @@ namespace AZ
 
             //! Initializes the backing resources of an image.
             ResultCode InitImage(const StreamingImageInitRequest& request);
+
+            //! Updates the device mask of an image instance created from this pool.
+            ResultCode UpdateImageDeviceMask(const StreamingImageDeviceMaskRequest& request);
 
             //! Expands a streaming image with new mip chain data. The expansion can be performed
             //! asynchronously or synchronously depends on @m_waitForUpload in @StreamingImageExpandRequest.

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -8,7 +8,6 @@
 #include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
-#include <Atom/RHI/RHISystemInterface.h>
 
 namespace AZ::RHI
 {
@@ -73,16 +72,16 @@ namespace AZ::RHI
         {
             m_deviceMask = m_buffer->GetDeviceMask();
 
-            for (auto checkDeviceIndex{ 0 }; checkDeviceIndex < RHISystemInterface::Get()->GetDeviceCount(); ++checkDeviceIndex)
-            {
-                if (!m_buffer->IsDeviceSet(checkDeviceIndex))
+            MultiDeviceObject::IterateDevices(
+                m_deviceMask,
+                [this](int deviceIndex)
                 {
-                    if (auto it{ m_cache.find(checkDeviceIndex) }; it != m_cache.end())
+                    if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
                     {
                         m_cache.erase(it);
                     }
-                }
-            }
+                    return true;
+                });
         }
 
         auto iterator{ m_cache.find(deviceIndex) };

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -96,6 +96,10 @@ namespace AZ::RHI
                 return new_iterator->second;
             }
         }
+        else if (&iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
+        {
+            iterator->second = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
+        }
 
         return iterator->second;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -167,6 +167,7 @@ namespace AZ::RHI
                             if (createBuffer)
                             {
                                 initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
+
                                 DeviceBufferInitRequest bufferInitRequest(
                                     *initRequest.m_buffer->GetDeviceBuffer(deviceIndex),
                                     initRequest.m_descriptor,
@@ -174,9 +175,20 @@ namespace AZ::RHI
                                 return deviceBufferPool->InitBuffer(bufferInitRequest);
                             }
                         }
-                        else if (!createBuffer)
+                        else
                         {
-                            initRequest.m_buffer->m_deviceObjects.erase(deviceIndex);
+                            if (createBuffer)
+                            {
+                                DeviceBufferInitRequest bufferInitRequest(
+                                    *initRequest.m_buffer->GetDeviceBuffer(deviceIndex),
+                                    initRequest.m_descriptor,
+                                    initRequest.m_initialData);
+                                return deviceBufferPool->InitBuffer(bufferInitRequest);
+                            }
+                            else
+                            {
+                                initRequest.m_buffer->m_deviceObjects.erase(deviceIndex);
+                            }
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -155,20 +155,75 @@ namespace AZ::RHI
             initRequest.m_descriptor,
             [this, &initRequest]()
             {
-                return IterateObjects<DeviceBufferPool>([&initRequest](auto deviceIndex, auto deviceBufferPool)
-                {
-                    if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
-                    {
-                        initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
-                    }
+                initRequest.m_buffer->Init(GetDeviceMask() & initRequest.m_deviceMask);
 
-                    DeviceBufferInitRequest bufferInitRequest(
-                        *initRequest.m_buffer->GetDeviceBuffer(deviceIndex), initRequest.m_descriptor, initRequest.m_initialData);
-                    return deviceBufferPool->InitBuffer(bufferInitRequest);
-                });
+                return IterateObjects<DeviceBufferPool>(
+                    [&initRequest](auto deviceIndex, auto deviceBufferPool)
+                    {
+                        bool createBuffer = ((AZStd::to_underlying(initRequest.m_buffer->GetDeviceMask()) >> deviceIndex) & 1) == 1;
+
+                        if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
+                        {
+                            if (createBuffer)
+                            {
+                                initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
+                                DeviceBufferInitRequest bufferInitRequest(
+                                    *initRequest.m_buffer->GetDeviceBuffer(deviceIndex),
+                                    initRequest.m_descriptor,
+                                    initRequest.m_initialData);
+                                return deviceBufferPool->InitBuffer(bufferInitRequest);
+                            }
+                        }
+                        else if (!createBuffer)
+                        {
+                            initRequest.m_buffer->m_deviceObjects.erase(deviceIndex);
+                        }
+
+                        return ResultCode::Success;
+                    });
             });
 
         return resultCode;
+    }
+
+    ResultCode BufferPool::UpdateBufferDeviceMask(const BufferDeviceMaskRequest& request)
+    {
+        AZ_PROFILE_FUNCTION(RHI);
+
+        return IterateObjects<DeviceBufferPool>(
+            [&request, this](auto deviceIndex, auto deviceBufferPool)
+            {
+                bool createBuffer = ((AZStd::to_underlying(GetDeviceMask() & request.m_deviceMask) >> deviceIndex) & 1) == 1;
+
+                if (!request.m_buffer->m_deviceObjects.contains(deviceIndex))
+                {
+                    if (createBuffer)
+                    {
+                        request.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
+
+                        DeviceBufferInitRequest bufferInitRequest(
+                            *request.m_buffer->GetDeviceBuffer(deviceIndex), request.m_buffer->m_descriptor, request.m_initialData);
+                        auto result = deviceBufferPool->InitBuffer(bufferInitRequest);
+
+                        if (result == ResultCode::Success)
+                        {
+                            request.m_buffer->Init(
+                                MultiDevice::DeviceMask(AZStd::to_underlying(request.m_buffer->GetDeviceMask()) | (1 << deviceIndex)));
+                        }
+
+                        return result;
+                    }
+                }
+                else if (!createBuffer)
+                {
+                    request.m_buffer->Init(
+                        MultiDevice::DeviceMask(AZStd::to_underlying(request.m_buffer->GetDeviceMask()) & ~(1 << deviceIndex)));
+                    request.m_buffer->m_deviceObjects.erase(deviceIndex);
+                    return ResultCode::Success;
+                }
+
+                return ResultCode::Success;
+            });
     }
 
     ResultCode BufferPool::OrphanBuffer(Buffer& buffer)
@@ -186,7 +241,7 @@ namespace AZ::RHI
         AZ_PROFILE_SCOPE(RHI, "BufferPool::OrphanBuffer");
 
         buffer.Invalidate();
-        buffer.Init(GetDeviceMask());
+        buffer.Init(MultiDevice::NoDevices);
 
         return ResultCode::Success;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -160,35 +160,28 @@ namespace AZ::RHI
                 return IterateObjects<DeviceBufferPool>(
                     [&initRequest](auto deviceIndex, auto deviceBufferPool)
                     {
-                        bool createBuffer = ((AZStd::to_underlying(initRequest.m_buffer->GetDeviceMask()) >> deviceIndex) & 1) == 1;
+                        bool initBuffer = ((AZStd::to_underlying(initRequest.m_buffer->GetDeviceMask()) >> deviceIndex) & 1) == 1;
 
                         if (!initRequest.m_buffer->m_deviceObjects.contains(deviceIndex))
                         {
-                            if (createBuffer)
+                            if (initBuffer)
                             {
                                 initRequest.m_buffer->m_deviceObjects[deviceIndex] = Factory::Get().CreateBuffer();
-
-                                DeviceBufferInitRequest bufferInitRequest(
-                                    *initRequest.m_buffer->GetDeviceBuffer(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_initialData);
-                                return deviceBufferPool->InitBuffer(bufferInitRequest);
                             }
                         }
                         else
                         {
-                            if (createBuffer)
-                            {
-                                DeviceBufferInitRequest bufferInitRequest(
-                                    *initRequest.m_buffer->GetDeviceBuffer(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_initialData);
-                                return deviceBufferPool->InitBuffer(bufferInitRequest);
-                            }
-                            else
+                            if (!initBuffer)
                             {
                                 initRequest.m_buffer->m_deviceObjects.erase(deviceIndex);
                             }
+                        }
+
+                        if (initBuffer)
+                        {
+                            DeviceBufferInitRequest bufferInitRequest(
+                                *initRequest.m_buffer->GetDeviceBuffer(deviceIndex), initRequest.m_descriptor, initRequest.m_initialData);
+                            return deviceBufferPool->InitBuffer(bufferInitRequest);
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceShaderResourceGroup.cpp
@@ -62,7 +62,7 @@ namespace AZ::RHI
         m_rhiUpdateMask |= sourceUpdateMask;
         for (uint32_t i = 0; i < static_cast<uint32_t>(DeviceShaderResourceGroupData::ResourceType::Count); i++)
         {
-            if (RHI::CheckBit(sourceUpdateMask, static_cast<AZ::u8>(i)))
+            if (CheckBit(sourceUpdateMask, i))
             {
                 m_resourceTypeIteration[i] = 0;
             }
@@ -73,7 +73,7 @@ namespace AZ::RHI
     {
         for (uint32_t i = 0; i < static_cast<uint32_t>(DeviceShaderResourceGroupData::ResourceType::Count); i++)
         {
-            if (RHI::CheckBit(m_rhiUpdateMask, static_cast<AZ::u8>(i)))
+            if (CheckBit(m_rhiUpdateMask, i))
             {
                 //Ensure that a SRG update is alive for m_updateMaskResetLatency times
                 //after SRG compile is called. This is because SRGs are triple buffered

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameAttachment.cpp
@@ -26,7 +26,17 @@ namespace AZ::RHI
     {
         if (m_resource)
         {
-            m_resource->SetFrameAttachment(nullptr);
+            if (m_lifetimeType == AttachmentLifetimeType::Imported)
+            {
+                m_resource->SetFrameAttachment(nullptr);
+            }
+            else
+            {
+                for (auto& [deviceIndex, scopeInfo] : m_scopeInfos)
+                {
+                    m_resource->SetFrameAttachment(nullptr, deviceIndex);
+                }
+            }
         }
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -135,6 +135,10 @@ namespace AZ::RHI
                 return new_iterator->second;
             }
         }
+        else if (&iterator->second->GetImage() != m_image->GetDeviceImage(deviceIndex).get())
+        {
+            iterator->second = m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
+        }
 
         return iterator->second;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -75,35 +75,30 @@ namespace AZ::RHI
                 ResultCode result = IterateObjects<DeviceImagePool>(
                     [&initRequest](auto deviceIndex, auto deviceImagePool)
                     {
-                        bool createImage = ((AZStd::to_underlying(initRequest.m_image->GetDeviceMask()) >> deviceIndex) & 1) == 1;
+                        bool initImage = ((AZStd::to_underlying(initRequest.m_image->GetDeviceMask()) >> deviceIndex) & 1) == 1;
 
                         if (!initRequest.m_image->m_deviceObjects.contains(deviceIndex))
                         {
-                            if (createImage)
+                            if (initImage)
                             {
                                 initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
-
-                                DeviceImageInitRequest imageInitRequest(
-                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_optimizedClearValue);
-                                return deviceImagePool->InitImage(imageInitRequest);
                             }
                         }
                         else
                         {
-                            if (createImage)
-                            {
-                                DeviceImageInitRequest imageInitRequest(
-                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_optimizedClearValue);
-                                return deviceImagePool->InitImage(imageInitRequest);
-                            }
-                            else
+                            if (!initImage)
                             {
                                 initRequest.m_image->m_deviceObjects.erase(deviceIndex);
                             }
+                        }
+
+                        if (initImage)
+                        {
+                            DeviceImageInitRequest imageInitRequest(
+                                *initRequest.m_image->GetDeviceImage(deviceIndex),
+                                initRequest.m_descriptor,
+                                initRequest.m_optimizedClearValue);
+                            return deviceImagePool->InitImage(imageInitRequest);
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -90,9 +90,20 @@ namespace AZ::RHI
                                 return deviceImagePool->InitImage(imageInitRequest);
                             }
                         }
-                        else if (!createImage)
+                        else
                         {
-                            initRequest.m_image->m_deviceObjects.erase(deviceIndex);
+                            if (createImage)
+                            {
+                                DeviceImageInitRequest imageInitRequest(
+                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
+                                    initRequest.m_descriptor,
+                                    initRequest.m_optimizedClearValue);
+                                return deviceImagePool->InitImage(imageInitRequest);
+                            }
+                            else
+                            {
+                                initRequest.m_image->m_deviceObjects.erase(deviceIndex);
+                            }
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourcePool.cpp
@@ -135,16 +135,20 @@ namespace AZ::RHI
             return ResultCode::InvalidArgument;
         }
 
+        resource->Init(GetDeviceMask());
         const ResultCode resultCode = platformInitResourceMethod();
         if (resultCode == ResultCode::Success)
         {
-            resource->Init(GetDeviceMask());
             Register(*resource);
 
             if (const auto& name = resource->GetName(); !name.IsEmpty())
             {
                 resource->SetName(name);
             }
+        }
+        else
+        {
+            resource->Init(MultiDevice::NoDevices);
         }
         return resultCode;
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -139,9 +139,20 @@ namespace AZ::RHI
                                 return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
                             }
                         }
-                        else if (!createImage)
+                        else
                         {
-                            initRequest.m_image->m_deviceObjects.erase(deviceIndex);
+                            if (createImage)
+                            {
+                                DeviceStreamingImageInitRequest streamingImageInitRequest(
+                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
+                                    initRequest.m_descriptor,
+                                    initRequest.m_tailMipSlices);
+                                return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
+                            }
+                            else
+                            {
+                                initRequest.m_image->m_deviceObjects.erase(deviceIndex);
+                            }
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -124,35 +124,28 @@ namespace AZ::RHI
                 ResultCode result = IterateObjects<DeviceStreamingImagePool>(
                     [&initRequest](auto deviceIndex, auto deviceStreamingImagePool)
                     {
-                        bool createImage = ((AZStd::to_underlying(initRequest.m_image->GetDeviceMask()) >> deviceIndex) & 1) == 1;
+                        bool initImage = ((AZStd::to_underlying(initRequest.m_image->GetDeviceMask()) >> deviceIndex) & 1) == 1;
 
                         if (!initRequest.m_image->m_deviceObjects.contains(deviceIndex))
                         {
-                            if (createImage)
+                            if (initImage)
                             {
                                 initRequest.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
-
-                                DeviceStreamingImageInitRequest streamingImageInitRequest(
-                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_tailMipSlices);
-                                return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
                             }
                         }
                         else
                         {
-                            if (createImage)
-                            {
-                                DeviceStreamingImageInitRequest streamingImageInitRequest(
-                                    *initRequest.m_image->GetDeviceImage(deviceIndex),
-                                    initRequest.m_descriptor,
-                                    initRequest.m_tailMipSlices);
-                                return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
-                            }
-                            else
+                            if (!initImage)
                             {
                                 initRequest.m_image->m_deviceObjects.erase(deviceIndex);
                             }
+                        }
+
+                        if (initImage)
+                        {
+                            DeviceStreamingImageInitRequest streamingImageInitRequest(
+                                *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);
+                            return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
                         }
 
                         return ResultCode::Success;

--- a/Gems/Atom/RHI/Code/Tests/FrameGraphTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/FrameGraphTests.cpp
@@ -470,8 +470,8 @@ namespace UnitTest
                 frameGraph.BeginScope(*m_state->m_scopes[0]);
                 frameGraph.SetHardwareQueueClass(RHI::HardwareQueueClass::Graphics);
 
-                constexpr uint32_t numImports = 10;
-                for (uint32_t i = 0; i < numImports; ++i)
+                constexpr uint32_t numBufferImports = 6;
+                for (uint32_t i = 0; i < numBufferImports; ++i)
                 {
                     frameGraph.GetAttachmentDatabase().ImportBuffer(
                         m_state->m_bufferAttachments[i].m_id, m_state->m_bufferAttachments[i].m_buffer);
@@ -535,7 +535,8 @@ namespace UnitTest
                     AZ_TEST_STOP_ASSERTTEST(1);
                 }
 
-                for (uint32_t i = 0; i < numImports; ++i)
+                constexpr uint32_t numImageImports = 9;
+                for (uint32_t i = 0; i < numImageImports; ++i)
                 {
                     frameGraph.GetAttachmentDatabase().ImportImage(
                         m_state->m_imageAttachments[i].m_id, m_state->m_imageAttachments[i].m_image);
@@ -562,7 +563,7 @@ namespace UnitTest
                     AZ_TEST_STOP_ASSERTTEST(1);
 
                     // Mipmap overlap, Slice Overlap
-                    desc.m_attachmentId = m_state->m_imageAttachments[3].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[2].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 1, 0, 1);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 1, 2, 1, 2);
@@ -571,7 +572,7 @@ namespace UnitTest
                     AZ_TEST_STOP_ASSERTTEST(1);
 
                     // No overlap, different aspect mask
-                    desc.m_attachmentId = m_state->m_imageAttachments[4].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[3].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor();
                     desc.m_imageViewDescriptor.m_aspectFlags = RHI::ImageAspectFlags::Depth;
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
@@ -579,34 +580,34 @@ namespace UnitTest
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
 
                     // No overlap on mimap
-                    desc.m_attachmentId = m_state->m_imageAttachments[5].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[4].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 1, 0, 1);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 2, 3, 0, 1);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
 
                     // No overlap on slice
-                    desc.m_attachmentId = m_state->m_imageAttachments[6].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[5].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 1, 0, 1);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 1, 2, 3);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
 
                     // No overlap on mipmap and slice
-                    desc.m_attachmentId = m_state->m_imageAttachments[7].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[6].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 0, 1, 1, 2);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 2, 3, 3, 4);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::AnyGraphics);
 
                     // Overlap read only
-                    desc.m_attachmentId = m_state->m_imageAttachments[8].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[7].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor();
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentStage::AnyGraphics);
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentStage::AnyGraphics);
 
                     // Overlap invalid usage
-                    desc.m_attachmentId = m_state->m_imageAttachments[9].m_id;
+                    desc.m_attachmentId = m_state->m_imageAttachments[8].m_id;
                     desc.m_imageViewDescriptor = RHI::ImageViewDescriptor();
                     frameGraph.UseDepthStencilAttachment(
                         desc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentStage::EarlyFragmentTest);
@@ -614,7 +615,7 @@ namespace UnitTest
                     frameGraph.UseDepthStencilAttachment(
                         desc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentStage::EarlyFragmentTest);
                     AZ_TEST_STOP_ASSERTTEST(1);
-                }              
+                }
 
                 frameGraph.EndScope();
 


### PR DESCRIPTION
## What does this PR do?

This PR changes the API of images and buffers to support having an own device mask which may include less devices than the pool they were allocated from as well as updating this device mask when necessary. This might be used for resources that are only required on a subset of devices that may change in dynamic scheduling situations as passes are moved between devices.

## How was this PR tested?

Tested with sample code in the RHI MultiGPU sample in ASV.
