### PR TITLE
[Cherry Pick] Removing $<TARGET_OBJECTS::Gem...> usage from project templates 

### DIFF
--- a/Templates/CppToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/Code/CMakeLists.txt
@@ -143,7 +143,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Templates/GraphicsGem/Template/Code/CMakeLists.txt
+++ b/Templates/GraphicsGem/Template/Code/CMakeLists.txt
@@ -149,7 +149,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::Atom_Utils.Static
                 Gem::Atom_Feature_Common.Static
                 Gem::CommonFeaturesAtom.Static

--- a/Templates/UnifiedMultiplayerGem/Template/Code/CMakeLists.txt
+++ b/Templates/UnifiedMultiplayerGem/Template/Code/CMakeLists.txt
@@ -222,7 +222,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Unified.Private.Object>
+                ${gem_name}.Unified.Private.Object
     )
 
     ly_add_target(


### PR DESCRIPTION
## What does this PR do?

Cherry picks template fix from https://github.com/o3de/o3de/pull/18182
