### PR TITLE
Fixes script-only "Quickstart" mode.

### DIFF
--- a/Templates/ScriptOnlyProject/Template/package.sh
+++ b/Templates/ScriptOnlyProject/Template/package.sh
@@ -12,13 +12,29 @@
 # To get more information about the possible tweakable parameters, run 
 # (engine folder)/scripts/o3de.sh export-project -es ExportScripts/export_source_built_project.py --script-help
 
+# The output of this script will be placed in the "ProjectPackages" folder and will include
+# * A standalone version of the project game client, shippable, with all the assets and binaries
+# * A standalone version of the project server (if the project has one), shippable, with all the assets and binaries
+# * A standalone version of the project's "Unified" (Client + 'listen' Server), with assets and binaries
+# * zip files of each of the above (based on the --archive-output zip) option below - xz, bz2, gzip and 'none' 
+#   are also available.
+
 O3DE_PATH=${EnginePath}
 O3DE_PROJECT_PATH=${ProjectPath}
+
+# The seedlist is a list of assets that will be included in the package (it automatically computes dependencies
+# based on these assets and will include dependencies recusively on anything in the seed list.  Modify it
+# to include your own 'root' assets that you want to include in the package using the AssetBundler tool
 O3DE_PROJECT_SEEDLIST=${O3DE_PROJECT_PATH}/AssetBundling/SeedLists/Example.seed
 OUTPUT_PATH=${O3DE_PROJECT_PATH}/ProjectPackages
 
-# change this to release or debug if you want it to make a release or debug package
-# (Only works if the installer you have actually includes release and debug binaries)
+# change this to release, profile, or debug 
+# (Only works if the installer you have actually includes release, profile or debug binaries)
+
+# note that script-only-projects cannot support monolithic configurations and the default installer
+# only includes monolithic release configuration (along with non-monolithic debug and profile).
+# you can build your own installer that has non-monolithic release, and then use release, in that case,
+# but otherwise, stick to either profile or debug.
 OUTPUT_CONFIGURATION=profile
 
-${O3DE_PATH}/scripts/o3de.sh export-project -es ExportScripts/export_source_built_project.py --project-path ${O3DE_PROJECT_PATH} --no-monolithic-build  --log-level INFO -assets --config ${OUTPUT_CONFIGURATION} --archive-output gztar --seedlist ${O3DE_PROJECT_SEEDLIST} -out ${OUTPUT_PATH}
+${O3DE_PATH}/scripts/o3de.sh export-project -es ExportScripts/export_source_built_project.py --project-path ${O3DE_PROJECT_PATH} -nomono  --log-level INFO -assets --config ${OUTPUT_CONFIGURATION} --archive-output zip --seedlist ${O3DE_PROJECT_SEEDLIST} -out ${OUTPUT_PATH}

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -900,21 +900,44 @@ function(ly_setup_assets)
     # Gem Source Assets and configuration files
     # Find all gem directories relative to the CMake Source Dir
 
-    # This first loop is to filter out transient and .gitignore'd folders that should be added to
+    # this first loop real-path-izes all the paths to avoid doing so repeatedly.
+    get_external_subdirectories_in_use(external_subdirs_non_realpath)
+    foreach(gem_candidate_dir IN LISTS external_subdirs_non_realpath)
+        file(REAL_PATH ${gem_candidate_dir} gem_candidate_dir BASE_DIRECTORY ${LY_ROOT_FOLDER})
+        list(APPEND external_subdirs ${gem_candidate_dir})
+    endforeach()
+
+    # This next loop is to filter out transient and .gitignore'd folders that should be added to
     # the install layout from the root directory. Such as <external-subdirectory-root>/Cache.
     # This is also done to avoid globbing thousands of files in subdirectories that shouldn't
     # be processed.
-    get_external_subdirectories_in_use(external_subdirs)
+    # It also filters out subdirectories that are themselves gem candidate directories so they are
+    # not double-visited.
+    
     foreach(gem_candidate_dir IN LISTS external_subdirs)
-        file(REAL_PATH ${gem_candidate_dir} gem_candidate_dir BASE_DIRECTORY ${LY_ROOT_FOLDER})
+        unset(external_subdir_files)
+        unset(external_subdir_files_tenative)
+
         # Don't recurse immediately in order to exclude transient source artifacts
         file(GLOB
-            external_subdir_files
+            external_subdir_files_tenative
             LIST_DIRECTORIES TRUE
             "${gem_candidate_dir}/*"
         )
         # Exclude transient artifacts that shouldn't be copied to the install layout
-        list(FILTER external_subdir_files EXCLUDE REGEX "/([Bb]uild|[Cc]ache|[Uu]ser)$")
+        list(FILTER external_subdir_files_tenative EXCLUDE REGEX "/([Bb]uild|[Cc]ache|[Uu]ser)$")
+
+        # Exclude folders that themselves are gem_candidate_dirs with their own gem.json
+        foreach(check_file IN LISTS external_subdir_files_tenative)
+            if(IS_DIRECTORY ${check_file})
+                list(FIND external_subdirs ${check_file} is_gem_candidate_dir)
+                if(is_gem_candidate_dir EQUAL -1)
+                    # it is not already in the list, so it is unique to this gem folder.
+                    list(APPEND external_subdir_files ${check_file})
+                endif()
+            endif()
+        endforeach()
+
         # Storing a "mapping" of gem candidate directories, to external_subdirectory files using
         # a DIRECTORY property for the "value" and the GLOBAL property for the "key"
         set_property(DIRECTORY ${gem_candidate_dir} APPEND PROPERTY directory_filtered_asset_paths "${external_subdir_files}")


### PR DESCRIPTION
## What does this PR do?

Fixes issue : https://github.com/o3de/o3de/issues/18054

This might have been causing all sorts of other issues in other specific cases too, but this is the one that brought it to my attention.

Root cause analysis (as best as I can tell)

When generating the installer, the cmake script to do so would copy assets for gems, and in doing so, would glob all the files and directories in that candidate gem folder over to the target folder.

In order for such "asset only" gems to function, they need to have a cmakelists.txt generated which created a Builders target.  So it would generate one...

To do so, it would check each candidate gem folder, and if it found that the candidate gem folder DID NOT have a cmakelists.txt generated already (which happens if it contains targets), it would make one that was "asset only" and would only get run when the gem.json specified that it was an "asset" gem.

The problem is that Atom consists of many gems-inside-gems, and it ended up processing the same directory multiple times.  For example it would process Atom/RHI/DX12 and notice that this did indeed have real targets (not an asset only gem) and thus leave it alone, not generating a cmakelists.txt for it.

But then it would process Atom/RHI, and loop over the files in there and all the directories in there, and end up processing Atom/RHI/DX12
in the context of Atom/RHI.   Since Atom/RHI had no targets, it would
generate a cmakelists.txt for Atom/RHI/DX12 that was "Asset Only",
overwriting the already generated one that was correct.

To fix this, I made it so that the candidate gem files globbed from a directory do not include subfolders that themselves were also in the list of candidate gems (and thus would get their own turn at processing).

## How was this PR tested?

transparent and opaque box testing of the full pipeline of building and using a script-only and regular project.

* Creating an installer from the source
* using that installer to create a regular AND script only project
* running the editor for those projects
* running the package script for those projects
* inspecting the packaged projects.


