### PR TITLE
cherry-pick bugfix from stabilization - Fixes a crash in test LevelEntityComponentCRUD test

### DIFF
--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -28,6 +28,7 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 // Folder in which levels are stored
 static const char kNewLevelDialog_LevelsFolder[] = "Levels";
 static constexpr const char* RegistryKey_CustomTemplatePaths = "/O3DE/Preferences/Prefab/CustomTemplatePaths";
+static constexpr const char* DefaultTemplate = "Default_Level.prefab";
 
 class LevelFolderValidator : public QValidator
 {
@@ -139,6 +140,7 @@ void CNewLevelDialog::InitTemplateListWidget() const
     // Get all prefab files.
     const QStringList fileFilter = {"*.prefab"};
     QStringList allTemplateFiles;
+    int defaultItem = 0;
     for(const QString& path: templatePaths)
     {
         QDir projectTemplateDirectory(path);
@@ -147,6 +149,10 @@ void CNewLevelDialog::InitTemplateListWidget() const
         const QStringList projectTemplateFiles = projectTemplateDirectory.entryList(QDir::Files);
         for (const QString& fileName: projectTemplateFiles)
         {
+            if (fileName.compare(QString::fromUtf8(DefaultTemplate), Qt::CaseInsensitive) == 0)
+            {
+                defaultItem = allTemplateFiles.size();
+            }
             allTemplateFiles.push_back(projectTemplateDirectory.filePath(fileName));
         }
     }
@@ -168,11 +174,30 @@ void CNewLevelDialog::InitTemplateListWidget() const
     ui->listTemplates->setViewMode(QListWidget::IconMode);
     ui->listTemplates->setIconSize(iconSize);
     ui->listTemplates->setDragDropMode(QAbstractItemView::NoDragDrop);
+    if (ui->listTemplates->count() > 0)
+    {
+        ui->listTemplates->setCurrentRow(defaultItem);
+    }
 }
 
 QString CNewLevelDialog::GetTemplateName() const
 {
-    const QString name = ui->listTemplates->currentItem()->data(Qt::UserRole).toString();
+    const auto* item = ui->listTemplates->currentItem();
+    if (item == nullptr)
+    {
+        if (ui->listTemplates->count() > 0)
+        {
+            // for safety, return the 0th item.
+            return ui->listTemplates->item(0)->data(Qt::UserRole).toString();
+        }
+        else
+        {
+            // if we have no templates at all, return an empty string.
+            return QString();
+        }
+    }
+
+    const QString name =item->data(Qt::UserRole).toString();
     return name;
 }
 


### PR DESCRIPTION
This is a cherry-pick of the already merged bugfix https://github.com/o3de/o3de/pull/18164 from stabilization

AutomatedTesting\Gem\PythonTests\editor\EditorScripts\BasicEditorWorkflows_LevelEntityComponentCRUD.py

I really have no idea how this didn't constantly crash before.

The above named script opens a New Level Dialog and before it even manages to fully appear, it auto-accepts it, which calls the GetTemplatePath function. This function de-references (without checking), the pointer given by the UI to the currently selected item in the list view.

There is no default selection so this would always be nullptr, resulting in a nullptr de-reference.

I don't know when this changed, but this change makes it so that there is a preferred default selection, and if the default is missing, it uses the first item in the list as a final fail-safe.

Tested by running the script.  It crashed 100% of the time for me before, and after, it no longer crashes.  Also, the GUI now nicely selects the default level by default.
