### PR TITLE
Add RHI::AttachmentLoadAction::None and RHI::AttachmentStoreAction::None

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SkyBox.pass
@@ -14,8 +14,13 @@
                 },
                 {
                     "Name": "SkyBoxDepth",
-                    "SlotType": "InputOutput",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "DepthStencil",
+                    "LoadStoreAction": {
+                        "StoreAction": "None",
+                        "LoadActionStencil": "None",
+                        "StoreActionStencil": "None"
+                    }
                 }
             ],
             "PassData": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
@@ -30,7 +30,11 @@
                 {
                     "Name": "DepthStencil",
                     "SlotType": "Input",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "ScopeAttachmentUsage": "DepthStencil",
+                    "LoadStoreAction": {
+                        "StoreAction": "None",
+                        "StoreActionStencil": "None"
+                    }
                 },
                 // Input/Outputs
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ProjectedShadowmaps.pass
@@ -10,7 +10,11 @@
                 {
                     "Name": "Shadowmap",
                     "SlotType": "Output",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "ScopeAttachmentUsage": "DepthStencil",
+                    "LoadStoreAction": {
+                        "LoadActionStencil": "DontCare",
+                        "StoreActionStencil": "DontCare"
+                    }
                 },
                 {
                     "Name": "SkinnedMeshes",

--- a/Gems/Atom/Feature/Common/Assets/Passes/SilhouetteGather.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SilhouetteGather.pass
@@ -26,7 +26,11 @@
                 {
                     "Name": "DepthStencilInputOutput",
                     "SlotType": "Input",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "ScopeAttachmentUsage": "DepthStencil",
+                    "LoadStoreAction": {
+                        "StoreAction": "None",
+                        "StoreActionStencil": "None"
+                    }
                 }
             ],
             "ImageAttachments": [

--- a/Gems/Atom/Feature/Common/Assets/Passes/UI.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/UI.pass
@@ -15,7 +15,10 @@
                         "ClearValue": {
                             "Type": "DepthStencil"
                         },
-                        "LoadActionStencil": "Clear"
+                        "LoadAction": "None",
+                        "LoadActionStencil": "Clear",
+                        "StoreAction": "None",
+                        "StoreActionStencil": "DontCare"
                     }
                 },
                 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.shader
@@ -2,7 +2,7 @@
     "Source" : "SkyBox.azsl",
 
     "DepthStencilState" : { 
-        "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }
+        "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual", "WriteMask" : "Zero" }
     },
 
     "DrawList" : "forward",

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -108,6 +108,8 @@ namespace AZ
             RHI::AttachmentLoadStoreAction action;
             action.m_clearValue = RHI::ClearValue::CreateDepth(1.f);
             action.m_loadAction = m_clearEnabled ? RHI::AttachmentLoadAction::Clear : RHI::AttachmentLoadAction::DontCare;
+            action.m_loadActionStencil = RHI::AttachmentLoadAction::None;
+            action.m_storeActionStencil = RHI::AttachmentStoreAction::None;
             binding.m_unifiedScopeDesc = RHI::UnifiedScopeAttachmentDescriptor(attachmentId, imageViewDescriptor, action);
 
             Base::BuildInternal();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentEnums.h
@@ -221,7 +221,11 @@ namespace AZ::RHI
         Clear,
 
         //! The attachment contents are undefined. Use when writing to entire contents of view.
-        DontCare
+        DontCare,
+
+        //! The attachment contents will be undefined inside the current scope and the resource is not accessed.
+        //! Will fallback to a Load op if the platform doesn't support it.
+        None
     };
 
     //! Describes the action the hardware should use when storing an attachment after a scope.
@@ -231,7 +235,12 @@ namespace AZ::RHI
         Store = 0,
 
         //! The attachment contents can be undefined after the current scope.
-        DontCare
+        DontCare,
+
+        //! The attachment contents are read only. This avoid any write back operations.
+        //! If values are written this behaves identically to the DontCare op.
+        //! Will fallback to a Store op if the platform doesn't support it.
+        None
     };
 
     //! Describes the type of data the attachment represents

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
@@ -249,11 +249,13 @@ namespace AZ::RHI
             ->Value("Load", AttachmentLoadAction::Load)
             ->Value("Clear", AttachmentLoadAction::Clear)
             ->Value("DontCare", AttachmentLoadAction::DontCare)
+            ->Value("None", AttachmentLoadAction::None)
             ;
 
         serializeContext->Enum<AttachmentStoreAction>()
             ->Value("Store", AttachmentStoreAction::Store)
             ->Value("DontCare", AttachmentStoreAction::DontCare)
+            ->Value("None", AttachmentStoreAction::None)
             ;
 
         serializeContext->Enum<AttachmentType>()

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderAttachmentLayoutBuilder.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderAttachmentLayoutBuilder.cpp
@@ -400,7 +400,7 @@ namespace AZ::RHI
             AZ::RHI::ScopeAttachmentStage::ShadingRate,
             extras
         };
-        m_shadingRateAttachment.m_loadStoreAction.m_storeAction = AttachmentStoreAction::DontCare;
+        m_shadingRateAttachment.m_loadStoreAction.m_storeAction = AttachmentStoreAction::None;
         return this;
     }
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -145,9 +145,12 @@ namespace AZ
                 const bool isClearActionStencil = bindingDescriptor.m_loadStoreAction.m_loadActionStencil == RHI::AttachmentLoadAction::Clear;
                 
                 const bool isLoadAction         = bindingDescriptor.m_loadStoreAction.m_loadAction == RHI::AttachmentLoadAction::Load;
-                
-                const bool isStoreAction         = bindingDescriptor.m_loadStoreAction.m_storeAction == RHI::AttachmentStoreAction::Store;
-                const bool isStoreActionStencil  = bindingDescriptor.m_loadStoreAction.m_storeActionStencil == RHI::AttachmentStoreAction::Store;
+
+                // Metal doesn't support RHI::AttachmentStoreAction::None so we treat it as RHI::AttachmentStoreAction::Store
+                const bool isStoreAction = bindingDescriptor.m_loadStoreAction.m_storeAction == RHI::AttachmentStoreAction::Store ||
+                    bindingDescriptor.m_loadStoreAction.m_storeAction == RHI::AttachmentStoreAction::None;
+                const bool isStoreActionStencil  = bindingDescriptor.m_loadStoreAction.m_storeActionStencil == RHI::AttachmentStoreAction::Store ||
+                    bindingDescriptor.m_loadStoreAction.m_storeActionStencil == RHI::AttachmentStoreAction::None;
                 
                 
                 MTLLoadAction mtlLoadAction = MTLLoadActionDontCare;

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/Conversion.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/Conversion.h
@@ -48,8 +48,6 @@ namespace AZ
         VkBlendOp ConvertBlendOp(const RHI::BlendOp blendOp);
         VkColorComponentFlags ConvertComponentFlags(uint8_t flags);
         VkSampleCountFlagBits ConvertSampleCount(uint16_t samples);
-        VkAttachmentLoadOp ConvertAttachmentLoadAction(RHI::AttachmentLoadAction loadAction);
-        VkAttachmentStoreOp ConvertAttachmentStoreAction(RHI::AttachmentStoreAction storeAction);
         void FillClearValue(const RHI::ClearValue& rhiClearValue, VkClearValue& vulkanClearValue);
         VkFilter ConvertFilterMode(RHI::FilterMode filterMode);
         VkSamplerAddressMode ConvertAddressMode(RHI::AddressMode addressMode);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -397,37 +397,7 @@ namespace AZ
                 AZ_Assert(false, "SampleCount is invalid.");
                 return VK_SAMPLE_COUNT_1_BIT;
             }
-        }
-
-        VkAttachmentLoadOp ConvertAttachmentLoadAction(RHI::AttachmentLoadAction loadAction)
-        {
-            switch (loadAction)
-            {
-            case RHI::AttachmentLoadAction::Load:
-                return VK_ATTACHMENT_LOAD_OP_LOAD;
-            case RHI::AttachmentLoadAction::Clear:
-                return VK_ATTACHMENT_LOAD_OP_CLEAR;
-            case RHI::AttachmentLoadAction::DontCare:
-                return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-            default:    
-                AZ_Assert(false, "AttachmentLoadAction is illegal.");
-                return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-            }
-        }
-
-        VkAttachmentStoreOp ConvertAttachmentStoreAction(RHI::AttachmentStoreAction storeAction)
-        {
-            switch (storeAction)
-            {
-            case RHI::AttachmentStoreAction::Store:
-                return VK_ATTACHMENT_STORE_OP_STORE;
-            case RHI::AttachmentStoreAction::DontCare:
-                return VK_ATTACHMENT_STORE_OP_DONT_CARE;
-            default:
-                AZ_Assert(false, "AttachmentStoreAction is illegal.");
-                return VK_ATTACHMENT_STORE_OP_DONT_CARE;
-            }
-        }
+        }        
 
         void FillClearValue(const RHI::ClearValue& rhiClearValue, VkClearValue& vulkanClearValue)
         {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RHI/Resource.h>
 #include <Atom/RHI/DeviceImageView.h>
 #include <RHI/Conversion.h>
+#include <RHI/Device.h>
 #include <RHI/Image.h>
 #include <RHI/PhysicalDevice.h>
 
@@ -620,6 +621,44 @@ namespace AZ
             }
 
             return layout;
+        }
+
+        VkAttachmentLoadOp ConvertAttachmentLoadAction(RHI::AttachmentLoadAction loadAction, const Device& device)
+        {
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
+            switch (loadAction)
+            {
+            case RHI::AttachmentLoadAction::Load:
+                return VK_ATTACHMENT_LOAD_OP_LOAD;
+            case RHI::AttachmentLoadAction::Clear:
+                return VK_ATTACHMENT_LOAD_OP_CLEAR;
+            case RHI::AttachmentLoadAction::DontCare:
+                return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            case RHI::AttachmentLoadAction::None:
+                return physicalDevice.IsFeatureSupported(DeviceFeature::LoadNoneOp) ? VK_ATTACHMENT_LOAD_OP_NONE_EXT
+                                                                                    : VK_ATTACHMENT_LOAD_OP_LOAD;
+            default:
+                AZ_Assert(false, "AttachmentLoadAction is illegal.");
+                return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            }
+        }
+
+        VkAttachmentStoreOp ConvertAttachmentStoreAction(RHI::AttachmentStoreAction storeAction, const Device& device)
+        {
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
+            switch (storeAction)
+            {
+            case RHI::AttachmentStoreAction::Store:
+                return VK_ATTACHMENT_STORE_OP_STORE;
+            case RHI::AttachmentStoreAction::DontCare:
+                return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            case RHI::AttachmentStoreAction::None:
+                return physicalDevice.IsFeatureSupported(DeviceFeature::StoreNoneOp) ? VK_ATTACHMENT_STORE_OP_NONE
+                                                                                     : VK_ATTACHMENT_STORE_OP_STORE;
+            default:
+                AZ_Assert(false, "AttachmentStoreAction is illegal.");
+                return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            }
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.h
@@ -29,6 +29,7 @@ namespace AZ
     namespace Vulkan
     {
         class Image;
+        class Device;
 
         VkIndexType ConvertIndexBufferFormat(RHI::IndexFormat indexFormat);
         VkQueryControlFlags ConvertQueryControlFlags(RHI::QueryControlFlags flags);
@@ -57,5 +58,7 @@ namespace AZ
         VmaAllocationCreateInfo GetVmaAllocationCreateInfo(const RHI::HeapMemoryLevel level);
         VkImageLayout CombineImageLayout(VkImageLayout lhs, VkImageLayout rhs);
         VkImageLayout FilterImageLayout(VkImageLayout layout, RHI::ImageAspectFlags aspectFlags);
+        VkAttachmentLoadOp ConvertAttachmentLoadAction(RHI::AttachmentLoadAction loadAction, const Device& device);
+        VkAttachmentStoreOp ConvertAttachmentStoreAction(RHI::AttachmentStoreAction storeAction, const Device& device);
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -299,6 +299,10 @@ namespace AZ
                 static_cast<size_t>(DeviceFeature::MemoryBudget),
                 VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_memory_budget) && m_deviceProperties.vendorID != VendorID_Intel);
             m_features.set(static_cast<size_t>(DeviceFeature::SubgroupOperation), (majorVersion >= 1 && minorVersion >= 1));
+            m_features.set(static_cast<size_t>(DeviceFeature::LoadNoneOp), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_load_store_op_none));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::StoreNoneOp),
+                VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_load_store_op_none) || (majorVersion >= 1 && minorVersion >= 3));
         }
 
         RawStringList PhysicalDevice::FilterSupportedOptionalExtensions()
@@ -331,6 +335,7 @@ namespace AZ
                 VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
                 VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
                 VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME
             } };
 
             [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -35,6 +35,8 @@ namespace AZ
             BufferDeviceAddress,
             SubgroupOperation,
             MemoryBudget,
+            LoadNoneOp,
+            StoreNoneOp,
             Count // Must be last
         };
 
@@ -63,6 +65,7 @@ namespace AZ
             FragmentDensityMap,
             Renderpass2,
             TimelineSempahore,
+            LoadStoreOpNone,
             Count
         };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -168,10 +168,10 @@ namespace AZ
                         SetStructureType(desc, VkAttachmentDescriptionTraits::struct_type, special_());
                         desc.format = ConvertFormat(binding.m_format);
                         desc.samples = ConvertSampleCount(binding.m_multisampleState.m_samples);
-                        desc.loadOp = ConvertAttachmentLoadAction(binding.m_loadStoreAction.m_loadAction);
-                        desc.storeOp = ConvertAttachmentStoreAction(binding.m_loadStoreAction.m_storeAction);
-                        desc.stencilLoadOp = ConvertAttachmentLoadAction(binding.m_loadStoreAction.m_loadActionStencil);
-                        desc.stencilStoreOp = ConvertAttachmentStoreAction(binding.m_loadStoreAction.m_storeActionStencil);
+                        desc.loadOp = ConvertAttachmentLoadAction(binding.m_loadStoreAction.m_loadAction, m_device);
+                        desc.storeOp = ConvertAttachmentStoreAction(binding.m_loadStoreAction.m_storeAction, m_device);
+                        desc.stencilLoadOp = ConvertAttachmentLoadAction(binding.m_loadStoreAction.m_loadActionStencil, m_device);
+                        desc.stencilStoreOp = ConvertAttachmentStoreAction(binding.m_loadStoreAction.m_storeActionStencil, m_device);
                         desc.initialLayout = binding.m_initialLayout;
                         desc.finalLayout = binding.m_finalLayout;
                     }

--- a/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
@@ -20,7 +20,10 @@
                         "ClearValue": {
                             "Type": "DepthStencil"
                         },
-                        "LoadActionStencil": "Clear"
+                        "LoadAction": "None",
+                        "LoadActionStencil": "Clear",
+                        "StoreAction": "None",
+                        "StoreActionStencil": "DontCare"
                     }
                 }
             ],


### PR DESCRIPTION
## What does this PR do?

Add "None" load/store operations to avoid extra synchronization when using render attachments. On Vulkan, using an extension you can specify that the attachment contents to be preserved if not being used, or is being used as read only. Previously you have to load/store the contents in order to preserve them, which comes with a penalty on bandwidth. Using the "DonCare" op is not possible if the contents will be used by later passes, since it makes the content undefined.

None operations depends on platform support. If not available, we use the Load/Store op. 

## How was this PR tested?

Run PC Vulkan, DX12 and Android.