### PR TITLE
Fix stencil store op on Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -696,7 +696,8 @@ namespace AZ
                     loadStoreAction.m_loadActionStencil,
                     attachmentLoadStoreAction.m_loadActionStencil);
                 attachmentLoadStoreAction.m_loadActionStencil = loadStoreAction.m_loadActionStencil;
-                attachmentLoadStoreAction.m_storeActionStencil = loadStoreAction.m_storeActionStencil != RHI::AttachmentStoreAction::Store
+                attachmentLoadStoreAction.m_storeActionStencil =
+                    loadStoreAction.m_storeActionStencil != RHI::AttachmentStoreAction::DontCare
                     ? loadStoreAction.m_storeActionStencil
                     : attachmentLoadStoreAction.m_storeActionStencil;
             };


### PR DESCRIPTION
## What does this PR do?

Fix stencil store operation bug introduced with commit 3a769943d0fa2a873c2553a0de847dacfe9fc173

## How was this PR tested?

Run PC Vulkan