### PR TITLE
Fix renderpass builder layout

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPassBuilder.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPassBuilder.cpp
@@ -157,7 +157,9 @@ namespace AZ
                         break;
                     }
                 default:
-                    break;
+                    // Image attachment is not a render attachment, so we do not add it to the m_framebufferAttachments list.
+                    // Continue to the next attachment.
+                    continue;
                 }
 
                 auto insertResult = m_framebufferAttachments.insert(AZStd::make_pair(scopeAttachmentId, framebufferInfo));


### PR DESCRIPTION
## What does this PR do?

Fix Vulkan layout when using RenderpassBuilder. Non render attachments were being added causing an issue when setting the image layout.

## How was this PR tested?

Run PC Vulkan.