### PR TITLE
Fix FFont position issue when using r_renderScale

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
@@ -253,7 +253,7 @@ namespace AZ
             AZ::Vector2 m_position;
             AZ::Vector2 m_size;
             AZ::RPI::ViewportContextPtr m_viewportContext;
-            const AZ::RHI::Viewport* m_viewport;
+            AZ::RHI::Viewport m_viewport;
         };
         DrawParameters ExtractDrawParameters(const AzFramework::TextDrawParameters& params, AZStd::string_view text, bool forceCalculateSize);
 

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1609,8 +1609,9 @@ AZ::FFont::DrawParameters AZ::FFont::ExtractDrawParameters(const AzFramework::Te
     float posX = params.m_position.GetX();
     float posY = params.m_position.GetY();
     internalParams.m_viewportContext = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get()->GetViewportContextById(params.m_drawViewportId);
-    const AZ::RHI::Viewport& viewport = internalParams.m_viewportContext->GetWindowContext()->GetViewport();
-    internalParams.m_viewport = &viewport;
+    const auto viewportSize = internalParams.m_viewportContext->GetViewportSize();
+    internalParams.m_viewport = AZ::RHI::Viewport(0, aznumeric_caster(viewportSize.m_width), 0, aznumeric_caster(viewportSize.m_height));
+    auto& viewport = internalParams.m_viewport;
     if (params.m_virtual800x600ScreenSize)
     {
         posX *= WindowScaleWidth / (viewport.m_maxX - viewport.m_minX);
@@ -1686,7 +1687,7 @@ void AZ::FFont::DrawScreenAlignedText2d(
     }
 
     DrawStringUInternal(
-        *internalParams.m_viewport, 
+        internalParams.m_viewport, 
         internalParams.m_viewportContext, 
         internalParams.m_position.GetX(), 
         internalParams.m_position.GetY(), 
@@ -1725,10 +1726,10 @@ void AZ::FFont::DrawScreenAlignedText3d(
     internalParams.m_ctx.m_sizeIn800x600 = false;
 
     DrawStringUInternal(
-        *internalParams.m_viewport, 
+        internalParams.m_viewport, 
         internalParams.m_viewportContext, 
-        positionNdc.GetX() * internalParams.m_viewport->GetWidth() + internalParams.m_position.GetX(), 
-        (1.0f - positionNdc.GetY()) * internalParams.m_viewport->GetHeight() + internalParams.m_position.GetY(), 
+        positionNdc.GetX() * internalParams.m_viewport.GetWidth() + internalParams.m_position.GetX(), 
+        (1.0f - positionNdc.GetY()) * internalParams.m_viewport.GetHeight() + internalParams.m_position.GetY(), 
         positionNdc.GetZ(), // Z
         text.data(),
         params.m_multiline,

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -164,23 +164,9 @@ namespace AZ::Render
 
         m_drawParams.m_drawViewportId = viewportContext->GetId();
         
-        AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
-        uint32_t r_width, r_resolutionMode  = 0;
-        console->GetCvarValue("r_resolutionMode", r_resolutionMode);
-        
-        if (r_resolutionMode > 0u)
-        {
-            //This ensures the debug text is always attached to the top right when r_resolutionMode is enabled
-            console->GetCvarValue("r_width", r_width);
-            m_drawParams.m_position = AZ::Vector3(static_cast<float>(r_width), 0.0f, 1.0f) +
-                AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
-        }
-        else
-        {
-            auto viewportSize = viewportContext->GetViewportSize();
-            m_drawParams.m_position = AZ::Vector3(static_cast<float>(viewportSize.m_width), 0.0f, 1.0f) +
-                AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
-        }
+        auto viewportSize = viewportContext->GetViewportSize();
+        m_drawParams.m_position = AZ::Vector3(static_cast<float>(viewportSize.m_width), 0.0f, 1.0f) +
+            AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
         
         m_drawParams.m_color = AZ::Colors::White;
         m_drawParams.m_scale = AZ::Vector2(BaseFontSize);


### PR DESCRIPTION
## What does this PR do?

Atom debug text was rendering in the wrong position when the viewport was scaled from the window's size (when using the r_renderScale CVAR)

FFont was using the window's size instead of the viewport size when doing the text rendering.

## How was this PR tested?

Run Editor and GameLauncher PC. Run Android.