### PR TITLE
Add WM_DEVICECHANGE handling for the Native Windows Launcher to trigg…

### DIFF
--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -27,6 +27,8 @@
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 
+#include <dbt.h>
+
 namespace Editor
 {
     EditorQtApplication* EditorQtApplication::newInstance(int& argc, char** argv)
@@ -111,7 +113,7 @@ namespace Editor
             }
             else if (msg->message == WM_DEVICECHANGE)
             {
-                if (msg->wParam == 0x0007) // DBT_DEVNODES_CHANGED
+                if (msg->wParam == DBT_DEVNODES_CHANGED) // DBT_DEVNODES_CHANGED
                 {
                     AzFramework::RawInputNotificationBusWindows::Broadcast(
                         &AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -16,6 +16,8 @@
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/string/conversions.h>
 
+#include <dbt.h>
+
 namespace AzFramework
 {
     const wchar_t* NativeWindowImpl_Win32::s_defaultClassName = L"O3DEWin32Class";
@@ -386,6 +388,12 @@ namespace AzFramework
             shouldBubbleEventUp = true;
             break;
         }
+        case WM_DEVICECHANGE:
+            if (wParam == DBT_DEVNODES_CHANGED)
+            {
+                // If any device changes were detected, broadcast to the input device notification
+                AzFramework::RawInputNotificationBusWindows::Broadcast(&AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);
+            }
         default:
             shouldBubbleEventUp = true;
             break;


### PR DESCRIPTION
## What does this PR do?
Fixes the issue where the gamepad (and other input device) detection was only happening on game launch, but not when a device has been added or removed after game launch.

Fixes https://github.com/o3de/o3de/issues/18040 

## How was this PR tested?
Test scenario described by https://github.com/o3de/o3de/issues/18040 with the Paper Delivery Boy project

