### PR TITLE
[Cherrry-pick] Fixing Vulkan SparseBinding memoryBindings for 3D texture (#18143)

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -192,8 +192,9 @@ namespace AZ
                 {
                     // find the offset base on bound blocks
                     VkOffset3D offset;
+                    // The offset need to modulo over the blockCountPerRow/PerColumn to ensure it stays in the boundary
                     offset.x = (boundBlockCount % blockCountPerRow) * imageGranularity.width;
-                    offset.y = (boundBlockCount / blockCountPerRow) * imageGranularity.height;
+                    offset.y = ((boundBlockCount / blockCountPerRow) % blockCountPerColumn) * imageGranularity.height;
                     offset.z = (boundBlockCount / (blockCountPerRow * blockCountPerColumn)) * imageGranularity.depth;
 
                     // only update the width of the extent 


### PR DESCRIPTION
## What does this PR do?

Cherry-pick #18143 from development to stabilization/2409

The current `UpdateMipMemoryBindInfo(uint16_t mipLevel)` did not consider the 3D volume texture case, as explained in code, when the VkImage's depth is not 1(aka 3D texture), the image binding will lead to horrendous error. This patch basically patch this issue.

## How was this PR tested?

Run PC